### PR TITLE
fix(telegram): resolve private t.me/c links from session history

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7309,7 +7309,7 @@ class GatewayRunner:
         finally:
             notify_path.unlink(missing_ok=True)
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(self, context: SessionContext) -> dict:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -7318,19 +7318,45 @@ class GatewayRunner:
         Returns a list of reset tokens; pass them to ``_clear_session_env``
         in a ``finally`` block.
         """
-        from gateway.session_context import set_session_vars
-        return set_session_vars(
+        from gateway.session_context import get_session_env, set_session_vars
+
+        baseline = {
+            "platform": get_session_env("HERMES_SESSION_PLATFORM"),
+            "chat_id": get_session_env("HERMES_SESSION_CHAT_ID"),
+            "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME"),
+            "thread_id": get_session_env("HERMES_SESSION_THREAD_ID"),
+            "user_id": get_session_env("HERMES_SESSION_USER_ID"),
+            "user_name": get_session_env("HERMES_SESSION_USER_NAME"),
+            "session_key": get_session_env("HERMES_SESSION_KEY"),
+        }
+        tokens = set_session_vars(
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
-            session_key=context.session_key,
+            session_key=context.session_key or "",
         )
+        return {"tokens": tokens, "baseline": baseline}
 
-    def _clear_session_env(self, tokens: list) -> None:
+    def _clear_session_env(self, tokens: Any) -> None:
         """Restore session context variables to their pre-handler values."""
+        from gateway.session_context import set_session_vars
+
+        if isinstance(tokens, dict) and "baseline" in tokens:
+            baseline = tokens.get("baseline") or {}
+            set_session_vars(
+                platform=baseline.get("platform", ""),
+                chat_id=baseline.get("chat_id", ""),
+                chat_name=baseline.get("chat_name", ""),
+                thread_id=baseline.get("thread_id", ""),
+                user_id=baseline.get("user_id", ""),
+                user_name=baseline.get("user_name", ""),
+                session_key=baseline.get("session_key", ""),
+            )
+            return
+
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
     
@@ -8364,6 +8390,7 @@ class GatewayRunner:
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
+        preview_callback_sent = [False]  # Tracks preview text delivered before final response
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_event_loop()
@@ -8531,6 +8558,7 @@ class GatewayRunner:
 
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if _stream_consumer is not None:
+                    preview_callback_sent[0] = True
                     if already_streamed:
                         _stream_consumer.on_segment_break()
                     else:
@@ -8547,6 +8575,7 @@ class GatewayRunner:
                         ),
                         _loop_for_step,
                     )
+                    preview_callback_sent[0] = True
                 except Exception as _e:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
@@ -9464,9 +9493,14 @@ class GatewayRunner:
         if _sc and isinstance(response, dict) and not response.get("failed"):
             _final = response.get("final_response") or ""
             _is_empty_sentinel = not _final or _final == "(empty)"
+            _response_previewed = bool(response.get("response_previewed"))
             if not _is_empty_sentinel and (
                 getattr(_sc, "final_response_sent", False)
                 or getattr(_sc, "already_sent", False)
+                or (
+                    _response_previewed
+                    and preview_callback_sent[0]
+                )
             ):
                 response["already_sent"] = True
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -8805,17 +8806,31 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(
-                    message,
-                    conversation_history=agent_history,
-                    task_id=session_id,
-                    user_message_metadata={
-                        "platform": source.platform.value if source.platform else None,
-                        "chat_id": source.chat_id,
-                        "thread_id": source.thread_id,
-                        "message_id": event.message_id,
-                    },
-                )
+                run_conversation_kwargs = {
+                    "conversation_history": agent_history,
+                    "task_id": session_id,
+                }
+                user_message_metadata = {
+                    "platform": source.platform.value if source.platform else None,
+                    "chat_id": source.chat_id,
+                    "thread_id": source.thread_id,
+                    "message_id": event_message_id,
+                }
+                try:
+                    run_conversation_signature = inspect.signature(agent.run_conversation)
+                    accepts_message_metadata = (
+                        "user_message_metadata" in run_conversation_signature.parameters
+                        or any(
+                            param.kind == inspect.Parameter.VAR_KEYWORD
+                            for param in run_conversation_signature.parameters.values()
+                        )
+                    )
+                except (TypeError, ValueError):
+                    accepts_message_metadata = True
+                if accepts_message_metadata:
+                    run_conversation_kwargs["user_message_metadata"] = user_message_metadata
+
+                result = agent.run_conversation(message, **run_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4075,7 +4075,17 @@ class GatewayRunner:
                 if not new_messages:
                     self.session_store.append_to_transcript(
                         session_entry.session_id,
-                        {"role": "user", "content": message_text, "timestamp": ts}
+                        {
+                            "role": "user",
+                            "content": message_text,
+                            "timestamp": ts,
+                            "message_metadata": {
+                                "platform": source.platform.value if source.platform else None,
+                                "chat_id": source.chat_id,
+                                "thread_id": source.thread_id,
+                                "message_id": event.message_id,
+                            },
+                        }
                     )
                     if response:
                         self.session_store.append_to_transcript(
@@ -8795,7 +8805,17 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(
+                    message,
+                    conversation_history=agent_history,
+                    task_id=session_id,
+                    user_message_metadata={
+                        "platform": source.platform.value if source.platform else None,
+                        "chat_id": source.chat_id,
+                        "thread_id": source.thread_id,
+                        "message_id": event.message_id,
+                    },
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -963,6 +963,7 @@ class SessionStore:
                     tool_name=message.get("tool_name"),
                     tool_calls=message.get("tool_calls"),
                     tool_call_id=message.get("tool_call_id"),
+                    message_metadata=message.get("message_metadata"),
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
@@ -994,6 +995,7 @@ class SessionStore:
                         reasoning=msg.get("reasoning") if role == "assistant" else None,
                         reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                         codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                        message_metadata=msg.get("message_metadata"),
                     )
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -81,7 +81,10 @@ CREATE TABLE IF NOT EXISTS messages (
     finish_reason TEXT,
     reasoning TEXT,
     reasoning_details TEXT,
-    codex_reasoning_items TEXT
+    codex_reasoning_items TEXT,
+    platform_chat_id TEXT,
+    platform_thread_id TEXT,
+    platform_message_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -329,6 +332,30 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: persist per-message platform identifiers so native
+                # platform links (for example Telegram private deep links)
+                # can be resolved from Hermes' local transcript store.
+                for col_name, col_type in [
+                    ("platform_chat_id", "TEXT"),
+                    ("platform_thread_id", "TEXT"),
+                    ("platform_message_id", "TEXT"),
+                ]:
+                    try:
+                        safe = col_name.replace('"', '""')
+                        cursor.execute(
+                            f'ALTER TABLE messages ADD COLUMN "{safe}" {col_type}'
+                        )
+                    except sqlite3.OperationalError:
+                        pass
+                try:
+                    cursor.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_messages_platform_ref "
+                        "ON messages(platform_chat_id, platform_message_id, platform_thread_id)"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -339,6 +366,13 @@ class SessionDB:
             )
         except sqlite3.OperationalError:
             pass  # Index already exists
+        try:
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_messages_platform_ref "
+                "ON messages(platform_chat_id, platform_message_id, platform_thread_id)"
+            )
+        except sqlite3.OperationalError:
+            pass
 
         # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
         try:
@@ -801,6 +835,7 @@ class SessionDB:
         reasoning: str = None,
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
+        message_metadata: Optional[Dict[str, Any]] = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -824,12 +859,21 @@ class SessionDB:
         if tool_calls is not None:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
+        platform_chat_id = None
+        platform_thread_id = None
+        platform_message_id = None
+        if isinstance(message_metadata, dict):
+            platform_chat_id = message_metadata.get("chat_id")
+            platform_thread_id = message_metadata.get("thread_id")
+            platform_message_id = message_metadata.get("message_id")
+
         def _do(conn):
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_details, codex_reasoning_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   reasoning, reasoning_details, codex_reasoning_items,
+                   platform_chat_id, platform_thread_id, platform_message_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -843,6 +887,9 @@ class SessionDB:
                     reasoning,
                     reasoning_details_json,
                     codex_items_json,
+                    platform_chat_id,
+                    platform_thread_id,
+                    platform_message_id,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -929,6 +976,47 @@ class SessionDB:
                         msg["codex_reasoning_items"] = None
             messages.append(msg)
         return messages
+
+    def find_telegram_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        thread_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Find a persisted Telegram message by chat/message identifiers."""
+        params: List[Any] = ["telegram", chat_id, message_id]
+        thread_sql = ""
+        if thread_id is not None:
+            thread_sql = " AND (m.platform_thread_id = ? OR m.platform_thread_id IS NULL)"
+            params.append(thread_id)
+        with self._lock:
+            cursor = self._conn.execute(
+                f"""
+                SELECT
+                    m.id,
+                    m.session_id,
+                    m.role,
+                    m.content,
+                    m.timestamp,
+                    m.platform_chat_id,
+                    m.platform_thread_id,
+                    m.platform_message_id
+                FROM messages m
+                JOIN sessions s ON s.id = m.session_id
+                WHERE s.source = ?
+                  AND m.platform_chat_id = ?
+                  AND m.platform_message_id = ?
+                  {thread_sql}
+                ORDER BY
+                    CASE WHEN m.platform_thread_id = ? THEN 0 ELSE 1 END,
+                    m.timestamp DESC,
+                    m.id DESC
+                LIMIT 1
+                """,
+                params + [thread_id],
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
 
     # =========================================================================
     # Search

--- a/run_agent.py
+++ b/run_agent.py
@@ -2412,6 +2412,7 @@ class AIAgent:
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                    message_metadata=msg.get("message_metadata"),
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
@@ -7941,6 +7942,7 @@ class AIAgent:
         task_id: str = None,
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
+        user_message_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run a complete conversation with tool calling until completion.
@@ -7956,6 +7958,8 @@ class AIAgent:
             persist_user_message: Optional clean user message to store in
                 transcripts/history when user_message contains API-only
                 synthetic prefixes.
+            user_message_metadata: Optional transport metadata persisted
+                alongside the current user message.
                     or queuing follow-up prefetch work.
 
         Returns:
@@ -8072,6 +8076,8 @@ class AIAgent:
 
         # Add user message
         user_msg = {"role": "user", "content": user_message}
+        if user_message_metadata:
+            user_msg["message_metadata"] = dict(user_message_metadata)
         messages.append(user_msg)
         current_turn_user_idx = len(messages) - 1
         self._persist_user_message_idx = current_turn_user_idx

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -170,6 +170,30 @@ class TestMessageStorage:
         assert conv[0] == {"role": "user", "content": "Hello"}
         assert conv[1] == {"role": "assistant", "content": "Hi!"}
 
+    def test_message_metadata_persisted_for_platform_lookup(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        db.append_message(
+            "s1",
+            role="user",
+            content="linked message",
+            message_metadata={
+                "platform": "telegram",
+                "chat_id": "-1003712897238",
+                "thread_id": "712",
+                "message_id": "1031",
+            },
+        )
+
+        messages = db.get_messages("s1")
+        assert messages[0]["platform_chat_id"] == "-1003712897238"
+        assert messages[0]["platform_thread_id"] == "712"
+        assert messages[0]["platform_message_id"] == "1031"
+
+        match = db.find_telegram_message("-1003712897238", "1031", thread_id="712")
+        assert match is not None
+        assert match["content"] == "linked message"
+        assert match["platform_message_id"] == "1031"
+
     def test_finish_reason_stored(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="assistant", content="Done", finish_reason="stop")
@@ -935,7 +959,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -991,12 +1015,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to v7
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tests/tools/test_telegram_link_resolver.py
+++ b/tests/tools/test_telegram_link_resolver.py
@@ -1,0 +1,130 @@
+import json
+import importlib
+import sys
+import types
+import asyncio
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.telegram_link_resolver import (
+    parse_private_telegram_link,
+    resolve_private_telegram_link,
+)
+
+
+def test_parse_private_telegram_link_with_thread():
+    parsed = parse_private_telegram_link("https://t.me/c/3712897238/712/1031")
+
+    assert parsed == {
+        "chat_id": "-1003712897238",
+        "thread_id": "712",
+        "message_id": "1031",
+        "internal_chat_id": "3712897238",
+    }
+
+
+def test_parse_private_telegram_link_without_thread():
+    parsed = parse_private_telegram_link("https://t.me/c/3712897238/1031")
+
+    assert parsed == {
+        "chat_id": "-1003712897238",
+        "thread_id": None,
+        "message_id": "1031",
+        "internal_chat_id": "3712897238",
+    }
+
+
+def test_resolve_private_telegram_link_from_session_db(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id="s1", source="telegram")
+    db.append_message(
+        "s1",
+        role="user",
+        content="historic telegram note",
+        message_metadata={
+            "platform": "telegram",
+            "chat_id": "-1003712897238",
+            "thread_id": "712",
+            "message_id": "1031",
+        },
+    )
+    db.close()
+
+    resolved = resolve_private_telegram_link(
+        "https://t.me/c/3712897238/712/1031",
+        db_path=db_path,
+    )
+
+    assert resolved is not None
+    assert resolved["title"] == "Telegram message 1031"
+    assert resolved["content"] == "historic telegram note"
+    assert resolved["metadata"]["session_id"] == "s1"
+
+
+def test_resolve_private_telegram_link_returns_clear_error_when_unknown(tmp_path):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id="s1", source="telegram")
+    db.close()
+
+    resolved = resolve_private_telegram_link(
+        "https://t.me/c/3712897238/712/1031",
+        db_path=db_path,
+    )
+
+    assert resolved is not None
+    assert resolved["content"] == ""
+    assert "could not resolve" in resolved["error"].lower()
+
+
+def test_web_extract_short_circuits_private_telegram_links(monkeypatch):
+    class _DummyClient:
+        def __init__(self, *args, **kwargs):
+            self.api_key = kwargs.get("api_key")
+            self.base_url = kwargs.get("base_url")
+
+    sys.modules.setdefault(
+        "openai",
+        types.SimpleNamespace(OpenAI=_DummyClient, AsyncOpenAI=_DummyClient),
+    )
+    sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=_DummyClient))
+    web_tools = importlib.import_module("tools.web_tools")
+    web_extract_tool = web_tools.web_extract_tool
+
+    monkeypatch.setattr(
+        "tools.web_tools.resolve_private_telegram_link",
+        lambda url: {
+            "url": url,
+            "title": "Telegram message 1031",
+            "content": "native telegram content",
+        },
+    )
+    monkeypatch.setattr(
+        "tools.web_tools._get_backend",
+        lambda: (_ for _ in ()).throw(AssertionError("backend should not run")),
+    )
+
+    result = json.loads(asyncio.run(
+        web_extract_tool(
+            ["https://t.me/c/3712897238/712/1031"],
+            use_llm_processing=False,
+        )
+    ))
+
+    assert result["results"][0]["title"] == "Telegram message 1031"
+    assert result["results"][0]["content"] == "native telegram content"
+    assert result["results"][0]["error"] is None
+
+
+def test_browser_navigate_rejects_private_telegram_links():
+    sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=object))
+    browser_tool = importlib.import_module("tools.browser_tool")
+    browser_navigate = browser_tool.browser_navigate
+
+    result = json.loads(browser_navigate("https://t.me/c/3712897238/712/1031"))
+
+    assert result["success"] is False
+    assert result["suggested_tool"] == "web_extract"
+    assert "not browser-accessible" in result["error"]

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -77,6 +77,7 @@ try:
     from tools.url_safety import is_safe_url as _is_safe_url
 except Exception:
     _is_safe_url = lambda url: False  # noqa: E731 — fail-closed: block all if safety module unavailable
+from tools.telegram_link_resolver import parse_private_telegram_link
 from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
@@ -1298,6 +1299,21 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
             "error": "Blocked: URL contains what appears to be an API key or token. "
                      "Secrets must not be sent in URLs.",
         })
+
+    private_telegram = parse_private_telegram_link(url)
+    if private_telegram:
+        return json.dumps({
+            "success": False,
+            "error": (
+                "Private Telegram t.me/c links are not browser-accessible. "
+                "Use web_extract so Hermes can resolve them from stored Telegram history."
+            ),
+            "suggested_tool": "web_extract",
+            "platform": "telegram",
+            "chat_id": private_telegram["chat_id"],
+            "thread_id": private_telegram["thread_id"],
+            "message_id": private_telegram["message_id"],
+        }, ensure_ascii=False)
 
     # SSRF protection — block private/internal addresses before navigating.
     # Skipped for local backends (Camofox, headless Chromium without a cloud

--- a/tools/telegram_link_resolver.py
+++ b/tools/telegram_link_resolver.py
@@ -1,0 +1,112 @@
+"""Helpers for resolving private Telegram deep links from Hermes history."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from hermes_state import SessionDB
+
+
+_PRIVATE_TELEGRAM_HOSTS = {
+    "t.me",
+    "www.t.me",
+    "telegram.me",
+    "www.telegram.me",
+}
+
+
+def parse_private_telegram_link(url: str) -> Optional[Dict[str, Optional[str]]]:
+    """Parse ``t.me/c/...`` links into Telegram chat/thread/message identifiers."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+
+    if parsed.scheme not in ("http", "https"):
+        return None
+    if parsed.netloc.lower() not in _PRIVATE_TELEGRAM_HOSTS:
+        return None
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if not parts or parts[0] != "c":
+        return None
+
+    if len(parts) == 3:
+        _, internal_chat_id, message_id = parts
+        thread_id = None
+    elif len(parts) >= 4:
+        _, internal_chat_id, thread_id, message_id = parts[:4]
+    else:
+        return None
+
+    if not internal_chat_id.isdigit() or not message_id.isdigit():
+        return None
+    if thread_id is not None and not thread_id.isdigit():
+        return None
+
+    return {
+        "chat_id": f"-100{internal_chat_id}",
+        "thread_id": thread_id,
+        "message_id": message_id,
+        "internal_chat_id": internal_chat_id,
+    }
+
+
+def resolve_private_telegram_link(
+    url: str,
+    db_path=None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve a private Telegram deep link from Hermes' local transcript store."""
+    link = parse_private_telegram_link(url)
+    if not link:
+        return None
+
+    db = SessionDB(db_path=db_path)
+    try:
+        message = db.find_telegram_message(
+            chat_id=link["chat_id"],
+            message_id=link["message_id"],
+            thread_id=link["thread_id"],
+        )
+    finally:
+        db.close()
+
+    if not message:
+        thread_text = (
+            f" topic {link['thread_id']}" if link["thread_id"] is not None else ""
+        )
+        return {
+            "url": url,
+            "title": "Telegram private message",
+            "content": "",
+            "error": (
+                "Private Telegram links are not directly web-accessible. "
+                f"Hermes could not resolve chat {link['chat_id']}{thread_text} "
+                f"message {link['message_id']} from its stored Telegram history."
+            ),
+            "metadata": {
+                "platform": "telegram",
+                **link,
+            },
+        }
+
+    body = (message.get("content") or "").strip()
+    if not body:
+        body = (
+            "[Hermes observed this Telegram message, but no text content was stored. "
+            "It may have been media-only or reduced during ingestion.]"
+        )
+
+    return {
+        "url": url,
+        "title": f"Telegram message {link['message_id']}",
+        "content": body,
+        "metadata": {
+            "platform": "telegram",
+            "session_id": message.get("session_id"),
+            "role": message.get("role"),
+            "timestamp": message.get("timestamp"),
+            **link,
+        },
+    }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -60,6 +60,7 @@ from tools.managed_tool_gateway import (
     resolve_managed_tool_gateway,
 )
 from tools.tool_backend_helpers import managed_nous_tools_enabled
+from tools.telegram_link_resolver import resolve_private_telegram_link
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
 
@@ -1222,35 +1223,46 @@ async def web_extract_tool(
     try:
         logger.info("Extracting content from %d URL(s)", len(urls))
 
-        # ── SSRF protection — filter out private/internal URLs before any backend ──
-        safe_urls = []
-        ssrf_blocked: List[Dict[str, Any]] = []
+        # Resolve platform-native deep links before falling back to generic web
+        # extraction. Private Telegram links are not browser/web readable.
+        ordered_inputs: List[Any] = []
+        safe_urls: List[str] = []
         for url in urls:
+            native_result = resolve_private_telegram_link(url)
+            if native_result is not None:
+                ordered_inputs.append(("resolved", native_result))
+                continue
             if not is_safe_url(url):
-                ssrf_blocked.append({
-                    "url": url, "title": "", "content": "",
-                    "error": "Blocked: URL targets a private or internal network address",
-                })
-            else:
-                safe_urls.append(url)
+                ordered_inputs.append((
+                    "resolved",
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "error": "Blocked: URL targets a private or internal network address",
+                    },
+                ))
+                continue
+            ordered_inputs.append(("fetch", url))
+            safe_urls.append(url)
 
-        # Dispatch only safe URLs to the configured backend
+        backend_results: List[Dict[str, Any]] = []
         if not safe_urls:
             results = []
         else:
             backend = _get_backend()
 
             if backend == "parallel":
-                results = await _parallel_extract(safe_urls)
+                backend_results = await _parallel_extract(safe_urls)
             elif backend == "exa":
-                results = _exa_extract(safe_urls)
+                backend_results = _exa_extract(safe_urls)
             elif backend == "tavily":
                 logger.info("Tavily extract: %d URL(s)", len(safe_urls))
                 raw = _tavily_request("extract", {
                     "urls": safe_urls,
                     "include_images": False,
                 })
-                results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+                backend_results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1265,7 +1277,7 @@ async def web_extract_tool(
 
                 # Always use individual scraping for simplicity and reliability
                 # Batch scraping adds complexity without much benefit for small numbers of URLs
-                results: List[Dict[str, Any]] = []
+                backend_results = []
 
                 from tools.interrupt import is_interrupted as _is_interrupted
                 for url in safe_urls:
@@ -1277,7 +1289,7 @@ async def web_extract_tool(
                     blocked = check_website_access(url)
                     if blocked:
                         logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
-                        results.append({
+                        backend_results.append({
                             "url": url, "title": "", "content": "",
                             "error": blocked["message"],
                             "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
@@ -1328,7 +1340,7 @@ async def web_extract_tool(
                         final_blocked = check_website_access(final_url)
                         if final_blocked:
                             logger.info("Blocked redirected web_extract for %s by rule %s", final_blocked["host"], final_blocked["rule"])
-                            results.append({
+                            backend_results.append({
                                 "url": final_url, "title": title, "content": "", "raw_content": "",
                                 "error": final_blocked["message"],
                                 "blocked_by_policy": {"host": final_blocked["host"], "rule": final_blocked["rule"], "source": final_blocked["source"]},
@@ -1338,7 +1350,7 @@ async def web_extract_tool(
                         # Choose content based on requested format
                         chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
 
-                        results.append({
+                        backend_results.append({
                             "url": final_url,
                             "title": title,
                             "content": chosen_content,
@@ -1348,7 +1360,7 @@ async def web_extract_tool(
 
                     except Exception as scrape_err:
                         logger.debug("Scrape failed for %s: %s", url, scrape_err)
-                        results.append({
+                        backend_results.append({
                             "url": url,
                             "title": "",
                             "content": "",
@@ -1356,9 +1368,13 @@ async def web_extract_tool(
                             "error": str(scrape_err)
                         })
 
-        # Merge any SSRF-blocked results back in
-        if ssrf_blocked:
-            results = ssrf_blocked + results
+        backend_iter = iter(backend_results)
+        results = []
+        for kind, value in ordered_inputs:
+            if kind == "resolved":
+                results.append(value)
+            else:
+                results.append(next(backend_iter))
 
         response = {"results": results}
         


### PR DESCRIPTION
Closes #10020

## Summary
- persist Telegram chat/thread/message identifiers for inbound gateway messages
- resolve private `t.me/c/...` links from Hermes local Telegram session history
- short-circuit generic browser/web fetch paths for those links with Telegram-specific handling
- harden gateway preview/session handling so rebased gateway tests stay compatible

## Testing
- `pytest -q tests/test_hermes_state.py -q`
- `pytest -q tests/tools/test_telegram_link_resolver.py -q`
- `python -m py_compile hermes_state.py run_agent.py gateway/run.py gateway/session.py tools/telegram_link_resolver.py tools/web_tools.py tools/browser_tool.py`
- `source .venv/bin/activate && python -m pytest -q tests/gateway/test_fast_command.py::test_run_agent_passes_priority_processing_to_gateway_agent tests/gateway/test_run_progress_topics.py::test_run_agent_surfaces_interim_commentary_by_default tests/gateway/test_run_progress_topics.py::test_run_agent_surfaces_real_interim_commentary tests/gateway/test_run_progress_topics.py::test_run_agent_previewed_final_marks_already_sent tests/gateway/test_run_progress_topics.py::test_run_agent_matrix_streaming_omits_cursor tests/gateway/test_reasoning_command.py::TestReasoningCommand::test_run_agent_reloads_reasoning_config_per_message tests/cron/test_codex_execution_paths.py::test_gateway_run_agent_codex_path_handles_internal_401_refresh tests/run_agent/test_anthropic_error_handling.py::test_429_rate_limit_is_retried_and_recovers tests/gateway/test_session_env.py -n 2`