### PR TITLE
feat: add Chatterbox TTS provider with voice cloning

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -922,6 +922,7 @@ def _setup_tts_provider(config: dict):
         "openai": "OpenAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
+        "chatterbox": "Chatterbox",
         "neutts": "NeuTTS",
     }
     current_label = provider_labels.get(current_provider, current_provider)
@@ -943,10 +944,11 @@ def _setup_tts_provider(config: dict):
             "OpenAI TTS (good quality, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
+            "Chatterbox (voice cloning, local or server, no API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts"])
+    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "chatterbox", "neutts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1035,6 +1037,22 @@ def _setup_tts_provider(config: dict):
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"
+
+    elif selected == "chatterbox":
+        mode_choices = ["Local (on-device inference)", "Server (HTTP API)"]
+        mode_idx = prompt_choice("Chatterbox deployment mode:", mode_choices, 0)
+        mode = "local" if mode_idx == 0 else "server"
+        config.setdefault("tts", {})["chatterbox"] = {"mode": mode}
+        if mode == "server":
+            url = input("Chatterbox server URL [http://localhost:7860]: ").strip()
+            config["tts"]["chatterbox"]["url"] = url or "http://localhost:7860"
+        ref = input("Voice reference audio path (leave empty for default voice): ").strip()
+        if ref:
+            config["tts"]["chatterbox"]["ref_audio"] = ref
+        model_choices = ["original (500M, best quality)", "turbo (350M, fastest)", "multilingual (500M, 23 languages)"]
+        model_idx = prompt_choice("Model variant:", model_choices, 0)
+        model = ["original", "turbo", "multilingual"][model_idx]
+        config["tts"]["chatterbox"]["model"] = model
 
     # Save the selection
     if "tts" not in config:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -164,6 +164,13 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "mistral",
             },
+            {
+                "name": "Chatterbox",
+                "badge": "free · local",
+                "tag": "Open-source voice cloning (local or server)",
+                "env_vars": [],
+                "tts_provider": "chatterbox",
+            },
         ],
     },
     "web": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
   "fal-client>=0.13.1,<1",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts>=7.2.7,<8",
+  # Language detection (used by Chatterbox TTS to auto-detect prompt language)
+  "langdetect>=1.0.9,<2",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
   "PyJWT[crypto]>=2.12.0,<3",  # CVE-2026-32597
 ]

--- a/tests/tools/test_tts_chatterbox.py
+++ b/tests/tools/test_tts_chatterbox.py
@@ -1,0 +1,320 @@
+"""Tests for the Chatterbox TTS provider.
+
+All tests use mocks — no real model loading, no network calls, no GPU
+required.  Safe to run in CI environments without PyTorch or chatterbox-tts.
+"""
+
+import os
+import struct
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the provider module.  We import individual functions so that tests
+# remain independent of the rest of the Hermes codebase.
+# ---------------------------------------------------------------------------
+
+from tools.chatterbox_tts_provider import (
+    _check_chatterbox_available,
+    _concatenate_wav_bytes,
+    _resolve_device,
+    _split_text_for_chatterbox,
+    generate_chatterbox_tts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_wav_bytes(n_samples: int = 2400, sample_rate: int = 24000) -> bytes:
+    """Build a minimal valid WAV file (16-bit PCM mono)."""
+    pcm = b"\x00\x00" * n_samples
+    data_size = len(pcm)
+    fmt_chunk = struct.pack(
+        "<4sIHHIIHH", b"fmt ", 16, 1, 1, sample_rate, sample_rate * 2, 2, 16
+    )
+    riff_size = 4 + len(fmt_chunk) + 8 + data_size
+    return (
+        b"RIFF"
+        + struct.pack("<I", riff_size)
+        + b"WAVE"
+        + fmt_chunk
+        + b"data"
+        + struct.pack("<I", data_size)
+        + pcm
+    )
+
+
+# ===========================================================================
+# Text chunking
+# ===========================================================================
+
+
+class TestTextChunking:
+    """Tests for _split_text_for_chatterbox."""
+
+    def test_short_text_single_chunk(self):
+        chunks = _split_text_for_chatterbox("Hello world.", limit=240)
+        assert len(chunks) == 1
+        assert chunks[0] == "Hello world."
+
+    def test_long_text_splits_at_sentence_boundary(self):
+        text = (
+            "First sentence. Second sentence. "
+            "Third sentence is a bit longer to push the limit."
+        )
+        chunks = _split_text_for_chatterbox(text, limit=40)
+        assert len(chunks) >= 2
+        for c in chunks:
+            assert len(c) <= 40
+
+    def test_single_long_sentence_splits_on_words(self):
+        text = "A " * 200  # 400 chars, no sentence breaks
+        chunks = _split_text_for_chatterbox(text.strip(), limit=100)
+        assert all(len(c) <= 100 for c in chunks)
+        reconstructed = " ".join(chunks)
+        assert reconstructed.count("A") == text.strip().count("A")
+
+    def test_empty_text_returns_single_empty(self):
+        chunks = _split_text_for_chatterbox("", limit=240)
+        assert chunks == [""]
+
+    def test_whitespace_only_returns_single_empty(self):
+        chunks = _split_text_for_chatterbox("   \n\t  ", limit=240)
+        assert chunks == [""]
+
+    def test_exact_limit_no_split(self):
+        text = "X" * 240
+        chunks = _split_text_for_chatterbox(text, limit=240)
+        assert len(chunks) == 1
+        assert chunks[0] == text
+
+    def test_preserves_punctuation(self):
+        text = "Hello! How are you? I'm fine."
+        chunks = _split_text_for_chatterbox(text, limit=15)
+        combined = " ".join(chunks)
+        assert "!" in combined
+        assert "?" in combined
+        assert "." in combined
+
+    def test_unicode_and_emoji(self):
+        text = "Héllo wörld! 🔥 This has üñíçödé. And emoji too! 😏👀"
+        chunks = _split_text_for_chatterbox(text, limit=30)
+        assert all(len(c) <= 30 for c in chunks)
+        combined = " ".join(chunks)
+        assert "🔥" in combined
+        assert "😏" in combined
+
+    def test_oversized_word_split_at_limit(self):
+        text = "X" * 500  # Single "word" exceeding limit
+        chunks = _split_text_for_chatterbox(text, limit=240)
+        assert all(len(c) <= 240 for c in chunks)
+        assert "".join(chunks) == text
+
+
+# ===========================================================================
+# WAV concatenation
+# ===========================================================================
+
+
+class TestWavConcatenation:
+    """Tests for _concatenate_wav_bytes."""
+
+    def test_empty_list_returns_empty(self):
+        result = _concatenate_wav_bytes([])
+        assert result == b""
+
+    def test_single_segment_passthrough(self):
+        wav = _make_wav_bytes(100)
+        result = _concatenate_wav_bytes([wav])
+        assert result == wav
+
+    def test_two_segments_larger_than_either(self):
+        wav1 = _make_wav_bytes(100)
+        wav2 = _make_wav_bytes(200)
+        result = _concatenate_wav_bytes([wav1, wav2])
+        assert result[:4] == b"RIFF"
+        assert len(result) > len(wav1)
+        assert len(result) > len(wav2)
+
+    def test_concatenated_data_size_correct(self):
+        wav1 = _make_wav_bytes(1000)
+        wav2 = _make_wav_bytes(500)
+        result = _concatenate_wav_bytes([wav1, wav2])
+        assert result[:4] == b"RIFF"
+        data_pos = result.index(b"data")
+        data_size = struct.unpack_from("<I", result, data_pos + 4)[0]
+        # (1000 + 500) samples * 2 bytes each = 3000
+        assert data_size == 3000
+
+    def test_tiny_segment_skipped(self):
+        wav = _make_wav_bytes(100)
+        result = _concatenate_wav_bytes([wav, b"tiny", wav])
+        assert result[:4] == b"RIFF"
+
+
+# ===========================================================================
+# Device resolution
+# ===========================================================================
+
+
+class TestDeviceResolution:
+    """Tests for _resolve_device."""
+
+    @pytest.fixture(autouse=True)
+    def _require_torch(self):
+        pytest.importorskip("torch")
+
+    def test_cuda_preferred(self):
+        with mock.patch("torch.cuda.is_available", return_value=True):
+            assert _resolve_device() == "cuda"
+
+    def test_mps_when_no_cuda(self):
+        with mock.patch("torch.cuda.is_available", return_value=False), mock.patch(
+            "torch.backends.mps.is_available", return_value=True
+        ):
+            assert _resolve_device() == "mps"
+
+    def test_cpu_fallback(self):
+        with mock.patch("torch.cuda.is_available", return_value=False), mock.patch(
+            "torch.backends.mps.is_available", return_value=False
+        ):
+            assert _resolve_device() == "cpu"
+
+
+# ===========================================================================
+# Local mode (mocked model)
+# ===========================================================================
+
+
+class TestGenerateLocal:
+    """Tests for the local generation path with a mocked model."""
+
+    @pytest.fixture(autouse=True)
+    def _require_torch(self):
+        pytest.importorskip("torch")
+
+    @staticmethod
+    def _make_mock_model():
+        import torch
+
+        model = mock.MagicMock()
+        model.generate.return_value = torch.zeros(1, 24000)  # 1s silence
+        return model
+
+    def test_generates_wav_file(self, tmp_path):
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "local", "model": "original"}}
+        model = self._make_mock_model()
+
+        with mock.patch(
+            "tools.chatterbox_tts_provider._get_or_load_model",
+            return_value=model,
+        ), mock.patch(
+            "tools.chatterbox_tts_provider._check_chatterbox_available",
+            return_value=True,
+        ):
+            result = generate_chatterbox_tts("Hello", out, config)
+
+        assert os.path.exists(result)
+        assert os.path.getsize(result) > 0
+
+    def test_passes_ref_audio(self, tmp_path):
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(_make_wav_bytes(100))
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "local", "ref_audio": str(ref)}}
+        model = self._make_mock_model()
+
+        with mock.patch(
+            "tools.chatterbox_tts_provider._get_or_load_model",
+            return_value=model,
+        ), mock.patch(
+            "tools.chatterbox_tts_provider._check_chatterbox_available",
+            return_value=True,
+        ):
+            generate_chatterbox_tts("Hello", out, config)
+
+        call_kwargs = model.generate.call_args[1]
+        assert call_kwargs["audio_prompt_path"] == str(ref)
+
+    def test_raises_when_not_installed(self, tmp_path):
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "local"}}
+
+        with mock.patch(
+            "tools.chatterbox_tts_provider._check_chatterbox_available",
+            return_value=False,
+        ):
+            with pytest.raises(ValueError, match="chatterbox-tts.*not installed"):
+                generate_chatterbox_tts("Hello", out, config)
+
+    def test_chunks_long_text(self, tmp_path):
+        out = str(tmp_path / "test.wav")
+        long_text = "This is a sentence. " * 30  # ~600 chars
+        config = {"chatterbox": {"mode": "local"}}
+        model = self._make_mock_model()
+
+        with mock.patch(
+            "tools.chatterbox_tts_provider._get_or_load_model",
+            return_value=model,
+        ), mock.patch(
+            "tools.chatterbox_tts_provider._check_chatterbox_available",
+            return_value=True,
+        ):
+            generate_chatterbox_tts(long_text, out, config)
+
+        assert model.generate.call_count > 1
+
+    def test_empty_text_raises(self, tmp_path):
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "local"}}
+
+        with pytest.raises(ValueError, match="Text is required"):
+            generate_chatterbox_tts("", out, config)
+
+
+# ===========================================================================
+# Server mode (mocked HTTP)
+# ===========================================================================
+
+
+class TestGenerateServer:
+    """Tests for the server generation path with mocked HTTP."""
+
+    def test_openai_compatible_endpoint(self, tmp_path):
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "server", "url": "http://localhost:7860"}}
+
+        mock_resp = mock.MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = _make_wav_bytes(2400)
+        mock_resp.raise_for_status = mock.MagicMock()
+
+        with mock.patch("requests.post", return_value=mock_resp) as mock_post:
+            result = generate_chatterbox_tts("Hello", out, config)
+
+        assert os.path.exists(result)
+        call_url = mock_post.call_args[0][0]
+        assert "/v1/audio/speech" in call_url
+
+    def test_server_unreachable_raises_runtime_error(self, tmp_path):
+        import requests
+
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "server", "url": "http://localhost:99999"}}
+
+        with mock.patch(
+            "requests.post", side_effect=requests.ConnectionError("refused")
+        ):
+            with pytest.raises(RuntimeError, match="unreachable"):
+                generate_chatterbox_tts("Hello", out, config)
+
+    def test_empty_text_raises(self, tmp_path):
+        out = str(tmp_path / "test.wav")
+        config = {"chatterbox": {"mode": "server"}}
+
+        with pytest.raises(ValueError, match="Text is required"):
+            generate_chatterbox_tts("   ", out, config)

--- a/tools/chatterbox_tts_provider.py
+++ b/tools/chatterbox_tts_provider.py
@@ -1,0 +1,577 @@
+"""
+Chatterbox TTS provider for Hermes Agent.
+
+Supports two deployment modes:
+- **Local mode**: Imports the chatterbox-tts Python library directly for
+  on-device inference. Requires PyTorch and a GPU (CUDA) or Apple Silicon
+  (MPS). No API key needed.
+- **Server mode**: Calls an OpenAI-compatible HTTP API served by a separate
+  Chatterbox server instance (e.g. travisvn/chatterbox-tts-api Docker image).
+  Decouples inference from the agent machine.
+
+Both modes support voice cloning via a reference audio file — a unique
+capability among Hermes TTS providers.
+
+Configuration (in ~/.hermes/config.yaml)::
+
+    tts:
+      provider: chatterbox
+      chatterbox:
+        mode: local                  # "local" or "server"
+        model: original              # "original", "turbo", or "multilingual"
+        ref_audio: /path/to/ref.wav  # Voice cloning reference (optional)
+        exaggeration: 0.5            # 0.0-2.0, emotion intensity
+        cfg_weight: 0.5              # 0.0-1.0, classifier-free guidance
+        temperature: 0.8             # Sampling temperature
+        language_id: en               # Language (multilingual model only, e.g. en, fr, de)
+        # Server mode only:
+        url: http://localhost:7860   # Chatterbox API server URL
+
+Chatterbox has a practical generation limit of ~250 characters per call.
+Longer text is automatically split at sentence boundaries, generated in
+chunks, and concatenated into a single output file.
+"""
+
+import io
+import logging
+import os
+import re
+import shutil
+import struct
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ===========================================================================
+# Defaults
+# ===========================================================================
+
+DEFAULT_CHATTERBOX_MODE = "local"
+DEFAULT_CHATTERBOX_MODEL = "original"
+DEFAULT_CHATTERBOX_EXAGGERATION = 0.5
+DEFAULT_CHATTERBOX_CFG_WEIGHT = 0.5
+DEFAULT_CHATTERBOX_TEMPERATURE = 0.8
+DEFAULT_CHATTERBOX_URL = "http://localhost:7860"
+CHATTERBOX_CHUNK_LIMIT = 240  # chars per generation chunk (safe under ~250 limit)
+CHATTERBOX_SAMPLE_RATE = 24000
+DEFAULT_CHATTERBOX_LANGUAGE_ID = "en"
+_MIN_WAV_HEADER_SIZE = 44  # Minimum valid WAV file: 44-byte header + data
+
+
+# ===========================================================================
+# Text chunking
+# ===========================================================================
+
+def _split_text_for_chatterbox(
+    text: str,
+    limit: int = CHATTERBOX_CHUNK_LIMIT,
+) -> List[str]:
+    """Split text into chunks at sentence boundaries, respecting the char limit.
+
+    Chatterbox produces degraded output for inputs over ~250 characters.
+    This splitter prioritises sentence boundaries (``.`` ``!`` ``?`` ``;``
+    ``—``) and falls back to word boundaries when a single sentence
+    exceeds the limit.
+
+    Args:
+        text: The input text to split.
+        limit: Maximum character count per chunk.
+
+    Returns:
+        List of non-empty text chunks, each at most *limit* characters long.
+        Returns ``[""]`` only if *text* is empty or whitespace-only.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return [""]
+
+    # Split on sentence-ending punctuation while keeping the delimiter
+    sentences = re.split(r"(?<=[.!?;—])\s+", stripped)
+    chunks: List[str] = []
+    current = ""
+
+    for sentence in sentences:
+        if not sentence.strip():
+            continue
+        # If adding this sentence stays under limit, accumulate
+        candidate = f"{current} {sentence}".strip() if current else sentence
+        if len(candidate) <= limit:
+            current = candidate
+        else:
+            # Flush current chunk if non-empty
+            if current:
+                chunks.append(current)
+            # If the sentence itself exceeds the limit, split on words
+            if len(sentence) > limit:
+                words = sentence.split()
+                current = ""
+                for word in words:
+                    test = f"{current} {word}".strip() if current else word
+                    if len(test) <= limit:
+                        current = test
+                    else:
+                        if current:
+                            chunks.append(current)
+                        # If a single word exceeds the limit (e.g. a URL),
+                        # split it at the limit boundary
+                        if len(word) > limit:
+                            for start in range(0, len(word), limit):
+                                chunks.append(word[start : start + limit])
+                            current = ""
+                        else:
+                            current = word
+            else:
+                current = sentence
+
+    if current:
+        chunks.append(current)
+
+    return chunks or [stripped[:limit]]
+
+
+# ===========================================================================
+# WAV concatenation
+# ===========================================================================
+
+def _concatenate_wav_bytes(wav_segments: List[bytes]) -> bytes:
+    """Concatenate multiple single-channel WAV byte strings into one.
+
+    Assumes all segments share the same sample rate and bit depth.
+    Parses each segment's RIFF structure to extract raw PCM data, then
+    rebuilds a single valid WAV file.
+
+    Args:
+        wav_segments: List of WAV file contents as byte strings.
+
+    Returns:
+        A single concatenated WAV file as bytes.
+    """
+    if not wav_segments:
+        return b""
+    if len(wav_segments) == 1:
+        return wav_segments[0]
+
+    all_pcm = bytearray()
+    fmt_chunk = None
+
+    for seg in wav_segments:
+        if len(seg) < _MIN_WAV_HEADER_SIZE:
+            continue
+        # Walk RIFF chunks to locate fmt and data
+        pos = 12  # skip "RIFF" + size + "WAVE"
+        while pos < len(seg) - 8:
+            chunk_id = seg[pos : pos + 4]
+            chunk_size = struct.unpack_from("<I", seg, pos + 4)[0]
+            if chunk_id == b"fmt ":
+                if fmt_chunk is None:
+                    fmt_chunk = seg[pos : pos + 8 + chunk_size]
+            elif chunk_id == b"data":
+                all_pcm.extend(seg[pos + 8 : pos + 8 + chunk_size])
+                break
+            pos += 8 + chunk_size
+
+    if fmt_chunk is None or not all_pcm:
+        # Parsing failed — return the first segment unmodified
+        return wav_segments[0]
+
+    # Rebuild a valid WAV file
+    data_size = len(all_pcm)
+    riff_size = 4 + len(fmt_chunk) + 8 + data_size
+    header = b"RIFF" + struct.pack("<I", riff_size) + b"WAVE"
+    data_header = b"data" + struct.pack("<I", data_size)
+    return bytes(header + fmt_chunk + data_header + all_pcm)
+
+
+# ===========================================================================
+# Local mode
+# ===========================================================================
+
+def _check_chatterbox_available() -> bool:
+    """Check if the chatterbox-tts package is importable."""
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec("chatterbox") is not None
+    except Exception:
+        return False
+
+
+def _resolve_device() -> str:
+    """Pick the best available PyTorch device for local inference.
+
+    Returns:
+        ``"cuda"`` if an NVIDIA GPU is available, ``"mps"`` on Apple
+        Silicon, or ``"cpu"`` as a fallback.
+    """
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return "cuda"
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return "mps"
+    except ImportError:
+        pass
+    return "cpu"
+
+
+def _load_local_model(model_variant: str, device: str):
+    """Load a Chatterbox model variant onto *device*.
+
+    Handles the ``perth`` watermarker compatibility issue on platforms where
+    the native watermarker C extension is unavailable (macOS ARM, some Linux
+    containers).  Falls back to the bundled ``DummyWatermarker`` transparently.
+
+    Args:
+        model_variant: One of ``"original"``, ``"turbo"``, ``"multilingual"``.
+        device: PyTorch device string (``"cuda"``, ``"mps"``, ``"cpu"``).
+
+    Returns:
+        A loaded Chatterbox model instance.
+    """
+    # Patch watermarker for environments where the native library is absent.
+    try:
+        import perth
+
+        if perth.PerthImplicitWatermarker is None:
+            logger.debug(
+                "perth native watermarker unavailable, using DummyWatermarker"
+            )
+            perth.PerthImplicitWatermarker = perth.DummyWatermarker
+    except (ImportError, AttributeError):
+        pass
+
+    if model_variant == "turbo":
+        from chatterbox.tts_turbo import ChatterboxTurboTTS
+
+        return ChatterboxTurboTTS.from_pretrained(device=device)
+    elif model_variant == "multilingual":
+        from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+
+        return ChatterboxMultilingualTTS.from_pretrained(device=device)
+    else:
+        from chatterbox.tts import ChatterboxTTS
+
+        return ChatterboxTTS.from_pretrained(device=device)
+
+
+# Module-level model cache to avoid reloading on every call.
+_model_lock = threading.Lock()
+_cached_model = None
+_cached_model_key: Optional[tuple] = None
+
+
+def _get_or_load_model(model_variant: str, device: str):
+    """Return a cached model or load a new one (thread-safe).
+
+    Args:
+        model_variant: One of ``"original"``, ``"turbo"``, ``"multilingual"``.
+        device: PyTorch device string.
+
+    Returns:
+        A loaded Chatterbox model instance.
+    """
+    global _cached_model, _cached_model_key
+    key = (model_variant, device)
+    with _model_lock:
+        if _cached_model is not None and _cached_model_key == key:
+            return _cached_model
+        logger.info("Loading Chatterbox %s model on %s...", model_variant, device)
+        _cached_model = _load_local_model(model_variant, device)
+        _cached_model_key = key
+        logger.info("Chatterbox model loaded.")
+        return _cached_model
+
+
+def _generate_local(
+    text: str,
+    output_path: str,
+    cb_config: Dict[str, Any],
+) -> str:
+    """Generate audio using the local chatterbox-tts library.
+
+    Splits long text into chunks, generates each with the configured
+    parameters, and concatenates into a single WAV file.
+
+    Args:
+        text: The text to synthesise.
+        output_path: Destination file path (WAV format).
+        cb_config: The ``tts.chatterbox`` config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    import torch
+    import torchaudio
+
+    model_variant = cb_config.get("model", DEFAULT_CHATTERBOX_MODEL)
+    device = _resolve_device()
+    model = _get_or_load_model(model_variant, device)
+
+    ref_audio = cb_config.get("ref_audio", "")
+    exaggeration = float(
+        cb_config.get("exaggeration", DEFAULT_CHATTERBOX_EXAGGERATION)
+    )
+    cfg_weight = float(cb_config.get("cfg_weight", DEFAULT_CHATTERBOX_CFG_WEIGHT))
+    temperature = float(
+        cb_config.get("temperature", DEFAULT_CHATTERBOX_TEMPERATURE)
+    )
+
+    # Validate ref_audio if provided
+    if ref_audio and not os.path.isfile(ref_audio):
+        logger.warning(
+            "Chatterbox ref_audio not found: %s (proceeding without voice cloning)",
+            ref_audio,
+        )
+        ref_audio = ""
+
+    chunks = _split_text_for_chatterbox(text)
+    wav_segments: List[bytes] = []
+
+    for i, chunk in enumerate(chunks):
+        if not chunk.strip():
+            continue
+        logger.debug(
+            "Chatterbox generating chunk %d/%d (%d chars)",
+            i + 1,
+            len(chunks),
+            len(chunk),
+        )
+
+        kwargs: Dict[str, Any] = {"text": chunk}
+        if ref_audio:
+            kwargs["audio_prompt_path"] = ref_audio
+        # Pass variant-specific parameters
+        if model_variant == "multilingual":
+            kwargs["language_id"] = cb_config.get(
+                "language_id", DEFAULT_CHATTERBOX_LANGUAGE_ID
+            )
+        if model_variant in ("original", "turbo"):
+            kwargs["exaggeration"] = exaggeration
+            kwargs["cfg_weight"] = cfg_weight
+            kwargs["temperature"] = temperature
+
+        wav_tensor = model.generate(**kwargs)
+
+        # Normalise tensor shape to (1, samples) for torchaudio.save
+        if wav_tensor.ndim == 3:
+            wav_tensor = wav_tensor.squeeze(0)
+        elif wav_tensor.ndim == 1:
+            wav_tensor = wav_tensor.unsqueeze(0)
+
+        # Convert to WAV bytes via an in-memory buffer
+        buf = io.BytesIO()
+        torchaudio.save(buf, wav_tensor.cpu(), CHATTERBOX_SAMPLE_RATE, format="wav")
+        wav_segments.append(buf.getvalue())
+
+    if not wav_segments:
+        raise RuntimeError("Chatterbox produced no audio segments")
+
+    # Concatenate all chunks and write to output
+    combined = _concatenate_wav_bytes(wav_segments)
+    with open(output_path, "wb") as f:
+        f.write(combined)
+
+    return output_path
+
+
+# ===========================================================================
+# Server mode
+# ===========================================================================
+
+def _generate_server(
+    text: str,
+    output_path: str,
+    cb_config: Dict[str, Any],
+) -> str:
+    """Generate audio via a Chatterbox HTTP server.
+
+    Tries an OpenAI-compatible ``/v1/audio/speech`` endpoint first, then
+    falls back to a Gradio ``/api/predict`` endpoint.
+
+    Args:
+        text: The text to synthesise.
+        output_path: Destination file path (WAV format).
+        cb_config: The ``tts.chatterbox`` config dict.
+
+    Returns:
+        Path to the saved audio file.
+
+    Raises:
+        RuntimeError: If the server is unreachable or returns an error.
+    """
+    import requests
+
+    url = cb_config.get("url", DEFAULT_CHATTERBOX_URL).rstrip("/")
+    ref_audio = cb_config.get("ref_audio", "")
+    model_variant = cb_config.get("model", DEFAULT_CHATTERBOX_MODEL)
+    exaggeration = float(
+        cb_config.get("exaggeration", DEFAULT_CHATTERBOX_EXAGGERATION)
+    )
+    cfg_weight = float(cb_config.get("cfg_weight", DEFAULT_CHATTERBOX_CFG_WEIGHT))
+    temperature = float(
+        cb_config.get("temperature", DEFAULT_CHATTERBOX_TEMPERATURE)
+    )
+
+    chunks = _split_text_for_chatterbox(text)
+    wav_segments: List[bytes] = []
+
+    for i, chunk in enumerate(chunks):
+        if not chunk.strip():
+            continue
+        logger.debug("Chatterbox server chunk %d/%d", i + 1, len(chunks))
+
+        # --- Try OpenAI-compatible endpoint first ---
+        payload: Dict[str, Any] = {
+            "model": model_variant,
+            "input": chunk,
+            "voice": ref_audio or "default",
+            "response_format": "wav",
+        }
+        if exaggeration != DEFAULT_CHATTERBOX_EXAGGERATION:
+            payload["exaggeration"] = exaggeration
+        if cfg_weight != DEFAULT_CHATTERBOX_CFG_WEIGHT:
+            payload["cfg_weight"] = cfg_weight
+        if temperature != DEFAULT_CHATTERBOX_TEMPERATURE:
+            payload["temperature"] = temperature
+
+        try:
+            resp = requests.post(
+                f"{url}/v1/audio/speech",
+                json=payload,
+                timeout=120,
+            )
+            resp.raise_for_status()
+            wav_segments.append(resp.content)
+            continue
+        except requests.exceptions.RequestException as exc:
+            logger.debug(
+                "OpenAI-compatible endpoint failed: %s — trying Gradio", exc
+            )
+
+        # --- Fallback: Gradio predict endpoint ---
+        gradio_payload = {
+            "data": [
+                chunk,
+                ref_audio or None,
+                exaggeration,
+                cfg_weight,
+                temperature,
+            ],
+        }
+        try:
+            resp = requests.post(
+                f"{url}/api/predict",
+                json=gradio_payload,
+                timeout=120,
+            )
+            resp.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            raise RuntimeError(
+                f"Chatterbox server unreachable at {url}: {exc}"
+            ) from exc
+
+        result = resp.json()
+        audio_data = result.get("data", [None])[0]
+
+        if isinstance(audio_data, str) and audio_data.startswith("data:audio"):
+            import base64
+
+            b64_part = audio_data.split(",", 1)[1]
+            wav_segments.append(base64.b64decode(b64_part))
+        # Server returned a file path — only safe when the server is trusted
+        elif isinstance(audio_data, str) and os.path.isfile(audio_data):
+            with open(audio_data, "rb") as f:
+                wav_segments.append(f.read())
+        else:
+            raise RuntimeError(
+                f"Chatterbox server returned unexpected data format "
+                f"(type={type(audio_data).__name__})"
+            )
+
+    if not wav_segments:
+        raise RuntimeError("Chatterbox server produced no audio segments")
+
+    combined = _concatenate_wav_bytes(wav_segments)
+    with open(output_path, "wb") as f:
+        f.write(combined)
+
+    return output_path
+
+
+# ===========================================================================
+# Public entry point
+# ===========================================================================
+
+def generate_chatterbox_tts(
+    text: str,
+    output_path: str,
+    tts_config: Dict[str, Any],
+) -> str:
+    """Generate speech using Chatterbox TTS.
+
+    Dispatches to local or server mode based on configuration.  Text
+    chunking and WAV concatenation are handled transparently.
+
+    Args:
+        text: The text to convert to speech.
+        output_path: Where to save the audio file.  Chatterbox generates
+            WAV natively; the gateway's Opus converter handles downstream
+            format conversion when needed.
+        tts_config: The full ``tts:`` config dict from config.yaml.
+
+    Returns:
+        Path to the saved audio file.
+
+    Raises:
+        ValueError: If local mode is selected but chatterbox-tts is not
+            installed, or if *text* is empty.
+        RuntimeError: On generation failure.
+    """
+    if not text or not text.strip():
+        raise ValueError("Text is required for Chatterbox TTS generation")
+
+    cb_config = tts_config.get("chatterbox", {})
+    mode = cb_config.get("mode", DEFAULT_CHATTERBOX_MODE)
+
+    # Chatterbox generates WAV natively.  If the caller requests a
+    # different extension, generate WAV first — the gateway's Opus
+    # converter handles MP3/WAV -> OGG conversion transparently.
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav" if "." in output_path else output_path + ".wav"
+
+    if mode == "server":
+        logger.info("Generating speech with Chatterbox (server mode)...")
+        _generate_server(text, wav_path, cb_config)
+    else:
+        if not _check_chatterbox_available():
+            raise ValueError(
+                "Chatterbox TTS provider selected but 'chatterbox-tts' package is "
+                "not installed. Install it with: pip install chatterbox-tts\n"
+                "Or switch to server mode: set tts.chatterbox.mode to 'server' "
+                "and run a Chatterbox server separately."
+            )
+        logger.info("Generating speech with Chatterbox (local mode)...")
+        _generate_local(text, wav_path, cb_config)
+
+    # Convert WAV to the requested format, or rename if no ffmpeg.
+    # Matches the NeuTTS provider pattern in tts_tool.py.
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            subprocess.run(
+                [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path],
+                check=True,
+                timeout=30,
+            )
+            os.remove(wav_path)
+        else:
+            # No ffmpeg — rename WAV to the requested extension; the
+            # downstream Opus converter detects content format correctly.
+            os.rename(wav_path, output_path)
+
+    return output_path

--- a/tools/chatterbox_tts_provider.py
+++ b/tools/chatterbox_tts_provider.py
@@ -515,6 +515,29 @@ def _generate_server(
 
 
 # ===========================================================================
+# Language detection
+# ===========================================================================
+
+def _detect_language(text: str, fallback: str = DEFAULT_CHATTERBOX_LANGUAGE_ID) -> str:
+    """Detect the ISO 639-1 language code of *text* using langdetect.
+
+    Args:
+        text: The input text.
+        fallback: Language code to return when detection fails.
+
+    Returns:
+        Two-letter ISO 639-1 language code (e.g. ``"en"``, ``"fr"``).
+    """
+    try:
+        from langdetect import detect, LangDetectException
+
+        return detect(text)
+    except Exception:
+        logger.debug("Language detection failed, falling back to %s", fallback)
+        return fallback
+
+
+# ===========================================================================
 # Public entry point
 # ===========================================================================
 
@@ -546,8 +569,17 @@ def generate_chatterbox_tts(
     if not text or not text.strip():
         raise ValueError("Text is required for Chatterbox TTS generation")
 
-    cb_config = tts_config.get("chatterbox", {})
+    cb_config = dict(tts_config.get("chatterbox", {}))
     mode = cb_config.get("mode", DEFAULT_CHATTERBOX_MODE)
+
+    # Auto-detect language when not explicitly configured (multilingual model only).
+    if (
+        cb_config.get("model", DEFAULT_CHATTERBOX_MODEL) == "multilingual"
+        and not cb_config.get("language_id")
+    ):
+        detected = _detect_language(text)
+        logger.info("Chatterbox auto-detected language: %s", detected)
+        cb_config["language_id"] = detected
 
     # Chatterbox generates WAV natively.  If the caller requests a
     # different extension, generate WAV first — the gateway's Opus

--- a/tools/chatterbox_tts_provider.py
+++ b/tools/chatterbox_tts_provider.py
@@ -460,28 +460,28 @@ def _generate_server(
             continue
         except requests.exceptions.RequestException as exc:
             response_text = getattr(getattr(exc, "response", None), "text", None)
-            logger.info(
+            logger.debug(
                 "/tts endpoint failed: %s — trying Gradio. Server response: %s", exc, response_text
             )
 
         # --- Fallback: Gradio predict endpoint ---
-        # gradio_payload = {
-        #     "data": [
-        #         chunk,
-        #         ref_audio or None,
-        #         exaggeration,
-        #         cfg_weight,
-        #         temperature,
-        #     ],
-        # }
-        # try:
-        #     resp = requests.post(
-        #         f"{url}/api/predict",
-        #         json=gradio_payload,
-        #         timeout=120,
-        #     )
-        #     resp.raise_for_status()
-        # except requests.exceptions.RequestException as exc:
+        gradio_payload = {
+            "data": [
+                chunk,
+                ref_audio or None,
+                exaggeration,
+                cfg_weight,
+                temperature,
+            ],
+        }
+        try:
+            resp = requests.post(
+                f"{url}/api/predict",
+                json=gradio_payload,
+                timeout=120,
+            )
+            resp.raise_for_status()
+        except requests.exceptions.RequestException as exc:
             raise RuntimeError(
                 f"Chatterbox server unreachable at {url}: {exc}"
             ) from exc

--- a/tools/chatterbox_tts_provider.py
+++ b/tools/chatterbox_tts_provider.py
@@ -26,6 +26,7 @@ Configuration (in ~/.hermes/config.yaml)::
         language_id: en               # Language (multilingual model only, e.g. en, fr, de)
         # Server mode only:
         url: http://localhost:7860   # Chatterbox API server URL
+        predefined_voice_id: Abigail.wav  # Predefined voice filename (server mode)
 
 Chatterbox has a practical generation limit of ~250 characters per call.
 Longer text is automatically split at sentence boundaries, generated in
@@ -424,52 +425,63 @@ def _generate_server(
             continue
         logger.debug("Chatterbox server chunk %d/%d", i + 1, len(chunks))
 
-        # --- Try OpenAI-compatible endpoint first ---
+        # --- Try /tts endpoint ---
+        voice_mode = "clone" if ref_audio else "predefined"
         payload: Dict[str, Any] = {
-            "model": model_variant,
-            "input": chunk,
-            "voice": ref_audio or "default",
-            "response_format": "wav",
+            "text": chunk,
+            "voice_mode": voice_mode,
+            "output_format": "wav",
+            "split_text": False,
         }
+        if voice_mode == "predefined":
+            payload["predefined_voice_id"] = cb_config.get("predefined_voice_id", "default")
+        else:
+            payload["reference_audio_filename"] = os.path.basename(ref_audio)
         if exaggeration != DEFAULT_CHATTERBOX_EXAGGERATION:
             payload["exaggeration"] = exaggeration
         if cfg_weight != DEFAULT_CHATTERBOX_CFG_WEIGHT:
             payload["cfg_weight"] = cfg_weight
         if temperature != DEFAULT_CHATTERBOX_TEMPERATURE:
             payload["temperature"] = temperature
+        if model_variant == "multilingual":
+            payload["language"] = cb_config.get("language_id", DEFAULT_CHATTERBOX_LANGUAGE_ID)
 
+
+        logger.info("Chatterbox server request: POST %s/tts payload=%s", url, payload)
         try:
             resp = requests.post(
-                f"{url}/v1/audio/speech",
+                f"{url}/tts",
                 json=payload,
+                headers={"Connection": "close"},
                 timeout=120,
             )
             resp.raise_for_status()
             wav_segments.append(resp.content)
             continue
         except requests.exceptions.RequestException as exc:
-            logger.debug(
-                "OpenAI-compatible endpoint failed: %s — trying Gradio", exc
+            response_text = getattr(getattr(exc, "response", None), "text", None)
+            logger.info(
+                "/tts endpoint failed: %s — trying Gradio. Server response: %s", exc, response_text
             )
 
         # --- Fallback: Gradio predict endpoint ---
-        gradio_payload = {
-            "data": [
-                chunk,
-                ref_audio or None,
-                exaggeration,
-                cfg_weight,
-                temperature,
-            ],
-        }
-        try:
-            resp = requests.post(
-                f"{url}/api/predict",
-                json=gradio_payload,
-                timeout=120,
-            )
-            resp.raise_for_status()
-        except requests.exceptions.RequestException as exc:
+        # gradio_payload = {
+        #     "data": [
+        #         chunk,
+        #         ref_audio or None,
+        #         exaggeration,
+        #         cfg_weight,
+        #         temperature,
+        #     ],
+        # }
+        # try:
+        #     resp = requests.post(
+        #         f"{url}/api/predict",
+        #         json=gradio_payload,
+        #         timeout=120,
+        #     )
+        #     resp.raise_for_status()
+        # except requests.exceptions.RequestException as exc:
             raise RuntimeError(
                 f"Chatterbox server unreachable at {url}: {exc}"
             ) from exc

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,13 +2,14 @@
 """
 Text-to-Speech Tool Module
 
-Supports six TTS providers:
+Supports seven TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- Chatterbox (local or server, voice cloning): Open-source voice cloning TTS by Resemble AI
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -50,6 +51,11 @@ from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_opena
 # Lazy imports -- providers are imported only when actually used to avoid
 # crashing in headless environments (SSH, Docker, WSL, no PortAudio).
 # ---------------------------------------------------------------------------
+
+def _import_chatterbox_provider():
+    """Lazy import Chatterbox provider module."""
+    from tools.chatterbox_tts_provider import generate_chatterbox_tts
+    return generate_chatterbox_tts
 
 def _import_edge_tts():
     """Lazy import edge_tts. Returns the module or raises ImportError."""
@@ -622,6 +628,19 @@ def text_to_speech_tool(
             logger.info("Generating speech with NeuTTS (local)...")
             _generate_neutts(text, file_str, tts_config)
 
+        elif provider == "chatterbox":
+            try:
+                _gen_cb = _import_chatterbox_provider()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Chatterbox provider selected but module not available. "
+                             "Install chatterbox-tts (pip install chatterbox-tts) for local mode, "
+                             "or configure server mode with tts.chatterbox.url."
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Chatterbox TTS...")
+            _gen_cb(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -661,7 +680,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "chatterbox") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -742,6 +761,11 @@ def check_tts_requirements() -> bool:
         pass
     if _check_neutts_available():
         return True
+    try:
+        _import_chatterbox_provider()
+        return True
+    except ImportError:
+        pass
     return False
 
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -10,7 +10,7 @@ Hermes Agent supports both text-to-speech output and voice message transcription
 
 ## Text-to-Speech
 
-Convert text to speech with six providers:
+Convert text to speech with seven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -19,6 +19,7 @@ Convert text to speech with six providers:
 | **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
+| **Chatterbox** | Good | Free | None needed |
 | **NeuTTS** | Good | Free | None needed |
 
 ### Platform Delivery
@@ -35,7 +36,7 @@ Convert text to speech with six providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "neutts"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "chatterbox" | "neutts"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -57,6 +58,15 @@ tts:
   mistral:
     model: "voxtral-mini-tts-2603"
     voice_id: "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral (default)
+  chatterbox:
+    mode: local                  # "local" (on-device) or "server" (HTTP API)
+    model: original              # "original", "turbo", or "multilingual"
+    ref_audio: ""                # Path to voice reference WAV (enables cloning)
+    exaggeration: 0.5            # 0.0–2.0, emotion/expression intensity
+    cfg_weight: 0.5              # 0.0–1.0, classifier-free guidance strength
+    temperature: 0.8             # Sampling temperature
+    language_id: en              # Language (multilingual model only)
+    url: http://localhost:7860   # Server mode URL
   neutts:
     ref_audio: ''
     ref_text: ''
@@ -73,6 +83,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
+- **Chatterbox** outputs WAV and needs **ffmpeg** to convert for Telegram voice bubbles
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 
 ```bash
@@ -86,7 +97,7 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, and NeuTTS audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, Chatterbox, and NeuTTS audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -65,8 +65,9 @@ tts:
     exaggeration: 0.5            # 0.0–2.0, emotion/expression intensity
     cfg_weight: 0.5              # 0.0–1.0, classifier-free guidance strength
     temperature: 0.8             # Sampling temperature
-    language_id: en              # Language (multilingual model only)
+    language_id: en              # Language code (multilingual model only). Optional — if omitted, langdetect auto-detects the language. If set, this value is always used and langdetect is bypassed.
     url: http://localhost:7860   # Server mode URL
+    predefined_voice_id: Alice.wav  # Predefined voice (server mode)
   neutts:
     ref_audio: ''
     ref_text: ''


### PR DESCRIPTION
## Summary

Add [Chatterbox](https://github.com/resemble-ai/chatterbox) by Resemble AI as the seventh TTS provider for Hermes Agent.

- **Voice cloning** from a short reference audio clip — a unique capability among Hermes TTS providers
- **Two deployment modes**: local (on-device via `chatterbox-tts` library) and server (OpenAI-compatible HTTP API)
- **Three model variants**: original (500M, best quality), turbo (350M, fastest), multilingual (500M, 23 languages)
- MIT-licensed, no API key required, runs on CUDA / Apple Silicon MPS / CPU

### Why

Hermes has six TTS providers but none support open-source voice cloning from a reference audio. Chatterbox enables persona voices for AI agents — each agent can sound different using a short voice sample. It runs fully locally with no data sent to third parties.

### Implementation details

- Text chunking at sentence boundaries (~240 char limit per Chatterbox generation)
- WAV segment concatenation for seamless long-text output
- Thread-safe model caching to avoid reloading on every call
- Perth watermarker fallback for macOS/ARM environments
- ffmpeg WAV→target format conversion (matches the NeuTTS pattern)
- Provider module is a separate file (`tools/chatterbox_tts_provider.py`) rather than inlined into `tts_tool.py` because it contains ~550 lines of self-contained logic (chunking, WAV concat, model cache, dual-mode dispatch) that would nearly double the file. This follows the same pattern as NeuTTS keeping its synthesis logic in `tools/neutts_synth.py`.

### Files changed

| File | Change |
|------|--------|
| `tools/chatterbox_tts_provider.py` | New provider module |
| `tests/tools/test_tts_chatterbox.py` | 20 test cases (CI-safe, no GPU/model required) |
| `tools/tts_tool.py` | Dispatch, Opus conversion group, requirements check |
| `hermes_cli/setup.py` | Setup wizard with mode/model/ref_audio configuration |
| `hermes_cli/tools_config.py` | Provider registry entry |
| `website/docs/user-guide/features/tts.md` | Full documentation with config examples |

## Test plan

- [ ] Run `pytest tests/tools/test_tts_chatterbox.py` (no GPU or chatterbox-tts install needed)
- [ ] Verify `hermes setup tts` shows Chatterbox option and config flow works
- [ ] Test local mode with `pip install chatterbox-tts` on a GPU/MPS machine
- [ ] Test server mode against a running Chatterbox API server
- [ ] Verify Telegram voice bubble delivery (Opus conversion via ffmpeg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)