### PR TITLE
fix(security): add body size limit and defusedxml to prevent XML DoS before signature verification in WeCom callback

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -249,7 +249,13 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         msg_signature = request.query.get("msg_signature", "")
         timestamp = request.query.get("timestamp", "")
         nonce = request.query.get("nonce", "")
-        body = await request.text()
+        # Guard against oversized payloads (zip bombs, DoS) before XML parse.
+        _MAX_BODY = 65_536  # 64 KB is ample for any WeCom message
+        body_bytes = await request.read()
+        if len(body_bytes) > _MAX_BODY:
+            logger.warning("[WecomCallback] Payload too large (%d bytes) — rejected", len(body_bytes))
+            return web.Response(status=413, text="payload too large")
+        body = body_bytes.decode("utf-8", errors="replace")
 
         for app in self._apps:
             try:
@@ -294,7 +300,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self, app: Dict[str, Any], body: str,
         msg_signature: str, timestamp: str, nonce: str,
     ) -> str:
-        root = ET.fromstring(body)
+        # Use defusedxml to prevent billion-laughs / malformed XML DoS pre-auth.
+        try:
+            import defusedxml.ElementTree as _safe_ET
+            root = _safe_ET.fromstring(body)
+        except ImportError:
+            root = ET.fromstring(body)
         encrypt = root.findtext("Encrypt", default="")
         crypt = self._crypt_for_app(app)
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")


### PR DESCRIPTION
## What does this PR do?

`gateway/platforms/wecom_callback.py` parsed untrusted XML **before**
verifying the WeCom signature, on an internet-facing endpoint
(`DEFAULT_HOST = "0.0.0.0"`).

### The vulnerability

```python
# Before (vulnerable)
async def _handle_callback(self, request):
    body = await request.text()
    # ...
    decrypted = self._decrypt_request(app, body, ...)  # XML parsed here, auth later
```

Inside `_decrypt_request`:
```python
root = ET.fromstring(body)   # ← untrusted XML parsed BEFORE signature check
encrypt = root.findtext("Encrypt", default="")
crypt.decrypt(msg_signature, ...)  # ← auth happens here, too late
```

Any attacker can POST malformed or malicious XML to `/wecom/callback`
before any credential check runs. Python's `xml.etree.ElementTree`
(expat-based) is not safe against malicious input — billion laughs,
deeply nested trees, and malformed content all happen pre-auth.

### Fix 1 — Body size limit (64 KB)

Added a payload size check before any parsing:

```python
_MAX_BODY = 65_536  # 64 KB is ample for any WeCom message
body_bytes = await request.read()
if len(body_bytes) > _MAX_BODY:
    return web.Response(status=413, text="payload too large")
```

### Fix 2 — defusedxml for safe XML parsing

Replaced `ET.fromstring()` with `defusedxml.ElementTree.fromstring()`
which protects against billion laughs, quadratic blowup, and external
entity expansion:

```python
try:
    import defusedxml.ElementTree as _safe_ET
    root = _safe_ET.fromstring(body)
except ImportError:
    root = ET.fromstring(body)  # fallback if defusedxml not installed
```

## Type of Change

- [x] 🔒 Security fix (XML DoS / pre-auth parse)
- [x] 🔒 Security fix (oversized payload / zip bomb)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] `defusedxml` gracefully falls back to stdlib if not installed
- [x] No behavior change for legitimate WeCom callbacks