### PR TITLE
feat(delegate): add DELEGATION_GUIDANCE to the system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -170,6 +170,16 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+DELEGATION_GUIDANCE = (
+    "Prefer delegate_task when a request clearly breaks into multiple independent subtasks "
+    "or will require 3 or more independent tool calls.\n"
+    "Use it proactively at task intake for reasoning-heavy work, parallel workstreams, or "
+    "multi-step investigations that should be isolated.\n"
+    "Do not delegate simple, single-step, or purely mechanical tasks.\n"
+    "When delegating, pass enough context for the subagent to act without your conversation history.\n"
+    "Prefer delegation when it will reduce context pressure or let you work on other parts in parallel."
+)
+
 TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "# Tool-use enforcement\n"
     "You MUST use your tools to take action — do not describe what you would do "
@@ -180,6 +190,8 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "Keep working until the task is actually complete. Do not stop with a summary of "
     "what you plan to do next time. If you have tools available that can accomplish "
     "the task, use them instead of telling the user what you would do.\n"
+    "Delegating work with delegate_task counts as tool use, so use it when it is the "
+    "best way to proceed.\n"
     "Every response should either (a) contain tool calls that make progress, or "
     "(b) deliver a final result to the user. Responses that only describe intentions "
     "without acting are not acceptable."

--- a/run_agent.py
+++ b/run_agent.py
@@ -80,7 +80,7 @@ from agent.retry_utils import jittered_backoff
 from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
-    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE, DELEGATION_GUIDANCE,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -3181,6 +3181,8 @@ class AIAgent:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)
         if "skill_manage" in self.valid_tool_names:
             tool_guidance.append(SKILLS_GUIDANCE)
+        if "delegate_task" in self.valid_tool_names:
+            tool_guidance.append(DELEGATION_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
 

--- a/tests/agent/test_delegation_guidance.py
+++ b/tests/agent/test_delegation_guidance.py
@@ -1,0 +1,151 @@
+"""Tests for DELEGATION_GUIDANCE — content, injection, and enforcement interaction."""
+
+from agent.prompt_builder import (
+    DELEGATION_GUIDANCE,
+    TOOL_USE_ENFORCEMENT_GUIDANCE,
+    MEMORY_GUIDANCE,
+    SESSION_SEARCH_GUIDANCE,
+    SKILLS_GUIDANCE,
+)
+
+
+class TestDelegationGuidanceContent:
+    def test_is_string(self):
+        assert isinstance(DELEGATION_GUIDANCE, str)
+
+    def test_not_empty(self):
+        assert len(DELEGATION_GUIDANCE.strip()) > 50
+
+    def test_within_length_limit(self):
+        line_count = DELEGATION_GUIDANCE.count("\n") + 1
+        assert 3 <= line_count <= 8, f"Expected 3-8 lines, got {line_count}"
+
+    def test_mentions_delegate_task(self):
+        assert "delegate_task" in DELEGATION_GUIDANCE
+
+    def test_uses_prospective_language(self):
+        lower = DELEGATION_GUIDANCE.lower()
+        assert any(phrase in lower for phrase in [
+            "at task intake",
+            "when a request",
+            "breaks into",
+            "will require",
+        ])
+
+    def test_no_retrospective_triggers(self):
+        assert "would flood" not in DELEGATION_GUIDANCE.lower()
+        assert "already doing" not in DELEGATION_GUIDANCE.lower()
+
+    def test_includes_complexity_threshold(self):
+        lower = DELEGATION_GUIDANCE.lower()
+        assert any(phrase in lower for phrase in ["3 or more", "3+", "multiple"])
+
+    def test_uses_prefer_not_always(self):
+        lower = DELEGATION_GUIDANCE.lower()
+        assert "prefer" in lower
+        assert "always delegate" not in lower
+        assert "you must delegate" not in lower
+
+    def test_mentions_independent(self):
+        assert "independent" in DELEGATION_GUIDANCE.lower()
+
+    def test_discourages_simple_delegation(self):
+        lower = DELEGATION_GUIDANCE.lower()
+        assert any(phrase in lower for phrase in ["do not delegate", "simple", "mechanical"])
+
+    def test_mentions_context_for_subagent(self):
+        assert "context" in DELEGATION_GUIDANCE.lower()
+
+    def test_consistent_with_other_guidance_style(self):
+        assert "```" not in DELEGATION_GUIDANCE
+        assert "#" not in DELEGATION_GUIDANCE
+        assert "**" not in DELEGATION_GUIDANCE
+
+
+class TestEnforcementDelegationInteraction:
+    def test_enforcement_mentions_delegate_task(self):
+        assert "delegate_task" in TOOL_USE_ENFORCEMENT_GUIDANCE
+
+    def test_enforcement_says_delegation_is_tool_use(self):
+        lower = TOOL_USE_ENFORCEMENT_GUIDANCE.lower()
+        assert "delegation" in lower or "delegating" in lower
+        assert "counts as tool use" in lower or "is tool use" in lower or "best way to proceed" in lower
+
+    def test_enforcement_still_has_original_directives(self):
+        assert "MUST" in TOOL_USE_ENFORCEMENT_GUIDANCE
+        assert "tool call" in TOOL_USE_ENFORCEMENT_GUIDANCE.lower()
+        assert "Every response should" in TOOL_USE_ENFORCEMENT_GUIDANCE
+
+
+class TestDelegationGuidanceInjection:
+    def test_all_four_guidance_constants_exist_and_are_strings(self):
+        for const in [MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE, DELEGATION_GUIDANCE]:
+            assert isinstance(const, str)
+            assert len(const) > 20
+
+    def test_delegation_guidance_does_not_leak_into_other_constants(self):
+        for const_name, const in [
+            ("MEMORY", MEMORY_GUIDANCE),
+            ("SESSION_SEARCH", SESSION_SEARCH_GUIDANCE),
+            ("SKILLS", SKILLS_GUIDANCE),
+        ]:
+            assert "delegate_task" not in const, f"{const_name}_GUIDANCE should not reference delegate_task"
+
+    def test_simulated_injection_pattern(self):
+        valid_tool_names = {"memory", "session_search", "skill_manage", "delegate_task"}
+        tool_guidance = []
+        if "memory" in valid_tool_names:
+            tool_guidance.append(MEMORY_GUIDANCE)
+        if "session_search" in valid_tool_names:
+            tool_guidance.append(SESSION_SEARCH_GUIDANCE)
+        if "skill_manage" in valid_tool_names:
+            tool_guidance.append(SKILLS_GUIDANCE)
+        if "delegate_task" in valid_tool_names:
+            tool_guidance.append(DELEGATION_GUIDANCE)
+
+        assert len(tool_guidance) == 4
+        combined = " ".join(tool_guidance)
+        assert "delegate_task" in combined
+
+    def test_delegation_absent_when_tool_disabled(self):
+        valid_tool_names = {"memory", "session_search"}
+        tool_guidance = []
+        if "memory" in valid_tool_names:
+            tool_guidance.append(MEMORY_GUIDANCE)
+        if "session_search" in valid_tool_names:
+            tool_guidance.append(SESSION_SEARCH_GUIDANCE)
+        if "skill_manage" in valid_tool_names:
+            tool_guidance.append(SKILLS_GUIDANCE)
+        if "delegate_task" in valid_tool_names:
+            tool_guidance.append(DELEGATION_GUIDANCE)
+
+        combined = " ".join(tool_guidance)
+        assert "delegate_task" not in combined
+        assert len(tool_guidance) == 2
+
+    def test_only_delegation_when_sole_tool(self):
+        valid_tool_names = {"delegate_task"}
+        tool_guidance = []
+        if "memory" in valid_tool_names:
+            tool_guidance.append(MEMORY_GUIDANCE)
+        if "session_search" in valid_tool_names:
+            tool_guidance.append(SESSION_SEARCH_GUIDANCE)
+        if "skill_manage" in valid_tool_names:
+            tool_guidance.append(SKILLS_GUIDANCE)
+        if "delegate_task" in valid_tool_names:
+            tool_guidance.append(DELEGATION_GUIDANCE)
+
+        assert len(tool_guidance) == 1
+        assert tool_guidance[0] == DELEGATION_GUIDANCE
+
+
+class TestDelegationImportSafety:
+    def test_delegation_guidance_importable_from_prompt_builder(self):
+        from agent.prompt_builder import DELEGATION_GUIDANCE as dg
+        assert isinstance(dg, str)
+
+    def test_no_name_collision_with_existing_constants(self):
+        import agent.prompt_builder as pb
+        names = [n for n in dir(pb) if n.endswith("_GUIDANCE")]
+        assert "DELEGATION_GUIDANCE" in names
+        assert names.count("DELEGATION_GUIDANCE") == 1


### PR DESCRIPTION
## Summary
- add `DELEGATION_GUIDANCE` to the system prompt so the parent agent knows when to use `delegate_task`
- inject the guidance only when `delegate_task` is actually available
- clarify in `TOOL_USE_ENFORCEMENT_GUIDANCE` that delegating with `delegate_task` counts as valid tool use
- add focused regression tests for guidance content, injection, and non-injection cases

## Why
`delegate_task` was implemented and validated but underused in practice because the system prompt never told the model when delegation was appropriate. Other meta-tools (`memory`, `session_search`, `skill_manage`) already had dedicated guidance blocks; delegation did not.

This change adds a short, conservative guidance block with prospective triggers:
- multiple independent subtasks
- 3+ independent tool calls likely needed
- reasoning-heavy / parallel / context-heavy work
- avoid delegating trivial single-step tasks

## Test plan
- `python3 -m pytest tests/agent/test_delegation_guidance.py tests/agent/test_prompt_builder.py -o "addopts=" -q`
- validated a real Hermes tmux smoke on `gpt-5.4` where a complex prompt triggered `delegate_task` and completed 3 parallel tasks successfully

## Notes
- intentionally separate from #9737 (`feat/delegate-task-tiers`)
- this PR changes delegation decision-making; it does not change tier routing logic
