### PR TITLE
fix(streaming): pass reply_to in streaming responses and strip leading blank lines

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7845,6 +7845,7 @@ class GatewayRunner:
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        reply_to=event_message_id,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
@@ -8411,6 +8412,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -82,11 +82,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self._reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -317,7 +319,7 @@ class GatewayStreamConsumer:
                             self._accumulated, _safe_limit
                         )
                         for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
+                            await self._send_new_chunk(chunk, self._message_id or self._reply_to)
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
@@ -450,6 +452,7 @@ class GatewayStreamConsumer:
         Returns the message_id so callers can thread subsequent chunks.
         """
         text = self._clean_for_display(text)
+        text = text.lstrip("\n")
         if not text.strip():
             return reply_to_id
         try:
@@ -531,6 +534,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
+                    reply_to=self._reply_to if not sent_any_chunk else None,
                     metadata=self.metadata,
                 )
                 if result.success:
@@ -607,6 +611,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
+                reply_to=self._reply_to,
                 metadata=self.metadata,
             )
             if result.success:
@@ -627,6 +632,11 @@ class GatewayStreamConsumer:
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
         text = self._clean_for_display(text)
+        # Strip leading newlines that _fire_stream_delta prepends for
+        # paragraph separation between tool iterations.  These are needed
+        # in the CLI's single-box display but create unwanted blank lines
+        # in platform messages (both first sends AND progressive edits).
+        text = text.lstrip("\n")
         # A bare streaming cursor is not meaningful user-visible content and
         # can render as a stray tofu/white-box message on some clients.
         visible_without_cursor = text
@@ -718,6 +728,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self._reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:


### PR DESCRIPTION
## What does this PR do?

Bot replies in group chats appeared as standalone messages instead of threaded replies when using streaming mode. The `GatewayStreamConsumer` never received the original `event_message_id`, so it could not pass `reply_to` to `adapter.send()`. This PR propagates `event_message_id` as `reply_to` through **both** `GatewayStreamConsumer` creation sites (`_run_agent` and `_run_agent_via_proxy`), and passes it on the first send, commentary messages, fallback chunks, and overflow splits.

 It also strips leading newlines from the first message send to remove blank lines that `_fire_stream_delta` prepends for paragraph separation within the same message but are unwanted at the start of a new independent message bubble.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- [gateway/stream_consumer.py](gateway/stream_consumer.py): Accept `reply_to` parameter in `GatewayStreamConsumer.__init__()`, store as `self._reply_to`
- [gateway/stream_consumer.py](gateway/stream_consumer.py): Pass `reply_to` on the first `_send_or_edit()` call (new message bubble) and omit it for subsequent edits (same bubble)
- [gateway/stream_consumer.py](gateway/stream_consumer.py): Pass `reply_to` when sending commentary messages (`_send_commentary`)
- [gateway/stream_consumer.py](gateway/stream_consumer.py): Pass `reply_to` for fallback chunks (`_send_fallback_final`) — only on the first chunk of a multi-chunk send
- [gateway/stream_consumer.py](gateway/stream_consumer.py): Pass `reply_to` for overflow split chunks in the main `run()` loop
- [gateway/stream_consumer.py](gateway/stream_consumer.py): Strip leading `\n` from the first message send (`lstrip("\n")`) to avoid a visible blank line at the top of the reply bubble
- [gateway/run.py](gateway/run.py): Pass `reply_to=event_message_id` when constructing `GatewayStreamConsumer` in `_run_agent_via_proxy`
- [gateway/run.py](gateway/run.py): Pass `reply_to=event_message_id` when constructing `GatewayStreamConsumer` in `_run_agent` (the main non-proxy path — this was the root cause)

## How to Test

1. Start a group chat on any platform that supports threaded replies (e.g. Feishu, Discord, Telegram)
2. Send a message that triggers a streaming bot response
3. Verify the bot reply appears as a threaded reply to the original message, not a standalone message
4. Trigger a long streaming response that overflows into a second message — verify the overflow also threads correctly
5. Verify that the middle message bubble has no leading blank line in multi-message scenarios with intermediate content
6. Run: `pytest tests/ -q`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Debian, MacOS

### Documentation & Housekeeping

- [x] N/A — no documentation, config keys, or architecture changes

