### PR TITLE
fix(mirror): report transcript write failures

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -52,8 +52,12 @@ def mirror_to_session(
             "mirror_source": source_label,
         }
 
-        _append_to_jsonl(session_id, mirror_msg)
-        _append_to_sqlite(session_id, mirror_msg)
+        jsonl_ok = _append_to_jsonl(session_id, mirror_msg)
+        sqlite_ok = _append_to_sqlite(session_id, mirror_msg)
+
+        if not (jsonl_ok or sqlite_ok):
+            logger.debug("Mirror: no transcript backend succeeded for session %s", session_id)
+            return False
 
         logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
         return True
@@ -104,17 +108,19 @@ def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = Non
     return best_match
 
 
-def _append_to_jsonl(session_id: str, message: dict) -> None:
+def _append_to_jsonl(session_id: str, message: dict) -> bool:
     """Append a message to the JSONL transcript file."""
     transcript_path = _SESSIONS_DIR / f"{session_id}.jsonl"
     try:
         with open(transcript_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(message, ensure_ascii=False) + "\n")
+        return True
     except Exception as e:
         logger.debug("Mirror JSONL write failed: %s", e)
+        return False
 
 
-def _append_to_sqlite(session_id: str, message: dict) -> None:
+def _append_to_sqlite(session_id: str, message: dict) -> bool:
     """Append a message to the SQLite session database."""
     db = None
     try:
@@ -125,8 +131,10 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
             role=message.get("role", "assistant"),
             content=message.get("content"),
         )
+        return True
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)
+        return False
     finally:
         if db is not None:
             db.close()

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -118,9 +118,10 @@ class TestAppendToJsonl:
         sessions_dir.mkdir()
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
-            _append_to_jsonl("sess_1", {"role": "assistant", "content": "Hello"})
+            result = _append_to_jsonl("sess_1", {"role": "assistant", "content": "Hello"})
 
         transcript = sessions_dir / "sess_1.jsonl"
+        assert result is True
         lines = transcript.read_text().strip().splitlines()
         assert len(lines) == 1
         msg = json.loads(lines[0])
@@ -132,12 +133,22 @@ class TestAppendToJsonl:
         sessions_dir.mkdir()
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
-            _append_to_jsonl("sess_1", {"role": "assistant", "content": "msg1"})
-            _append_to_jsonl("sess_1", {"role": "assistant", "content": "msg2"})
+            assert _append_to_jsonl("sess_1", {"role": "assistant", "content": "msg1"}) is True
+            assert _append_to_jsonl("sess_1", {"role": "assistant", "content": "msg2"}) is True
 
         transcript = sessions_dir / "sess_1.jsonl"
         lines = transcript.read_text().strip().splitlines()
         assert len(lines) == 2
+
+    def test_returns_false_when_jsonl_write_fails(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("builtins.open", side_effect=OSError("disk full")):
+            result = _append_to_jsonl("sess_1", {"role": "assistant", "content": "Hello"})
+
+        assert result is False
 
 
 class TestMirrorToSession:
@@ -204,6 +215,40 @@ class TestMirrorToSession:
 
         assert result is False
 
+    def test_returns_false_when_all_backends_fail(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "s1": {
+                "session_id": "sess_abc",
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_jsonl", return_value=False), \
+             patch("gateway.mirror._append_to_sqlite", return_value=False):
+            result = mirror_to_session("telegram", "12345", "Hello!", source_label="cli")
+
+        assert result is False
+
+    def test_returns_true_when_sqlite_succeeds_but_jsonl_fails(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "s1": {
+                "session_id": "sess_abc",
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_jsonl", return_value=False), \
+             patch("gateway.mirror._append_to_sqlite", return_value=True):
+            result = mirror_to_session("telegram", "12345", "Hello!", source_label="cli")
+
+        assert result is True
+
 
 class TestAppendToSqlite:
     def test_connection_is_closed_after_use(self, tmp_path):
@@ -212,8 +257,9 @@ class TestAppendToSqlite:
         mock_db = MagicMock()
 
         with patch("hermes_state.SessionDB", return_value=mock_db):
-            _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
+            result = _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
 
+        assert result is True
         mock_db.append_message.assert_called_once()
         mock_db.close.assert_called_once()
 
@@ -224,6 +270,7 @@ class TestAppendToSqlite:
         mock_db.append_message.side_effect = Exception("db error")
 
         with patch("hermes_state.SessionDB", return_value=mock_db):
-            _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
+            result = _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
 
+        assert result is False
         mock_db.close.assert_called_once()


### PR DESCRIPTION
## Summary
- make JSONL and SQLite mirror writers return success status instead of silently swallowing write outcomes
- return False from mirror_to_session when both transcript backends fail, while still treating partial success as success
- add regression tests for JSONL failures, total backend failure, and mixed backend success

## Testing
- python3 -m pytest -o addopts="-m 'not integration'" tests/gateway/test_mirror.py -q

Fixes #10130