### PR TITLE
fix: include profile in resume hints

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7982,10 +7982,19 @@ class HermesCLI:
                 except Exception:
                     pass
 
+            profile_prefix = "hermes"
+            try:
+                from hermes_cli.profiles import get_active_profile_name
+                profile = get_active_profile_name()
+                if profile not in ("default", "custom"):
+                    profile_prefix = f"hermes -p {profile}"
+            except Exception:
+                pass
+
             print("Resume this session with:")
-            print(f"  hermes --resume {self.session_id}")
+            print(f"  {profile_prefix} --resume {self.session_id}")
             if session_title:
-                print(f"  hermes -c \"{session_title}\"")
+                print(f"  {profile_prefix} -c \"{session_title}\"")
             print()
             print(f"Session:        {self.session_id}")
             if session_title:

--- a/tests/cli/test_cli_exit_summary.py
+++ b/tests/cli/test_cli_exit_summary.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.conversation_history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    cli_obj.session_start = datetime.now() - timedelta(seconds=65)
+    cli_obj.session_id = "20260101_010203_deadbe"
+    cli_obj._session_db = MagicMock()
+    cli_obj._session_db.get_session_title.return_value = "Example Session"
+    return cli_obj
+
+
+def test_print_exit_summary_uses_plain_resume_commands_for_default_profile(capsys):
+    cli_obj = _make_cli()
+
+    with patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+        cli_obj._print_exit_summary()
+
+    output = capsys.readouterr().out
+    assert "Resume this session with:" in output
+    assert "  hermes --resume 20260101_010203_deadbe" in output
+    assert '  hermes -c "Example Session"' in output
+    assert "hermes -p default" not in output
+
+
+def test_print_exit_summary_includes_profile_in_resume_commands_for_named_profile(capsys):
+    cli_obj = _make_cli()
+
+    with patch("hermes_cli.profiles.get_active_profile_name", return_value="example-profile"):
+        cli_obj._print_exit_summary()
+
+    output = capsys.readouterr().out
+    assert "Resume this session with:" in output
+    assert "  hermes -p example-profile --resume 20260101_010203_deadbe" in output
+    assert '  hermes -p example-profile -c "Example Session"' in output


### PR DESCRIPTION
## Summary
- make CLI exit resume hints profile-aware for named profiles
- keep plain `hermes` commands for the default profile
- add regression tests for default and named profile output

## Example
Before, a named profile session could print:
```bash
Resume this session with:
  hermes --resume 20260415_232520_d8cbcb
  hermes -c "Example Session"
```

That was misleading because the session lived under a non-default profile, so those commands could fail with `Session not found`.

After this change, named profiles print the correct profile-aware commands:
```bash
Resume this session with:
  hermes -p example-profile --resume 20260101_010203_deadbe
  hermes -p example-profile -c "Example Session"
```

Default profile output is unchanged:
```bash
Resume this session with:
  hermes --resume 20260101_010203_deadbe
  hermes -c "Example Session"
```

## Testing
- source venv/bin/activate && python -m pytest tests/cli/test_cli_exit_summary.py tests/cli/test_cli_status_command.py -o 'addopts=' -q