### PR TITLE
feat(skills): add jMunch MCP suite — token-efficient code/doc/data retrieval

### DIFF
--- a/optional-skills/mcp/jmunch/README.md
+++ b/optional-skills/mcp/jmunch/README.md
@@ -1,0 +1,47 @@
+# jMunch MCP Suite — Optional Skill for Hermes Agent
+
+Token-efficient retrieval for **code**, **documentation**, and **tabular data** via three MCP servers.
+
+## What's Included
+
+| Server | PyPI Package | Tools | Domain |
+|--------|-------------|-------|--------|
+| jCodeMunch | `jcodemunch-mcp` | 52 | Code intelligence (70+ languages) |
+| jDocMunch | `jdocmunch-mcp` | 13 | Documentation retrieval |
+| jDataMunch | `jdatamunch-mcp` | 18 | Tabular data (CSV/Excel/Parquet) |
+
+## Quick Setup
+
+1. **Install** (pick what you need):
+
+```bash
+pip install jcodemunch-mcp jdocmunch-mcp jdatamunch-mcp
+```
+
+2. **Configure** `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  jcodemunch:
+    command: "uvx"
+    args: ["jcodemunch-mcp"]
+  jdocmunch:
+    command: "uvx"
+    args: ["jdocmunch-mcp"]
+  jdatamunch:
+    command: "uvx"
+    args: ["jdatamunch-mcp"]
+```
+
+3. **Restart Hermes** and start using the tools.
+
+## Benchmarks
+
+- **37x** fewer tokens vs raw file reading
+- **19.6x** fewer tool calls
+- **12.4 billion** tokens saved across all users
+
+## Links
+
+- [jCodeMunch](https://github.com/jgravelle/jcodemunch-mcp) | [jDocMunch](https://github.com/jgravelle/jdocmunch-mcp) | [jDataMunch](https://github.com/jgravelle/jdatamunch-mcp)
+- [jMRI Specification](https://github.com/jgravelle/mcp-retrieval-spec) (Apache 2.0)

--- a/optional-skills/mcp/jmunch/SKILL.md
+++ b/optional-skills/mcp/jmunch/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: jmunch
+description: Token-efficient code, documentation, and tabular data retrieval using the jMunch MCP suite (jCodeMunch, jDocMunch, jDataMunch). Use when navigating unfamiliar codebases, searching documentation, profiling CSV/Excel data, or performing impact analysis before edits. Reduces token consumption by up to 37x compared to raw file reading.
+version: 1.0.0
+author: jgravelle
+license: MIT
+metadata:
+  hermes:
+    tags: [MCP, Code Intelligence, Documentation, Data Analysis, Retrieval, AST, Token Efficiency]
+    homepage: https://github.com/jgravelle/jcodemunch-mcp
+    related_skills: [native-mcp]
+prerequisites:
+  commands: [uvx]
+---
+
+# jMunch MCP Suite
+
+Token-efficient retrieval for code, documentation, and tabular data. The jMunch suite provides three MCP servers that index your sources and serve precise, minimal-token responses instead of dumping entire files into context.
+
+**Benchmarks:** 37x fewer tokens, 19.6x fewer tool calls vs raw file reading. Over 12.4 billion tokens saved across all users.
+
+## When to Use
+
+Use this skill when the task involves:
+
+- navigating or understanding an unfamiliar codebase
+- searching for functions, classes, or symbols across a project
+- reading documentation without pulling entire files into context
+- profiling CSV, Excel, Parquet, or JSONL data files
+- checking the impact or blast radius of a code change before editing
+- understanding dependency graphs, class hierarchies, or call chains
+- finding dead code, untested symbols, or architectural violations
+
+Do **not** use this skill when:
+
+- you need to edit a file (read the file directly for edits)
+- the project has fewer than ~5 files (raw reads are fine for tiny projects)
+
+## Prerequisites
+
+Install the jMunch MCP servers. All three are optional -- install only what you need:
+
+```bash
+# Code intelligence (70+ languages via tree-sitter AST parsing)
+pip install jcodemunch-mcp
+
+# Documentation retrieval (Markdown, RST, AsciiDoc, Jupyter, HTML, OpenAPI)
+pip install jdocmunch-mcp
+
+# Tabular data (CSV, Excel, Parquet, JSONL)
+pip install jdatamunch-mcp
+```
+
+Or use `uvx` to run without installing (configured in Hermes config below).
+
+## Configuration
+
+Add to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  jcodemunch:
+    command: "uvx"
+    args: ["jcodemunch-mcp"]
+  jdocmunch:
+    command: "uvx"
+    args: ["jdocmunch-mcp"]
+  jdatamunch:
+    command: "uvx"
+    args: ["jdatamunch-mcp"]
+```
+
+Restart Hermes. Tools will be registered with prefixes `mcp_jcodemunch_*`, `mcp_jdocmunch_*`, and `mcp_jdatamunch_*`.
+
+## Core Workflow: Discover, Search, Retrieve
+
+All three servers follow the same pattern from the jMRI (jMunch Retrieval Interface) specification:
+
+1. **Discover** what's indexed: `list_repos` / `list_datasets`
+2. **Search** for what you need: `search_symbols` / `search_sections` / `search_data`
+3. **Retrieve** the precise result: `get_symbol_source` / `get_section` / `get_rows`
+
+Never read entire files when an index exists. The whole point is minimal-token, precise retrieval.
+
+---
+
+## jCodeMunch — Code Intelligence
+
+52 tools for navigating codebases in 70+ programming languages.
+
+### Index a Project
+
+Before searching, the project must be indexed:
+
+```
+# Index a local folder
+index_folder(folder_path="/path/to/project")
+
+# Index a GitHub repo
+index_repo(repo_url="https://github.com/owner/repo")
+
+# Check what's already indexed
+list_repos()
+```
+
+### Find and Read Code
+
+```
+# Search for symbols by name or description
+search_symbols(repo="owner/repo", query="authentication middleware")
+
+# Get the exact source code of a symbol
+get_symbol_source(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+
+# Get a file's structure without reading the whole file
+get_file_outline(repo="owner/repo", file_path="src/auth.py")
+
+# Browse the project tree
+get_file_tree(repo="owner/repo")
+```
+
+### Understand Relationships
+
+```
+# Who imports this module?
+find_importers(repo="owner/repo", file_path="src/auth.py")
+
+# Find all references to a symbol
+find_references(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+
+# Get the class inheritance hierarchy
+get_class_hierarchy(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+
+# Trace call chains
+get_call_hierarchy(repo="owner/repo", symbol_id="src/auth.py::authenticate")
+```
+
+### Before You Edit: Impact Analysis
+
+Always check impact before modifying code:
+
+```
+# What breaks if I change this symbol?
+get_blast_radius(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+
+# Is it safe to rename this?
+check_rename_safe(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware", new_name="AuthHandler")
+
+# Preview the full impact of a change
+get_impact_preview(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+```
+
+### Code Quality
+
+```
+# Find dead code
+find_dead_code(repo="owner/repo")
+
+# Get complexity metrics for a symbol
+get_symbol_complexity(repo="owner/repo", symbol_id="src/auth.py::authenticate")
+
+# Find hotspots (high churn + high complexity)
+get_hotspots(repo="owner/repo")
+
+# Check for dependency cycles
+get_dependency_cycles(repo="owner/repo")
+
+# Find untested symbols
+get_untested_symbols(repo="owner/repo")
+```
+
+### Budgeted Context Assembly
+
+When you need comprehensive context within a token budget:
+
+```
+# Get the most relevant context for a query, ranked and budgeted
+get_ranked_context(repo="owner/repo", query="how does auth work", max_tokens=4000)
+
+# Get a symbol with all its imports and dependencies as a bundle
+get_context_bundle(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+```
+
+---
+
+## jDocMunch — Documentation Retrieval
+
+13 tools for structured documentation search and retrieval.
+
+### Index Documentation
+
+```
+# Index a local docs folder
+index_local(folder_path="/path/to/docs")
+
+# Index a GitHub repo's docs
+doc_index_repo(repo_url="https://github.com/owner/repo")
+
+# Check what's indexed
+doc_list_repos()
+```
+
+### Search and Read
+
+```
+# Search for documentation sections
+search_sections(repo="owner/repo", query="authentication setup")
+
+# Get a specific section by ID (minimal tokens)
+get_section(repo="owner/repo", section_id="docs/auth.md::setup")
+
+# Get multiple related sections
+get_sections(repo="owner/repo", section_ids=["docs/auth.md::setup", "docs/auth.md::configuration"])
+
+# Get a section with surrounding context
+get_section_context(repo="owner/repo", section_id="docs/auth.md::setup")
+```
+
+### Navigate Document Structure
+
+```
+# Table of contents
+get_toc(repo="owner/repo")
+
+# Full hierarchical TOC tree
+get_toc_tree(repo="owner/repo")
+
+# Outline of a specific document
+get_document_outline(repo="owner/repo", file_path="docs/auth.md")
+```
+
+### Documentation Quality
+
+```
+# Find broken links
+get_broken_links(repo="owner/repo")
+
+# Check documentation coverage
+get_doc_coverage(repo="owner/repo")
+```
+
+---
+
+## jDataMunch — Tabular Data Analysis
+
+18 tools for CSV, Excel, Parquet, and JSONL exploration.
+
+### Index Data Files
+
+```
+# Index a local CSV, Excel, or Parquet file
+index_local(file_path="/path/to/data.csv")
+
+# Check what's indexed
+list_datasets()
+```
+
+### Explore and Profile
+
+```
+# Dataset overview (row count, columns, types, size)
+describe_dataset(dataset="data")
+
+# Deep column profiling (cardinality, nulls, min/max, distribution)
+describe_column(dataset="data", column="status")
+
+# Sample rows to understand the data
+sample_rows(dataset="data", n=10)
+```
+
+### Query and Analyze
+
+```
+# Filter rows with conditions
+get_rows(dataset="data", where="status = 'active'", limit=20)
+
+# Full-text search across all columns
+search_data(dataset="data", query="error timeout")
+
+# Server-side aggregations (COUNT, SUM, AVG, MIN, MAX, MEDIAN)
+aggregate(dataset="data", group_by="category", metrics=["count", "avg:price"])
+
+# Cross-dataset SQL JOINs
+join_datasets(left="orders", right="customers", on="customer_id", join_type="inner")
+```
+
+### Data Quality
+
+```
+# Find null hotspots, low-cardinality columns, outlier risks
+get_data_hotspots(dataset="data")
+
+# Pearson correlations between numeric columns
+get_correlations(dataset="data")
+
+# Check for schema drift between dataset versions
+get_schema_drift(dataset_a="data_v1", dataset_b="data_v2")
+```
+
+---
+
+## Combined Workflow Example
+
+**Task:** "Understand how the payment pipeline processes transactions"
+
+```
+# 1. Search code for payment-related symbols
+search_symbols(repo="myapp", query="payment pipeline transaction")
+
+# 2. Read the key function
+get_symbol_source(repo="myapp", symbol_id="src/payments/processor.py::PaymentProcessor.process")
+
+# 3. Check who calls it
+get_call_hierarchy(repo="myapp", symbol_id="src/payments/processor.py::PaymentProcessor.process")
+
+# 4. Find the documentation
+search_sections(repo="myapp", query="payment processing architecture")
+
+# 5. Read the relevant doc section
+get_section(repo="myapp", section_id="docs/architecture.md::payment-flow")
+
+# 6. Profile the transaction data
+index_local(file_path="/data/transactions.csv")
+describe_dataset(dataset="transactions")
+aggregate(dataset="transactions", group_by="status", metrics=["count", "avg:amount"])
+```
+
+This gives you a complete picture: code structure, call flow, documentation context, and actual data characteristics -- all with minimal token usage.
+
+## Token Savings
+
+Every jMunch response includes a `_meta` block with `tokens_saved` -- the difference between naive file reading and indexed retrieval. Report this to the user when relevant:
+
+> "Retrieved the `PaymentProcessor` class (342 tokens) instead of reading the full file (18,400 tokens). Saved 18,058 tokens (98% reduction)."
+
+## Troubleshooting
+
+### Tools not appearing after config change
+
+Restart Hermes completely. MCP servers connect at startup.
+
+### "repo not found" errors
+
+The project needs to be indexed first. Run `list_repos()` to check what's indexed, then `index_folder()` or `index_repo()` to index.
+
+### Stale results after code changes
+
+Run `index_folder()` again to re-index. jMunch detects changed files and only re-indexes what's different.
+
+## References
+
+- **jCodeMunch:** [PyPI](https://pypi.org/project/jcodemunch-mcp/) | [GitHub](https://github.com/jgravelle/jcodemunch-mcp)
+- **jDocMunch:** [PyPI](https://pypi.org/project/jdocmunch-mcp/) | [GitHub](https://github.com/jgravelle/jdocmunch-mcp)
+- **jDataMunch:** [PyPI](https://pypi.org/project/jdatamunch-mcp/) | [GitHub](https://github.com/jgravelle/jdatamunch-mcp)
+- **jMRI Spec:** [GitHub](https://github.com/jgravelle/mcp-retrieval-spec) (Apache 2.0)

--- a/optional-skills/mcp/jmunch/SKILL.md
+++ b/optional-skills/mcp/jmunch/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: jmunch
-description: Token-efficient code, documentation, and tabular data retrieval using the jMunch MCP suite (jCodeMunch, jDocMunch, jDataMunch). Use when navigating unfamiliar codebases, searching documentation, profiling CSV/Excel data, or performing impact analysis before edits. Reduces token consumption by up to 37x compared to raw file reading.
+description: Token-efficient code, docs, and tabular data retrieval.
 version: 1.0.0
-author: jgravelle
+author: J. Gravelle (jgravelle)
 license: MIT
 metadata:
   hermes:
@@ -70,15 +70,15 @@ mcp_servers:
     args: ["jdatamunch-mcp"]
 ```
 
-Restart Hermes. Tools will be registered with prefixes `mcp_jcodemunch_*`, `mcp_jdocmunch_*`, and `mcp_jdatamunch_*`.
+Restart Hermes. Hermes registers each server's tools as `mcp__<server>__<tool>`, so the tools appear as `mcp__jcodemunch__*`, `mcp__jdocmunch__*`, and `mcp__jdatamunch__*`. Every example below uses that convention -- call the tools by their prefixed names.
 
 ## Core Workflow: Discover, Search, Retrieve
 
 All three servers follow the same pattern from the jMRI (jMunch Retrieval Interface) specification:
 
-1. **Discover** what's indexed: `list_repos` / `list_datasets`
-2. **Search** for what you need: `search_symbols` / `search_sections` / `search_data`
-3. **Retrieve** the precise result: `get_symbol_source` / `get_section` / `get_rows`
+1. **Discover** what's indexed: `mcp__jcodemunch__list_repos` / `mcp__jdatamunch__list_datasets`
+2. **Search** for what you need: `mcp__jcodemunch__search_symbols` / `mcp__jdocmunch__search_sections` / `mcp__jdatamunch__search_data`
+3. **Retrieve** the precise result: `mcp__jcodemunch__get_symbol_source` / `mcp__jdocmunch__get_section` / `mcp__jdatamunch__get_rows`
 
 Never read entire files when an index exists. The whole point is minimal-token, precise retrieval.
 
@@ -86,7 +86,7 @@ Never read entire files when an index exists. The whole point is minimal-token, 
 
 ## jCodeMunch — Code Intelligence
 
-52 tools for navigating codebases in 70+ programming languages.
+Tools for navigating codebases in 70+ programming languages, registered under the `mcp__jcodemunch__` prefix.
 
 ### Index a Project
 
@@ -94,45 +94,45 @@ Before searching, the project must be indexed:
 
 ```
 # Index a local folder
-index_folder(folder_path="/path/to/project")
+mcp__jcodemunch__index_folder(folder_path="/path/to/project")
 
 # Index a GitHub repo
-index_repo(repo_url="https://github.com/owner/repo")
+mcp__jcodemunch__index_repo(repo_url="https://github.com/owner/repo")
 
 # Check what's already indexed
-list_repos()
+mcp__jcodemunch__list_repos()
 ```
 
 ### Find and Read Code
 
 ```
 # Search for symbols by name or description
-search_symbols(repo="owner/repo", query="authentication middleware")
+mcp__jcodemunch__search_symbols(repo="owner/repo", query="authentication middleware")
 
 # Get the exact source code of a symbol
-get_symbol_source(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+mcp__jcodemunch__get_symbol_source(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
 
 # Get a file's structure without reading the whole file
-get_file_outline(repo="owner/repo", file_path="src/auth.py")
+mcp__jcodemunch__get_file_outline(repo="owner/repo", file_path="src/auth.py")
 
 # Browse the project tree
-get_file_tree(repo="owner/repo")
+mcp__jcodemunch__get_file_tree(repo="owner/repo")
 ```
 
 ### Understand Relationships
 
 ```
 # Who imports this module?
-find_importers(repo="owner/repo", file_path="src/auth.py")
+mcp__jcodemunch__find_importers(repo="owner/repo", file_path="src/auth.py")
 
 # Find all references to a symbol
-find_references(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+mcp__jcodemunch__find_references(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
 
 # Get the class inheritance hierarchy
-get_class_hierarchy(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+mcp__jcodemunch__get_class_hierarchy(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
 
 # Trace call chains
-get_call_hierarchy(repo="owner/repo", symbol_id="src/auth.py::authenticate")
+mcp__jcodemunch__get_call_hierarchy(repo="owner/repo", symbol_id="src/auth.py::authenticate")
 ```
 
 ### Before You Edit: Impact Analysis
@@ -141,32 +141,32 @@ Always check impact before modifying code:
 
 ```
 # What breaks if I change this symbol?
-get_blast_radius(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+mcp__jcodemunch__get_blast_radius(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
 
 # Is it safe to rename this?
-check_rename_safe(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware", new_name="AuthHandler")
+mcp__jcodemunch__check_rename_safe(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware", new_name="AuthHandler")
 
 # Preview the full impact of a change
-get_impact_preview(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+mcp__jcodemunch__get_impact_preview(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
 ```
 
 ### Code Quality
 
 ```
 # Find dead code
-find_dead_code(repo="owner/repo")
+mcp__jcodemunch__find_dead_code(repo="owner/repo")
 
 # Get complexity metrics for a symbol
-get_symbol_complexity(repo="owner/repo", symbol_id="src/auth.py::authenticate")
+mcp__jcodemunch__get_symbol_complexity(repo="owner/repo", symbol_id="src/auth.py::authenticate")
 
 # Find hotspots (high churn + high complexity)
-get_hotspots(repo="owner/repo")
+mcp__jcodemunch__get_hotspots(repo="owner/repo")
 
 # Check for dependency cycles
-get_dependency_cycles(repo="owner/repo")
+mcp__jcodemunch__get_dependency_cycles(repo="owner/repo")
 
 # Find untested symbols
-get_untested_symbols(repo="owner/repo")
+mcp__jcodemunch__get_untested_symbols(repo="owner/repo")
 ```
 
 ### Budgeted Context Assembly
@@ -175,126 +175,126 @@ When you need comprehensive context within a token budget:
 
 ```
 # Get the most relevant context for a query, ranked and budgeted
-get_ranked_context(repo="owner/repo", query="how does auth work", max_tokens=4000)
+mcp__jcodemunch__get_ranked_context(repo="owner/repo", query="how does auth work", max_tokens=4000)
 
 # Get a symbol with all its imports and dependencies as a bundle
-get_context_bundle(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
+mcp__jcodemunch__get_context_bundle(repo="owner/repo", symbol_id="src/auth.py::AuthMiddleware")
 ```
 
 ---
 
 ## jDocMunch — Documentation Retrieval
 
-13 tools for structured documentation search and retrieval.
+Tools for structured documentation search and retrieval, registered under the `mcp__jdocmunch__` prefix.
 
 ### Index Documentation
 
 ```
 # Index a local docs folder
-index_local(folder_path="/path/to/docs")
+mcp__jdocmunch__index_local(folder_path="/path/to/docs")
 
 # Index a GitHub repo's docs
-doc_index_repo(repo_url="https://github.com/owner/repo")
+mcp__jdocmunch__doc_index_repo(repo_url="https://github.com/owner/repo")
 
 # Check what's indexed
-doc_list_repos()
+mcp__jdocmunch__doc_list_repos()
 ```
 
 ### Search and Read
 
 ```
 # Search for documentation sections
-search_sections(repo="owner/repo", query="authentication setup")
+mcp__jdocmunch__search_sections(repo="owner/repo", query="authentication setup")
 
 # Get a specific section by ID (minimal tokens)
-get_section(repo="owner/repo", section_id="docs/auth.md::setup")
+mcp__jdocmunch__get_section(repo="owner/repo", section_id="docs/auth.md::setup")
 
 # Get multiple related sections
-get_sections(repo="owner/repo", section_ids=["docs/auth.md::setup", "docs/auth.md::configuration"])
+mcp__jdocmunch__get_sections(repo="owner/repo", section_ids=["docs/auth.md::setup", "docs/auth.md::configuration"])
 
 # Get a section with surrounding context
-get_section_context(repo="owner/repo", section_id="docs/auth.md::setup")
+mcp__jdocmunch__get_section_context(repo="owner/repo", section_id="docs/auth.md::setup")
 ```
 
 ### Navigate Document Structure
 
 ```
 # Table of contents
-get_toc(repo="owner/repo")
+mcp__jdocmunch__get_toc(repo="owner/repo")
 
 # Full hierarchical TOC tree
-get_toc_tree(repo="owner/repo")
+mcp__jdocmunch__get_toc_tree(repo="owner/repo")
 
 # Outline of a specific document
-get_document_outline(repo="owner/repo", file_path="docs/auth.md")
+mcp__jdocmunch__get_document_outline(repo="owner/repo", file_path="docs/auth.md")
 ```
 
 ### Documentation Quality
 
 ```
 # Find broken links
-get_broken_links(repo="owner/repo")
+mcp__jdocmunch__get_broken_links(repo="owner/repo")
 
 # Check documentation coverage
-get_doc_coverage(repo="owner/repo")
+mcp__jdocmunch__get_doc_coverage(repo="owner/repo")
 ```
 
 ---
 
 ## jDataMunch — Tabular Data Analysis
 
-18 tools for CSV, Excel, Parquet, and JSONL exploration.
+Tools for CSV, Excel, Parquet, and JSONL exploration, registered under the `mcp__jdatamunch__` prefix.
 
 ### Index Data Files
 
 ```
 # Index a local CSV, Excel, or Parquet file
-index_local(file_path="/path/to/data.csv")
+mcp__jdatamunch__index_local(file_path="/path/to/data.csv")
 
 # Check what's indexed
-list_datasets()
+mcp__jdatamunch__list_datasets()
 ```
 
 ### Explore and Profile
 
 ```
 # Dataset overview (row count, columns, types, size)
-describe_dataset(dataset="data")
+mcp__jdatamunch__describe_dataset(dataset="data")
 
 # Deep column profiling (cardinality, nulls, min/max, distribution)
-describe_column(dataset="data", column="status")
+mcp__jdatamunch__describe_column(dataset="data", column="status")
 
 # Sample rows to understand the data
-sample_rows(dataset="data", n=10)
+mcp__jdatamunch__sample_rows(dataset="data", n=10)
 ```
 
 ### Query and Analyze
 
 ```
 # Filter rows with conditions
-get_rows(dataset="data", where="status = 'active'", limit=20)
+mcp__jdatamunch__get_rows(dataset="data", where="status = 'active'", limit=20)
 
 # Full-text search across all columns
-search_data(dataset="data", query="error timeout")
+mcp__jdatamunch__search_data(dataset="data", query="error timeout")
 
 # Server-side aggregations (COUNT, SUM, AVG, MIN, MAX, MEDIAN)
-aggregate(dataset="data", group_by="category", metrics=["count", "avg:price"])
+mcp__jdatamunch__aggregate(dataset="data", group_by="category", metrics=["count", "avg:price"])
 
 # Cross-dataset SQL JOINs
-join_datasets(left="orders", right="customers", on="customer_id", join_type="inner")
+mcp__jdatamunch__join_datasets(left="orders", right="customers", on="customer_id", join_type="inner")
 ```
 
 ### Data Quality
 
 ```
 # Find null hotspots, low-cardinality columns, outlier risks
-get_data_hotspots(dataset="data")
+mcp__jdatamunch__get_data_hotspots(dataset="data")
 
 # Pearson correlations between numeric columns
-get_correlations(dataset="data")
+mcp__jdatamunch__get_correlations(dataset="data")
 
 # Check for schema drift between dataset versions
-get_schema_drift(dataset_a="data_v1", dataset_b="data_v2")
+mcp__jdatamunch__get_schema_drift(dataset_a="data_v1", dataset_b="data_v2")
 ```
 
 ---
@@ -305,24 +305,24 @@ get_schema_drift(dataset_a="data_v1", dataset_b="data_v2")
 
 ```
 # 1. Search code for payment-related symbols
-search_symbols(repo="myapp", query="payment pipeline transaction")
+mcp__jcodemunch__search_symbols(repo="myapp", query="payment pipeline transaction")
 
 # 2. Read the key function
-get_symbol_source(repo="myapp", symbol_id="src/payments/processor.py::PaymentProcessor.process")
+mcp__jcodemunch__get_symbol_source(repo="myapp", symbol_id="src/payments/processor.py::PaymentProcessor.process")
 
 # 3. Check who calls it
-get_call_hierarchy(repo="myapp", symbol_id="src/payments/processor.py::PaymentProcessor.process")
+mcp__jcodemunch__get_call_hierarchy(repo="myapp", symbol_id="src/payments/processor.py::PaymentProcessor.process")
 
 # 4. Find the documentation
-search_sections(repo="myapp", query="payment processing architecture")
+mcp__jdocmunch__search_sections(repo="myapp", query="payment processing architecture")
 
 # 5. Read the relevant doc section
-get_section(repo="myapp", section_id="docs/architecture.md::payment-flow")
+mcp__jdocmunch__get_section(repo="myapp", section_id="docs/architecture.md::payment-flow")
 
 # 6. Profile the transaction data
-index_local(file_path="/data/transactions.csv")
-describe_dataset(dataset="transactions")
-aggregate(dataset="transactions", group_by="status", metrics=["count", "avg:amount"])
+mcp__jdatamunch__index_local(file_path="/data/transactions.csv")
+mcp__jdatamunch__describe_dataset(dataset="transactions")
+mcp__jdatamunch__aggregate(dataset="transactions", group_by="status", metrics=["count", "avg:amount"])
 ```
 
 This gives you a complete picture: code structure, call flow, documentation context, and actual data characteristics -- all with minimal token usage.
@@ -341,11 +341,11 @@ Restart Hermes completely. MCP servers connect at startup.
 
 ### "repo not found" errors
 
-The project needs to be indexed first. Run `list_repos()` to check what's indexed, then `index_folder()` or `index_repo()` to index.
+The project needs to be indexed first. Run `mcp__jcodemunch__list_repos()` to check what's indexed, then `mcp__jcodemunch__index_folder()` or `mcp__jcodemunch__index_repo()` to index.
 
 ### Stale results after code changes
 
-Run `index_folder()` again to re-index. jMunch detects changed files and only re-indexes what's different.
+Run `mcp__jcodemunch__index_folder()` again to re-index. jMunch detects changed files and only re-indexes what's different.
 
 ## References
 

--- a/optional-skills/mcp/jmunch/references/hermes-context-template.md
+++ b/optional-skills/mcp/jmunch/references/hermes-context-template.md
@@ -1,0 +1,37 @@
+# jMunch Context File Template for Hermes Agent
+
+Copy this content into a `.hermes.md` file at the root of any project to teach Hermes
+how to use jMunch tools for that project.
+
+---
+
+## Retrieval Policy
+
+Use jMunch MCP tools for all code, documentation, and data retrieval. Do not read raw
+files when an index exists. The jMunch tools return precise, minimal-token responses
+that save context window space.
+
+## Tool Routing
+
+| Intent | Tool | Follow-up |
+|--------|------|-----------|
+| Find a function or class | `search_symbols` | `get_symbol_source` |
+| Understand a file's structure | `get_file_outline` | — |
+| Browse project layout | `get_file_tree` | — |
+| Check impact before editing | `get_blast_radius` | `check_rename_safe` |
+| Find who calls a function | `get_call_hierarchy` | — |
+| Find documentation | `search_sections` | `get_section` |
+| Navigate doc structure | `get_toc_tree` | `get_document_outline` |
+| Profile a data file | `describe_dataset` | `describe_column` |
+| Query data rows | `search_data` or `get_rows` | `aggregate` |
+
+## Indexed Sources
+
+<!-- Update these after indexing your project -->
+- Code: `index_folder(folder_path=".")` — indexed via jCodeMunch
+- Docs: `index_local(folder_path="./docs")` — indexed via jDocMunch
+- Data: `index_local(file_path="./data/records.csv")` — indexed via jDataMunch
+
+## Efficiency
+
+Report `_meta.tokens_saved` from jMunch responses to show retrieval efficiency.

--- a/optional-skills/mcp/jmunch/references/hermes-context-template.md
+++ b/optional-skills/mcp/jmunch/references/hermes-context-template.md
@@ -3,6 +3,10 @@
 Copy this content into a `.hermes.md` file at the root of any project to teach Hermes
 how to use jMunch tools for that project.
 
+Hermes registers MCP tools as `mcp__<server>__<tool>`, so jMunch tools appear under the
+`mcp__jcodemunch__`, `mcp__jdocmunch__`, and `mcp__jdatamunch__` prefixes. The routing
+table below uses those prefixed names.
+
 ---
 
 ## Retrieval Policy
@@ -15,22 +19,22 @@ that save context window space.
 
 | Intent | Tool | Follow-up |
 |--------|------|-----------|
-| Find a function or class | `search_symbols` | `get_symbol_source` |
-| Understand a file's structure | `get_file_outline` | — |
-| Browse project layout | `get_file_tree` | — |
-| Check impact before editing | `get_blast_radius` | `check_rename_safe` |
-| Find who calls a function | `get_call_hierarchy` | — |
-| Find documentation | `search_sections` | `get_section` |
-| Navigate doc structure | `get_toc_tree` | `get_document_outline` |
-| Profile a data file | `describe_dataset` | `describe_column` |
-| Query data rows | `search_data` or `get_rows` | `aggregate` |
+| Find a function or class | `mcp__jcodemunch__search_symbols` | `mcp__jcodemunch__get_symbol_source` |
+| Understand a file's structure | `mcp__jcodemunch__get_file_outline` | — |
+| Browse project layout | `mcp__jcodemunch__get_file_tree` | — |
+| Check impact before editing | `mcp__jcodemunch__get_blast_radius` | `mcp__jcodemunch__check_rename_safe` |
+| Find who calls a function | `mcp__jcodemunch__get_call_hierarchy` | — |
+| Find documentation | `mcp__jdocmunch__search_sections` | `mcp__jdocmunch__get_section` |
+| Navigate doc structure | `mcp__jdocmunch__get_toc_tree` | `mcp__jdocmunch__get_document_outline` |
+| Profile a data file | `mcp__jdatamunch__describe_dataset` | `mcp__jdatamunch__describe_column` |
+| Query data rows | `mcp__jdatamunch__search_data` or `mcp__jdatamunch__get_rows` | `mcp__jdatamunch__aggregate` |
 
 ## Indexed Sources
 
 <!-- Update these after indexing your project -->
-- Code: `index_folder(folder_path=".")` — indexed via jCodeMunch
-- Docs: `index_local(folder_path="./docs")` — indexed via jDocMunch
-- Data: `index_local(file_path="./data/records.csv")` — indexed via jDataMunch
+- Code: `mcp__jcodemunch__index_folder(folder_path=".")` — indexed via jCodeMunch
+- Docs: `mcp__jdocmunch__index_local(folder_path="./docs")` — indexed via jDocMunch
+- Data: `mcp__jdatamunch__index_local(file_path="./data/records.csv")` — indexed via jDataMunch
 
 ## Efficiency
 

--- a/tests/skills/test_jmunch_skill.py
+++ b/tests/skills/test_jmunch_skill.py
@@ -1,0 +1,140 @@
+"""Offline validation for the jMunch optional skill.
+
+Covers the two things a Hermes user relies on the skill getting right:
+  1. Frontmatter meets the skill-authoring rules (AGENTS.md): a <=60-char,
+     single-sentence description; required fields present.
+  2. Every MCP tool referenced in the prose/examples uses Hermes's real
+     ``mcp__<server>__<tool>`` registration convention -- not a bare name or
+     the single-underscore ``mcp_<server>_`` form.
+
+Pure stdlib + pytest, no network, no imports from the skill.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "mcp" / "jmunch"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+TEMPLATE_MD = SKILL_DIR / "references" / "hermes-context-template.md"
+
+SERVERS = ("jcodemunch", "jdocmunch", "jdatamunch")
+
+# Representative jMunch tool names spanning all three servers. Every one of
+# these must appear only in prefixed form; a bare ``tool(`` call is a bug.
+JMUNCH_TOOLS = (
+    # jcodemunch
+    "index_folder", "index_repo", "list_repos", "search_symbols",
+    "get_symbol_source", "get_file_outline", "get_file_tree", "find_importers",
+    "find_references", "get_class_hierarchy", "get_call_hierarchy",
+    "get_blast_radius", "check_rename_safe", "get_impact_preview",
+    "find_dead_code", "get_symbol_complexity", "get_hotspots",
+    "get_dependency_cycles", "get_untested_symbols", "get_ranked_context",
+    "get_context_bundle",
+    # jdocmunch
+    "index_local", "doc_index_repo", "doc_list_repos", "search_sections",
+    "get_section", "get_sections", "get_section_context", "get_toc",
+    "get_toc_tree", "get_document_outline", "get_broken_links",
+    "get_doc_coverage",
+    # jdatamunch
+    "list_datasets", "describe_dataset", "describe_column", "sample_rows",
+    "get_rows", "search_data", "aggregate", "join_datasets",
+    "get_data_hotspots", "get_correlations", "get_schema_drift",
+)
+
+
+def _frontmatter(text: str) -> dict:
+    """Parse the leading ``---`` YAML block into flat top-level key/value pairs.
+
+    Deliberately regex-based (stdlib only, no PyYAML dependency); we only need
+    the scalar top-level fields.
+    """
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    assert m, "SKILL.md must start with a --- frontmatter block"
+    fields = {}
+    for line in m.group(1).splitlines():
+        fm = re.match(r"^([A-Za-z_]+):\s?(.*)$", line)
+        if fm:
+            fields[fm.group(1)] = fm.group(2).strip()
+    return fields
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text) -> dict:
+    return _frontmatter(skill_text)
+
+
+# ── Frontmatter ──────────────────────────────────────────────────────────────
+
+def test_skill_files_exist():
+    assert SKILL_MD.is_file()
+    assert TEMPLATE_MD.is_file()
+
+
+def test_required_frontmatter_fields(frontmatter):
+    for key in ("name", "description", "version", "author", "license"):
+        assert frontmatter.get(key), f"frontmatter missing '{key}'"
+    assert frontmatter["name"] == "jmunch"
+
+
+def test_description_within_60_chars(frontmatter):
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (limit 60): {desc!r}"
+
+
+def test_description_is_one_sentence_ending_in_period(frontmatter):
+    desc = frontmatter["description"]
+    assert desc.endswith("."), "description must end with a period"
+    # exactly one sentence: no interior sentence break
+    assert ". " not in desc, "description must be a single sentence"
+
+
+def test_description_has_no_marketing_words(frontmatter):
+    banned = ("powerful", "comprehensive", "seamless", "advanced")
+    low = frontmatter["description"].lower()
+    hits = [w for w in banned if w in low]
+    assert not hits, f"description contains banned marketing words: {hits}"
+
+
+# ── Tool naming convention ───────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [SKILL_MD, TEMPLATE_MD])
+def test_no_single_underscore_mcp_prefix(path):
+    """The wrong ``mcp_jcodemunch_*`` (single underscore) form must not appear;
+    Hermes registers ``mcp__<server>__<tool>``."""
+    text = path.read_text(encoding="utf-8")
+    bad = re.findall(r"mcp_j(?:codemunch|docmunch|datamunch)", text)
+    assert not bad, f"{path.name} uses single-underscore mcp prefix {set(bad)}"
+
+
+@pytest.mark.parametrize("path", [SKILL_MD, TEMPLATE_MD])
+def test_every_mcp_prefix_names_a_real_server(path):
+    text = path.read_text(encoding="utf-8")
+    prefixes = set(re.findall(r"mcp__([a-z0-9]+)__", text))
+    unknown = prefixes - set(SERVERS)
+    assert not unknown, f"{path.name} references unknown MCP servers: {unknown}"
+
+
+@pytest.mark.parametrize("path", [SKILL_MD, TEMPLATE_MD])
+def test_no_bare_jmunch_tool_calls(path):
+    """A jMunch tool invoked as a bare ``tool(`` (no ``mcp__server__`` prefix)
+    would fail against Hermes's registered names. Prefixed forms are preceded
+    by ``__`` so the word-boundary lookbehind excludes them."""
+    text = path.read_text(encoding="utf-8")
+    alternation = "|".join(re.escape(t) for t in JMUNCH_TOOLS)
+    bare = re.findall(rf"(?<!\w)(?:{alternation})\(", text)
+    assert not bare, f"{path.name} has un-prefixed jMunch tool calls: {sorted(set(bare))}"
+
+
+@pytest.mark.parametrize("path", [SKILL_MD, TEMPLATE_MD])
+def test_prefixed_examples_are_present(path):
+    """Sanity check the fix landed: each server's prefix actually appears."""
+    text = path.read_text(encoding="utf-8")
+    for server in SERVERS:
+        assert f"mcp__{server}__" in text, f"{path.name} missing mcp__{server}__ examples"


### PR DESCRIPTION
## Summary

Adds an optional skill for the **jMunch MCP suite** — three MCP servers that provide token-efficient retrieval for code (52 tools), documentation (13 tools), and tabular data (18 tools).

- **jCodeMunch** — code intelligence via tree-sitter AST parsing (70+ languages)
- **jDocMunch** — structured documentation retrieval (Markdown, RST, AsciiDoc, Jupyter, HTML, OpenAPI)
- **jDataMunch** — tabular data analysis (CSV, Excel, Parquet, JSONL) backed by SQLite

**Benchmarks:** 37x fewer tokens, 19.6x fewer tool calls vs raw file reading. +150B tokens saved across all users.

All three implement the [jMRI specification](https://github.com/jgravelle/mcp-retrieval-spec) (Apache 2.0).

## Changes

- `optional-skills/mcp/jmunch/SKILL.md` — Main skill file with discover-search-retrieve workflow, tool reference for all three servers, combined workflow examples, troubleshooting
- `optional-skills/mcp/jmunch/README.md` — Quick setup guide with config snippet
- `optional-skills/mcp/jmunch/references/hermes-context-template.md` — `.hermes.md` template for per-project context

## Config

```yaml
mcp_servers:
  jcodemunch:
    command: "uvx"
    args: ["jcodemunch-mcp"]
  jdocmunch:
    command: "uvx"
    args: ["jdocmunch-mcp"]
  jdatamunch:
    command: "uvx"
    args: ["jdatamunch-mcp"]
```

## Test plan

- [ ] Install `jcodemunch-mcp` via `pip install jcodemunch-mcp`
- [ ] Add config to `~/.hermes/config.yaml`
- [ ] Restart Hermes, verify `mcp_jcodemunch_*` tools appear
- [ ] Load skill: verify `skill_view("jmunch")` returns the SKILL.md content
- [ ] Run workflow: `list_repos` → `index_folder` → `search_symbols` → `get_symbol_source`

Closes #10409

🤖 Generated with [Claude Code](https://claude.com/claude-code)