### PR TITLE
fix: handle bytes in skills bundle content hash

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Summary
- Fixes `hermes skills check` crash when a skill bundle file is already bytes.
- `bundle_content_hash` now handles both `bytes` and `str` content.

## Root cause
`tools/skills_hub.py::bundle_content_hash` unconditionally called `.encode("utf-8")`, which raises on `bytes` objects.

## Verification
- Reproduced failure locally before fix:
  - `AttributeError: 'bytes' object has no attribute 'encode'`
- After fix:
  - `hermes skills check` completes and reports update status.

## Risk
Low. Hashing logic is unchanged for `str`; now just type-safe for `bytes`.
