### PR TITLE
feat: add self-evolution report workflow

### DIFF
--- a/agent/evolution.py
+++ b/agent/evolution.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+_ERROR_RE = re.compile(r"\b(error|failed|failure|exception|traceback|timeout|timed out|not found|invalid)\b", re.I)
+_CORRECTION_RE = re.compile(
+    r"\b(don't|do not|instead|use .* instead|should have|should've|actually|remember|stop)\b",
+    re.I,
+)
+_BLOCKAGE_RE = re.compile(r"\b(sorry|i can't|i cannot|unable to|not available|not supported|failed to)\b", re.I)
+
+
+def load_trajectory_entries(path: str | Path) -> list[dict[str, Any]]:
+    """Load JSONL trajectory entries, skipping blank and malformed rows."""
+    entries: list[dict[str, Any]] = []
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            entries.append(row)
+    return entries
+
+
+def analyze_sessions(
+    sessions: Iterable[dict[str, Any]],
+    trajectory_entries: Iterable[dict[str, Any]] | None = None,
+    min_count: int = 2,
+) -> dict[str, Any]:
+    counters: Counter[tuple[str, str]] = Counter()
+    examples: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    session_list = list(sessions)
+    for session in session_list:
+        for message in session.get("messages", []):
+            _record_message_findings(message, counters, examples)
+
+    trajectory_list = list(trajectory_entries or [])
+    for entry in trajectory_list:
+        _record_message_findings(entry, counters, examples)
+
+    findings = []
+    for (category, detail), count in sorted(counters.items(), key=lambda item: (-item[1], item[0])):
+        if count < min_count:
+            continue
+        findings.append(
+            {
+                "key": f"{category}:{detail}",
+                "category": category,
+                "label": _build_label(category, detail),
+                "count": count,
+                "examples": examples[(category, detail)][:3],
+            }
+        )
+
+    recommendations = _build_recommendations(findings)
+    prompt_deltas = _build_prompt_deltas(findings)
+
+    return {
+        "summary": {
+            "sessions_analyzed": len(session_list),
+            "trajectory_files": 1 if trajectory_list else 0,
+            "findings": len(findings),
+        },
+        "findings": findings,
+        "recommendations": recommendations,
+        "prompt_deltas": prompt_deltas,
+    }
+
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    summary = report.get("summary", {})
+    lines = [
+        "# Hermes Self-Evolution Report",
+        "",
+        f"- Sessions analyzed: {summary.get('sessions_analyzed', 0)}",
+        f"- Trajectory files analyzed: {summary.get('trajectory_files', 0)}",
+        f"- Repeated findings: {summary.get('findings', 0)}",
+        "",
+        "## Findings",
+    ]
+
+    findings = report.get("findings", [])
+    if not findings:
+        lines.extend(["", "No repeated patterns met the reporting threshold."])
+    else:
+        for finding in findings:
+            lines.append("")
+            lines.append(f"### {finding['label']} ({finding['count']}x)")
+            for example in finding.get("examples", []):
+                lines.append(f"- {example}")
+
+    lines.extend(["", "## Recommendations"])
+    recommendations = report.get("recommendations", [])
+    if recommendations:
+        lines.extend(f"- {item}" for item in recommendations)
+    else:
+        lines.append("- No recommendations yet.")
+
+    lines.extend(["", "## Candidate Prompt Deltas"])
+    prompt_deltas = report.get("prompt_deltas", [])
+    if prompt_deltas:
+        lines.extend(f"- {item}" for item in prompt_deltas)
+    else:
+        lines.append("- No prompt delta candidates yet.")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+
+def _record_message_findings(
+    message: dict[str, Any],
+    counters: Counter[tuple[str, str]],
+    examples: dict[tuple[str, str], list[str]],
+) -> None:
+    role = (message.get("role") or "").lower()
+    content = (message.get("content") or "").strip()
+    if role == "tool":
+        tool_name = (message.get("tool_name") or "").strip()
+        tool_failure = _extract_tool_failure(content, fallback_tool_name=tool_name)
+        if tool_failure is not None:
+            resolved_tool_name, example_content = tool_failure
+            _bump(("tool_failure", resolved_tool_name), example_content, counters, examples)
+    elif role == "user" and _is_user_correction(content):
+        _bump(("user_correction", "tool_choice"), content, counters, examples)
+    elif role == "assistant" and _BLOCKAGE_RE.search(content):
+        _bump(("assistant_blockage", "fallback_needed"), content, counters, examples)
+
+
+
+def _extract_tool_failure(content: str, fallback_tool_name: str = "") -> tuple[str, str] | None:
+    if not content:
+        return None
+
+    parsed = _maybe_parse_json_object(content)
+    if isinstance(parsed, dict):
+        exit_code = parsed.get("exit_code")
+        error_value = parsed.get("error")
+        success_value = parsed.get("success")
+        exit_code_meaning = str(parsed.get("exit_code_meaning") or "")
+        if success_value is True and not error_value and exit_code in (0, None):
+            return None
+        if "not an error" in exit_code_meaning.lower():
+            return None
+        if success_value is False or error_value or exit_code not in (0, None):
+            tool_name = _infer_tool_name(parsed, fallback_tool_name)
+            return tool_name, content
+        return None
+
+    if not _ERROR_RE.search(content):
+        return None
+
+    tool_name = fallback_tool_name or "unknown_tool"
+    return tool_name, content
+
+
+
+def _infer_tool_name(parsed: dict[str, Any], fallback_tool_name: str = "") -> str:
+    explicit_name = str(parsed.get("tool_name") or parsed.get("name") or fallback_tool_name or "").strip()
+    if explicit_name:
+        return explicit_name
+    if "tool_calls_made" in parsed and "duration_seconds" in parsed:
+        return "execute_code"
+    if "exit_code" in parsed and "output" in parsed:
+        return "terminal"
+    return "unknown_tool"
+
+
+
+def _is_user_correction(content: str) -> bool:
+    if not content:
+        return False
+    if content.lstrip().startswith("[SYSTEM:"):
+        return False
+    return bool(_CORRECTION_RE.search(content))
+
+
+
+def _maybe_parse_json_object(content: str) -> dict[str, Any] | None:
+    if not content.startswith("{"):
+        return None
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+
+def _bump(
+    key: tuple[str, str],
+    content: str,
+    counters: Counter[tuple[str, str]],
+    examples: dict[tuple[str, str], list[str]],
+) -> None:
+    counters[key] += 1
+    if content and len(examples[key]) < 3 and content not in examples[key]:
+        examples[key].append(content)
+
+
+
+def _build_label(category: str, detail: str) -> str:
+    if category == "tool_failure":
+        return f"Repeated failures for tool `{detail}`"
+    if category == "user_correction":
+        return "Repeated user corrections about tool choice"
+    if category == "assistant_blockage":
+        return "Repeated assistant blockage/apology responses"
+    return f"Repeated pattern: {category}:{detail}"
+
+
+
+def _build_recommendations(findings: list[dict[str, Any]]) -> list[str]:
+    recommendations: list[str] = []
+    for finding in findings:
+        if finding["category"] == "tool_failure":
+            tool_name = finding["key"].split(":", 1)[1]
+            recommendations.append(
+                f"Investigate `{tool_name}` reliability or strengthen fallback guidance."
+            )
+        elif finding["category"] == "user_correction":
+            recommendations.append(
+                "Promote recurring user corrections into durable memory or a skill if the pattern is stable."
+            )
+        elif finding["category"] == "assistant_blockage":
+            recommendations.append(
+                "Tighten action-oriented fallback guidance so the assistant switches tools before apologizing."
+            )
+    return _dedupe(recommendations)
+
+
+
+def _build_prompt_deltas(findings: list[dict[str, Any]]) -> list[str]:
+    deltas: list[str] = []
+    for finding in findings:
+        if finding["category"] == "tool_failure":
+            tool_name = finding["key"].split(":", 1)[1]
+            deltas.append(
+                f"When `{tool_name}` fails with URL/schema/runtime errors, immediately fall back to terminal or browser retrieval instead of retrying the same broken path."
+            )
+        elif finding["category"] == "user_correction":
+            deltas.append(
+                "When the user corrects tool choice or workflow, prefer saving the stable correction to memory or a skill after finishing the task."
+            )
+        elif finding["category"] == "assistant_blockage":
+            deltas.append(
+                "Before saying you cannot do something, try another available tool or explain the concrete blocked capability and the next best fallback."
+            )
+    return _dedupe(deltas)
+
+
+
+def _dedupe(items: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            ordered.append(item)
+    return ordered

--- a/docs/plans/2026-04-12-self-evolution-report-mvp.md
+++ b/docs/plans/2026-04-12-self-evolution-report-mvp.md
@@ -1,0 +1,114 @@
+# Self-Evolution Report MVP Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a first self-evolution CLI report that mines recent sessions and optional trajectory JSONL files for repeated failure/correction patterns, then emits concrete recommendations and candidate prompt deltas.
+
+**Architecture:** Create a small analysis module (`agent/evolution.py`) that ingests normalized session/trajectory records, extracts repeated patterns with simple heuristics, and renders a Markdown report. Wire it into the argparse CLI as `hermes evolve report` so it can analyze recent SQLite-backed sessions via `SessionDB` and optional external trajectory files.
+
+**Tech Stack:** Python 3.11, argparse, dataclasses, pathlib/json, existing `SessionDB`, pytest.
+
+---
+
+### Task 1: Add failing analyzer tests
+
+**Objective:** Lock in the core behavior before implementation.
+
+**Files:**
+- Create: `tests/agent/test_evolution.py`
+
+**Step 1: Write failing tests**
+- Test that repeated tool failures across sessions are counted and surfaced.
+- Test that repeated user corrections are counted and surfaced.
+- Test that Markdown rendering includes recommendations and candidate prompt deltas.
+- Test that trajectory JSONL loading tolerates blank lines and malformed JSON rows.
+
+**Step 2: Run test to verify failure**
+
+Run: `pytest tests/agent/test_evolution.py -v`
+Expected: FAIL because `agent.evolution` does not exist yet.
+
+### Task 2: Implement the analyzer module
+
+**Objective:** Add the minimal production code needed to satisfy the tests.
+
+**Files:**
+- Create: `agent/evolution.py`
+
+**Step 1: Implement normalized loaders**
+- Add helpers to load trajectory JSONL entries.
+- Add helpers to normalize session/message records.
+
+**Step 2: Implement heuristic pattern extraction**
+- Detect repeated tool failures from tool messages and failure-like content.
+- Detect repeated user corrections from user messages.
+- Detect repeated assistant blockage/apology patterns.
+
+**Step 3: Implement report rendering**
+- Produce deterministic Markdown with sections for findings, recommendations, and candidate prompt deltas.
+
+**Step 4: Run tests**
+
+Run: `pytest tests/agent/test_evolution.py -v`
+Expected: PASS.
+
+### Task 3: Add failing CLI tests
+
+**Objective:** Define the public interface for the new command before wiring it in.
+
+**Files:**
+- Create: `tests/hermes_cli/test_evolve_command.py`
+
+**Step 1: Write failing tests**
+- Test that `hermes evolve report --help` exposes the new command and key flags.
+- Test that `cmd_evolve()` writes the rendered report to stdout by default.
+- Test that `cmd_evolve()` writes to `--output` when provided.
+
+**Step 2: Run test to verify failure**
+
+Run: `pytest tests/hermes_cli/test_evolve_command.py -v`
+Expected: FAIL because the command does not exist yet.
+
+### Task 4: Implement CLI wiring
+
+**Objective:** Expose the analyzer through the main Hermes CLI.
+
+**Files:**
+- Modify: `hermes_cli/main.py`
+
+**Step 1: Add `evolve` parser**
+- Add top-level `evolve` command with `report` subcommand.
+- Support flags: `--source`, `--limit`, `--trajectory`, `--min-count`, `--output`.
+
+**Step 2: Add command handler**
+- Load recent sessions with `SessionDB.list_sessions_rich()` + `get_messages()`.
+- Optionally load trajectory files.
+- Render Markdown and print or write it.
+- Exit cleanly on errors with a concise message.
+
+**Step 3: Run CLI tests**
+
+Run: `pytest tests/hermes_cli/test_evolve_command.py -v`
+Expected: PASS.
+
+### Task 5: Regression verification
+
+**Objective:** Verify the new feature and nearby behavior together.
+
+**Files:**
+- No code changes unless tests expose regressions.
+
+**Step 1: Run targeted suite**
+
+Run: `pytest tests/agent/test_evolution.py tests/hermes_cli/test_evolve_command.py -v`
+Expected: PASS.
+
+**Step 2: Smoke test the CLI manually**
+
+Run: `python -m hermes_cli.main evolve report --help`
+Expected: help text shows the new subcommand and flags.
+
+**Step 3: Optional real-data smoke test**
+
+Run: `python -m hermes_cli.main evolve report --limit 5`
+Expected: emits a Markdown report or a concise ‘no findings yet’ report.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2816,6 +2816,46 @@ def cmd_debug(args):
     run_debug(args)
 
 
+def cmd_evolve(args):
+    """Generate self-evolution reports from recent sessions and trajectories."""
+    if getattr(args, "evolve_action", None) != "report":
+        raise SystemExit("Error: expected 'report' subcommand")
+
+    from hermes_state import SessionDB
+    from agent.evolution import analyze_sessions, load_trajectory_entries, render_markdown_report
+
+    db = SessionDB()
+    try:
+        sessions = db.list_sessions_rich(source=args.source, limit=args.limit)
+        for session in sessions:
+            session["messages"] = db.get_messages(session["id"])
+
+        trajectory_entries = []
+        for trajectory_path in getattr(args, "trajectory", []) or []:
+            trajectory_entries.extend(load_trajectory_entries(trajectory_path))
+
+        report = analyze_sessions(
+            sessions,
+            trajectory_entries=trajectory_entries,
+            min_count=args.min_count,
+        )
+        markdown = render_markdown_report(report)
+    except Exception as exc:
+        print(f"Error: failed to generate evolution report: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+    finally:
+        db.close()
+
+    output_path = getattr(args, "output", "-") or "-"
+    if output_path == "-":
+        print(markdown, end="")
+        return
+
+    target = Path(output_path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(markdown, encoding="utf-8")
+
+
 def cmd_config(args):
     """Configuration management."""
     from hermes_cli.config import config_command
@@ -5058,6 +5098,49 @@ Examples:
         help="Print the report locally instead of uploading",
     )
     debug_parser.set_defaults(func=cmd_debug)
+
+    # =========================================================================
+    # evolve command
+    # =========================================================================
+    evolve_parser = subparsers.add_parser(
+        "evolve",
+        help="Self-evolution report tools",
+        description="Analyze recent sessions and optional trajectories for repeated failure patterns",
+    )
+    evolve_subparsers = evolve_parser.add_subparsers(dest="evolve_action")
+    evolve_report = evolve_subparsers.add_parser(
+        "report",
+        help="Generate a Markdown self-evolution report",
+    )
+    evolve_report.add_argument(
+        "--source",
+        default=None,
+        help="Session source tag to analyze (default: all sources)",
+    )
+    evolve_report.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Number of recent sessions to analyze (default: 20)",
+    )
+    evolve_report.add_argument(
+        "--trajectory",
+        action="append",
+        default=[],
+        help="Optional trajectory JSONL file to include (repeat flag for multiple files)",
+    )
+    evolve_report.add_argument(
+        "--min-count",
+        type=int,
+        default=2,
+        help="Minimum repeated count required to surface a finding (default: 2)",
+    )
+    evolve_report.add_argument(
+        "--output", "-o",
+        default="-",
+        help="Write report to this path instead of stdout ('-' for stdout)",
+    )
+    evolve_report.set_defaults(func=cmd_evolve)
 
     # =========================================================================
     # backup command

--- a/tests/agent/test_evolution.py
+++ b/tests/agent/test_evolution.py
@@ -1,0 +1,225 @@
+import json
+
+from agent.evolution import (
+    analyze_sessions,
+    load_trajectory_entries,
+    render_markdown_report,
+)
+
+
+def test_analyze_sessions_surfaces_repeated_tool_failures_and_user_corrections():
+    sessions = [
+        {
+            "id": "s1",
+            "messages": [
+                {"role": "tool", "tool_name": "web_extract", "content": "Error: Invalid URL '/v2/scrape'"},
+                {"role": "user", "content": "Use terminal/python requests instead of web_extract."},
+            ],
+        },
+        {
+            "id": "s2",
+            "messages": [
+                {"role": "tool", "tool_name": "web_extract", "content": "Failed: Invalid URL '/v2/scrape'"},
+                {"role": "user", "content": "Don't use web_extract here; use requests."},
+            ],
+        },
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "tool_failure:web_extract" in finding_keys
+    assert "user_correction:tool_choice" in finding_keys
+
+    tool_failure = next(f for f in report["findings"] if f["key"] == "tool_failure:web_extract")
+    assert tool_failure["count"] == 2
+    assert any("Invalid URL" in example for example in tool_failure["examples"])
+
+
+def test_analyze_sessions_ignores_successful_tool_payloads_that_only_mention_errors_in_embedded_docs():
+    sessions = [
+        {
+            "id": "s1",
+            "messages": [
+                {
+                    "role": "tool",
+                    "content": json.dumps(
+                        {
+                            "success": True,
+                            "name": "skill_view",
+                            "content": "Docs mention error handling and invalid commands, but the tool call succeeded.",
+                        }
+                    ),
+                }
+            ],
+        },
+        {
+            "id": "s2",
+            "messages": [
+                {
+                    "role": "tool",
+                    "content": json.dumps(
+                        {
+                            "success": True,
+                            "name": "skill_view",
+                            "content": "Another successful payload that mentions failure modes in documentation.",
+                        }
+                    ),
+                }
+            ],
+        },
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "tool_failure:unknown_tool" not in finding_keys
+    assert "tool_failure:skill_view" not in finding_keys
+
+
+def test_analyze_sessions_ignores_scheduler_wrapper_prompts_as_user_corrections():
+    scheduler_wrapper = (
+        "[SYSTEM: You are running as a scheduled cron job. DELIVERY: Your final response will be automatically delivered to the user.]\n\n"
+        "Produce a daily Hermes self-evolution report and use terminal instead of web_extract if needed."
+    )
+    sessions = [
+        {"id": "s1", "messages": [{"role": "user", "content": scheduler_wrapper}]},
+        {"id": "s2", "messages": [{"role": "user", "content": scheduler_wrapper}]},
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "user_correction:tool_choice" not in finding_keys
+
+
+def test_analyze_sessions_ignores_successful_terminal_payloads_even_if_output_mentions_errors():
+    successful_payload = json.dumps(
+        {
+            "output": "# Hermes Self-Evolution Report\nThis output mentions hermes: error: invalid choice and other failure examples.",
+            "exit_code": 0,
+            "error": None,
+        }
+    )
+    sessions = [
+        {"id": "s1", "messages": [{"role": "tool", "content": successful_payload}]},
+        {"id": "s2", "messages": [{"role": "tool", "content": successful_payload}]},
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "tool_failure:unknown_tool" not in finding_keys
+
+
+def test_analyze_sessions_labels_terminal_failures_when_terminal_payload_lacks_tool_name():
+    terminal_failure = json.dumps(
+        {
+            "output": "/usr/bin/bash: line 3: python: command not found",
+            "exit_code": 127,
+            "error": None,
+        }
+    )
+    sessions = [
+        {"id": "s1", "messages": [{"role": "tool", "content": terminal_failure}]},
+        {"id": "s2", "messages": [{"role": "tool", "content": terminal_failure}]},
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "tool_failure:terminal" in finding_keys
+    assert "tool_failure:unknown_tool" not in finding_keys
+
+
+def test_analyze_sessions_ignores_terminal_non_error_exit_code_meanings():
+    non_error_payload = json.dumps(
+        {
+            "output": "",
+            "exit_code": 1,
+            "error": None,
+            "exit_code_meaning": "No matches found (not an error)",
+        }
+    )
+    sessions = [
+        {"id": "s1", "messages": [{"role": "tool", "content": non_error_payload}]},
+        {"id": "s2", "messages": [{"role": "tool", "content": non_error_payload}]},
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "tool_failure:terminal" not in finding_keys
+    assert "tool_failure:unknown_tool" not in finding_keys
+
+
+def test_analyze_sessions_labels_execute_code_failures_when_payload_matches_sandbox_shape():
+    execute_code_failure = json.dumps(
+        {
+            "status": "error",
+            "output": "Traceback... ModuleNotFoundError: No module named 'llama_cpp'",
+            "tool_calls_made": 0,
+            "duration_seconds": 0.21,
+            "error": "Traceback... ModuleNotFoundError: No module named 'llama_cpp'",
+        }
+    )
+    sessions = [
+        {"id": "s1", "messages": [{"role": "tool", "content": execute_code_failure}]},
+        {"id": "s2", "messages": [{"role": "tool", "content": execute_code_failure}]},
+    ]
+
+    report = analyze_sessions(sessions, min_count=2)
+
+    finding_keys = {finding["key"] for finding in report["findings"]}
+    assert "tool_failure:execute_code" in finding_keys
+    assert "tool_failure:unknown_tool" not in finding_keys
+
+
+def test_render_markdown_report_includes_recommendations_and_prompt_deltas():
+    report = {
+        "summary": {"sessions_analyzed": 2, "trajectory_files": 1, "findings": 2},
+        "findings": [
+            {
+                "key": "tool_failure:web_extract",
+                "category": "tool_failure",
+                "label": "Repeated failures for tool `web_extract`",
+                "count": 2,
+                "examples": ["Error: Invalid URL '/v2/scrape'"],
+            }
+        ],
+        "recommendations": [
+            "Investigate `web_extract` reliability or strengthen fallback guidance.",
+        ],
+        "prompt_deltas": [
+            "When `web_extract` fails with URL/schema errors, immediately fall back to terminal or browser retrieval.",
+        ],
+    }
+
+    markdown = render_markdown_report(report)
+
+    assert "# Hermes Self-Evolution Report" in markdown
+    assert "Repeated failures for tool `web_extract`" in markdown
+    assert "## Recommendations" in markdown
+    assert "## Candidate Prompt Deltas" in markdown
+    assert "fall back to terminal or browser retrieval" in markdown
+
+
+def test_load_trajectory_entries_skips_blank_and_malformed_lines(tmp_path):
+    path = tmp_path / "trajectory.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"role": "assistant", "content": "Sorry, I can't do that."}),
+                "",
+                "{not json}",
+                json.dumps({"role": "tool", "tool_name": "browser", "content": "Timeout error"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    entries = load_trajectory_entries(path)
+
+    assert len(entries) == 2
+    assert entries[0]["role"] == "assistant"
+    assert entries[1]["tool_name"] == "browser"

--- a/tests/hermes_cli/test_evolve_command.py
+++ b/tests/hermes_cli/test_evolve_command.py
@@ -1,0 +1,98 @@
+import argparse
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+import hermes_cli.main as main_mod
+
+
+class _FakeSessionDB:
+    def list_sessions_rich(self, source=None, limit=20, **kwargs):
+        return [{"id": "sess-1", "source": source or "cli"}]
+
+    def get_messages(self, session_id):
+        assert session_id == "sess-1"
+        return [
+            {"role": "tool", "tool_name": "web_extract", "content": "Error: Invalid URL '/v2/scrape'"},
+            {"role": "user", "content": "Use requests instead of web_extract."},
+        ]
+
+    def close(self):
+        return None
+
+
+class _FakeEvolutionModule:
+    @staticmethod
+    def analyze_sessions(sessions, trajectory_entries=None, min_count=2):
+        assert sessions[0]["id"] == "sess-1"
+        assert min_count == 2
+        return {
+            "summary": {"sessions_analyzed": len(sessions), "trajectory_files": 0, "findings": 1},
+            "findings": [],
+            "recommendations": ["do something"],
+            "prompt_deltas": ["tighten fallback"],
+        }
+
+    @staticmethod
+    def render_markdown_report(report):
+        return "# Hermes Self-Evolution Report\n\n- ok\n"
+
+    @staticmethod
+    def load_trajectory_entries(path):
+        raise AssertionError("trajectory loading not expected in this test")
+
+
+def test_evolve_report_help_includes_key_flags(capsys, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["hermes", "evolve", "report", "--help"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main()
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "hermes evolve report" in out
+    assert "--source" in out
+    assert "--trajectory" in out
+    assert "--min-count" in out
+    assert "--output" in out
+
+
+def test_cmd_evolve_prints_report_to_stdout(monkeypatch, capsys):
+    fake_hermes_state = MagicMock(SessionDB=lambda: _FakeSessionDB())
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+    monkeypatch.setitem(sys.modules, "agent.evolution", _FakeEvolutionModule)
+
+    args = argparse.Namespace(
+        evolve_action="report",
+        source="cli",
+        limit=5,
+        trajectory=[],
+        min_count=2,
+        output="-",
+    )
+
+    main_mod.cmd_evolve(args)
+
+    out = capsys.readouterr().out
+    assert "# Hermes Self-Evolution Report" in out
+
+
+def test_cmd_evolve_writes_report_to_file(monkeypatch, tmp_path):
+    fake_hermes_state = MagicMock(SessionDB=lambda: _FakeSessionDB())
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_hermes_state)
+    monkeypatch.setitem(sys.modules, "agent.evolution", _FakeEvolutionModule)
+
+    output_path = tmp_path / "report.md"
+    args = argparse.Namespace(
+        evolve_action="report",
+        source=None,
+        limit=5,
+        trajectory=[],
+        min_count=2,
+        output=str(output_path),
+    )
+
+    main_mod.cmd_evolve(args)
+
+    assert output_path.read_text(encoding="utf-8").startswith("# Hermes Self-Evolution Report")


### PR DESCRIPTION
## Summary
- add structured self-evolution analysis and markdown rendering
- wire `hermes evolve report` into the CLI
- add regression coverage for analyzer classification and CLI behavior

## Testing
- `source venv/bin/activate && pytest tests/hermes_cli/test_evolve_command.py tests/agent/test_evolution.py -q`
- `source venv/bin/activate && python -m hermes_cli.main evolve report --help`
- `source venv/bin/activate && python -m hermes_cli.main evolve report --limit 5`
