### PR TITLE
fix: don't downgrade xhigh reasoning effort when provider supports it

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6452,7 +6452,7 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
-        if requested_effort == "xhigh" and "high" in supported_efforts:
+        if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
             requested_effort = "high"
         elif requested_effort not in supported_efforts:
             if requested_effort == "minimal" and "low" in supported_efforts:


### PR DESCRIPTION
## Problem

The current reasoning effort negotiation code unconditionally downgrades `xhigh` to `high` whenever `high` is in the provider's supported efforts list:

```python
if requested_effort == "xhigh" and "high" in supported_efforts:
    requested_effort = "high"
```

This means that even when a provider explicitly supports `xhigh` (e.g., Copilot with `COPILOT_REASONING_EFFORTS_GPT5 = {"low", "medium", "high", "xhigh"}`), the effort is always silently downgraded to `high`.

## Fix

Add a check that `xhigh` is NOT in supported efforts before downgrading:

```python
if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
    requested_effort = "high"
```

This preserves the graceful degradation behavior (xhigh → high) for providers that don't support xhigh, while allowing it through for providers that do.

## Testing

One-line change. The fix is logically correct — it only adds an additional guard condition to the existing downgrade check.