### PR TITLE
feat(gateway/dingtalk): receive file attachments via Stream callback

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1537,7 +1537,7 @@ def save_config_value(key_path: str, value: any) -> bool:
         
         # Load existing config
         if config_path.exists():
-            with open(config_path, 'r') as f:
+            with open(config_path, 'r', encoding='utf-8') as f:
                 config = yaml.safe_load(f) or {}
         else:
             config = {}

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -632,7 +632,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
-                with open(_cfg_path) as _f:
+                with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
@@ -747,7 +747,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
-            disabled_toolsets=["cronjob", "messaging", "clarify"],
+            disabled_toolsets=["cronjob", "messaging", "clarify", "browser"],
             quiet_mode=True,
             skip_context_files=True,  # Don't inject SOUL.md/AGENTS.md from scheduler cwd
             skip_memory=True,  # Cron system prompts would corrupt user representations

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -307,6 +307,9 @@ class GatewayConfig:
             # QQBot uses extra dict for app credentials
             elif platform == Platform.QQBOT and config.extra.get("app_id") and config.extra.get("client_secret"):
                 connected.append(platform)
+            # DingTalk uses extra dict for app credentials
+            elif platform == Platform.DINGTALK and config.extra.get("client_id"):
+                connected.append(platform)
         return connected
     
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
@@ -1093,6 +1096,30 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 platform=Platform.WEIXIN,
                 chat_id=weixin_home,
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
+            )
+
+    # DingTalk
+    dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
+    dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
+    if dingtalk_client_id and dingtalk_client_secret:
+        if Platform.DINGTALK not in config.platforms:
+            config.platforms[Platform.DINGTALK] = PlatformConfig()
+        config.platforms[Platform.DINGTALK].enabled = True
+        config.platforms[Platform.DINGTALK].extra.update({
+            "client_id": dingtalk_client_id,
+            "client_secret": dingtalk_client_secret,
+        })
+        dingtalk_allowed_users = os.getenv("DINGTALK_ALLOWED_USERS", "")
+        if dingtalk_allowed_users:
+            config.platforms[Platform.DINGTALK].extra["allowed_users"] = [
+                u.strip() for u in dingtalk_allowed_users.split(",") if u.strip()
+            ]
+        dingtalk_home = os.getenv("DINGTALK_HOME_CHANNEL")
+        if dingtalk_home:
+            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+                platform=Platform.DINGTALK,
+                chat_id=dingtalk_home,
+                name=os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
             )
 
     # BlueBubbles (iMessage)

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -48,7 +48,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    cache_image_from_bytes,
+    cache_image_from_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -297,47 +297,43 @@ class DingTalkAdapter(BasePlatformAdapter):
         Returns a `(media_urls, media_types)` pair. Empty on any failure
         — callers fall back to the `[图片]` text placeholder.
         """
-        if self._handler is None or self._http_client is None:
+        if self._handler is None:
             return [], []
         try:
-            codes = message.get_image_list() or []
-        except Exception:
+            codes = [c for c in (message.get_image_list() or []) if c]
+        except AttributeError:
             logger.exception("[%s] get_image_list failed", self.name)
             return [], []
         if not codes:
             return [], []
 
-        paths: List[str] = []
-        types: List[str] = []
-        for code in codes:
-            if not code:
-                continue
-            try:
-                # SDK method is sync (requests-based); offload to a thread.
-                download_url = await asyncio.to_thread(
-                    self._handler.get_image_download_url, code
-                )
-            except Exception:
-                logger.exception("[%s] get_image_download_url failed", self.name)
-                continue
-            if not download_url:
-                logger.warning(
-                    "[%s] No downloadUrl returned for code %s…",
-                    self.name, code[:16],
-                )
-                continue
-            try:
-                resp = await self._http_client.get(download_url, timeout=30.0)
-                resp.raise_for_status()
-                cached = cache_image_from_bytes(resp.content, ext=".jpg")
-            except Exception:
-                logger.exception("[%s] Picture fetch failed for %s",
-                                 self.name, download_url[:80])
-                continue
-            paths.append(cached)
-            types.append("image/jpeg")
-            logger.info("[%s] Cached inbound picture at %s", self.name, cached)
-        return paths, types
+        paths = [p for p in await asyncio.gather(*(self._fetch_one(c) for c in codes)) if p]
+        if paths:
+            logger.info("[%s] Cached %d inbound picture(s)", self.name, len(paths))
+        return paths, ["image/jpeg"] * len(paths)
+
+    async def _fetch_one(self, code: str) -> Optional[str]:
+        """Exchange one downloadCode for a cached local path.
+
+        SDK's `get_image_download_url` is sync (requests-based) — offloaded
+        to a thread so a slow token refresh doesn't stall the event loop.
+        `cache_image_from_url` handles retries + SSRF guarding.
+        """
+        try:
+            download_url = await asyncio.to_thread(
+                self._handler.get_image_download_url, code
+            )
+        except Exception:
+            logger.exception("[%s] get_image_download_url failed", self.name)
+            return None
+        if not download_url:
+            logger.warning("[%s] No downloadUrl for code %s…", self.name, code[:16])
+            return None
+        try:
+            return await cache_image_from_url(download_url, ext=".jpg")
+        except (httpx.HTTPError, ValueError) as e:
+            logger.warning("[%s] Picture cache failed: %s", self.name, e)
+            return None
 
     @staticmethod
     def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -18,6 +18,7 @@ Configuration in config.yaml:
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -54,7 +55,7 @@ logger = logging.getLogger(__name__)
 MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
-_DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
+_DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:o?api)\.dingtalk\.com/')
 
 # DingTalk Stream only delivers these three msgtypes to chatbot callbacks.
 # The SDK exposes them as raw string literals, so we pin our own constants
@@ -99,6 +100,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator(max_size=1000)
         # Map chat_id -> session_webhook for reply routing
         self._session_webhooks: Dict[str, str] = {}
+        # Map chat_id -> "group" | "dm" for get_chat_info
+        self._chat_types: Dict[str, str] = {}
 
     # -- Connection lifecycle -----------------------------------------------
 
@@ -120,14 +123,14 @@ class DingTalkAdapter(BasePlatformAdapter):
             credential = dingtalk_stream.Credential(self._client_id, self._client_secret)
             self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
 
-            # Capture the current event loop for cross-thread dispatch
-            loop = asyncio.get_running_loop()
-            handler = _IncomingHandler(self, loop)
+            handler = _IncomingHandler(self)
             self._stream_client.register_callback_handler(
                 dingtalk_stream.ChatbotMessage.TOPIC, handler
             )
 
-            self._stream_task = asyncio.create_task(self._run_stream())
+            self._stream_task = asyncio.create_task(
+                self._run_stream(), name=f"{self.name}-stream"
+            )
             self._mark_connected()
             logger.info("[%s] Connected via Stream Mode", self.name)
             return True
@@ -180,6 +183,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         self._stream_client = None
         self._session_webhooks.clear()
+        self._chat_types.clear()
         self._dedup.clear()
         logger.info("[%s] Disconnected", self.name)
 
@@ -216,16 +220,18 @@ class DingTalkAdapter(BasePlatformAdapter):
         chat_id = conversation_id or sender_id
         chat_type = "group" if is_group else "dm"
 
-        # Store session webhook for reply routing (validate origin to prevent SSRF)
+        # Store session webhook for reply routing (validate origin to prevent SSRF).
+        # Eviction is FIFO (insertion order), not true LRU — adequate because
+        # stale webhooks are harmless; only the most recent one is ever used.
         session_webhook = getattr(message, "session_webhook", None) or ""
         if session_webhook and chat_id and _DINGTALK_WEBHOOK_RE.match(session_webhook):
-            if len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
-                # Evict oldest entry to cap memory growth
+            if chat_id not in self._session_webhooks and len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
                 try:
                     self._session_webhooks.pop(next(iter(self._session_webhooks)))
                 except StopIteration:
                     pass
             self._session_webhooks[chat_id] = session_webhook
+            self._chat_types[chat_id] = chat_type
 
         source = self.build_source(
             chat_id=chat_id,
@@ -334,6 +340,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         if not self._http_client:
             return SendResult(success=False, error="HTTP client not initialized")
 
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            logger.warning(
+                "[%s] Message truncated from %d to %d chars",
+                self.name, len(content), self.MAX_MESSAGE_LENGTH,
+            )
         payload = {
             "msgtype": "markdown",
             "markdown": {"title": "Hermes", "text": content[:self.MAX_MESSAGE_LENGTH]},
@@ -358,7 +369,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about a DingTalk conversation."""
-        return {"name": chat_id, "type": "group" if "group" in chat_id.lower() else "dm"}
+        return {"name": chat_id, "type": self._chat_types.get(chat_id, "dm")}
 
 
 # ---------------------------------------------------------------------------
@@ -368,11 +379,10 @@ class DingTalkAdapter(BasePlatformAdapter):
 class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
     """dingtalk-stream ChatbotHandler that forwards messages to the adapter."""
 
-    def __init__(self, adapter: DingTalkAdapter, loop: asyncio.AbstractEventLoop):
+    def __init__(self, adapter: DingTalkAdapter):
         if DINGTALK_STREAM_AVAILABLE:
             super().__init__()
         self._adapter = adapter
-        self._loop = loop
 
     async def process(self, callback):
         """Called by dingtalk-stream when a message arrives.
@@ -385,7 +395,6 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
                 message = callback
             else:
                 # CallbackMessage — parse .data into ChatbotMessage
-                import json
                 data = callback.data
                 if isinstance(data, str):
                     data = json.loads(data)

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -24,7 +24,7 @@ import os
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import dingtalk_stream
@@ -48,6 +48,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_image_from_bytes,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,6 +96,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._stream_client: Any = None
         self._stream_task: Optional[asyncio.Task] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
+        # Registered callback handler — kept around so picture downloads can
+        # piggyback on the SDK's access-token plumbing.
+        self._handler: Any = None
 
         # Message deduplication
         self._dedup = MessageDeduplicator(max_size=1000)
@@ -127,6 +131,9 @@ class DingTalkAdapter(BasePlatformAdapter):
             self._stream_client.register_callback_handler(
                 dingtalk_stream.ChatbotMessage.TOPIC, handler
             )
+            # register_callback_handler wires `handler.dingtalk_client = self`,
+            # giving us access_token + credential for OpenAPI calls.
+            self._handler = handler
 
             self._stream_task = asyncio.create_task(
                 self._run_stream(), name=f"{self.name}-stream"
@@ -182,6 +189,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             self._http_client = None
 
         self._stream_client = None
+        self._handler = None
         self._session_webhooks.clear()
         self._chat_types.clear()
         self._dedup.clear()
@@ -249,6 +257,18 @@ class DingTalkAdapter(BasePlatformAdapter):
         except (ValueError, OSError, TypeError):
             timestamp = datetime.now(tz=timezone.utc)
 
+        # Download picture attachments so the vision model sees real bytes
+        # instead of the [图片] placeholder. Applies to both `picture` and
+        # `richText` msgtypes (richText can carry inline images).
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        if msgtype in (_MSGTYPE_PICTURE, _MSGTYPE_RICH_TEXT):
+            media_urls, media_types = await self._fetch_picture_attachments(message)
+            if media_urls and msgtype == _MSGTYPE_PICTURE:
+                # Swap the bare placeholder for a short caption so the agent
+                # knows to look at the attachment list.
+                text = f"[图片 × {len(media_urls)}]"
+
         event = MessageEvent(
             text=text,
             message_type=event_type,
@@ -256,11 +276,68 @@ class DingTalkAdapter(BasePlatformAdapter):
             message_id=msg_id,
             raw_message=message,
             timestamp=timestamp,
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         logger.debug("[%s] Message from %s in %s: %s",
                       self.name, sender_nick, chat_id[:20] if chat_id else "?", text[:50])
         await self.handle_message(event)
+
+    async def _fetch_picture_attachments(
+        self, message: "ChatbotMessage"
+    ) -> Tuple[List[str], List[str]]:
+        """Download every picture referenced by an inbound message.
+
+        Uses the SDK's `get_image_download_url` (sync) to exchange each
+        downloadCode for a short-lived CDN URL, then fetches the bytes
+        via the adapter's async httpx client and caches them locally so
+        the vision tool can read them as file paths.
+
+        Returns a `(media_urls, media_types)` pair. Empty on any failure
+        — callers fall back to the `[图片]` text placeholder.
+        """
+        if self._handler is None or self._http_client is None:
+            return [], []
+        try:
+            codes = message.get_image_list() or []
+        except Exception:
+            logger.exception("[%s] get_image_list failed", self.name)
+            return [], []
+        if not codes:
+            return [], []
+
+        paths: List[str] = []
+        types: List[str] = []
+        for code in codes:
+            if not code:
+                continue
+            try:
+                # SDK method is sync (requests-based); offload to a thread.
+                download_url = await asyncio.to_thread(
+                    self._handler.get_image_download_url, code
+                )
+            except Exception:
+                logger.exception("[%s] get_image_download_url failed", self.name)
+                continue
+            if not download_url:
+                logger.warning(
+                    "[%s] No downloadUrl returned for code %s…",
+                    self.name, code[:16],
+                )
+                continue
+            try:
+                resp = await self._http_client.get(download_url, timeout=30.0)
+                resp.raise_for_status()
+                cached = cache_image_from_bytes(resp.content, ext=".jpg")
+            except Exception:
+                logger.exception("[%s] Picture fetch failed for %s",
+                                 self.name, download_url[:80])
+                continue
+            paths.append(cached)
+            types.append("image/jpeg")
+            logger.info("[%s] Cached inbound picture at %s", self.name, cached)
+        return paths, types
 
     @staticmethod
     def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -24,7 +24,9 @@ import os
 import re
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 try:
     import dingtalk_stream
@@ -44,10 +46,12 @@ except ImportError:
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
+    SUPPORTED_DOCUMENT_TYPES,
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     SendResult,
+    cache_document_from_bytes,
     cache_image_from_url,
 )
 
@@ -58,13 +62,20 @@ RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:o?api)\.dingtalk\.com/')
 
-# DingTalk Stream only delivers these three msgtypes to chatbot callbacks.
+# DingTalk Stream only delivers a handful of msgtypes to chatbot callbacks.
 # The SDK exposes them as raw string literals, so we pin our own constants
 # to keep dispatch sites from growing divergent typos.
 _MSGTYPE_TEXT = "text"
 _MSGTYPE_PICTURE = "picture"
 _MSGTYPE_RICH_TEXT = "richText"
+_MSGTYPE_FILE = "file"
 _PICTURE_PLACEHOLDER = "[图片]"
+_FILE_PLACEHOLDER = "[文件]"
+_DEFAULT_FILE_MIME = "application/octet-stream"
+# Hard ceiling per inbound file — avoids caching a whole 200 MB archive
+# just because someone drops it in a group. 32 MB covers realistic docs
+# (PDFs, slide decks, small datasets) without blocking obvious abuse.
+_MAX_FILE_BYTES = 32 * 1024 * 1024
 
 
 def check_dingtalk_requirements() -> bool:
@@ -215,7 +226,12 @@ class DingTalkAdapter(BasePlatformAdapter):
                 return
             text = f"[未能解析的 {msgtype} 类型消息]"
 
-        event_type = MessageType.PHOTO if msgtype == _MSGTYPE_PICTURE else MessageType.TEXT
+        if msgtype == _MSGTYPE_PICTURE:
+            event_type = MessageType.PHOTO
+        elif msgtype == _MSGTYPE_FILE:
+            event_type = MessageType.DOCUMENT
+        else:
+            event_type = MessageType.TEXT
 
         # Chat context
         conversation_id = getattr(message, "conversation_id", "") or ""
@@ -257,9 +273,10 @@ class DingTalkAdapter(BasePlatformAdapter):
         except (ValueError, OSError, TypeError):
             timestamp = datetime.now(tz=timezone.utc)
 
-        # Download picture attachments so the vision model sees real bytes
-        # instead of the [图片] placeholder. Applies to both `picture` and
-        # `richText` msgtypes (richText can carry inline images).
+        # Download attachments so the agent sees real bytes instead of a
+        # bare ``[图片]`` / ``[文件]`` placeholder. Pictures flow through
+        # both ``picture`` and ``richText`` msgtypes (richText can carry
+        # inline images); files are their own top-level msgtype.
         media_urls: List[str] = []
         media_types: List[str] = []
         if msgtype in (_MSGTYPE_PICTURE, _MSGTYPE_RICH_TEXT):
@@ -268,6 +285,14 @@ class DingTalkAdapter(BasePlatformAdapter):
                 # Swap the bare placeholder for a short caption so the agent
                 # knows to look at the attachment list.
                 text = f"[图片 × {len(media_urls)}]"
+        elif msgtype == _MSGTYPE_FILE:
+            file_path, file_mime, file_name = await self._fetch_file_attachment(message)
+            if file_path:
+                media_urls = [file_path]
+                media_types = [file_mime]
+                # Surface the original filename so the agent knows what it
+                # got without having to peek inside media_urls.
+                text = f"[文件: {file_name}]" if file_name else _FILE_PLACEHOLDER
 
         event = MessageEvent(
             text=text,
@@ -335,14 +360,121 @@ class DingTalkAdapter(BasePlatformAdapter):
             logger.warning("[%s] Picture cache failed: %s", self.name, e)
             return None
 
+    async def _fetch_file_attachment(
+        self, message: "ChatbotMessage"
+    ) -> Tuple[Optional[str], str, Optional[str]]:
+        """Download a ``msgtype=file`` attachment to the document cache.
+
+        The SDK's ``from_dict`` does not parse the ``file`` msgtype, so
+        the payload (``downloadCode`` + ``fileName``) lands in
+        ``message.extensions['content']`` verbatim. The download itself
+        reuses ``get_image_download_url`` — despite the name, that SDK
+        method hits ``/v1.0/robot/messageFiles/download`` which handles
+        files and pictures uniformly.
+
+        Returns ``(local_path, mime_type, file_name)``. Any failure yields
+        ``(None, _DEFAULT_FILE_MIME, file_name_if_known)`` so the caller
+        can still surface the filename in the text placeholder.
+        """
+        content = message.extensions.get("content")
+        if not isinstance(content, dict):
+            return None, _DEFAULT_FILE_MIME, None
+
+        download_code = content.get("downloadCode")
+        file_name = content.get("fileName") or None
+        if not download_code or self._handler is None or self._http_client is None:
+            return None, _DEFAULT_FILE_MIME, file_name
+
+        try:
+            download_url = await asyncio.to_thread(
+                self._handler.get_image_download_url, download_code
+            )
+        except Exception:
+            logger.exception("[%s] get_image_download_url(file) failed", self.name)
+            return None, _DEFAULT_FILE_MIME, file_name
+        if not download_url:
+            logger.warning(
+                "[%s] No downloadUrl for file code %s…",
+                self.name, str(download_code)[:16],
+            )
+            return None, _DEFAULT_FILE_MIME, file_name
+
+        # Single-user agent, URL is signed by DingTalk's authenticated API:
+        # no pre-flight URL validation needed. httpx rejects non-http(s)
+        # schemes itself, and CN accelerators rewriting aliyuncs.com to
+        # 198.18.0.0/15 virtual IPs would trip any SSRF/scheme guard.
+
+        try:
+            # HEAD is not reliable on DingTalk CDN; use a streaming GET
+            # so we can reject oversized bodies via Content-Length before
+            # buffering the whole thing into memory.
+            async with self._http_client.stream("GET", download_url, timeout=60.0) as resp:
+                resp.raise_for_status()
+                declared = resp.headers.get("content-length")
+                if declared and declared.isdigit() and int(declared) > _MAX_FILE_BYTES:
+                    logger.warning(
+                        "[%s] File %s declared %s bytes > %d cap, skipping",
+                        self.name, file_name or "?", declared, _MAX_FILE_BYTES,
+                    )
+                    return None, _DEFAULT_FILE_MIME, file_name
+                chunks: List[bytes] = []
+                total = 0
+                async for chunk in resp.aiter_bytes():
+                    total += len(chunk)
+                    if total > _MAX_FILE_BYTES:
+                        logger.warning(
+                            "[%s] File %s exceeded %d bytes mid-stream, aborting",
+                            self.name, file_name or "?", _MAX_FILE_BYTES,
+                        )
+                        return None, _DEFAULT_FILE_MIME, file_name
+                    chunks.append(chunk)
+                content_type = resp.headers.get("content-type", "")
+        except httpx.HTTPError as e:
+            host = urlparse(download_url).hostname or "?"
+            logger.warning(
+                "[%s] File download failed (host=%s): %s",
+                self.name, host, e,
+            )
+            return None, _DEFAULT_FILE_MIME, file_name
+
+        data = b"".join(chunks)
+        if not data:
+            logger.warning("[%s] File download returned empty body", self.name)
+            return None, _DEFAULT_FILE_MIME, file_name
+
+        # Extension table first (vetted whitelist), CDN content-type next
+        # (often lies as octet-stream for unknown ext), octet-stream last.
+        safe_name = file_name or "attachment.bin"
+        ext = Path(safe_name).suffix.lower()
+        mime = (
+            SUPPORTED_DOCUMENT_TYPES.get(ext)
+            or content_type.split(";")[0].strip()
+            or _DEFAULT_FILE_MIME
+        )
+
+        try:
+            # POSIX-form path: the agent's shell is usually bash (WSL on
+            # Windows), which chokes on backslashes. Forward-slash form
+            # is accepted by Python, WSL, and native Windows tools alike.
+            local_path = Path(cache_document_from_bytes(data, safe_name)).as_posix()
+        except (OSError, ValueError) as e:
+            logger.warning("[%s] File cache failed: %s", self.name, e)
+            return None, _DEFAULT_FILE_MIME, file_name
+
+        logger.info(
+            "[%s] Cached inbound file %s (%d bytes) -> %s",
+            self.name, safe_name, len(data), local_path,
+        )
+        return local_path, mime, file_name
+
     @staticmethod
     def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:
         """Render a DingTalk chatbot message as human-readable text.
 
-        Pictures download require the ``robot/messageFiles/download`` OpenAPI
-        scope which this adapter deliberately does not call — picture
-        segments are replaced with a ``[图片]`` placeholder so the agent at
-        least sees that something visual arrived.
+        Binary payloads (pictures, files) resolve to a placeholder here;
+        the caller in :meth:`_on_message` downloads the bytes via the
+        ``robot/messageFiles/download`` OpenAPI and replaces this text
+        with a richer caption once media_urls are attached.
         """
         if msgtype is None:
             msgtype = getattr(message, "message_type", None) or ""
@@ -353,6 +485,10 @@ class DingTalkAdapter(BasePlatformAdapter):
             return DingTalkAdapter._render_rich_text(message)
         if msgtype == _MSGTYPE_PICTURE:
             return _PICTURE_PLACEHOLDER
+        if msgtype == _MSGTYPE_FILE:
+            content = message.extensions.get("content")
+            name = content.get("fileName") if isinstance(content, dict) else None
+            return f"[文件: {name}]" if name else _FILE_PLACEHOLDER
         if msgtype:
             return f"[未支持的消息类型: {msgtype}]"
         return DingTalkAdapter._read_plain_text(message)

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -56,6 +56,14 @@ RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
 
+# DingTalk Stream only delivers these three msgtypes to chatbot callbacks.
+# The SDK exposes them as raw string literals, so we pin our own constants
+# to keep dispatch sites from growing divergent typos.
+_MSGTYPE_TEXT = "text"
+_MSGTYPE_PICTURE = "picture"
+_MSGTYPE_RICH_TEXT = "richText"
+_PICTURE_PLACEHOLDER = "[图片]"
+
 
 def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured."""
@@ -133,7 +141,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
-                await asyncio.to_thread(self._stream_client.start)
+                # dingtalk-stream >= 0.24 made start() a coroutine
+                if asyncio.iscoroutinefunction(self._stream_client.start):
+                    await self._stream_client.start()
+                else:
+                    await asyncio.to_thread(self._stream_client.start)
             except asyncio.CancelledError:
                 return
             except Exception as e:
@@ -174,16 +186,24 @@ class DingTalkAdapter(BasePlatformAdapter):
     # -- Inbound message processing -----------------------------------------
 
     async def _on_message(self, message: "ChatbotMessage") -> None:
-        """Process an incoming DingTalk chatbot message."""
         msg_id = getattr(message, "message_id", None) or uuid.uuid4().hex
         if self._dedup.is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
 
-        text = self._extract_text(message)
+        msgtype = getattr(message, "message_type", None) or ""
+        text = self._extract_text(message, msgtype)
+
+        # Empty plain-text is usually a stripped at-mention or bot keep-alive
+        # — drop it. Every other msgtype still dispatches with a placeholder
+        # so the agent knows something arrived.
         if not text:
-            logger.debug("[%s] Empty message, skipping", self.name)
-            return
+            if msgtype in ("", _MSGTYPE_TEXT):
+                logger.debug("[%s] Empty text message, skipping", self.name)
+                return
+            text = f"[未能解析的 {msgtype} 类型消息]"
+
+        event_type = MessageType.PHOTO if msgtype == _MSGTYPE_PICTURE else MessageType.TEXT
 
         # Chat context
         conversation_id = getattr(message, "conversation_id", "") or ""
@@ -225,7 +245,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=event_type,
             source=source,
             message_id=msg_id,
             raw_message=message,
@@ -237,22 +257,62 @@ class DingTalkAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     @staticmethod
-    def _extract_text(message: "ChatbotMessage") -> str:
-        """Extract plain text from a DingTalk chatbot message."""
-        text = getattr(message, "text", None) or ""
-        if isinstance(text, dict):
-            content = text.get("content", "").strip()
-        else:
-            content = str(text).strip()
+    def _extract_text(message: "ChatbotMessage", msgtype: Optional[str] = None) -> str:
+        """Render a DingTalk chatbot message as human-readable text.
 
-        # Fall back to rich text if present
-        if not content:
-            rich_text = getattr(message, "rich_text", None)
-            if rich_text and isinstance(rich_text, list):
-                parts = [item["text"] for item in rich_text
-                         if isinstance(item, dict) and item.get("text")]
-                content = " ".join(parts).strip()
-        return content
+        Pictures download require the ``robot/messageFiles/download`` OpenAPI
+        scope which this adapter deliberately does not call — picture
+        segments are replaced with a ``[图片]`` placeholder so the agent at
+        least sees that something visual arrived.
+        """
+        if msgtype is None:
+            msgtype = getattr(message, "message_type", None) or ""
+
+        if msgtype == _MSGTYPE_TEXT:
+            return DingTalkAdapter._read_plain_text(message)
+        if msgtype == _MSGTYPE_RICH_TEXT:
+            return DingTalkAdapter._render_rich_text(message)
+        if msgtype == _MSGTYPE_PICTURE:
+            return _PICTURE_PLACEHOLDER
+        if msgtype:
+            return f"[未支持的消息类型: {msgtype}]"
+        return DingTalkAdapter._read_plain_text(message)
+
+    @staticmethod
+    def _read_plain_text(message: "ChatbotMessage") -> str:
+        text_attr = getattr(message, "text", None)
+        if text_attr is None:
+            return ""
+        if hasattr(text_attr, "content"):
+            return (text_attr.content or "").strip()
+        # Older SDKs / custom handlers may pass dicts instead of TextContent.
+        if isinstance(text_attr, dict):
+            return (text_attr.get("content") or "").strip()
+        return str(text_attr).strip()
+
+    @staticmethod
+    def _render_rich_text(message: "ChatbotMessage") -> str:
+        rich = getattr(message, "rich_text_content", None)
+        items = getattr(rich, "rich_text_list", None) if rich is not None else None
+        if not isinstance(items, list):
+            return ""
+
+        out = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text_val = item.get("text")
+            if text_val:
+                out.append(str(text_val))
+                continue
+            if item.get("downloadCode") or item.get("type") == "picture":
+                out.append(_PICTURE_PLACEHOLDER)
+                continue
+            if item.get("type") == "at":
+                who = item.get("name") or item.get("userId")
+                if who:
+                    out.append(f"@{who}")
+        return " ".join(out).strip()
 
     # -- Outbound messaging -------------------------------------------------
 
@@ -314,19 +374,23 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
         self._adapter = adapter
         self._loop = loop
 
-    def process(self, message: "ChatbotMessage"):
-        """Called by dingtalk-stream in its thread when a message arrives.
+    async def process(self, callback):
+        """Called by dingtalk-stream when a message arrives.
 
-        Schedules the async handler on the main event loop.
+        dingtalk-stream >= 0.24 passes a CallbackMessage to process().
+        Convert it to ChatbotMessage so the adapter gets the expected type.
         """
-        loop = self._loop
-        if loop is None or loop.is_closed():
-            logger.error("[DingTalk] Event loop unavailable, cannot dispatch message")
-            return dingtalk_stream.AckMessage.STATUS_OK, "OK"
-
-        future = asyncio.run_coroutine_threadsafe(self._adapter._on_message(message), loop)
         try:
-            future.result(timeout=60)
+            if isinstance(callback, dingtalk_stream.chatbot.ChatbotMessage):
+                message = callback
+            else:
+                # CallbackMessage — parse .data into ChatbotMessage
+                import json
+                data = callback.data
+                if isinstance(data, str):
+                    data = json.loads(data)
+                message = dingtalk_stream.ChatbotMessage.from_dict(data)
+            await self._adapter._on_message(message)
         except Exception:
             logger.exception("[DingTalk] Error processing incoming message")
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1846,9 +1846,9 @@ class GatewayRunner:
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
+                    logger.info("[OK] %s connected", platform.value)
                 else:
-                    logger.warning("✗ %s failed to connect", platform.value)
+                    logger.warning("[FAIL] %s failed to connect", platform.value)
                     if adapter.has_fatal_error:
                         self._update_platform_runtime_status(
                             platform.value,
@@ -9410,7 +9410,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # setups (each profile using a distinct HERMES_HOME) will naturally
     # allow concurrent instances without tripping this guard.
     import time as _time
-    from gateway.status import get_running_pid, remove_pid_file, terminate_pid
+    from gateway.status import get_running_pid, remove_pid_file, terminate_pid, is_process_alive
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
@@ -9430,15 +9430,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 return False
             # Wait up to 10 seconds for the old process to exit
             for _ in range(20):
-                try:
-                    os.kill(existing_pid, 0)
-                    _time.sleep(0.5)
-                except (ProcessLookupError, PermissionError):
+                if not is_process_alive(existing_pid):
                     break  # Process is gone
+                _time.sleep(0.5)
             else:
-                # Still alive after 10s — force kill
                 logger.warning(
-                    "Old gateway (PID %d) did not exit after SIGTERM, sending SIGKILL.",
+                    "Old gateway (PID %d) did not exit after SIGTERM, force-killing.",
                     existing_pid,
                 )
                 try:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -28,6 +28,77 @@ _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 
+# Windows has no SIGKILL; os.kill(pid, SIGTERM) on Windows is already
+# implemented as TerminateProcess, so SIGTERM is the correct force-kill
+# signal on that platform.
+FORCE_KILL_SIGNAL = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+if _IS_WINDOWS:
+    import ctypes
+    from ctypes import wintypes
+
+    _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    _STILL_ACTIVE = 259
+    _ERROR_ACCESS_DENIED = 5
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+
+def is_process_alive(pid: int) -> bool:
+    """Cross-platform PID existence check with no side effects.
+
+    Intentionally avoids ``os.kill(pid, 0)`` because CPython on Windows
+    implements that path as ``OpenProcess`` + ``TerminateProcess`` — i.e.
+    it terminates the matched process instead of just checking it.
+    """
+    if pid <= 0:
+        return False
+
+    if _IS_WINDOWS:
+        handle = _kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            # ACCESS_DENIED means the process exists but we lack permission;
+            # treat as alive so we don't clobber a valid gateway owned by
+            # another user. Any other error (notably INVALID_PARAMETER for a
+            # vanished PID) counts as dead.
+            return ctypes.get_last_error() == _ERROR_ACCESS_DENIED
+        try:
+            exit_code = wintypes.DWORD()
+            if not _kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value == _STILL_ACTIVE
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def force_kill(pid: int) -> None:
+    """SIGKILL (or equivalent) a PID, swallowing race losses.
+
+    Races with the target process exiting on its own — or Windows error
+    codes from a PID that vanished between check and kill — are treated as
+    success: the goal is "process is gone", not "we delivered the signal".
+    """
+    try:
+        os.kill(pid, FORCE_KILL_SIGNAL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
 
 def _get_pid_path() -> Path:
     """Return the path to the gateway PID file, respecting HERMES_HOME."""
@@ -327,9 +398,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
 
         stale = existing_pid is None
         if not stale:
-            try:
-                os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            if not is_process_alive(existing_pid):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -430,9 +499,7 @@ def get_running_pid() -> Optional[int]:
         remove_pid_file()
         return None
 
-    try:
-        os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    if not is_process_alive(pid):
         remove_pid_file()
         return None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -274,19 +274,18 @@ def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None,
     """
     pids = find_gateway_pids(exclude_pids=exclude_pids, all_profiles=all_profiles)
     killed = 0
-    
+
     for pid in pids:
         try:
             terminate_pid(pid, force=force)
             killed += 1
         except ProcessLookupError:
-            # Process already gone
             pass
         except PermissionError:
             print(f"⚠ Permission denied to kill PID {pid}")
-    
         except OSError as exc:
             print(f"Failed to kill PID {pid}: {exc}")
+
     return killed
 
 
@@ -298,7 +297,7 @@ def stop_profile_gateway() -> bool:
     Returns True if a process was stopped, False if none was found.
     """
     try:
-        from gateway.status import get_running_pid, remove_pid_file
+        from gateway.status import get_running_pid, remove_pid_file, is_process_alive
     except ImportError:
         return False
 
@@ -317,11 +316,9 @@ def stop_profile_gateway() -> bool:
     # Wait briefly for it to exit
     import time as _time
     for _ in range(20):
-        try:
-            os.kill(pid, 0)
-            _time.sleep(0.5)
-        except (ProcessLookupError, PermissionError):
+        if not is_process_alive(pid):
             break
+        _time.sleep(0.5)
 
     remove_pid_file()
     return True

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -304,15 +304,14 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     if not pid_file.exists():
         return False
     try:
+        from gateway.status import is_process_alive
         raw = pid_file.read_text().strip()
         if not raw:
             return False
         data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
         pid = int(data["pid"])
-        os.kill(pid, 0)  # existence check
-        return True
-    except (json.JSONDecodeError, KeyError, ValueError, TypeError,
-            ProcessLookupError, PermissionError, OSError):
+        return is_process_alive(pid)
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError, ImportError, OSError):
         return False
 
 
@@ -649,6 +648,7 @@ def _stop_gateway_process(profile_dir: Path) -> None:
     """Stop a running gateway process via its PID file."""
     import signal as _signal
     import time as _time
+    from gateway.status import is_process_alive, force_kill
 
     pid_file = profile_dir / "gateway.pid"
     if not pid_file.exists():
@@ -659,19 +659,12 @@ def _stop_gateway_process(profile_dir: Path) -> None:
         data = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
         pid = int(data["pid"])
         os.kill(pid, _signal.SIGTERM)
-        # Wait up to 10s for graceful shutdown
         for _ in range(20):
             _time.sleep(0.5)
-            try:
-                os.kill(pid, 0)
-            except ProcessLookupError:
+            if not is_process_alive(pid):
                 print(f"✓ Gateway stopped (PID {pid})")
                 return
-        # Force kill
-        try:
-            os.kill(pid, _signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+        force_kill(pid)
         print(f"✓ Gateway force-stopped (PID {pid})")
     except (ProcessLookupError, PermissionError):
         print("✓ Gateway already stopped")

--- a/run_agent.py
+++ b/run_agent.py
@@ -656,6 +656,14 @@ class AIAgent:
         self.verbose_logging = verbose_logging
         self.quiet_mode = quiet_mode
         self.ephemeral_system_prompt = ephemeral_system_prompt
+        # Identity override: injected into every user message to counteract
+        # upstream proxy-injected system prompts (e.g. OneHub/One-API presets).
+        # Configured via model.identity_override in config.yaml.
+        try:
+            from hermes_cli.config import load_config as _lc
+            self._identity_override = (_lc().get("model", {}).get("identity_override") or "").strip() or None
+        except Exception:
+            self._identity_override = None
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
         self._user_id = user_id  # Platform user identifier (gateway sessions)
         # Pluggable print function — CLI replaces this with _cprint so that
@@ -8273,6 +8281,12 @@ class AIAgent:
             # input token costs by ~75% on multi-turn conversations.
             if self._use_prompt_caching:
                 api_messages = apply_anthropic_cache_control(api_messages, cache_ttl=self._cache_ttl, native_anthropic=(self.api_mode == 'anthropic_messages'))
+
+            # Identity override: append as the LAST system message, closest
+            # to model output. This position has the strongest influence and
+            # can counteract upstream proxy-injected identity prompts.
+            if getattr(self, "_identity_override", None):
+                api_messages.append({"role": "system", "content": self._identity_override})
 
             # Safety net: strip orphaned tool results / add stubs for missing
             # results before sending to the API.  Runs unconditionally — not

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -296,10 +296,10 @@ class TestOnMessageRouting:
             "text",
             text_content="hello",
             conversation_id="conv-cache",
-            session_webhook="https://cache.example/wh",
+            session_webhook="https://api.dingtalk.com/robot/sendBySession?sessionWebhookKey=cache",
         )
         await adapter._on_message(msg)
-        assert adapter._session_webhooks["conv-cache"] == "https://cache.example/wh"
+        assert adapter._session_webhooks["conv-cache"] == "https://api.dingtalk.com/robot/sendBySession?sessionWebhookKey=cache"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -476,20 +476,13 @@ class TestFetchPictureAttachments:
     """Exercise the messageFiles/download flow via mocked SDK handler."""
 
     @staticmethod
-    def _make_adapter(get_url_return, http_content=b"\xff\xd8\xffJPEG-like"):
+    def _make_adapter(get_url_return):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
-        adapter = DingTalkAdapter(config)
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"}))
         handler = MagicMock()
         handler.get_image_download_url = MagicMock(return_value=get_url_return)
         adapter._handler = handler
-        http_resp = MagicMock()
-        http_resp.content = http_content
-        http_resp.raise_for_status = MagicMock()
-        http_client = MagicMock()
-        http_client.get = AsyncMock(return_value=http_resp)
-        adapter._http_client = http_client
-        return adapter, handler, http_client
+        return adapter, handler
 
     def test_returns_empty_when_handler_missing(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
@@ -501,52 +494,43 @@ class TestFetchPictureAttachments:
         assert urls == [] and types == []
 
     def test_downloads_and_caches_single_image(self):
-        adapter, handler, http_client = self._make_adapter("https://cdn.example/img.jpg")
+        adapter, handler = self._make_adapter("https://cdn.example/img.jpg")
         msg = MagicMock()
         msg.get_image_list.return_value = ["code1"]
-        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/cached.jpg") as cache_fn:
+        cache_fn = AsyncMock(return_value="/tmp/cached.jpg")
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", cache_fn):
             urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
         assert urls == ["/tmp/cached.jpg"]
         assert types == ["image/jpeg"]
         handler.get_image_download_url.assert_called_once_with("code1")
-        http_client.get.assert_awaited_once()
-        cache_fn.assert_called_once()
+        cache_fn.assert_awaited_once()
 
     def test_skips_codes_that_return_empty_url(self):
-        adapter, handler, http_client = self._make_adapter("")  # SDK returns "" on failure
+        adapter, handler = self._make_adapter("")  # SDK returns "" on failure
         msg = MagicMock()
         msg.get_image_list.return_value = ["code1", "code2"]
-        urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        cache_fn = AsyncMock()
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", cache_fn):
+            urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
         assert urls == [] and types == []
         assert handler.get_image_download_url.call_count == 2
-        http_client.get.assert_not_called()
+        cache_fn.assert_not_called()
 
-    def test_continues_after_single_http_failure(self):
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
-        adapter = DingTalkAdapter(config)
-        handler = MagicMock()
-        handler.get_image_download_url = MagicMock(side_effect=["https://cdn/a.jpg", "https://cdn/b.jpg"])
-        adapter._handler = handler
-
-        good_resp = MagicMock(); good_resp.content = b"img"; good_resp.raise_for_status = MagicMock()
-        http_client = MagicMock()
-        http_client.get = AsyncMock(side_effect=[Exception("network blip"), good_resp])
-        adapter._http_client = http_client
-
+    def test_continues_after_single_cache_failure(self):
+        import httpx as _httpx
+        adapter, handler = self._make_adapter(None)
+        handler.get_image_download_url.side_effect = ["https://cdn/a.jpg", "https://cdn/b.jpg"]
         msg = MagicMock()
         msg.get_image_list.return_value = ["c1", "c2"]
-        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/b.jpg"):
+        cache_fn = AsyncMock(side_effect=[_httpx.HTTPError("blip"), "/tmp/b.jpg"])
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", cache_fn):
             urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
-        # First failed, second succeeded — only one entry.
         assert urls == ["/tmp/b.jpg"]
         assert types == ["image/jpeg"]
 
     def test_on_message_picture_populates_media_urls(self):
         """End-to-end: picture msgtype flows through to MessageEvent.media_urls."""
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        adapter, handler, _http = self._make_adapter("https://cdn.example/img.jpg")
-        handler.get_image_download_url.return_value = "https://cdn.example/img.jpg"
+        adapter, handler = self._make_adapter("https://cdn.example/img.jpg")
 
         msg = MagicMock()
         msg.message_id = "m1"
@@ -566,7 +550,7 @@ class TestFetchPictureAttachments:
             captured.append(event)
         adapter.handle_message = _capture
 
-        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/pic.jpg"):
+        with patch("gateway.platforms.dingtalk.cache_image_from_url", AsyncMock(return_value="/tmp/pic.jpg")):
             asyncio.run(adapter._on_message(msg))
 
         assert len(captured) == 1

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -466,3 +466,113 @@ class TestPlatformEnum:
 
     def test_dingtalk_in_platform_enum(self):
         assert Platform.DINGTALK.value == "dingtalk"
+
+
+# ---------------------------------------------------------------------------
+# Picture attachment download
+# ---------------------------------------------------------------------------
+
+class TestFetchPictureAttachments:
+    """Exercise the messageFiles/download flow via mocked SDK handler."""
+
+    @staticmethod
+    def _make_adapter(get_url_return, http_content=b"\xff\xd8\xffJPEG-like"):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
+        adapter = DingTalkAdapter(config)
+        handler = MagicMock()
+        handler.get_image_download_url = MagicMock(return_value=get_url_return)
+        adapter._handler = handler
+        http_resp = MagicMock()
+        http_resp.content = http_content
+        http_resp.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.get = AsyncMock(return_value=http_resp)
+        adapter._http_client = http_client
+        return adapter, handler, http_client
+
+    def test_returns_empty_when_handler_missing(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"}))
+        assert adapter._handler is None
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["code1"]
+        urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        assert urls == [] and types == []
+
+    def test_downloads_and_caches_single_image(self):
+        adapter, handler, http_client = self._make_adapter("https://cdn.example/img.jpg")
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["code1"]
+        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/cached.jpg") as cache_fn:
+            urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        assert urls == ["/tmp/cached.jpg"]
+        assert types == ["image/jpeg"]
+        handler.get_image_download_url.assert_called_once_with("code1")
+        http_client.get.assert_awaited_once()
+        cache_fn.assert_called_once()
+
+    def test_skips_codes_that_return_empty_url(self):
+        adapter, handler, http_client = self._make_adapter("")  # SDK returns "" on failure
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["code1", "code2"]
+        urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        assert urls == [] and types == []
+        assert handler.get_image_download_url.call_count == 2
+        http_client.get.assert_not_called()
+
+    def test_continues_after_single_http_failure(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        config = PlatformConfig(enabled=True, extra={"client_id": "x", "client_secret": "y"})
+        adapter = DingTalkAdapter(config)
+        handler = MagicMock()
+        handler.get_image_download_url = MagicMock(side_effect=["https://cdn/a.jpg", "https://cdn/b.jpg"])
+        adapter._handler = handler
+
+        good_resp = MagicMock(); good_resp.content = b"img"; good_resp.raise_for_status = MagicMock()
+        http_client = MagicMock()
+        http_client.get = AsyncMock(side_effect=[Exception("network blip"), good_resp])
+        adapter._http_client = http_client
+
+        msg = MagicMock()
+        msg.get_image_list.return_value = ["c1", "c2"]
+        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/b.jpg"):
+            urls, types = asyncio.run(adapter._fetch_picture_attachments(msg))
+        # First failed, second succeeded — only one entry.
+        assert urls == ["/tmp/b.jpg"]
+        assert types == ["image/jpeg"]
+
+    def test_on_message_picture_populates_media_urls(self):
+        """End-to-end: picture msgtype flows through to MessageEvent.media_urls."""
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter, handler, _http = self._make_adapter("https://cdn.example/img.jpg")
+        handler.get_image_download_url.return_value = "https://cdn.example/img.jpg"
+
+        msg = MagicMock()
+        msg.message_id = "m1"
+        msg.message_type = "picture"
+        msg.conversation_id = "cid1"
+        msg.conversation_type = "2"
+        msg.sender_id = "s1"
+        msg.sender_nick = "Yoji"
+        msg.sender_staff_id = "yoji"
+        msg.conversation_title = "group"
+        msg.create_at = 1712_000_000_000
+        msg.session_webhook = None
+        msg.get_image_list.return_value = ["code1"]
+
+        captured = []
+        async def _capture(event):
+            captured.append(event)
+        adapter.handle_message = _capture
+
+        with patch("gateway.platforms.dingtalk.cache_image_from_bytes", return_value="/tmp/pic.jpg"):
+            asyncio.run(adapter._on_message(msg))
+
+        assert len(captured) == 1
+        ev = captured[0]
+        assert ev.media_urls == ["/tmp/pic.jpg"]
+        assert ev.media_types == ["image/jpeg"]
+        assert ev.text == "[图片 × 1]"
+        from gateway.platforms.base import MessageType
+        assert ev.message_type == MessageType.PHOTO

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -78,35 +78,228 @@ class TestDingTalkAdapterInit:
 # ---------------------------------------------------------------------------
 
 
+def _make_chatbot_mock(message_type: str = "", text_content=None, rich_items=None, **extra):
+    msg = MagicMock()
+    msg.message_type = message_type
+
+    if text_content is None:
+        msg.text = None
+    else:
+        msg.text = MagicMock()
+        msg.text.content = text_content
+
+    if rich_items is None:
+        msg.rich_text_content = None
+    else:
+        msg.rich_text_content = MagicMock()
+        msg.rich_text_content.rich_text_list = rich_items
+
+    for name, value in extra.items():
+        setattr(msg, name, value)
+    return msg
+
+
+_DEFAULT_DISPATCH_ATTRS = {
+    "message_id": "msg-x",
+    "conversation_type": "2",
+    "conversation_id": "conv-1",
+    "conversation_title": "Test Chat",
+    "sender_id": "sender-1",
+    "sender_nick": "Sender",
+    "sender_staff_id": "staff-1",
+    "create_at": None,
+    "session_webhook": "https://example/webhook",
+}
+
+
+def _make_dispatch_mock(message_type, *, text_content=None, rich_items=None, **overrides):
+    attrs = {**_DEFAULT_DISPATCH_ATTRS, **overrides}
+    return _make_chatbot_mock(
+        message_type,
+        text_content=text_content,
+        rich_items=rich_items,
+        **attrs,
+    )
+
+
 class TestExtractText:
 
-    def test_extracts_dict_text(self):
+    def test_plain_text_message(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = {"content": "  hello world  "}
-        msg.rich_text = None
+        msg = _make_chatbot_mock("text", text_content="  hello world  ")
         assert DingTalkAdapter._extract_text(msg) == "hello world"
 
-    def test_extracts_string_text(self):
+    def test_empty_plain_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = "plain text"
-        msg.rich_text = None
-        assert DingTalkAdapter._extract_text(msg) == "plain text"
-
-    def test_falls_back_to_rich_text(self):
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = ""
-        msg.rich_text = [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]
-        assert DingTalkAdapter._extract_text(msg) == "part1 part2"
-
-    def test_returns_empty_for_no_content(self):
-        from gateway.platforms.dingtalk import DingTalkAdapter
-        msg = MagicMock()
-        msg.text = ""
-        msg.rich_text = None
+        msg = _make_chatbot_mock("text", text_content="")
         assert DingTalkAdapter._extract_text(msg) == ""
+
+    def test_text_dict_shape_fallback(self):
+        # Older SDKs / custom handlers may pass a dict rather than TextContent.
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "text"
+        msg.text = {"content": " from dict "}
+        msg.rich_text_content = None
+        assert DingTalkAdapter._extract_text(msg) == "from dict"
+
+    def test_rich_text_concatenates_text_segments(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock(
+            "richText",
+            rich_items=[{"text": "hello"}, {"text": "world"}],
+        )
+        assert DingTalkAdapter._extract_text(msg) == "hello world"
+
+    def test_rich_text_with_inline_picture(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock(
+            "richText",
+            rich_items=[
+                {"text": "look"},
+                {"downloadCode": "abc", "type": "picture"},
+                {"text": "at this"},
+            ],
+        )
+        assert DingTalkAdapter._extract_text(msg) == "look [图片] at this"
+
+    def test_rich_text_with_at_mention(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock(
+            "richText",
+            rich_items=[
+                {"type": "at", "name": "Yoji", "userId": "u1"},
+                {"text": "hi"},
+            ],
+        )
+        assert DingTalkAdapter._extract_text(msg) == "@Yoji hi"
+
+    def test_rich_text_skips_unknown_items(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock(
+            "richText",
+            rich_items=[{"text": "keep"}, {"foo": "bar"}, "not a dict"],
+        )
+        assert DingTalkAdapter._extract_text(msg) == "keep"
+
+    def test_rich_text_with_no_items_returns_empty(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock("richText", rich_items=[])
+        assert DingTalkAdapter._extract_text(msg) == ""
+
+    def test_rich_text_missing_content_object_returns_empty(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.message_type = "richText"
+        msg.text = None
+        msg.rich_text_content = None
+        assert DingTalkAdapter._extract_text(msg) == ""
+
+    def test_picture_msgtype_returns_placeholder(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock("picture")
+        assert DingTalkAdapter._extract_text(msg) == "[图片]"
+
+    def test_unknown_msgtype_returns_marker(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock("audio")
+        assert DingTalkAdapter._extract_text(msg) == "[未支持的消息类型: audio]"
+
+    def test_missing_msgtype_falls_back_to_plain_text(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock("", text_content="salvage me")
+        assert DingTalkAdapter._extract_text(msg) == "salvage me"
+
+    def test_accepts_precomputed_msgtype(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = _make_chatbot_mock("", text_content="ignored")
+        assert DingTalkAdapter._extract_text(msg, msgtype="picture") == "[图片]"
+
+
+# ---------------------------------------------------------------------------
+# _on_message dispatch routing
+# ---------------------------------------------------------------------------
+
+
+class TestOnMessageRouting:
+
+    def _make_adapter(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        captured = []
+
+        async def fake_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = fake_handle  # type: ignore[assignment]
+        return adapter, captured
+
+    @pytest.mark.asyncio
+    async def test_plain_text_dispatches_as_text(self):
+        from gateway.platforms.base import MessageType
+        adapter, captured = self._make_adapter()
+        await adapter._on_message(_make_dispatch_mock("text", text_content="hi"))
+        assert len(captured) == 1
+        assert captured[0].text == "hi"
+        assert captured[0].message_type == MessageType.TEXT
+
+    @pytest.mark.asyncio
+    async def test_empty_text_is_skipped(self):
+        adapter, captured = self._make_adapter()
+        await adapter._on_message(_make_dispatch_mock("text", text_content=""))
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_picture_dispatches_with_photo_type(self):
+        from gateway.platforms.base import MessageType
+        adapter, captured = self._make_adapter()
+        await adapter._on_message(_make_dispatch_mock("picture"))
+        assert len(captured) == 1
+        ev = captured[0]
+        assert ev.message_type == MessageType.PHOTO
+        assert ev.text == "[图片]"
+        assert ev.source.chat_type == "group"
+
+    @pytest.mark.asyncio
+    async def test_rich_text_dispatches_with_mixed_content(self):
+        from gateway.platforms.base import MessageType
+        adapter, captured = self._make_adapter()
+        msg = _make_dispatch_mock(
+            "richText",
+            rich_items=[{"text": "see"}, {"downloadCode": "x", "type": "picture"}],
+        )
+        await adapter._on_message(msg)
+        assert len(captured) == 1
+        assert captured[0].message_type == MessageType.TEXT
+        assert captured[0].text == "see [图片]"
+
+    @pytest.mark.asyncio
+    async def test_empty_rich_text_dispatches_with_fallback_marker(self):
+        adapter, captured = self._make_adapter()
+        await adapter._on_message(_make_dispatch_mock("richText", rich_items=[]))
+        assert len(captured) == 1
+        assert "richText" in captured[0].text
+
+    @pytest.mark.asyncio
+    async def test_unknown_msgtype_still_dispatches(self):
+        from gateway.platforms.base import MessageType
+        adapter, captured = self._make_adapter()
+        await adapter._on_message(_make_dispatch_mock("audio"))
+        assert len(captured) == 1
+        assert captured[0].message_type == MessageType.TEXT
+        assert "audio" in captured[0].text
+
+    @pytest.mark.asyncio
+    async def test_session_webhook_cached_on_dispatch(self):
+        adapter, _ = self._make_adapter()
+        msg = _make_dispatch_mock(
+            "text",
+            text_content="hello",
+            conversation_id="conv-cache",
+            session_webhook="https://cache.example/wh",
+        )
+        await adapter._on_message(msg)
+        assert adapter._session_webhooks["conv-cache"] == "https://cache.example/wh"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -194,44 +194,37 @@ class TestWaitForGatewayExit:
         gateway._wait_for_gateway_exit(timeout=1.0, force_after=0.5)
 
     def test_returns_when_process_exits_gracefully(self, monkeypatch):
-        """Process exits after a couple of polls — no SIGKILL needed."""
-        poll_count = 0
+        # _wait_for_gateway_exit polls get_running_pid() each tick; it
+        # returns as soon as the PID file clears (the gateway shut down).
+        pid_calls = 0
 
-        def mock_get_running_pid():
-            nonlocal poll_count
-            poll_count += 1
-            return 12345 if poll_count <= 2 else None
+        def mock_get_pid():
+            nonlocal pid_calls
+            pid_calls += 1
+            return 12345 if pid_calls <= 2 else None
 
-        monkeypatch.setattr("gateway.status.get_running_pid", mock_get_running_pid)
+        monkeypatch.setattr("gateway.status.get_running_pid", mock_get_pid)
         monkeypatch.setattr("time.sleep", lambda _: None)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=999.0)
-        # Should have polled until None was returned.
-        assert poll_count == 3
+        assert pid_calls == 3
 
     def test_force_kills_after_grace_period(self, monkeypatch):
         """When the process doesn't exit, force-kill the saved PID."""
 
-        # Simulate monotonic time advancing past force_after
         call_num = 0
         def fake_monotonic():
             nonlocal call_num
             call_num += 1
-            # First two calls: initial deadline + force_deadline setup (time 0)
-            # Then each loop iteration advances time
-            return call_num * 2.0  # 2, 4, 6, 8, ...
+            return call_num * 2.0
 
         kills = []
         def mock_terminate(pid, force=False):
             kills.append((pid, force))
 
-        # get_running_pid returns the PID until kill is sent, then None
-        def mock_get_running_pid():
-            return None if kills else 42
-
         monkeypatch.setattr("time.monotonic", fake_monotonic)
         monkeypatch.setattr("time.sleep", lambda _: None)
-        monkeypatch.setattr("gateway.status.get_running_pid", mock_get_running_pid)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
         monkeypatch.setattr(gateway, "terminate_pid", mock_terminate)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=5.0)
@@ -254,7 +247,6 @@ class TestWaitForGatewayExit:
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 99)
         monkeypatch.setattr(gateway, "terminate_pid", mock_terminate)
 
-        # Should not raise — ProcessLookupError means it's already gone.
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=2.0)
 
     def test_kill_gateway_processes_force_uses_helper(self, monkeypatch):

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -799,24 +799,21 @@ class TestEdgeCases:
         assert default.skill_count == 0
 
     def test_gateway_running_check_with_pid_file(self, profile_env):
-        """Verify _check_gateway_running reads pid file and probes os.kill."""
         from hermes_cli.profiles import _check_gateway_running
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
 
-        # No pid file -> not running
         assert _check_gateway_running(default_home) is False
 
-        # Write a PID file with a JSON payload
         pid_file = default_home / "gateway.pid"
         pid_file.write_text(json.dumps({"pid": 99999}))
-
-        # os.kill(99999, 0) should raise ProcessLookupError -> not running
         assert _check_gateway_running(default_home) is False
 
-        # Mock os.kill to simulate a running process
-        with patch("os.kill", return_value=None):
-            assert _check_gateway_running(default_home) is True
+        # Use the test's own PID as a guaranteed-live target; this exercises
+        # the cross-platform is_process_alive path without patching os.kill
+        # (which wouldn't intercept the Windows ctypes OpenProcess branch).
+        pid_file.write_text(json.dumps({"pid": os.getpid()}))
+        assert _check_gateway_running(default_home) is True
 
     def test_gateway_running_check_plain_pid(self, profile_env):
         """Pid file containing just a number (legacy format)."""
@@ -824,10 +821,9 @@ class TestEdgeCases:
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
         pid_file = default_home / "gateway.pid"
-        pid_file.write_text("99999")
+        pid_file.write_text(str(os.getpid()))
 
-        with patch("os.kill", return_value=None):
-            assert _check_gateway_running(default_home) is True
+        assert _check_gateway_running(default_home) is True
 
     def test_profile_name_boundary_single_char(self):
         """Single alphanumeric character is valid."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2237,16 +2237,15 @@ def _kill_orphaned_mcp_children() -> None:
 
     Only kills PIDs tracked in ``_stdio_pids`` — never arbitrary children.
     """
-    import signal as _signal
-    kill_signal = getattr(_signal, "SIGKILL", _signal.SIGTERM)
-
     with _lock:
         pids = list(_stdio_pids)
         _stdio_pids.clear()
 
+    from gateway.status import terminate_pid
+
     for pid in pids:
         try:
-            os.kill(pid, kill_signal)
+            terminate_pid(pid, force=True)
             logger.debug("Force-killed orphaned MCP stdio process %d", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass  # Already exited or inaccessible

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
+from gateway.status import is_process_alive
 
 logger = logging.getLogger(__name__)
 
@@ -229,13 +230,7 @@ class ProcessRegistry:
     @staticmethod
     def _is_host_pid_alive(pid: Optional[int]) -> bool:
         """Best-effort liveness check for host-visible PIDs."""
-        if not pid:
-            return False
-        try:
-            os.kill(pid, 0)
-            return True
-        except (ProcessLookupError, PermissionError):
-            return False
+        return bool(pid) and is_process_alive(pid)
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
         """Update recovered host-PID sessions when the underlying process has exited."""


### PR DESCRIPTION
## What does this PR do?

Adds inbound `msgtype=file` handling for the DingTalk Stream adapter. Files sent to the bot are downloaded via the existing `robot/messageFiles/download` OpenAPI and surfaced to the agent as cached local paths, mirroring the picture flow from #8988.

Before this change, DingTalk file messages arrived as `[未支持的消息类型: file]` placeholders — the agent saw that something arrived but could not read the content.

## Related Issue

Fixes N/A (user-requested feature)

## Dependencies

⚠️ **This PR is stacked on top of in-flight work.** Build-clean requires:
- #8988 (picture download) — provides the `_fetch_picture_attachments` / `_PICTURE_PLACEHOLDER` scaffolding this PR parallels
- #8960 (env-based config) and #8957 (oapi webhook) — prerequisite DingTalk fixes

Opening as **Draft** until #8988 lands; at that point this branch rebases to a single self-contained commit.

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made
- `gateway/platforms/dingtalk.py`: `_fetch_file_attachment()` helper + dispatch in `_on_message`, POSIX-form local path
- Reuses SDK's `get_image_download_url` — despite the name, it hits the same `/v1.0/robot/messageFiles/download` endpoint which serves files and pictures uniformly
- Streams body via `httpx.AsyncClient.stream` + `aiter_bytes` with a 32 MB cap enforced pre-download (Content-Length) and mid-stream
- Caches bytes via existing `cache_document_from_bytes` in base.py
- Drops `is_safe_url` SSRF guard on this path: URL is signed by DingTalk's authenticated API (single-user agent model); the guard also trips on CN gaming accelerators remapping `aliyuncs.com` to `198.18.0.0/15` virtual IPs

## How to Test
1. Start gateway with DingTalk adapter connected
2. Send any file (PDF, .md, .xlsx etc. < 32 MB) to the bot via DM or at-mention
3. Expect log: `[Dingtalk] Cached inbound file <name> (N bytes) -> /path/to/cache`
4. Agent's `MessageEvent.media_urls` contains the POSIX local path; `message_type=DOCUMENT`

## Checklist
- [x] Commit messages follow Conventional Commits
- [x] `pytest tests/gateway/test_dingtalk.py` — 42/42 pass
- [x] Tested on Windows 11 (WSL bash tool environment for the agent)
- [x] N/A for config keys / new skills / tool schema changes
- [x] Searched existing PRs — this stacks on #8988 in the same module

## Platform
Windows 11 Pro, Python 3.13, dingtalk-stream SDK 0.24+