### PR TITLE
docs(llm-wiki): Add Markdown table wikilink escaping documentation

### DIFF
--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -436,6 +436,28 @@ sudo loginctl enable-linger $USER
 This lets the agent write to `~/wiki` on a server while you browse the same
 vault in Obsidian on your laptop/phone — changes appear within seconds.
 
+### Markdown Tables with Wikilinks
+
+When using wikilinks inside Markdown tables, the pipe character `|` in
+`[[target|Display]]` conflicts with table column delimiters.
+
+**Syntax:** Inside table cells, escape the pipe with backslash:
+```markdown
+| Method | Paper |
+|--------|-------|
+| GPTQ   | [[gptq\|GPTQ paper]] |  ✓ Correct (escaped)
+| GPTQ   | [[gptq|GPTQ paper]]  |  ✗ Breaks table rendering
+```
+
+**Detect violations:**
+```bash
+# Find unescaped wikilinks in tables
+grep -r "^|.*\[\[[^\\]*|[^\\]*\]\]" ~/wiki --include="*.md" | grep -v "\\\\|"
+```
+
+**Fix:** Replace `[[target|Display]]` with `[[target\|Display]]` in table cells.
+Consider adding this convention to `SCHEMA.md` for your wiki.
+
 ## Pitfalls
 
 - **Never modify files in `raw/`** — sources are immutable. Corrections go in wiki pages.


### PR DESCRIPTION
Documents the pipe escaping requirement when using wikilinks inside tables.

Includes:
- Syntax examples showing correct vs broken rendering
- Grep command to detect violations  
- Recommendation to add to SCHEMA.md conventions

Fixes common Obsidian rendering issue where table columns break due to unescaped pipe characters in wikilink display text.