### PR TITLE
fix(wecom): correct image extension detection and handle URL-encoded aeskey

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -730,6 +730,9 @@ class WeComAdapter(BasePlatformAdapter):
 
         aes_key = str(media.get("aeskey") or "").strip()
         if aes_key:
+            from urllib.parse import unquote
+            aes_key = unquote(aes_key)
+            aes_key = aes_key + "=" * ((4 - len(aes_key) % 4) % 4)
             try:
                 raw = self._decrypt_file_bytes(raw, aes_key)
             except Exception as exc:
@@ -772,7 +775,7 @@ class WeComAdapter(BasePlatformAdapter):
     @staticmethod
     def _guess_extension(url: str, content_type: str, fallback: str) -> str:
         ext = mimetypes.guess_extension(content_type) if content_type else None
-        if ext:
+        if ext and ext != ".bin":
             return ext
         path_ext = Path(urlparse(url).path).suffix
         if path_ext:


### PR DESCRIPTION
## Summary
Fixes two WeCom image handling issues: wrong file extensions (.bin instead of .jpg/.png) and silent decryption failures for URL-encoded aeskey parameters.

## Root Cause
1. _guess_extension() returned .bin for application/octet-stream (WeCom CDN content-type for images), short-circuiting before magic-byte detection could identify JPEG/PNG.
2. aeskey parameter in WeCom CDN URLs was sometimes URL-encoded (%2F, %3D) and missing base64 padding, causing base64.b64decode() to fail and all images to return None.

## Fix
- Skip .bin in _guess_extension() so it falls through to URL path suffix or magic-byte detection
- URL-decode aeskey and add base64 padding before calling _decrypt_file_bytes()

## Test Plan
- [x] All 32 WeCom tests pass
- [ ] Manual verification: receive images via WeCom, check file extensions

Closes NousResearch/hermes-agent#10085