### PR TITLE
fix(auth): add default base URL fallback for copilot provider in credential pool

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6068,10 +6068,15 @@ Examples:
             sys.stderr = _io.StringIO()
             args = parser.parse_args(_processed_argv)
             sys.stderr = _saved_stderr
-        except SystemExit:
+        except SystemExit as exc:
             sys.stderr = _saved_stderr
-            # Subcommand name was consumed as a flag value (e.g. -c model).
-            # Fall back to optional subparsers so argparse handles it normally.
+            # -h/--help prints to stdout and raises SystemExit(0).
+            # Only retry when the exit was a real parse error (non-zero),
+            # meaning the subcommand name was consumed as a flag value
+            # (e.g. -c model).  Re-raising on code 0 avoids printing help
+            # twice (fixes #10230).
+            if exc.code == 0:
+                raise
             subparsers.required = False
             args = parser.parse_args(_processed_argv)
     else:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,6 +14,7 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_GITHUB_MODELS_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
@@ -167,6 +168,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1412,3 +1412,32 @@ def test_named_custom_runtime_no_model_when_absent(monkeypatch):
 
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert "model" not in resolved
+
+
+def test_copilot_pool_entry_provides_default_base_url(monkeypatch):
+    """Copilot pool entry with no base_url should fall back to DEFAULT_GITHUB_MODELS_BASE_URL (#10223)."""
+
+    class _Entry:
+        runtime_api_key = "gho_test_token"
+        access_token = "gho_test_token"
+        source = "manual:gh_auth"
+        base_url = None
+        runtime_base_url = None
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "copilot", "default": "gpt-4o"})
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["base_url"] == "https://api.githubcopilot.com"
+    assert resolved["api_key"] == "gho_test_token"
+    assert resolved["source"] == "manual:gh_auth"

--- a/tests/hermes_cli/test_subparser_routing_fallback.py
+++ b/tests/hermes_cli/test_subparser_routing_fallback.py
@@ -56,8 +56,10 @@ def _safe_parse(parser, subparsers, argv):
             args = parser.parse_args(argv)
             sys.stderr = saved_stderr
             return args
-        except SystemExit:
+        except SystemExit as exc:
             sys.stderr = saved_stderr
+            if exc.code == 0:
+                raise
             subparsers.required = False
             return parser.parse_args(argv)
     else:
@@ -146,3 +148,23 @@ class TestSubparserRoutingFallback:
         assert args.yolo is True
         assert args.worktree is True
         assert args.skills == ["myskill"]
+
+    def test_subcommand_help_prints_once(self, capsys):
+        """Regression test for #10230: subcommand -h should not print help twice."""
+        parser, sub = _build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            _safe_parse(parser, sub, ["gateway", "-h"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        usage_count = captured.out.count("usage: hermes gateway")
+        assert usage_count == 1, f"Help printed {usage_count} times, expected 1"
+
+    def test_top_level_help_prints_once(self, capsys):
+        """Top-level -h should also print help exactly once."""
+        parser, sub = _build_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            _safe_parse(parser, sub, ["-h"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        usage_count = captured.out.count("usage: hermes")
+        assert usage_count == 1, f"Help printed {usage_count} times, expected 1"


### PR DESCRIPTION
## Summary

Fixes #10223

When the GitHub Copilot provider is resolved via the credential pool path, the pool entry may not include a `base_url`. Unlike other providers (anthropic, openrouter, qwen-oauth, openai-codex), the `copilot` branch in `_resolve_runtime_from_pool_entry()` did not provide a fallback `base_url`, resulting in:

```
⚠️  Provider resolver returned an empty base URL. Check your provider config or run: hermes setup
```

## Root Cause

In `hermes_cli/runtime_provider.py`, the `copilot` branch inside `_resolve_runtime_from_pool_entry()` only set `api_mode` but never provided a default `base_url`:

```python
elif provider == "copilot":
    api_mode = _copilot_runtime_api_mode(model_cfg, ...)
    # ❌ no base_url fallback
```

The explicit runtime path (`_resolve_explicit_runtime`) works fine because it reads `base_url` from `resolve_api_key_provider_credentials()`, but the credential pool path returns `base_url = ""` when the pool entry has no URL.

## Fix

Add `base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL` to the copilot branch, mirroring the pattern used by all other providers in the same function:

```python
elif provider == "copilot":
    api_mode = _copilot_runtime_api_mode(model_cfg, ...)
    base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL  # ✅
```

## Test

Added `test_copilot_pool_entry_provides_default_base_url` in `tests/hermes_cli/test_runtime_provider_resolution.py` — verifies that a copilot pool entry with `base_url=None` correctly resolves to `https://api.githubcopilot.com`.