### PR TITLE
fix(mcp): pass full server URL to OAuthClientProvider, strip trailing slash

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -169,6 +169,40 @@ class TestBuildOAuthAuth:
         assert provider is not None
         assert provider.context.client_metadata.scope == "read write admin"
 
+    def test_server_url_preserves_path(self, tmp_path, monkeypatch):
+        """OAuthClientProvider must receive the full URL including path.
+
+        Passing only the base URL (scheme+host) causes RFC 8707 resource
+        validation to fail when the server's protected resource metadata
+        reports the full path URL as its resource identifier.
+        See: https://github.com/modelcontextprotocol/python-sdk/pull/2069
+        """
+        try:
+            from mcp.client.auth import OAuthClientProvider
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = build_oauth_auth("granola", "https://mcp.granola.ai/mcp")
+        assert provider is not None
+        assert provider.context.server_url == "https://mcp.granola.ai/mcp"
+
+    def test_server_url_no_trailing_slash(self, tmp_path, monkeypatch):
+        """Trailing slash in config URL must be stripped before passing to the SDK.
+
+        The server's protected resource metadata reports the resource without a
+        trailing slash; a mismatch triggers the same RFC 8707 validation failure.
+        """
+        try:
+            from mcp.client.auth import OAuthClientProvider
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = build_oauth_auth("example", "https://mcp.example.com/mcp/")
+        assert provider is not None
+        assert provider.context.server_url == "https://mcp.example.com/mcp"
+
 
 # ---------------------------------------------------------------------------
 # Utility functions

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -465,13 +465,9 @@ def build_oauth_auth(
         _write_json(storage._client_info_path(), client_info.model_dump(exclude_none=True))
         logger.debug("Pre-registered client_id=%s for '%s'", client_id, server_name)
 
-    # --- Base URL for discovery ---
-    parsed = urlparse(server_url)
-    base_url = f"{parsed.scheme}://{parsed.netloc}"
-
     # --- Build provider ---
     provider = OAuthClientProvider(
-        server_url=base_url,
+        server_url=server_url.rstrip("/"),
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,


### PR DESCRIPTION
## What does this PR do?

Passes the full server URL (including path) to `OAuthClientProvider` instead of stripping it down to scheme+host. Also normalizes trailing slashes.

The path stripping caused MCP SDK 1.27.0's RFC 8707 resource validation to reject any server whose endpoint has a path component (e.g. `https://mcp.granola.ai/mcp`), since the server advertises the full URL as its resource identifier but the client was initialized with only the origin.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #10271

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/mcp_oauth.py`: removed `parsed`/`base_url` path-stripping block;
  pass `server_url.rstrip("/")` directly to `OAuthClientProvider`
- `tests/tools/test_mcp_oauth.py`: added `test_server_url_preserves_path`
  and `test_server_url_no_trailing_slash` to `TestBuildOAuthAuth`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Add a Granola MCP server to your config:
   ```yaml
   mcp_servers:
     granola:
       url: https://mcp.granola.ai/mcp
       auth: oauth
2. Run `hermes mcp test granola` — connection should proceed to the OAuth browser flow instead of failing with a resource mismatch error

```shell
open@cloud-one:~$ hermes mcp test granola

  Testing 'granola'...
  Transport: HTTP → https://mcp.granola.ai/mcp
  Auth: OAuth 2.1 PKCE

  MCP OAuth: authorization required.
  Open this URL in your browser:

    https://mcp-auth.granola.ai/oauth2/authorize?response_type=code&client_id=[redacted]&redirect_uri=http%3A%2F%2F127.0.0.1%3A60849%2Fcallback&state=[redacted]&code_challenge=[redacted]&code_challenge_method=S256&resource=https%3A%2F%2Fmcp.granola.ai%2Fmcp&scope=email+offline_access+openid+profile

  (Headless environment detected — open the URL manually.)

  ✓ Connected (29625ms)
  ✓ Tools discovered: 5

    query_granola_meetings      Query Granola about the user's meetings using natural l...
    list_meetings               List the user's Granola meeting notes within a time ran...
    list_meeting_folders        List the user's Granola meeting folders. Returns folder...
    get_meetings                Get detailed meeting information for one or more Granol...
    get_meeting_transcript      Get the full transcript for a specific Granola meeting ...
```

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
