### PR TITLE
Fix cron reminder delivery by setting all session env vars in run_sync()

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8314,7 +8314,16 @@ class GatewayRunner:
 
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
+            # Since run_sync() runs in a separate thread via run_in_executor(),
+            # contextvars are NOT automatically propagated, so we must set ALL
+            # session env vars explicitly in os.environ.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
+            os.environ["HERMES_SESSION_PLATFORM"] = (source.platform.value if hasattr(source.platform, "value") else str(source.platform)) or ""
+            os.environ["HERMES_SESSION_CHAT_ID"] = source.chat_id or ""
+            os.environ["HERMES_SESSION_CHAT_NAME"] = source.chat_name or ""
+            os.environ["HERMES_SESSION_THREAD_ID"] = str(source.thread_id) if source.thread_id else ""
+            os.environ["HERMES_SESSION_USER_ID"] = str(source.user_id) if source.user_id else ""
+            os.environ["HERMES_SESSION_USER_NAME"] = str(source.user_name) if source.user_name else ""
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))


### PR DESCRIPTION
## Problem

Cron reminder delivery fails when created via messaging platforms (WeChat, Telegram, Discord, etc.) because the session context gets lost.

The issue is that `_handle_message_with_agent` in gateway sets session context via contextvars, but `run_sync()` runs in a separate thread via `loop.run_in_executor()`, and Python's `contextvars.ContextVar` does not automatically propagate to threads created by `run_in_executor()`.

When the cronjob tool calls `get_session_env()`, it can only fall back to `os.environ`, but only `HERMES_SESSION_KEY` was set there—all other session variables were missing, causing the `origin` field to be null and delivery to fail.

## Fix

This PR sets **all** session-related environment variables in `run_sync()`, not just `HERMES_SESSION_KEY`:
- `HERMES_SESSION_PLATFORM`
- `HERMES_SESSION_CHAT_ID`
- `HERMES_SESSION_CHAT_NAME`
- `HERMES_SESSION_THREAD_ID`
- `HERMES_SESSION_USER_ID`
- `HERMES_SESSION_USER_NAME`

This ensures `get_session_env()` can read the correct values from `os.environ` even when contextvars aren't available in the executor thread.

## Impact

- Fixes cron reminder delivery for all platforms
- No breaking changes
- Simple, targeted fix
