### PR TITLE
fix(gateway): fix matrix read receipts

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1598,11 +1598,21 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return False
         try:
-            await self._client.set_read_markers(
-                RoomID(room_id),
-                fully_read_event=EventID(event_id),
-                read_receipt=EventID(event_id),
-            )
+            room = RoomID(room_id)
+            event = EventID(event_id)
+            if hasattr(self._client, "set_fully_read_marker"):
+                await self._client.set_fully_read_marker(room, event, event)
+            elif hasattr(self._client, "send_receipt"):
+                await self._client.send_receipt(room, event)
+            elif hasattr(self._client, "set_read_markers"):
+                await self._client.set_read_markers(
+                    room,
+                    fully_read_event=event,
+                    read_receipt=event,
+                )
+            else:
+                logger.debug("Matrix: client has no read receipt method")
+                return False
             logger.debug("Matrix: sent read receipt for %s in %s", event_id, room_id)
             return True
         except Exception as exc:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",
     # contributors (manual mapping from git names)
+    "ahmedsherif95@gmail.com": "asheriif",
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1741,15 +1741,48 @@ class TestMatrixReadReceipts:
         self.adapter = _make_adapter()
 
     @pytest.mark.asyncio
+    async def test_accepted_message_schedules_read_receipt(self):
+        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._get_display_name = AsyncMock(return_value="Alice")
+        self.adapter._background_read_receipt = MagicMock()
+
+        ctx = await self.adapter._resolve_message_context(
+            room_id="!room:ex",
+            sender="@alice:ex",
+            event_id="$event1",
+            body="hello",
+            source_content={"body": "hello"},
+            relates_to={},
+        )
+
+        assert ctx is not None
+        self.adapter._background_read_receipt.assert_called_once_with(
+            "!room:ex", "$event1"
+        )
+
+    @pytest.mark.asyncio
     async def test_send_read_receipt(self):
-        """send_read_receipt should call client.set_read_markers."""
+        """send_read_receipt should call mautrix's real read-marker API."""
         mock_client = MagicMock()
-        mock_client.set_read_markers = AsyncMock(return_value=None)
+        mock_client.set_fully_read_marker = AsyncMock(return_value=None)
         self.adapter._client = mock_client
 
         result = await self.adapter.send_read_receipt("!room:ex", "$event1")
         assert result is True
-        mock_client.set_read_markers.assert_called_once()
+        mock_client.set_fully_read_marker.assert_awaited_once_with(
+            "!room:ex", "$event1", "$event1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_read_receipt_falls_back_to_receipt_only(self):
+        """send_read_receipt should still work with clients lacking read markers."""
+        mock_client = MagicMock(spec=["send_receipt"])
+        mock_client.send_receipt = AsyncMock(return_value=None)
+        self.adapter._client = mock_client
+
+        result = await self.adapter.send_read_receipt("!room:ex", "$event1")
+        assert result is True
+        mock_client.send_receipt.assert_awaited_once_with("!room:ex", "$event1")
 
     @pytest.mark.asyncio
     async def test_read_receipt_no_client(self):
@@ -1852,5 +1885,3 @@ class TestMatrixPresence:
         self.adapter._client = None
         result = await self.adapter.set_presence("online")
         assert result is False
-
-


### PR DESCRIPTION
## What does this PR do?

This fixes the currently broken read receipts on Matrix.

The Matrix adapter was calling `client.set_read_markers(...)`, but the pinned `mautrix` client does not expose that method. That caused read receipt attempts to fail silently through the existing debug-level exception handling.

This updates `send_read_receipt()` to prefer:

- `set_fully_read_marker(room, event, event)`
- fallback to `send_receipt(room, event)`
- fallback to the old `set_read_markers(...)` name if a compatible client ever provides it

Read receipts are still only scheduled for messages Hermes accepts for processing, so ignored group-room messages remain unread by design.

## Tests

```bash
python -m pytest tests/gateway/test_matrix.py::TestMatrixReadReceipts -q
python -m pytest tests/gateway/test_matrix.py -q
python -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_voice.py -q
```

All passing.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Fix Matrix read receipts by calling the real `mautrix` read-marker API.
- Add fallback support for clients that only expose receipt-only sending.
- Add Matrix tests covering receipt scheduling and the correct `mautrix` API call.


## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Send a message to your agent on Matrix.
2. The message is correctly marked as read by the agent.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

