### PR TITLE
fix(hermes-cli): prevent printing subcommand's help document twice

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6060,6 +6060,7 @@ Examples:
     import io as _io
     _known_cmds = set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
     _has_cmd_token = any(t in _known_cmds for t in _processed_argv if not t.startswith("-"))
+    _is_help = any(t in ("-h", "--help") for t in _processed_argv)
 
     if _has_cmd_token:
         subparsers.required = True
@@ -6068,11 +6069,13 @@ Examples:
             sys.stderr = _io.StringIO()
             args = parser.parse_args(_processed_argv)
             sys.stderr = _saved_stderr
-        except SystemExit:
+        except SystemExit as e:
             sys.stderr = _saved_stderr
             # Subcommand name was consumed as a flag value (e.g. -c model).
             # Fall back to optional subparsers so argparse handles it normally.
             subparsers.required = False
+            if e.code == 0 and _is_help:
+                sys.exit(0)
             args = parser.parse_args(_processed_argv)
     else:
         subparsers.required = False

--- a/tests/hermes_cli/test_subparser_routing_fallback.py
+++ b/tests/hermes_cli/test_subparser_routing_fallback.py
@@ -47,6 +47,7 @@ def _safe_parse(parser, subparsers, argv):
     """Replica of the defensive parsing logic from main()."""
     known_cmds = set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
     has_cmd_token = any(t in known_cmds for t in argv if not t.startswith("-"))
+    _is_help = any(t in ("-h", "--help") for t in argv)
 
     if has_cmd_token:
         subparsers.required = True
@@ -56,9 +57,11 @@ def _safe_parse(parser, subparsers, argv):
             args = parser.parse_args(argv)
             sys.stderr = saved_stderr
             return args
-        except SystemExit:
+        except SystemExit as e:
             sys.stderr = saved_stderr
             subparsers.required = False
+            if e.code == 0 and _is_help:
+                return None  # Help was printed successfully, no error
             return parser.parse_args(argv)
     else:
         subparsers.required = False
@@ -146,3 +149,20 @@ class TestSubparserRoutingFallback:
         assert args.yolo is True
         assert args.worktree is True
         assert args.skills == ["myskill"]
+
+    def test_subcommand_help_printed_once(self, capsys):
+        parser, sub = _build_parser()
+        args = _safe_parse(parser, sub, ["chat", "-h"])
+        captured = capsys.readouterr()
+        assert args is None
+        assert captured.out.count("usage: hermes chat") == 1
+        assert captured.err == ""
+
+    def test_top_level_help_printed_once(self, capsys):
+        parser, sub = _build_parser()
+        with pytest.raises(SystemExit) as exc:
+            _safe_parse(parser, sub, ["-h"])
+        captured = capsys.readouterr()
+        assert exc.value.code == 0
+        assert captured.out.count("usage: hermes") == 1
+        assert captured.err == ""


### PR DESCRIPTION
## What does this PR do?

closes #10230

Fix subcommand's help document print twice when we do `hermes dashboard -h` 

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No related issue.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Declarations a variable `_is_help` to indicate whether the user proactively prints the subcommand's help document
- When `SystemExit` was caught, check the error code equals 0
- Exit ealier when `_is_help` and the error code equals 0

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

It is pretty simple to reproduce:

```
hermes dashboard -h
```

Output belike:

```
usage: hermes dashboard [-h] [--port PORT] [--host HOST] [--no-open] [--insecure]

Launch the Hermes Agent web dashboard for managing config, API keys, and sessions

options:
  -h, --help   show this help message and exit
  --port PORT  Port (default 9119)
  --host HOST  Host (default 127.0.0.1)
  --no-open    Don't open browser automatically
  --insecure   Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)
usage: hermes dashboard [-h] [--port PORT] [--host HOST] [--no-open] [--insecure]

Launch the Hermes Agent web dashboard for managing config, API keys, and sessions

options:
  -h, --help   show this help message and exit
  --port PORT  Port (default 9119)
  --host HOST  Host (default 127.0.0.1)
  --no-open    Don't open browser automatically
  --insecure   Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)
```

Same behavior with other subcommands.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

## Screenshots / Logs

Before:
<img width="742" height="423" alt="Clipboard_Screenshot_1776243357" src="https://github.com/user-attachments/assets/29bf9ede-4bc6-4267-8029-db1752e30f5a" />

After:
<img width="740" height="232" alt="Clipboard_Screenshot_1776243325" src="https://github.com/user-attachments/assets/0accf11e-1716-4652-993f-b46a5794e548" />

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

