### PR TITLE
fix(browser): use 127.0.0.1 instead of localhost for CDP default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5956,7 +5956,7 @@ class HermesCLI:
         parts = cmd.strip().split(None, 1)
         sub = parts[1].lower().strip() if len(parts) > 1 else "status"
 
-        _DEFAULT_CDP = "http://localhost:9222"
+        _DEFAULT_CDP = "http://127.0.0.1:9222"
         current = os.environ.get("BROWSER_CDP_URL", "").strip()
 
         if sub.startswith("connect"):


### PR DESCRIPTION
## Summary

`/browser connect` set `BROWSER_CDP_URL` to `http://localhost:9222`, but Chrome's `--remote-debugging-port` only binds to `127.0.0.1` (IPv4). On macOS, `localhost` can resolve to `::1` (IPv6) first, causing both `_resolve_cdp_override`'s `/json/version` fetch and agent-browser's `--cdp` connection to fail.

The socket check in the `/browser connect` handler already used `127.0.0.1` explicitly and succeeded — the user saw "Chrome is already listening on port 9222" — but the downstream code used `localhost`, which could fail on IPv6-first systems.

**Root cause:** `_DEFAULT_CDP = "http://localhost:9222"` → DNS resolution mismatch on macOS.

**Fix:** `_DEFAULT_CDP = "http://127.0.0.1:9222"` — matches what Chrome actually binds to.

## Diagnosed from
User bug report via X (PIXO) — `/browser connect` reported success but `browser_navigate` failed with `Failed to connect via CDP to http://localhost:9222`. Debug logs confirmed Chrome was running and port was open.

## Test plan
- Existing tests pass: `test_cli_browser_connect.py`, `test_browser_cdp_override.py` (7/7)
- One-line change, no behavioral impact for users who already pass explicit URLs via `/browser connect ws://...`