### PR TITLE
fix(skills): resolve correct skill_dir for external skills in _load_skill_payload

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,3 +105,5 @@ tesseracttars-creator <tesseracttars@gmail.com> <tesseracttars@gmail.com>
 xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
+
+MestreY0d4-Uninter <241404605+MestreY0d4-Uninter@users.noreply.github.com> <241404605+MestreY0d4-Uninter@users.noreply.github.com>

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -74,9 +74,27 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
     skill_dir = None
     if skill_path:
         try:
-            skill_dir = SKILLS_DIR / Path(skill_path).parent
+            skill_path_obj = Path(skill_path)
+            skills_dir_resolved = SKILLS_DIR.resolve()
+            identifier_path = Path(raw_identifier).expanduser()
+            identifier_is_external = False
+            if identifier_path.is_absolute():
+                try:
+                    identifier_path.resolve().relative_to(skills_dir_resolved)
+                except Exception:
+                    identifier_is_external = True
+
+            if identifier_is_external:
+                skill_dir = identifier_path.parent.resolve()
+            else:
+                skill_path_resolved = skill_path_obj.resolve() if skill_path_obj.is_absolute() else (SKILLS_DIR / skill_path_obj).resolve()
+                skill_path_resolved.relative_to(skills_dir_resolved)
+                skill_dir = SKILLS_DIR / skill_path_obj.parent
         except Exception:
-            skill_dir = None
+            try:
+                skill_dir = Path(skill_path).parent.resolve()
+            except Exception:
+                skill_dir = None
 
     return loaded_skill, skill_dir, skill_name
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -63,6 +63,7 @@ AUTHOR_MAP = {
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",
+    "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",

--- a/tests/agent/test_skill_commands_external.py
+++ b/tests/agent/test_skill_commands_external.py
@@ -1,0 +1,99 @@
+"""Regression tests for skill path resolution in skill commands."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.skill_commands import _load_skill_payload
+
+
+def _skill_view_payload(*, name: str, path: str, content: str = "# Skill\n") -> str:
+    return json.dumps(
+        {
+            "success": True,
+            "name": name,
+            "path": path,
+            "content": content,
+            "raw_content": content,
+        }
+    )
+
+
+def test_load_skill_payload_builtin_keeps_skills_dir_parent(tmp_path):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    builtin_dir = skills_dir / "team" / "myskill"
+    builtin_dir.mkdir(parents=True)
+    builtin_md = builtin_dir / "SKILL.md"
+
+    with patch("tools.skills_tool.SKILLS_DIR", skills_dir), patch(
+        "tools.skills_tool.skill_view",
+        return_value=_skill_view_payload(name="myskill", path="team/myskill/SKILL.md"),
+    ) as skill_view_mock:
+        result = _load_skill_payload(str(builtin_md))
+
+    assert result is not None
+    loaded_skill, skill_dir, skill_name = result
+    assert skill_view_mock.call_args.args[0] == "team/myskill/SKILL.md"
+    assert loaded_skill["path"] == "team/myskill/SKILL.md"
+    assert skill_name == "myskill"
+    assert skill_dir == builtin_dir
+
+
+def test_load_skill_payload_builtin_via_symlinked_skills_dir(tmp_path):
+    real_skills_dir = tmp_path / "real-skills"
+    real_builtin_dir = real_skills_dir / "team" / "myskill"
+    real_builtin_dir.mkdir(parents=True)
+    builtin_md = real_builtin_dir / "SKILL.md"
+    symlinked_skills_dir = tmp_path / ".hermes" / "skills"
+    symlinked_skills_dir.parent.mkdir(parents=True)
+    symlinked_skills_dir.symlink_to(real_skills_dir, target_is_directory=True)
+
+    with patch("tools.skills_tool.SKILLS_DIR", symlinked_skills_dir), patch(
+        "tools.skills_tool.skill_view",
+        return_value=_skill_view_payload(name="myskill", path="team/myskill/SKILL.md"),
+    ):
+        result = _load_skill_payload(str(builtin_md))
+
+    assert result is not None
+    _, skill_dir, _ = result
+    assert skill_dir == symlinked_skills_dir / "team" / "myskill"
+
+
+def test_load_skill_payload_external_absolute_path_uses_real_parent(tmp_path):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    skills_dir.mkdir(parents=True)
+    external_dir = Path("/tmp/external-skills/myteam/myskill")
+    external_md = external_dir / "SKILL.md"
+
+    with patch("tools.skills_tool.SKILLS_DIR", skills_dir), patch(
+        "tools.skills_tool.skill_view",
+        return_value=_skill_view_payload(name="myskill", path=str(external_md)),
+    ) as skill_view_mock:
+        result = _load_skill_payload(str(external_md))
+
+    assert result is not None
+    loaded_skill, skill_dir, skill_name = result
+    assert skill_view_mock.call_args.args[0] == str(external_md)
+    assert loaded_skill["path"] == str(external_md)
+    assert skill_name == "myskill"
+    assert skill_dir == external_dir.resolve()
+
+
+def test_load_skill_payload_external_substring_not_inside_skills_dir(tmp_path):
+    skills_dir = tmp_path / ".hermes" / "skills"
+    skills_dir.mkdir(parents=True)
+    external_dir = Path("/opt/hermes-skills/team/myskill")
+    external_md = external_dir / "SKILL.md"
+
+    with patch("tools.skills_tool.SKILLS_DIR", skills_dir), patch(
+        "tools.skills_tool.skill_view",
+        return_value=_skill_view_payload(name="myskill", path="team/myskill/SKILL.md"),
+    ) as skill_view_mock:
+        result = _load_skill_payload(str(external_md))
+
+    assert result is not None
+    loaded_skill, skill_dir, skill_name = result
+    assert skill_view_mock.call_args.args[0] == str(external_md)
+    assert loaded_skill["path"] == "team/myskill/SKILL.md"
+    assert skill_name == "myskill"
+    assert skill_dir == external_dir.resolve()


### PR DESCRIPTION
Fixes #10313

## Problem

`_load_skill_payload()` in `agent/skill_commands.py` reconstructs `skill_dir` using `SKILLS_DIR / Path(skill_path).parent`, which produces a wrong path for external skills registered via `skills.external_dirs`.

For example, an external skill at `/opt/shared-skills/teamA/myskill/SKILL.md` would resolve to `~/.hermes/skills/teamA/myskill` instead, breaking `skill_view()` and any linked file resolution for that skill.

## Fix

Use `Path(skill_path).parent` directly when the skill path is outside `SKILLS_DIR`. Fall back to `SKILLS_DIR`-relative reconstruction only for builtin skills.

## Tests

- Added `tests/agent/test_skill_commands_external.py` with regression test covering external skill path resolution
- Existing skill tests continue to pass