### PR TITLE
fix: normalize string schedule in update_job to prevent AttributeError

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -501,6 +501,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if schedule_changed:
             updated_schedule = updated["schedule"]
+            # Normalize string schedule to parsed dict (same as create_job does)
+            if isinstance(updated_schedule, str):
+                updated_schedule = parse_schedule(updated_schedule)
+                updated["schedule"] = updated_schedule
             updated["schedule_display"] = updates.get(
                 "schedule_display",
                 updated_schedule.get("display", updated.get("schedule_display")),


### PR DESCRIPTION
## Summary
Fixes cron job update API crash when schedule is passed as a string (e.g., "every 10m").

## Root Cause
update_job() in cron/jobs.py assumed the schedule field was always a parsed dict and called .get("display") on it. The API endpoint forwards JSON bodies directly, so a valid payload like {"schedule": "every 10m"} causes AttributeError: 'str' object has no attribute 'get'.

## Fix
Added string detection and normalization in update_job() — when schedule is a string, parse it via parse_schedule() before accessing dict keys. This matches the same normalization already done in create_job().

## Test Plan
- [ ] cron update job tests pass (4 passed)
- [ ] Manual: curl -X PATCH /api/cron/jobs/<id> -d '{"schedule": "every 10m"}'

Closes NousResearch/hermes-agent#10129