### PR TITLE
fix: add dedup check in WeCom callback to prevent duplicate message enqueue

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -244,6 +244,24 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                 continue
         return web.Response(status=403, text="signature verification failed")
 
+    def _is_duplicate(self, msg_id: str) -> bool:
+        """Return True if *msg_id* was already seen within the TTL window."""
+        if not msg_id:
+            return False
+        now = time.time()
+        if msg_id in self._seen_messages:
+            if now - self._seen_messages[msg_id] <= MESSAGE_DEDUP_TTL_SECONDS:
+                return True
+            # Expired — remove and allow this message
+            del self._seen_messages[msg_id]
+        self._seen_messages[msg_id] = now
+        if len(self._seen_messages) > 2000:
+            cutoff = now - MESSAGE_DEDUP_TTL_SECONDS
+            self._seen_messages = {
+                k: v for k, v in self._seen_messages.items() if v > cutoff
+            }
+        return False
+
     async def _handle_callback(self, request: web.Request) -> web.Response:
         """POST endpoint — receive an encrypted message callback."""
         msg_signature = request.query.get("msg_signature", "")
@@ -258,6 +276,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                 )
                 event = self._build_event(app, decrypted)
                 if event is not None:
+                    if self._is_duplicate(event.message_id):
+                        logger.debug(
+                            "[WecomCallback] Duplicate message %s, skipping",
+                            event.message_id,
+                        )
+                        return web.Response(text="success", content_type="text/plain")
                     # Record which app this user belongs to.
                     if event.source and event.source.user_id:
                         map_key = self._user_app_key(

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -183,3 +183,25 @@ class TestWecomCallbackPollLoop:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert calls == ["test"]
+
+
+class TestWecomCallbackDedup:
+    def test_is_duplicate_returns_false_for_new_message(self):
+        adapter = WecomCallbackAdapter(_config())
+        assert adapter._is_duplicate("msg-1") is False
+
+    def test_is_duplicate_returns_true_for_recent_message(self):
+        adapter = WecomCallbackAdapter(_config())
+        assert adapter._is_duplicate("msg-1") is False
+        assert adapter._is_duplicate("msg-1") is True
+
+    def test_is_duplicate_expires_after_ttl(self, monkeypatch):
+        import time as _time
+        adapter = WecomCallbackAdapter(_config())
+        assert adapter._is_duplicate("msg-1") is False
+
+        # Simulate time passing beyond TTL
+        fake_now = _time.time() + 400  # MESSAGE_DEDUP_TTL_SECONDS = 300
+        monkeypatch.setattr(_time, "time", lambda: fake_now)
+
+        assert adapter._is_duplicate("msg-1") is False


### PR DESCRIPTION
## Summary
WeCom callback adapter never checked its dedup cache before queueing messages, causing duplicate processing on retried callback deliveries.

## Root Cause
`_handle_callback()` had `_seen_messages` and `MESSAGE_DEDUP_TTL_SECONDS` defined but never used them. Every retry was treated as a fresh message.

## Fix
Added `_is_duplicate()` method with TTL-based dedup logic (consistent with MessageDeduplicator pattern). Called before putting events on the message queue. Duplicate messages are acknowledged but not enqueued.

## Test Plan
- [x] 3 new unit tests for dedup: new message, duplicate, TTL expiry
- [x] All 11 tests in test_wecom_callback.py pass

Closes NousResearch/hermes-agent#10305