### PR TITLE
fix(gateway): chown pairing files to dir owner when CLI runs as root

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -19,6 +19,7 @@ Storage: ~/.hermes/pairing/
 """
 
 import json
+import logging
 import os
 import secrets
 import tempfile
@@ -26,6 +27,8 @@ import threading
 import time
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from hermes_constants import get_hermes_dir
 
@@ -46,6 +49,23 @@ MAX_FAILED_ATTEMPTS = 5             # Failed approvals before lockout
 PAIRING_DIR = get_hermes_dir("platforms/pairing", "pairing")
 
 
+def _match_dir_owner(path: Path) -> None:
+    """If running as root, chown *path* to match its parent directory's owner.
+
+    This handles the common Docker scenario where ``docker exec`` runs as root
+    but the gateway process dropped privileges to a non-root user.  Without the
+    chown the gateway cannot read files the CLI just wrote.
+    """
+    if os.getuid() != 0:
+        return
+    try:
+        dir_stat = path.parent.stat()
+        if dir_stat.st_uid != 0:
+            os.chown(path, dir_stat.st_uid, dir_stat.st_gid)
+    except OSError:
+        pass
+
+
 def _secure_write(path: Path, data: str) -> None:
     """Write data to file with restrictive permissions (owner read/write only).
 
@@ -64,6 +84,7 @@ def _secure_write(path: Path, data: str) -> None:
             os.chmod(path, 0o600)
         except OSError:
             pass  # Windows doesn't support chmod the same way
+        _match_dir_owner(path)
     except BaseException:
         try:
             os.unlink(tmp_path)
@@ -101,6 +122,13 @@ class PairingStore:
         if path.exists():
             try:
                 return json.loads(path.read_text(encoding="utf-8"))
+            except PermissionError:
+                logger.warning(
+                    "Cannot read %s (permission denied). If running in Docker, "
+                    "re-run the pairing command with: docker exec -u hermes …",
+                    path,
+                )
+                return {}
             except (json.JSONDecodeError, OSError):
                 return {}
         return {}

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -1,6 +1,7 @@
 """Tests for gateway/pairing.py — DM pairing security system."""
 
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -15,6 +16,7 @@ from gateway.pairing import (
     MAX_PENDING_PER_PLATFORM,
     MAX_FAILED_ATTEMPTS,
     LOCKOUT_SECONDS,
+    _match_dir_owner,
     _secure_write,
 )
 
@@ -42,6 +44,65 @@ class TestSecureWrite:
         _secure_write(target, "data")
         mode = oct(target.stat().st_mode & 0o777)
         assert mode == "0o600"
+
+    def test_match_dir_owner_skips_non_root(self, tmp_path):
+        target = tmp_path / "file.json"
+        target.write_text("x")
+        uid_before = target.stat().st_uid
+        with patch("gateway.pairing.os.getuid", return_value=1000):
+            _match_dir_owner(target)
+        assert target.stat().st_uid == uid_before
+
+    def test_match_dir_owner_calls_chown_when_root(self, tmp_path):
+        target = tmp_path / "file.json"
+        target.write_text("x")
+        dir_stat = tmp_path.stat()
+        with patch("gateway.pairing.os.getuid", return_value=0), \
+             patch("gateway.pairing.os.chown") as mock_chown:
+            _match_dir_owner(target)
+        if dir_stat.st_uid != 0:
+            mock_chown.assert_called_once_with(
+                target, dir_stat.st_uid, dir_stat.st_gid,
+            )
+
+    def test_secure_write_calls_match_dir_owner(self, tmp_path):
+        target = tmp_path / "file.json"
+        with patch("gateway.pairing._match_dir_owner") as mock_match:
+            _secure_write(target, "data")
+        mock_match.assert_called_once_with(target)
+
+
+# ---------------------------------------------------------------------------
+# Permission error logging
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionErrorLogging:
+    def test_load_json_logs_warning_on_permission_error(self, tmp_path, caplog):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            path = tmp_path / "weixin-approved.json"
+            path.write_text('{"user1": {}}')
+            path.chmod(0o000)
+            try:
+                with caplog.at_level(logging.WARNING, logger="gateway.pairing"):
+                    result = store.is_approved("weixin", "user1")
+            finally:
+                path.chmod(0o600)
+        assert result is False
+        assert "permission denied" in caplog.text.lower()
+
+    def test_load_json_returns_empty_on_permission_error(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            path = tmp_path / "telegram-approved.json"
+            path.write_text('{"user1": {}}')
+            path.chmod(0o000)
+            try:
+                result = store._load_json(path)
+            finally:
+                path.chmod(0o600)
+        assert result == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #10270 — `docker exec` runs as root by default, so `hermes pairing approve` creates approval files (`weixin-approved.json`) owned by `root:root` with `0600` permissions. After the gateway drops privileges to the `hermes` user it cannot read those files, silently treating approved users as unauthorized.

- **`_match_dir_owner()`**: after `_secure_write` creates a file, if the current process is root and the parent directory is owned by a non-root user, `chown` the file to match. This covers the `docker exec` case without requiring users to remember `-u hermes`.
- **`_load_json()` warning**: when a pairing file exists but raises `PermissionError`, log an actionable warning (`"Cannot read … (permission denied). If running in Docker, re-run the pairing command with: docker exec -u hermes …"`) instead of silently returning `{}`.

## Test plan

- Added unit tests for `_match_dir_owner` (skips when non-root, calls `os.chown` when root)
- Added unit test confirming `_secure_write` calls `_match_dir_owner`
- Added tests for `PermissionError` logging in `_load_json`
- All 33 pairing tests pass