### PR TITLE
fix(pairing): enforce lockout check in approve_code() to prevent brute-force bypass

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -194,11 +194,17 @@ class PairingStore:
         """
         Approve a pairing code. Adds the user to the approved list.
 
-        Returns {user_id, user_name} on success, None if code is invalid/expired.
+        Returns {user_id, user_name} on success, None if code is invalid/expired
+        or the platform is currently locked out due to too many failed attempts.
         """
         with self._lock:
             self._cleanup_expired(platform)
             code = code.upper().strip()
+
+            # Check lockout before validating the code — prevents brute-force
+            # bypass by guessing or reusing a valid code during lockout.
+            if self._is_locked_out(platform):
+                return None
 
             pending = self._load_json(self._pending_path(platform))
             if code not in pending:

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -252,6 +252,27 @@ class TestLockout:
 
             assert store._is_locked_out("telegram") is False
 
+    def test_lockout_blocks_valid_code_approval(self, tmp_path):
+        """A valid pairing code must NOT be approved while the platform is locked out."""
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            valid_code = store.generate_code("telegram", "user1", "Alice")
+            assert valid_code is not None
+
+            # Exhaust failed attempts to trigger lockout
+            for _ in range(MAX_FAILED_ATTEMPTS):
+                result = store.approve_code("telegram", "WRONGCODE")
+                assert result is None
+
+            assert store._is_locked_out("telegram") is True
+
+            # Attempting to approve the valid code during lockout must fail
+            result = store.approve_code("telegram", valid_code)
+            assert result is None
+
+            # User should NOT be added to the approved list
+            assert store.is_approved("telegram", "user1") is False
+
 
 # ---------------------------------------------------------------------------
 # Code expiry


### PR DESCRIPTION
## Summary

Fixes a security issue where the DM pairing lockout mechanism could be bypassed by submitting a valid pairing code during lockout.

### Problem

`PairingStore.approve_code()` did not check whether the platform was currently locked out before validating a pairing code. After 5 failed approval attempts, a platform enters a 1-hour lockout (`_is_locked_out() == True`). However, an attacker who had obtained or guessed a pending valid pairing code could still call `approve_code()` successfully **during the lockout period**, gaining unauthorized access to the bot. This effectively nullified the brute-force protection.

### Fix

Added a `_is_locked_out(platform)` guard in `approve_code()` right after `_cleanup_expired()` and before looking up the pending code. If the platform is locked out, the method returns `None` immediately.

### Test

Added `test_lockout_blocks_valid_code_approval` in `tests/gateway/test_pairing.py` which verifies that:
1. 5 failed attempts trigger lockout.
2. A previously-generated valid pairing code is **rejected** during lockout.
3. The user is **not** added to the approved list.

All 29 pairing tests pass.

### Related Issue

Fixes #10195

### Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added/updated tests
- [x] Security impact assessed