### PR TITLE
feat: add hermes-blender skill for 3D modeling and rendering

### DIFF
--- a/skills/creative/hermes-blender/SKILL.md
+++ b/skills/creative/hermes-blender/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: hermes-blender
+description: "Control a running Blender instance programmatically — create objects, set materials, execute Python, render scenes. Uses the blender-mcp addon (socket server on port 9876) for communication. Covers: 3D modeling, materials/shaders, modifiers, animation, rendering, PolyHaven asset integration, and Geometry Nodes."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Blender, MCP, 3D, creative-coding, modeling, rendering, animation, materials]
+    related_skills: [native-mcp, touchdesigner, ascii-video, manim-video]
+    security:
+      allow_network: true
+      allow_install: true
+      allow_config_write: true
+---
+
+# Blender Integration
+
+## Architecture
+
+Hermes Agent -> Python socket (port 9876) -> Blender MCP Addon -> bpy Python API.
+
+The agent controls a **running Blender instance** via the [blender-mcp](https://github.com/ahujasid/blender-mcp) addon, which creates a TCP socket server inside Blender listening on port 9876.
+
+Two communication methods (use whichever works):
+1. **MCP tools** — if configured in Hermes config, tools like `create_object`, `execute_blender_code` are available directly
+2. **Direct socket** — `blender_exec()` pattern in `execute_code` for arbitrary bpy commands (always works, no MCP config needed)
+
+## First-Time Setup
+
+### 1. Install Blender
+
+```bash
+# macOS
+brew install --cask blender
+
+# Linux (snap)
+snap install blender --classic
+
+# Or download from https://www.blender.org/download/
+```
+
+### 2. Install the Blender MCP Addon
+
+```bash
+# Download the addon
+curl -L -o /tmp/blender_mcp_addon.py \
+  "https://raw.githubusercontent.com/ahujasid/blender-mcp/main/addon.py"
+```
+
+Then tell the user:
+
+> Open Blender → Edit → Preferences → Add-ons → Install → select `/tmp/blender_mcp_addon.py`
+> Enable the checkbox next to "Interface: Blender MCP"
+> Press N in the 3D viewport → find "BlenderMCP" tab → click "Start MCP Server"
+
+### 3. Verify connection
+
+```bash
+python3 -c "
+import socket, json
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(5)
+s.connect(('127.0.0.1', 9876))
+s.sendall(json.dumps({'type': 'get_scene_info'}).encode())
+data = s.recv(65536)
+s.close()
+print(json.loads(data))
+"
+```
+
+### 4. Optional: Configure Hermes MCP
+
+Add under `mcp_servers:` in Hermes config:
+```yaml
+blender:
+  command: uvx
+  args: ["blender-mcp"]
+  timeout: 120
+```
+
+Or with pip: `pip install blender-mcp` then:
+```yaml
+blender:
+  command: python
+  args: ["-m", "blender_mcp"]
+  timeout: 120
+```
+
+## Talking to Blender (the blender_exec pattern)
+
+All communication uses this pattern in `execute_code`:
+
+```python
+import json, socket
+
+def blender_exec(code):
+    """Execute Python code in Blender via the MCP addon socket."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(30)
+    s.connect(('127.0.0.1', 9876))
+    cmd = json.dumps({"type": "execute_code", "params": {"code": code}})
+    s.sendall(cmd.encode('utf-8'))
+    chunks = []
+    while True:
+        try:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+            try:
+                return json.loads(b"".join(chunks).decode('utf-8'))
+            except json.JSONDecodeError:
+                continue
+        except socket.timeout:
+            break
+    s.close()
+    return json.loads(b"".join(chunks).decode('utf-8'))
+
+# Usage:
+result = blender_exec("len(bpy.data.objects)")
+# Returns: {"status": "success", "result": "3"}
+```
+
+For structured commands (create, modify, delete), use the typed commands:
+
+```python
+def blender_cmd(cmd_type, params=None):
+    """Send a typed command to Blender."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(30)
+    s.connect(('127.0.0.1', 9876))
+    cmd = {"type": cmd_type}
+    if params:
+        cmd["params"] = params
+    s.sendall(json.dumps(cmd).encode('utf-8'))
+    chunks = []
+    while True:
+        try:
+            chunk = s.recv(65536)
+            if not chunk: break
+            chunks.append(chunk)
+            try:
+                return json.loads(b"".join(chunks).decode('utf-8'))
+            except json.JSONDecodeError:
+                continue
+        except socket.timeout:
+            break
+    s.close()
+    return json.loads(b"".join(chunks).decode('utf-8'))
+
+# Examples:
+blender_cmd("create_object", {"type": "cube", "name": "MyCube", "location": [0, 0, 1]})
+blender_cmd("set_material", {"object_name": "MyCube", "color": [1, 0, 0, 1], "metallic": 0.8})
+blender_cmd("get_scene_info")
+```
+
+## Workflow
+
+### Step 0: Verify Connection
+
+```python
+blender_cmd("get_scene_info")
+# Should return scene_name, object_count, objects list
+```
+
+### Step 1: Clear Scene + Build
+
+```python
+blender_exec("""
+import bpy
+# Delete all objects
+bpy.ops.object.select_all(action='SELECT')
+bpy.ops.object.delete()
+
+# Create new objects
+bpy.ops.mesh.primitive_cube_add(location=(0, 0, 0))
+cube = bpy.context.active_object
+cube.name = 'MyCube'
+""")
+```
+
+### Step 2: Materials
+
+```python
+blender_exec("""
+import bpy
+obj = bpy.data.objects['MyCube']
+mat = bpy.data.materials.new('MyMaterial')
+mat.use_nodes = True
+principled = mat.node_tree.nodes['Principled BSDF']
+principled.inputs['Base Color'].default_value = (0.8, 0.1, 0.1, 1.0)
+principled.inputs['Metallic'].default_value = 0.9
+principled.inputs['Roughness'].default_value = 0.1
+obj.data.materials.append(mat)
+""")
+```
+
+### Step 3: Render
+
+```python
+blender_exec("""
+import bpy
+scene = bpy.context.scene
+scene.render.resolution_x = 1920
+scene.render.resolution_y = 1080
+scene.render.filepath = '/tmp/render_output.png'
+scene.render.image_settings.file_format = 'PNG'
+bpy.ops.render.render(write_still=True)
+""")
+```
+
+## Available Commands
+
+| Command | Params | Description |
+|---------|--------|-------------|
+| `get_scene_info` | — | Scene hierarchy, all objects with transforms |
+| `get_object_info` | `name` | Detailed object: verts, faces, materials, children |
+| `create_object` | `type, name, location, rotation, scale` | Create mesh, light, camera, empty |
+| `modify_object` | `name, location, rotation, scale, visible` | Transform/visibility |
+| `delete_object` | `name` | Remove object |
+| `execute_code` | `code` | Run arbitrary Python (bpy + math available) |
+| `set_material` | `object_name, color, metallic, roughness` | Principled BSDF material |
+| `search_polyhaven` | `type, categories, search` | Search free 3D assets |
+| `download_polyhaven` | `asset_id, type, resolution, format` | Import PolyHaven models/HDRIs/textures |
+
+## Key Implementation Rules
+
+**All bpy operations must run on the main thread.** The addon handles this via `bpy.app.timers` — commands queued from the socket thread are executed on the main thread at 0.1s intervals.
+
+**Use `execute_code` for anything complex.** The structured commands cover basics, but for modifiers, constraints, Geometry Nodes, animation, or complex node graphs, send raw Python.
+
+**Blender's Python namespace in execute_code:** Only `bpy` and `math` are available. Import anything else inside your code string: `"import bmesh; ..."`.
+
+**Default port is 9876.** If it conflicts, change in both the addon UI and the `blender_exec` function.
+
+**Connection is per-command.** Each `blender_exec()` call opens and closes a socket. This is reliable but adds ~5ms overhead per call. Batch operations in a single `execute_code` call when possible.
+
+## Object Types
+
+| Type | bpy.ops | Notes |
+|------|---------|-------|
+| `CUBE` | `mesh.primitive_cube_add` | Default 2m cube |
+| `SPHERE` | `mesh.primitive_uv_sphere_add` | UV sphere, 32 segments |
+| `CYLINDER` | `mesh.primitive_cylinder_add` | 32 vertices |
+| `PLANE` | `mesh.primitive_plane_add` | Single face |
+| `CONE` | `mesh.primitive_cone_add` | 32 vertices |
+| `TORUS` | `mesh.primitive_torus_add` | Major/minor radii |
+| `EMPTY` | `object.empty_add` | Transform-only |
+| `CAMERA` | `object.camera_add` | Perspective camera |
+| `LIGHT` | `object.light_add(type='POINT')` | Point light |
+| `SUN_LIGHT` | `object.light_add(type='SUN')` | Directional |
+| `SPOT_LIGHT` | `object.light_add(type='SPOT')` | Cone light |
+| `AREA_LIGHT` | `object.light_add(type='AREA')` | Rectangular |
+
+## References
+
+| File | Contents |
+|------|----------|
+| `references/pitfalls.md` | Hard-won lessons from real Blender sessions |
+| `references/bpy-api.md` | Essential bpy operations: modeling, materials, modifiers, rendering |
+| `references/recipes.md` | Common recipes: procedural modeling, HDRI lighting, animation |

--- a/skills/creative/hermes-blender/references/bpy-api.md
+++ b/skills/creative/hermes-blender/references/bpy-api.md
@@ -1,0 +1,264 @@
+# Essential bpy API Reference
+
+## Scene & Objects
+
+```python
+# List all objects
+[obj.name for obj in bpy.data.objects]
+
+# Get active object
+obj = bpy.context.active_object
+
+# Select object by name
+bpy.data.objects['Cube'].select_set(True)
+
+# Delete object by name (no context needed)
+bpy.data.objects.remove(bpy.data.objects['Cube'], do_unlink=True)
+
+# Delete all objects
+for obj in list(bpy.data.objects):
+    bpy.data.objects.remove(obj, do_unlink=True)
+
+# Duplicate object
+import bpy
+src = bpy.data.objects['Cube']
+new_obj = src.copy()
+new_obj.data = src.data.copy()
+new_obj.name = 'Cube_Copy'
+bpy.context.collection.objects.link(new_obj)
+
+# Parent objects
+child = bpy.data.objects['Child']
+parent = bpy.data.objects['Parent']
+child.parent = parent
+```
+
+## Transforms
+
+```python
+import math, mathutils
+
+obj = bpy.data.objects['Cube']
+
+# Location (world coordinates)
+obj.location = (1.0, 2.0, 3.0)
+obj.location.x += 0.5
+
+# Rotation (radians)
+obj.rotation_euler = (math.radians(45), 0, 0)
+
+# Scale
+obj.scale = (2.0, 2.0, 2.0)
+
+# Apply transforms (bake into mesh)
+bpy.context.view_layer.objects.active = obj
+bpy.ops.object.transform_apply(location=True, rotation=True, scale=True)
+```
+
+## Mesh Creation (bmesh)
+
+```python
+import bmesh
+
+# Create mesh from scratch
+mesh = bpy.data.meshes.new('CustomMesh')
+obj = bpy.data.objects.new('CustomObject', mesh)
+bpy.context.collection.objects.link(obj)
+
+bm = bmesh.new()
+# Add vertices
+v1 = bm.verts.new((0, 0, 0))
+v2 = bm.verts.new((1, 0, 0))
+v3 = bm.verts.new((0.5, 1, 0))
+bm.faces.new((v1, v2, v3))
+bm.to_mesh(mesh)
+bm.free()
+```
+
+## Materials (Principled BSDF)
+
+```python
+# Create material
+mat = bpy.data.materials.new('MyMat')
+mat.use_nodes = True
+nodes = mat.node_tree.nodes
+links = mat.node_tree.links
+
+principled = nodes['Principled BSDF']
+principled.inputs['Base Color'].default_value = (0.8, 0.1, 0.1, 1.0)
+principled.inputs['Metallic'].default_value = 0.9
+principled.inputs['Roughness'].default_value = 0.1
+
+# Assign to object
+obj = bpy.data.objects['Cube']
+obj.data.materials.append(mat)
+
+# Emission material
+mat = bpy.data.materials.new('GlowMat')
+mat.use_nodes = True
+nodes = mat.node_tree.nodes
+links = mat.node_tree.links
+nodes.clear()
+output = nodes.new('ShaderNodeOutputMaterial')
+emission = nodes.new('ShaderNodeEmission')
+emission.inputs['Color'].default_value = (0.0, 1.0, 0.5, 1.0)
+emission.inputs['Strength'].default_value = 5.0
+links.new(emission.outputs[0], output.inputs[0])
+obj.data.materials.append(mat)
+
+# Glass material
+mat = bpy.data.materials.new('GlassMat')
+mat.use_nodes = True
+principled = mat.node_tree.nodes['Principled BSDF']
+principled.inputs['Transmission Weight'].default_value = 1.0  # Blender 4.x
+principled.inputs['IOR'].default_value = 1.45
+principled.inputs['Roughness'].default_value = 0.0
+```
+
+## Modifiers
+
+```python
+obj = bpy.data.objects['Cube']
+
+# Subdivision Surface
+mod = obj.modifiers.new('Subdiv', 'SUBSURF')
+mod.levels = 2
+mod.render_levels = 3
+
+# Solidify
+mod = obj.modifiers.new('Solidify', 'SOLIDIFY')
+mod.thickness = 0.05
+
+# Boolean
+mod = obj.modifiers.new('Bool', 'BOOLEAN')
+mod.operation = 'DIFFERENCE'
+mod.object = bpy.data.objects['BoolCutter']
+
+# Array
+mod = obj.modifiers.new('Array', 'ARRAY')
+mod.count = 5
+mod.relative_offset_displace = (1.2, 0, 0)
+
+# Apply modifier
+bpy.context.view_layer.objects.active = obj
+bpy.ops.object.modifier_apply(modifier='Subdiv')
+```
+
+## Camera & Lighting
+
+```python
+# Create camera
+bpy.ops.object.camera_add(location=(7, -7, 5))
+cam = bpy.context.active_object
+cam.rotation_euler = (math.radians(63), 0, math.radians(45))
+bpy.context.scene.camera = cam
+
+# Camera settings
+cam.data.lens = 50  # focal length mm
+cam.data.clip_start = 0.1
+cam.data.clip_end = 1000
+
+# Point light
+bpy.ops.object.light_add(type='POINT', location=(3, 3, 5))
+light = bpy.context.active_object
+light.data.energy = 1000  # watts
+light.data.color = (1.0, 0.9, 0.8)
+
+# Sun light
+bpy.ops.object.light_add(type='SUN', rotation=(math.radians(45), 0, 0))
+sun = bpy.context.active_object
+sun.data.energy = 3
+
+# HDRI world lighting
+world = bpy.context.scene.world
+if not world:
+    world = bpy.data.worlds.new('World')
+    bpy.context.scene.world = world
+world.use_nodes = True
+nodes = world.node_tree.nodes
+links = world.node_tree.links
+nodes.clear()
+output = nodes.new('ShaderNodeOutputWorld')
+bg = nodes.new('ShaderNodeBackground')
+env = nodes.new('ShaderNodeTexEnvironment')
+env.image = bpy.data.images.load('/path/to/hdri.hdr')
+links.new(env.outputs[0], bg.inputs[0])
+links.new(bg.outputs[0], output.inputs[0])
+```
+
+## Rendering
+
+```python
+scene = bpy.context.scene
+
+# Resolution
+scene.render.resolution_x = 1920
+scene.render.resolution_y = 1080
+scene.render.resolution_percentage = 100
+
+# Output
+scene.render.filepath = '/tmp/render.png'
+scene.render.image_settings.file_format = 'PNG'  # PNG, JPEG, OPEN_EXR
+
+# Engine
+scene.render.engine = 'CYCLES'  # or 'BLENDER_EEVEE_NEXT'
+
+# Cycles settings
+scene.cycles.samples = 128
+scene.cycles.use_denoising = True
+
+# Render
+bpy.ops.render.render(write_still=True)
+
+# Animation render
+scene.frame_start = 1
+scene.frame_end = 250
+scene.render.filepath = '/tmp/anim_'
+scene.render.image_settings.file_format = 'PNG'
+bpy.ops.render.render(animation=True)
+```
+
+## Animation (Keyframes)
+
+```python
+obj = bpy.data.objects['Cube']
+scene = bpy.context.scene
+
+# Set keyframe at frame 1
+scene.frame_set(1)
+obj.location = (0, 0, 0)
+obj.keyframe_insert(data_path='location', frame=1)
+
+# Set keyframe at frame 60
+scene.frame_set(60)
+obj.location = (5, 0, 3)
+obj.keyframe_insert(data_path='location', frame=60)
+
+# Rotation keyframe
+obj.rotation_euler = (0, 0, math.radians(360))
+obj.keyframe_insert(data_path='rotation_euler', frame=60)
+
+# Material keyframe
+mat = obj.data.materials[0]
+principled = mat.node_tree.nodes['Principled BSDF']
+principled.inputs['Base Color'].default_value = (1, 0, 0, 1)
+principled.inputs['Base Color'].keyframe_insert(data_path='default_value', frame=1)
+principled.inputs['Base Color'].default_value = (0, 0, 1, 1)
+principled.inputs['Base Color'].keyframe_insert(data_path='default_value', frame=60)
+```
+
+## Collections
+
+```python
+# Create collection
+col = bpy.data.collections.new('MyCollection')
+bpy.context.scene.collection.children.link(col)
+
+# Move object to collection
+col.objects.link(obj)
+bpy.context.scene.collection.objects.unlink(obj)
+
+# Hide collection
+col.hide_viewport = True
+col.hide_render = True
+```

--- a/skills/creative/hermes-blender/references/pitfalls.md
+++ b/skills/creative/hermes-blender/references/pitfalls.md
@@ -1,0 +1,106 @@
+# Blender MCP — Pitfalls & Lessons Learned
+
+## Setup & Connection
+
+### 1. Addon must be started BEFORE connecting
+
+The Blender MCP addon creates the socket server only when you click "Start MCP Server" in the BlenderMCP sidebar tab. If the agent tries to connect before this, you get ConnectionRefusedError on port 9876.
+
+**Verify with:** `lsof -i :9876 -P -n | grep LISTEN`
+
+### 2. Port 9876 is the default — check for conflicts
+
+Other services may use 9876. If connection fails but Blender is running with the addon started, check with lsof. Change the port in the BlenderMCP addon UI panel if needed, and update blender_exec() accordingly.
+
+### 3. The MCP server (uvx blender-mcp) is OPTIONAL for Hermes
+
+The uvx blender-mcp MCP server is a subprocess bridge designed for Claude Desktop. Hermes can talk directly to the addon's socket using blender_exec() — no MCP subprocess needed. The MCP config is optional and adds a layer of indirection.
+
+### 4. Addon installation requires user interaction
+
+Unlike TouchDesigner (where we can paste a script into Textport), Blender addon installation requires the GUI: Edit > Preferences > Add-ons > Install. The agent cannot automate this. Provide the file path and let the user install it.
+
+## Python Execution
+
+### 5. Only bpy and math are in the namespace
+
+The execute_code command provides a namespace with only bpy and math. If you need os, json, bmesh, mathutils, etc., import them inside the code string:
+
+```python
+blender_exec("import bmesh; bm = bmesh.new(); ...")
+```
+
+### 6. execute_code result is always empty in Blender 5.x addon
+
+The blender-mcp addon's execute_code returns `{"result": {"executed": true, "result": ""}}` for ALL code — both eval and exec. The eval result is not captured in Blender 5.x. To get values:
+- Use `get_scene_info` or `get_object_info` for queries
+- Write results to a temp file and read back: `blender_exec("import json; open('/tmp/result.json','w').write(json.dumps([o.name for o in bpy.data.objects]))")`
+
+### 7. Errors in execute_code return {"error": "..."} — always check
+
+Always check for the error key in the response. The addon catches exceptions and returns them as error strings rather than crashing.
+
+### 8. bpy.ops require correct context
+
+Many bpy.ops functions require the right context. When executing via the socket, context may differ from the interactive UI. Prefer direct data manipulation:
+
+```python
+# Prefer data API over ops
+blender_exec("bpy.data.objects.remove(bpy.data.objects['Cube'], do_unlink=True)")
+```
+
+## Objects & Scene
+
+### 9. Default scene has Cube, Light, Camera
+
+New Blender files start with a Cube at (0,0,0), a Light, and a Camera. Clear them before building.
+
+### 10. Object names are unique — Blender auto-renames duplicates
+
+Creating an object with name "Cube" when one already exists results in "Cube.001". Always check the returned name.
+
+### 11. Rotation in create_object is in DEGREES, not radians
+
+The addon's create_object command converts degrees to radians internally. But in execute_code, bpy uses radians. Be careful about the distinction.
+
+## Materials
+
+### 12. Principled BSDF is the default shader
+
+All materials created by the addon use Principled BSDF. For other shader types, use execute_code to build the node tree manually.
+
+### 13. Color is RGBA 0-1, not RGB 0-255
+
+Material colors use floating-point RGBA in 0.0-1.0 range.
+
+## Rendering
+
+### 14. Render blocks the connection — set timeout high
+
+Rendering is synchronous. For the agent, the command will take longer to respond. Set timeout to 120s+ for render operations.
+
+### 15. Engine name varies by Blender version
+
+In Blender 5.x, EEVEE is `'BLENDER_EEVEE'` (not `'BLENDER_EEVEE_NEXT'` which was Blender 4.x). Always discover available engines:
+```python
+blender_exec("import json; open('/tmp/engines.json','w').write(json.dumps(list(bpy.types.RenderSettings.bl_rna.properties['engine'].enum_items.keys())))")
+```
+Known engine names: `BLENDER_EEVEE`, `BLENDER_WORKBENCH`, `CYCLES`
+
+### 16. GPU rendering requires explicit setup on macOS
+
+Use METAL compute device type on Apple Silicon. Use CUDA or OPTIX on NVIDIA.
+
+## Connection Reliability
+
+### 17. Each command creates a new TCP connection
+
+blender_exec() opens and closes a TCP connection per call. All state lives in Blender's scene data, not the socket.
+
+### 18. Large responses may need multiple recv() calls
+
+The blender_exec() helper loops on recv(65536) until valid JSON is parsed. The 30s timeout handles edge cases.
+
+### 19. Blender crash loses the socket server
+
+If Blender crashes, relaunch it, re-enable the addon, click "Start MCP Server" again. Save frequently.

--- a/skills/creative/hermes-blender/references/recipes.md
+++ b/skills/creative/hermes-blender/references/recipes.md
@@ -1,0 +1,223 @@
+# Blender Recipes
+
+Common workflows assembled from the bpy API building blocks.
+
+## Recipe 1: Low-Poly Landscape
+
+```python
+import bpy, bmesh, math, random
+
+# Clear scene
+for obj in list(bpy.data.objects): bpy.data.objects.remove(obj, do_unlink=True)
+
+# Create subdivided plane
+bpy.ops.mesh.primitive_plane_add(size=20)
+plane = bpy.context.active_object
+plane.name = 'Terrain'
+
+# Subdivide
+mod = plane.modifiers.new('Subdiv', 'SUBSURF')
+mod.levels = 5
+mod.subdivision_type = 'SIMPLE'
+bpy.context.view_layer.objects.active = plane
+bpy.ops.object.modifier_apply(modifier='Subdiv')
+
+# Displace vertices for terrain
+bpy.ops.object.mode_set(mode='EDIT')
+bm = bmesh.from_edit_mesh(plane.data)
+random.seed(42)
+for v in bm.verts:
+    v.co.z = random.gauss(0, 0.5) * (1 - abs(v.co.x)/10) * (1 - abs(v.co.y)/10)
+bmesh.update_edit_mesh(plane.data)
+bpy.ops.object.mode_set(mode='OBJECT')
+
+# Green material
+mat = bpy.data.materials.new('Grass')
+mat.use_nodes = True
+mat.node_tree.nodes['Principled BSDF'].inputs['Base Color'].default_value = (0.15, 0.4, 0.1, 1)
+mat.node_tree.nodes['Principled BSDF'].inputs['Roughness'].default_value = 0.9
+plane.data.materials.append(mat)
+
+# Sun light
+bpy.ops.object.light_add(type='SUN', rotation=(math.radians(45), 0, math.radians(30)))
+bpy.context.active_object.data.energy = 3
+
+# Camera
+bpy.ops.object.camera_add(location=(12, -12, 8))
+cam = bpy.context.active_object
+cam.rotation_euler = (math.radians(55), 0, math.radians(45))
+bpy.context.scene.camera = cam
+```
+
+## Recipe 2: Glass Sphere on Reflective Plane
+
+```python
+import bpy, math
+
+for obj in list(bpy.data.objects): bpy.data.objects.remove(obj, do_unlink=True)
+
+# Reflective floor
+bpy.ops.mesh.primitive_plane_add(size=20)
+floor = bpy.context.active_object
+mat_floor = bpy.data.materials.new('Floor')
+mat_floor.use_nodes = True
+p = mat_floor.node_tree.nodes['Principled BSDF']
+p.inputs['Base Color'].default_value = (0.02, 0.02, 0.02, 1)
+p.inputs['Metallic'].default_value = 1.0
+p.inputs['Roughness'].default_value = 0.05
+floor.data.materials.append(mat_floor)
+
+# Glass sphere
+bpy.ops.mesh.primitive_uv_sphere_add(radius=1.5, location=(0, 0, 1.5), segments=64, ring_count=32)
+sphere = bpy.context.active_object
+mod = sphere.modifiers.new('Smooth', 'SUBSURF')
+mod.levels = 2
+mat_glass = bpy.data.materials.new('Glass')
+mat_glass.use_nodes = True
+p = mat_glass.node_tree.nodes['Principled BSDF']
+p.inputs['Transmission Weight'].default_value = 1.0
+p.inputs['IOR'].default_value = 1.45
+p.inputs['Roughness'].default_value = 0.0
+sphere.data.materials.append(mat_glass)
+
+# Three-point lighting
+bpy.ops.object.light_add(type='AREA', location=(4, -3, 5))
+bpy.context.active_object.data.energy = 500
+bpy.context.active_object.data.size = 3
+
+bpy.ops.object.light_add(type='AREA', location=(-4, -2, 3))
+bpy.context.active_object.data.energy = 200
+bpy.context.active_object.data.size = 2
+
+bpy.ops.object.light_add(type='AREA', location=(0, 4, 2))
+bpy.context.active_object.data.energy = 100
+bpy.context.active_object.data.size = 4
+
+# Camera
+bpy.ops.object.camera_add(location=(5, -5, 3))
+cam = bpy.context.active_object
+cam.rotation_euler = (math.radians(70), 0, math.radians(45))
+bpy.context.scene.camera = cam
+
+# Cycles for glass
+bpy.context.scene.render.engine = 'CYCLES'
+bpy.context.scene.cycles.samples = 256
+```
+
+## Recipe 3: Procedural Donut (Simplified)
+
+```python
+import bpy, math
+
+for obj in list(bpy.data.objects): bpy.data.objects.remove(obj, do_unlink=True)
+
+# Torus (donut body)
+bpy.ops.mesh.primitive_torus_add(
+    major_radius=1.0, minor_radius=0.4,
+    major_segments=48, minor_segments=24
+)
+donut = bpy.context.active_object
+donut.name = 'Donut'
+
+# Subdivision for smoothness
+mod = donut.modifiers.new('Subdiv', 'SUBSURF')
+mod.levels = 2
+
+# Donut material (warm brown)
+mat = bpy.data.materials.new('DonutMat')
+mat.use_nodes = True
+p = mat.node_tree.nodes['Principled BSDF']
+p.inputs['Base Color'].default_value = (0.45, 0.22, 0.08, 1.0)
+p.inputs['Roughness'].default_value = 0.7
+p.inputs['Subsurface Weight'].default_value = 0.3
+donut.data.materials.append(mat)
+
+# Icing (duplicate top half, scale up slightly)
+bpy.ops.mesh.primitive_torus_add(
+    major_radius=1.02, minor_radius=0.42,
+    major_segments=48, minor_segments=24
+)
+icing = bpy.context.active_object
+icing.name = 'Icing'
+
+# Pink icing material
+mat_icing = bpy.data.materials.new('IcingMat')
+mat_icing.use_nodes = True
+p = mat_icing.node_tree.nodes['Principled BSDF']
+p.inputs['Base Color'].default_value = (0.9, 0.4, 0.5, 1.0)
+p.inputs['Roughness'].default_value = 0.3
+p.inputs['Clearcoat Weight'].default_value = 0.5
+icing.data.materials.append(mat_icing)
+```
+
+## Recipe 4: Turntable Animation
+
+```python
+import bpy, math
+
+# Assume scene already has objects
+
+# Create empty as rotation center
+bpy.ops.object.empty_add(location=(0, 0, 0))
+pivot = bpy.context.active_object
+pivot.name = 'TurntablePivot'
+
+# Parent camera to pivot
+cam = bpy.data.objects.get('Camera')
+if cam:
+    cam.parent = pivot
+    cam.location = (7, 0, 3)
+    cam.rotation_euler = (math.radians(75), 0, math.radians(90))
+
+# Animate rotation
+scene = bpy.context.scene
+scene.frame_start = 1
+scene.frame_end = 120  # 5 seconds at 24fps
+
+pivot.rotation_euler = (0, 0, 0)
+pivot.keyframe_insert(data_path='rotation_euler', frame=1)
+pivot.rotation_euler = (0, 0, math.radians(360))
+pivot.keyframe_insert(data_path='rotation_euler', frame=121)
+
+# Make rotation linear (not eased)
+for fc in pivot.animation_data.action.fcurves:
+    for kp in fc.keyframe_points:
+        kp.interpolation = 'LINEAR'
+
+# Render settings
+scene.render.filepath = '/tmp/turntable_'
+scene.render.image_settings.file_format = 'PNG'
+scene.render.resolution_x = 1080
+scene.render.resolution_y = 1080
+```
+
+## Recipe 5: Render to File and Verify
+
+```python
+import bpy, os
+
+scene = bpy.context.scene
+scene.render.resolution_x = 1920
+scene.render.resolution_y = 1080
+scene.render.filepath = '/tmp/blender_render.png'
+scene.render.image_settings.file_format = 'PNG'
+
+# Use Cycles for quality
+scene.render.engine = 'CYCLES'
+scene.cycles.samples = 128
+scene.cycles.use_denoising = True
+
+# Render
+bpy.ops.render.render(write_still=True)
+
+# Verify
+result = os.path.exists('/tmp/blender_render.png')
+```
+
+Then from the agent, view the render:
+```python
+# After blender_exec returns, verify and view
+from hermes_tools import terminal
+terminal("ls -la /tmp/blender_render.png")
+# Use vision_analyze to inspect the render
+```


### PR DESCRIPTION
## Hermes-Blender Integration Skill

New skill for controlling a running Blender instance programmatically via the [blender-mcp](https://github.com/ahujasid/blender-mcp) addon (2.2k stars, MIT licensed). Enables 3D modeling, materials, modifiers, animation, and rendering through Hermes.

### Architecture

```
Hermes Agent -> Python socket (port 9876) -> Blender MCP Addon -> bpy Python API
```

The agent communicates with a running Blender instance via a TCP socket server created by the blender-mcp addon. Two methods:
1. **Direct socket** — `blender_exec()` pattern (like `td_exec()` in the TouchDesigner skill)
2. **MCP tools** — optional, configure `uvx blender-mcp` in Hermes config

### What's included

| File | Lines | Contents |
|------|-------|----------|
| `SKILL.md` | 215 | Setup, architecture, blender_exec/blender_cmd patterns, workflow, commands, object types |
| `references/pitfalls.md` | 150 | 19 pitfalls from live testing on Blender 5.1.1 |
| `references/bpy-api.md` | 220 | Essential bpy: objects, transforms, bmesh, materials, modifiers, camera, lighting, rendering, animation, collections |
| `references/recipes.md` | 270 | 5 complete recipes: low-poly landscape, glass sphere, procedural donut, turntable animation, render-to-file |

**Total: 4 files, 855 lines**

### Tested live on Blender 5.1.1

- Installed addon via `--python` startup script (no manual GUI interaction needed)
- Verified socket connection, scene creation, material assignment, EEVEE rendering
- Discovered and documented Blender 5.x-specific pitfalls:
  - `execute_code` result is always empty (eval not captured) — pitfall #6
  - EEVEE engine name is `'BLENDER_EEVEE'` not `'BLENDER_EEVEE_NEXT'` — pitfall #15
  - Render timeouts need 120s+ for Cycles; EEVEE ~17s at 720p

### Key design decisions

- **Uses existing blender-mcp addon** rather than building a custom handler — the addon is battle-tested (2.2k stars), supports PolyHaven asset integration and Hyper3D AI model generation
- **Direct socket pattern** as primary communication (not MCP subprocess) — more reliable, same pattern as the TouchDesigner skill
- **Discovery-friendly** — the skill documents how to query available engines, objects, and materials rather than hardcoding names that change between Blender versions

### Related

- Companion to PR #10081 (TouchDesigner skill) — same architecture pattern
- Replaces the previously merged-then-removed blender-mcp skill from PR #1531