### PR TITLE
fix: use empty string for unauthenticated custom endpoints (closes #10375)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -886,7 +886,7 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[st
     # local servers ignore the Authorization header.  Same fix as cli.py
     # _ensure_runtime_credentials() (PR #2556).
     if not isinstance(custom_key, str) or not custom_key.strip():
-        custom_key = "no-key-required"
+        custom_key = ""
 
     if not isinstance(custom_mode, str) or not custom_mode.strip():
         custom_mode = None
@@ -1406,7 +1406,7 @@ def resolve_provider_client(
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
-                or "no-key-required"  # local servers don't need auth
+                or ""
             )
             if not custom_base:
                 logger.warning(
@@ -1452,7 +1452,7 @@ def resolve_provider_client(
             custom_key_env = custom_entry.get("key_env", "").strip()
             if not custom_key and custom_key_env:
                 custom_key = os.getenv(custom_key_env, "").strip()
-            custom_key = custom_key or "no-key-required"
+            custom_key = custom_key or ""
             if custom_base:
                 final_model = _normalize_resolved_model(
                     model or custom_entry.get("model") or _read_main_model() or "gpt-4o-mini",


### PR DESCRIPTION
## Fix #10375 — Custom endpoint 400 error when API key is empty

### Problem

When using a custom endpoint (llama.cpp, koboldcpp, Ollama, LM Studio, vLLM) without an API key, Hermes Agent returns a 400 error. Workaround: enter a random string in the API key field.

### Root Cause

Three places in `agent/auxiliary_client.py` were using the placeholder string `"no-key-required"` when no API key was configured. The OpenAI SDK sends this as:

    Authorization: Bearer no-key-required

Local inference servers (llama.cpp, koboldcpp, etc.) reject this with 400.

### Fix

Replace `"no-key-required"` with `""` (empty string) in all three locations:

1. `_resolve_custom_runtime()` — handles `OPENAI_BASE_URL` / `OPENAI_API_KEY` env vars
2. `resolve_provider_client()` — handles explicit `custom` provider with base URL
3. Named custom providers (config.yaml `custom_providers`)

When `api_key=""` is passed to the OpenAI SDK, no `Authorization` header is sent — correct for unauthenticated local servers.

### Testing

- [ ] Custom endpoint (llama.cpp local) with empty API key — no 400 error
- [ ] Koboldcpp local with empty API key — works without workaround
- [ ] Ollama local with empty API key — works without workaround
- [ ] Named custom provider with empty API key — works
- [ ] Regular OpenAI/OpenRouter endpoints — unchanged (key still sent when configured)
