### PR TITLE
fix: add base_url fallback for copilot provider in credential pool resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,6 +14,7 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_GITHUB_MODELS_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
@@ -167,6 +168,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider


### PR DESCRIPTION
## Summary
GitHub Copilot provider fails to start with "empty base URL" error when credentials are resolved via the credential pool path.

## Root Cause
In `_resolve_runtime_from_pool_entry()`, the `copilot` branch sets `api_mode` but never provides a fallback `base_url`. When the credential pool entry has no explicit `base_url`, it remains `None`, gets coerced to empty string, and the startup fails. Other providers (anthropic, openrouter, qwen-oauth, openai-codex) all have fallback URLs in this same function.

## Fix
Added `base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL` in the copilot branch (`hermes_cli/runtime_provider.py`), matching the established pattern for other providers.

## Test Plan
- [ ] `hermes` starts successfully with `model.provider: copilot` when using credential pool auth
- [ ] `hermes model` continues to work
- [ ] Copilot chat requests succeed

Closes NousResearch/hermes-agent#10223