### PR TITLE
fix: implement --check flag for the update subcommand

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3662,6 +3662,8 @@ def cmd_update(args):
         print(f"  {origin_url}")
         print()
 
+    check_mode = getattr(args, "check", False)
+
     if use_zip_update:
         # ZIP-based update for Windows when git is broken
         _update_via_zip(args)
@@ -3689,6 +3691,46 @@ def cmd_update(args):
                 if stderr:
                     print(f"  {stderr.splitlines()[0]}")
             sys.exit(1)
+
+        # In --check mode, show status and exit without pulling/reinstalling
+        if check_mode:
+            result = subprocess.run(
+                git_cmd + ["rev-parse", "--short", "HEAD"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            current_sha = result.stdout.strip()
+
+            result = subprocess.run(
+                git_cmd + ["rev-parse", "--short", "origin/main"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            remote_sha = result.stdout.strip()
+
+            result = subprocess.run(
+                git_cmd + ["rev-list", f"HEAD..origin/main", "--count"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            commit_count = int(result.stdout.strip())
+
+            from hermes_cli import __version__
+            version = __version__
+            print(f"Current version: {version} ({current_sha})")
+            print(f"Remote (origin/main): {remote_sha}")
+            if commit_count == 0:
+                print("✓ Already up to date!")
+            else:
+                print(f"→ {commit_count} update(s) available.")
+                print(f"  Run 'hermes update' to install.")
+            return
 
         # Get current branch (returns literal "HEAD" when detached)
         result = subprocess.run(
@@ -5845,6 +5887,10 @@ Examples:
     update_parser.add_argument(
         "--gateway", action="store_true", default=False,
         help="Gateway mode: use file-based IPC for prompts instead of stdin (used internally by /update)"
+    )
+    update_parser.add_argument(
+        "--check", action="store_true", default=False,
+        help="Check for updates without installing them"
     )
     update_parser.set_defaults(func=cmd_update)
     


### PR DESCRIPTION
## Summary
The `--check` flag for the update subcommand is documented in the official docs but was not implemented in the CLI.

## Root Cause
The update subparser only defined `--gateway` flag. No `--check` argument existed, causing argparse to reject it as an unrecognized argument.

## Fix
1. Added `--check` argument to the update subparser
2. In the update handler, when `--check` is set: fetch updates, compare local HEAD with origin/main, display version info and available updates, then exit without pulling or reinstalling

## Test Plan
- [x] The new flag shows current version, remote SHA, and update count
- [x] The help output shows the new `--check` flag
- [x] Normal update behavior unchanged

Closes NousResearch/hermes-agent#10318
