### PR TITLE
feat(gateway): add session-scoped repo pinning

### DIFF
--- a/agent/repo_context.py
+++ b/agent/repo_context.py
@@ -1,0 +1,82 @@
+"""Utilities for session-scoped repository/workspace pinning."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+class RepoContextError(ValueError):
+    """Raised when a repo/workspace pin cannot be resolved."""
+
+
+def resolve_repo_target(raw_path: str, base_dir: str | None = None) -> tuple[str, str, bool]:
+    """Resolve *raw_path* into a canonical repo/workspace root.
+
+    Returns ``(root_path, name, is_git_repo)``.
+
+    - Relative paths resolve against ``base_dir`` when provided, otherwise the
+      current working directory.
+    - File paths are converted to their parent directory.
+    - If the path is inside a Git repo, the repo toplevel is returned.
+    - Non-Git directories are still allowed and treated as workspace roots.
+    """
+    raw = str(raw_path or "").strip()
+    if not raw:
+        raise RepoContextError("Usage: /repo <path> (or /repo clear)")
+
+    base = Path(base_dir or os.getcwd()).expanduser()
+    target = Path(raw).expanduser()
+    if not target.is_absolute():
+        target = base / target
+
+    try:
+        target = target.resolve(strict=False)
+    except OSError as exc:
+        raise RepoContextError(f"Could not resolve path '{raw}': {exc}") from exc
+
+    if target.exists() and target.is_file():
+        target = target.parent
+
+    if not target.exists():
+        raise RepoContextError(f"Path does not exist: {target}")
+    if not target.is_dir():
+        raise RepoContextError(f"Path is not a directory: {target}")
+
+    git_root = _git_toplevel(target)
+    root = Path(git_root) if git_root else target
+    root = root.resolve()
+    return str(root), root.name or str(root), bool(git_root)
+
+
+def build_repo_pin_prompt(repo_root: str | None, repo_name: str | None = None) -> str:
+    """Return an ephemeral prompt block describing the pinned repo/workspace."""
+    root = str(repo_root or "").strip()
+    if not root:
+        return ""
+    name = str(repo_name or Path(root).name or root).strip()
+    return (
+        "[SESSION REPOSITORY PIN]\n"
+        f"This session is pinned to the repository/workspace `{name}` at `{root}`.\n"
+        "Treat this location as the default scope for coding, file edits, searches, "
+        "and terminal work. Do not drift to another repository unless the user "
+        "explicitly changes the repo pin or clearly asks to work elsewhere."
+    )
+
+
+def _git_toplevel(path: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    top = (proc.stdout or "").strip()
+    return top or None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3245,6 +3245,9 @@ class GatewayRunner:
         if canonical == "title":
             return await self._handle_title_command(event)
 
+        if canonical == "repo":
+            return await self._handle_repo_command(event)
+
         if canonical == "resume":
             return await self._handle_resume_command(event)
 
@@ -3622,6 +3625,14 @@ class GatewayRunner:
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+        if session_entry.repo_root:
+            try:
+                from agent.repo_context import build_repo_pin_prompt
+                repo_prompt = build_repo_pin_prompt(session_entry.repo_root, session_entry.repo_name)
+            except Exception:
+                repo_prompt = ""
+            if repo_prompt:
+                context_prompt = (repo_prompt + "\n\n" + context_prompt).strip()
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
@@ -4605,6 +4616,9 @@ class GatewayRunner:
         ]
         if title:
             lines.append(f"**Title:** {title}")
+        if session_entry.repo_root:
+            repo_label = session_entry.repo_name or Path(session_entry.repo_root).name
+            lines.append(f"**Repo:** `{repo_label}` — `{session_entry.repo_root}`")
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
@@ -6678,6 +6692,48 @@ class GatewayRunner:
                 return f"📌 Session: `{session_id}`\nTitle: **{title}**"
             else:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
+
+    async def _handle_repo_command(self, event: MessageEvent) -> str:
+        """Handle /repo command — show, set, or clear the session repo pin."""
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        session_id = session_entry.session_id
+        session_key = session_entry.session_key
+        arg = event.get_command_args().strip()
+
+        if not arg or arg.lower() == "status":
+            if session_entry.repo_root:
+                repo_label = session_entry.repo_name or Path(session_entry.repo_root).name
+                return (
+                    f"📌 Session: `{session_id}`\n"
+                    f"Repo pin: **{repo_label}**\n"
+                    f"Path: `{session_entry.repo_root}`"
+                )
+            return f"📌 Session: `{session_id}`\nNo repo pinned. Usage: `/repo /path/to/repo`"
+
+        if arg.lower() in {"clear", "unset", "none", "off"}:
+            if not self.session_store.set_session_repo(session_key, None, None):
+                return "⚠️ Session not found."
+            self._evict_cached_agent(session_key)
+            return f"🧹 Cleared repo pin for session `{session_id}`"
+
+        try:
+            from agent.repo_context import RepoContextError, resolve_repo_target
+
+            base_dir = os.getenv("TERMINAL_CWD") or os.getenv("MESSAGING_CWD") or str(Path.home())
+            repo_root, repo_name, is_git_repo = resolve_repo_target(arg, base_dir=base_dir)
+        except RepoContextError as e:
+            return f"⚠️ {e}"
+
+        if not self.session_store.set_session_repo(session_key, repo_root, repo_name):
+            return "⚠️ Session not found."
+
+        self._evict_cached_agent(session_key)
+        repo_kind = "repository" if is_git_repo else "workspace"
+        return (
+            f"📌 Pinned this session to {repo_kind} **{repo_name}**\n"
+            f"Path: `{repo_root}`"
+        )
 
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — switch to a previously-named session."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6858,6 +6858,8 @@ class GatewayRunner:
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 parent_session_id=parent_session_id,
+                repo_root=current_entry.repo_root,
+                repo_name=current_entry.repo_name,
             )
         except Exception as e:
             logger.error("Failed to create branch session: %s", e)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -977,6 +977,8 @@ class SessionStore:
         """
         db_end_session_id = None
         new_entry = None
+        repo_root = None
+        repo_name = None
 
         with self._lock:
             self._ensure_loaded_locked()
@@ -992,6 +994,16 @@ class SessionStore:
 
             db_end_session_id = old_entry.session_id
 
+            if self._db:
+                try:
+                    repo_info = self._db.get_session_repo(target_session_id)
+                except Exception as e:
+                    logger.debug("Session DB get_session_repo failed: %s", e)
+                    repo_info = None
+                if repo_info:
+                    repo_root = repo_info.get("repo_root")
+                    repo_name = repo_info.get("repo_name")
+
             now = _now()
             new_entry = SessionEntry(
                 session_key=session_key,
@@ -1002,6 +1014,8 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                repo_root=repo_root,
+                repo_name=repo_name,
             )
 
             self._entries[session_key] = new_entry

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -348,6 +348,10 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+
+    # Session-scoped repo/workspace pin
+    repo_root: Optional[str] = None
+    repo_name: Optional[str] = None
     
     # Token tracking
     input_tokens: int = 0
@@ -387,6 +391,8 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "repo_root": self.repo_root,
+            "repo_name": self.repo_name,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_read_tokens": self.cache_read_tokens,
@@ -424,6 +430,8 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            repo_root=data.get("repo_root"),
+            repo_name=data.get("repo_name"),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_read_tokens=data.get("cache_read_tokens", 0),
@@ -754,6 +762,8 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "repo_root": entry.repo_root,
+                "repo_name": entry.repo_name,
             }
 
         # SQLite operations outside the lock
@@ -786,6 +796,33 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def set_session_repo(
+        self,
+        session_key: str,
+        repo_root: Optional[str],
+        repo_name: Optional[str] = None,
+    ) -> bool:
+        """Set or clear a session's pinned repo/workspace."""
+        db_session_id = None
+        clean_root = str(repo_root or "").strip() or None
+        clean_name = str(repo_name or "").strip() or None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry:
+                return False
+            entry.repo_root = clean_root
+            entry.repo_name = clean_name
+            db_session_id = entry.session_id
+            self._save()
+
+        if self._db and db_session_id:
+            try:
+                self._db.set_session_repo(db_session_id, clean_root, clean_name)
+            except Exception as e:
+                logger.debug("Session DB operation failed: %s", e)
+        return True
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.
@@ -911,6 +948,8 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "repo_root": None,
+                "repo_name": None,
             }
 
         if self._db and db_end_session_id:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -97,6 +97,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
+    CommandDef("repo", "Show or pin the current session's repository/workspace", "Session",
+               gateway_only=True, args_hint="[path|clear]"),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -65,6 +65,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     cost_source TEXT,
     pricing_version TEXT,
     title TEXT,
+    repo_root TEXT,
+    repo_name TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -329,6 +331,16 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                for col_name in ("repo_root", "repo_name"):
+                    try:
+                        safe = col_name.replace('"', '""')
+                        cursor.execute(
+                            f'ALTER TABLE sessions ADD COLUMN "{safe}" TEXT'
+                        )
+                    except sqlite3.OperationalError:
+                        pass
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -361,13 +373,15 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        repo_root: str = None,
+        repo_name: str = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, repo_root, repo_name)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -377,6 +391,8 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    repo_root,
+                    repo_name,
                 ),
             )
         self._execute_write(_do)
@@ -528,6 +544,45 @@ class SessionDB:
             )
             row = cursor.fetchone()
         return dict(row) if row else None
+
+    def set_session_repo(
+        self,
+        session_id: str,
+        repo_root: Optional[str],
+        repo_name: Optional[str] = None,
+    ) -> bool:
+        """Set or clear a session's pinned repo/workspace."""
+        clean_root = str(repo_root or "").strip() or None
+        clean_name = str(repo_name or "").strip() or None
+
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET repo_root = ?, repo_name = ? WHERE id = ?",
+                (clean_root, clean_name, session_id),
+            )
+            return cursor.rowcount
+
+        rowcount = self._execute_write(_do)
+        return rowcount > 0
+
+    def get_session_repo(self, session_id: str) -> Optional[Dict[str, str]]:
+        """Return repo pin info for a session, or None when unset."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT repo_root, repo_name FROM sessions WHERE id = ?",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        repo_root = row["repo_root"]
+        repo_name = row["repo_name"]
+        if not repo_root:
+            return None
+        return {
+            "repo_root": repo_root,
+            "repo_name": repo_name or Path(repo_root).name,
+        }
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.

--- a/tests/gateway/test_repo_command.py
+++ b/tests/gateway/test_repo_command.py
@@ -1,8 +1,7 @@
 """Tests for /repo gateway command and repo-pinned status output."""
 
 from datetime import datetime
-from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -124,3 +123,32 @@ async def test_status_command_includes_repo_pin():
     runner._session_db.get_session_title.return_value = None
     result = await GatewayRunner._handle_status_command(runner, _make_event("/status"))
     assert "**Repo:** `project` — `/tmp/project`" in result
+
+
+@pytest.mark.asyncio
+async def test_branch_inherits_repo_pin_to_new_session():
+    from gateway.run import GatewayRunner
+
+    entry = _make_session_entry()
+    entry.repo_root = "/tmp/project"
+    entry.repo_name = "project"
+
+    session_db = MagicMock()
+    session_db.get_session_title.return_value = "Current Work"
+    session_db.get_next_title_in_lineage.return_value = "Current Work #2"
+
+    runner = _make_runner(session_entry=entry, session_db=session_db)
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    runner.session_store.switch_session.return_value = entry
+    runner._session_key_for_source = MagicMock(return_value=entry.session_key)
+
+    result = await GatewayRunner._handle_branch_command(runner, _make_event("/branch"))
+
+    assert "Branched to" in result
+    session_db.create_session.assert_called_once()
+    kwargs = session_db.create_session.call_args.kwargs
+    assert kwargs["repo_root"] == "/tmp/project"
+    assert kwargs["repo_name"] == "project"

--- a/tests/gateway/test_repo_command.py
+++ b/tests/gateway/test_repo_command.py
@@ -1,0 +1,126 @@
+"""Tests for /repo gateway command and repo-pinned status output."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+def _make_event(text="/repo", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_session_entry():
+    return SessionEntry(
+        session_key="telegram:12345:67890",
+        session_id="test_session_123",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+
+
+def _make_runner(session_entry=None, session_db=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = session_db
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._evict_cached_agent = MagicMock()
+
+    if session_entry is None:
+        session_entry = _make_session_entry()
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = session_entry
+    mock_store.set_session_repo.return_value = True
+    runner.session_store = mock_store
+    return runner
+
+
+class TestHandleRepoCommand:
+    @pytest.mark.asyncio
+    async def test_show_repo_when_not_set(self):
+        runner = _make_runner()
+        result = await runner._handle_repo_command(_make_event("/repo"))
+        assert "No repo pinned" in result
+        assert "/repo /path/to/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_show_repo_when_set(self):
+        entry = _make_session_entry()
+        entry.repo_root = "/tmp/project"
+        entry.repo_name = "project"
+        runner = _make_runner(session_entry=entry)
+        result = await runner._handle_repo_command(_make_event("/repo"))
+        assert "Repo pin: **project**" in result
+        assert "/tmp/project" in result
+
+    @pytest.mark.asyncio
+    async def test_clear_repo(self):
+        entry = _make_session_entry()
+        entry.repo_root = "/tmp/project"
+        entry.repo_name = "project"
+        runner = _make_runner(session_entry=entry)
+        result = await runner._handle_repo_command(_make_event("/repo clear"))
+        runner.session_store.set_session_repo.assert_called_once_with(entry.session_key, None, None)
+        runner._evict_cached_agent.assert_called_once_with(entry.session_key)
+        assert "Cleared repo pin" in result
+
+    @pytest.mark.asyncio
+    async def test_set_repo(self, monkeypatch):
+        runner = _make_runner()
+        monkeypatch.setattr(
+            "agent.repo_context.resolve_repo_target",
+            lambda arg, base_dir=None: ("/tmp/project", "project", True),
+        )
+        result = await runner._handle_repo_command(_make_event("/repo ~/code/project"))
+        runner.session_store.set_session_repo.assert_called_once_with(
+            "telegram:12345:67890", "/tmp/project", "project"
+        )
+        runner._evict_cached_agent.assert_called_once_with("telegram:12345:67890")
+        assert "Pinned this session to repository **project**" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_repo_path_returns_error(self, monkeypatch):
+        from agent.repo_context import RepoContextError
+
+        runner = _make_runner()
+        monkeypatch.setattr(
+            "agent.repo_context.resolve_repo_target",
+            lambda arg, base_dir=None: (_ for _ in ()).throw(RepoContextError("bad path")),
+        )
+        result = await runner._handle_repo_command(_make_event("/repo nope"))
+        assert "bad path" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_repo_pin():
+    from gateway.run import GatewayRunner
+
+    entry = _make_session_entry()
+    entry.repo_root = "/tmp/project"
+    entry.repo_name = "project"
+    runner = _make_runner(session_entry=entry, session_db=MagicMock())
+    runner._session_db.get_session_title.return_value = None
+    result = await GatewayRunner._handle_status_command(runner, _make_event("/status"))
+    assert "**Repo:** `project` — `/tmp/project`" in result

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -603,6 +603,42 @@ class TestSessionStoreSwitchSession:
         assert resumed["end_reason"] is None
         db.close()
 
+    def test_switch_session_restores_repo_pin_from_db(self, tmp_path):
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        db = SessionDB(db_path=tmp_path / "state.db")
+        store._db = db
+        store._loaded = True
+
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="chat-1",
+            chat_type="dm",
+            user_id="user-1",
+            user_name="tester",
+        )
+        current_entry = store.get_or_create_session(source)
+
+        target_session_id = "old_session_abc"
+        db.create_session(
+            target_session_id,
+            source="feishu",
+            user_id="user-1",
+            repo_root="/tmp/project",
+            repo_name="project",
+        )
+
+        switched = store.switch_session(current_entry.session_key, target_session_id)
+
+        assert switched is not None
+        assert switched.session_id == target_session_id
+        assert switched.repo_root == "/tmp/project"
+        assert switched.repo_name == "project"
+        db.close()
+
 
 class TestWhatsAppDMSessionKeyConsistency:
     """Regression: all session-key construction must go through build_session_key

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -935,7 +935,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -991,12 +991,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to v7
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1009,6 +1009,22 @@ class TestSchemaInit:
         assert session["title"] == "Migrated Title"
 
         migrated_db.close()
+
+
+class TestRepoPinning:
+    def test_set_and_get_repo_pin(self, db):
+        db.create_session("s1", "cli")
+        assert db.set_session_repo("s1", "/tmp/project", "project") is True
+        assert db.get_session_repo("s1") == {
+            "repo_root": "/tmp/project",
+            "repo_name": "project",
+        }
+
+    def test_clear_repo_pin(self, db):
+        db.create_session("s1", "cli")
+        db.set_session_repo("s1", "/tmp/project", "project")
+        assert db.set_session_repo("s1", None, None) is True
+        assert db.get_session_repo("s1") is None
 
 
 class TestTitleUniqueness:


### PR DESCRIPTION
## Summary
- add a gateway `/repo` command to pin the current session to a repository/workspace
- persist repo pin metadata in gateway session storage and SQLite session records
- inject pinned repo context into gateway prompt construction so repo identity survives compression, restart, and resume flows
- restore repo pins when `/resume` switches back to an older session
- make `/branch` inherit the current session’s repo pin
- show the pinned repo in `/status` and cover the behavior with targeted tests

## Scope
This PR intentionally focuses on gateway/messaging sessions, where repo identity drift is most problematic.

## Test Plan
- [x] `source venv/bin/activate && python -m pytest tests/gateway/test_repo_command.py tests/gateway/test_session.py tests/gateway/test_resume_command.py tests/test_hermes_state.py -q`
- [x] `python -m py_compile agent/repo_context.py gateway/run.py gateway/session.py hermes_cli/commands.py hermes_state.py tests/gateway/test_repo_command.py tests/gateway/test_session.py tests/test_hermes_state.py`

## Notes
The full local suite currently has unrelated baseline failures in this environment/branch, so this PR is validated with targeted tests for the new repo-pinning behavior.

Refs #10309
