### PR TITLE
feat: run topic capture via direct cli commands

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -682,6 +682,13 @@ class MessageEvent:
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
+
+    # Optional topic-bound deterministic capture command. This should be a direct
+    # CLI argv list (or a simple command string), not a script-path hook.
+    topic_capture_command: Optional[list[str] | str] = None
+
+    # Optional topic-bound workspace root for the full agent turn.
+    topic_cwd: Optional[str] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2680,12 +2680,16 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id_str = str(thread_id_raw) if thread_id_raw else None
         chat_topic = None
         topic_skill = None
+        topic_capture_command = None
+        topic_cwd = None
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
             if topic_info:
                 chat_topic = topic_info.get("name")
                 topic_skill = topic_info.get("skill")
+                topic_capture_command = topic_info.get("capture_command")
+                topic_cwd = topic_info.get("cwd")
 
             # Also check forum_topic_created service message for topic discovery
             if hasattr(message, "forum_topic_created") and message.forum_topic_created:
@@ -2705,6 +2709,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         if tid is not None and str(tid) == thread_id_str:
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
+                            topic_capture_command = topic.get("capture_command")
+                            topic_cwd = topic.get("cwd")
                             break
                     break
 
@@ -2735,6 +2741,8 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
+            topic_capture_command=topic_capture_command,
+            topic_cwd=topic_cwd,
             timestamp=message.date,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19,11 +19,13 @@ import logging
 import os
 import re
 import shlex
+import subprocess
 import sys
 import signal
 import tempfile
 import threading
 import time
+from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
@@ -3089,6 +3091,101 @@ class GatewayRunner:
 
         return message_text
 
+    async def _maybe_apply_topic_capture_command(self, event: MessageEvent, source: SessionSource) -> None:
+        command = getattr(event, "topic_capture_command", None)
+        if not command or not (event.text or "").strip() or event.is_command():
+            return
+
+        if isinstance(command, str):
+            command_argv = shlex.split(command)
+        elif isinstance(command, (list, tuple)):
+            command_argv = [str(part) for part in command]
+        else:
+            logger.warning("[Gateway] Topic capture command must be a list or string: %r", command)
+            return
+
+        cwd_raw = getattr(event, "topic_cwd", None) or os.getenv("MESSAGING_CWD") or str(Path.home())
+        cwd_path = Path(cwd_raw).expanduser().resolve()
+        if not cwd_path.exists():
+            logger.warning("[Gateway] Topic cwd does not exist: %s", cwd_path)
+            return
+
+        timestamp = getattr(event, "timestamp", None)
+        first_seen_at = None
+        if isinstance(timestamp, datetime):
+            try:
+                first_seen_at = timestamp.astimezone().isoformat(timespec="seconds")
+            except Exception:
+                first_seen_at = timestamp.isoformat()
+
+        message_ref = None
+        if source.platform and source.chat_id and event.message_id:
+            platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+            message_ref = f"{platform_name}:{source.chat_id}:{event.message_id}"
+
+        full_command = list(command_argv)
+        if "--json" not in full_command and "--plain" not in full_command:
+            full_command.append("--json")
+        if "--from-file" not in full_command:
+            full_command.extend(["--from-file", "-"])
+        if "--repo-root" not in full_command and getattr(event, "topic_cwd", None):
+            full_command.extend(["--repo-root", str(cwd_path)])
+        if first_seen_at and "--first-seen-at" not in full_command:
+            full_command.extend(["--first-seen-at", first_seen_at])
+        if source.thread_id and "--thread" not in full_command:
+            full_command.extend(["--thread", str(source.thread_id)])
+        if message_ref and "--message-ref" not in full_command:
+            full_command.extend(["--message-ref", message_ref])
+
+        try:
+            completed = await asyncio.to_thread(
+                subprocess.run,
+                full_command,
+                input=event.text,
+                capture_output=True,
+                text=True,
+                cwd=str(cwd_path),
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.warning("[Gateway] Topic capture command failed to run: %s", exc)
+            return
+
+        if completed.returncode != 0:
+            logger.warning(
+                "[Gateway] Topic capture command exited non-zero (%s): %s",
+                completed.returncode,
+                (completed.stderr or completed.stdout or "").strip(),
+            )
+            return
+
+        raw_output = (completed.stdout or "").strip()
+        if not raw_output:
+            return
+
+        try:
+            result = json.loads(raw_output)
+        except Exception as exc:
+            logger.warning("[Gateway] Topic capture command emitted invalid JSON: %s", exc)
+            return
+
+        event.text = self._format_topic_capture_command_message(event.text, result)
+
+    @staticmethod
+    def _format_topic_capture_command_message(original_text: str, result: dict[str, Any]) -> str:
+        next_steps = result.get("agent_next_steps") or []
+        steps_block = "\n".join(f"- {step}" for step in next_steps) if next_steps else "- none"
+        return (
+            "[Topic capture command ran before this turn. Use its results as grounded context; do not redo the deterministic capture unless needed.]\n"
+            f"- Route: {result.get('route', 'unknown')}\n"
+            f"- Requires follow-up: {'yes' if result.get('requires_agent_followup') else 'no'}\n"
+            f"- Handoff: {result.get('agent_handoff', 'none')}\n"
+            "- Suggested next steps:\n"
+            f"{steps_block}\n\n"
+            "Original user message:\n"
+            f"{original_text}"
+        )
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -3099,6 +3196,8 @@ class GatewayRunner:
             _platform_name, source.user_name or source.user_id or "unknown",
             source.chat_id or "unknown", _msg_preview,
         )
+
+        await self._maybe_apply_topic_capture_command(event, source)
 
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
@@ -3121,7 +3220,10 @@ class GatewayRunner:
         context = build_session_context(source, self.config, session_entry)
         
         # Set session context variables for tools (task-local, concurrency-safe)
-        _session_env_tokens = self._set_session_env(context)
+        _session_env_tokens = self._set_session_env(
+            context,
+            terminal_cwd=getattr(event, "topic_cwd", None) or "",
+        )
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -3561,6 +3663,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                terminal_cwd=getattr(event, "topic_cwd", None) or "",
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -5379,7 +5482,8 @@ class GatewayRunner:
                 )
 
             loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            _ctx = copy_context()
+            result = await loop.run_in_executor(None, _ctx.run, run_sync)
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -5562,7 +5666,8 @@ class GatewayRunner:
                 )
 
             loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            _ctx = copy_context()
+            result = await loop.run_in_executor(None, _ctx.run, run_sync)
 
             response = (result.get("final_response") or "") if result else ""
             if not response and result and result.get("error"):
@@ -6963,7 +7068,7 @@ class GatewayRunner:
         finally:
             notify_path.unlink(missing_ok=True)
 
-    def _set_session_env(self, context: SessionContext) -> list:
+    def _set_session_env(self, context: SessionContext, terminal_cwd: str = "") -> list:
         """Set session context variables for the current async task.
 
         Uses ``contextvars`` instead of ``os.environ`` so that concurrent
@@ -6981,6 +7086,7 @@ class GatewayRunner:
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            terminal_cwd=terminal_cwd or "",
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -7325,6 +7431,7 @@ class GatewayRunner:
         runtime: dict,
         enabled_toolsets: list,
         ephemeral_prompt: str,
+        terminal_cwd: str = "",
     ) -> str:
         """Compute a stable string key from agent config values.
 
@@ -7353,6 +7460,7 @@ class GatewayRunner:
                 # reasoning_config excluded — it's set per-message on the
                 # cached agent and doesn't affect system prompt or tools.
                 ephemeral_prompt or "",
+                terminal_cwd or "",
             ],
             sort_keys=True,
             default=str,
@@ -7402,6 +7510,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        terminal_cwd: str = "",
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -7736,6 +7845,7 @@ class GatewayRunner:
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
+            os.environ["HERMES_TERMINAL_CWD"] = terminal_cwd or ""
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
@@ -7869,6 +7979,7 @@ class GatewayRunner:
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
+                terminal_cwd or "",
             )
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
@@ -8667,6 +8778,9 @@ class GatewayRunner:
                     if next_message is None:
                         return result
                     next_message_id = getattr(pending_event, "message_id", None)
+                    next_terminal_cwd = getattr(pending_event, "topic_cwd", None) or terminal_cwd
+                else:
+                    next_terminal_cwd = terminal_cwd
 
                 return await self._run_agent(
                     message=next_message,
@@ -8677,6 +8791,7 @@ class GatewayRunner:
                     session_key=session_key,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
+                    terminal_cwd=next_terminal_cwd,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -49,6 +49,7 @@ _SESSION_THREAD_ID: ContextVar[str] = ContextVar("HERMES_SESSION_THREAD_ID", def
 _SESSION_USER_ID: ContextVar[str] = ContextVar("HERMES_SESSION_USER_ID", default="")
 _SESSION_USER_NAME: ContextVar[str] = ContextVar("HERMES_SESSION_USER_NAME", default="")
 _SESSION_KEY: ContextVar[str] = ContextVar("HERMES_SESSION_KEY", default="")
+_SESSION_TERMINAL_CWD: ContextVar[str] = ContextVar("HERMES_SESSION_TERMINAL_CWD", default="")
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -58,6 +59,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
+    "HERMES_SESSION_TERMINAL_CWD": _SESSION_TERMINAL_CWD,
 }
 
 
@@ -69,6 +71,7 @@ def set_session_vars(
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
+    terminal_cwd: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -86,6 +89,7 @@ def set_session_vars(
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
+        _SESSION_TERMINAL_CWD.set(terminal_cwd),
     ]
     return tokens
 
@@ -102,6 +106,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,
+        _SESSION_TERMINAL_CWD,
     ]
     for var, token in zip(vars_in_order, tokens):
         var.reset(token)
@@ -126,3 +131,11 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def get_terminal_cwd(default: str = "") -> str:
+    value = _SESSION_TERMINAL_CWD.get()
+    if value:
+        return value
+    import os
+    return os.getenv("TERMINAL_CWD", default)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1411,8 +1411,10 @@ class AIAgent:
             except Exception as _ce_err:
                 logger.debug("Context engine on_session_start: %s", _ce_err)
 
+        from gateway.session_context import get_terminal_cwd as _get_terminal_cwd
+
         self._subdirectory_hints = SubdirectoryHintTracker(
-            working_dir=os.getenv("TERMINAL_CWD") or None,
+            working_dir=_get_terminal_cwd() or None,
         )
         self._user_turn_count = 0
 
@@ -3244,7 +3246,9 @@ class AIAgent:
             # mode).  The gateway process runs from the hermes-agent install
             # dir, so os.getcwd() would pick up the repo's AGENTS.md and
             # other dev files — inflating token usage by ~10k for no benefit.
-            _context_cwd = os.getenv("TERMINAL_CWD") or None
+            from gateway.session_context import get_terminal_cwd as _get_terminal_cwd
+
+            _context_cwd = _get_terminal_cwd() or None
             context_files_prompt = build_context_files_prompt(
                 cwd=_context_cwd, skip_soul=_soul_loaded)
             if context_files_prompt:
@@ -7022,7 +7026,9 @@ class AIAgent:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
-                        cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        from gateway.session_context import get_terminal_cwd as _get_terminal_cwd
+
+                        cwd = function_args.get("workdir") or _get_terminal_cwd(os.getcwd())
                         self._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )
@@ -7279,7 +7285,9 @@ class AIAgent:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
-                        cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        from gateway.session_context import get_terminal_cwd as _get_terminal_cwd
+
+                        cwd = function_args.get("workdir") or _get_terminal_cwd(os.getcwd())
                         self._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -544,6 +544,63 @@ def test_group_topic_skill_binding_second_topic():
     assert event.source.chat_topic == "Sales"
 
 
+def test_group_topic_cwd_binding_sets_topic_cwd():
+    """Group topic cwd config should be attached to the event."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {
+                    "name": "dm.core",
+                    "thread_id": 1094,
+                    "cwd": "/Users/dongming/projects/dming.brain",
+                },
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=1094,
+        text="implement this",
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.topic_cwd == "/Users/dongming/projects/dming.brain"
+
+
+def test_group_topic_capture_command_binding_sets_command():
+    """Group topic capture_command should be attached to the event."""
+    from gateway.platforms.base import MessageType
+
+    command = ["uv", "run", "brain", "capture", "--topic", "knowledge"]
+    adapter = _make_adapter(group_topics_config=[
+        {
+            "chat_id": -1001234567890,
+            "topics": [
+                {
+                    "name": "Knowledge",
+                    "thread_id": 14,
+                    "capture_command": command,
+                },
+            ],
+        }
+    ])
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=14,
+        text="https://example.com/article",
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.topic_capture_command == command
+
+
 def test_group_topic_no_skill_binding():
     """Group topic without a skill key should have auto_skill=None but set chat_topic."""
     from gateway.platforms.base import MessageType

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -6,6 +6,7 @@ from gateway.run import GatewayRunner
 from gateway.session import SessionContext, SessionSource
 from gateway.session_context import (
     get_session_env,
+    get_terminal_cwd,
     set_session_vars,
     clear_session_vars,
 )
@@ -169,8 +170,9 @@ def test_session_key_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_KEY") == "env-session-123"
 
 
-def test_set_session_env_includes_session_key():
+def test_set_session_env_includes_session_key(monkeypatch):
     """_set_session_env should propagate session_key from SessionContext."""
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     runner = object.__new__(GatewayRunner)
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -190,6 +192,33 @@ def test_set_session_env_includes_session_key():
     assert get_session_env("HERMES_SESSION_KEY") == "tg:-1001:17585"
     runner._clear_session_env(tokens)
     assert get_session_env("HERMES_SESSION_KEY") == ""
+
+
+def test_set_session_env_propagates_topic_terminal_cwd(monkeypatch):
+    """Topic-scoped cwd should flow into session context for this message."""
+    runner = object.__new__(GatewayRunner)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_name="Group",
+        chat_type="group",
+        thread_id="1094",
+    )
+    context = SessionContext(source=source, connected_platforms=[], home_channels={})
+
+    monkeypatch.setenv("TERMINAL_CWD", "/fallback/global")
+
+    tokens = runner._set_session_env(context, terminal_cwd="/repo/root")
+    try:
+        assert get_terminal_cwd() == "/repo/root"
+    finally:
+        runner._clear_session_env(tokens)
+
+
+def test_get_terminal_cwd_falls_back_to_terminal_env(monkeypatch):
+    """Without a session override, terminal cwd should fall back to TERMINAL_CWD."""
+    monkeypatch.setenv("TERMINAL_CWD", "/global/cwd")
+    assert get_terminal_cwd() == "/global/cwd"
 
 
 def test_session_key_no_race_condition_with_contextvars(monkeypatch):

--- a/tests/gateway/test_topic_capture_command.py
+++ b/tests/gateway/test_topic_capture_command.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001234567890",
+        chat_name="Mingdom",
+        chat_type="group",
+        thread_id="14",
+        chat_topic="Knowledge",
+        user_id="42",
+        user_name="Dong",
+    )
+
+
+def _make_event(text: str = "https://example.com/article") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="77",
+        timestamp=datetime(2026, 4, 14, 21, 0, 0),
+        topic_cwd="/Users/dongming/projects/dming.brain",
+        topic_capture_command=["uv", "run", "brain", "capture", "--topic", "knowledge"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_topic_capture_command_runs_cli_and_rewrites_event_text():
+    runner = object.__new__(GatewayRunner)
+    event = _make_event()
+
+    completed = SimpleNamespace(
+        returncode=0,
+        stdout=(
+            '{"route":"shared_link_ingest","requires_agent_followup":false,'
+            '"agent_handoff":"stored link","agent_next_steps":["none"]}'
+        ),
+        stderr="",
+    )
+
+    with patch("gateway.run.asyncio.to_thread", return_value=completed) as to_thread:
+        await runner._maybe_apply_topic_capture_command(event, event.source)
+
+    assert "Topic capture command ran before this turn" in event.text
+    assert "Original user message:" in event.text
+    assert "https://example.com/article" in event.text
+
+    called = to_thread.call_args
+    assert called is not None
+    assert called.args[0].__name__ == "run"
+    command = called.args[1]
+    assert command[:6] == ["uv", "run", "brain", "capture", "--topic", "knowledge"]
+    assert "--json" in command
+    assert "--from-file" in command
+    assert "--repo-root" in command
+    assert "--message-ref" in command
+
+
+@pytest.mark.asyncio
+async def test_topic_capture_command_skips_slash_commands():
+    runner = object.__new__(GatewayRunner)
+    event = _make_event("/help")
+
+    with patch("gateway.run.asyncio.to_thread") as to_thread:
+        await runner._maybe_apply_topic_capture_command(event, event.source)
+
+    to_thread.assert_not_called()
+    assert event.text == "/help"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -129,8 +129,10 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     teaching subagents a fake container path while still helping them avoid
     guessing `/workspace/...` for local repo tasks.
     """
+    from gateway.session_context import get_terminal_cwd as _get_terminal_cwd
+
     candidates = [
-        os.getenv("TERMINAL_CWD"),
+        _get_terminal_cwd(),
         getattr(getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None),
         getattr(parent_agent, "terminal_cwd", None),
         getattr(parent_agent, "cwd", None),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -612,15 +612,17 @@ def _get_env_config() -> Dict[str, Any]:
     else:
         default_cwd = "/root"
 
+    from gateway.session_context import get_terminal_cwd as _get_terminal_cwd
+
     # Read TERMINAL_CWD but sanity-check it for container backends.
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = _get_terminal_cwd(default_cwd)
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or os.getcwd()
+        docker_cwd_source = _get_terminal_cwd() or os.getcwd()
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in host_prefixes)


### PR DESCRIPTION
## Summary
- replace script-path topic capture with a first-class direct CLI command contract
- thread topic-scoped cwd through gateway session context, agent cache signatures, terminal, and delegation workspace hints
- add regression tests for topic cwd binding, topic capture command execution, and session cwd propagation

## Verification
- pytest tests/gateway/test_dm_topics.py tests/gateway/test_session_env.py tests/gateway/test_topic_capture_command.py -q
- pytest tests/gateway/test_config_cwd_bridge.py tests/gateway/test_fast_command.py tests/cli/test_worktree.py tests/tools/test_parse_env_var.py tests/tools/test_delegate.py tests/tools/test_terminal_tool_requirements.py -q

## Notes
- this changes the repo-side runtime contract to command-based topic capture; live rollout still requires an explicit gateway restart/reload window
- local Hera config was also switched to direct  commands, but that admin-layer change is not part of this PR