### PR TITLE
fix: check agent.context.engine before top-level context.engine

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1326,15 +1326,22 @@ class AIAgent:
                     break
         
         # Select context engine: config-driven (like memory providers).
-        # 1. Check config.yaml context.engine setting
-        # 2. Check plugins/context_engine/<name>/ directory (repo-shipped)
-        # 3. Check general plugin system (user-installed plugins)
-        # 4. Fall back to built-in ContextCompressor
+        # 1. Check agent.context.engine (profile-specific, highest priority)
+        # 2. Check top-level context.engine setting (global default)
+        # 3. Check plugins/context_engine/<name>/ directory (repo-shipped)
+        # 4. Check general plugin system (user-installed plugins)
+        # 5. Fall back to built-in ContextCompressor
         _selected_engine = None
         _engine_name = "compressor"  # default
         try:
-            _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
-            _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
+            # Profile-specific: agent.context.engine takes priority
+            _agent_section = _agent_cfg.get("agent", {}) if isinstance(_agent_cfg, dict) else {}
+            _agent_ctx = _agent_section.get("context", {}) if isinstance(_agent_section, dict) else {}
+            _engine_name = _agent_ctx.get("engine", "") or ""
+            if not _engine_name:
+                # Fallback: top-level context.engine
+                _ctx_cfg = _agent_cfg.get("context", {}) if isinstance(_agent_cfg, dict) else {}
+                _engine_name = _ctx_cfg.get("engine", "compressor") or "compressor"
         except Exception:
             pass
 


### PR DESCRIPTION
## Problem

The context engine selection in `AIAgent.__init__` only checks the top-level `context.engine` config key:

```python
_ctx_cfg = _agent_cfg.get("context", {})
_engine_name = _ctx_cfg.get("engine", "compressor")
```

However, `load_config()` injects `context.engine: compressor` as a default at the top level. This means that profile-specific overrides placed under `agent.context.engine` in the YAML config are always shadowed by the top-level default.

Example config that doesn't work as expected:
```yaml
# Top-level (default injected by load_config)
context:
  engine: compressor

# Profile-specific override (ignored)
agent:
  context:
    engine: my_custom_engine
```

## Fix

Check `agent.context.engine` first (profile-specific, highest priority), then fall back to the top-level `context.engine` (global default):

```python
# Profile-specific: agent.context.engine takes priority
_agent_section = _agent_cfg.get("agent", {})
_agent_ctx = _agent_section.get("context", {})
_engine_name = _agent_ctx.get("engine", "") or ""
if not _engine_name:
    # Fallback: top-level context.engine
    _ctx_cfg = _agent_cfg.get("context", {})
    _engine_name = _ctx_cfg.get("engine", "compressor")
```

This follows the same pattern used elsewhere in the codebase where profile-specific config overrides global defaults.