### PR TITLE
fix: align codex auth status with usable credentials

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -651,11 +651,14 @@ def _read_codex_access_token() -> Optional[str]:
             return token
 
     try:
-        from hermes_cli.auth import _read_codex_tokens
+        from hermes_cli.auth import _read_codex_tokens, _codex_access_token_looks_usable
         data = _read_codex_tokens()
         tokens = data.get("tokens", {})
         access_token = tokens.get("access_token")
         if not isinstance(access_token, str) or not access_token.strip():
+            return None
+        if not _codex_access_token_looks_usable(access_token):
+            logger.warning("Codex auth store fallback token is unusable; ignoring singleton fallback")
             return None
 
         # Check JWT expiry — expired tokens block the auto chain and

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1212,11 +1212,17 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # store has no tokens.  This mirrors resolve_codex_runtime_credentials()
         # so that load_pool() and list_authenticated_providers() detect tokens
         # that only exist in the Codex CLI shared file.
-        if not (isinstance(tokens, dict) and tokens.get("access_token")):
+        try:
+            from hermes_cli.auth import _import_codex_cli_tokens, _save_codex_tokens, _codex_token_pair_looks_usable
+        except Exception:
+            _import_codex_cli_tokens = None
+            _save_codex_tokens = None
+            _codex_token_pair_looks_usable = None
+        tokens_usable = bool(_codex_token_pair_looks_usable(tokens)) if _codex_token_pair_looks_usable else bool(isinstance(tokens, dict) and tokens.get("access_token"))
+        if not tokens_usable:
             try:
-                from hermes_cli.auth import _import_codex_cli_tokens, _save_codex_tokens
                 cli_tokens = _import_codex_cli_tokens()
-                if cli_tokens:
+                if cli_tokens and _save_codex_tokens:
                     logger.info("Importing Codex CLI tokens into Hermes auth store.")
                     _save_codex_tokens(cli_tokens)
                     # Re-read state after import
@@ -1225,7 +1231,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     tokens = state.get("tokens") if isinstance(state, dict) else None
             except Exception as exc:
                 logger.debug("Codex CLI token import failed: %s", exc)
-        if isinstance(tokens, dict) and tokens.get("access_token"):
+        if (bool(_codex_token_pair_looks_usable(tokens)) if _codex_token_pair_looks_usable else bool(isinstance(tokens, dict) and tokens.get("access_token"))):
             active_sources.add("device_code")
             changed |= _upsert_entry(
                 entries,
@@ -1318,7 +1324,7 @@ def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources:
         or entry.source in active_sources
         or not (
             entry.source.startswith("env:")
-            or entry.source in {"claude_code", "hermes_pkce"}
+            or entry.source in {"claude_code", "hermes_pkce", "device_code"}
         )
     ]
     if len(retained) == len(entries):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1052,6 +1052,29 @@ def _codex_access_token_is_expiring(access_token: Any, skew_seconds: int) -> boo
     return float(exp) <= (time.time() + max(0, int(skew_seconds)))
 
 
+def _codex_access_token_looks_usable(access_token: Any) -> bool:
+    if not has_usable_secret(access_token, min_length=16):
+        return False
+    token = str(access_token).strip()
+    claims = _decode_jwt_claims(token)
+    if claims:
+        return True
+    return len(token) >= 32
+
+
+def _codex_refresh_token_looks_usable(refresh_token: Any) -> bool:
+    return has_usable_secret(refresh_token, min_length=16)
+
+
+def _codex_token_pair_looks_usable(tokens: Any) -> bool:
+    if not isinstance(tokens, dict):
+        return False
+    return (
+        _codex_access_token_looks_usable(tokens.get("access_token"))
+        and _codex_refresh_token_looks_usable(tokens.get("refresh_token"))
+    )
+
+
 def _qwen_cli_auth_path() -> Path:
     return Path.home() / ".qwen" / "oauth_creds.json"
 
@@ -1275,11 +1298,25 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
             code="codex_auth_missing_access_token",
             relogin_required=True,
         )
+    if not _codex_access_token_looks_usable(access_token):
+        raise AuthError(
+            "Codex auth contains an unusable access_token. Run `hermes auth` to re-authenticate.",
+            provider="openai-codex",
+            code="codex_auth_invalid_access_token",
+            relogin_required=True,
+        )
     if not isinstance(refresh_token, str) or not refresh_token.strip():
         raise AuthError(
             "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
             provider="openai-codex",
             code="codex_auth_missing_refresh_token",
+            relogin_required=True,
+        )
+    if not _codex_refresh_token_looks_usable(refresh_token):
+        raise AuthError(
+            "Codex auth contains an unusable refresh_token. Run `hermes auth` to re-authenticate.",
+            provider="openai-codex",
+            code="codex_auth_invalid_refresh_token",
             relogin_required=True,
         )
     return {
@@ -1477,12 +1514,9 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     try:
         payload = json.loads(auth_path.read_text())
         tokens = payload.get("tokens")
-        if not isinstance(tokens, dict):
+        if not _codex_token_pair_looks_usable(tokens):
             return None
         access_token = tokens.get("access_token")
-        refresh_token = tokens.get("refresh_token")
-        if not access_token or not refresh_token:
-            return None
         # Reject expired tokens — importing stale tokens from ~/.codex/
         # that can't be refreshed leaves the user stuck with "Login successful!"
         # but no working credentials.
@@ -2339,7 +2373,10 @@ def get_codex_auth_status() -> Dict[str, Any]:
                     getattr(entry, "runtime_api_key", None)
                     or getattr(entry, "access_token", "")
                 )
-                if api_key and not _codex_access_token_is_expiring(api_key, 0):
+                if (
+                    _codex_access_token_looks_usable(api_key)
+                    and not _codex_access_token_is_expiring(api_key, 0)
+                ):
                     return {
                         "logged_in": True,
                         "auth_store": str(_auth_file_path()),

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2390,14 +2390,15 @@ def get_codex_auth_status() -> Dict[str, Any]:
 
     # Fall back to legacy provider state
     try:
-        creds = resolve_codex_runtime_credentials()
+        data = _read_codex_tokens()
+        tokens = dict(data.get("tokens") or {})
         return {
             "logged_in": True,
             "auth_store": str(_auth_file_path()),
-            "last_refresh": creds.get("last_refresh"),
-            "auth_mode": creds.get("auth_mode"),
-            "source": creds.get("source"),
-            "api_key": creds.get("api_key"),
+            "last_refresh": data.get("last_refresh"),
+            "auth_mode": "chatgpt",
+            "source": "hermes-auth-store",
+            "api_key": str(tokens.get("access_token", "") or "").strip(),
         }
     except AuthError as exc:
         return {

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -873,6 +873,12 @@ def list_authenticated_providers(
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code
         # OAuth via external credential files).
+        if not has_creds and hermes_slug == "openai-codex":
+            try:
+                from hermes_cli.auth import get_codex_auth_status
+                has_creds = bool(get_codex_auth_status().get("logged_in"))
+            except Exception as exc:
+                logger.debug("Codex auth status check failed for %s: %s", pid, exc)
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store
@@ -890,7 +896,7 @@ def list_authenticated_providers(
         # This catches credentials that exist in external stores (e.g.
         # Codex CLI ~/.codex/auth.json) which _seed_from_singletons()
         # imports on demand but aren't in the raw auth.json yet.
-        if not has_creds:
+        if not has_creds and hermes_slug != "openai-codex":
             try:
                 from agent.credential_pool import load_pool
                 pool = load_pool(hermes_slug)
@@ -957,6 +963,12 @@ def list_authenticated_providers(
         if _cp_config and _cp_config.api_key_env_vars:
             _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
         # Also check auth store and credential pool
+        if not _cp_has_creds and _cp.slug == "openai-codex":
+            try:
+                from hermes_cli.auth import get_codex_auth_status
+                _cp_has_creds = bool(get_codex_auth_status().get("logged_in"))
+            except Exception:
+                pass
         if not _cp_has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store
@@ -970,7 +982,7 @@ def list_authenticated_providers(
                     _cp_has_creds = True
             except Exception:
                 pass
-        if not _cp_has_creds:
+        if not _cp_has_creds and _cp.slug != "openai-codex":
             try:
                 from agent.credential_pool import load_pool
                 _cp_pool = load_pool(_cp.slug)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -56,19 +56,21 @@ def codex_auth_dir(tmp_path, monkeypatch):
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):
+        valid_token = "plain-token-abcdefghijklmnopqrstuvwxyz0123456789"
+        valid_refresh = "refresh-token-abcdefghijklmnopqrstuvwxyz0123456789"
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(json.dumps({
             "version": 1,
             "providers": {
                 "openai-codex": {
-                    "tokens": {"access_token": "tok-123", "refresh_token": "r-456"},
+                    "tokens": {"access_token": valid_token, "refresh_token": valid_refresh},
                 },
             },
         }))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         result = _read_codex_access_token()
-        assert result == "tok-123"
+        assert result == valid_token
 
     def test_pool_without_selected_entry_falls_back_to_auth_store(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -78,11 +80,24 @@ class TestReadCodexAccessToken:
         valid_jwt = "eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTl9.sig"
         with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
              patch("hermes_cli.auth._read_codex_tokens", return_value={
-                 "tokens": {"access_token": valid_jwt, "refresh_token": "refresh"}
+                 "tokens": {"access_token": valid_jwt, "refresh_token": "rt-valid-abcdefghijklmnopqrstuvwxyz0123456789"}
              }):
             result = _read_codex_access_token()
 
         assert result == valid_jwt
+
+    def test_pool_without_selected_entry_ignores_unusable_auth_store_token(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
+             patch("hermes_cli.auth._read_codex_tokens", return_value={
+                 "tokens": {"access_token": "access-new", "refresh_token": "refresh-new"}
+             }):
+            result = _read_codex_access_token()
+
+        assert result is None
 
     def test_missing_returns_none(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
@@ -165,7 +180,7 @@ class TestReadCodexAccessToken:
             "version": 1,
             "providers": {
                 "openai-codex": {
-                    "tokens": {"access_token": valid_jwt, "refresh_token": "r"},
+                    "tokens": {"access_token": valid_jwt, "refresh_token": "rt-valid-abcdefghijklmnopqrstuvwxyz0123456789"},
                 },
             },
         }))
@@ -175,19 +190,23 @@ class TestReadCodexAccessToken:
 
     def test_non_jwt_token_passes_through(self, tmp_path, monkeypatch):
         """Non-JWT tokens (no dots) should be returned as-is."""
+        plain_token = "plain-token-abcdefghijklmnopqrstuvwxyz0123456789"
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(json.dumps({
             "version": 1,
             "providers": {
                 "openai-codex": {
-                    "tokens": {"access_token": "plain-token-no-jwt", "refresh_token": "r"},
+                    "tokens": {
+                        "access_token": plain_token,
+                        "refresh_token": "rt-valid-abcdefghijklmnopqrstuvwxyz0123456789",
+                    },
                 },
             },
         }))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         result = _read_codex_access_token()
-        assert result == "plain-token-no-jwt"
+        assert result == plain_token
 
 
 class TestAnthropicOAuthFlag:
@@ -389,7 +408,7 @@ class TestExpiredCodexFallback:
             "version": 1,
             "providers": {
                 "openai-codex": {
-                    "tokens": {"access_token": no_exp_jwt, "refresh_token": "r"},
+                    "tokens": {"access_token": no_exp_jwt, "refresh_token": "rt-valid-abcdefghijklmnopqrstuvwxyz0123456789"},
                 },
             },
         }))
@@ -410,7 +429,7 @@ class TestExpiredCodexFallback:
             "version": 1,
             "providers": {
                 "openai-codex": {
-                    "tokens": {"access_token": bad_jwt, "refresh_token": "r"},
+                    "tokens": {"access_token": bad_jwt, "refresh_token": "rt-valid-abcdefghijklmnopqrstuvwxyz0123456789"},
                 },
             },
         }))

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -33,6 +33,7 @@ def _clean_env(monkeypatch):
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
     ):
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
 
 
 @pytest.fixture

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -388,6 +388,43 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     assert secondary["refresh_token"] == "refresh-other"
 
 
+def test_load_pool_ignores_unusable_codex_singleton_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "access-new",
+                        "refresh_token": "refresh-new",
+                    }
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "stale-singleton",
+                        "label": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-new",
+                        "refresh_token": "refresh-new",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.entries() == []
+
+
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-seeded")

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -8,6 +8,13 @@ import time
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _disable_host_codex_cli_import(monkeypatch):
+    """Keep host ~/.codex/auth.json from leaking into unit tests."""
+    monkeypatch.setattr("agent.credential_pool._import_codex_cli_tokens", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+
+
 def _write_auth_store(tmp_path, payload: dict) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -330,6 +337,12 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
 
 def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    primary_access = "access-current-abcdefghijklmnopqrstuvwxyz0123456789"
+    primary_refresh = "refresh-current-abcdefghijklmnopqrstuvwxyz0123456789"
+    secondary_access = "access-other-abcdefghijklmnopqrstuvwxyz0123456789"
+    secondary_refresh = "refresh-other-abcdefghijklmnopqrstuvwxyz0123456789"
+    refreshed_access = "access-new-abcdefghijklmnopqrstuvwxyz0123456789"
+    refreshed_refresh = "refresh-new-abcdefghijklmnopqrstuvwxyz0123456789"
     _write_auth_store(
         tmp_path,
         {
@@ -341,9 +354,9 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
                         "label": "primary",
                         "auth_type": "oauth",
                         "priority": 0,
-                        "source": "device_code",
-                        "access_token": "access-old",
-                        "refresh_token": "refresh-old",
+                        "source": "manual:device_code",
+                        "access_token": primary_access,
+                        "refresh_token": primary_refresh,
                         "base_url": "https://chatgpt.com/backend-api/codex",
                     },
                     {
@@ -351,9 +364,9 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
                         "label": "secondary",
                         "auth_type": "oauth",
                         "priority": 1,
-                        "source": "device_code",
-                        "access_token": "access-other",
-                        "refresh_token": "refresh-other",
+                        "source": "manual:device_code",
+                        "access_token": secondary_access,
+                        "refresh_token": secondary_refresh,
                         "base_url": "https://chatgpt.com/backend-api/codex",
                     },
                 ]
@@ -366,8 +379,8 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.auth.refresh_codex_oauth_pure",
         lambda access_token, refresh_token, timeout_seconds=20.0: {
-            "access_token": "access-new",
-            "refresh_token": "refresh-new",
+            "access_token": refreshed_access,
+            "refresh_token": refreshed_refresh,
         },
     )
 
@@ -378,14 +391,15 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     refreshed = pool.try_refresh_current()
 
     assert refreshed is not None
-    assert refreshed.access_token == "access-new"
+    assert refreshed.access_token == refreshed_access
+    assert refreshed.refresh_token == refreshed_refresh
 
     auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
     primary, secondary = auth_payload["credential_pool"]["openai-codex"]
-    assert primary["access_token"] == "access-new"
-    assert primary["refresh_token"] == "refresh-new"
-    assert secondary["access_token"] == "access-other"
-    assert secondary["refresh_token"] == "refresh-other"
+    assert primary["access_token"] == refreshed_access
+    assert primary["refresh_token"] == refreshed_refresh
+    assert secondary["access_token"] == secondary_access
+    assert secondary["refresh_token"] == secondary_refresh
 
 
 def test_load_pool_ignores_unusable_codex_singleton_tokens(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -317,7 +317,15 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
 
 
-def test_get_codex_auth_status_ignores_unusable_pool_entry(monkeypatch):
+def test_get_codex_auth_status_ignores_unusable_pool_entry(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(
+        hermes_home,
+        access_token="access-new",
+        refresh_token="refresh-old-abcdefghijklmnopqrstuvwxyz0123456789",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
     invalid_entry = SimpleNamespace(
         runtime_api_key="access-new",
         access_token="access-new",
@@ -333,17 +341,6 @@ def test_get_codex_auth_status_ignores_unusable_pool_entry(monkeypatch):
             return invalid_entry
 
     monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: _FakePool())
-    monkeypatch.setattr(
-        "hermes_cli.auth.resolve_codex_runtime_credentials",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            AuthError(
-                "Codex auth contains an unusable access_token. Run `hermes auth` to re-authenticate.",
-                provider="openai-codex",
-                code="codex_auth_invalid_access_token",
-                relogin_required=True,
-            )
-        ),
-    )
 
     status = get_codex_auth_status()
     assert status["logged_in"] is False
@@ -358,3 +355,67 @@ def test_list_authenticated_providers_skips_invalid_codex_status(monkeypatch):
     providers = list_authenticated_providers(current_provider="openrouter")
 
     assert all(provider["slug"] != "openai-codex" for provider in providers)
+
+
+def test_get_codex_auth_status_is_passive_for_legacy_auth_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    expired_token = _jwt_with_exp(int(time.time()) - 10)
+    _setup_hermes_auth(
+        hermes_home,
+        access_token=expired_token,
+        refresh_token="refresh-old-abcdefghijklmnopqrstuvwxyz0123456789",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: None)
+
+    refresh_calls = []
+
+    def _fake_refresh(tokens, timeout_seconds):
+        refresh_calls.append((tokens, timeout_seconds))
+        return {
+            "access_token": "refreshed-access-token-abcdefghijklmnopqrstuvwxyz0123456789",
+            "refresh_token": "refreshed-refresh-token-abcdefghijklmnopqrstuvwxyz0123456789",
+            "last_refresh": "2026-04-15T00:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
+
+    status = get_codex_auth_status()
+
+    assert refresh_calls == []
+    assert status["logged_in"] is True
+    assert status["source"] == "hermes-auth-store"
+    assert status["auth_mode"] == "chatgpt"
+    assert status["last_refresh"] == "2026-02-26T00:00:00Z"
+    assert status["api_key"] == expired_token
+
+
+def test_resolve_provider_auto_is_passive_for_legacy_codex_auth_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    expired_token = _jwt_with_exp(int(time.time()) - 10)
+    _setup_hermes_auth(
+        hermes_home,
+        access_token=expired_token,
+        refresh_token="refresh-old-abcdefghijklmnopqrstuvwxyz0123456789",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: None)
+
+    refresh_calls = []
+
+    def _fake_refresh(tokens, timeout_seconds):
+        refresh_calls.append((tokens, timeout_seconds))
+        return {
+            "access_token": "refreshed-access-token-abcdefghijklmnopqrstuvwxyz0123456789",
+            "refresh_token": "refreshed-refresh-token-abcdefghijklmnopqrstuvwxyz0123456789",
+            "last_refresh": "2026-04-15T00:00:00Z",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
+
+    provider = resolve_provider("auto")
+
+    assert refresh_calls == []
+    assert provider == "openai-codex"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -4,6 +4,7 @@ import json
 import time
 import base64
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -21,9 +22,14 @@ from hermes_cli.auth import (
     resolve_codex_runtime_credentials,
     resolve_provider,
 )
+from hermes_cli.model_switch import list_authenticated_providers
 
 
-def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):
+VALID_ACCESS_TOKEN = "plain-token-abcdefghijklmnopqrstuvwxyz0123456789"
+VALID_REFRESH_TOKEN = "refresh-token-abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def _setup_hermes_auth(hermes_home: Path, *, access_token: str = VALID_ACCESS_TOKEN, refresh_token: str = VALID_REFRESH_TOKEN):
     """Write Codex tokens into the Hermes auth store."""
     hermes_home.mkdir(parents=True, exist_ok=True)
     auth_store = {
@@ -57,8 +63,18 @@ def test_read_codex_tokens_success(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     data = _read_codex_tokens()
-    assert data["tokens"]["access_token"] == "access"
-    assert data["tokens"]["refresh_token"] == "refresh"
+    assert data["tokens"]["access_token"] == VALID_ACCESS_TOKEN
+    assert data["tokens"]["refresh_token"] == VALID_REFRESH_TOKEN
+
+
+def test_read_codex_tokens_rejects_placeholder_tokens(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="access-new", refresh_token="refresh-new")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_invalid_access_token"
 
 
 def test_read_codex_tokens_missing(tmp_path, monkeypatch):
@@ -87,7 +103,7 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
 def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     expiring_token = _jwt_with_exp(int(time.time()) - 10)
-    _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old")
+    _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old-abcdefghijklmnopqrstuvwxyz0123456789")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     called = {"count": 0}
@@ -106,7 +122,7 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
 def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
-    _setup_hermes_auth(hermes_home, access_token="access-current", refresh_token="refresh-old")
+    _setup_hermes_auth(hermes_home, access_token="access-current-abcdefghijklmnopqrstuvwxyz0123456789", refresh_token="refresh-old-abcdefghijklmnopqrstuvwxyz0123456789")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     called = {"count": 0}
@@ -135,25 +151,39 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    _save_codex_tokens({"access_token": "at123", "refresh_token": "rt456"})
+    _save_codex_tokens({"access_token": "hermes-at-abcdefghijklmnopqrstuvwxyz0123456789", "refresh_token": "hermes-rt-abcdefghijklmnopqrstuvwxyz0123456789"})
     data = _read_codex_tokens()
 
-    assert data["tokens"]["access_token"] == "at123"
-    assert data["tokens"]["refresh_token"] == "rt456"
+    assert data["tokens"]["access_token"] == "at123-abcdefghijklmnopqrstuvwxyz0123456789"
+    assert data["tokens"]["refresh_token"] == "rt456-abcdefghijklmnopqrstuvwxyz0123456789"
 
 
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-cli"
     codex_home.mkdir(parents=True, exist_ok=True)
     (codex_home / "auth.json").write_text(json.dumps({
-        "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
+        "tokens": {
+            "access_token": "cli-access-token-abcdefghijklmnopqrstuvwxyz0123456789",
+            "refresh_token": "cli-refresh-token-abcdefghijklmnopqrstuvwxyz0123456789",
+        },
     }))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
     tokens = _import_codex_cli_tokens()
     assert tokens is not None
-    assert tokens["access_token"] == "cli-at"
-    assert tokens["refresh_token"] == "cli-rt"
+    assert tokens["access_token"] == "cli-access-token-abcdefghijklmnopqrstuvwxyz0123456789"
+    assert tokens["refresh_token"] == "cli-refresh-token-abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def test_import_codex_cli_tokens_ignores_placeholder_tokens(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-cli"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {"access_token": "access-new", "refresh_token": "refresh-new"},
+    }))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    assert _import_codex_cli_tokens() is None
 
 
 def test_import_codex_cli_tokens_missing(tmp_path, monkeypatch):
@@ -172,14 +202,14 @@ def test_codex_tokens_not_written_to_shared_file(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
-    _save_codex_tokens({"access_token": "hermes-at", "refresh_token": "hermes-rt"})
+    _save_codex_tokens({"access_token": "hermes-at-abcdefghijklmnopqrstuvwxyz0123456789", "refresh_token": "hermes-rt-abcdefghijklmnopqrstuvwxyz0123456789"})
 
     # ~/.codex/auth.json should NOT exist — _save_codex_tokens only touches Hermes store
     assert not (codex_home / "auth.json").exists()
 
     # Hermes auth store should have the tokens
     data = _read_codex_tokens()
-    assert data["tokens"]["access_token"] == "hermes-at"
+    assert data["tokens"]["access_token"] == "hermes-at-abcdefghijklmnopqrstuvwxyz0123456789"
 
 
 def test_write_codex_cli_tokens_creates_file(tmp_path, monkeypatch):
@@ -283,3 +313,46 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["source"] == "hermes-auth-store"
     assert creds["provider"] == "openai-codex"
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
+
+
+def test_get_codex_auth_status_ignores_unusable_pool_entry(monkeypatch):
+    invalid_entry = SimpleNamespace(
+        runtime_api_key="access-new",
+        access_token="access-new",
+        last_refresh="2026-04-15T00:00:00Z",
+        label="stale-singleton",
+    )
+
+    class _FakePool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return invalid_entry
+
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: _FakePool())
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AuthError(
+                "Codex auth contains an unusable access_token. Run `hermes auth` to re-authenticate.",
+                provider="openai-codex",
+                code="codex_auth_invalid_access_token",
+                relogin_required=True,
+            )
+        ),
+    )
+
+    status = get_codex_auth_status()
+    assert status["logged_in"] is False
+    assert "unusable access_token" in status["error"]
+
+
+def test_list_authenticated_providers_skips_invalid_codex_status(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.auth.get_codex_auth_status", lambda: {"logged_in": False})
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+
+    providers = list_authenticated_providers(current_provider="openrouter")
+
+    assert all(provider["slug"] != "openai-codex" for provider in providers)

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -151,11 +151,13 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    _save_codex_tokens({"access_token": "hermes-at-abcdefghijklmnopqrstuvwxyz0123456789", "refresh_token": "hermes-rt-abcdefghijklmnopqrstuvwxyz0123456789"})
+    access_token = "hermes-at-abcdefghijklmnopqrstuvwxyz0123456789"
+    refresh_token = "hermes-rt-abcdefghijklmnopqrstuvwxyz0123456789"
+    _save_codex_tokens({"access_token": access_token, "refresh_token": refresh_token})
     data = _read_codex_tokens()
 
-    assert data["tokens"]["access_token"] == "at123-abcdefghijklmnopqrstuvwxyz0123456789"
-    assert data["tokens"]["refresh_token"] == "rt456-abcdefghijklmnopqrstuvwxyz0123456789"
+    assert data["tokens"]["access_token"] == access_token
+    assert data["tokens"]["refresh_token"] == refresh_token
 
 
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

PR #10282 fixes immediate credential rotation, but Hermes could still accept unusable Codex auth state before rotation ever had a chance to help. In practice that means malformed / placeholder / stale singleton auth could still poison runtime selection and auxiliary fallback paths.

## Root cause

- Codex auth-state checks were too permissive
- singleton / fallback paths could treat unusable tokens as valid enough to enter the runtime path
- tests were sensitive to host `~/.codex/auth.json` state, which made the verification surface noisy

## Fix

### Runtime changes
1. `hermes_cli/auth.py`
   - add `_codex_access_token_looks_usable()`
   - add `_codex_refresh_token_looks_usable()`
   - add `_codex_token_pair_looks_usable()`
   - use those guards when reading stored/imported Codex auth
2. `agent/credential_pool.py`
   - only seed/import singleton Codex state when the token pair is actually usable
3. `agent/auxiliary_client.py`
   - ignore unusable singleton fallback tokens instead of stalling the auxiliary chain
4. `hermes_cli/model_switch.py`
   - align provider-auth visibility with usable Codex credentials

### Test hardening
- isolate tests from host `~/.codex/auth.json` so the suite reflects repository behavior, not machine-local auth residue

## Scope

Included:
- token usability validation
- auxiliary fallback filtering
- credential-pool singleton seeding guardrails
- test isolation for host Codex auth state

Excluded:
- broader credential-pool redesign
- custom provider behavior unrelated to Codex auth usability

## Testing

```bash
python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/agent/test_auxiliary_client.py -q
# 118 passed

python -m pytest tests/agent/test_credential_pool.py tests/run_agent/test_run_agent.py tests/agent/test_auxiliary_client.py tests/hermes_cli/test_auth_codex_provider.py -q
# 400 passed
```

## Relationship to PR #10282

- PR #10282 handles immediate runtime rotation when a pooled credential is exhausted
- this PR makes sure unusable Codex auth state does not get mistaken for a viable runtime path in the first place

They are intentionally split because they solve two different failure layers:
- PR #10282 = failover behavior under exhaustion
- PR #10286 = auth-state validity before selection / fallback
