### PR TITLE
fix(gateway): pass unknown platform config keys to extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -176,14 +176,18 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+
+        _KNOWN_KEYS = {"enabled", "token", "api_key", "home_channel", "reply_to_mode", "extra"}
+        unknown = {k: v for k, v in data.items() if k not in _KNOWN_KEYS}
+        extra = {**unknown, **data.get("extra", {})}
+
         return cls(
             enabled=data.get("enabled", False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -53,6 +53,53 @@ class TestPlatformConfigRoundtrip:
         assert restored.token is None
 
 
+class TestPlatformConfigUnknownKeysPassthrough:
+    """Unknown top-level keys in a platform block should be forwarded to extra."""
+
+    def test_unknown_keys_land_in_extra(self):
+        pc = PlatformConfig.from_dict({"enabled": True, "port": 9100, "host": "0.0.0.0"})
+        assert pc.enabled is True
+        assert pc.extra["port"] == 9100
+        assert pc.extra["host"] == "0.0.0.0"
+
+    def test_explicit_extra_takes_priority_over_top_level(self):
+        pc = PlatformConfig.from_dict({
+            "enabled": True,
+            "port": 9100,
+            "extra": {"port": 8080, "secret": "s3cret"},
+        })
+        assert pc.extra["port"] == 8080  # explicit extra wins
+        assert pc.extra["secret"] == "s3cret"
+
+    def test_unknown_keys_merged_with_explicit_extra(self):
+        pc = PlatformConfig.from_dict({
+            "enabled": True,
+            "host": "0.0.0.0",
+            "extra": {"secret": "s3cret"},
+        })
+        assert pc.extra == {"host": "0.0.0.0", "secret": "s3cret"}
+
+    def test_no_unknown_keys_still_works(self):
+        pc = PlatformConfig.from_dict({"enabled": True, "token": "tok"})
+        assert pc.extra == {}
+
+    def test_known_keys_not_duplicated_in_extra(self):
+        pc = PlatformConfig.from_dict({
+            "enabled": True,
+            "token": "tok",
+            "api_key": "ak",
+            "reply_to_mode": "all",
+        })
+        for key in ("enabled", "token", "api_key", "reply_to_mode"):
+            assert key not in pc.extra
+
+    def test_roundtrip_preserves_unknown_keys_via_extra(self):
+        """to_dict() puts unknown keys inside extra, so from_dict(to_dict()) keeps them."""
+        original = PlatformConfig.from_dict({"enabled": True, "port": 9100})
+        restored = PlatformConfig.from_dict(original.to_dict())
+        assert restored.extra["port"] == 9100
+
+
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
         config = GatewayConfig(


### PR DESCRIPTION
## Fixes #10206

**Problem:** `PlatformConfig.from_dict()` only recognized a fixed set of known fields (`enabled`, `token`, `api_key`, `home_channel`, `reply_to_mode`, `extra`). Any other key — like `port`, `host`, `secret`, `routes` — was silently discarded. This meant intuitive config like:

```yaml
platforms:
  webhook:
    enabled: true
    port: 9100
```

...would be silently ignored, forcing users to use the non-obvious nested form:

```yaml
platforms:
  webhook:
    enabled: true
    extra:
      port: 9100
```

**Fix:** Collect unrecognized top-level keys and merge them into `extra`, with explicit `extra` entries taking priority over top-level unknowns when both exist.

**Changes:**
- `gateway/config.py`: Added unknown-key collection and merge logic in `PlatformConfig.from_dict()`
- `tests/gateway/test_config.py`: Added 6 test cases covering unknown key passthrough, priority, merge, no-op, known-key exclusion, and roundtrip

**Testing:**
- All 23 tests in `test_config.py` pass
- Verified manually that `port: 9100` at top level correctly reaches `config.extra['port']`