### PR TITLE
feat: add busy command API and compressor info for context compression

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6350,39 +6350,46 @@ class HermesCLI:
                 focus_topic = parts[1].strip()
 
         original_count = len(self.conversation_history)
-        try:
-            from agent.model_metadata import estimate_messages_tokens_rough
-            from agent.manual_compression_feedback import summarize_manual_compression
-            original_history = list(self.conversation_history)
-            approx_tokens = estimate_messages_tokens_rough(original_history)
-            if focus_topic:
-                print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens), "
-                      f"focus: \"{focus_topic}\"...")
-            else:
-                print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens)...")
 
-            compressed, _ = self.agent._compress_context(
-                original_history,
-                self.agent._cached_system_prompt or "",
-                approx_tokens=approx_tokens,
-                focus_topic=focus_topic or None,
-            )
-            self.conversation_history = compressed
-            new_tokens = estimate_messages_tokens_rough(self.conversation_history)
-            summary = summarize_manual_compression(
-                original_history,
-                self.conversation_history,
-                approx_tokens,
-                new_tokens,
-            )
-            icon = "🗜️" if summary["noop"] else "✅"
-            print(f"  {icon} {summary['headline']}")
-            print(f"     {summary['token_line']}")
-            if summary["note"]:
-                print(f"     {summary['note']}")
+        # Build compressor info for the busy status
+        _comp_info = self.agent._compressor_info()
 
-        except Exception as e:
-            print(f"  ❌ Compression failed: {e}")
+        with self._busy_command("Compressing context..."):
+            try:
+                from agent.model_metadata import estimate_messages_tokens_rough
+                from agent.manual_compression_feedback import summarize_manual_compression
+                original_history = list(self.conversation_history)
+                approx_tokens = estimate_messages_tokens_rough(original_history)
+                if focus_topic:
+                    print(f"🗜️  /compress  [{_comp_info}]")
+                    print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens), "
+                          f"focus: \"{focus_topic}\"...")
+                else:
+                    print(f"🗜️  /compress  [{_comp_info}]")
+                    print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens)...")
+
+                compressed, _ = self.agent._compress_context(
+                    original_history,
+                    self.agent._cached_system_prompt or "",
+                    approx_tokens=approx_tokens,
+                    focus_topic=focus_topic or None,
+                )
+                self.conversation_history = compressed
+                new_tokens = estimate_messages_tokens_rough(self.conversation_history)
+                summary = summarize_manual_compression(
+                    original_history,
+                    self.conversation_history,
+                    approx_tokens,
+                    new_tokens,
+                )
+                icon = "🗜️" if summary["noop"] else "✅"
+                print(f"  {icon} {summary['headline']}")
+                print(f"     {summary['token_line']}")
+                if summary["note"]:
+                    print(f"     {summary['note']}")
+
+            except Exception as e:
+                print(f"  ❌ Compression failed: {e}")
 
     def _handle_debug_command(self):
         """Handle /debug — upload debug report + logs and print paste URLs."""

--- a/plugins/context_engine/ironin_compressor
+++ b/plugins/context_engine/ironin_compressor
@@ -1,0 +1,1 @@
+/Users/ironin/Work/Hermes/hermes-context-compressor/plugins/context_engine/ironin_compressor

--- a/run_agent.py
+++ b/run_agent.py
@@ -1399,6 +1399,7 @@ class AIAgent:
                 api_mode=self.api_mode,
             )
         self.compression_enabled = compression_enabled
+        self._compressing = False  # True while compression is in-flight
 
         # Reject models whose context window is below the minimum required
         # for reliable tool-calling workflows (64K tokens).
@@ -6784,6 +6785,17 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
+    def _compressor_info(self) -> str:
+        """Return a human-readable string describing the active compressor."""
+        cc = self.context_compressor
+        name = getattr(cc, "name", "compressor")
+        # Smart compressor (IroninCompressor) extra settings
+        keep = getattr(cc, "_keep_threshold", None)
+        drop = getattr(cc, "_drop_threshold", None)
+        if keep is not None and drop is not None:
+            return f"{name} (keep>={keep}, drop<{drop})"
+        return name
+
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
@@ -10242,12 +10254,17 @@ class AIAgent:
                                 }
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
-                        self._safe_print("  ⟳ compacting context…")
-                        messages, active_system_prompt = self._compress_context(
-                            messages, system_message,
-                            approx_tokens=self.context_compressor.last_prompt_tokens,
-                            task_id=effective_task_id,
-                        )
+                        _comp_info = self._compressor_info()
+                        self._safe_print(f"  🗜️  {_comp_info} -- compacting {len(messages)} messages (~{_real_tokens:,} tokens)...")
+                        self._compressing = True
+                        try:
+                            messages, active_system_prompt = self._compress_context(
+                                messages, system_message,
+                                approx_tokens=self.context_compressor.last_prompt_tokens,
+                                task_id=effective_task_id,
+                            )
+                        finally:
+                            self._compressing = False
                         # Compression created a new session — clear history so
                         # _flush_messages_to_session_db writes compressed messages
                         # to the new session (see preflight compression comment).


### PR DESCRIPTION
## Problem

When `/compress` or automatic context compression runs, the TUI input prompt remains active and unblocked. The user can type while compression is in-flight, which causes input to be consumed by a prompt that is about to be replaced.

Additionally, there is no visible indication of which compressor is active or what settings it uses.

## Solution

### run_agent.py
- **`_compressing` flag** on AIAgent -- set to `True` while compression is in-flight, reset in a `finally` block so the flag is always cleared even on error
- **`_compressor_info()` method** -- returns a human-readable string describing the active compressor. For the built-in compressor it returns `"compressor"`, for smart compressors (e.g. IroninCompressor) it returns `"ironin-compressor (keep>=6, drop<5)"`
- **Auto-compression message** updated from `  ⟳ compacting context…` to `  🗜️  ironin-compressor (keep>=6, drop<5) -- compacting 510 messages (~224,081 tokens)...`

### cli.py
- **`/compress` wrapped in `_busy_command()`** -- the existing context manager that sets `_command_running = True` (blocking input rendering) and shows a spinner + status message in the TUI status bar

## Output

Manual compression (`/compress`):
```
⚙️  /compress
⏳ Compressing context...
🗜️  /compress  [ironin-compressor (keep>=6, drop<5)]
🗜️  Compressing 878 messages (~545,632 tokens)...
  ✅ Compressed: 878 → 142 messages (~545,632 → ~89,210 tokens)
```

Auto-compression:
```
  🗜️  ironin-compressor (keep>=6, drop<5) -- compacting 510 messages (~224,081 tokens)...
```

## Design

This lays the groundwork for a formal busy command API that plugins and extensions can use to block input during long operations. The `_busy_command()` context manager already exists in `cli.py`; this PR demonstrates its use and adds the `_compressing` flag on AIAgent for the agent loop path (which runs outside the CLI).

Closes #10281