### PR TITLE
fix(mcp): clear stale thread interrupt before MCP discovery

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2014,7 +2014,19 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
 
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
-    _run_on_mcp_loop(_discover_all(), timeout=120)
+    #
+    # Temporarily clear the interrupt flag on the current thread so that MCP
+    # discovery is never cancelled by a stale interrupt from a prior agent
+    # session (executor threads get reused and may carry old interrupt state).
+    from tools.interrupt import is_interrupted as _is_interrupted, set_interrupt as _set_interrupt
+    _was_interrupted = _is_interrupted()
+    if _was_interrupted:
+        _set_interrupt(False)
+    try:
+        _run_on_mcp_loop(_discover_all(), timeout=120)
+    finally:
+        if _was_interrupted:
+            _set_interrupt(True)
 
     # Log a summary so ACP callers get visibility into what was registered.
     with _lock:


### PR DESCRIPTION
## Problem

Closes #9930

When an agent session is interrupted (Ctrl+C, gateway timeout, or `/reset`), the current thread's interrupt flag is set in `_interrupted_threads`. asyncio executor threads are pooled and **reused across sessions**, so a thread that carried an interrupt flag from a prior session will immediately cancel any new asyncio work dispatched to it — including MCP server discovery.

This causes all MCP servers to fail with `asyncio.exceptions.CancelledError` on the *next* session after any interruption, even though the new session has nothing to do with the prior interrupt.

## Root Cause

`register_mcp_servers()` calls `_run_on_mcp_loop(_discover_all(), timeout=120)`, which dispatches work to an executor thread. If that thread happens to be one that previously had its interrupt flag set and never got cleared (because the thread was returned to the pool rather than destroyed), `is_interrupted()` returns `True` at the start of discovery and `CancelledError` is raised immediately.

## Fix

In `register_mcp_servers()`, temporarily clear the interrupt flag on the current thread before running `_discover_all()`, then restore it in a `finally` block so the original interrupt state is preserved:

```python
from tools.interrupt import is_interrupted as _is_interrupted, set_interrupt as _set_interrupt
_was_interrupted = _is_interrupted()
if _was_interrupted:
    _set_interrupt(False)
try:
    _run_on_mcp_loop(_discover_all(), timeout=120)
finally:
    if _was_interrupted:
        _set_interrupt(True)
```

## Testing

Verified by simulating stale interrupt state before calling `register_mcp_servers()`: 154 tools from 20 servers discovered successfully in ~3.8s with no `CancelledError`.