### PR TITLE
fix(model): warn on stale context_length after /model --global

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4569,6 +4569,15 @@ class HermesCLI:
         if result.warning_message:
             _cprint(f"    ⚠ {result.warning_message}")
         if persist_global:
+            try:
+                from hermes_cli.model_switch import get_context_length_mismatch_warning
+
+                ctx_warning = get_context_length_mismatch_warning(result)
+                if ctx_warning:
+                    _cprint(f"    ⚠ {ctx_warning}")
+            except Exception:
+                pass
+        if persist_global:
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
@@ -4798,6 +4807,15 @@ class HermesCLI:
         # Warning from validation
         if result.warning_message:
             _cprint(f"    ⚠ {result.warning_message}")
+        if persist_global:
+            try:
+                from hermes_cli.model_switch import get_context_length_mismatch_warning
+
+                ctx_warning = get_context_length_mismatch_warning(result)
+                if ctx_warning:
+                    _cprint(f"    ⚠ {ctx_warning}")
+            except Exception:
+                pass
 
         # Persistence
         if persist_global:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4883,6 +4883,15 @@ class GatewayRunner:
 
         if result.warning_message:
             lines.append(f"Warning: {result.warning_message}")
+        if persist_global:
+            try:
+                from hermes_cli.model_switch import get_context_length_mismatch_warning
+
+                ctx_warning = get_context_length_mismatch_warning(result)
+                if ctx_warning:
+                    lines.append(f"Warning: {ctx_warning}")
+            except Exception:
+                pass
 
         if persist_global:
             lines.append("Saved to config.yaml (`--global`)")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -91,6 +91,71 @@ def _check_hermes_model_warning(model_name: str) -> str:
     return ""
 
 
+def _parse_config_context_length(value: object) -> Optional[int]:
+    """Parse a persisted context-length override from config.yaml."""
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, str):
+        cleaned = value.replace(",", "").strip()
+        if cleaned.isdigit():
+            parsed = int(cleaned)
+            return parsed if parsed > 0 else None
+    return None
+
+
+def get_context_length_mismatch_warning(result: "ModelSwitchResult") -> str:
+    """Warn when ``/model --global`` leaves a stale config context override.
+
+    The explicit ``model.context_length`` override is intentionally higher
+    priority than dynamic model metadata. When the user switches models with
+    ``--global``, Hermes should preserve that override but still surface when
+    it no longer matches the newly selected model.
+    """
+    if not result.success or not result.is_global:
+        return ""
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return ""
+
+    model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(model_cfg, dict):
+        return ""
+
+    config_ctx = _parse_config_context_length(model_cfg.get("context_length"))
+    if config_ctx is None:
+        return ""
+
+    target_ctx = 0
+    if result.model_info and isinstance(result.model_info.context_window, int):
+        target_ctx = result.model_info.context_window
+
+    if target_ctx <= 0:
+        try:
+            from agent.model_metadata import get_model_context_length
+
+            target_ctx = get_model_context_length(
+                result.new_model,
+                base_url=result.base_url,
+                api_key=result.api_key,
+                provider=result.target_provider,
+                config_context_length=None,
+            ) or 0
+        except Exception:
+            target_ctx = 0
+
+    if target_ctx <= 0 or target_ctx == config_ctx:
+        return ""
+
+    return (
+        f"config.yaml context_length ({config_ctx:,}) doesn't match this model. "
+        f"Run /context {target_ctx} to update, or keep the current value if intentional."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Model aliases -- short names -> (vendor, family) with NO version numbers.
 # Resolved dynamically against the live models.dev catalog.
@@ -1086,5 +1151,4 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
 

--- a/tests/cli/test_model_switch_context_warning.py
+++ b/tests/cli/test_model_switch_context_warning.py
@@ -1,0 +1,80 @@
+"""CLI regression tests for /model --global context-length warnings."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+from agent.models_dev import ModelInfo
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+def _import_cli():
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs):
+        import cli as cli_mod
+
+        return importlib.reload(cli_mod)
+
+
+def test_apply_model_switch_result_surfaces_context_mismatch_warning():
+    cli_mod = _import_cli()
+    cli_obj = object.__new__(cli_mod.HermesCLI)
+    cli_obj.model = "kimi-k2.5"
+    cli_obj.provider = "moonshotai"
+    cli_obj.requested_provider = "moonshotai"
+    cli_obj.api_key = "old-key"
+    cli_obj._explicit_api_key = "old-key"
+    cli_obj.base_url = "https://api.moonshot.ai/v1"
+    cli_obj._explicit_base_url = "https://api.moonshot.ai/v1"
+    cli_obj.api_mode = "chat_completions"
+    cli_obj.agent = None
+
+    result = ModelSwitchResult(
+        success=True,
+        new_model="glm-5-turbo",
+        target_provider="zai",
+        provider_changed=True,
+        api_key="new-key",
+        base_url="https://api.z.ai/v1",
+        api_mode="chat_completions",
+        provider_label="Z.AI",
+        model_info=ModelInfo(
+            id="glm-5-turbo",
+            name="GLM-5 Turbo",
+            family="glm-5",
+            provider_id="zai",
+            context_window=202752,
+        ),
+        is_global=True,
+    )
+
+    printed = []
+    with (
+        patch.object(cli_mod, "_cprint", side_effect=printed.append),
+        patch.object(cli_mod, "save_config_value", return_value=True),
+        patch(
+            "hermes_cli.model_switch.get_context_length_mismatch_warning",
+            return_value="config.yaml context_length (256,000) doesn't match this model.",
+        ),
+    ):
+        cli_obj._apply_model_switch_result(result, persist_global=True)
+
+    assert any("Context: 202,752 tokens" in line for line in printed)
+    assert any("context_length (256,000) doesn't match this model" in line for line in printed)
+    assert any("Saved to config.yaml (--global)" in line for line in printed)

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -3,10 +3,12 @@
 import yaml
 import pytest
 
+from agent.models_dev import ModelInfo
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
+from hermes_cli.model_switch import ModelSwitchResult
 
 
 def _make_runner():
@@ -61,3 +63,64 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_reports_context_override_mismatch(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "kimi-k2.5",
+                    "provider": "moonshotai",
+                    "base_url": "https://api.moonshot.ai/v1",
+                    "context_length": 256000,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kwargs: ModelSwitchResult(
+            success=True,
+            new_model="glm-5-turbo",
+            target_provider="zai",
+            provider_changed=True,
+            api_key="new-key",
+            base_url="https://api.z.ai/v1",
+            api_mode="chat_completions",
+            provider_label="Z.AI",
+            model_info=ModelInfo(
+                id="glm-5-turbo",
+                name="GLM-5 Turbo",
+                family="glm-5",
+                provider_id="zai",
+                context_window=202752,
+            ),
+            is_global=True,
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_context_length_mismatch_warning",
+        lambda result: "config.yaml context_length (256,000) doesn't match this model.",
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+    runner = _make_runner()
+    runner._session_key_for_source = lambda source: "sess-1"
+    runner._evict_cached_agent = lambda session_key: None
+    runner._pending_model_notes = {}
+
+    result = await runner._handle_model_command(_make_event("/model glm-5-turbo --global"))
+
+    assert result is not None
+    assert "Model switched to `glm-5-turbo`" in result
+    assert "Warning: config.yaml context_length (256,000) doesn't match this model." in result
+    assert "Saved to config.yaml (`--global`)" in result

--- a/tests/hermes_cli/test_model_switch_context_length_warning.py
+++ b/tests/hermes_cli/test_model_switch_context_length_warning.py
@@ -1,0 +1,84 @@
+"""Tests for context-length mismatch warnings after /model --global."""
+
+from agent.models_dev import ModelInfo
+from hermes_cli.model_switch import (
+    ModelSwitchResult,
+    get_context_length_mismatch_warning,
+)
+
+
+def _result(*, is_global=True, model_info=None):
+    return ModelSwitchResult(
+        success=True,
+        new_model="glm-5-turbo",
+        target_provider="zai",
+        provider_changed=True,
+        api_key="test-key",
+        base_url="https://api.z.ai/v1",
+        api_mode="chat_completions",
+        model_info=model_info,
+        is_global=is_global,
+    )
+
+
+def _model_info(context_window: int) -> ModelInfo:
+    return ModelInfo(
+        id="glm-5-turbo",
+        name="GLM-5 Turbo",
+        family="glm-5",
+        provider_id="zai",
+        context_window=context_window,
+    )
+
+
+def test_warns_when_global_switch_leaves_stale_config_override(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"context_length": 256000}},
+    )
+
+    warning = get_context_length_mismatch_warning(
+        _result(model_info=_model_info(202752))
+    )
+
+    assert "256,000" in warning
+    assert "/context 202752" in warning
+
+
+def test_no_warning_without_global_persistence(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"context_length": 256000}},
+    )
+
+    warning = get_context_length_mismatch_warning(
+        _result(is_global=False, model_info=_model_info(202752))
+    )
+
+    assert warning == ""
+
+
+def test_no_warning_when_config_has_no_explicit_override(monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+
+    warning = get_context_length_mismatch_warning(
+        _result(model_info=_model_info(202752))
+    )
+
+    assert warning == ""
+
+
+def test_falls_back_to_runtime_context_lookup_when_model_info_missing(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"context_length": "256000"}},
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *args, **kwargs: 202752,
+    )
+
+    warning = get_context_length_mismatch_warning(_result(model_info=None))
+
+    assert "256,000" in warning
+    assert "/context 202752" in warning


### PR DESCRIPTION
## Summary
- warn when `/model --global` leaves an existing `model.context_length` override out of sync with the newly selected model
- preserve the explicit override instead of auto-rewriting it, while pointing users to `/context <n>` when they do want to update it
- surface the same warning in both the terminal CLI and gateway `/model` command, with focused regression coverage

Fixes #10157

## Testing
- python3 -m pytest -o addopts="-m 'not integration'" tests/hermes_cli/test_model_switch_context_length_warning.py -q
- python3 -m pytest -o addopts="-m 'not integration'" tests/cli/test_model_switch_context_warning.py -q
- python3 -m pytest -o addopts="-m 'not integration'" tests/gateway/test_model_command_custom_providers.py -q
- python3 -m pytest -o addopts="-m 'not integration'" tests/hermes_cli/test_model_switch_custom_providers.py -q
- python3 -m pytest -o addopts="-m 'not integration'" tests/gateway/test_model_switch_persistence.py -q