### PR TITLE
fix: accept list-type models in _normalize_custom_provider_entry

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1689,6 +1689,8 @@ def _normalize_custom_provider_entry(
     models = entry.get("models")
     if isinstance(models, dict) and models:
         normalized["models"] = models
+    elif isinstance(models, list) and models:
+        normalized["models"] = models
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:


### PR DESCRIPTION
## Summary

`_normalize_custom_provider_entry()` in `hermes_cli/config.py` only accepted `dict` for the `models` field, silently dropping `list` values.

When users write `custom_providers` with the natural YAML list format:

\`\`\`yaml
custom_providers:
  - name: superdoor
    model: gpt-5.4
    models:
      - gpt-5.4
      - gpt-5.4-mini
      - gpt-5.3-codex
\`\`\`

All models from the list are dropped during normalization. Only the singular `model` field survives, causing the `/mode` picker to show "1 model" instead of the full list.

## Fix

Add an `elif isinstance(models, list)` branch alongside the existing `dict` check (line 1691).

## Reproduction

1. Add a `custom_providers` entry with `models` as a YAML list
2. Run `/mode` — only the `model` (singular) appears, the list is ignored

## Scope

- 2 lines added, no existing behavior changed
- `dict` type continues to work as before