### PR TITLE
fix(gateway): add hermes-gateway script pattern to PID detection

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -121,6 +121,7 @@ def _looks_like_gateway_process(pid: int) -> bool:
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",
         "hermes gateway",
+        "hermes-gateway",
         "gateway/run.py",
     )
     return any(pattern in cmdline for pattern in patterns)


### PR DESCRIPTION
## Summary

- Add `hermes-gateway` script pattern to `_looks_like_gateway_process` function

## Problem

Dashboard was reporting gateway as "not running" even when the process was active.

The `_looks_like_gateway_process` function checks the process cmdline against known patterns, but the `hermes-gateway` script entry point was missing.

## Root Cause

Actual cmdline: `.../scripts/hermes-gateway run`

Patterns checked:
- `hermes_cli.main gateway` ✗
- `hermes_cli/main.py gateway` ✗  
- `hermes gateway` ✗
- `gateway/run.py` ✗

None matched, so `get_running_pid()` returned `None`.

## Fix

Add `hermes-gateway` to the patterns list:

```python
patterns = (
    "hermes_cli.main gateway",
    "hermes_cli/main.py gateway",
    "hermes gateway",
    "hermes-gateway",  # new
    "gateway/run.py",
)
```

## Test plan

- [x] Dashboard now correctly shows gateway as running
- [ ] (optional) Add unit test for this specific pattern