### PR TITLE
fix(cli): tolerate missing current working directory

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -404,11 +404,18 @@ def load_cli_config() -> Dict[str, Any]:
     if terminal_config.get("cwd") in (".", "auto", "cwd"):
         effective_backend = terminal_config.get("env_type", "local")
         if effective_backend == "local":
-            terminal_config["cwd"] = os.getcwd()
-            defaults["terminal"]["cwd"] = terminal_config["cwd"]
+            try:
+                terminal_config["cwd"] = os.getcwd()
+                defaults["terminal"]["cwd"] = terminal_config["cwd"]
+            except FileNotFoundError:
+                logger.warning("Current working directory no longer exists; leaving terminal.cwd unset")
+                terminal_config.pop("cwd", None)
+                defaults["terminal"].pop("cwd", None)
+                os.environ.pop("TERMINAL_CWD", None)
         else:
             # Remove so TERMINAL_CWD stays unset → tool picks backend default
             terminal_config.pop("cwd", None)
+            os.environ.pop("TERMINAL_CWD", None)
     
     env_mappings = {
         "env_type": "TERMINAL_ENV",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -96,6 +96,26 @@ class TestVerboseAndToolProgress:
         assert cli.tool_progress_mode in ("off", "new", "all", "verbose")
 
 
+class TestLoadCliConfig:
+    def test_missing_current_working_directory_falls_back_safely(self, tmp_path, monkeypatch):
+        import importlib
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import cli as _cli_mod
+        _cli_mod = importlib.reload(_cli_mod)
+        monkeypatch.setattr(_cli_mod, "_hermes_home", hermes_home)
+        monkeypatch.setenv("TERMINAL_CWD", "/tmp/stale")
+        monkeypatch.setattr(_cli_mod.os, "getcwd", MagicMock(side_effect=FileNotFoundError("gone")))
+
+        cfg = _cli_mod.load_cli_config()
+
+        assert cfg["terminal"].get("cwd") in (None, "")
+        assert "TERMINAL_CWD" not in _cli_mod.os.environ
+
+
 class TestBusyInputMode:
     def test_default_busy_input_mode_is_interrupt(self):
         cli = _make_cli()


### PR DESCRIPTION
## Summary
- handle `FileNotFoundError` when `load_cli_config()` resolves `terminal.cwd` from `os.getcwd()`
- clear stale `TERMINAL_CWD` when the working directory is gone or auto-cwd is unset
- add a regression test covering startup from a deleted current directory

## Why
If Hermes is launched from a shell whose current working directory has been deleted or moved, `os.getcwd()` raises `FileNotFoundError` during CLI startup. This change makes Hermes fall back safely instead of crashing.

## Test Plan
- [x] `pytest tests/cli/test_cli_init.py::TestLoadCliConfig::test_missing_current_working_directory_falls_back_safely -q`
- [x] `pytest tests/cli/test_cli_init.py tests/hermes_cli/test_config_env_expansion.py tests/tools/test_modal_sandbox_fixes.py -q`
- [x] manually verified `hermes --help` succeeds from a deleted cwd

## Disclosure
This PR was prepared by Rook, an AI coding assistant, and reviewed by Ian before opening.
