### PR TITLE
fix: repair dingtalk stream callbacks and replies

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -18,6 +18,7 @@ Configuration in config.yaml:
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import re
@@ -54,7 +55,7 @@ logger = logging.getLogger(__name__)
 MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
-_DINGTALK_WEBHOOK_RE = re.compile(r'^https://api\.dingtalk\.com/')
+_DINGTALK_WEBHOOK_RE = re.compile(r'^https://([a-zA-Z0-9-]+\.)*dingtalk\.com/')
 
 
 def check_dingtalk_requirements() -> bool:
@@ -112,9 +113,9 @@ class DingTalkAdapter(BasePlatformAdapter):
             credential = dingtalk_stream.Credential(self._client_id, self._client_secret)
             self._stream_client = dingtalk_stream.DingTalkStreamClient(credential)
 
-            # Capture the current event loop for cross-thread dispatch
-            loop = asyncio.get_running_loop()
-            handler = _IncomingHandler(self, loop)
+            # The current dingtalk-stream SDK runs async in the same event loop,
+            # so the callback handler can await the message processing directly.
+            handler = _IncomingHandler(self)
             self._stream_client.register_callback_handler(
                 dingtalk_stream.ChatbotMessage.TOPIC, handler
             )
@@ -133,7 +134,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
-                await asyncio.to_thread(self._stream_client.start)
+                start_result = self._stream_client.start()
+                if inspect.isawaitable(start_result):
+                    await start_result
             except asyncio.CancelledError:
                 return
             except Exception as e:
@@ -198,14 +201,15 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         # Store session webhook for reply routing (validate origin to prevent SSRF)
         session_webhook = getattr(message, "session_webhook", None) or ""
-        if session_webhook and chat_id and _DINGTALK_WEBHOOK_RE.match(session_webhook):
-            if len(self._session_webhooks) >= _SESSION_WEBHOOKS_MAX:
-                # Evict oldest entry to cap memory growth
+        if session_webhook and _DINGTALK_WEBHOOK_RE.match(session_webhook):
+            chat_keys = [k for k in (chat_id, sender_id, sender_staff_id, conversation_id) if k]
+            while len(self._session_webhooks) + len(chat_keys) > _SESSION_WEBHOOKS_MAX:
                 try:
                     self._session_webhooks.pop(next(iter(self._session_webhooks)))
                 except StopIteration:
-                    pass
-            self._session_webhooks[chat_id] = session_webhook
+                    break
+            for key in chat_keys:
+                self._session_webhooks[key] = session_webhook
 
         source = self.build_source(
             chat_id=chat_id,
@@ -231,6 +235,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             raw_message=message,
             timestamp=timestamp,
         )
+        event.metadata = {"session_webhook": session_webhook} if session_webhook else None
 
         logger.debug("[%s] Message from %s in %s: %s",
                       self.name, sender_nick, chat_id[:20] if chat_id else "?", text[:50])
@@ -308,26 +313,18 @@ class DingTalkAdapter(BasePlatformAdapter):
 class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
     """dingtalk-stream ChatbotHandler that forwards messages to the adapter."""
 
-    def __init__(self, adapter: DingTalkAdapter, loop: asyncio.AbstractEventLoop):
+    def __init__(self, adapter: DingTalkAdapter):
         if DINGTALK_STREAM_AVAILABLE:
             super().__init__()
         self._adapter = adapter
-        self._loop = loop
 
-    def process(self, message: "ChatbotMessage"):
-        """Called by dingtalk-stream in its thread when a message arrives.
-
-        Schedules the async handler on the main event loop.
-        """
-        loop = self._loop
-        if loop is None or loop.is_closed():
-            logger.error("[DingTalk] Event loop unavailable, cannot dispatch message")
-            return dingtalk_stream.AckMessage.STATUS_OK, "OK"
-
-        future = asyncio.run_coroutine_threadsafe(self._adapter._on_message(message), loop)
+    async def process(self, message):
+        """Called by dingtalk-stream when a callback arrives."""
         try:
-            future.result(timeout=60)
+            inbound = message
+            if hasattr(message, "data") and isinstance(message.data, dict):
+                inbound = dingtalk_stream.ChatbotMessage.from_dict(message.data)
+            await self._adapter._on_message(inbound)
         except Exception:
             logger.exception("[DingTalk] Error processing incoming message")
-
         return dingtalk_stream.AckMessage.STATUS_OK, "OK"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2556,7 +2556,8 @@ class GatewayRunner:
             return True
 
         user_id = source.user_id
-        if not user_id:
+        user_id_alt = getattr(source, "user_id_alt", None)
+        if not user_id and not user_id_alt:
             return False
 
         platform_env_map = {
@@ -2603,7 +2604,9 @@ class GatewayRunner:
 
         # Check pairing store (always checked, regardless of allowlists)
         platform_name = source.platform.value if source.platform else ""
-        if self.pairing_store.is_approved(platform_name, user_id):
+        if user_id and self.pairing_store.is_approved(platform_name, user_id):
+            return True
+        if user_id_alt and self.pairing_store.is_approved(platform_name, user_id_alt):
             return True
 
         # Check platform-specific and global allowlists
@@ -2626,9 +2629,14 @@ class GatewayRunner:
         if "*" in allowed_ids:
             return True
 
-        check_ids = {user_id}
-        if "@" in user_id:
-            check_ids.add(user_id.split("@")[0])
+        check_ids = set()
+        if user_id:
+            check_ids.add(user_id)
+        if user_id_alt:
+            check_ids.add(user_id_alt)
+        for candidate in list(check_ids):
+            if "@" in candidate:
+                check_ids.add(candidate.split("@")[0])
 
         # WhatsApp: resolve phone↔LID aliases from bridge session mapping files
         if source.platform == Platform.WHATSAPP:
@@ -7824,6 +7832,9 @@ class GatewayRunner:
             _thread_metadata: Optional[Dict[str, Any]] = {"thread_id": source.thread_id}
         else:
             _thread_metadata = None
+        _event_metadata = getattr(event, "metadata", None)
+        if _event_metadata:
+            _thread_metadata = {**(_thread_metadata or {}), **_event_metadata}
 
         if _streaming_enabled:
             try:

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -130,6 +130,48 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
     assert runner._is_user_authorized(source) is True
 
 
+def test_dingtalk_alt_user_id_matches_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("DINGTALK_ALLOWED_USERS", "03341631400920119088")
+
+    runner, _adapter = _make_runner(
+        Platform.DINGTALK,
+        GatewayConfig(platforms={Platform.DINGTALK: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.DINGTALK,
+        user_id="$:LWCP_v1:$abc123openuserid",
+        user_id_alt="03341631400920119088",
+        chat_id="conversation-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_alt_user_id_can_match_pairing_approval(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.DINGTALK,
+        GatewayConfig(platforms={Platform.DINGTALK: PlatformConfig(enabled=True)}),
+    )
+    runner.pairing_store.is_approved.side_effect = lambda platform, user_id: user_id == "03341631400920119088"
+
+    source = SessionSource(
+        platform=Platform.DINGTALK,
+        user_id="$:LWCP_v1:$abc123openuserid",
+        user_id_alt="03341631400920119088",
+        chat_id="conversation-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
 @pytest.mark.asyncio
 async def test_unauthorized_dm_pairs_by_default(monkeypatch):
     _clear_auth_env(monkeypatch)

--- a/tests/test_dingtalk_adapter.py
+++ b/tests/test_dingtalk_adapter.py
@@ -1,0 +1,97 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.dingtalk import DingTalkAdapter, _IncomingHandler
+
+
+@pytest.mark.asyncio
+async def test_run_stream_awaits_async_sdk_start():
+    adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={}))
+    calls = []
+
+    class FakeStreamClient:
+        async def start(self):
+            calls.append("started")
+            adapter._running = False
+
+    adapter._stream_client = FakeStreamClient()
+    adapter._running = True
+
+    await asyncio.wait_for(adapter._run_stream(), timeout=0.2)
+
+    assert calls == ["started"]
+
+
+@pytest.mark.asyncio
+async def test_incoming_handler_process_awaits_adapter_message_handling():
+    adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._on_message = AsyncMock()
+    handler = _IncomingHandler(adapter)
+    message = object()
+
+    code, text = await handler.process(message)
+
+    adapter._on_message.assert_awaited_once_with(message)
+    assert code == 200
+    assert text == "OK"
+
+
+@pytest.mark.asyncio
+async def test_incoming_handler_converts_callback_message_data_to_chatbot_message():
+    adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter._on_message = AsyncMock()
+    handler = _IncomingHandler(adapter)
+    callback_message = SimpleNamespace(
+        data={
+            "msgId": "m1",
+            "conversationId": "cid-1",
+            "conversationType": "1",
+            "senderId": "$:LWCP_v1:$abc123openuserid",
+            "senderStaffId": "03341631400920119088",
+            "senderNick": "tester",
+            "sessionWebhook": "https://api.dingtalk.com/v1.0/im/robot/messages",
+            "msgtype": "text",
+            "text": {"content": "hello"},
+        }
+    )
+
+    code, text = await handler.process(callback_message)
+
+    inbound = adapter._on_message.await_args.args[0]
+    assert inbound.message_id == "m1"
+    assert inbound.sender_id == "$:LWCP_v1:$abc123openuserid"
+    assert inbound.sender_staff_id == "03341631400920119088"
+    assert inbound.text.content == "hello"
+    assert code == 200
+    assert text == "OK"
+
+
+@pytest.mark.asyncio
+async def test_on_message_caches_session_webhook_for_multiple_dingtalk_ids():
+    adapter = DingTalkAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter.handle_message = AsyncMock()
+
+    message = SimpleNamespace(
+        message_id="m1",
+        text={"content": "hello"},
+        conversation_id="cid-1",
+        conversation_type="1",
+        sender_id="$:LWCP_v1:$abc123openuserid",
+        sender_nick="tester",
+        sender_staff_id="03341631400920119088",
+        session_webhook="https://oapi.dingtalk.com/robot/sendBySession?session=abc",
+        conversation_title=None,
+        create_at=None,
+    )
+
+    await adapter._on_message(message)
+
+    assert adapter._session_webhooks["cid-1"] == message.session_webhook
+    assert adapter._session_webhooks[message.sender_id] == message.session_webhook
+    assert adapter._session_webhooks[message.sender_staff_id] == message.session_webhook
+    event = adapter.handle_message.await_args.args[0]
+    assert event.metadata == {"session_webhook": message.session_webhook}


### PR DESCRIPTION
## Summary
- unwrap DingTalk callback payloads into `ChatbotMessage` objects before processing
- handle async DingTalk stream startup and callback dispatch for the current SDK
- authorize DingTalk users via alternate staff IDs and preserve session webhooks for reply routing
- add regression tests for callback handling, alternate ID authorization, and webhook caching

## Testing
- `venv/bin/python -m pytest tests/test_dingtalk_adapter.py tests/gateway/test_unauthorized_dm_behavior.py -q`
- `venv/bin/python -m py_compile gateway/platforms/dingtalk.py gateway/run.py`

## Notes
- keeps the unrelated `scripts/whatsapp-bridge/package-lock.json` change out of this PR
