### PR TITLE
fix: handle bytes in skills bundle content hash

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -695,6 +695,27 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_accepts_bytes(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "assets/icon.png": b"\x89PNG\r\n\x1a\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "assets").mkdir()
+        (skill_dir / "assets" / "icon.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Summary
- fix `bundle_content_hash()` to handle both `bytes` and `str` file contents
- prevent `hermes skills check` from crashing when a skill bundle contains binary assets
- add a regression test covering mixed text + binary bundle contents

## Verification
- `python -m pytest tests/tools/test_skills_hub.py -q -o 'addopts='` ✅
- `hermes skills check` ✅
- `python -m pytest tests/tools/ -q -o 'addopts='` shows 5 existing unrelated failures
- confirmed the same 5 failures also reproduce on `origin/main`

## Existing unrelated test failures on base branch
- `tests/tools/test_file_staleness.py::TestStalenessCheck::test_warning_when_file_modified_externally`
- `tests/tools/test_file_staleness.py::TestPatchStaleness::test_patch_warns_on_stale_file`
- `tests/tools/test_send_message_missing_platforms.py::TestSendMatrix::test_success`
- `tests/tools/test_transcription.py::TestGetProvider::test_explicit_local_no_cloud_fallback`
- `tests/tools/test_transcription.py::TestGetProvider::test_local_nothing_available`

## Root cause
`bundle_content_hash()` assumed every bundle entry was text and called `.encode("utf-8")` unconditionally. When a skill bundle included binary content already represented as `bytes`, `hermes skills check` crashed with:

```python
AttributeError: 'bytes' object has no attribute 'encode'
```
