### PR TITLE
fix(skills): fix falsy-zero coordinate bug in find-nearby and add missing field validation in gws_bridge

### DIFF
--- a/skills/leisure/find-nearby/scripts/find_nearby.py
+++ b/skills/leisure/find-nearby/scripts/find_nearby.py
@@ -98,7 +98,7 @@ def find_nearby(lat: float, lon: float, types: list[str], radius: int = 1500, li
         # Get coordinates (nodes have lat/lon directly, ways/relations use center)
         plat = el.get("lat") or (el.get("center", {}) or {}).get("lat")
         plon = el.get("lon") or (el.get("center", {}) or {}).get("lon")
-        if not plat or not plon:
+        if plat is None or plon is None:
             continue
 
         dist = haversine(lat, lon, plat, plon)

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -25,6 +25,13 @@ def refresh_token(token_data: dict) -> dict:
     import urllib.parse
     import urllib.request
 
+    required_keys = ["client_id", "client_secret", "refresh_token", "token_uri"]
+    missing = [k for k in required_keys if k not in token_data]
+    if missing:
+        print(f"ERROR: google_token.json is missing required fields: {', '.join(missing)}", file=sys.stderr)
+        print("Please re-authenticate by running the Google Workspace setup script.", file=sys.stderr)
+        sys.exit(1)
+
     params = urllib.parse.urlencode({
         "client_id": token_data["client_id"],
         "client_secret": token_data["client_secret"],


### PR DESCRIPTION
Salvage of #10173 by @haileymarshall (Misturi.eth), cherry-picked onto current main.

## Changes

**find_nearby.py:** `if not plat or not plon:` → `if plat is None or plon is None:` — fixes silently dropping locations at latitude/longitude 0 (equator/prime meridian) due to Python's falsy-zero behavior.

**gws_bridge.py:** Validates required keys (`client_id`, `client_secret`, `refresh_token`, `token_uri`) before accessing them — produces a clear error message instead of raw KeyError on incomplete/corrupted token files.

Contributor authorship preserved in git log.