### PR TITLE
fix(pairing): skip malformed pending entries

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -285,13 +285,15 @@ class PairingStore:
     # ----- Cleanup -----
 
     def _cleanup_expired(self, platform: str) -> None:
-        """Remove expired pending codes."""
+        """Remove expired or malformed pending codes."""
         path = self._pending_path(platform)
         pending = self._load_json(path)
         now = time.time()
         expired = [
             code for code, info in pending.items()
-            if (now - info["created_at"]) > CODE_TTL_SECONDS
+            if not isinstance(info, dict)
+            or not isinstance(info.get("created_at"), (int, float))
+            or (now - info["created_at"]) > CODE_TTL_SECONDS
         ]
         if expired:
             for code in expired:

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -286,6 +286,35 @@ class TestCodeExpiry:
             result = store.approve_code("telegram", code)
         assert result is None
 
+    def test_list_pending_skips_entries_missing_created_at(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            store._save_json(
+                store._pending_path("telegram"),
+                {"CODE1234": {"user_id": "user1", "user_name": "Alice"}},
+            )
+
+            remaining = store.list_pending("telegram")
+            pending = store._load_json(store._pending_path("telegram"))
+
+        assert remaining == []
+        assert pending == {}
+
+    def test_generate_code_cleans_up_entries_missing_created_at(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            store._save_json(
+                store._pending_path("telegram"),
+                {"CODE1234": {"user_id": "user1", "user_name": "Alice"}},
+            )
+
+            code = store.generate_code("telegram", "user2", "Bob")
+            pending = store._load_json(store._pending_path("telegram"))
+
+        assert isinstance(code, str) and len(code) == CODE_LENGTH
+        assert list(pending.keys()) == [code]
+        assert pending[code]["user_id"] == "user2"
+
 
 # ---------------------------------------------------------------------------
 # Revoke


### PR DESCRIPTION
## Summary
- treat pending entries without a numeric created_at as malformed during pairing cleanup
- prevent list_pending and generate_code from crashing on valid JSON objects that are missing the timestamp field
- add regression tests covering malformed pending entries in both read and write flows

## Testing
- python3 -m pytest -o addopts="-m 'not integration'" tests/gateway/test_pairing.py -q

Fixes #10132