### PR TITLE
feat(state): accept explicit timestamps in SessionDB.create_session and append_message

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -361,6 +361,7 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        started_at: float = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
         def _do(conn):
@@ -376,7 +377,7 @@ class SessionDB:
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
-                    time.time(),
+                    started_at if started_at is not None else time.time(),
                 ),
             )
         self._execute_write(_do)
@@ -801,6 +802,7 @@ class SessionDB:
         reasoning: str = None,
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
+        timestamp: float = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -837,7 +839,7 @@ class SessionDB:
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
-                    time.time(),
+                    timestamp if timestamp is not None else time.time(),
                     token_count,
                     finish_reason,
                     reasoning,

--- a/tests/test_hermes_state_timestamps.py
+++ b/tests/test_hermes_state_timestamps.py
@@ -1,0 +1,48 @@
+"""Tests for explicit-timestamp kwargs on SessionDB.create_session and append_message."""
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+def test_append_message_uses_explicit_timestamp(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "20260415_083111_deadbeef"
+    db.create_session(sid, source="test", model="test-model")
+    fixed_ts = 1_700_000_000.0
+    msg_id = db.append_message(sid, role="user", content="hi", timestamp=fixed_ts)
+    rows = db.get_messages(sid)
+    assert len(rows) == 1
+    assert rows[0]["timestamp"] == pytest.approx(fixed_ts, abs=1e-6)
+
+
+def test_append_message_defaults_to_now_when_timestamp_omitted(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "20260415_083111_cafebabe"
+    db.create_session(sid, source="test")
+    before = time.time()
+    db.append_message(sid, role="user", content="hi")
+    after = time.time()
+    ts = db.get_messages(sid)[0]["timestamp"]
+    assert before <= ts <= after
+
+
+def test_create_session_uses_explicit_started_at(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "20260415_083111_01234567"
+    fixed_ts = 1_700_000_000.0
+    db.create_session(sid, source="test", started_at=fixed_ts)
+    row = db.get_session(sid)
+    assert row["started_at"] == pytest.approx(fixed_ts, abs=1e-6)
+
+
+def test_create_session_defaults_to_now_when_started_at_omitted(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = "20260415_083111_89abcdef"
+    before = time.time()
+    db.create_session(sid, source="test")
+    after = time.time()
+    row = db.get_session(sid)
+    assert before <= row["started_at"] <= after


### PR DESCRIPTION
## Summary

Adds two optional keyword arguments to `SessionDB`:

- `create_session(..., started_at: float = None)`
- `append_message(..., timestamp: float = None)`

Both default to `None`; when `None`, behavior is unchanged (`time.time()` is used). When supplied, the explicit value is persisted instead.

## Why

Downstream tools that import historical messages (e.g. replaying transcripts from another agent into Hermes) need to preserve the **original** event timestamps rather than have them rewritten to wall-clock-now. With the current API there is no way to do this short of monkey-patching.

The concrete consumer is **hermes-bridge** — a Stop-hook + MCP server that imports Claude Code JSONL transcripts into Hermes's `state.db`. Without this patch, every imported message gets the import-time timestamp instead of the actual conversation timestamp, breaking time-based session ordering and search relevance.

## Compatibility

Strictly additive and backwards compatible:
- All existing call sites are unaffected (kwargs default to `None`).
- Existing tests pass without modification.
- New tests in \`tests/test_hermes_state_timestamps.py\` (4 cases) lock in both the explicit-value and default-to-now behaviors.

## Diff size

2 files changed, ~50 insertions. Self-contained.

## Test plan
- [x] Existing test suite: no regressions
- [x] New tests: \`pytest tests/test_hermes_state_timestamps.py -v\` (4 passed)