### PR TITLE
fix: final response suppressed when interim_assistant_messages is enabled

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6006,7 +6006,21 @@ class GatewayRunner:
                     # response before processing the queued follow-up.
                     # Skip if streaming already delivered it.
                     _sc = stream_consumer_holder[0]
-                    _already_streamed = _sc and getattr(_sc, "already_sent", False)
+                    if _sc and stream_task:
+                        try:
+                            await asyncio.wait_for(stream_task, timeout=5.0)
+                        except (asyncio.TimeoutError, asyncio.CancelledError):
+                            stream_task.cancel()
+                            try:
+                                await stream_task
+                            except asyncio.CancelledError:
+                                pass
+                        except Exception as e:
+                            logger.debug("Stream consumer wait before queued message failed: %s", e)
+                    _already_streamed = bool(
+                        _sc
+                        and getattr(_sc, "final_response_sent", False)
+                    )
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
@@ -6061,9 +6075,18 @@ class GatewayRunner:
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).
+        # BUT: never suppress delivery when the agent failed — the error
+        # message is new content the user hasn't seen, and it must reach
+        # them even if streaming had sent earlier partial output.
+        # BUGFIX: only check final_response_sent here, NOT already_sent.
+        # already_sent is True when interim messages (tool progress) were
+        # delivered via the stream consumer, but that doesn't mean the
+        # final response was also streamed. Only final_response_sent
+        # indicates the actual final text was delivered.
         _sc = stream_consumer_holder[0]
-        if _sc and _sc.already_sent and isinstance(response, dict):
-            response["already_sent"] = True
+        if _sc and isinstance(response, dict) and not response.get("failed"):
+            if getattr(_sc, "final_response_sent", False):
+                response["already_sent"] = True
         
         return response
 


### PR DESCRIPTION
## Problem

When `interim_assistant_messages: true` is set in config, the gateway's `StreamConsumer` delivers interim tool progress messages (e.g. `memory: "..."`) and sets `already_sent = True`. The final delivery suppression logic in `gateway/run.py` then checks `already_sent` and skips sending the actual final response, causing complete message truncation on Telegram and other platforms.

## Root Cause

Two locations in `gateway/run.py` used `already_sent` to determine if the response was already delivered:

1. **Queued message handler** (before processing follow-up messages) — checked `already_sent` to decide whether to send the first response
2. **Final response gate** — checked `already_sent OR final_response_sent` to mark `response["already_sent"] = True`

`already_sent` is set when *any* message goes out through the stream consumer — including interim tool updates. Only `final_response_sent` indicates the actual final response text was delivered.

## Fix

- Replace `already_sent` with `final_response_sent` in both suppression checks
- Add a guard to never suppress delivery when the agent failed (error messages must always reach the user)
- Use `getattr()` with defaults for defensive access to stream consumer attributes

## Testing

- Verified on live Telegram deployment with `interim_assistant_messages: true`
- Messages now deliver in full without truncation
- No duplicate messages observed

## Config Reference

```yaml
# This config triggers the bug in unfixed versions:
streaming:
  interim_assistant_messages: true
```