### PR TITLE
fix(mcp): seed protocol header before HTTP initialize

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -926,6 +926,78 @@ class TestHTTPConfig:
 
         asyncio.run(_test())
 
+    def test_http_seeds_initial_protocol_header(self):
+        from tools.mcp_tool import LATEST_PROTOCOL_VERSION, MCPServerTask
+
+        server = MCPServerTask("remote")
+        captured = {}
+
+        class DummyAsyncClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummyTransportCtx:
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def initialize(self):
+                return None
+
+        class DummyLegacyTransportCtx:
+            def __init__(self, **kwargs):
+                captured["legacy_headers"] = kwargs.get("headers")
+
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def _discover_tools(self):
+            self._shutdown_event.set()
+
+        async def _run(config, *, new_http):
+            captured.clear()
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._MCP_NEW_HTTP", new_http), \
+                 patch("httpx.AsyncClient", DummyAsyncClient), \
+                 patch("tools.mcp_tool.streamable_http_client", return_value=DummyTransportCtx()), \
+                 patch("tools.mcp_tool.streamablehttp_client", side_effect=lambda url, **kwargs: DummyLegacyTransportCtx(**kwargs)), \
+                 patch("tools.mcp_tool.ClientSession", DummySession), \
+                 patch.object(MCPServerTask, "_discover_tools", _discover_tools):
+                await server._run_http(config)
+
+        asyncio.run(_run({"url": "https://example.com/mcp"}, new_http=True))
+        assert captured["headers"]["mcp-protocol-version"] == LATEST_PROTOCOL_VERSION
+
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"mcp-protocol-version": "custom-version"},
+        }, new_http=True))
+        assert captured["headers"]["mcp-protocol-version"] == "custom-version"
+
+        asyncio.run(_run({"url": "https://example.com/mcp"}, new_http=False))
+        assert captured["legacy_headers"]["mcp-protocol-version"] == LATEST_PROTOCOL_VERSION
+
 
 # ---------------------------------------------------------------------------
 # Reconnection logic

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -92,6 +92,10 @@ _MCP_HTTP_AVAILABLE = False
 _MCP_SAMPLING_TYPES = False
 _MCP_NOTIFICATION_TYPES = False
 _MCP_MESSAGE_HANDLER_SUPPORTED = False
+# Conservative fallback for SDK builds that don't export LATEST_PROTOCOL_VERSION.
+# Streamable HTTP was introduced by 2025-03-26, so this remains valid for the
+# HTTP transport path even on older-but-supported SDK versions.
+LATEST_PROTOCOL_VERSION = "2025-03-26"
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
@@ -108,6 +112,10 @@ try:
         _MCP_NEW_HTTP = True
     except ImportError:
         _MCP_NEW_HTTP = False
+    try:
+        from mcp.types import LATEST_PROTOCOL_VERSION
+    except ImportError:
+        logger.debug("mcp.types.LATEST_PROTOCOL_VERSION not available -- using fallback protocol version")
     # Sampling types -- separated so older SDK versions don't break MCP support
     try:
         from mcp.types import (
@@ -883,6 +891,11 @@ class MCPServerTask:
 
         url = config["url"]
         headers = dict(config.get("headers") or {})
+        # Some MCP servers require MCP-Protocol-Version on the initial
+        # initialize request and reject session-less POSTs otherwise.
+        # Seed it as a client-level default so strict servers can establish
+        # the first session; request-specific headers still override this.
+        headers.setdefault("mcp-protocol-version", LATEST_PROTOCOL_VERSION)
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
 
         # OAuth 2.1 PKCE: build httpx.Auth handler using the MCP SDK.


### PR DESCRIPTION
## Summary

Fixes a StreamableHTTP MCP interoperability bug where Hermes fails to connect to stricter HTTP MCP servers that require `mcp-protocol-version` on the very first `initialize` request.

In `tools/mcp_tool.py`, Hermes was only adding the protocol header after negotiation. That works for tolerant servers, but it breaks servers that refuse to create a session until the header is already present.

This PR seeds a client-level default `mcp-protocol-version` header before `initialize`, while still preserving any user-supplied override.

## Root cause

I reproduced this against Financial Modeling Prep's MCP endpoint.

Without the protocol header on the initial request, the server responded with errors equivalent to:
- `Invalid or missing session ID`
- `No valid session ID provided`
- downstream Hermes symptom: `McpError: Session terminated`

A manual `initialize` POST that included `MCP-Protocol-Version` succeeded immediately, returned an `mcp-session-id`, and unblocked tool discovery + tool calls.

## Changes

- seed `mcp-protocol-version` before the first HTTP MCP initialize call
- preserve explicit user config with `headers.setdefault(...)`
- add a defensive fallback if `mcp.types.LATEST_PROTOCOL_VERSION` is unavailable
- add regression coverage for:
  - default header seeding
  - user override preservation
  - legacy HTTP transport path

## Why this should be upstreamed

This is not an FMP-only hack.

It improves Hermes compatibility with any strict HTTP/StreamableHTTP MCP server that expects protocol versioning to be explicit from the first request. FMP was just the server that made the bug obvious.

## Testing

Ran locally:

```bash
source venv/bin/activate
python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py -q
```

Result:
- `172 passed`

## Review

I had Claude Code do an independent review before opening this PR, then addressed the non-blocking concerns it raised by:
- decoupling the `LATEST_PROTOCOL_VERSION` import from the sampling-type import block
- clarifying the client-level header comment
- extending test coverage for override + legacy transport behavior
