### PR TITLE
fix(gateway): use yaml.safe_load instead of json.load for --config flag

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9638,9 +9638,9 @@ def main():
     
     config = None
     if args.config:
-        import json
+        import yaml
         with open(args.config, encoding="utf-8") as f:
-            data = json.load(f)
+            data = yaml.safe_load(f)
             config = GatewayConfig.from_dict(data)
     
     # Run the gateway - exit with code 1 if no platforms connected,

--- a/tests/gateway/test_config_yaml_parse.py
+++ b/tests/gateway/test_config_yaml_parse.py
@@ -1,0 +1,55 @@
+"""Test that the gateway main() function parses YAML config files correctly."""
+
+import textwrap
+from unittest.mock import patch
+
+from gateway.config import GatewayConfig
+
+
+class TestMainConfigYamlParse:
+    def test_main_parses_yaml_config(self, tmp_path):
+        """main() should parse a YAML config file via --config flag."""
+        config_file = tmp_path / "gateway.yaml"
+        config_file.write_text(textwrap.dedent("""\
+            platforms:
+              telegram:
+                enabled: true
+                token: "test-token-123"
+            session_reset:
+              mode: idle
+              idle_minutes: 60
+        """))
+
+        captured = {}
+
+        async def fake_start_gateway(config):
+            captured["config"] = config
+            return True
+
+        with (
+            patch("sys.argv", ["run", "--config", str(config_file)]),
+            patch("gateway.run.start_gateway", fake_start_gateway),
+        ):
+            from gateway.run import main
+            main()
+
+        config = captured["config"]
+        assert isinstance(config, GatewayConfig)
+        assert config.platforms  # at least one platform parsed
+
+    def test_main_no_config_flag_passes_none(self):
+        """main() should pass None to start_gateway when --config is omitted."""
+        captured = {}
+
+        async def fake_start_gateway(config):
+            captured["config"] = config
+            return True
+
+        with (
+            patch("sys.argv", ["run"]),
+            patch("gateway.run.start_gateway", fake_start_gateway),
+        ):
+            from gateway.run import main
+            main()
+
+        assert captured["config"] is None


### PR DESCRIPTION
## Summary

Fixes #10216

The `main()` function in `gateway/run.py` uses `json.load()` to parse the config file passed via the `--config` / `-c` CLI flag. However, the documented and expected config format is YAML, causing a `json.JSONDecodeError` on any valid YAML config file.

## Changes

- **`gateway/run.py`**: Replace `import json` + `json.load(f)` with `import yaml` + `yaml.safe_load(f)` in the `main()` function (the CLI entry point)
- **`tests/gateway/test_config_yaml_parse.py`**: Add two tests verifying:
  - YAML config files are correctly parsed via `--config` flag
  - `None` is passed to `start_gateway()` when no `--config` flag is given

## Testing

All existing tests pass. Two new tests pass.