### PR TITLE
fix(update): use [termux] extras group on Android

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3572,10 +3572,24 @@ def _install_python_dependencies_with_optional_fallback(
     *,
     env: dict[str, str] | None = None,
 ) -> None:
-    """Install base deps plus as many optional extras as the environment supports."""
+    """Install base deps plus as many optional extras as the environment supports.
+
+    On Termux/Android, uses the ``[termux]`` extras group and
+    ``constraints-termux.txt`` instead of ``[all]`` to avoid pulling in
+    heavy C-extension packages (voice, matrix, messaging) that require
+    source compilation on ARM and can hang for 30+ minutes.
+    """
+    from hermes_constants import is_termux as _is_termux
+
+    extras_group = "termux" if _is_termux() else "all"
+    install_args = ["install", "-e", f".[{extras_group}]", "--quiet"]
+    if _is_termux():
+        constraints = PROJECT_ROOT / "constraints-termux.txt"
+        if constraints.exists():
+            install_args += ["-c", str(constraints)]
     try:
         subprocess.run(
-            install_cmd_prefix + ["install", "-e", ".[all]", "--quiet"],
+            install_cmd_prefix + install_args,
             cwd=PROJECT_ROOT,
             check=True,
             env=env,


### PR DESCRIPTION
## Problem

`hermes update` always runs `pip install -e .[all]`, which pulls in heavy C-extension packages (`faster-whisper` via `[voice]`, `discord.py[voice]` via `[messaging]`, `mautrix` via `[matrix]`) that require source compilation on ARM. On a Pixel 8a running Termux, this hangs pip for 30+ minutes compiling `tornado`, `PyNaCl`, etc. before eventually failing.

## Root Cause

The bash install scripts (`setup-hermes.sh`, `scripts/install.sh`) already detect Termux via `is_termux()` and correctly use `.[termux]` + `constraints-termux.txt`. But `_install_python_dependencies_with_optional_fallback()` in `hermes_cli/main.py` — the Python update path — was never wired to do the same. All the pieces exist, they just aren't connected in the update command.

## Fix

Reuse the existing `hermes_constants.is_termux()` in `_install_python_dependencies_with_optional_fallback()` to:
- Select `.[termux]` instead of `.[all]` on Android
- Apply `constraints-termux.txt` when present

One function changed, 16 lines added, 2 removed. No new dependencies.

## Testing

Tested on Pixel 8a (Termux, Python 3.13, ARM64):
- **Before:** `hermes update` hangs at `pip install -e .[all]` (94% CPU, 30+ min)
- **After:** `hermes update` completes instantly with `.[termux]`

Desktop (macOS, Python 3.14) still uses `.[all]` — no behavior change on non-Termux platforms.