### PR TITLE
fix: remove _completion_consumed marking from poll() to prevent watcher suppression

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -318,8 +318,8 @@ class TestCompletionConsumed:
         # Now the completion is marked as consumed
         assert registry.is_completion_consumed("proc_wait")
 
-    def test_poll_marks_completion_consumed(self, registry):
-        """poll() returning exited status marks session as consumed."""
+    def test_poll_does_not_mark_completion_consumed(self, registry):
+        """poll() is a read-only status query and should NOT mark session as consumed."""
         s = _make_session(sid="proc_poll", notify_on_complete=True, output="done")
         s.exited = True
         s.exit_code = 0
@@ -327,7 +327,7 @@ class TestCompletionConsumed:
 
         result = registry.poll("proc_poll")
         assert result["status"] == "exited"
-        assert registry.is_completion_consumed("proc_poll")
+        assert not registry.is_completion_consumed("proc_poll")
 
     def test_log_marks_completion_consumed(self, registry):
         """read_log() on exited session marks as consumed."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -648,7 +648,6 @@ class ProcessRegistry:
         }
         if session.exited:
             result["exit_code"] = session.exit_code
-            self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"


### PR DESCRIPTION
## Summary
Fixes a regression where notify_on_complete notifications were silently suppressed when the agent called process(action='poll') on an exited background process.

## Root Cause
PR #8228 added _completion_consumed tracking to suppress duplicate notifications. However, it incorrectly extended the same semantics to poll() — a read-only status query. When poll() saw an exited process, it marked the session as consumed, causing the gateway's _run_process_watcher to skip the notification entirely (with a permanent break, no retry).

## Fix
Removed _completion_consumed.add(session_id) from poll(). Only wait() and log() mark consumed, since they represent actual consumption of output. Updated the corresponding test to match new behavior.

## Test Plan
- [x] All 21 notify_on_complete tests pass
- [x] All 212 process-related tests pass

Closes NousResearch/hermes-agent#10156