### PR TITLE
fix(cron): avoid duplicate delivery after live-adapter timeouts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -166,7 +166,35 @@ _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
 _IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
 
 
-def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: dict | None, loop, job: dict) -> None:
+def _cancel_inflight_future(future: concurrent.futures.Future, *, wait_timeout: float = 1.0) -> bool:
+    """Best-effort cancellation for a thread-safe future.
+
+    Returns True when the future is already finished or cancellation is
+    observed promptly.  False means the work may still be running, so callers
+    must not retry the same non-idempotent send.
+    """
+    if future.done():
+        return True
+    future.cancel()
+    try:
+        future.result(timeout=wait_timeout)
+    except concurrent.futures.CancelledError:
+        return True
+    except concurrent.futures.TimeoutError:
+        return False
+    except Exception:
+        return future.done()
+    return future.cancelled() or future.done()
+
+
+def _send_media_via_adapter(
+    adapter,
+    chat_id: str,
+    media_files: list,
+    metadata: dict | None,
+    loop,
+    job: dict,
+) -> Optional[str]:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
@@ -175,6 +203,7 @@ def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: 
     """
     from pathlib import Path
 
+    errors: list[str] = []
     for media_path, _is_voice in media_files:
         try:
             ext = Path(media_path).suffix.lower()
@@ -188,14 +217,30 @@ def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: 
                 coro = adapter.send_document(chat_id=chat_id, file_path=media_path, metadata=metadata)
 
             future = asyncio.run_coroutine_threadsafe(coro, loop)
-            result = future.result(timeout=30)
-            if result and not getattr(result, "success", True):
-                logger.warning(
-                    "Job '%s': media send failed for %s: %s",
-                    job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
+            try:
+                result = future.result(timeout=30)
+            except concurrent.futures.TimeoutError:
+                cancelled = _cancel_inflight_future(future)
+                detail = (
+                    "timed out and may still be in flight"
+                    if not cancelled
+                    else "timed out; cancelled to avoid duplicate delivery"
                 )
+                msg = f"media send failed for {media_path}: {detail}"
+                logger.warning("Job '%s': %s", job.get("id", "?"), msg)
+                errors.append(msg)
+                continue
+            if result and not getattr(result, "success", True):
+                msg = f"media send failed for {media_path}: {getattr(result, 'error', 'unknown')}"
+                logger.warning("Job '%s': %s", job.get("id", "?"), msg)
+                errors.append(msg)
         except Exception as e:
-            logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+            msg = f"failed to send media {media_path}: {e}"
+            logger.warning("Job '%s': %s", job.get("id", "?"), msg)
+            errors.append(msg)
+    if errors:
+        return "; ".join(errors)
+    return None
 
 
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
@@ -318,7 +363,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
                     loop,
                 )
-                send_result = future.result(timeout=60)
+                try:
+                    send_result = future.result(timeout=60)
+                except concurrent.futures.TimeoutError:
+                    cancelled = _cancel_inflight_future(future)
+                    msg = (
+                        f"live adapter delivery to {platform_name}:{chat_id} timed out "
+                        f"and {'may still be in flight' if not cancelled else 'was cancelled'}; "
+                        "not falling back to avoid duplicate delivery"
+                    )
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    return msg
                 if send_result and not getattr(send_result, "success", True):
                     err = getattr(send_result, "error", "unknown")
                     logger.warning(
@@ -329,7 +384,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
             # Send extracted media files as native attachments via the live adapter
             if adapter_ok and media_files:
-                _send_media_via_adapter(runtime_adapter, chat_id, media_files, send_metadata, loop, job)
+                media_error = _send_media_via_adapter(
+                    runtime_adapter,
+                    chat_id,
+                    media_files,
+                    send_metadata,
+                    loop,
+                    job,
+                )
+                if media_error:
+                    return media_error
 
             if adapter_ok:
                 logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
@@ -350,7 +414,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # prevent "coroutine was never awaited" RuntimeWarning, then retry in a
         # fresh thread that has no running loop.
         coro.close()
-        import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
             future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
             result = future.result(timeout=30)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,5 +1,6 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -495,6 +496,109 @@ class TestDeliverResultWrapping:
         text_sent = adapter.send.call_args[0][1]
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
+
+    def test_live_adapter_text_timeout_does_not_fallback_to_standalone(self):
+        """Timeouts are ambiguous for non-idempotent sends, so cron must not retry
+        them via the standalone path and risk duplicate delivery."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        future = MagicMock()
+        future.result.side_effect = concurrent.futures.TimeoutError()
+        future.done.return_value = False
+        future.cancel.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return future
+
+        job = {
+            "id": "timeout-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "555"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = _deliver_result(
+                job,
+                "Report body",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is not None
+        assert "timed out" in result
+        assert "not falling back" in result
+        assert future.cancel.called
+        send_mock.assert_not_called()
+
+    def test_live_adapter_media_timeout_does_not_fallback_to_standalone(self):
+        """A timed-out media send may still complete later, so cron must not
+        retry the whole delivery through the standalone path."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+        adapter.send_image_file.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        text_future = MagicMock()
+        text_future.result.return_value = MagicMock(success=True)
+        text_future.done.return_value = True
+
+        media_future = MagicMock()
+        media_future.result.side_effect = concurrent.futures.TimeoutError()
+        media_future.done.return_value = False
+        media_future.cancel.return_value = True
+
+        futures = [text_future, media_future]
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return futures.pop(0)
+
+        job = {
+            "id": "media-timeout",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "777"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = _deliver_result(
+                job,
+                "Report\nMEDIA:/tmp/chart.png",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is not None
+        assert "media send failed" in result
+        assert "timed out" in result
+        assert media_future.cancel.called
+        send_mock.assert_not_called()
 
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
@@ -1175,7 +1279,7 @@ class TestSendMediaViaAdapter:
         t = threading.Thread(target=loop.run_forever, daemon=True)
         t.start()
         try:
-            _send_media_via_adapter(adapter, chat_id, media_files, metadata, loop, job)
+            return _send_media_via_adapter(adapter, chat_id, media_files, metadata, loop, job)
         finally:
             loop.call_soon_threadsafe(loop.stop)
             t.join(timeout=5)
@@ -1203,5 +1307,44 @@ class TestSendMediaViaAdapter:
         adapter.send_image_file = AsyncMock()
         media_files = [("/tmp/voice.mp3", False), ("/tmp/photo.jpg", False)]
         self._run_with_loop(adapter, "123", media_files, None, {"id": "j3"})
+        adapter.send_voice.assert_called_once()
+        adapter.send_image_file.assert_called_once()
+
+    def test_single_failure_does_not_block_others(self):
+        adapter = MagicMock()
+        adapter.send_voice = AsyncMock(side_effect=RuntimeError("network error"))
+        adapter.send_image_file = AsyncMock()
+        media_files = [("/tmp/voice.ogg", False), ("/tmp/photo.png", False)]
+        self._run_with_loop(adapter, "123", media_files, None, {"id": "j4"})
+        adapter.send_voice.assert_called_once()
+        adapter.send_image_file.assert_called_once()
+
+    def test_timeout_returns_error_and_continues_other_media(self):
+        adapter = MagicMock()
+        adapter.send_voice = AsyncMock()
+        adapter.send_image_file = AsyncMock()
+        loop = MagicMock()
+
+        timeout_future = MagicMock()
+        timeout_future.result.side_effect = concurrent.futures.TimeoutError()
+        timeout_future.done.return_value = False
+        timeout_future.cancel.return_value = True
+
+        ok_future = MagicMock()
+        ok_future.result.return_value = MagicMock(success=True)
+        ok_future.done.return_value = True
+
+        futures = [timeout_future, ok_future]
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return futures.pop(0)
+
+        media_files = [("/tmp/voice.ogg", False), ("/tmp/photo.png", False)]
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _send_media_via_adapter(adapter, "123", media_files, None, loop, {"id": "j5"})
+
+        assert result is not None
+        assert "timed out" in result
         adapter.send_voice.assert_called_once()
         adapter.send_image_file.assert_called_once()


### PR DESCRIPTION
When cron delivery uses a live gateway adapter, `_deliver_result()` waits on `asyncio.run_coroutine_threadsafe(...).result(timeout=60)`. If that wait times out, the code falls back to the standalone send path without cancelling the original future.

That means the original adapter send can still complete later, so the same cron response gets delivered twice. The same issue exists for native media forwarding in `_send_media_via_adapter()`: a timed-out attachment send can still be in flight while cron falls back and re-sends the whole message.

## Changes Made

- Added `_cancel_inflight_future()` for best-effort cancellation of timed-out thread-safe send futures
- Treat live-adapter timeouts as ambiguous delivery states and return an error instead of falling back to standalone delivery
- Applied the same timeout handling to native media sends so attachment timeouts do not trigger duplicate fallback delivery
- Added regression tests for text timeout, media timeout, and media timeout continuation behavior

## How to Test

```bash
pytest -n0 tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_live_adapter_sends_media_as_attachments \
  tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_live_adapter_media_only_no_text \
  tests/cron/test_scheduler.py::TestDeliverResultErrorReturns::test_returns_none_on_successful_delivery \
  tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_live_adapter_text_timeout_does_not_fallback_to_standalone \
  tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_live_adapter_media_timeout_does_not_fallback_to_standalone \
  tests/cron/test_scheduler.py::TestSendMediaViaAdapter::test_timeout_returns_error_and_continues_other_media -q
```

These cover:

- existing live-adapter success paths still succeed
- text timeout does not fall back to standalone delivery
- media timeout does not fall back to standalone delivery
- timed-out media sends still allow later media files to be attempted

## Checklist

- [x] Tests added
- [x] Targeted local tests run — no regressions in the touched paths
- [x] Tested on Linux (Ubuntu 22.04)
