### PR TITLE
fix(email): honor adapter send contract reply targets

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -532,11 +532,12 @@ class EmailAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image URL as part of an email body."""
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata=metadata)
 
     async def send_document(
         self,
@@ -545,6 +546,7 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:
@@ -556,6 +558,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                reply_to,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -568,6 +571,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
@@ -580,7 +584,7 @@ class EmailAdapter(BasePlatformAdapter):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
+        original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
             msg["References"] = original_msg_id

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -724,6 +724,28 @@ class TestSendMethods(unittest.TestCase):
         self.assertIn("https://img.com/photo.jpg", body)
         self.assertIn("My photo", body)
 
+    def test_send_image_accepts_metadata(self):
+        """send_image should preserve the base adapter metadata contract."""
+        import asyncio
+        from unittest.mock import AsyncMock
+        adapter = self._make_adapter()
+
+        adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        asyncio.run(
+            adapter.send_image(
+                "user@test.com",
+                "https://img.com/photo.jpg",
+                "My photo",
+                metadata={"thread_id": "ignored-for-email"},
+            )
+        )
+
+        self.assertEqual(
+            adapter.send.call_args.kwargs["metadata"],
+            {"thread_id": "ignored-for-email"},
+        )
+
     def test_send_document_with_attachment(self):
         """send_document should send email with file attachment."""
         import asyncio
@@ -753,6 +775,41 @@ class TestSendMethods(unittest.TestCase):
                     for p in parts
                 )
                 self.assertTrue(has_attachment)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_send_document_uses_explicit_reply_to(self):
+        """send_document should thread attachments from the caller-specified reply target."""
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {
+            "subject": "Existing thread",
+            "message_id": "<context@test.com>",
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Test document content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                result = asyncio.run(
+                    adapter.send_document(
+                        "user@test.com",
+                        tmp_path,
+                        "Here is the file",
+                        reply_to="<explicit@test.com>",
+                    )
+                )
+
+                self.assertTrue(result.success)
+                sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["In-Reply-To"], "<explicit@test.com>")
+                self.assertEqual(sent_msg["References"], "<explicit@test.com>")
         finally:
             os.unlink(tmp_path)
 


### PR DESCRIPTION
## Summary
- add the missing metadata parameter to EmailAdapter.send_image so generic platform callers can pass metadata without crashing
- thread send_document attachments from the explicit reply target instead of silently falling back to cached thread context
- add regression tests for metadata passthrough and explicit reply threading on document sends

## Testing
- python3 -m pytest -o addopts="-m 'not integration'" tests/gateway/test_email.py -q

Fixes #10131