### PR TITLE
feat: add configurable custom web search backend

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -13,6 +13,7 @@ import json
 import os
 import sys
 import types
+import httpx
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -367,6 +368,12 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "Tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_custom(self):
+        """web.backend=custom in config → 'custom'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "custom"}):
+            assert _get_backend() == "custom"
+
     # ── Fallback (no web.backend in config) ───────────────────────────
 
     def test_fallback_parallel_only_key(self):
@@ -491,6 +498,214 @@ class TestParallelClientConfig:
             assert client1 is client2
 
 
+class TestCustomWebSearch:
+    """Tests for the config-driven custom JSON web_search backend."""
+
+    @staticmethod
+    def _custom_config(**overrides):
+        config = {
+            "backend": "custom",
+            "custom": {
+                "url_template": "https://example.com/search?q=%s&format=json&engines=google,duckduckgo",
+                "results_path": "data.items",
+                "title_field": "headline",
+                "url_field": "link",
+                "description_field": "summary",
+                "headers": {
+                    "Accept": "application/json",
+                },
+                "timeout": 20,
+            },
+        }
+        config["custom"].update(overrides)
+        return config
+
+    @staticmethod
+    def _make_response(*, payload=None, json_side_effect=None, raise_for_status_side_effect=None):
+        response = MagicMock()
+        if raise_for_status_side_effect is None:
+            response.raise_for_status.return_value = None
+        else:
+            response.raise_for_status.side_effect = raise_for_status_side_effect
+
+        if json_side_effect is None:
+            response.json.return_value = payload
+        else:
+            response.json.side_effect = json_side_effect
+        return response
+
+    def _run_search(self, response, *, config=None, query="test query", limit=3):
+        import tools.web_tools
+
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value=config or self._custom_config(),
+        ), patch("tools.web_tools.httpx.get", return_value=response) as mock_get, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool(query, limit=limit))
+        return result, mock_get
+
+    def test_custom_backend_happy_path(self):
+        result, _ = self._run_search(
+            self._make_response(payload={
+                "data": {
+                    "items": [
+                        {"headline": "First", "link": "https://one.example", "summary": "Alpha"},
+                        {"headline": "Second", "link": "https://two.example", "summary": None},
+                    ]
+                }
+            }),
+            query="C++ tools",
+            limit=2,
+        )
+
+        assert result == {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "First",
+                        "url": "https://one.example",
+                        "description": "Alpha",
+                        "position": 1,
+                    },
+                    {
+                        "title": "Second",
+                        "url": "https://two.example",
+                        "description": "",
+                        "position": 2,
+                    },
+                ]
+            },
+        }
+
+    def test_custom_backend_sends_headers_and_preserves_template_params(self):
+        result, mock_get = self._run_search(
+            self._make_response(payload={
+                "data": {
+                    "items": [
+                        {"headline": "First", "link": "https://one.example", "summary": "Alpha"},
+                    ]
+                }
+            }),
+            query="C++ tools",
+            limit=5,
+        )
+
+        assert result["success"] is True
+        mock_get.assert_called_once_with(
+            "https://example.com/search?q=C%2B%2B+tools&format=json&engines=google,duckduckgo",
+            headers={"Accept": "application/json"},
+            timeout=20.0,
+        )
+
+    def test_custom_backend_limit_truncation_and_skip_malformed_items(self):
+        result, _ = self._run_search(
+            self._make_response(payload={
+                "data": {
+                    "items": [
+                        {"headline": "", "link": "https://skip-title.example", "summary": "bad"},
+                        {"headline": "Missing URL", "summary": "bad"},
+                        {"headline": "First", "link": "https://one.example", "summary": "Alpha"},
+                        {"headline": "Second", "link": "https://two.example", "summary": 123},
+                        {"headline": "Third", "link": "https://three.example", "summary": "Gamma"},
+                    ]
+                }
+            }),
+            limit=2,
+        )
+
+        assert result == {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "First",
+                        "url": "https://one.example",
+                        "description": "Alpha",
+                        "position": 1,
+                    },
+                    {
+                        "title": "Second",
+                        "url": "https://two.example",
+                        "description": "123",
+                        "position": 2,
+                    },
+                ]
+            },
+        }
+
+    def test_custom_backend_invalid_config_returns_error(self):
+        result, _ = self._run_search(
+            self._make_response(payload={"items": []}),
+            config={
+                "backend": "custom",
+                "custom": {
+                    "url_template": "https://example.com/search?q=%s",
+                    "results_path": "items",
+                    "title_field": "title",
+                },
+            },
+        )
+
+        assert result == {
+            "error": "Error searching web: Missing required web.custom config keys: url_field, description_field"
+        }
+
+    def test_custom_backend_missing_template_placeholder_returns_error(self):
+        result, _ = self._run_search(
+            self._make_response(payload={"items": []}),
+            config=self._custom_config(url_template="https://example.com/search?q=query"),
+        )
+
+        assert result == {
+            "error": "Error searching web: web.custom.url_template must contain %s for the encoded query"
+        }
+
+    def test_custom_backend_http_error_returns_error(self):
+        result, _ = self._run_search(
+            self._make_response(
+                raise_for_status_side_effect=httpx.HTTPStatusError(
+                    "502 Bad Gateway",
+                    request=httpx.Request("GET", "https://example.com/search?q=test"),
+                    response=httpx.Response(502),
+                )
+            ),
+        )
+
+        assert result["error"].startswith("Error searching web: 502 Bad Gateway")
+
+    def test_custom_backend_invalid_json_returns_error(self):
+        result, _ = self._run_search(
+            self._make_response(json_side_effect=ValueError("not json")),
+        )
+
+        assert result == {
+            "error": "Error searching web: Custom backend returned invalid JSON"
+        }
+
+    def test_custom_backend_missing_results_path_returns_error(self):
+        result, _ = self._run_search(
+            self._make_response(payload={"data": {}}),
+        )
+
+        assert result == {
+            "error": "Error searching web: web.custom.results_path not found: data.items"
+        }
+
+    def test_custom_backend_non_list_results_path_returns_error(self):
+        result, _ = self._run_search(
+            self._make_response(payload={"data": {"items": {"headline": "not a list"}}}),
+        )
+
+        assert result == {
+            "error": "Error searching web: web.custom.results_path must point to a list"
+        }
+
+
+
 class TestWebSearchErrorHandling:
     """Test suite for web_search_tool() error responses."""
 
@@ -547,28 +762,82 @@ class TestCheckWebApiKey:
 
     def test_parallel_key_only(self):
         with patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
-            from tools.web_tools import check_web_api_key
-            assert check_web_api_key() is True
+            with patch("tools.web_tools._load_web_config", return_value={}):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
 
     def test_exa_key_only(self):
         with patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
-            from tools.web_tools import check_web_api_key
-            assert check_web_api_key() is True
+            with patch("tools.web_tools._load_web_config", return_value={}):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
 
     def test_firecrawl_key_only(self):
         with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
-            from tools.web_tools import check_web_api_key
-            assert check_web_api_key() is True
+            with patch("tools.web_tools._load_web_config", return_value={}):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
 
     def test_firecrawl_url_only(self):
         with patch.dict(os.environ, {"FIRECRAWL_API_URL": "http://localhost:3002"}):
-            from tools.web_tools import check_web_api_key
-            assert check_web_api_key() is True
+            with patch("tools.web_tools._load_web_config", return_value={}):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
 
     def test_tavily_key_only(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            with patch("tools.web_tools._load_web_config", return_value={}):
+                from tools.web_tools import check_web_api_key
+                assert check_web_api_key() is True
+
+    def test_configured_custom_backend_with_complete_config_returns_true(self):
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value={
+                "backend": "custom",
+                "custom": {
+                    "url_template": "https://example.com/search?q=%s",
+                    "results_path": "items",
+                    "title_field": "title",
+                    "url_field": "url",
+                    "description_field": "snippet",
+                },
+            },
+        ):
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
+
+    def test_configured_custom_backend_with_incomplete_config_returns_false(self):
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value={
+                "backend": "custom",
+                "custom": {
+                    "url_template": "https://example.com/search?q=%s",
+                    "results_path": "items",
+                    "title_field": "title",
+                },
+            },
+        ):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
+    def test_configured_custom_backend_without_template_placeholder_returns_false(self):
+        with patch(
+            "tools.web_tools._load_web_config",
+            return_value={
+                "backend": "custom",
+                "custom": {
+                    "url_template": "https://example.com/search?q=query",
+                    "results_path": "items",
+                    "title_field": "title",
+                    "url_field": "url",
+                    "description_field": "snippet",
+                },
+            },
+        ):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
 
     def test_no_keys_returns_false(self):
         from tools.web_tools import check_web_api_key

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -46,6 +46,7 @@ import os
 import re
 import asyncio
 from typing import List, Dict, Any, Optional
+from urllib.parse import quote_plus
 import httpx
 from firecrawl import Firecrawl
 from agent.auxiliary_client import (
@@ -80,6 +81,16 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
+
+_ALL_WEB_BACKENDS = ("exa", "parallel", "firecrawl", "tavily", "custom")
+_CUSTOM_WEB_REQUIRED_KEYS = (
+    "url_template",
+    "results_path",
+    "title_field",
+    "url_field",
+    "description_field",
+)
+
 def _get_backend() -> str:
     """Determine which web backend to use.
 
@@ -88,7 +99,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in _ALL_WEB_BACKENDS:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -107,6 +118,46 @@ def _get_backend() -> str:
     return "firecrawl"  # default (backward compat)
 
 
+def _load_custom_web_search_config() -> dict:
+    """Return validated config for the custom JSON search backend."""
+    config = _load_web_config().get("custom", {})
+    if not isinstance(config, dict):
+        raise ValueError("web.custom must be a mapping")
+
+    missing = [key for key in _CUSTOM_WEB_REQUIRED_KEYS if not str(config.get(key, "")).strip()]
+    if missing:
+        raise ValueError(f"Missing required web.custom config keys: {', '.join(missing)}")
+
+    url_template = str(config["url_template"])
+    if "%s" not in url_template:
+        raise ValueError("web.custom.url_template must contain %s for the encoded query")
+
+    headers = config.get("headers")
+    if headers is not None and not isinstance(headers, dict):
+        raise ValueError("web.custom.headers must be a mapping when provided")
+
+    timeout = config.get("timeout")
+    if timeout is not None:
+        try:
+            timeout_value = float(timeout)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("web.custom.timeout must be a number") from exc
+        if timeout_value <= 0:
+            raise ValueError("web.custom.timeout must be greater than 0")
+    else:
+        timeout_value = 30.0
+
+    return {
+        "url_template": url_template,
+        "results_path": str(config["results_path"]),
+        "title_field": str(config["title_field"]),
+        "url_field": str(config["url_field"]),
+        "description_field": str(config["description_field"]),
+        "headers": headers or None,
+        "timeout": timeout_value,
+    }
+
+
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
     if backend == "exa":
@@ -117,6 +168,12 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "custom":
+        try:
+            _load_custom_web_search_config()
+        except ValueError:
+            return False
+        return True
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -395,6 +452,89 @@ def _normalize_result_list(values: Any) -> List[Dict[str, Any]]:
         if isinstance(plain, dict):
             normalized.append(plain)
     return normalized
+
+
+def _get_nested_value(data: Any, path: str) -> Any:
+    """Resolve dotted paths through nested dict/list JSON payloads."""
+    value = data
+    for part in path.split('.'):
+        if isinstance(value, dict):
+            if part not in value:
+                raise ValueError(f"web.custom.results_path not found: {path}")
+            value = value[part]
+            continue
+        if isinstance(value, list):
+            try:
+                index = int(part)
+            except ValueError as exc:
+                raise ValueError(f"web.custom.results_path not found: {path}") from exc
+            try:
+                value = value[index]
+            except IndexError as exc:
+                raise ValueError(f"web.custom.results_path not found: {path}") from exc
+            continue
+        raise ValueError(f"web.custom.results_path not found: {path}")
+    return value
+
+
+def _normalize_custom_web_results(items: Any, config: dict, limit: int) -> dict:
+    """Map arbitrary JSON search results into the Hermes web result schema."""
+    if not isinstance(items, list):
+        raise ValueError("web.custom.results_path must point to a list")
+
+    title_field = str(config["title_field"])
+    url_field = str(config["url_field"])
+    description_field = str(config["description_field"])
+
+    web_results = []
+    for item in items:
+        plain = _to_plain_object(item)
+        if not isinstance(plain, dict):
+            continue
+
+        title = plain.get(title_field)
+        url = plain.get(url_field)
+        if not isinstance(title, str) or not title.strip():
+            continue
+        if not isinstance(url, str) or not url.strip():
+            continue
+
+        description = plain.get(description_field, "")
+        if description is None:
+            description = ""
+        elif not isinstance(description, str):
+            description = str(description)
+
+        web_results.append({
+            "title": title.strip(),
+            "url": url.strip(),
+            "description": description,
+            "position": len(web_results) + 1,
+        })
+
+        if len(web_results) >= limit:
+            break
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _custom_web_search(query: str, limit: int = 5) -> dict:
+    """Search using a config-driven custom JSON endpoint."""
+    config = _load_custom_web_search_config()
+    encoded_query = quote_plus(query)
+    url = config["url_template"].replace("%s", encoded_query)
+
+    logger.info("Custom web search: '%s' (limit=%d)", query, limit)
+    response = httpx.get(url, headers=config["headers"], timeout=config["timeout"])
+    response.raise_for_status()
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("Custom backend returned invalid JSON") from exc
+
+    items = _get_nested_value(payload, config["results_path"])
+    return _normalize_custom_web_results(items, config, limit)
 
 
 def _extract_web_search_results(response: Any) -> List[Dict[str, Any]]:
@@ -1110,6 +1250,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "include_images": False,
             })
             response_data = _normalize_tavily_search_results(raw)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "custom":
+            response_data = _custom_web_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
@@ -1921,9 +2070,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in _ALL_WEB_BACKENDS:
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in _ALL_WEB_BACKENDS)
 
 
 def check_auxiliary_model() -> bool:
@@ -2042,7 +2191,8 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
-from tools.registry import registry, tool_error
+# Imported here intentionally so tool schemas stay next to registration.
+from tools.registry import registry, tool_error  # noqa: E402
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",


### PR DESCRIPTION
## What does this PR do?

Adds a `custom` backend for `web_search` so Hermes can query any JSON search endpoint defined in `~/.hermes/config.yaml`

The scope is intentionally narrow:

- `web_search` only
- `GET` only
- fixed config-driven mapping into Hermes' existing search result shape

The `web_search` tool schema stays unchanged. This makes local or self-hosted search APIs usable through the existing tool without adding another provider-specific backend. Examples include 4get and SearXNG, but the implementation stays generic and does not hardcode either provider

## Related Issue

Fixes #10284

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/web_tools.py` to recognize `web.backend: custom`
- Added config validation for `web.custom.url_template`, `results_path`, `title_field`, `url_field`, `description_field`, optional `headers`, and optional `timeout`
- Added config-driven search execution for custom JSON backends using URL-encoded `%s` substitution
- Normalized custom backend responses into Hermes' existing `web_search` result format
- Extended backend availability checks so `check_web_api_key()` can treat a valid custom config as available without an API key
- Expanded `tests/tools/test_web_tools_config.py` to cover request formatting, headers, truncation, malformed item skipping, config validation, and runtime error paths

## How to Test

1. Add a custom backend config to `~/.hermes/config.yaml`, for example:

```yaml
    web:
      backend: custom
      custom:
        url_template: http://127.0.0.1:8080/api/v1/web?s=%s
        results_path: web
        title_field: title
        url_field: url
        description_field: description
        headers:
          Accept: application/json
        timeout: 20
```

2. Run the focused test suite:

```bash
python -m pytest tests/tools/test_web_tools_config.py -q
```

3. Start Hermes with the web tool enabled and run a query that triggers `web_search`

4. Confirm the custom endpoint receives a `GET` request with the encoded query and Hermes returns normalized results with `title`, `url`, `description`, and `position`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A. N/A for this change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A. N/A because this is a read-path config addition with no default config change
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A. N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A. This only adds `httpx` calls and config parsing
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A. The `web_search` schema stays unchanged by design

## Screenshots / Logs

Focused validation:

```text
$ python -m pytest tests/tools/test_web_tools_config.py -q
63 passed, 11 warnings in 2.12s
```

Note: I did not run `pytest tests/ -q` for this PR draft, so that checklist item is intentionally left unchecked