### PR TITLE
fix(gateway): suppress allowlist warning for pairing configs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1719,7 +1719,7 @@ class GatewayRunner:
         except Exception:
             pass
         
-        # Warn if no user allowlists are configured and open access is not opted in
+        # Warn if no user authorization mode is configured.
         _any_allowlist = any(
             os.getenv(v)
             for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
@@ -1750,7 +1750,17 @@ class GatewayRunner:
                        "BLUEBUBBLES_ALLOW_ALL_USERS",
                        "QQ_ALLOW_ALL_USERS")
         )
-        if not _any_allowlist and not _allow_all:
+        _pairing_enabled = any(
+            os.getenv(v, "").strip().lower() == "pairing"
+            for v in ("WECOM_DM_POLICY", "WEIXIN_DM_POLICY")
+        )
+        _has_paired_users = False
+        try:
+            _has_paired_users = bool(self.pairing_store.list_approved())
+        except Exception:
+            pass
+
+        if not _any_allowlist and not _allow_all and not _pairing_enabled and not _has_paired_users:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
                 "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "

--- a/tests/gateway/test_allowlist_startup_check.py
+++ b/tests/gateway/test_allowlist_startup_check.py
@@ -14,6 +14,7 @@ def _would_warn():
                    "EMAIL_ALLOWED_USERS",
                    "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
                    "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
+                   "WECOM_CALLBACK_ALLOWED_USERS", "WEIXIN_ALLOWED_USERS", "BLUEBUBBLES_ALLOWED_USERS",
                    "GATEWAY_ALLOWED_USERS")
     )
     _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
@@ -22,9 +23,15 @@ def _would_warn():
                    "WHATSAPP_ALLOW_ALL_USERS", "SLACK_ALLOW_ALL_USERS",
                    "SIGNAL_ALLOW_ALL_USERS", "EMAIL_ALLOW_ALL_USERS",
                    "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
-                   "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS")
+                   "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
+                   "WECOM_CALLBACK_ALLOW_ALL_USERS", "WEIXIN_ALLOW_ALL_USERS", "BLUEBUBBLES_ALLOW_ALL_USERS")
     )
-    return not _any_allowlist and not _allow_all
+    _pairing_enabled = any(
+        os.getenv(v, "").strip().lower() == "pairing"
+        for v in ("WECOM_DM_POLICY", "WEIXIN_DM_POLICY")
+    )
+    _has_paired_users = os.getenv("TEST_HAS_PAIRED_USERS", "").lower() in ("true", "1", "yes")
+    return not _any_allowlist and not _allow_all and not _pairing_enabled and not _has_paired_users
 
 
 class TestAllowlistStartupCheck:
@@ -43,4 +50,12 @@ class TestAllowlistStartupCheck:
 
     def test_gateway_allow_all_users_suppresses_warning(self):
         with patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "yes"}, clear=True):
+            assert _would_warn() is False
+
+    def test_weixin_pairing_mode_suppresses_warning(self):
+        with patch.dict(os.environ, {"WEIXIN_DM_POLICY": "pairing"}, clear=True):
+            assert _would_warn() is False
+
+    def test_existing_paired_users_suppress_warning(self):
+        with patch.dict(os.environ, {"TEST_HAS_PAIRED_USERS": "true"}, clear=True):
             assert _would_warn() is False


### PR DESCRIPTION
## Summary
- suppress the startup allowlist warning when WeCom or Weixin is intentionally using pairing mode
- also suppress the warning when paired users already exist in the pairing store
- add focused regression coverage for both pairing-based authorization paths

## Root cause
The startup warning only considered static allowlists and allow-all flags. Pairing mode is a legitimate authorization flow, so the gateway was warning even when authorization had already been configured correctly.

## Validation
- `python -m pytest -o addopts='' tests/gateway/test_allowlist_startup_check.py -q`
