### PR TITLE
feat: route background failures to dedicated target

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1191,12 +1191,33 @@ def _format_process_notification(evt: dict) -> "str | None":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
-        text = (
-            f"[SYSTEM: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\n"
-            f"Matched output:\n{_out}"
-        )
+        text = None
+        try:
+            from tools.ansi_strip import strip_ansi
+            from tools.process_registry import process_registry
+
+            _session = process_registry.get(_sid)
+            if _session and getattr(_session, "exited", False) and getattr(_session, "exit_code", None) not in (None, 0):
+                _final = strip_ansi(getattr(_session, "output_buffer", "")[-2000:])
+                text = (
+                    f"[SYSTEM: Background process {_sid} matched "
+                    f"watch pattern \"{_pat}\", but the process exited with code "
+                    f"{_session.exit_code}.\n"
+                    f"Command: {_cmd}\n"
+                    f"Matched output:\n{_out}"
+                )
+                if _final and _final.strip() and _final.strip() != _out.strip():
+                    text += f"\nFinal output:\n{_final}"
+        except Exception:
+            text = None
+
+        if text is None:
+            text = (
+                f"[SYSTEM: Background process {_sid} matched "
+                f"watch pattern \"{_pat}\".\n"
+                f"Command: {_cmd}\n"
+                f"Matched output:\n{_out}"
+            )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1289,6 +1289,109 @@ class GatewayRunner:
         return mode
 
     @staticmethod
+    def _load_background_failure_target() -> dict | None:
+        """Load an optional target for background-process failure notifications.
+
+        The target uses the same string format as send_message targets, e.g.
+        ``discord:1493886407981269062`` or ``discord:1493886407981269062:123``.
+        When unset, failures continue going back to the originating chat.
+        """
+        target = os.getenv("HERMES_BACKGROUND_FAILURE_TARGET", "")
+        if not target:
+            try:
+                import yaml as _y
+                cfg_path = _hermes_home / "config.yaml"
+                if cfg_path.exists():
+                    with open(cfg_path, encoding="utf-8") as _f:
+                        cfg = _y.safe_load(_f) or {}
+                    raw = cfg.get("display", {}).get("background_process_failure_target")
+                    if raw not in (None, "", False):
+                        target = str(raw)
+            except Exception:
+                pass
+        target = (target or "").strip()
+        if not target:
+            return None
+
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            from tools.send_message_tool import _parse_target_ref
+        except Exception as exc:
+            logger.warning("Could not load background failure target helpers: %s", exc)
+            return None
+
+        parts = target.split(":", 1)
+        platform_name = parts[0].strip().lower()
+        target_ref = parts[1].strip() if len(parts) > 1 else None
+        try:
+            platform = Platform(platform_name)
+        except ValueError:
+            logger.warning("Unknown background_process_failure_target platform '%s'", platform_name)
+            return None
+
+        config = load_gateway_config()
+        chat_id = None
+        thread_id = None
+        is_explicit = False
+        if target_ref:
+            chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+            if target_ref and not is_explicit:
+                resolved = resolve_channel_name(platform_name, target_ref)
+                if not resolved:
+                    logger.warning(
+                        "Could not resolve background_process_failure_target '%s' on %s",
+                        target_ref,
+                        platform_name,
+                    )
+                    return None
+                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+        else:
+            home = config.get_home_channel(platform)
+            if home:
+                chat_id = home.chat_id
+
+        if not chat_id:
+            logger.warning("background_process_failure_target '%s' did not resolve to a chat_id", target)
+            return None
+
+        return {
+            "platform": platform,
+            "chat_id": str(chat_id),
+            "thread_id": str(thread_id) if thread_id not in (None, "") else None,
+            "raw": target,
+        }
+
+    async def _send_background_failure_notification(self, message_text: str) -> bool:
+        """Send a failure/watch alert to the dedicated target if configured."""
+        target = self._load_background_failure_target()
+        if not target:
+            return False
+
+        adapter = self.adapters.get(target["platform"])
+        if not adapter:
+            logger.warning(
+                "Background failure target adapter for %s is not connected",
+                target["platform"].value,
+            )
+            return False
+
+        metadata = {"thread_id": target["thread_id"]} if target.get("thread_id") else None
+        try:
+            await adapter.send(target["chat_id"], message_text, metadata=metadata)
+            return True
+        except Exception as exc:
+            logger.warning("Background failure target delivery failed: %s", exc)
+            return False
+
+    async def _dispatch_watch_notification(self, message_text: str, event) -> bool:
+        """Deliver a watch notification to the failure target or fall back to origin."""
+        routed = await self._send_background_failure_notification(message_text)
+        if routed:
+            return True
+        await self._inject_watch_notification(message_text, event)
+        return False
+
+    @staticmethod
     def _load_provider_routing() -> dict:
         """Load OpenRouter provider routing preferences from config.yaml."""
         try:
@@ -3979,7 +4082,7 @@ class GatewayRunner:
                     synth_text = _format_gateway_process_notification(evt)
                     if synth_text:
                         try:
-                            await self._inject_watch_notification(synth_text, event)
+                            await self._dispatch_watch_notification(synth_text, event)
                         except Exception as e2:
                             logger.error("Watch notification injection error: %s", e2)
             except Exception as e:
@@ -7568,6 +7671,10 @@ class GatewayRunner:
                         f"Command: {session.command}\n"
                         f"Output:\n{_out}]"
                     )
+                    if session.exit_code not in (0, None):
+                        routed = await self._send_background_failure_notification(synth_text)
+                        if routed:
+                            break
                     adapter = None
                     for p, a in self.adapters.items():
                         if p.value == platform_name:
@@ -7613,6 +7720,10 @@ class GatewayRunner:
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
                     )
+                    if session.exit_code not in (0, None):
+                        routed = await self._send_background_failure_notification(message_text)
+                        if routed:
+                            break
                     adapter = None
                     for p, a in self.adapters.items():
                         if p.value == platform_name:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -495,12 +495,33 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
-        text = (
-            f"[SYSTEM: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\n"
-            f"Matched output:\n{_out}"
-        )
+        text = None
+        try:
+            from tools.ansi_strip import strip_ansi
+            from tools.process_registry import process_registry
+
+            _session = process_registry.get(_sid)
+            if _session and getattr(_session, "exited", False) and getattr(_session, "exit_code", None) not in (None, 0):
+                _final = strip_ansi(getattr(_session, "output_buffer", "")[-2000:])
+                text = (
+                    f"[SYSTEM: Background process {_sid} matched "
+                    f"watch pattern \"{_pat}\", but the process exited with code "
+                    f"{_session.exit_code}.\n"
+                    f"Command: {_cmd}\n"
+                    f"Matched output:\n{_out}"
+                )
+                if _final and _final.strip() and _final.strip() != _out.strip():
+                    text += f"\nFinal output:\n{_final}"
+        except Exception:
+            text = None
+
+        if text is None:
+            text = (
+                f"[SYSTEM: Background process {_sid} matched "
+                f"watch pattern \"{_pat}\".\n"
+                f"Command: {_cmd}\n"
+                f"Matched output:\n{_out}"
+            )
         if _sup:
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -33,20 +33,21 @@ class _FakeRegistry:
         return None
 
 
-def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
+def _build_runner(monkeypatch, tmp_path, mode: str, *, extra_display: str = "") -> GatewayRunner:
     """Create a GatewayRunner with a fake config for the given mode."""
-    (tmp_path / "config.yaml").write_text(
-        f"display:\n  background_process_notifications: {mode}\n",
-        encoding="utf-8",
-    )
+    display_yaml = f"display:\n  background_process_notifications: {mode}\n"
+    if extra_display:
+        display_yaml += extra_display
+    (tmp_path / "config.yaml").write_text(display_yaml, encoding="utf-8")
 
     import gateway.run as gateway_run
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
     runner = GatewayRunner(GatewayConfig())
-    adapter = SimpleNamespace(send=AsyncMock())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
     runner.adapters[Platform.TELEGRAM] = adapter
+    runner.adapters[Platform.DISCORD] = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
     return runner
 
 
@@ -111,9 +112,114 @@ class TestLoadBackgroundNotificationsMode:
         assert GatewayRunner._load_background_notifications_mode() == "all"
 
 
+class TestLoadBackgroundFailureTarget:
+
+    def test_defaults_to_none(self, monkeypatch, tmp_path):
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+        monkeypatch.delenv("HERMES_BACKGROUND_FAILURE_TARGET", raising=False)
+        assert GatewayRunner._load_background_failure_target() is None
+
+    def test_reads_config_yaml(self, monkeypatch, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "display:\n  background_process_failure_target: discord:999:321\n",
+            encoding="utf-8",
+        )
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+        monkeypatch.delenv("HERMES_BACKGROUND_FAILURE_TARGET", raising=False)
+
+        target = GatewayRunner._load_background_failure_target()
+
+        assert target == {
+            "platform": Platform.DISCORD,
+            "chat_id": "999",
+            "thread_id": "321",
+            "raw": "discord:999:321",
+        }
+
+    def test_env_var_overrides_config(self, monkeypatch, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "display:\n  background_process_failure_target: discord:999\n",
+            encoding="utf-8",
+        )
+        import gateway.run as gw
+        monkeypatch.setattr(gw, "_hermes_home", tmp_path)
+        monkeypatch.setenv("HERMES_BACKGROUND_FAILURE_TARGET", "discord:555:42")
+
+        target = GatewayRunner._load_background_failure_target()
+
+        assert target == {
+            "platform": Platform.DISCORD,
+            "chat_id": "555",
+            "thread_id": "42",
+            "raw": "discord:555:42",
+        }
+
+
 # ---------------------------------------------------------------------------
 # _run_process_watcher integration tests
 # ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dispatch_watch_notification_prefers_dedicated_target(monkeypatch, tmp_path):
+    runner = _build_runner(
+        monkeypatch,
+        tmp_path,
+        "all",
+        extra_display="  background_process_failure_target: discord:999:321\n",
+    )
+    failure_adapter = runner.adapters[Platform.DISCORD]
+    monkeypatch.setattr(runner, "_inject_watch_notification", AsyncMock())
+
+    routed = await runner._dispatch_watch_notification("[SYSTEM: watch matched]", SimpleNamespace())
+
+    assert routed is True
+    assert failure_adapter.send.await_count == 1
+    assert failure_adapter.send.await_args.args[0] == "999"
+    assert failure_adapter.send.await_args.kwargs["metadata"] == {"thread_id": "321"}
+    runner._inject_watch_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_watch_notification_falls_back_to_origin_when_unconfigured(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_inject_watch_notification", AsyncMock())
+
+    routed = await runner._dispatch_watch_notification("[SYSTEM: watch matched]", SimpleNamespace())
+
+    assert routed is False
+    runner._inject_watch_notification.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_run_process_watcher_routes_failures_to_dedicated_target(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1, command="make deploy")]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(
+        monkeypatch,
+        tmp_path,
+        "all",
+        extra_display="  background_process_failure_target: discord:999:321\n",
+    )
+    origin_adapter = runner.adapters[Platform.TELEGRAM]
+    failure_adapter = runner.adapters[Platform.DISCORD]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    assert failure_adapter.send.await_count == 1
+    assert failure_adapter.send.await_args.args[0] == "999"
+    assert "exit code 1" in failure_adapter.send.await_args.args[1]
+    assert failure_adapter.send.await_args.kwargs["metadata"] == {"thread_id": "321"}
+    assert origin_adapter.send.await_count == 0
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(

--- a/tests/tools/test_process_watch_notifications.py
+++ b/tests/tools/test_process_watch_notifications.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import pytest
+
+from cli import _format_process_notification
+from gateway.run import _format_gateway_process_notification
+from tools.process_registry import process_registry
+
+
+@pytest.fixture(autouse=True)
+def reset_process_registry_get(monkeypatch):
+    monkeypatch.setattr(process_registry, "get", lambda _sid: None)
+
+
+def test_cli_watch_match_reports_failed_process_context(monkeypatch):
+    monkeypatch.setattr(
+        process_registry,
+        "get",
+        lambda _sid: SimpleNamespace(
+            exited=True,
+            exit_code=1,
+            output_buffer=(
+                "INFO:     Application startup complete.\n"
+                "ERROR:    [Errno 98] error while attempting to bind on address "
+                "('127.0.0.1', 18085): address already in use\n"
+            ),
+        ),
+    )
+    evt = {
+        "type": "watch_match",
+        "session_id": "proc_test",
+        "command": "python3 -m uvicorn app:app --port 18085",
+        "pattern": "Application startup complete",
+        "output": "INFO:     Application startup complete.",
+        "suppressed": 0,
+    }
+
+    text = _format_process_notification(evt)
+
+    assert "exited with code 1" in text
+    assert "address already in use" in text
+    assert "Matched output" in text
+    assert "Final output" in text
+
+
+def test_gateway_watch_match_reports_failed_process_context(monkeypatch):
+    monkeypatch.setattr(
+        process_registry,
+        "get",
+        lambda _sid: SimpleNamespace(
+            exited=True,
+            exit_code=1,
+            output_buffer="INFO:     Application startup complete.\nERROR: bind failed\n",
+        ),
+    )
+    evt = {
+        "type": "watch_match",
+        "session_id": "proc_test",
+        "command": "python3 -m uvicorn app:app --port 18085",
+        "pattern": "Application startup complete",
+        "output": "INFO:     Application startup complete.",
+        "suppressed": 0,
+    }
+
+    text = _format_gateway_process_notification(evt)
+
+    assert "exited with code 1" in text
+    assert "bind failed" in text
+    assert "Final output" in text


### PR DESCRIPTION
## Summary
- add `display.background_process_failure_target` / `HERMES_BACKGROUND_FAILURE_TARGET` support using `send_message`-style targets
- route failed background completions and watch alerts to the dedicated target when configured
- preserve existing origin-chat behavior for successful completions and running-output updates

## Test Plan
- `pytest -q tests/gateway/test_background_process_notifications.py tests/gateway/test_internal_event_bypass_pairing.py tests/tools/test_process_watch_notifications.py tests/tools/test_notify_on_complete.py tests/tools/test_watch_patterns.py`

Linear: PAB-165