### PR TITLE
fix(gateway): PlatformConfig.from_dict now maps top-level platform keys into extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -176,7 +176,16 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+
+        # Known top-level fields — everything else falls into extra so that
+        # users can write e.g. `platforms.webhook.port: 9000` directly in
+        # config.yaml without having to nest it under `extra:`.
+        _KNOWN_KEYS = {"enabled", "token", "api_key", "home_channel", "reply_to_mode", "extra"}
+        extra = dict(data.get("extra", {}))
+        for key, value in data.items():
+            if key not in _KNOWN_KEYS:
+                extra.setdefault(key, value)
+
         return cls(
             enabled=data.get("enabled", False),
             token=data.get("token"),


### PR DESCRIPTION
Add handling for extra fields in from_dict method to solve platforms.webhook.port doesn't work problem

## What does this PR do?

Fix a silent config drop bug where top-level keys written under a platform
block in `config.yaml` (e.g. `platforms.webhook.port`) were silently ignored
instead of being forwarded to the adapter.

## Problem

`PlatformConfig.from_dict()` only recognised a fixed set of known fields
(`enabled`, `token`, `api_key`, `home_channel`, `reply_to_mode`, `extra`).
Any other key — such as `port`, `host`, `secret`, or `routes` — was silently
dropped when the YAML block was parsed.

Platform adapters (e.g. `WebhookAdapter`) read their settings exclusively from
`config.extra`:

```python
# gateway/platforms/webhook.py
self._port = int(config.extra.get("port", DEFAULT_PORT))
```

So a user writing the natural top-level form:

```yaml
# config.yaml
platforms:
  webhook:
    enabled: true
    port: 9000        # ← silently dropped, DEFAULT_PORT (8644) used instead
```

…would never see the port change take effect. The only working form was the
nested `extra:` block, which is not obvious from the documentation or the
error log (no warning is emitted):

```yaml
platforms:
  webhook:
    enabled: true
    extra:
      port: 9000      # ← works, but not user-friendly
```

The same silent drop affected every other platform adapter that reads
settings from `config.extra` (e.g. `api_server.host`, `api_server.key`,
webhook `secret`, `routes`, etc.).


## Related Issue

https://github.com/NousResearch/hermes-agent/issues/10206

Fixes #

## Type of Change

- [ ✅] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

In `PlatformConfig.from_dict()` (`gateway/config.py`), after extracting the
known fields, iterate over the remaining keys and merge them into `extra` via
`setdefault` (so an explicit `extra:` sub-dict always takes precedence):

```python
_KNOWN_KEYS = {"enabled", "token", "api_key", "home_channel", "reply_to_mode", "extra"}
extra = dict(data.get("extra", {}))
for key, value in data.items():
    if key not in _KNOWN_KEYS:
        extra.setdefault(key, value)
```

This means both config styles now work identically:

```yaml
# Style 1 — top-level (now works)
platforms:
  webhook:
    enabled: true
    port: 9000

# Style 2 — nested extra (always worked, still takes precedence)
platforms:
  webhook:
    enabled: true
    extra:
      port: 9000
```

- 

## How to Test

```bash
# Start gateway with top-level port in config.yaml:
#   platforms:
#     webhook:
#       enabled: true
#       port: 9100
# Verify the server binds on 9100 instead of the default 8644.
python -m pytest tests/gateway/ -q
```
