### PR TITLE
fix: pass media_files to _send_feishu in send_message_tool

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -421,7 +421,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary

Fix Feishu file sending — `media_files` parameter was not passed to `_send_feishu()`, causing file attachments to be silently dropped.

## The Fix

In `tools/send_message_tool.py:424`, changed:
```python
result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
```
to:
```python
result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
```

The `_send_feishu()` function already correctly handles `media_files` (images, videos, voice, audio, documents) — it just needed to be wired up.

## Impact

- Files sent via `send_message` tool to Feishu now work correctly
- Matches the behavior of other platforms (Telegram, WeChat, etc.)