### PR TITLE
fix(security): block _EXTRA_ENV_KEYS from subprocess env

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,6 +83,7 @@ AUTHOR_MAP = {
     "pickett.austin@gmail.com": "austinpickett",
     "jaisehgal11299@gmail.com": "jaisup",
     "percydikec@gmail.com": "PercyDikec",
+    "dangtc94@gmail.com": "dieutx",
     "dean.kerr@gmail.com": "deankerr",
     "socrates1024@gmail.com": "socrates1024",
     "satelerd@gmail.com": "satelerd",

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -137,6 +137,21 @@ class TestProviderEnvBlocklist:
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_extra_env_keys_are_stripped(self):
+        """Hermes-managed .env keys outside OPTIONAL_ENV_VARS must not leak."""
+        leaked_vars = {
+            "WEIXIN_TOKEN": "wx-token",
+            "WECOM_SECRET": "wecom-secret",
+            "FEISHU_APP_SECRET": "feishu-secret",
+            "WECOM_CALLBACK_CORP_SECRET": "cb-secret",
+            "WECOM_CALLBACK_ENCODING_AES_KEY": "aes-key",
+            "TERMINAL_ENV": "docker",
+        }
+        result_env = _run_with_env(extra_os_env=leaked_vars)
+
+        for var in leaked_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+
     def test_safe_vars_are_preserved(self):
         """Standard env vars (PATH, HOME, USER) must still be passed through."""
         result_env = _run_with_env()
@@ -247,6 +262,12 @@ class TestBlocklistCoverage:
                 assert name in _HERMES_PROVIDER_ENV_BLOCKLIST, (
                     f"Secret setting env var {name} missing from blocklist"
                 )
+
+    def test_extra_env_keys_are_in_blocklist(self):
+        """Hermes-managed .env keys outside OPTIONAL_ENV_VARS should stay covered."""
+        from hermes_cli.config import _EXTRA_ENV_KEYS
+
+        assert _EXTRA_ENV_KEYS.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
 
     def test_gateway_runtime_vars_are_in_blocklist(self):
         extras = {

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -30,13 +30,14 @@ def _build_provider_env_blocklist() -> frozenset:
         pass
 
     try:
-        from hermes_cli.config import OPTIONAL_ENV_VARS
+        from hermes_cli.config import OPTIONAL_ENV_VARS, _EXTRA_ENV_KEYS
         for name, metadata in OPTIONAL_ENV_VARS.items():
             category = metadata.get("category")
             if category in {"tool", "messaging"}:
                 blocked.add(name)
             elif category == "setting" and metadata.get("password"):
                 blocked.add(name)
+        blocked.update(_EXTRA_ENV_KEYS)
     except ImportError:
         pass
 


### PR DESCRIPTION
## Summary

Subprocess env sanitization still missed Hermes-managed secrets that live in `hermes_cli.config._EXTRA_ENV_KEYS`. Values such as `WEIXIN_TOKEN`, `WECOM_SECRET`, `FEISHU_APP_SECRET`, `WECOM_CALLBACK_CORP_SECRET`, and `WECOM_CALLBACK_ENCODING_AES_KEY` were still passed to local child processes.

## Root Cause

`_build_provider_env_blocklist()` only pulled dynamic keys from `OPTIONAL_ENV_VARS`. Hermes also writes a separate set of managed `.env` keys in `_EXTRA_ENV_KEYS`, but those names were never added to `_HERMES_PROVIDER_ENV_BLOCKLIST`.

Follow-up to #1264 and #1658, not a duplicate exact fix. #1658 correctly covered Modal and Daytona, but its assumption that the remaining gateway/tool secrets were already covered via `OPTIONAL_ENV_VARS` does not hold for secrets that are only tracked through `_EXTRA_ENV_KEYS`.

## Fix

- import `_EXTRA_ENV_KEYS` alongside `OPTIONAL_ENV_VARS`
- add all `_EXTRA_ENV_KEYS` entries to `_HERMES_PROVIDER_ENV_BLOCKLIST`
- add regression tests for both runtime stripping and blocklist coverage

## Tests

- `pytest -q tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py tests/tools/test_docker_environment.py tests/test_subprocess_home_isolation.py`
- `67 passed` locally

## CI Note

As of 2026-04-15, the base `main` commit (`722331a57de9e18f134c896d733870b4a493dc84`) already had a failing `Tests` workflow:

- https://github.com/NousResearch/hermes-agent/actions/runs/24453178812
