### PR TITLE
fix: prevent help text from printing twice on subcommand -h

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6068,8 +6068,11 @@ Examples:
             sys.stderr = _io.StringIO()
             args = parser.parse_args(_processed_argv)
             sys.stderr = _saved_stderr
-        except SystemExit:
+        except SystemExit as e:
             sys.stderr = _saved_stderr
+            # Re-raise help/version exits — they already printed their output.
+            if e.code == 0:
+                raise
             # Subcommand name was consumed as a flag value (e.g. -c model).
             # Fall back to optional subparsers so argparse handles it normally.
             subparsers.required = False


### PR DESCRIPTION
## Summary
Subcommand help text (e.g. `hermes dashboard -h`) prints twice instead of once.

## Root Cause
When `--help` is passed, argparse's HelpAction prints help and raises `SystemExit(0)`. This was caught by the `except SystemExit` block that handles flag-value consumption (e.g. `-c model`). After restoring stderr, `parse_args` was called again, triggering the help action a second time.

## Fix
Re-raise `SystemExit` when `code == 0` (help/version exits), since these have already printed their output and should propagate normally.

## Test Plan
- [x] `hermes dashboard -h` prints help exactly once
- [x] `hermes update -h` prints help exactly once
- [x] Error cases (code != 0) still fall back correctly

Closes NousResearch/hermes-agent#10230
