### PR TITLE
fix(security): restrict session token endpoint to SPA origin and restore SystemExit for non-localhost binding

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -473,13 +473,17 @@ async def update_config(body: ConfigUpdate):
 
 
 @app.get("/api/auth/session-token")
-async def get_session_token():
+async def get_session_token(request: Request):
     """Return the ephemeral session token for this server instance.
 
-    The token protects sensitive endpoints (reveal).  It's served to the SPA
-    which stores it in memory — it's never persisted and dies when the server
-    process exits.  CORS already restricts this to localhost origins.
+    Only served to requests originating from the local SPA (same host/port).
+    Referer check prevents other localhost origins from obtaining the token.
     """
+    referer = request.headers.get("referer", "")
+    origin = request.headers.get("origin", "")
+    server_base = f"http://{request.url.hostname}:{request.url.port}"
+    if not (referer.startswith(server_base) or origin == server_base):
+        raise HTTPException(status_code=403, detail="Forbidden")
     return {"token": _SESSION_TOKEN}
 
 
@@ -1818,10 +1822,10 @@ def start_server(host: str = "127.0.0.1", port: int = 9119, open_browser: bool =
     import uvicorn
 
     if host not in ("127.0.0.1", "localhost", "::1"):
-        import logging
-        logging.warning(
-            "Binding to %s — the web UI exposes config and API keys. "
-            "Only bind to non-localhost if you trust all users on the network.", host,
+        raise SystemExit(
+            f"Refusing to bind web dashboard to {host} — "
+            "the dashboard exposes API keys and config to the network.\n"
+            "Use 127.0.0.1 (default) to restrict access to localhost only."
         )
 
     if open_browser:


### PR DESCRIPTION
## What does this PR do?

Two security regressions in `hermes_cli/web_server.py` introduced
with the local web dashboard:

### 1. Unauthenticated session token endpoint (CRITICAL)

`GET /api/auth/session-token` returned `_SESSION_TOKEN` to any caller
with no authentication:

```python
# Before (vulnerable)
@app.get("/api/auth/session-token")
async def get_session_token():
    return {"token": _SESSION_TOKEN}
```

**Attack chain:**
1. Any process on the machine calls `GET localhost:9119/api/auth/session-token`
2. Gets `_SESSION_TOKEN` in the response
3. Calls `POST /api/env/reveal` with `Authorization: Bearer <token>`
4. All stored API keys, OAuth tokens, and secrets are revealed

CORS only restricts browser clients — non-browser scripts bypass it
entirely. Additionally, the broad `^https?://(localhost|127\.0\.0\.1)(:\d+)?$`
CORS regex allows ALL localhost ports in-browser, meaning any other
local dev server with XSS (React devserver, Storybook, etc.) can
fetch the token and reveal secrets.

**Fix:** Added `Referer`/`Origin` check — token only served to requests
originating from the same host:port as the dashboard:

```python
server_base = f"http://{request.url.hostname}:{request.url.port}"
if not (referer.startswith(server_base) or origin == server_base):
    raise HTTPException(status_code=403, detail="Forbidden")
```

### 2. Binding guard downgraded from fatal to warning (HIGH)

```python
# Before (vulnerable)
if host not in ("127.0.0.1", "localhost", "::1"):
    logging.warning("Binding to %s ...", host)  # silently continues!
```

If a user configures `host: 0.0.0.0` (common in Docker), the server
starts without error and exposes all endpoints — including
`/api/env/reveal` — to the entire local network.

**Fix:** Restored `raise SystemExit` to prevent non-localhost binding:

```python
if host not in ("127.0.0.1", "localhost", "::1"):
    raise SystemExit(
        f"Refusing to bind web dashboard to {host} — "
        "the dashboard exposes API keys and config to the network."
    )
```

## Type of Change

- [x] 🔒 Security fix (session token exfiltration — CRITICAL)
- [x] 🔒 Security fix (non-localhost binding guard — HIGH)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] No behavior change for legitimate localhost usage
- [x] Token endpoint still works for SPA on same origin