### PR TITLE
fix: include absolute skill_dir in skill_view() result for external skills

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -72,7 +72,11 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
     skill_name = str(loaded_skill.get("name") or normalized)
     skill_path = str(loaded_skill.get("path") or "")
     skill_dir = None
-    if skill_path:
+    # Prefer the absolute skill_dir from skill_view() (works for external skills)
+    skill_dir_str = loaded_skill.get("skill_dir")
+    if skill_dir_str:
+        skill_dir = Path(skill_dir_str)
+    elif skill_path:
         try:
             skill_dir = SKILLS_DIR / Path(skill_path).parent
         except Exception:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1263,6 +1263,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             "related_skills": related_skills,
             "content": content,
             "path": rel_path,
+            "skill_dir": str(skill_dir) if skill_dir else None,
             "linked_files": linked_files if linked_files else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files


### PR DESCRIPTION
## Summary
External skills registered via `skills.external_dirs` get wrong `skill_dir` paths when loaded via `/skill` command, preventing the agent from locating skill scripts.

## Root Cause
`skill_view()` returned a relative `path` that `_load_skill_payload()` resolved against `SKILLS_DIR`. For external skills, this produced paths under `~/.hermes/skills/` instead of the actual external directory.

## Fix
- Added `skill_dir` (absolute path) to the `skill_view()` result dict
- `_load_skill_payload()` now prefers the `skill_dir` from the result over the reconstructed path

## Test Plan
- [x] tests/agent/test_skill_commands.py: 37 passed
- [x] tests/agent/test_external_skills.py: passed
- [x] tests/tools/test_skills_tool.py: 74 passed

Closes NousResearch/hermes-agent#10313