### PR TITLE
fix(gateway): honor QQ_GROUP_ALLOWED_USERS in runner auth

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2577,6 +2577,9 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
         }
+        platform_group_env_map = {
+            Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
+        }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
             Platform.DISCORD: "DISCORD_ALLOW_ALL_USERS",
@@ -2608,11 +2611,22 @@ class GatewayRunner:
 
         # Check platform-specific and global allowlists
         platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        group_allowlist = ""
+        if source.chat_type == "group":
+            group_allowlist = os.getenv(platform_group_env_map.get(source.platform, ""), "").strip()
         global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
-        if not platform_allowlist and not global_allowlist:
+        if not platform_allowlist and not group_allowlist and not global_allowlist:
             # No allowlists configured -- check global allow-all flag
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+
+        # Some platforms authorize group traffic by chat ID rather than sender ID.
+        if group_allowlist and source.chat_type == "group" and source.chat_id:
+            allowed_group_ids = {
+                chat_id.strip() for chat_id in group_allowlist.split(",") if chat_id.strip()
+            }
+            if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
+                return True
 
         # Check if user is in any allowlist
         allowed_ids = set()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,6 +81,7 @@ AUTHOR_MAP = {
     "mcosma@gmail.com": "wakamex",
     "clawdia.nash@proton.me": "clawdia-nash",
     "pickett.austin@gmail.com": "austinpickett",
+    "dangtc94@gmail.com": "dieutx",
     "jaisehgal11299@gmail.com": "jaisup",
     "percydikec@gmail.com": "PercyDikec",
     "dean.kerr@gmail.com": "deankerr",

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -21,6 +21,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATTERMOST_ALLOWED_USERS",
         "MATRIX_ALLOWED_USERS",
         "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
+        "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "TELEGRAM_ALLOW_ALL_USERS",
         "DISCORD_ALLOW_ALL_USERS",
@@ -32,6 +33,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATTERMOST_ALLOW_ALL_USERS",
         "MATRIX_ALLOW_ALL_USERS",
         "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
+        "QQ_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -128,6 +130,46 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
         chat_type="dm",
     )
     assert runner._is_user_authorized(source) is True
+
+
+def test_qq_group_allowlist_authorizes_group_chat_without_user_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("QQ_GROUP_ALLOWED_USERS", "group-openid-1")
+
+    runner, _adapter = _make_runner(
+        Platform.QQBOT,
+        GatewayConfig(platforms={Platform.QQBOT: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        user_id="member-openid-999",
+        chat_id="group-openid-1",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_qq_group_allowlist_does_not_authorize_other_groups(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("QQ_GROUP_ALLOWED_USERS", "group-openid-1")
+
+    runner, _adapter = _make_runner(
+        Platform.QQBOT,
+        GatewayConfig(platforms={Platform.QQBOT: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        user_id="member-openid-999",
+        chat_id="group-openid-2",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`QQ_GROUP_ALLOWED_USERS` did not actually authorize QQ group traffic in the gateway runner. Group messages that passed `QQAdapter._is_group_allowed()` were still rejected later by `GatewayRunner._is_user_authorized()` unless the sender was also listed in `QQ_ALLOWED_USERS`.

## Root Cause

`_is_user_authorized()` only checked `QQ_ALLOWED_USERS` against `source.user_id`. QQ group allowlisting is keyed by `source.chat_id` (`group_openid`), so `QQ_GROUP_ALLOWED_USERS` was never consulted in the runner-level auth path.

## Fix

- added a QQ group allowlist env map in `_is_user_authorized()`
- authorize QQ group messages by `source.chat_id` when `QQ_GROUP_ALLOWED_USERS` matches
- keep the existing sender-based checks unchanged for DMs and other allowlists
- added regression tests for allowed and disallowed QQ groups

## Tests

- `pytest -q tests/gateway/test_unauthorized_dm_behavior.py`
- `pytest -q tests/gateway/test_qqbot.py`