### PR TITLE
fix: add on_memory_write bridge in _execute_tool_calls_sequential

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7384,6 +7384,16 @@ class AIAgent:
                     old_text=function_args.get("old_text"),
                     store=self._memory_store,
                 )
+                # Bridge: notify external memory provider of built-in memory writes
+                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                    try:
+                        self._memory_manager.on_memory_write(
+                            function_args.get("action", ""),
+                            target,
+                            function_args.get("content", ""),
+                        )
+                    except Exception:
+                        pass
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")


### PR DESCRIPTION
## Summary
Fixes missing on_memory_write notification in the sequential tool execution path, ensuring external memory providers (ClawMem, retaindb, etc.) receive write notifications for single memory tool calls.

## Root Cause
The memory tool has two execution paths in run_agent.py:
1. Concurrent path (_invoke_tool, line ~6955): calls on_memory_write bridge ✅
2. Sequential path (_execute_tool_calls_sequential, line ~7377): does NOT call on_memory_write ❌

When a single memory tool call is made (the common case), it routes through the sequential path and the bridge is skipped. External memory providers never receive the write notification.

## Fix
Added the same on_memory_write bridge call after memory tool execution in _execute_tool_calls_sequential, matching the concurrent path behavior exactly.

## Test Plan
- [x] Memory-related tests pass (316 passed)
- [ ] Manual verification with external memory provider

Closes NousResearch/hermes-agent#10174