### PR TITLE
fix: add on_memory_write bridge to sequential tool execution path

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -501,6 +501,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if schedule_changed:
             updated_schedule = updated["schedule"]
+            # Accept either a parsed dict or a raw schedule string (e.g. "every 10m")
+            if isinstance(updated_schedule, str):
+                updated_schedule = parse_schedule(updated_schedule)
+                updated["schedule"] = updated_schedule
             updated["schedule_display"] = updates.get(
                 "schedule_display",
                 updated_schedule.get("display", updated.get("schedule_display")),

--- a/run_agent.py
+++ b/run_agent.py
@@ -7136,6 +7136,16 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
+                # Bridge: notify external memory provider of built-in memory writes
+                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                    try:
+                        self._memory_manager.on_memory_write(
+                            function_args.get("action", ""),
+                            target,
+                            function_args.get("content", ""),
+                        )
+                    except Exception:
+                        pass
             elif function_name == "clarify":
                 from tools.clarify_tool import clarify_tool as _clarify_tool
                 function_result = _clarify_tool(


### PR DESCRIPTION
## Summary

Add the missing `on_memory_write` bridge call to `_execute_tool_calls_sequential`, ensuring external memory providers receive write notifications regardless of which execution path is used.

## Root Cause

The `memory` tool has two execution paths in `run_agent.py`:
1. **Concurrent path** (`_invoke_tool`): calls `on_memory_write` bridge ✅
2. **Sequential path** (`_execute_tool_calls_sequential`): did NOT call `on_memory_write` ❌

Since single tool calls route through the sequential path (the common case for `memory`), external memory providers (ClawMem, retaindb, etc.) never received write notifications in normal usage.

## The Fix

Added the same `on_memory_write` bridge call after the memory tool execution in `_execute_tool_calls_sequential`, mirroring the concurrent path at line 6761-6770.

## Impact

- External memory providers now correctly receive `on_memory_write` notifications
- Fixes cross-process sync issues for providers like ClawMem