### PR TITLE
feat(gateway): expose /v1/hermes/config with primary + fallback chain

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -612,6 +612,66 @@ class APIServerAdapter(BasePlatformAdapter):
             ],
         })
 
+    async def _handle_hermes_config(self, request: "web.Request") -> "web.Response":
+        """GET /v1/hermes/config — expose configured primary + fallback chain.
+
+        Returns the server's parsed ``~/.hermes/config.yaml`` as a minimal
+        ``{primary, fallback_chain}`` envelope. This complements ``/v1/models``,
+        which advertises ``API_SERVER_MODEL_NAME`` (an OpenAI-compatible label
+        that may not match the actual primary model the gateway will use).
+
+        The endpoint is intended for dashboards and remote OpenAI-compatible
+        clients (e.g. desktop apps connecting over a private network) that
+        cannot read the server's local config file directly and need to
+        display which model the gateway will actually call.
+
+        On any error — missing config, parse failure, helper exception —
+        the response is a graceful ``200`` with ``{primary: null,
+        fallback_chain: []}``. Clients can fall through to other strategies
+        (e.g. ``/v1/models``) without having to special-case error codes.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        empty_payload = {"primary": None, "fallback_chain": []}
+
+        try:
+            # Imported lazily to avoid the circular import between
+            # gateway.run and gateway.platforms.api_server.
+            from gateway.run import _load_gateway_config, _resolve_gateway_model
+
+            cfg = _load_gateway_config()
+            primary = _resolve_gateway_model(cfg) or None
+            if not primary:
+                return web.json_response(empty_payload)
+
+            chain: list[str] = [primary]
+
+            # Inline parse of fallback config — kept independent of
+            # GatewayRunner._load_fallback_model() so the handler can be
+            # tested without spinning up a runner.  The shape mirrors what
+            # AIAgent.__init__ accepts: either a list of provider dicts
+            # (``fallback_providers``) or a single dict (legacy
+            # ``fallback_model``).
+            fallback_raw = cfg.get("fallback_providers") or cfg.get("fallback_model")
+            if isinstance(fallback_raw, dict):
+                fb_model = fallback_raw.get("model")
+                if isinstance(fb_model, str) and fb_model and fb_model not in chain:
+                    chain.append(fb_model)
+            elif isinstance(fallback_raw, list):
+                for entry in fallback_raw:
+                    if not isinstance(entry, dict):
+                        continue
+                    fb_model = entry.get("model")
+                    if isinstance(fb_model, str) and fb_model and fb_model not in chain:
+                        chain.append(fb_model)
+
+            return web.json_response({"primary": primary, "fallback_chain": chain})
+        except Exception as exc:
+            logger.warning("[%s] /v1/hermes/config failed: %s", self.name, exc)
+            return web.json_response(empty_payload)
+
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
@@ -2317,6 +2377,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
+            self._app.router.add_get("/v1/hermes/config", self._handle_hermes_config)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -223,6 +223,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
+    app.router.add_get("/v1/hermes/config", adapter._handle_hermes_config)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
@@ -398,6 +399,133 @@ class TestModelsEndpoint:
                 headers={"Authorization": "Bearer sk-secret"},
             )
             assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# /v1/hermes/config endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestHermesConfigEndpoint:
+    """
+    GET /v1/hermes/config exposes the server's parsed ~/.hermes/config.yaml
+    as a minimal {primary, fallback_chain} envelope. Useful for clients that
+    need to know the *configured* primary model and fallback chain (rather
+    than the API_SERVER_MODEL_NAME label that /v1/models advertises).
+    """
+
+    @pytest.mark.asyncio
+    async def test_returns_primary_and_legacy_fallback_dict(self, adapter):
+        """legacy fallback_model: dict → chain = [primary, fallback.model]."""
+        fake_config = {
+            "model": {"default": "gemini-2.5-flash"},
+            "fallback_model": {"provider": "gemini", "model": "gemini-2.5-pro"},
+        }
+        with patch("gateway.run._load_gateway_config", return_value=fake_config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/hermes/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] == "gemini-2.5-flash"
+                assert data["fallback_chain"] == ["gemini-2.5-flash", "gemini-2.5-pro"]
+
+    @pytest.mark.asyncio
+    async def test_returns_primary_and_fallback_providers_list(self, adapter):
+        """fallback_providers: list → chain = [primary, ...providers[*].model]."""
+        fake_config = {
+            "model": {"default": "gpt-5.4"},
+            "fallback_providers": [
+                {"provider": "openai", "model": "gpt-5.4"},
+                {"provider": "gemini", "model": "gemini-2.5-pro"},
+                {"provider": "anthropic", "model": "claude-3.5-sonnet"},
+            ],
+        }
+        with patch("gateway.run._load_gateway_config", return_value=fake_config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/hermes/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] == "gpt-5.4"
+                # gpt-5.4 appears in fallback_providers as well; it must not
+                # be duplicated in the returned chain.
+                assert data["fallback_chain"] == [
+                    "gpt-5.4",
+                    "gemini-2.5-pro",
+                    "claude-3.5-sonnet",
+                ]
+
+    @pytest.mark.asyncio
+    async def test_returns_primary_only_when_no_fallback(self, adapter):
+        """No fallback configured → chain is just [primary]."""
+        fake_config = {"model": {"default": "gpt-5.4"}}
+        with patch("gateway.run._load_gateway_config", return_value=fake_config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/hermes/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] == "gpt-5.4"
+                assert data["fallback_chain"] == ["gpt-5.4"]
+
+    @pytest.mark.asyncio
+    async def test_returns_null_primary_when_config_empty(self, adapter):
+        """Empty config → null primary, empty chain (graceful 200)."""
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/hermes/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] is None
+                assert data["fallback_chain"] == []
+
+    @pytest.mark.asyncio
+    async def test_handles_load_exception_gracefully(self, adapter):
+        """Helper raises → graceful 200 with empty payload, never 500."""
+        with patch("gateway.run._load_gateway_config", side_effect=Exception("boom")):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/hermes/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] is None
+                assert data["fallback_chain"] == []
+
+    @pytest.mark.asyncio
+    async def test_supports_top_level_string_model(self, adapter):
+        """``model: <name>`` (string form) → primary resolves correctly."""
+        fake_config = {"model": "claude-3.5-sonnet"}
+        with patch("gateway.run._load_gateway_config", return_value=fake_config):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/v1/hermes/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] == "claude-3.5-sonnet"
+                assert data["fallback_chain"] == ["claude-3.5-sonnet"]
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_key_set(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/hermes/config")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_with_valid_auth(self, auth_adapter):
+        fake_config = {"model": {"default": "gemini-2.5-flash"}}
+        with patch("gateway.run._load_gateway_config", return_value=fake_config):
+            app = _create_app(auth_adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    "/v1/hermes/config",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["primary"] == "gemini-2.5-flash"
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -156,6 +156,23 @@ Delete a stored response.
 
 Lists the agent as an available model. The advertised model name defaults to the [profile](/docs/user-guide/features/profiles) name (or `hermes-agent` for the default profile). Required by most frontends for model discovery.
 
+### GET /v1/hermes/config
+
+Returns the **configured primary model and fallback chain** parsed from the gateway's `~/.hermes/config.yaml`:
+
+```json
+{
+  "primary": "gemini-2.5-flash",
+  "fallback_chain": ["gemini-2.5-flash", "gemini-2.5-pro"]
+}
+```
+
+This is distinct from `/v1/models`, which advertises the OpenAI-compatible label set by `API_SERVER_MODEL_NAME` (often a static name like `hermes-agent`). `/v1/hermes/config` returns the model the gateway will *actually* call for new requests, plus its fallback chain — useful for dashboards and remote OpenAI-compatible clients (e.g. desktop apps over a private network) that cannot read the server's local config file directly.
+
+If the config can't be parsed or contains no model, the endpoint responds with `200` and `{"primary": null, "fallback_chain": []}` so clients can fall through to other discovery strategies without special-casing error codes.
+
+Bearer token auth applies when `API_SERVER_KEY` is configured.
+
 ### GET /health
 
 Health check. Returns `{"status": "ok"}`. Also available at **GET /v1/health** for OpenAI-compatible clients that expect the `/v1/` prefix.


### PR DESCRIPTION
## Summary

Adds `GET /v1/hermes/config` to the OpenAI-compatible API server. The endpoint returns a minimal `{primary, fallback_chain}` envelope parsed from the gateway's `~/.hermes/config.yaml`, so dashboards and remote OpenAI-compatible clients can display **which model the gateway will actually call** — distinct from the `API_SERVER_MODEL_NAME` label that `/v1/models` advertises.

## Why

`/v1/models` returns the OpenAI-compatible advertised label (e.g. `hermes-agent` or whatever `API_SERVER_MODEL_NAME` is set to). For local single-machine setups that's fine, but for **remote** OpenAI-compatible clients the advertised label often doesn't match the configured primary model, and clients have no way to know which model the gateway will route to.

The concrete motivating case is a desktop client (`hermes-desktop`) that connects to a Mac mini gateway over Tailscale from a Windows laptop. Before this endpoint existed the client tried two strategies:

1. Read its own local `~/.hermes/config.yaml` (doesn't exist on a Windows laptop that's never run hermes-agent locally).
2. Fall back to `/v1/models` (returns the advertised label, not the configured primary).

Neither yields the actual configured primary, so the client's "current model" badge sat in an `unknown` state. With `/v1/hermes/config`, the client gets `{primary: "gemini-2.5-flash", fallback_chain: ["gemini-2.5-flash", "gemini-2.5-pro"]}` directly from the source of truth — the server's parsed `config.yaml`.

## Response shape

```json
{
  "primary": "gemini-2.5-flash",
  "fallback_chain": ["gemini-2.5-flash", "gemini-2.5-pro"]
}
```

- `primary` — the resolved primary model name from `model.default` (or `model.model`, or top-level `model: <string>`)
- `fallback_chain` — primary first, then any fallback models from `fallback_providers` (new list form) or `fallback_model` (legacy single dict), deduplicated and in declared order

On any error — missing config, parse failure, helper exception — the response is a graceful `200` with `{primary: null, fallback_chain: []}`. This lets clients fall through to other discovery strategies (e.g. `/v1/models`) without special-casing status codes. Existing `_check_auth()` Bearer-token flow applies, identical to `/v1/models`.

## What's in this PR

- `gateway/platforms/api_server.py`: new `_handle_hermes_config` method (lazy import of `gateway.run` helpers to avoid the existing circular import) + route registration alongside `/v1/models`.
- `tests/gateway/test_api_server.py`: new `TestHermesConfigEndpoint` class with 8 tests covering legacy `fallback_model` dict, new `fallback_providers` list with dedup, primary-only, empty config, exception handling, top-level string model form, auth required (key set), and valid-auth flow.
- `website/docs/user-guide/features/api-server.md`: doc section for the new endpoint right after `/v1/models`.

Diff stat: 3 files changed, 206 insertions(+), 0 deletions(-). Pure addition — no existing tests or code paths modified.

## Test plan

- [x] `pytest tests/gateway/test_api_server.py` — all 122 tests pass (114 pre-existing + 8 new)
- [x] TDD verified: tests written first, observed failing with clean 404s, then handler added and tests turn green
- [x] HTTP smoke test against real `~/.hermes/config.yaml` returns the expected `{primary, fallback_chain}` (not just the mocked unit-test fixture)
- [x] HTTP smoke test confirms security headers (`X-Content-Type-Options: nosniff`) flow through middleware
- [x] Dedup verified: a primary that also appears in `fallback_providers[0]` is not duplicated in the response chain

## Notes for reviewers

- The handler intentionally parses fallback config inline rather than reusing `GatewayRunner._load_fallback_model()` so it can be unit-tested without spinning up a runner. The parsing logic mirrors what `AIAgent.__init__` accepts (list of provider dicts or single dict).
- The lazy import of `_load_gateway_config` / `_resolve_gateway_model` from `gateway.run` follows the same pattern already used elsewhere in `api_server.py` to avoid the existing circular import.
- Auth uses the existing `_check_auth()` helper — no new auth surface area.