### PR TITLE
fix(feishu): patch approval cards after button resolution

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -66,6 +66,8 @@ try:
         GetMessageRequest,
         GetMessageResourceRequest,
         P2ImMessageMessageReadV1,
+        PatchMessageRequest,
+        PatchMessageRequestBody,
         ReplyMessageRequest,
         ReplyMessageRequestBody,
         UpdateMessageRequest,
@@ -1455,7 +1457,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 }
 
             card = {
-                "config": {"wide_screen_mode": True},
+                "config": {"wide_screen_mode": True, "update_multi": True},
                 "header": {
                     "title": {"content": "⚠️ Command Approval Required", "tag": "plain_text"},
                     "template": "orange",
@@ -1506,7 +1508,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         icon = "❌" if choice == "deny" else "✅"
         card = {
-            "config": {"wide_screen_mode": True},
+            "config": {"wide_screen_mode": True, "update_multi": True},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
@@ -1520,9 +1522,9 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         try:
             payload = json.dumps(card, ensure_ascii=False)
-            body = self._build_update_message_body(msg_type="interactive", content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            await asyncio.to_thread(self._client.im.v1.message.update, request)
+            body = self._build_patch_message_body(content=payload)
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            await asyncio.to_thread(self._client.im.v1.message.patch, request)
         except Exception as exc:
             logger.warning("[Feishu] Failed to update approval card %s: %s", message_id, exc)
 
@@ -1957,12 +1959,35 @@ class FeishuAdapter(BasePlatformAdapter):
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
+        if isinstance(action_value, str):
+            try:
+                action_value = json.loads(action_value)
+            except Exception:
+                logger.debug("[Feishu] Card action value is non-JSON string: %r", action_value)
+                action_value = {}
 
         # --- Exec approval button intercept ---
         hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
         if hermes_action:
             approval_id = action_value.get("approval_id")
-            state = self._approval_state.pop(approval_id, None)
+            lookup_keys = []
+            if approval_id is not None:
+                lookup_keys.extend([approval_id, str(approval_id)])
+                try:
+                    lookup_keys.append(int(str(approval_id)))
+                except Exception:
+                    pass
+
+            state = None
+            seen_lookup = set()
+            for key in lookup_keys:
+                marker = (type(key), str(key))
+                if marker in seen_lookup:
+                    continue
+                seen_lookup.add(marker)
+                state = self._approval_state.pop(key, None)
+                if state:
+                    break
             if not state:
                 logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
                 return
@@ -3537,6 +3562,23 @@ class FeishuAdapter(BasePlatformAdapter):
         if "UpdateMessageRequest" in globals():
             return (
                 UpdateMessageRequest.builder()
+                .message_id(message_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        if "PatchMessageRequestBody" in globals():
+            return PatchMessageRequestBody.builder().content(content).build()
+        return SimpleNamespace(content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        if "PatchMessageRequest" in globals():
+            return (
+                PatchMessageRequest.builder()
                 .message_id(message_id)
                 .request_body(request_body)
                 .build()

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -111,6 +111,7 @@ class TestFeishuExecApproval:
         # Verify card payload contains the command and buttons
         card = json.loads(kwargs["payload"])
         assert card["header"]["template"] == "orange"
+        assert card["config"]["update_multi"] is True
         assert "rm -rf /important" in card["elements"][0]["content"]
         assert "dangerous deletion" in card["elements"][0]["content"]
 
@@ -293,6 +294,34 @@ class TestFeishuApprovalCallback:
         mock_update.assert_called_once_with("msg_003", "Approved for session", "Bob", "session")
 
     @pytest.mark.asyncio
+    async def test_resolves_when_action_value_is_json_string_and_id_is_string(self):
+        adapter = _make_adapter()
+        adapter._approval_state[5] = {
+            "session_key": "sess-5",
+            "message_id": "msg_005",
+            "chat_id": "oc_500",
+        }
+
+        data = _make_card_action_data(
+            action_value=json.dumps({"hermes_action": "approve_once", "approval_id": "5"}),
+            token="tok_json_string",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u", "user_name": "Eve", "user_id_alt": None},
+            ),
+            patch.object(adapter, "_update_approval_card", new_callable=AsyncMock) as mock_update,
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_resolve.assert_called_once_with("sess-5", "once")
+        mock_update.assert_called_once_with("msg_005", "Approved once", "Eve", "once")
+        assert 5 not in adapter._approval_state
+
+    @pytest.mark.asyncio
     async def test_always_approval(self):
         adapter = _make_adapter()
         adapter._approval_state[4] = {
@@ -374,8 +403,7 @@ class TestFeishuUpdateApprovalCard:
     async def test_updates_card_on_approve(self):
         adapter = _make_adapter()
 
-        mock_update = AsyncMock()
-        adapter._client.im.v1.message.update = MagicMock()
+        adapter._client.im.v1.message.patch = MagicMock()
 
         with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
             await adapter._update_approval_card(
@@ -383,13 +411,18 @@ class TestFeishuUpdateApprovalCard:
             )
 
         mock_thread.assert_called_once()
-        # Verify the update request was built
+        # Verify the patch request was built
         call_args = mock_thread.call_args
-        assert call_args[0][0] == adapter._client.im.v1.message.update
+        assert call_args[0][0] == adapter._client.im.v1.message.patch
+        request = call_args[0][1]
+        payload = json.loads(request.request_body.content)
+        assert payload["config"]["update_multi"] is True
 
     @pytest.mark.asyncio
     async def test_updates_card_on_deny(self):
         adapter = _make_adapter()
+
+        adapter._client.im.v1.message.patch = MagicMock()
 
         with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
             await adapter._update_approval_card(
@@ -397,6 +430,8 @@ class TestFeishuUpdateApprovalCard:
             )
 
         mock_thread.assert_called_once()
+        call_args = mock_thread.call_args
+        assert call_args[0][0] == adapter._client.im.v1.message.patch
 
     @pytest.mark.asyncio
     async def test_skips_update_when_not_connected(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the Feishu command-approval card flow after a button click.

Previously, the card-resolution path could fail to match the pending approval when Feishu delivered `action.value` as a JSON string and/or returned `approval_id` as a string. The follow-up card update also used `message.update`, which is less suitable for mutating the existing interactive card after a button click. This change makes the callback path tolerant to those payload shapes and patches the original card in place after resolution.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- In `gateway/platforms/feishu.py`:
  - enable `update_multi` on approval cards so they can be updated after an action
  - switch approval-card mutation from `message.update` to `message.patch`
  - parse stringified `action.value` payloads in card callbacks
  - resolve approvals even when `approval_id` arrives as a string instead of an int
  - add request builders for Feishu patch-message requests
- In `tests/gateway/test_feishu_approval_buttons.py`:
  - assert `update_multi=True` is present on approval cards
  - cover JSON-string `action.value` with string `approval_id`
  - update approval-card tests to expect `message.patch`

## How to Test

1. Run `source venv/bin/activate && python -m pytest tests/gateway/test_feishu_approval_buttons.py -q`
2. Confirm all 17 tests pass.
3. In Feishu, trigger a dangerous-command approval card and click an approval/deny button.
4. Confirm the pending approval resolves and the original card is patched to the final approved/denied state.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ source venv/bin/activate && python -m pytest tests/gateway/test_feishu_approval_buttons.py -q
.................                                                        [100%]
17 passed in 1.52s
```
