### PR TITLE
fix(config): support models list in custom_providers picker (#8216)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1689,6 +1689,8 @@ def _normalize_custom_provider_entry(
     models = entry.get("models")
     if isinstance(models, dict) and models:
         normalized["models"] = models
+    elif isinstance(models, list) and models:
+        normalized["models"] = models
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1066,6 +1066,17 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            models_field = entry.get("models")
+            if isinstance(models_field, dict):
+                for m in models_field:
+                    m = str(m).strip()
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
+            elif isinstance(models_field, list):
+                for m in models_field:
+                    m = str(m).strip()
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
 
         for slug, grp in groups.items():
             if slug in seen_slugs:

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -156,3 +156,62 @@ def test_list_deduplicates_same_model_in_group(monkeypatch):
     assert len(my_rows) == 1
     assert my_rows[0]["models"] == ["llama3", "mistral"]
     assert my_rows[0]["total_models"] == 2
+
+
+def test_list_models_field_as_list(monkeypatch):
+    """custom_providers entry with models as a list should expose all models."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Custom LLM",
+                "base_url": "https://llm.example.com/v1",
+                "models": [
+                    "my-model-v1",
+                    "my-model-v2",
+                    "my-model-v3",
+                ],
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p["name"] == "My Custom LLM"]
+    assert len(rows) == 1
+    assert rows[0]["models"] == [
+        "my-model-v1",
+        "my-model-v2",
+        "my-model-v3",
+    ]
+    assert rows[0]["total_models"] == 3
+
+
+def test_list_models_field_as_dict(monkeypatch):
+    """custom_providers entry with models as a dict should expose all keys as models."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local vLLM",
+                "base_url": "http://localhost:8000/v1",
+                "models": {
+                    "llama-3-70b": {},
+                    "mistral-large": {},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p["name"] == "Local vLLM"]
+    assert len(rows) == 1
+    assert rows[0]["models"] == ["llama-3-70b", "mistral-large"]
+    assert rows[0]["total_models"] == 2


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model` picker ignoring the `models` field in `custom_providers` config entries when declared as a list (not just dict). Previously, only the `model` (singular) field and `models` as a dict were recognized, making it impossible to declare a curated set of models for custom endpoints with many available models.

## Related Issue

Fixes #8216

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: `_normalize_custom_provider_entry` now preserves `models` fields that are lists (previously only dicts were kept).
- `hermes_cli/model_switch.py`: `list_authenticated_providers` section 4 now reads and merges the `models` field from custom_providers entries, supporting both dict keys and list items.
- `tests/hermes_cli/test_model_switch_custom_providers.py`: Added `test_list_models_field_as_list` and `test_list_models_field_as_dict` regression tests.

## How to Test

1. Add a custom_providers entry with `models` as a list:
   ```yaml
   custom_providers:
     - name: MyProvider
       base_url: http://localhost:8000/v1
       models:
         - model-a
         - model-b
   ```
2. Run `hermes model` — the picker should show all listed models.
3. Run `pytest tests/hermes_cli/test_model_switch_custom_providers.py -v` — all tests pass.

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/` and all tests pass
- [x] I have added tests for my changes
