### PR TITLE
fix(models): use curated list for Nous in provider_model_ids()

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1237,16 +1237,12 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
     if normalized == "nous":
-        # Try live Nous Portal /models endpoint
-        try:
-            from hermes_cli.auth import fetch_nous_models, resolve_nous_runtime_credentials
-            creds = resolve_nous_runtime_credentials()
-            if creds:
-                live = fetch_nous_models(api_key=creds.get("api_key", ""), inference_base_url=creds.get("base_url", ""))
-                if live:
-                    return live
-        except Exception:
-            pass
+        # Use curated list — the live /models endpoint returns 300+ models
+        # (including non-agentic ones like image generators and rerankers).
+        # The curated list matches the `hermes model` and gateway pickers.
+        curated = _PROVIDER_MODELS.get("nous", [])
+        if curated:
+            return list(curated)
     if normalized == "anthropic":
         live = _fetch_anthropic_models()
         if live:


### PR DESCRIPTION
## Summary

`provider_model_ids('nous')` was calling `fetch_nous_models()` which hits the live Nous Portal `/models` endpoint and returns the **full API catalog** — 382 models including image generators, rerankers, embedding models, and other non-agentic models.

This caused the `/model` picker's fallback (when the curated list was unavailable due to stale `.pyc` caches on WSL2) to dump hundreds of models into the picker, making it scroll off-screen and unusable.

**Root cause:** PR #10146 fixed the `/model` picker to prefer the curated list first. But the fallback still called `provider_model_ids()`, which for Nous returned 382 live models. On WSL2 where `.pyc` timestamp mismatches prevented the #10146 fix from being compiled, users saw the full catalog.

## Fix

Return the curated `_PROVIDER_MODELS['nous']` list (29 models) directly, matching:
- `hermes model` (uses `_PROVIDER_MODELS`)
- Gateway `/model` picker (uses `list_authenticated_providers()` → curated)
- OpenRouter flow (uses `fetch_openrouter_models()` → curated cross-ref)

| Call | Before | After |
|------|--------|-------|
| `provider_model_ids('nous')` | 382 (live API) | 29 (curated) |
| `provider_model_ids('openrouter')` | 30 (curated) | 30 (curated) |
| `provider_model_ids('anthropic')` | 7 (live) | 7 (live) |

## Test plan
- 63 model validation tests pass
- 2057 hermes_cli tests pass (9 pre-existing failures in env_loader/gateway_service)
- py_compile verified
- E2E: `provider_model_ids('nous')` confirmed returning 29 models