### PR TITLE
feat: add gateway restart --all

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -104,6 +104,139 @@ def _get_service_pids() -> set:
     return pids
 
 
+def _list_systemd_gateway_services() -> list[tuple[bool, str]]:
+    """Return ``(system_scope, service_name)`` for installed gateway units."""
+    services: list[tuple[bool, str]] = []
+    seen: set[tuple[bool, str]] = set()
+
+    if not supports_systemd_services():
+        return services
+
+    for system in (False, True):
+        try:
+            result = subprocess.run(
+                _systemctl_cmd(system) + [
+                    "list-units",
+                    "hermes-gateway*",
+                    "--plain",
+                    "--no-legend",
+                    "--no-pager",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, RuntimeError):
+            continue
+
+        for line in result.stdout.strip().splitlines():
+            parts = line.split()
+            if not parts:
+                continue
+            unit = parts[0]
+            if not unit.endswith(".service"):
+                continue
+            entry = (system, unit.removesuffix(".service"))
+            if entry not in seen:
+                services.append(entry)
+                seen.add(entry)
+
+    return services
+
+
+def _list_launchd_gateway_labels() -> list[str]:
+    """Return launchd gateway labels for the default profile and named profiles."""
+    if not is_macos():
+        return []
+
+    launch_agents_dir = get_launchd_plist_path().parent
+    if not launch_agents_dir.exists():
+        return []
+
+    return [plist_path.stem for plist_path in sorted(launch_agents_dir.glob("ai.hermes.gateway*.plist"))]
+
+
+def restart_all_gateways() -> tuple[list[str], set[int], list[str]]:
+    """Restart every installed gateway service and stop manual gateways."""
+    restarted_services: list[str] = []
+    stopped_manual_pids: set[int] = set()
+    failed_services: list[str] = []
+
+    if supports_systemd_services():
+        for system, service_name in _list_systemd_gateway_services():
+            try:
+                check = _run_systemctl(
+                    ["is-active", service_name],
+                    system=system,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=False,
+                )
+            except RuntimeError:
+                continue
+
+            if check.stdout.strip() != "active":
+                continue
+
+            try:
+                restart = _run_systemctl(
+                    ["restart", service_name],
+                    system=system,
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    check=False,
+                )
+            except RuntimeError as exc:
+                failed_services.append(f"{service_name}: {exc}")
+                continue
+
+            if restart.returncode == 0:
+                restarted_services.append(service_name)
+            else:
+                stderr = (restart.stderr or restart.stdout or f"exit {restart.returncode}").strip()
+                failed_services.append(f"{service_name}: {stderr}")
+
+    if is_macos():
+        current_label = get_launchd_label()
+        for label in _list_launchd_gateway_labels():
+            try:
+                check = subprocess.run(
+                    ["launchctl", "list", label],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+
+            if check.returncode != 0:
+                continue
+
+            try:
+                if label == current_label:
+                    launchd_restart()
+                else:
+                    target = f"{_launchd_domain()}/{label}"
+                    subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+                restarted_services.append(label)
+            except subprocess.CalledProcessError as exc:
+                stderr = (getattr(exc, "stderr", "") or getattr(exc, "stdout", "") or str(exc)).strip()
+                failed_services.append(f"{label}: {stderr}")
+
+    service_pids = _get_service_pids()
+    manual_pids = find_gateway_pids(exclude_pids=service_pids, all_profiles=True)
+    for pid in manual_pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            stopped_manual_pids.add(pid)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    return restarted_services, stopped_manual_pids, failed_services
+
+
 def _get_parent_pid(pid: int) -> int | None:
     """Return the parent PID for ``pid``, or ``None`` when unavailable."""
     if pid <= 1:
@@ -2946,6 +3079,24 @@ def gateway_command(args):
                 print(f"✓ Stopped {get_service_name()} service")
     
     elif subcmd == "restart":
+        if getattr(args, 'all', False):
+            restarted_services, killed_pids, failed_services = restart_all_gateways()
+
+            if restarted_services or killed_pids or failed_services:
+                print()
+                for svc in restarted_services:
+                    print(f"  ✓ Restarted {svc}")
+                for failure in failed_services:
+                    print(f"  ⚠ Failed to restart {failure}")
+                if killed_pids:
+                    print(f"  → Stopped {len(killed_pids)} manual gateway process(es)")
+                    print("    Restart manually: hermes gateway run")
+                    if len(killed_pids) > 1:
+                        print("    (or: hermes -p <profile> gateway run  for each profile)")
+            else:
+                print("✗ No gateway processes found")
+            return
+
         # Try service first, fall back to killing and restarting
         service_available = False
         system = getattr(args, 'system', False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3993,102 +3993,21 @@ def cmd_update(args):
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
         try:
-            from hermes_cli.gateway import (
-                is_macos, supports_systemd_services, _ensure_user_systemd_env,
-                find_gateway_pids,
-                _get_service_pids,
-            )
-            import signal as _signal
+            from hermes_cli.gateway import restart_all_gateways
 
-            restarted_services = []
-            killed_pids = set()
+            restarted_services, killed_pids, failed_services = restart_all_gateways()
 
-            # --- Systemd services (Linux) ---
-            # Discover all hermes-gateway* units (default + profiles)
-            if supports_systemd_services():
-                try:
-                    _ensure_user_systemd_env()
-                except Exception:
-                    pass
-
-                for scope, scope_cmd in [("user", ["systemctl", "--user"]), ("system", ["systemctl"])]:
-                    try:
-                        result = subprocess.run(
-                            scope_cmd + ["list-units", "hermes-gateway*", "--plain", "--no-legend", "--no-pager"],
-                            capture_output=True, text=True, timeout=10,
-                        )
-                        for line in result.stdout.strip().splitlines():
-                            parts = line.split()
-                            if not parts:
-                                continue
-                            unit = parts[0]  # e.g. hermes-gateway.service or hermes-gateway-coder.service
-                            if not unit.endswith(".service"):
-                                continue
-                            svc_name = unit.removesuffix(".service")
-                            # Check if active
-                            check = subprocess.run(
-                                scope_cmd + ["is-active", svc_name],
-                                capture_output=True, text=True, timeout=5,
-                            )
-                            if check.stdout.strip() == "active":
-                                restart = subprocess.run(
-                                    scope_cmd + ["restart", svc_name],
-                                    capture_output=True, text=True, timeout=15,
-                                )
-                                if restart.returncode == 0:
-                                    restarted_services.append(svc_name)
-                                else:
-                                    print(f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}")
-                    except (FileNotFoundError, subprocess.TimeoutExpired):
-                        pass
-
-            # --- Launchd services (macOS) ---
-            if is_macos():
-                try:
-                    from hermes_cli.gateway import launchd_restart, get_launchd_label, get_launchd_plist_path
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True, text=True, timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
-                    pass
-
-            # --- Manual (non-service) gateways ---
-            # Kill any remaining gateway processes not managed by a service.
-            # Exclude PIDs that belong to just-restarted services so we don't
-            # immediately kill the process that systemd/launchd just spawned.
-            service_pids = _get_service_pids()
-            manual_pids = find_gateway_pids(exclude_pids=service_pids, all_profiles=True)
-            for pid in manual_pids:
-                try:
-                    os.kill(pid, _signal.SIGTERM)
-                    killed_pids.add(pid)
-                except (ProcessLookupError, PermissionError):
-                    pass
-
-            if restarted_services or killed_pids:
+            if restarted_services or killed_pids or failed_services:
                 print()
                 for svc in restarted_services:
                     print(f"  ✓ Restarted {svc}")
+                for failure in failed_services:
+                    print(f"  ⚠ Failed to restart {failure}")
                 if killed_pids:
                     print(f"  → Stopped {len(killed_pids)} manual gateway process(es)")
                     print("    Restart manually: hermes gateway run")
-                    # Also restart for each profile if needed
                     if len(killed_pids) > 1:
                         print("    (or: hermes -p <profile> gateway run  for each profile)")
-
-            if not restarted_services and not killed_pids:
-                # No gateways were running — nothing to do
-                pass
 
         except Exception as e:
             logger.debug("Gateway restart during update failed: %s", e)
@@ -4720,6 +4639,7 @@ For more help on a command:
     # gateway restart
     gateway_restart = gateway_subparsers.add_parser("restart", help="Restart gateway service")
     gateway_restart.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_restart.add_argument("--all", action="store_true", help="Restart all gateway services across all profiles and stop manual gateway processes")
     
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -179,6 +179,36 @@ def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeyp
     assert calls == [(True, True, "alice")]
 
 
+def test_gateway_restart_all_prints_restarted_services_and_manual_restart_hint(monkeypatch, capsys):
+    monkeypatch.setattr(
+        gateway,
+        "restart_all_gateways",
+        lambda: (
+            ["hermes-gateway", "hermes-gateway-writer"],
+            {4321},
+            ["hermes-gateway-broken: Permission denied"],
+        ),
+    )
+
+    gateway.gateway_command(SimpleNamespace(gateway_command="restart", all=True, system=False))
+
+    out = capsys.readouterr().out
+    assert "Restarted hermes-gateway" in out
+    assert "Restarted hermes-gateway-writer" in out
+    assert "Failed to restart hermes-gateway-broken: Permission denied" in out
+    assert "Stopped 1 manual gateway process(es)" in out
+    assert "Restart manually: hermes gateway run" in out
+
+
+def test_gateway_restart_all_reports_when_nothing_is_running(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "restart_all_gateways", lambda: ([], set(), []))
+
+    gateway.gateway_command(SimpleNamespace(gateway_command="restart", all=True, system=False))
+
+    out = capsys.readouterr().out
+    assert "No gateway processes found" in out
+
+
 # ---------------------------------------------------------------------------
 # _wait_for_gateway_exit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `hermes gateway restart --all` to restart every running gateway service across profiles
- extract shared restart-all logic so `hermes update` and the new CLI flag use the same implementation
- add gateway CLI tests covering the new restart-all output paths

## Test Plan
- `python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_update_gateway_restart.py`
- `python -m pytest tests/hermes_cli/test_gateway.py -k 'restart_all'`
- `python -m hermes_cli.main gateway restart --help`
