### PR TITLE
fix: enable Feishu media delivery in send_message

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -442,6 +442,107 @@ class TestSendTelegramMediaDelivery:
         bot.send_message.assert_not_awaited()
 
 
+class TestSendFeishuMediaDelivery:
+    def test_send_to_platform_routes_text_and_media_to_feishu_helper(self):
+        send = AsyncMock(return_value={"success": True, "platform": "feishu", "message_id": "42"})
+        cfg = SimpleNamespace(enabled=True, token="***", extra={})
+
+        with patch("tools.send_message_tool._send_feishu", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    cfg,
+                    "oc_testchat",
+                    "hello",
+                    media_files=[("/tmp/example.png", False)],
+                    thread_id="om_testthread",
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            cfg,
+            "oc_testchat",
+            "hello",
+            media_files=[("/tmp/example.png", False)],
+            thread_id="om_testthread",
+        )
+        assert result.get("warnings") is None
+
+    def test_send_to_platform_allows_media_only_for_feishu(self):
+        send = AsyncMock(return_value={"success": True, "platform": "feishu", "message_id": "43"})
+        cfg = SimpleNamespace(enabled=True, token="***", extra={})
+
+        with patch("tools.send_message_tool._send_feishu", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    cfg,
+                    "oc_testchat",
+                    "",
+                    media_files=[("/tmp/example.png", False)],
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            cfg,
+            "oc_testchat",
+            "",
+            media_files=[("/tmp/example.png", False)],
+            thread_id=None,
+        )
+
+    def test_long_feishu_message_without_media_is_chunked(self):
+        send = AsyncMock(return_value={"success": True, "platform": "feishu", "message_id": "44"})
+        cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        long_msg = "word " * 2000
+
+        with patch("tools.send_message_tool._send_feishu", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    cfg,
+                    "oc_testchat",
+                    long_msg,
+                    media_files=[],
+                )
+            )
+
+        assert result["success"] is True
+        assert send.await_count >= 2
+        for call in send.await_args_list:
+            assert len(call.args[2]) <= 8100
+            assert call.kwargs["media_files"] == []
+
+    def test_long_feishu_message_with_media_only_attaches_on_last_chunk(self):
+        send = AsyncMock(return_value={"success": True, "platform": "feishu", "message_id": "45"})
+        cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        long_msg = "word " * 2000
+        media = [("/tmp/example.png", False)]
+
+        with patch("tools.send_message_tool._send_feishu", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    cfg,
+                    "oc_testchat",
+                    long_msg,
+                    media_files=media,
+                    thread_id="om_testthread",
+                )
+            )
+
+        assert result["success"] is True
+        assert send.await_count >= 2
+        for call in send.await_args_list[:-1]:
+            assert call.kwargs["media_files"] == []
+            assert call.kwargs["thread_id"] == "om_testthread"
+        last = send.await_args_list[-1]
+        assert last.kwargs["media_files"] == media
+        assert last.kwargs["thread_id"] == "om_testthread"
+
+
 # ---------------------------------------------------------------------------
 # Regression: long messages are chunked before platform dispatch
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -380,15 +380,34 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Weixin: use the native one-shot adapter helper for text + media ---
+    # --- Weixin: use native helper for text + media ---
     if platform == Platform.WEIXIN:
         return await _send_weixin(pconfig, chat_id, message, media_files=media_files)
+
+    # --- Feishu: preserve chunking, attach media on the final chunk ---
+    if platform == Platform.FEISHU:
+        if not chunks:
+            chunks = [""]
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
 
     # --- Non-Telegram platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram; "
+                f"send_message MEDIA delivery is currently only supported for telegram, feishu, and weixin; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -396,7 +415,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram"
+            "native send_message media delivery is currently only supported for telegram, feishu, and weixin"
         )
 
     last_result = None


### PR DESCRIPTION
fix: enable Feishu media delivery in send_message

## Summary
- route Feishu through native `send_message` media delivery instead of dropping `MEDIA:` attachments
- preserve Feishu text chunking while attaching media only on the final chunk
- add regression coverage for Feishu text+media, media-only, and long-message chunking

## Problem
The Feishu gateway adapter already supported native image/file sending, but the `send_message` tool did not expose that path. `send_message` parsed `MEDIA:/path/to/file.png`, yet `_send_to_platform()` only enabled native media delivery for Telegram and Weixin. For Feishu, media attachments were silently omitted even though the adapter could send them.

## Root cause
`tools/send_message_tool.py` had a Feishu-specific helper (`_send_feishu`) that already accepted `media_files`, but `_send_to_platform()` routed Feishu through the generic non-media path.

## Fix
- add a dedicated Feishu branch in `_send_to_platform()`
- preserve existing chunking behavior for long Feishu text messages
- attach `media_files` only on the final Feishu chunk
- update user-facing warning/error strings to reflect that native media delivery is now supported for Telegram, Feishu, and Weixin
