### PR TITLE
fix: honour TTL in MessageDeduplicator instead of only on cache overflow

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -49,7 +49,11 @@ class MessageDeduplicator:
             return False
         now = time.time()
         if msg_id in self._seen:
-            return True
+            if now - self._seen[msg_id] > self._ttl:
+                # Entry expired — remove it and treat as new message.
+                del self._seen[msg_id]
+            else:
+                return True
         self._seen[msg_id] = now
         if len(self._seen) > self._max_size:
             cutoff = now - self._ttl


### PR DESCRIPTION
## Summary
MessageDeduplicator never expires entries unless the cache exceeds max_size, contradicting its documented TTL-based behaviour.

## Root Cause
`is_duplicate()` returned `True` for any previously seen message ID without checking its age. TTL expiry was only checked during size-based compaction (`if len(self._seen) > self._max_size`), so on normal workloads that stay under `max_size`, old message IDs remained duplicates forever.

## Fix
Check entry timestamp before returning `True`. If the entry has expired past the TTL, delete it and treat the message as new.

## Test Plan
- [x] Manual verification: expired entries now correctly return `False`
- [x] Still within TTL entries correctly return `True`

Closes NousResearch/hermes-agent#10306
