### PR TITLE
fix: replace hardcoded ~/.hermes with display_hermes_home() in agent-facing text

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from hermes_constants import display_hermes_home
+
 logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
@@ -108,7 +110,7 @@ def _inject_skill_config(loaded_skill: dict[str, Any], parts: list[str]) -> None
         if not resolved:
             return
 
-        lines = ["", "[Skill config (from ~/.hermes/config.yaml):"]
+        lines = ["", f"[Skill config (from {display_hermes_home()}/config.yaml):"]
         for key, value in resolved.items():
             display_val = str(value) if value else "(not set)"
             lines.append(f"  {key} = {display_val}")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import display_hermes_home
+
 logger = logging.getLogger(__name__)
 
 # Import from cron module (will be available when properly installed)
@@ -455,7 +457,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "script": {
                 "type": "string",
-                "description": "Optional path to a Python script that runs before each cron job execution. Its stdout is injected into the prompt as context. Use for data collection and change detection. Relative paths resolve under ~/.hermes/scripts/. On update, pass empty string to clear."
+                "description": f"Optional path to a Python script that runs before each cron job execution. Its stdout is injected into the prompt as context. Use for data collection and change detection. Relative paths resolve under {display_hermes_home()}/scripts/. On update, pass empty string to clear."
             },
         },
         "required": ["action"]

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -39,7 +39,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home
 from typing import Dict, Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -655,7 +655,7 @@ SKILL_MANAGE_SCHEMA = {
     "description": (
         "Manage skills (create, update, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
-        "New skills go to ~/.hermes/skills/; existing skills can be modified wherever they live.\n\n"
+        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,7 +69,7 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home
 import os
 import re
 from enum import Enum
@@ -408,7 +408,7 @@ def _gateway_setup_hint() -> str:
 
         return GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE
     except Exception:
-        return "Secure secret entry is not available. Load this skill in the local CLI to be prompted, or add the key to ~/.hermes/.env manually."
+        return f"Secure secret entry is not available. Load this skill in the local CLI to be prompted, or add the key to {display_hermes_home()}/.env manually."
 
 
 def _build_setup_note(
@@ -666,7 +666,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                     "success": True,
                     "skills": [],
                     "categories": [],
-                    "message": "No skills found. Skills directory created at ~/.hermes/skills/",
+                    "message": f"No skills found. Skills directory created at {display_hermes_home()}/skills/",
                 },
                 ensure_ascii=False,
             )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -40,6 +40,8 @@ from pathlib import Path
 from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
 
+from hermes_constants import display_hermes_home
+
 logger = logging.getLogger(__name__)
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_openai_audio_api_key
@@ -1050,7 +1052,7 @@ TTS_SCHEMA = {
             },
             "output_path": {
                 "type": "string",
-                "description": "Optional custom file path to save the audio. Defaults to ~/.hermes/audio_cache/<timestamp>.mp3"
+                "description": f"Optional custom file path to save the audio. Defaults to {display_hermes_home()}/audio_cache/<timestamp>.mp3"
             }
         },
         "required": ["text"]


### PR DESCRIPTION
## Summary

Tool schema descriptions and tool return values contained hardcoded `~/.hermes` paths that the model sees and uses. When `HERMES_HOME` is set to a custom path (e.g. `/opt/data` in Docker containers, or `~/.hermes/profiles/X` for profiles), the agent would still reference `~/.hermes` — looking at the wrong directory.

## What changed

Fixes 6 agent-facing hardcoded `~/.hermes` references across 5 files:

| File | Location | What it affects |
|------|----------|----------------|
| `tools/tts_tool.py` | `output_path` schema description | Model sees wrong default path |
| `tools/cronjob_tools.py` | `script` schema description | Model resolves scripts to wrong dir |
| `tools/skill_manager_tool.py` | `skill_manage` schema description | Model creates skills in wrong dir |
| `tools/skills_tool.py` | Secret setup hint return value | Agent tells user wrong .env path |
| `tools/skills_tool.py` | Empty skills list message | Agent shows wrong skills dir |
| `agent/skill_commands.py` | Skill config injection text | Agent shows wrong config.yaml path |

All now use `display_hermes_home()` from `hermes_constants`, which resolves to the actual HERMES_HOME path at import time (after profile override).

## Non-agent-facing references

The remaining ~100 `~/.hermes` references in the codebase are in:
- Python docstrings and code comments (developer docs, not model-visible)
- Test fixtures
- Developer documentation  

These are informational for developers and don't affect agent behavior.

## Test plan

- 3027 tests passed (2 pre-existing failures unrelated to this change)
- `py_compile` verified on all 5 modified files

Reported by: Sandeep Narahari (PrithviDevs)