### PR TITLE
feat: make Hermes memory config more retentive

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -488,7 +488,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 30,
+            "timeout": 45,
         },
     },
     
@@ -586,8 +586,10 @@ DEFAULT_CONFIG = {
     "memory": {
         "memory_enabled": True,
         "user_profile_enabled": True,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 20000,  # ~7.3k tokens at 2.75 chars/token
+        "user_char_limit": 10000,    # ~3.6k tokens at 2.75 chars/token
+        "nudge_interval": 4,
+        "flush_min_turns": 2,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -26,8 +26,8 @@ except Exception:  # pragma: no cover - handled at runtime
 
 
 ENTRY_DELIMITER = "\n§\n"
-DEFAULT_MEMORY_CHAR_LIMIT = 2200
-DEFAULT_USER_CHAR_LIMIT = 1375
+DEFAULT_MEMORY_CHAR_LIMIT = 20000
+DEFAULT_USER_CHAR_LIMIT = 10000
 SKILL_CATEGORY_DIRNAME = "openclaw-imports"
 SKILL_CATEGORY_DESCRIPTION = (
     "Skills migrated from an OpenClaw workspace."


### PR DESCRIPTION
## Summary
- raise default built-in memory capacity to 20000 / 10000 chars
- add default memory review cadence settings (, )
- increase  to 45s
- keep OpenClaw migration defaults aligned with the new memory limits

## Verification
- verified both local profile configs now use the same settings
- ran 
