### PR TITLE
fix(honcho): make client timeout configurable

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -159,6 +159,8 @@ class HonchoClientConfig:
     environment: str = "production"
     # Optional base URL for self-hosted Honcho (overrides environment mapping)
     base_url: str | None = None
+    # Client-side HTTP timeout in seconds for Honcho SDK requests
+    timeout_seconds: float = 60.0
     # Identity
     peer_name: str | None = None
     ai_peer: str = "hermes"
@@ -224,12 +226,14 @@ class HonchoClientConfig:
         resolved_host = host or resolve_active_host()
         api_key = os.environ.get("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+        timeout_seconds = float(os.environ.get("HONCHO_TIMEOUT_SECONDS", "60"))
         return cls(
             host=resolved_host,
             workspace_id=workspace_id,
             api_key=api_key,
             environment=os.environ.get("HONCHO_ENVIRONMENT", "production"),
             base_url=base_url,
+            timeout_seconds=timeout_seconds,
             ai_peer=resolved_host,
             enabled=bool(api_key or base_url),
         )
@@ -340,6 +344,12 @@ class HonchoClientConfig:
             enabled=enabled,
             save_messages=save_messages,
             write_frequency=write_frequency,
+            timeout_seconds=float(
+                host_block.get("timeoutSeconds")
+                or raw.get("timeoutSeconds")
+                or os.environ.get("HONCHO_TIMEOUT_SECONDS")
+                or 60
+            ),
             context_tokens=host_block.get("contextTokens") or raw.get("contextTokens"),
             dialectic_reasoning_level=(
                 host_block.get("dialecticReasoningLevel")
@@ -550,6 +560,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         "workspace_id": config.workspace_id,
         "api_key": effective_api_key,
         "environment": config.environment,
+        "timeout": config.timeout_seconds,
     }
     if resolved_base_url:
         kwargs["base_url"] = resolved_base_url

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -232,6 +232,24 @@ class TestFromGlobalConfig:
         config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://root:9000"
 
+    def test_timeout_seconds_default(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"apiKey": "abc"}))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.timeout_seconds == 60.0
+
+    def test_timeout_seconds_host_block_wins(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "abc",
+            "timeoutSeconds": 120,
+            "hosts": {"hermes": {"timeoutSeconds": 180}},
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.timeout_seconds == 180.0
+
 
 class TestResolveSessionName:
     def test_manual_override(self):
@@ -549,3 +567,21 @@ class TestResetHonchoClient:
         assert mod._honcho_client is not None
         reset_honcho_client()
         assert mod._honcho_client is None
+
+
+class TestGetHonchoClient:
+    def test_passes_timeout_to_sdk(self):
+        reset_honcho_client()
+        mock_sdk_client = MagicMock()
+        config = HonchoClientConfig(
+            api_key="key",
+            enabled=True,
+            timeout_seconds=180.0,
+        )
+
+        with patch("honcho.Honcho", return_value=mock_sdk_client) as mock_honcho:
+            result = get_honcho_client(config)
+
+        assert result is mock_sdk_client
+        mock_honcho.assert_called_once()
+        assert mock_honcho.call_args.kwargs["timeout"] == 180.0


### PR DESCRIPTION
## Summary
- add `timeout_seconds` to `HonchoClientConfig`
- allow timeout override from config and `HONCHO_TIMEOUT_SECONDS`
- pass the configured timeout through to the Honcho SDK client
- add regression tests for defaults, host override precedence, and SDK wiring

## Problem
The Honcho client timeout is currently fixed in code. That is too rigid for self-hosted or local deployments, and it forces one hardcoded policy instead of letting operators tune the timeout explicitly.

## Notes
This is related to #8527 but takes a config-driven approach instead of hardcoding a longer timeout for local base URLs only.

## Test Plan
- source venv/bin/activate && python -m pytest -q tests/honcho_plugin/test_client.py
