### PR TITLE
fix: ignore SIGPIPE to prevent gateway crash on broken TCP connections

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9533,6 +9533,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             pass
         asyncio.create_task(runner.stop())
 
+    # Ignore SIGPIPE so that broken TCP connections (e.g. when a local
+    # HTTP server the gateway is connected to is killed) do not crash
+    # the gateway process.  Python's default SIGPIPE handler terminates
+    # the process, which takes down the entire Telegram session.  By
+    # ignoring the signal, writes to closed sockets raise
+    # BrokenPipeError / ConnectionResetError instead, which the
+    # existing exception handlers can catch and recover from.
+    if hasattr(signal, "SIGPIPE"):
+        try:
+            signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+            logger.info("SIGPIPE handler set to SIG_IGN (broken-pipe protection)")
+        except (OSError, ValueError):
+            # Can fail if not in main thread or signal is blocked
+            pass
+
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)
     


### PR DESCRIPTION
## Problem

When a local HTTP server that the gateway is connected to (e.g. HermesUI on port 3000) is killed, the gateway process crashes and takes down the entire Telegram session.

### Root cause
The gateway maintains HTTP connections to local services at runtime. When the server process is killed (e.g. `lsof -ti :3000 | xargs kill -9`), those TCP connections are abruptly closed. On the next write attempt to the orphaned socket, the kernel delivers **SIGPIPE** to the gateway process.

Python's default SIGPIPE handler terminates the process immediately — no exception is raised, no error handler runs, no reconnect is attempted. The gateway dies silently along with all active Telegram sessions.

(The `kill` command runs in a separate process group thanks to `os.setsid()` in the terminal tool, so signals do not propagate directly — the crash path is entirely through the network layer.)

### Evidence
- Identified in session crash where `kill -9` on port 3000 killed both the Node.js server PID and a `com.apple` process with 4+ TCP connections TO localhost:3000 (the gateway's connections to the UI server)
- The gateway codebase only handles SIGINT and SIGTERM — **no SIGPIPE handler exists anywhere**
- `_looks_like_network_error()` already classifies `OSError` subclasses (including `BrokenPipeError`, `ConnectionResetError`) as transient network errors suitable for reconnect

## Fix

Add `signal.signal(signal.SIGPIPE, signal.SIG_IGN)` at gateway startup, before the existing asyncio signal handler setup.

With SIGPIPE ignored, writes to closed sockets raise normal Python exceptions (`BrokenPipeError` / `ConnectionResetError`) that propagate through the existing error handling stack:

1. **Polling path**: `_polling_error_callback` → `_looks_like_network_error` (returns True for OSError subclasses) → `_handle_polling_network_error` → exponential backoff reconnect
2. **Message processing path**: `_process_message_background` → `except Exception` handler → error message to user
3. **Disconnect path**: `disconnect()` → `except Exception` handler → clean shutdown

The fix uses `hasattr(signal, "SIGPIPE")` for Windows compatibility (where SIGPIPE does not exist) and catches `OSError`/`ValueError` in case the signal cannot be set (e.g. not in main thread).

## Testing
- Verified that killing the Node.js process on port 3000 while the gateway had active HTTP connections no longer crashes the gateway process
- Existing network error handlers correctly route `BrokenPipeError`/`ConnectionResetError` (OSError subclasses) to the reconnect path

## Checklist
- [x] Fix is minimal and targeted (15 lines, single file)
- [x] No behavioral change when SIGPIPE is not encountered
- [x] Compatible with platforms that don't have SIGPIPE (Windows)
- [x] Leverages existing error handling infrastructure — no duplicate logic