### PR TITLE
fix(gateway): use yaml.safe_load for config file parsing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9630,9 +9630,9 @@ def main():
     
     config = None
     if args.config:
-        import json
+        import yaml
         with open(args.config, encoding="utf-8") as f:
-            data = json.load(f)
+            data = yaml.safe_load(f)
             config = GatewayConfig.from_dict(data)
     
     # Run the gateway - exit with code 1 if no platforms connected,


### PR DESCRIPTION
The gateway fails to start with --config flag because it uses json.load() to parse YAML config files. Changed to yaml.safe_load().

Fixes #10216.