### PR TITLE
fix(cli): replace ps -ax with POSIX -e for Docker compatibility

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -222,11 +222,13 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "eww", "-ax", "-o", "pid=,command="],
+                ["ps", "eww", "-e", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
+            if result.returncode != 0:
+                return pids
             for line in result.stdout.split('\n'):
                 stripped = line.strip()
                 if not stripped or 'grep' in stripped:

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -801,6 +801,80 @@ class TestFindGatewayPidsExclude:
 
 
 # ---------------------------------------------------------------------------
+# find_gateway_pids uses POSIX ps flags & handles errors (#9723)
+# ---------------------------------------------------------------------------
+
+
+class TestFindGatewayPidsDocker:
+    """Verify find_gateway_pids uses POSIX ``-e`` flag and handles ps failure."""
+
+    def test_ps_uses_posix_e_flag(self, monkeypatch):
+        """The ps command must use '-e' (POSIX), not '-ax' (BSD)."""
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway_cli, "get_hermes_home",
+                            lambda: __import__("pathlib").Path("/tmp/.hermes"))
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda hermes_home=None: "")
+
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        gateway_cli.find_gateway_pids()
+
+        assert len(captured_cmds) == 1
+        ps_cmd = captured_cmds[0]
+        assert "-e" in ps_cmd, f"Expected '-e' in ps command, got {ps_cmd}"
+        assert "-ax" not in ps_cmd, f"'-ax' should not appear in ps command, got {ps_cmd}"
+
+    def test_ps_nonzero_exit_returns_service_pids_only(self, monkeypatch):
+        """When ps fails (e.g. in Docker), return service-managed PIDs only."""
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {42})
+        monkeypatch.setattr(gateway_cli, "get_hermes_home",
+                            lambda: __import__("pathlib").Path("/tmp/.hermes"))
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda hermes_home=None: "")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 1,
+                stdout="error: personality not set\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        pids = gateway_cli.find_gateway_pids()
+
+        # Should still have the service PID, but should NOT have parsed
+        # the error output as if it were valid ps data.
+        assert pids == [42]
+
+    def test_ps_nonzero_exit_no_service_pids(self, monkeypatch):
+        """When ps fails and there are no service PIDs, return empty list."""
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway_cli, "get_hermes_home",
+                            lambda: __import__("pathlib").Path("/tmp/.hermes"))
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda hermes_home=None: "")
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="ps: error")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        pids = gateway_cli.find_gateway_pids()
+        assert pids == []
+
+
+# ---------------------------------------------------------------------------
 # Gateway mode writes exit code before restart (#8300)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #9723.

`find_gateway_pids()` in `hermes_cli/gateway.py` calls `ps eww -ax` which fails in Docker containers running `procps 4.0.4` because the BSD-style `-ax` flag requires a personality setting that isn't available. This causes `hermes cron list`, `hermes dump`, and other commands to falsely report the gateway as not running.

## Changes

### `hermes_cli/gateway.py`
- Replace `-ax` with `-e` (POSIX standard) in the `ps` command — functionally equivalent (selects all processes) but works without BSD personality
- Add early return when `ps` returns non-zero exit code to prevent parsing error output as process data; falls back to service-manager PID detection

### `tests/hermes_cli/test_update_gateway_restart.py`
- Added `TestFindGatewayPidsDocker` test class with 3 tests:
  - Verifies `-e` flag is used instead of `-ax`
  - Verifies graceful fallback when `ps` fails with non-zero exit
  - Verifies empty result when both `ps` and service manager fail

All 51 tests in the test file pass.