### PR TITLE
feat(discord): add native send_animation for inline GIF playback

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1379,6 +1379,68 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return await super().send_image(chat_id, image_url, caption, reply_to)
 
+    async def send_animation(
+        self,
+        chat_id: str,
+        animation_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an animated GIF natively as a Discord file attachment."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        if not is_safe_url(animation_url):
+            logger.warning("[%s] Blocked unsafe animation URL during Discord send_animation", self.name)
+            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+
+        try:
+            import aiohttp
+
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return SendResult(success=False, error=f"Channel {chat_id} not found")
+
+            # Download the GIF and send as a Discord file attachment
+            # (Discord renders .gif attachments as auto-playing animations inline)
+            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+            _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+            _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+            async with aiohttp.ClientSession(**_sess_kw) as session:
+                async with session.get(animation_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw) as resp:
+                    if resp.status != 200:
+                        raise Exception(f"Failed to download animation: HTTP {resp.status}")
+
+                    animation_data = await resp.read()
+
+                    import io
+                    file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
+
+                    msg = await channel.send(
+                        content=caption if caption else None,
+                        file=file,
+                    )
+                    return SendResult(success=True, message_id=str(msg.id))
+
+        except ImportError:
+            logger.warning(
+                "[%s] aiohttp not installed, falling back to URL. Run: pip install aiohttp",
+                self.name,
+                exc_info=True,
+            )
+            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error(
+                "[%s] Failed to send animation attachment, falling back to URL: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+
     async def send_video(
         self,
         chat_id: str,


### PR DESCRIPTION
## What does this PR do?

Adds a `send_animation` override to the Discord platform adapter so that animated GIFs are sent as native Discord file attachments and auto-play inline, instead of falling back to `send_image`.

Telegram already has this override. Discord's base class fallback sends GIFs through `send_image`, which works but loses the animation context. Discord's CDN serves GIF attachments with the correct MIME type when the filename ends in `.gif`, triggering the client's native animation renderer. Without this override, GIFs sent via `send_image` are uploaded as `image.gif` but without the animation context path — this override ensures the file is explicitly named `animation.gif` and routed through the animation code path.

## Type of Change
- [x] New feature (non-breaking addition)

## Changes Made
- Added `send_animation` method to `DiscordPlatform` in `gateway/platforms/discord.py`
- Downloads GIF from `animation_url` via `aiohttp` using the same proxy pattern as `send_image`
- Sends as `discord.File` with `filename="animation.gif"` so Discord renders it as an auto-playing animation
- Safety check via `is_safe_url` before any network call
- Graceful fallback to `super().send_animation()` on `ImportError` or any exception

## How to Test
1. Configure a Discord gateway bot
2. Ask Hermes to send a GIF URL (e.g. `https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif`)
3. Confirm the GIF appears inline and auto-plays in Discord (not as a static image or plain URL)

## Checklist
- [x] Code follows project style (matches `send_image` pattern exactly)
- [x] No new dependencies (aiohttp already used in `send_image`)
- [x] Fallbacks handled gracefully