### PR TITLE
fix: produce valid JSON when truncating tool_call arguments in context compressor

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -456,7 +456,14 @@ class ContextCompressor(ContextEngine):
                 if isinstance(tc, dict):
                     args = tc.get("function", {}).get("arguments", "")
                     if len(args) > 500:
-                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
+                        # Produce valid JSON — raw truncation breaks API parsing
+                        # and permanently poisons the session in state.db
+                        truncated = json.dumps({
+                            "_truncated": True,
+                            "_original_length": len(args),
+                            "_prefix": args[:200],
+                        })
+                        tc = {**tc, "function": {**tc["function"], "arguments": truncated}}
                         modified = True
                 new_tcs.append(tc)
             if modified:


### PR DESCRIPTION
## Summary
Context compressor truncates large tool_call arguments via string slicing (`args[:200] + '...[truncated]'`), producing invalid JSON that some AI gateway servers reject with HTTP 400. The bad data persists in state.db, permanently breaking the session.

## Root Cause
The `function.arguments` field must be valid JSON per the OpenAI API spec. Raw string truncation creates unterminated JSON.

## Fix
Truncated arguments are wrapped in a valid JSON object containing `_truncated: true`, `_original_length`, and `_prefix` (first 200 chars).

## Test Plan
- [x] tests/agent/test_context_compressor.py: 40 passed

Closes NousResearch/hermes-agent#10398