### PR TITLE
feat: display compressor name and settings in /compress output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6350,39 +6350,46 @@ class HermesCLI:
                 focus_topic = parts[1].strip()
 
         original_count = len(self.conversation_history)
-        try:
-            from agent.model_metadata import estimate_messages_tokens_rough
-            from agent.manual_compression_feedback import summarize_manual_compression
-            original_history = list(self.conversation_history)
-            approx_tokens = estimate_messages_tokens_rough(original_history)
-            if focus_topic:
-                print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens), "
-                      f"focus: \"{focus_topic}\"...")
-            else:
-                print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens)...")
 
-            compressed, _ = self.agent._compress_context(
-                original_history,
-                self.agent._cached_system_prompt or "",
-                approx_tokens=approx_tokens,
-                focus_topic=focus_topic or None,
-            )
-            self.conversation_history = compressed
-            new_tokens = estimate_messages_tokens_rough(self.conversation_history)
-            summary = summarize_manual_compression(
-                original_history,
-                self.conversation_history,
-                approx_tokens,
-                new_tokens,
-            )
-            icon = "🗜️" if summary["noop"] else "✅"
-            print(f"  {icon} {summary['headline']}")
-            print(f"     {summary['token_line']}")
-            if summary["note"]:
-                print(f"     {summary['note']}")
+        # Build compressor info for display
+        _comp_info = self.agent._compressor_info()
 
-        except Exception as e:
-            print(f"  ❌ Compression failed: {e}")
+        with self._busy_command("Compressing context..."):
+            try:
+                from agent.model_metadata import estimate_messages_tokens_rough
+                from agent.manual_compression_feedback import summarize_manual_compression
+                original_history = list(self.conversation_history)
+                approx_tokens = estimate_messages_tokens_rough(original_history)
+                if focus_topic:
+                    print(f"🗜️  /compress  [{_comp_info}]")
+                    print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens), "
+                          f"focus: \"{focus_topic}\"...")
+                else:
+                    print(f"🗜️  /compress  [{_comp_info}]")
+                    print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens)...")
+
+                compressed, _ = self.agent._compress_context(
+                    original_history,
+                    self.agent._cached_system_prompt or "",
+                    approx_tokens=approx_tokens,
+                    focus_topic=focus_topic or None,
+                )
+                self.conversation_history = compressed
+                new_tokens = estimate_messages_tokens_rough(self.conversation_history)
+                summary = summarize_manual_compression(
+                    original_history,
+                    self.conversation_history,
+                    approx_tokens,
+                    new_tokens,
+                )
+                icon = "🗜️" if summary["noop"] else "✅"
+                print(f"  {icon} {summary['headline']}")
+                print(f"     {summary['token_line']}")
+                if summary["note"]:
+                    print(f"     {summary['note']}")
+
+            except Exception as e:
+                print(f"  ❌ Compression failed: {e}")
 
     def _handle_debug_command(self):
         """Handle /debug — upload debug report + logs and print paste URLs."""

--- a/plugins/context_engine/ironin_compressor
+++ b/plugins/context_engine/ironin_compressor
@@ -1,0 +1,1 @@
+/Users/ironin/Work/Hermes/hermes-context-compressor/plugins/context_engine/ironin_compressor

--- a/run_agent.py
+++ b/run_agent.py
@@ -6784,6 +6784,21 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
+    def _compressor_info(self) -> str:
+        """Return a human-readable string describing the active compressor.
+
+        Examples:
+            Built-in:   "compressor"
+            Smart:      "ironin-compressor (keep>=6, drop<5)"
+        """
+        cc = self.context_compressor
+        name = getattr(cc, "name", "compressor")
+        keep = getattr(cc, "_keep_threshold", None)
+        drop = getattr(cc, "_drop_threshold", None)
+        if keep is not None and drop is not None:
+            return f"{name} (keep>={keep}, drop<{drop})"
+        return name
+
     def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
@@ -10242,7 +10257,8 @@ class AIAgent:
                                 }
 
                     if self.compression_enabled and _compressor.should_compress(_real_tokens):
-                        self._safe_print("  ⟳ compacting context…")
+                        _comp_info = self._compressor_info()
+                        self._safe_print(f"  🗜️  {_comp_info} -- compacting {len(messages)} messages (~{_real_tokens:,} tokens)...")
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message,
                             approx_tokens=self.context_compressor.last_prompt_tokens,


### PR DESCRIPTION
## Problem

When `/compress` or automatic context compression runs, there is no indication of which compressor is active or what settings it uses. Users with custom context engines (e.g. ironin-compressor with heuristic scoring) have no way to verify the active compressor from the CLI output.

## Solution

### run_agent.py
- **`_compressor_info()` method** -- returns a human-readable string describing the active compressor. For the built-in compressor it returns `"compressor"`, for smart compressors (e.g. IroninCompressor) it returns `"ironin-compressor (keep>=6, drop<5)"`
- **Auto-compression message** updated from `  ⟳ compacting context…` to `  🗜️  ironin-compressor (keep>=6, drop<5) -- compacting 510 messages (~224,081 tokens)...`

### cli.py
- **`/compress` output** now displays compressor info: `🗜️  /compress  [ironin-compressor (keep>=6, drop<5)]`
- Wrapped in `_busy_command()` to block input during compression

## Output

Manual compression (`/compress`):
```
⚙️  /compress
⏳ Compressing context...
🗜️  /compress  [ironin-compressor (keep>=6, drop<5)]
🗜️  Compressing 878 messages (~545,632 tokens)...
  ✅ Compressed: 878 → 142 messages (~545,632 → ~89,210 tokens)
```

Auto-compression:
```
  🗜️  ironin-compressor (keep>=6, drop<5) -- compacting 510 messages (~224,081 tokens)...
```

Closes #10295