### PR TITLE
fix: accept schedule string in cron update_job

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -501,6 +501,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if schedule_changed:
             updated_schedule = updated["schedule"]
+            # Accept either a parsed dict or a raw schedule string (e.g. "every 10m")
+            if isinstance(updated_schedule, str):
+                updated_schedule = parse_schedule(updated_schedule)
+                updated["schedule"] = updated_schedule
             updated["schedule_display"] = updates.get(
                 "schedule_display",
                 updated_schedule.get("display", updated.get("schedule_display")),


### PR DESCRIPTION
## Summary

Fix `cron update_job` crash when schedule is passed as a string (e.g. `"every 10m"`) instead of a parsed dict.

## Root Cause

`update_job` assumed `updated["schedule"]` was always a dict, calling `.get("display")` on it. When a string was passed via the API, it raised `AttributeError: 'str' object has no attribute 'get'`.

## The Fix

Added normalization in `cron/jobs.py:504-507`: if schedule is a string, parse it through `parse_schedule()` to produce the expected dict. This mirrors the same normalization that `create_job` does.

## Impact

- API updates with natural language schedules (e.g. `"every 10m"`) now work correctly
- Consistent with the create_job behavior