### PR TITLE
fix(gateway): handle busy-session slash commands coherently

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1509,7 +1509,25 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart"):
+            from hermes_cli.commands import resolve_command as _resolve_gateway_command
+
+            _cmd_def = _resolve_gateway_command(cmd) if cmd else None
+            canonical = _cmd_def.name if _cmd_def else cmd
+
+            if canonical in (
+                # Session control / state mutation
+                "approve", "deny", "status", "stop", "new",
+                "background", "queue", "restart",
+                # Execute immediately while agent is busy
+                "help", "commands", "profile", "provider",
+                "usage", "insights", "sethome", "voice",
+                "yolo", "btw",
+                # Reject with a helpful message while agent is busy
+                "model", "retry", "undo", "title", "branch",
+                "compress", "rollback", "resume",
+                "reasoning", "fast", "personality",
+                "update", "reload-mcp",
+            ):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2874,6 +2874,18 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "model":
                 return "Agent is running — wait or /stop first, then switch models."
 
+            # Commands that require an idle agent should bypass the adapter guard
+            # but still reject here with a helpful message instead of silently
+            # interrupting the current run.
+            _REJECT_IF_RUNNING = frozenset({
+                "retry", "undo", "title", "branch",
+                "compress", "rollback", "resume",
+                "reasoning", "fast", "personality",
+                "update", "reload-mcp",
+            })
+            if _cmd_def_inner and _cmd_def_inner.name in _REJECT_IF_RUNNING:
+                return "Agent is running — wait or /stop first."
+
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside
             # tools/approval.py — sending an interrupt won't unblock it.
@@ -2888,7 +2900,20 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
-            if event.message_type == MessageType.PHOTO:
+            # Informational/config commands should execute immediately without
+            # interrupting the active run. Let normal command dispatch below
+            # handle them.
+            _EXECUTE_IMMEDIATELY = frozenset({
+                "help", "commands", "profile", "provider",
+                "usage", "insights", "sethome", "voice",
+                "yolo", "btw",
+            })
+            if _cmd_def_inner and _cmd_def_inner.name in _EXECUTE_IMMEDIATELY:
+                logger.debug(
+                    "Busy session %s: executing '/%s' without interrupt",
+                    _quick_key[:20], _cmd_def_inner.name,
+                )
+            elif event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -2918,13 +2943,16 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
-            logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
-            running_agent.interrupt(event.text)
-            if _quick_key in self._pending_messages:
-                self._pending_messages[_quick_key] += "\n" + event.text
+            if _cmd_def_inner and _cmd_def_inner.name in _EXECUTE_IMMEDIATELY:
+                pass
             else:
-                self._pending_messages[_quick_key] = event.text
-            return None
+                logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
+                running_agent.interrupt(event.text)
+                if _quick_key in self._pending_messages:
+                    self._pending_messages[_quick_key] += "\n" + event.text
+                else:
+                    self._pending_messages[_quick_key] = event.text
+                return None
 
         # Check for commands
         command = event.get_command()

--- a/tests/gateway/test_active_session_busy_commands.py
+++ b/tests/gateway/test_active_session_busy_commands.py
@@ -1,0 +1,133 @@
+"""Runner-level tests for slash commands while an agent is already running."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class _PendingAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="tester",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: _PendingAdapter()}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._pending_model_notes = {}
+    runner._update_prompt_pending = {}
+    runner._voice_mode = {}
+    runner._draining = False
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._session_db = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=[])
+    runner.pairing_store = MagicMock()
+    runner._is_user_authorized = lambda _source: True
+    runner._queue_during_drain_enabled = lambda: False
+    return runner
+
+
+class TestBusySessionExecImmediateCommands:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("cmd", "canonical", "handler_attr"),
+        [
+            ("/help", "help", "_handle_help_command"),
+            ("/commands", "commands", "_handle_commands_command"),
+            ("/profile", "profile", "_handle_profile_command"),
+            ("/provider", "provider", "_handle_provider_command"),
+            ("/usage", "usage", "_handle_usage_command"),
+            ("/insights", "insights", "_handle_insights_command"),
+            ("/sethome", "sethome", "_handle_set_home_command"),
+            ("/set-home", "sethome", "_handle_set_home_command"),
+            ("/voice", "voice", "_handle_voice_command"),
+            ("/yolo", "yolo", "_handle_yolo_command"),
+            ("/btw side question", "btw", "_handle_btw_command"),
+        ],
+    )
+    async def test_exec_immediate_command_returns_without_interrupt(self, cmd, canonical, handler_attr):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        setattr(runner, handler_attr, AsyncMock(return_value=f"handled:{canonical}"))
+
+        result = await runner._handle_message(_make_event(cmd))
+
+        assert result == f"handled:{canonical}"
+        running_agent.interrupt.assert_not_called()
+        assert runner._pending_messages == {}
+
+
+class TestBusySessionRejectCommands:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            ("/model", "Agent is running — wait or /stop first, then switch models."),
+            ("/retry", "Agent is running — wait or /stop first."),
+            ("/undo", "Agent is running — wait or /stop first."),
+            ("/title", "Agent is running — wait or /stop first."),
+            ("/branch", "Agent is running — wait or /stop first."),
+            ("/fork", "Agent is running — wait or /stop first."),
+            ("/compress", "Agent is running — wait or /stop first."),
+            ("/rollback", "Agent is running — wait or /stop first."),
+            ("/resume", "Agent is running — wait or /stop first."),
+            ("/reasoning", "Agent is running — wait or /stop first."),
+            ("/fast", "Agent is running — wait or /stop first."),
+            ("/personality", "Agent is running — wait or /stop first."),
+            ("/update", "Agent is running — wait or /stop first."),
+            ("/reload-mcp", "Agent is running — wait or /stop first."),
+            ("/reload_mcp", "Agent is running — wait or /stop first."),
+        ],
+    )
+    async def test_reject_command_returns_helpful_message_without_interrupt(self, cmd, expected):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+
+        result = await runner._handle_message(_make_event(cmd))
+
+        assert result == expected
+        running_agent.interrupt.assert_not_called()
+        assert runner._pending_messages == {}

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -327,3 +327,63 @@ class TestBypassWithBotnameSuffix:
 
         assert sk not in adapter._pending_messages
         assert any("handled:new" in r for r in adapter.sent_responses)
+
+
+# ---------------------------------------------------------------------------
+# Tests: expanded busy-session bypass coverage
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteImmediatelyCommands:
+    """Commands that should bypass and execute even while agent is running."""
+
+    EXEC_IMMEDIATE = [
+        "help", "commands", "profile", "provider",
+        "usage", "insights", "sethome", "set-home",
+        "voice", "yolo", "btw", "queue",
+        "model", "bg",
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cmd", EXEC_IMMEDIATE)
+    async def test_exec_immediate_bypasses_guard(self, cmd):
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        payload = f"/{cmd} test payload" if cmd in {"queue", "q", "bg"} else f"/{cmd}"
+        await adapter.handle_message(_make_event(payload))
+
+        assert sk not in adapter._pending_messages, (
+            f"/{cmd} was queued as pending instead of being dispatched"
+        )
+        assert any(f"handled:{cmd}" in r for r in adapter.sent_responses), (
+            f"/{cmd} response was not sent back to the user"
+        )
+
+
+class TestRejectWithMessageCommands:
+    """Commands that should bypass the adapter guard even though the runner will reject them."""
+
+    REJECT_COMMANDS = [
+        "retry", "undo", "title", "branch", "fork",
+        "compress", "rollback", "resume",
+        "reasoning", "fast", "personality",
+        "update", "reload-mcp", "reload_mcp",
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cmd", REJECT_COMMANDS)
+    async def test_reject_command_bypasses_guard(self, cmd):
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event(f"/{cmd}"))
+
+        assert sk not in adapter._pending_messages, (
+            f"/{cmd} was queued as pending instead of being dispatched"
+        )
+        assert any(f"handled:{cmd}" in r for r in adapter.sent_responses), (
+            f"/{cmd} response was not sent back to the user"
+        )


### PR DESCRIPTION
## Summary
- route gateway busy-session slash commands through a coherent allow/deny path
- stop inconsistent handling when a live agent run is already active
- add regression coverage for active-session quick-command behavior

## Problem
Some gateway slash commands were handled inconsistently while a session was busy. Depending on which path saw the command first, a command could be blocked, partially bypass the guard, or behave differently from adjacent built-ins.

## Test Plan
- source venv/bin/activate && python -m pytest -q tests/gateway/test_active_session_busy_commands.py tests/gateway/test_command_bypass_active_session.py
