### PR TITLE
fix: add missing base_url fallback for copilot provider in credential pool path

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -167,6 +167,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        base_url = base_url or "https://api.githubcopilot.com"
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider


### PR DESCRIPTION
## Summary
GitHub Copilot provider fails to start with empty base URL error when using credential pool authentication.

## Root Cause
`_resolve_runtime_from_pool_entry()` sets `api_mode` for copilot but never provides a fallback `base_url`. When credential pool path is taken, `base_url` is `None`.

## Fix
Added `base_url = base_url or "https://api.githubcopilot.com"` to the copilot branch.

## Test Plan
- [x] Copilot unit tests pass (`pytest -k copilot`)

Closes NousResearch/hermes-agent#10223
