### PR TITLE
fix(feishu): preserve command content in resolved approval card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1501,6 +1501,8 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "command": cmd_preview,
+                    "description": description,
                 }
             return result
         except Exception as exc:
@@ -1508,22 +1510,34 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+    def _build_resolved_approval_card(
+        *, choice: str, user_name: str,
+        command: str = "", description: str = "",
+    ) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
+        header_title = f"{icon} {label} by {user_name}" if user_name else f"{icon} {label}"
+        elements = []
+        if command:
+            cmd_block = f"```\n{command}\n```"
+            if description:
+                cmd_block += f"\n**Reason:** {description}"
+            elements.append({"tag": "markdown", "content": cmd_block})
+        if not elements:
+            # Fallback: always show at least the resolution status so
+            # the card never renders with an empty body (only header).
+            elements.append({
+                "tag": "markdown",
+                "content": f"{icon} **{label}**" + (f" by {user_name}" if user_name else ""),
+            })
         return {
             "config": {"wide_screen_mode": True},
             "header": {
-                "title": {"content": f"{icon} {label}", "tag": "plain_text"},
+                "title": {"content": header_title, "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "elements": elements,
         }
 
     async def send_voice(
@@ -1901,6 +1915,12 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = str(getattr(operator, "open_id", "") or "")
         user_name = self._get_cached_sender_name(open_id) or open_id
 
+        # Snapshot approval state *before* scheduling async work.
+        # _resolve_approval runs on the adapter event-loop thread and pops
+        # the state.  If we read after scheduling, a tight race window
+        # exists where the pop has already happened → empty card elements.
+        state = self._approval_state.get(approval_id, {})
+
         self._submit_on_loop(loop, self._resolve_approval(approval_id, choice, user_name))
 
         if P2CardActionTriggerResponse is None:
@@ -1909,7 +1929,11 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = self._build_resolved_approval_card(
+                choice=choice, user_name=user_name,
+                command=state.get("command", ""),
+                description=state.get("description", ""),
+            )
             response.card = card
         return response
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2121,6 +2121,8 @@ class FeishuAdapter(BasePlatformAdapter):
                     "session_key": session_key,
                     "message_id": result.message_id or "",
                     "chat_id": chat_id,
+                    "command": command,
+                    "description": description,
                 }
             return result
         except Exception as exc:
@@ -2196,22 +2198,18 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+    def _build_resolved_approval_card(*, choice: str, user_name: str, body: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
+        header_title = f"{icon} {label} by {user_name}" if user_name else f"{icon} {label}"
         return {
             "config": {"wide_screen_mode": True},
             "header": {
-                "title": {"content": f"{icon} {label}", "tag": "plain_text"},
+                "title": {"content": header_title, "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "elements": [{"tag": "markdown", "content": body}],
         }
 
     @staticmethod
@@ -2830,7 +2828,13 @@ class FeishuAdapter(BasePlatformAdapter):
         if CallBackCard is not None:
             card = CallBackCard()
             card.type = "raw"
-            card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            card.data = self._build_resolved_approval_card(
+                choice=choice,
+                user_name=user_name,
+                body=self._format_exec_approval(
+                    state.get("command", ""), state.get("description", ""),
+                ),
+            )
             response.card = card
         return response
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -152,6 +152,8 @@ class TestFeishuExecApproval:
         assert state["session_key"] == "my-session-key"
         assert state["message_id"] == "msg_002"
         assert state["chat_id"] == "oc_12345"
+        assert state["command"] == "echo test"
+        assert state["description"] == "dangerous command"
 
     @pytest.mark.asyncio
     async def test_not_connected(self):
@@ -353,6 +355,13 @@ class TestCardActionCallbackResponse:
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[1] = {
+            "session_key": "sess-1",
+            "message_id": "msg_001",
+            "chat_id": "oc_12345",
+            "command": "rm -rf /important",
+            "description": "dangerous deletion",
+        }
         data = _make_card_action_data(
             {"hermes_action": "approve_once", "approval_id": 1},
             open_id="ou_bob",
@@ -367,13 +376,22 @@ class TestCardActionCallbackResponse:
         assert response.card.type == "raw"
         card = response.card.data
         assert card["header"]["template"] == "green"
-        assert "Approved once" in card["header"]["title"]["content"]
-        assert "Bob" in card["elements"][0]["content"]
+        assert "Approved once by Bob" in card["header"]["title"]["content"]
+        # Command content preserved in card elements
+        assert any("rm -rf /important" in el["content"] for el in card["elements"])
+        assert any("dangerous deletion" in el["content"] for el in card["elements"])
 
     def test_returns_card_for_deny_action(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[2] = {
+            "session_key": "sess-2",
+            "message_id": "msg_002",
+            "chat_id": "oc_12345",
+            "command": "rm -rf /",
+            "description": "dangerous",
+        }
         data = _make_card_action_data(
             {"hermes_action": "deny", "approval_id": 2},
         )
@@ -415,6 +433,13 @@ class TestCardActionCallbackResponse:
         adapter = _make_adapter()
         adapter._loop = MagicMock()
         adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[3] = {
+            "session_key": "sess-3",
+            "message_id": "msg_003",
+            "chat_id": "oc_12345",
+            "command": "ls",
+            "description": "list",
+        }
         data = _make_card_action_data(
             {"hermes_action": "approve_session", "approval_id": 3},
             open_id="ou_unknown",
@@ -424,7 +449,8 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
-        assert "ou_unknown" in card["elements"][0]["content"]
+        # User name fallback to open_id is shown in the header
+        assert "ou_unknown" in card["header"]["title"]["content"]
 
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -440,5 +466,33 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
-        assert "Old Name" not in card["elements"][0]["content"]
-        assert "ou_expired" in card["elements"][0]["content"]
+        # Expired cache name should not appear; open_id used as fallback in header
+        assert "Old Name" not in card["header"]["title"]["content"]
+        assert "ou_expired" in card["header"]["title"]["content"]
+
+    def test_fallback_when_state_already_popped(self, _patch_callback_card_types):
+        """Card must never render with only a header and empty elements.
+
+        Simulates the race condition where the async resolver has already
+        popped the approval state before the sync handler reads it.
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        # NOTE: approval_id 5 is NOT in _approval_state — simulates a
+        # duplicate callback or race where _resolve_approval already ran.
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 5},
+            open_id="ou_alice",
+        )
+        adapter._sender_name_cache["ou_alice"] = ("Alice", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        card = response.card.data
+        # Header should still be present with user name
+        assert "Approved once by Alice" in card["header"]["title"]["content"]
+        # Elements must NOT be empty — fallback status text is shown
+        assert len(card["elements"]) >= 1
+        assert any("Approved once" in el["content"] for el in card["elements"])

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -152,6 +152,8 @@ class TestFeishuExecApproval:
         assert state["session_key"] == "my-session-key"
         assert state["message_id"] == "msg_002"
         assert state["chat_id"] == "oc_12345"
+        assert state["command"] == "echo test"
+        assert state["description"] == "dangerous command"
 
 
 # ===========================================================================
@@ -314,6 +316,8 @@ class TestCardActionCallbackResponse:
             "session_key": "sess-1",
             "message_id": "msg-1",
             "chat_id": "oc_12345",
+            "command": "rm -rf /important",
+            "description": "dangerous deletion",
         }
         data = _make_card_action_data(
             {"hermes_action": "approve_once", "approval_id": 1},
@@ -329,9 +333,59 @@ class TestCardActionCallbackResponse:
         assert response.card.type == "raw"
         card = response.card.data
         assert card["header"]["template"] == "green"
-        assert "Approved once" in card["header"]["title"]["content"]
-        assert "Bob" in card["elements"][0]["content"]
+        assert "Approved once by Bob" in card["header"]["title"]["content"]
+        # Command preview preserved in card body (same rendering as the pending card)
+        assert "rm -rf /important" in card["elements"][0]["content"]
+        assert "dangerous deletion" in card["elements"][0]["content"]
 
+    def test_returns_card_for_deny_action(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._approval_state[2] = {
+            "session_key": "sess-2",
+            "message_id": "msg-2",
+            "chat_id": "oc_12345",
+            "command": "rm -rf /",
+            "description": "dangerous",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "deny", "approval_id": 2},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "red"
+        assert "Denied by Bob" in card["header"]["title"]["content"]
+        assert "rm -rf /" in card["elements"][0]["content"]
+
+    def test_no_card_when_state_already_resolved(self, _patch_callback_card_types):
+        """Duplicate/already-resolved callbacks (state absent) return no card."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_alice"}
+        # approval_id 9 is NOT in _approval_state — simulates a duplicate
+        # callback or a race where _resolve_approval already popped it.
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 9},
+            open_id="ou_alice",
+        )
+        adapter._sender_name_cache["ou_alice"] = ("Alice", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        mock_submit.assert_not_called()
 
     def test_ignores_expired_cached_name(self, _patch_callback_card_types):
         adapter = _make_adapter()
@@ -342,6 +396,8 @@ class TestCardActionCallbackResponse:
             "session_key": "sess-4",
             "message_id": "msg-4",
             "chat_id": "oc_12345",
+            "command": "ls",
+            "description": "list",
         }
         data = _make_card_action_data(
             {"hermes_action": "approve_once", "approval_id": 4},
@@ -353,8 +409,9 @@ class TestCardActionCallbackResponse:
             response = adapter._on_card_action_trigger(data)
 
         card = response.card.data
-        assert "Old Name" not in card["elements"][0]["content"]
-        assert "ou_expired" in card["elements"][0]["content"]
+        # Expired cache name not used; open_id used as fallback in the header title
+        assert "Old Name" not in card["header"]["title"]["content"]
+        assert "ou_expired" in card["header"]["title"]["content"]
 
     def test_rejects_approval_click_from_unauthorized_user(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

When a user approved or denied a command via the Feishu approval card, the updated (resolved) card would only show the approval status (e.g. "✅ Approved") and discard the original command preview and description. This made it impossible to tell *which* command was approved after the fact.

This PR preserves the original `command` and `description` in the approval state and passes them through `CallBackCard` when building the resolved card, so the updated card retains the full command context alongside the approval result. It also moves the approver name into the card header title for better visibility.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- [gateway/platforms/feishu.py](gateway/platforms/feishu.py): Store `command` and `description` in the approval state dict when creating an approval card (`_send_approval_card`)
- [gateway/platforms/feishu.py](gateway/platforms/feishu.py): Extend `_build_resolved_approval_card()` to accept optional `command`/`description` params and render them as a markdown code block with optional reason text
- [gateway/platforms/feishu.py](gateway/platforms/feishu.py): Move approver name from card elements into the header title (e.g. `"✅ Approved once by Bob"`)
- [gateway/platforms/feishu.py](gateway/platforms/feishu.py): In `_on_card_action_trigger()`, look up the approval state to retrieve the stored command/description and pass them to the resolved card builder
- [tests/gateway/test_feishu_approval_buttons.py](tests/gateway/test_feishu_approval_buttons.py): Assert `command` and `description` are stored in approval state
- [tests/gateway/test_feishu_approval_buttons.py](tests/gateway/test_feishu_approval_buttons.py): Update existing card-action tests to seed approval state and verify command/description appear in the resolved card
- [tests/gateway/test_feishu_approval_buttons.py](tests/gateway/test_feishu_approval_buttons.py): Update open-id fallback and expired-cache tests to check header title instead of elements

## How to Test

1. Send a command that triggers the approval flow via Feishu (e.g. a command that requires approval)
2. Click **Approve** or **Deny** on the approval card
3. Verify the resolved card now shows:
   - The approver name in the header title (e.g. `✅ Approved once by Alice`)
   - The original command in a code block
   - The original description/reason if one was provided
4. Run the test suite: `pytest tests/gateway/test_feishu_approval_buttons.py -v`

## Checklist

N/A

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 11, macOS 14.8.4

## Screenshots / Logs

Before:

<img width="1220" height="212" alt="image" src="https://github.com/user-attachments/assets/1bd2f3b1-808f-4ee2-8adb-eb721391efcc" />

After:

<img width="1226" height="664" alt="image" src="https://github.com/user-attachments/assets/f7b36626-2582-436c-85e9-4554a4295d5f" />

