### PR TITLE
feat(skills): add lightweight versioning and changelog discipline

### DIFF
--- a/tests/tools/test_skill_improvements.py
+++ b/tests/tools/test_skill_improvements.py
@@ -19,6 +19,7 @@ SKILL_CONTENT = """\
 ---
 name: test-skill
 description: A test skill for unit testing.
+version: 1.0.0
 ---
 
 # Test Skill
@@ -56,6 +57,7 @@ class TestFuzzyPatchSkill:
 ---
 name: ws-skill
 description: Whitespace test
+version: 1.0.0
 ---
 
 # Commands
@@ -76,6 +78,7 @@ description: Whitespace test
 ---
 name: indent-skill
 description: Indentation test
+version: 1.0.0
 ---
 
 # Steps
@@ -101,6 +104,7 @@ description: Indentation test
 ---
 name: dup-skill
 description: Duplicate test
+version: 1.0.0
 ---
 
 # Steps
@@ -117,6 +121,7 @@ word word word
 ---
 name: dup-skill
 description: Duplicate test
+version: 1.0.0
 ---
 
 # Steps

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -40,6 +40,7 @@ VALID_SKILL_CONTENT = """\
 ---
 name: test-skill
 description: A test skill for unit testing.
+version: 1.0.0
 ---
 
 # Test Skill
@@ -51,6 +52,9 @@ VALID_SKILL_CONTENT_2 = """\
 ---
 name: test-skill
 description: Updated description.
+version: 1.0.1
+changelog:
+  - Clarified the main step ordering.
 ---
 
 # Test Skill v2
@@ -120,6 +124,14 @@ class TestValidateFrontmatter:
     def test_valid_content(self):
         assert _validate_frontmatter(VALID_SKILL_CONTENT) is None
 
+    def test_missing_version_field(self):
+        content = "---\nname: test\ndescription: desc\n---\n\nBody.\n"
+        assert _validate_frontmatter(content) == "Frontmatter must include 'version' field."
+
+    def test_invalid_version_format(self):
+        content = "---\nname: test\ndescription: desc\nversion: v1\n---\n\nBody.\n"
+        assert _validate_frontmatter(content) == "Frontmatter 'version' must look like semantic versioning (e.g. 1.0.0)."
+
     def test_empty_content(self):
         assert _validate_frontmatter("") == "Content cannot be empty."
         assert _validate_frontmatter("   ") == "Content cannot be empty."
@@ -141,7 +153,7 @@ class TestValidateFrontmatter:
         assert _validate_frontmatter(content) == "Frontmatter must include 'description' field."
 
     def test_no_body_after_frontmatter(self):
-        content = "---\nname: test\ndescription: desc\n---\n"
+        content = "---\nname: test\ndescription: desc\nversion: 1.0.0\n---\n"
         assert _validate_frontmatter(content) == "SKILL.md must have content after the frontmatter (instructions, procedures, etc.)."
 
     def test_invalid_yaml(self):
@@ -270,6 +282,14 @@ class TestEditSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "A test skill" in content
 
+    def test_edit_version_bump_requires_new_changelog_note(self, tmp_path):
+        updated = VALID_SKILL_CONTENT.replace("version: 1.0.0", "version: 1.0.1")
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _edit_skill("my-skill", updated)
+        assert result["success"] is False
+        assert "changelog" in result["error"].lower()
+
 
 class TestPatchSkill:
     def test_patch_unique_match(self, tmp_path):
@@ -292,6 +312,7 @@ class TestPatchSkill:
 ---
 name: test-skill
 description: A test skill.
+version: 1.0.0
 ---
 
 # Test
@@ -309,6 +330,7 @@ word word
 ---
 name: test-skill
 description: A test skill.
+version: 1.0.0
 ---
 
 # Test
@@ -326,6 +348,13 @@ word word
             _write_file("my-skill", "references/api.md", "old text here")
             result = _patch_skill("my-skill", "old text", "new text", file_path="references/api.md")
         assert result["success"] is True
+
+    def test_patch_version_bump_requires_new_changelog_note(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "version: 1.0.0", "version: 1.0.1")
+        assert result["success"] is False
+        assert "changelog" in result["error"].lower()
 
     def test_patch_skill_not_found(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tests/tools/test_skill_size_limits.py
+++ b/tests/tools/test_skill_size_limits.py
@@ -37,6 +37,7 @@ def _make_skill_content(body_chars: int) -> str:
         "---\n"
         "name: test-skill\n"
         "description: A test skill\n"
+        "version: 1.0.0\n"
         "---\n"
     )
     body = "# Test Skill\n\n" + ("x" * max(0, body_chars - 15))
@@ -79,7 +80,7 @@ class TestCreateSkillSizeLimit:
 
     def test_create_at_limit(self, isolate_skills):
         # Content at exactly the limit should succeed
-        frontmatter = "---\nname: edge-skill\ndescription: Edge case\n---\n# Edge\n\n"
+        frontmatter = "---\nname: edge-skill\ndescription: Edge case\nversion: 1.0.0\n---\n# Edge\n\n"
         body_budget = MAX_SKILL_CONTENT_CHARS - len(frontmatter)
         content = frontmatter + ("x" * body_budget)
         assert len(content) == MAX_SKILL_CONTENT_CHARS
@@ -109,8 +110,10 @@ class TestPatchSkillSizeLimit:
 
     def test_patch_that_would_exceed_limit(self, isolate_skills):
         # Create a skill near the limit
-        near_limit = _make_skill_content(MAX_SKILL_CONTENT_CHARS - 50)
-        json.loads(skill_manage(action="create", name="near-limit", content=near_limit))
+        near_limit = _make_skill_content(MAX_SKILL_CONTENT_CHARS - 250)
+        near_limit = near_limit.replace("name: test-skill", "name: near-limit")
+        create_result = json.loads(skill_manage(action="create", name="near-limit", content=near_limit))
+        assert create_result["success"] is True
 
         # Patch that adds enough to go over
         result = json.loads(skill_manage(

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -34,6 +34,7 @@ def _make_skill(
 ---
 name: {name}
 description: Description for {name}.
+version: 1.0.0
 {frontmatter_extra}---
 
 # {name}
@@ -278,6 +279,18 @@ class TestSkillsList:
             raw = skills_list()
         result = json.loads(raw)
         assert result["count"] == 2
+        assert all(skill["version"] == "1.0.0" for skill in result["skills"])
+
+    def test_lists_recent_change_when_present(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "alpha",
+                frontmatter_extra="changelog:\n  - Tightened safety wording.\n",
+            )
+            raw = skills_list()
+        result = json.loads(raw)
+        assert result["skills"][0]["recent_change"] == "Tightened safety wording."
 
     def test_category_filter(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -302,7 +315,19 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is True
         assert result["name"] == "my-skill"
+        assert result["version"] == "1.0.0"
         assert "Step 1" in result["content"]
+
+    def test_view_returns_changelog_when_present(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "my-skill",
+                frontmatter_extra="changelog:\n  - Tightened safety wording.\n",
+            )
+            raw = skill_view("my-skill")
+        result = json.loads(raw)
+        assert result["changelog"] == ["Tightened safety wording."]
 
     def test_view_nonexistent_skill(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -7,6 +7,11 @@ approaches into reusable procedural knowledge. New skills are created in
 ~/.hermes/skills/. Existing skills (bundled, hub-installed, or user-created)
 can be modified or deleted wherever they live.
 
+Managed SKILL.md files must include a semantic ``version`` field. When the
+version changes, append a short frontmatter ``changelog`` note describing the
+material behavior/rule change. This keeps prompt drift reviewable without
+introducing heavyweight release process overhead.
+
 Skills are the agent's procedural memory: they capture *how to do a specific
 type of task* based on proven experience. General memory (MEMORY.md, USER.md) is
 broad and declarative. Skills are narrow and actionable.
@@ -84,12 +89,83 @@ MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$")
 
 # Characters allowed in skill names (filesystem-safe, URL-friendly)
 VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 # Subdirectories allowed for write_file/remove_file
 ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+
+
+def _split_frontmatter(content: str) -> Tuple[Optional[Dict[str, Any]], Optional[str], Optional[str]]:
+    """Return parsed frontmatter, body, and an error string if parsing fails."""
+    if not content.startswith("---"):
+        return None, None, "SKILL.md must start with YAML frontmatter (---). See existing skills for format."
+
+    end_match = re.search(r'\n---\s*\n', content[3:])
+    if not end_match:
+        return None, None, "SKILL.md frontmatter is not closed. Ensure you have a closing '---' line."
+
+    yaml_content = content[3:end_match.start() + 3]
+    body = content[end_match.end() + 3:]
+
+    try:
+        parsed = yaml.safe_load(yaml_content)
+    except yaml.YAMLError as e:
+        return None, None, f"YAML frontmatter parse error: {e}"
+
+    if not isinstance(parsed, dict):
+        return None, None, "Frontmatter must be a YAML mapping (key: value pairs)."
+
+    return parsed, body, None
+
+
+def _normalize_changelog(value: Any) -> list[str]:
+    """Normalize changelog/frontmatter notes into a list of non-empty strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _validate_versioning_metadata(
+    parsed: Dict[str, Any],
+    previous_parsed: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Validate lightweight skill version/changelog discipline."""
+    version = str(parsed.get("version") or "").strip()
+    if not version:
+        return "Frontmatter must include 'version' field."
+    if not SEMVER_RE.match(version):
+        return "Frontmatter 'version' must look like semantic versioning (e.g. 1.0.0)."
+
+    changelog = parsed.get("changelog")
+    if changelog is not None:
+        notes = _normalize_changelog(changelog)
+        if not notes:
+            return "Frontmatter 'changelog' must be a non-empty string or list of short notes."
+        if len(notes) > 20:
+            return "Frontmatter 'changelog' must stay lightweight (20 notes max)."
+        too_long = [note for note in notes if len(note) > 240]
+        if too_long:
+            return "Each changelog note must stay short (240 characters max)."
+
+    if previous_parsed is not None:
+        prev_version = str(previous_parsed.get("version") or "").strip()
+        if version != prev_version:
+            previous_notes = _normalize_changelog(previous_parsed.get("changelog"))
+            current_notes = _normalize_changelog(parsed.get("changelog"))
+            if len(current_notes) <= len(previous_notes) or current_notes[: len(previous_notes)] != previous_notes:
+                return (
+                    "When changing a skill version, also append a short 'changelog' note "
+                    "describing the material behavior change."
+                )
+
+    return None
 
 
 # =============================================================================
@@ -135,7 +211,10 @@ def _validate_category(category: Optional[str]) -> Optional[str]:
     return None
 
 
-def _validate_frontmatter(content: str) -> Optional[str]:
+def _validate_frontmatter(
+    content: str,
+    previous_content: Optional[str] = None,
+) -> Optional[str]:
     """
     Validate that SKILL.md content has proper frontmatter with required fields.
     Returns error message or None if valid.
@@ -143,22 +222,12 @@ def _validate_frontmatter(content: str) -> Optional[str]:
     if not content.strip():
         return "Content cannot be empty."
 
-    if not content.startswith("---"):
-        return "SKILL.md must start with YAML frontmatter (---). See existing skills for format."
+    parsed, body, err = _split_frontmatter(content)
+    if err:
+        return err
 
-    end_match = re.search(r'\n---\s*\n', content[3:])
-    if not end_match:
-        return "SKILL.md frontmatter is not closed. Ensure you have a closing '---' line."
-
-    yaml_content = content[3:end_match.start() + 3]
-
-    try:
-        parsed = yaml.safe_load(yaml_content)
-    except yaml.YAMLError as e:
-        return f"YAML frontmatter parse error: {e}"
-
-    if not isinstance(parsed, dict):
-        return "Frontmatter must be a YAML mapping (key: value pairs)."
+    assert parsed is not None  # for type-checkers
+    assert body is not None
 
     if "name" not in parsed:
         return "Frontmatter must include 'name' field."
@@ -167,9 +236,19 @@ def _validate_frontmatter(content: str) -> Optional[str]:
     if len(str(parsed["description"])) > MAX_DESCRIPTION_LENGTH:
         return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
 
-    body = content[end_match.end() + 3:].strip()
-    if not body:
+    version_err = _validate_versioning_metadata(parsed)
+    if version_err:
+        return version_err
+
+    if not body.strip():
         return "SKILL.md must have content after the frontmatter (instructions, procedures, etc.)."
+
+    if previous_content is not None:
+        previous_parsed, _, prev_err = _split_frontmatter(previous_content)
+        if prev_err is None and previous_parsed is not None:
+            version_err = _validate_versioning_metadata(parsed, previous_parsed=previous_parsed)
+            if version_err:
+                return version_err
 
     return None
 
@@ -348,14 +427,6 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
-    err = _validate_frontmatter(content)
-    if err:
-        return {"success": False, "error": err}
-
-    err = _validate_content_size(content)
-    if err:
-        return {"success": False, "error": err}
-
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Use skills_list() to see available skills."}
@@ -363,6 +434,15 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
+
+    err = _validate_frontmatter(content, previous_content=original_content)
+    if err:
+        return {"success": False, "error": err}
+
+    err = _validate_content_size(content)
+    if err:
+        return {"success": False, "error": err}
+
     _atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
@@ -445,7 +525,7 @@ def _patch_skill(
 
     # If patching SKILL.md, validate frontmatter is still intact
     if not file_path:
-        err = _validate_frontmatter(new_content)
+        err = _validate_frontmatter(new_content, previous_content=content)
         if err:
             return {
                 "success": False,
@@ -669,7 +749,9 @@ SKILL_MANAGE_SCHEMA = {
         "After difficult/iterative tasks, offer to save as a skill. "
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
         "Good skills: trigger conditions, numbered steps with exact commands, "
-        "pitfalls section, verification steps. Use skill_view() to see format examples."
+        "pitfalls section, verification steps. Include a semantic 'version' in "
+        "frontmatter, and when behavior rules materially change, append a short "
+        "frontmatter 'changelog' note. Use skill_view() to see format examples."
     ),
     "parameters": {
         "type": "object",
@@ -691,7 +773,9 @@ SKILL_MANAGE_SCHEMA = {
                 "description": (
                     "Full SKILL.md content (YAML frontmatter + markdown body). "
                     "Required for 'create' and 'edit'. For 'edit', read the skill "
-                    "first with skill_view() and provide the complete updated text."
+                    "first with skill_view() and provide the complete updated text. "
+                    "Managed skills must include a semantic 'version' field; if you "
+                    "change that version, also append a short frontmatter 'changelog' note."
                 )
             },
             "old_string": {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -29,7 +29,9 @@ SKILL.md Format (YAML Frontmatter, agentskills.io compatible):
     ---
     name: skill-name              # Required, max 64 chars
     description: Brief description # Required, max 1024 chars
-    version: 1.0.0                # Optional
+    version: 1.0.0                # Required for managed/internal skills
+    changelog:                    # Optional lightweight notes for material rule changes
+      - Clarified setup order for remote backends
     license: MIT                  # Optional (agentskills.io)
     platforms: [macos]            # Optional — restrict to specific OS platforms
                                   #   Valid: macos, linux, windows
@@ -496,6 +498,17 @@ def _parse_tags(tags_value) -> List[str]:
     return [t.strip().strip("\"'") for t in tags_value.split(",") if t.strip()]
 
 
+def _parse_changelog(value: Any) -> List[str]:
+    """Normalize lightweight changelog notes from skill frontmatter."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
 
 def _get_disabled_skill_names() -> Set[str]:
     """Load disabled skill names from config.
@@ -533,7 +546,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
             filters out disabled skills.
 
     Returns:
-        List of skill metadata dicts (name, description, category).
+        List of skill metadata dicts (name, description, category, version, recent_change).
     """
     from agent.skill_utils import get_external_skills_dirs
 
@@ -581,13 +594,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
 
                 category = _get_category_from_path(skill_md)
+                version = str(frontmatter.get("version") or "").strip() or None
+                changelog = _parse_changelog(frontmatter.get("changelog"))
 
                 seen_names.add(name)
-                skills.append({
+                skill_entry = {
                     "name": name,
                     "description": description,
                     "category": category,
-                })
+                }
+                if version:
+                    skill_entry["version"] = version
+                if changelog:
+                    skill_entry["recent_change"] = changelog[-1]
+                skills.append(skill_entry)
 
             except (UnicodeDecodeError, PermissionError) as e:
                 logger.debug("Failed to read skill file %s: %s", skill_md, e)
@@ -648,15 +668,16 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
-    Returns only name + description to minimize token usage. Use skill_view() to
-    load full content, tags, related files, etc.
+    Returns small metadata (name, description, category, version, recent_change)
+    to minimize token usage. Use skill_view() to load full content, tags,
+    changelog, related files, etc.
 
     Args:
         category: Optional category filter (e.g., "mlops")
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
-        JSON string with minimal skill info: name, description, category
+        JSON string with minimal skill info: name, description, category, version, recent_change
     """
     try:
         if not SKILLS_DIR.exists():
@@ -1169,6 +1190,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         related_skills = _parse_tags(
             hermes_meta.get("related_skills") or frontmatter.get("related_skills", "")
         )
+        changelog = _parse_changelog(frontmatter.get("changelog"))
 
         # Build linked files structure for clear discovery
         linked_files = {}
@@ -1259,6 +1281,8 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             "success": True,
             "name": skill_name,
             "description": frontmatter.get("description", ""),
+            "version": frontmatter.get("version"),
+            "changelog": changelog or None,
             "tags": tags,
             "related_skills": related_skills,
             "content": content,
@@ -1314,6 +1338,19 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         return tool_error(str(e), success=False)
 
 
+# Tool description for model_tools.py
+SKILLS_TOOL_DESCRIPTION = """Access skill documents providing specialized instructions, guidelines, and executable knowledge.
+
+Progressive disclosure workflow:
+1. skills_list() - Returns metadata (name, description, category, version, recent_change) for all skills
+2. skill_view(name) - Loads full SKILL.md content + shows version, changelog, and available linked_files
+3. skill_view(name, file_path) - Loads specific linked file (e.g., 'references/api.md', 'scripts/train.py')
+
+Skills may include:
+- references/: Additional documentation, API specs, examples
+- templates/: Output formats, config files, boilerplate code
+- assets/: Supplementary files (agentskills.io standard)
+- scripts/: Executable helpers (Python, shell scripts)"""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require managed/internal `SKILL.md` files to include a semantic `version` field
- require a short frontmatter `changelog` note when a skill version changes
- expose `version` and latest change metadata in `skills_list()`
- expose `version` and full `changelog` in `skill_view()`
- update docs and tests for the new skill discipline

## Why
This adds lightweight prompt/version discipline for internal skills so behavior changes are easier to review and debug over time.

## Test Plan
- [ ] `source /Users/fusoon/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skill_improvements.py tests/tools/test_skill_size_limits.py tests/tools/test_skills_tool.py -q`
- [ ] `source /Users/fusoon/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_skill*.py -q`

## Results
- focused suite: `157 passed`
- broader skill suite: `351 passed, 1 skipped`

## Expected impact
- easier review of skill/prompt changes
- better debugging when skill outputs shift over time
- minimal process overhead compared with full release/changelog workflows
