### PR TITLE
fix(model_tools): auto-truncate verbose tool descriptions for size-li…

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -20,11 +20,12 @@ Public API (signatures preserved from the original 2,400-line version):
     check_tool_availability(quiet) -> tuple
 """
 
+import copy
 import json
 import asyncio
 import logging
 import threading
-from typing import Dict, Any, List, Optional, Tuple
+from typing import Dict, Any, List, Optional, Tuple, Union
 
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
@@ -190,6 +191,72 @@ _LEGACY_TOOLSET_MAP = {
 
 
 # =============================================================================
+# Schema truncation for providers with strict size limits
+# =============================================================================
+
+def _truncate_tool_schema(
+    tool_def: Dict[str, Any],
+    max_top_description: int = 600,
+    max_param_description: int = 300,
+) -> Dict[str, Any]:
+    """Return a copy of a tool definition with description lengths capped.
+
+    Some providers (e.g. Moonshot/Kimi) reject requests when the aggregated
+    ``tools.function.parameters`` schema exceeds a maximum allowed size.
+    Trimming verbose natural-language descriptions is the safest way to stay
+    under the limit without losing structural schema information.
+    """
+    tool_def = copy.deepcopy(tool_def)
+    fn = tool_def.get("function")
+    if not isinstance(fn, dict):
+        return tool_def
+
+    desc = fn.get("description")
+    if isinstance(desc, str) and len(desc) > max_top_description:
+        fn["description"] = desc[: max_top_description - 3].rsplit(" ", 1)[0] + "..."
+        logger.debug(
+            "Truncated top-level description for tool %s (%d -> %d chars)",
+            fn.get("name", "?"),
+            len(desc),
+            len(fn["description"]),
+        )
+
+    params = fn.get("parameters")
+    if isinstance(params, dict):
+        _truncate_schema_descriptions(params, max_param_description)
+    return tool_def
+
+
+def _truncate_schema_descriptions(node: Any, max_chars: int) -> None:
+    """Recursively truncate ``description`` fields inside a JSON Schema dict."""
+    if not isinstance(node, dict):
+        return
+
+    desc = node.get("description")
+    if isinstance(desc, str) and len(desc) > max_chars:
+        node["description"] = desc[: max_chars - 3].rsplit(" ", 1)[0] + "..."
+
+    for key in ("properties", "additionalProperties", "patternProperties"):
+        child = node.get(key)
+        if isinstance(child, dict):
+            for v in child.values():
+                _truncate_schema_descriptions(v, max_chars)
+
+    # items can be a single schema dict or a list of schemas (tuple form)
+    items = node.get("items")
+    if isinstance(items, dict):
+        _truncate_schema_descriptions(items, max_chars)
+    elif isinstance(items, list):
+        for item in items:
+            _truncate_schema_descriptions(item, max_chars)
+
+    # anyOf / oneOf / allOf
+    for key in ("anyOf", "oneOf", "allOf"):
+        for item in node.get(key, []):
+            _truncate_schema_descriptions(item, max_chars)
+
+
+# =============================================================================
 # get_tool_definitions  (the main schema provider)
 # =============================================================================
 
@@ -311,6 +378,10 @@ def get_tool_definitions(
 
     global _last_resolved_tool_names
     _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+
+    # Truncate verbose descriptions for providers with strict schema size limits
+    # (e.g. Moonshot/Kimi rejects "schema exceeds maximum allowed size").
+    filtered_tools = [_truncate_tool_schema(td) for td in filtered_tools]
 
     return filtered_tools
 

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -222,3 +222,116 @@ class TestBackwardCompat:
     def test_tool_to_toolset_map(self):
         assert isinstance(TOOL_TO_TOOLSET_MAP, dict)
         assert len(TOOL_TO_TOOLSET_MAP) > 0
+
+
+# =========================================================================
+# Schema truncation for size-limited providers (e.g. Moonshot/Kimi)
+# =========================================================================
+
+class TestTruncateToolSchema:
+    def test_top_level_description_truncated(self):
+        from model_tools import _truncate_tool_schema
+
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "test",
+                "description": "A" * 1000,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        result = _truncate_tool_schema(tool, max_top_description=100, max_param_description=50)
+        desc = result["function"]["description"]
+        assert len(desc) <= 100
+        assert desc.endswith("...")
+
+    def test_parameter_descriptions_truncated(self):
+        from model_tools import _truncate_tool_schema
+
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "test",
+                "description": "Short",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "foo": {
+                            "type": "string",
+                            "description": "B" * 200,
+                        }
+                    },
+                },
+            },
+        }
+        result = _truncate_tool_schema(tool, max_top_description=500, max_param_description=80)
+        desc = result["function"]["parameters"]["properties"]["foo"]["description"]
+        assert len(desc) <= 80
+        assert desc.endswith("...")
+
+    def test_nested_items_descriptions_truncated(self):
+        from model_tools import _truncate_tool_schema
+
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "test",
+                "description": "Short",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "bar": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "nested": {
+                                        "type": "string",
+                                        "description": "C" * 500,
+                                    }
+                                },
+                            },
+                        }
+                    },
+                },
+            },
+        }
+        result = _truncate_tool_schema(tool, max_top_description=500, max_param_description=100)
+        desc = result["function"]["parameters"]["properties"]["bar"]["items"]["properties"]["nested"]["description"]
+        assert len(desc) <= 100
+        assert desc.endswith("...")
+
+    def test_no_mutation_of_original(self):
+        from model_tools import _truncate_tool_schema
+
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "test",
+                "description": "A" * 1000,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        original_len = len(tool["function"]["description"])
+        _truncate_tool_schema(tool, max_top_description=100, max_param_description=50)
+        assert len(tool["function"]["description"]) == original_len
+
+    def test_short_descriptions_unchanged(self):
+        from model_tools import _truncate_tool_schema
+
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "test",
+                "description": "Short desc",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "foo": {"type": "string", "description": "Also short"}
+                    },
+                },
+            },
+        }
+        result = _truncate_tool_schema(tool)
+        assert result["function"]["description"] == "Short desc"
+        assert result["function"]["parameters"]["properties"]["foo"]["description"] == "Also short"


### PR DESCRIPTION
…mited providers

Some providers (e.g. Moonshot/Kimi) reject requests when the aggregated tools.function.parameters schema exceeds their maximum allowed size. Trimming verbose natural-language descriptions is the safest way to stay under the limit without losing structural schema information.

- Add _truncate_tool_schema() with 600/300 char defaults
- Recursively truncate nested schema descriptions (items, anyOf, etc.)
- Deep-copy to avoid mutating registry originals
- Add 5 unit tests for truncation edge cases

Saves ~7KB for the hermes-cli toolset.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

