### PR TITLE
feat: add localhost session APIs for internal integrations

### DIFF
--- a/gateway/session_query_service.py
+++ b/gateway/session_query_service.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from hermes_state import SessionDB
+
+
+class SessionQueryService:
+    """Shared session-query helpers for dashboard and future API surfaces."""
+
+    def __init__(self, db: SessionDB | None = None):
+        self._db = db or SessionDB()
+        self._owns_db = db is None
+
+    def close(self) -> None:
+        if self._owns_db:
+            self._db.close()
+
+    def list_sessions(self, limit: int = 20, offset: int = 0) -> dict[str, Any]:
+        """Return the current dashboard session list payload."""
+        sessions = self._db.list_sessions_rich(limit=limit, offset=offset)
+        total = self._db.session_count()
+        now = time.time()
+
+        for session in sessions:
+            session["is_active"] = (
+                session.get("ended_at") is None
+                and (now - session.get("last_active", session.get("started_at", 0))) < 300
+            )
+
+        return {
+            "sessions": sessions,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+        }
+
+    def search_sessions(self, q: str = "", limit: int = 20) -> dict[str, Any]:
+        """Return the current dashboard session-search payload."""
+        if not q or not q.strip():
+            return {"results": []}
+
+        terms = []
+        for token in re.findall(r'"[^"]*"|\S+', q.strip()):
+            if token.startswith('"') or token.endswith("*"):
+                terms.append(token)
+            else:
+                terms.append(token + "*")
+        prefix_query = " ".join(terms)
+
+        matches = self._db.search_messages(query=prefix_query, limit=limit)
+
+        seen: dict[str, dict[str, Any]] = {}
+        for match in matches:
+            session_id = match["session_id"]
+            if session_id not in seen:
+                seen[session_id] = {
+                    "session_id": session_id,
+                    "snippet": match.get("snippet", ""),
+                    "role": match.get("role"),
+                    "source": match.get("source"),
+                    "model": match.get("model"),
+                    "session_started": match.get("session_started"),
+                }
+
+        return {"results": list(seen.values())}
+
+    def get_session_detail(self, session_id: str) -> dict[str, Any] | None:
+        """Resolve a session ID/prefix and return the canonical session detail payload."""
+        sid = self._db.resolve_session_id(session_id)
+        if not sid:
+            return None
+        return self._db.get_session(sid)
+
+    def get_session_messages(self, session_id: str) -> dict[str, Any] | None:
+        """Resolve a session ID/prefix and return the canonical session messages payload."""
+        sid = self._db.resolve_session_id(session_id)
+        if not sid:
+            return None
+        return {
+            "session_id": sid,
+            "messages": self._db.get_messages(sid),
+        }
+
+    def get_root_task_snapshots(self) -> dict[str, Any]:
+        """Return root task snapshots shaped for the dashboard session-query API."""
+        snapshots: list[dict[str, Any]] = []
+        profile_id = self._current_profile_id()
+
+        for root_session in self._fetch_root_session_descriptors():
+            root_session_id = root_session["session_id"]
+            current_session_id = self._fetch_latest_descendant_session_id(root_session_id) or root_session_id
+            current_session = self._fetch_session_descriptor(current_session_id) or root_session
+            lineage = self._fetch_lineage(current_session_id)
+            lineage_ids = [descriptor["session_id"] for descriptor in lineage]
+            last_activity_at = self._fetch_last_activity_at(lineage_ids)
+
+            snapshots.append(
+                {
+                    "profile_id": profile_id,
+                    "root_session_id": root_session_id,
+                    "current_session_id": current_session_id,
+                    "root_session": root_session,
+                    "current_session": current_session,
+                    "lineage": lineage,
+                    "initial_user_message": self._fetch_initial_user_message(root_session_id),
+                    "latest_conversation_message": self._fetch_latest_conversation_message(lineage_ids),
+                    "last_activity_at": (
+                        last_activity_at
+                        if last_activity_at is not None
+                        else current_session.get("ended_at")
+                        or current_session.get("started_at")
+                        or root_session.get("started_at")
+                    ),
+                }
+            )
+
+        snapshots.sort(key=lambda snapshot: snapshot.get("last_activity_at") or float("-inf"), reverse=True)
+        return {"root_tasks": snapshots}
+
+    def get_session_messages_page(
+        self,
+        session_id: str,
+        limit: int = 24,
+        before_id: int | None = None,
+        before_ts: float | None = None,
+    ) -> dict[str, Any] | None:
+        """Return one transcript page using the Desk-compatible cursor semantics."""
+        if (before_id is None) != (before_ts is None):
+            raise ValueError("before_id and before_ts must be provided together")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+
+        sid = self._db.resolve_session_id(session_id)
+        if not sid:
+            return None
+
+        page_size = min(limit, 100)
+        parameters: list[Any] = [sid]
+        cursor_clause = ""
+        if before_id is not None and before_ts is not None:
+            cursor_clause = """
+              AND (
+                    timestamp < ?
+                    OR (timestamp = ? AND id < ?)
+              )
+            """
+            parameters.extend([before_ts, before_ts, before_id])
+        parameters.append(page_size + 1)
+
+        with self._db._lock:
+            cursor = self._db._conn.execute(
+                f"""
+                SELECT id, session_id, role, content, tool_name, reasoning, timestamp
+                FROM messages
+                WHERE session_id = ?
+                {cursor_clause}
+                ORDER BY timestamp DESC, id DESC
+                LIMIT ?
+                """,
+                parameters,
+            )
+            rows = cursor.fetchall()
+
+        has_more_before = len(rows) > page_size
+        page_rows = rows[:page_size]
+        messages = [self._row_to_message_page_item(row) for row in reversed(page_rows)]
+        return {
+            "messages": messages,
+            "has_more_before": has_more_before,
+        }
+
+    def get_session_binding(
+        self,
+        session_id: str,
+        root_session_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Return the Desk-compatible root/current binding for a session lineage."""
+        preferred_session_id = self._db.resolve_session_id(session_id)
+        if preferred_session_id is None:
+            return None
+
+        anchor_session_id = self._resolve_optional_session_id(root_session_id)
+        if root_session_id is not None and anchor_session_id is None:
+            return None
+
+        current_session_id = self._fetch_latest_descendant_session_id(preferred_session_id)
+        if current_session_id is None:
+            current_session_id = preferred_session_id
+
+        current_descriptor = self._fetch_session_descriptor(current_session_id)
+        if current_descriptor is None:
+            return None
+
+        lineage = self._fetch_lineage(current_descriptor["session_id"])
+        if not lineage:
+            return None
+
+        resolved_root_session_id = lineage[0]["session_id"]
+        if anchor_session_id is not None and resolved_root_session_id != anchor_session_id:
+            return None
+
+        return {
+            "root_session_id": resolved_root_session_id,
+            "current_session_id": current_descriptor["session_id"],
+            "lineage": lineage,
+        }
+
+    def _current_profile_id(self) -> str:
+        hermes_home = get_hermes_home()
+        if hermes_home.parent.name == "profiles":
+            return hermes_home.name
+        return "default"
+
+    def _fetch_root_session_descriptors(self) -> list[dict[str, Any]]:
+        with self._db._lock:
+            cursor = self._db._conn.execute(
+                """
+                SELECT id, parent_session_id, title, source, started_at, ended_at
+                FROM sessions
+                WHERE parent_session_id IS NULL
+                ORDER BY started_at DESC, id DESC
+                """
+            )
+            rows = cursor.fetchall()
+        return [self._row_to_session_descriptor(row) for row in rows]
+
+    def _fetch_session_descriptor(self, session_id: str) -> dict[str, Any] | None:
+        with self._db._lock:
+            cursor = self._db._conn.execute(
+                """
+                SELECT id, parent_session_id, title, source, started_at, ended_at
+                FROM sessions
+                WHERE id = ?
+                LIMIT 1
+                """,
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        return self._row_to_session_descriptor(row) if row else None
+
+    def _fetch_lineage(self, session_id: str) -> list[dict[str, Any]]:
+        lineage: list[dict[str, Any]] = []
+        cursor = session_id
+        seen: set[str] = set()
+
+        while cursor not in seen:
+            descriptor = self._fetch_session_descriptor(cursor)
+            if not descriptor:
+                break
+            lineage.append(descriptor)
+            seen.add(cursor)
+            parent_session_id = descriptor.get("parent_session_id")
+            if not parent_session_id:
+                break
+            cursor = parent_session_id
+
+        return list(reversed(lineage))
+
+    def _fetch_latest_descendant_session_id(self, anchor_session_id: str) -> str | None:
+        with self._db._lock:
+            cursor = self._db._conn.execute(
+                """
+                WITH RECURSIVE subtree(id, parent_session_id, started_at, depth) AS (
+                    SELECT id, parent_session_id, started_at, 0
+                    FROM sessions
+                    WHERE id = ?
+                    UNION ALL
+                    SELECT s.id, s.parent_session_id, s.started_at, subtree.depth + 1
+                    FROM sessions s
+                    JOIN subtree ON s.parent_session_id = subtree.id
+                )
+                SELECT subtree.id
+                FROM subtree
+                LEFT JOIN sessions child ON child.parent_session_id = subtree.id
+                WHERE child.id IS NULL
+                ORDER BY subtree.depth DESC, subtree.started_at DESC, subtree.id DESC
+                LIMIT 1
+                """,
+                (anchor_session_id,),
+            )
+            row = cursor.fetchone()
+        return row[0] if row else None
+
+    def _fetch_initial_user_message(self, root_session_id: str) -> str | None:
+        return self._fetch_single_string(
+            """
+            SELECT COALESCE(content, '')
+            FROM messages
+            WHERE session_id = ? AND role = 'user'
+            ORDER BY timestamp ASC, id ASC
+            LIMIT 1
+            """,
+            [root_session_id],
+        )
+
+    def _fetch_latest_conversation_message(self, session_ids: list[str]) -> str | None:
+        if not session_ids:
+            return None
+        placeholders = ",".join("?" for _ in session_ids)
+        return self._fetch_single_string(
+            f"""
+            SELECT COALESCE(content, '')
+            FROM messages
+            WHERE session_id IN ({placeholders})
+              AND role IN ('user', 'assistant')
+              AND TRIM(COALESCE(content, '')) != ''
+            ORDER BY timestamp DESC, id DESC
+            LIMIT 1
+            """,
+            session_ids,
+        )
+
+    def _fetch_last_activity_at(self, session_ids: list[str]) -> float | None:
+        if not session_ids:
+            return None
+        placeholders = ",".join("?" for _ in session_ids)
+        with self._db._lock:
+            cursor = self._db._conn.execute(
+                f"""
+                SELECT MAX(timestamp)
+                FROM messages
+                WHERE session_id IN ({placeholders})
+                """,
+                session_ids,
+            )
+            row = cursor.fetchone()
+        if not row or row[0] is None:
+            return None
+        return float(row[0])
+
+    def _resolve_optional_session_id(self, session_id: str | None) -> str | None:
+        if session_id is None:
+            return None
+        normalized = session_id.strip()
+        if not normalized:
+            return None
+        return self._db.resolve_session_id(normalized)
+
+    def _fetch_single_string(self, sql: str, parameters: list[Any]) -> str | None:
+        with self._db._lock:
+            cursor = self._db._conn.execute(sql, parameters)
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return self._normalize_optional_text(row[0])
+
+    @staticmethod
+    def _normalize_optional_text(value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _row_to_session_descriptor(row: Any) -> dict[str, Any]:
+        return {
+            "session_id": row["id"],
+            "parent_session_id": row["parent_session_id"],
+            "title": row["title"],
+            "source": row["source"],
+            "started_at": row["started_at"],
+            "ended_at": row["ended_at"],
+        }
+
+    @staticmethod
+    def _row_to_message_page_item(row: Any) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "session_id": row["session_id"],
+            "role": row["role"],
+            "content": row["content"],
+            "tool_name": row["tool_name"],
+            "reasoning": row["reasoning"],
+            "timestamp": row["timestamp"],
+        }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -478,21 +478,14 @@ async def get_status():
 @app.get("/api/sessions")
 async def get_sessions(limit: int = 20, offset: int = 0):
     try:
-        from hermes_state import SessionDB
-        db = SessionDB()
+        from gateway.session_query_service import SessionQueryService
+
+        service = SessionQueryService()
         try:
-            sessions = db.list_sessions_rich(limit=limit, offset=offset)
-            total = db.session_count()
-            now = time.time()
-            for s in sessions:
-                s["is_active"] = (
-                    s.get("ended_at") is None
-                    and (now - s.get("last_active", s.get("started_at", 0))) < 300
-                )
-            return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
+            return service.list_sessions(limit=limit, offset=offset)
         finally:
-            db.close()
-    except Exception as e:
+            service.close()
+    except Exception:
         _log.exception("GET /api/sessions failed")
         raise HTTPException(status_code=500, detail="Internal server error")
 
@@ -500,43 +493,28 @@ async def get_sessions(limit: int = 20, offset: int = 0):
 @app.get("/api/sessions/search")
 async def search_sessions(q: str = "", limit: int = 20):
     """Full-text search across session message content using FTS5."""
-    if not q or not q.strip():
-        return {"results": []}
     try:
-        from hermes_state import SessionDB
-        db = SessionDB()
+        from gateway.session_query_service import SessionQueryService
+
+        service = SessionQueryService()
         try:
-            # Auto-add prefix wildcards so partial words match
-            # e.g. "nimb" → "nimb*" matches "nimby"
-            # Preserve quoted phrases and existing wildcards as-is
-            import re
-            terms = []
-            for token in re.findall(r'"[^"]*"|\S+', q.strip()):
-                if token.startswith('"') or token.endswith("*"):
-                    terms.append(token)
-                else:
-                    terms.append(token + "*")
-            prefix_query = " ".join(terms)
-            matches = db.search_messages(query=prefix_query, limit=limit)
-            # Group by session_id — return unique sessions with their best snippet
-            seen: dict = {}
-            for m in matches:
-                sid = m["session_id"]
-                if sid not in seen:
-                    seen[sid] = {
-                        "session_id": sid,
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    }
-            return {"results": list(seen.values())}
+            return service.search_sessions(q=q, limit=limit)
         finally:
-            db.close()
+            service.close()
     except Exception:
         _log.exception("GET /api/sessions/search failed")
         raise HTTPException(status_code=500, detail="Search failed")
+
+
+@app.get("/api/sessions/root-tasks")
+async def get_root_tasks():
+    from gateway.session_query_service import SessionQueryService
+
+    service = SessionQueryService()
+    try:
+        return service.get_root_task_snapshots()
+    finally:
+        service.close()
 
 
 def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -1700,30 +1678,96 @@ async def cancel_oauth_session(session_id: str, request: Request):
 
 @app.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str):
-    from hermes_state import SessionDB
-    db = SessionDB()
+    from gateway.session_query_service import SessionQueryService
+
+    service = SessionQueryService()
     try:
-        sid = db.resolve_session_id(session_id)
-        session = db.get_session(sid) if sid else None
+        session = service.get_session_detail(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
         return session
     finally:
-        db.close()
+        service.close()
 
 
 @app.get("/api/sessions/{session_id}/messages")
 async def get_session_messages(session_id: str):
-    from hermes_state import SessionDB
-    db = SessionDB()
+    from gateway.session_query_service import SessionQueryService
+
+    service = SessionQueryService()
     try:
-        sid = db.resolve_session_id(session_id)
-        if not sid:
+        messages = service.get_session_messages(session_id)
+        if not messages:
             raise HTTPException(status_code=404, detail="Session not found")
-        messages = db.get_messages(sid)
-        return {"session_id": sid, "messages": messages}
+        return messages
     finally:
-        db.close()
+        service.close()
+
+
+@app.get("/api/sessions/{session_id}/messages-page")
+async def get_session_messages_page(
+    session_id: str,
+    limit: str = "24",
+    before_id: str | None = None,
+    before_ts: str | None = None,
+):
+    from gateway.session_query_service import SessionQueryService
+
+    try:
+        parsed_limit = int(limit)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="limit must be an integer")
+
+    if before_id is None and before_ts is None:
+        parsed_before_id = None
+        parsed_before_ts = None
+    elif before_id is None or before_ts is None:
+        raise HTTPException(status_code=400, detail="before_id and before_ts must be provided together")
+    else:
+        try:
+            parsed_before_id = int(before_id)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="before_id must be an integer")
+        try:
+            parsed_before_ts = float(before_ts)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="before_ts must be a number")
+
+    service = SessionQueryService()
+    try:
+        try:
+            page = service.get_session_messages_page(
+                session_id,
+                limit=parsed_limit,
+                before_id=parsed_before_id,
+                before_ts=parsed_before_ts,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if not page:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return page
+    finally:
+        service.close()
+
+
+@app.get("/api/sessions/{session_id}/binding")
+async def get_session_binding(session_id: str, root_session_id: str | None = None):
+    from gateway.session_query_service import SessionQueryService
+
+    service = SessionQueryService()
+    try:
+        if service.get_session_detail(session_id) is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        if root_session_id is not None and service.get_session_detail(root_session_id) is None:
+            raise HTTPException(status_code=404, detail="Root session not found")
+
+        binding = service.get_session_binding(session_id, root_session_id=root_session_id)
+        if not binding:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return binding
+    finally:
+        service.close()
 
 
 @app.delete("/api/sessions/{session_id}")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -112,6 +112,219 @@ class TestWebServerEndpoints:
         self.client = TestClient(app)
         self.client.headers["Authorization"] = f"Bearer {_SESSION_TOKEN}"
 
+    def test_get_session_detail_uses_session_query_service(self, monkeypatch):
+        calls = []
+
+        class DummyService:
+            def get_session_detail(self, session_id):
+                calls.append(("get_session_detail", session_id))
+                return {"session_id": "sess_123", "title": "Test session"}
+
+            def close(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/sess_123")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"session_id": "sess_123", "title": "Test session"}
+        assert calls == [
+            ("get_session_detail", "sess_123"),
+            ("close", None),
+        ]
+
+    def test_get_session_detail_returns_404_when_service_misses(self, monkeypatch):
+        class DummyService:
+            def get_session_detail(self, session_id):
+                return None
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/missing")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+
+    def test_get_session_messages_uses_session_query_service(self, monkeypatch):
+        calls = []
+
+        class DummyService:
+            def get_session_messages(self, session_id):
+                calls.append(("get_session_messages", session_id))
+                return {"session_id": "sess_123", "messages": [{"id": 1, "role": "user"}]}
+
+            def close(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/sess_123/messages")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "session_id": "sess_123",
+            "messages": [{"id": 1, "role": "user"}],
+        }
+        assert calls == [
+            ("get_session_messages", "sess_123"),
+            ("close", None),
+        ]
+
+    def test_get_session_messages_returns_404_when_service_misses(self, monkeypatch):
+        class DummyService:
+            def get_session_messages(self, session_id):
+                return None
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/missing/messages")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+
+    def test_get_root_tasks_uses_session_query_service(self, monkeypatch):
+        calls = []
+
+        class DummyService:
+            def get_root_task_snapshots(self):
+                calls.append(("get_root_task_snapshots", None))
+                return {"root_tasks": [{"root_session_id": "sess_root"}]}
+
+            def close(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/root-tasks")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"root_tasks": [{"root_session_id": "sess_root"}]}
+        assert calls == [
+            ("get_root_task_snapshots", None),
+            ("close", None),
+        ]
+
+    def test_get_session_messages_page_rejects_partial_cursor_params(self, monkeypatch):
+        class DummyService:
+            def __init__(self):
+                raise AssertionError("service should not be constructed for invalid cursor params")
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/sess_123/messages-page?before_id=1")
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "before_id and before_ts must be provided together"
+
+    def test_get_session_messages_page_returns_404_when_service_misses(self, monkeypatch):
+        calls = []
+
+        class DummyService:
+            def get_session_messages_page(self, session_id, limit, before_id, before_ts):
+                calls.append(("get_session_messages_page", session_id, limit, before_id, before_ts))
+                return None
+
+            def close(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/missing/messages-page?limit=10")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+        assert calls == [
+            ("get_session_messages_page", "missing", 10, None, None),
+            ("close", None),
+        ]
+
+    def test_get_session_binding_returns_404_when_session_missing(self, monkeypatch):
+        calls = []
+
+        class DummyService:
+            def get_session_detail(self, session_id):
+                calls.append(("get_session_detail", session_id))
+                return None
+
+            def close(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/missing/binding")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+        assert calls == [
+            ("get_session_detail", "missing"),
+            ("close", None),
+        ]
+
+
+    def test_get_session_binding_returns_404_when_root_session_is_unrelated(self, monkeypatch):
+        calls = []
+
+        class DummyService:
+            def get_session_detail(self, session_id):
+                calls.append(("get_session_detail", session_id))
+                if session_id in {"sess_leaf", "sess_other_root"}:
+                    return {"session_id": session_id}
+                return None
+
+            def get_session_binding(self, session_id, root_session_id=None):
+                calls.append(("get_session_binding", session_id, root_session_id))
+                return None
+
+            def close(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(
+            "gateway.session_query_service.SessionQueryService",
+            DummyService,
+        )
+
+        resp = self.client.get("/api/sessions/sess_leaf/binding?root_session_id=sess_other_root")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+        assert calls == [
+            ("get_session_detail", "sess_leaf"),
+            ("get_session_detail", "sess_other_root"),
+            ("get_session_binding", "sess_leaf", "sess_other_root"),
+            ("close", None),
+        ]
+
     def test_get_status(self):
         resp = self.client.get("/api/status")
         assert resp.status_code == 200

--- a/tests/test_session_query_service.py
+++ b/tests/test_session_query_service.py
@@ -1,0 +1,278 @@
+from gateway.session_query_service import SessionQueryService
+from hermes_state import SessionDB
+
+
+def _update_session_times(db: SessionDB, session_id: str, *, started_at: float, ended_at: float | None = None) -> None:
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+            (started_at, ended_at, session_id),
+        )
+    )
+
+
+def _update_message_timestamp(db: SessionDB, message_id: int, timestamp: float) -> None:
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE messages SET timestamp = ? WHERE id = ?",
+            (timestamp, message_id),
+        )
+    )
+
+
+def test_get_root_task_snapshots_returns_root_current_and_lineage(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        db.create_session("sess_root", "cli")
+        db.set_session_title("sess_root", "实现 Session Query")
+        _update_session_times(db, "sess_root", started_at=100.0)
+
+        db.create_session("sess_leaf", "cli", parent_session_id="sess_root")
+        db.set_session_title("sess_leaf", "继续处理分页")
+        _update_session_times(db, "sess_leaf", started_at=200.0)
+
+        root_user_id = db.append_message(
+            "sess_root",
+            "user",
+            "先把 dashboard session API 定下来",
+        )
+        _update_message_timestamp(db, root_user_id, 101.0)
+
+        root_assistant_id = db.append_message(
+            "sess_root",
+            "assistant",
+            "已经把 service 抽出来了",
+        )
+        _update_message_timestamp(db, root_assistant_id, 102.0)
+
+        leaf_assistant_id = db.append_message(
+            "sess_leaf",
+            "assistant",
+            "已经补齐分页游标语义",
+        )
+        _update_message_timestamp(db, leaf_assistant_id, 205.0)
+
+        service = SessionQueryService(db=db)
+
+        assert service.get_root_task_snapshots() == {
+            "root_tasks": [
+                {
+                    "profile_id": "coder",
+                    "root_session_id": "sess_root",
+                    "current_session_id": "sess_leaf",
+                    "root_session": {
+                        "session_id": "sess_root",
+                        "parent_session_id": None,
+                        "title": "实现 Session Query",
+                        "source": "cli",
+                        "started_at": 100.0,
+                        "ended_at": None,
+                    },
+                    "current_session": {
+                        "session_id": "sess_leaf",
+                        "parent_session_id": "sess_root",
+                        "title": "继续处理分页",
+                        "source": "cli",
+                        "started_at": 200.0,
+                        "ended_at": None,
+                    },
+                    "lineage": [
+                        {
+                            "session_id": "sess_root",
+                            "parent_session_id": None,
+                            "title": "实现 Session Query",
+                            "source": "cli",
+                            "started_at": 100.0,
+                            "ended_at": None,
+                        },
+                        {
+                            "session_id": "sess_leaf",
+                            "parent_session_id": "sess_root",
+                            "title": "继续处理分页",
+                            "source": "cli",
+                            "started_at": 200.0,
+                            "ended_at": None,
+                        },
+                    ],
+                    "initial_user_message": "先把 dashboard session API 定下来",
+                    "latest_conversation_message": "已经补齐分页游标语义",
+                    "last_activity_at": 205.0,
+                }
+            ]
+        }
+    finally:
+        db.close()
+
+
+def test_get_session_messages_page_uses_timestamp_and_id_cursor_for_stable_paging(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        db.create_session("sess_page", "cli")
+
+        message_ids = []
+        for index in range(1, 6):
+            message_id = db.append_message("sess_page", "assistant", f"message-{index}")
+            _update_message_timestamp(db, message_id, 100.0)
+            message_ids.append(message_id)
+
+        service = SessionQueryService(db=db)
+
+        first_page = service.get_session_messages_page("sess_page", limit=2)
+        assert first_page == {
+            "messages": [
+                {
+                    "id": message_ids[3],
+                    "session_id": "sess_page",
+                    "role": "assistant",
+                    "content": "message-4",
+                    "tool_name": None,
+                    "reasoning": None,
+                    "timestamp": 100.0,
+                },
+                {
+                    "id": message_ids[4],
+                    "session_id": "sess_page",
+                    "role": "assistant",
+                    "content": "message-5",
+                    "tool_name": None,
+                    "reasoning": None,
+                    "timestamp": 100.0,
+                },
+            ],
+            "has_more_before": True,
+        }
+
+        second_page = service.get_session_messages_page(
+            "sess_page",
+            limit=2,
+            before_id=first_page["messages"][0]["id"],
+            before_ts=first_page["messages"][0]["timestamp"],
+        )
+        assert second_page == {
+            "messages": [
+                {
+                    "id": message_ids[1],
+                    "session_id": "sess_page",
+                    "role": "assistant",
+                    "content": "message-2",
+                    "tool_name": None,
+                    "reasoning": None,
+                    "timestamp": 100.0,
+                },
+                {
+                    "id": message_ids[2],
+                    "session_id": "sess_page",
+                    "role": "assistant",
+                    "content": "message-3",
+                    "tool_name": None,
+                    "reasoning": None,
+                    "timestamp": 100.0,
+                },
+            ],
+            "has_more_before": True,
+        }
+
+        third_page = service.get_session_messages_page(
+            "sess_page",
+            limit=2,
+            before_id=second_page["messages"][0]["id"],
+            before_ts=second_page["messages"][0]["timestamp"],
+        )
+        assert third_page == {
+            "messages": [
+                {
+                    "id": message_ids[0],
+                    "session_id": "sess_page",
+                    "role": "assistant",
+                    "content": "message-1",
+                    "tool_name": None,
+                    "reasoning": None,
+                    "timestamp": 100.0,
+                }
+            ],
+            "has_more_before": False,
+        }
+    finally:
+        db.close()
+
+
+def test_get_session_binding_returns_latest_leaf_and_lineage(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        db.create_session("sess_root", "cli")
+        db.set_session_title("sess_root", "实现 Session Query")
+        _update_session_times(db, "sess_root", started_at=100.0)
+
+        db.create_session("sess_mid", "cli", parent_session_id="sess_root")
+        db.set_session_title("sess_mid", "继续处理分页")
+        _update_session_times(db, "sess_mid", started_at=200.0)
+
+        db.create_session("sess_leaf", "cli", parent_session_id="sess_mid")
+        db.set_session_title("sess_leaf", "补 binding 测试")
+        _update_session_times(db, "sess_leaf", started_at=300.0)
+
+        service = SessionQueryService(db=db)
+
+        assert service.get_session_binding("sess_mid", root_session_id="sess_root") == {
+            "root_session_id": "sess_root",
+            "current_session_id": "sess_leaf",
+            "lineage": [
+                {
+                    "session_id": "sess_root",
+                    "parent_session_id": None,
+                    "title": "实现 Session Query",
+                    "source": "cli",
+                    "started_at": 100.0,
+                    "ended_at": None,
+                },
+                {
+                    "session_id": "sess_mid",
+                    "parent_session_id": "sess_root",
+                    "title": "继续处理分页",
+                    "source": "cli",
+                    "started_at": 200.0,
+                    "ended_at": None,
+                },
+                {
+                    "session_id": "sess_leaf",
+                    "parent_session_id": "sess_mid",
+                    "title": "补 binding 测试",
+                    "source": "cli",
+                    "started_at": 300.0,
+                    "ended_at": None,
+                },
+            ],
+        }
+    finally:
+        db.close()
+
+
+
+def test_get_session_binding_returns_none_when_root_session_is_unrelated(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        db.create_session("sess_root_a", "cli")
+        db.create_session("sess_leaf_a", "cli", parent_session_id="sess_root_a")
+        db.create_session("sess_root_b", "cli")
+
+        service = SessionQueryService(db=db)
+
+        assert service.get_session_binding("sess_leaf_a", root_session_id="sess_root_b") is None
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- add `SessionQueryService` for localhost session data reads
- migrate existing `/api/sessions*` localhost routes to the shared service
- add advanced local internal APIs for root task snapshots, paged transcripts, and session binding
- add focused service and web tests for cursor semantics, route wiring, and lineage/root-mismatch behavior

## Included in this PR
- `GET /api/sessions/root-tasks`
- `GET /api/sessions/{session_id}/messages-page`
- `GET /api/sessions/{session_id}/binding`
- extraction of existing localhost session reads into `gateway/session_query_service.py`
- test coverage for the new service/web behavior

## Explicitly not included
- `/v1/runs` / public `api_server` replay changes
- any specific first-party client integration changes

## Why
The current localhost session API surface is too low-level for richer integrations.

This PR adds a more complete **local internal session data layer** so that dashboards, companion apps, and third-party clients can retrieve:
- task-oriented session snapshots
- paged transcript history
- root/current session lineage

through supported localhost APIs instead of coupling directly to SQLite.

## Validation
- `source venv/bin/activate && python -m pytest tests/test_session_query_service.py tests/hermes_cli/test_web_server.py -q`

## Issue
Closes #10384
