### PR TITLE
feat: add HERMES_FORCE_BUDGET_THINKING env var to disable adaptive thinking

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -91,7 +91,16 @@ def _get_anthropic_max_output(model: str) -> int:
 
 
 def _supports_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude 4.6 models that support adaptive thinking."""
+    """Return True for Claude 4.6 models that support adaptive thinking.
+
+    When the HERMES_FORCE_BUDGET_THINKING environment variable is set,
+    always returns False so that even 4.6 models use fixed budget_tokens
+    thinking instead of adaptive. Adaptive thinking can allocate zero
+    tokens on some turns, skipping reasoning entirely; budget mode
+    guarantees the model always thinks.
+    """
+    if os.environ.get("HERMES_FORCE_BUDGET_THINKING"):
+        return False
     return any(v in model for v in ("4-6", "4.6"))
 
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -968,6 +968,24 @@ class TestBuildAnthropicKwargs:
         assert kwargs["thinking"] == {"type": "adaptive"}
         assert kwargs["output_config"] == {"effort": "max"}
 
+    def test_force_budget_thinking_env_disables_adaptive_for_4_6(self):
+        """HERMES_FORCE_BUDGET_THINKING makes 4.6 models use budget thinking, not adaptive."""
+        import os
+        os.environ["HERMES_FORCE_BUDGET_THINKING"] = "1"
+        try:
+            kwargs = build_anthropic_kwargs(
+                model="claude-opus-4-6",
+                messages=[{"role": "user", "content": "think hard"}],
+                tools=None,
+                max_tokens=None,
+                reasoning_config={"enabled": True, "effort": "high"},
+            )
+            assert kwargs["thinking"]["type"] == "enabled"
+            assert kwargs["thinking"]["budget_tokens"] == 16000
+            assert "output_config" not in kwargs
+        finally:
+            del os.environ["HERMES_FORCE_BUDGET_THINKING"]
+
     def test_reasoning_disabled(self):
         kwargs = build_anthropic_kwargs(
             model="claude-sonnet-4-20250514",


### PR DESCRIPTION
## Summary

Adds an opt-in environment variable `HERMES_FORCE_BUDGET_THINKING` that makes `_supports_adaptive_thinking` return `False` for Claude 4.6 models, so they use fixed `budget_tokens` thinking instead of adaptive.

**Why:** Adaptive thinking on Opus 4.6 can allocate zero tokens on some turns, skipping reasoning entirely. In agentic pipelines where consistent reasoning is critical (multi-step tool orchestration, code generation), the occasional zero-thinking turn causes noticeable quality regressions.

**How:** When `HERMES_FORCE_BUDGET_THINKING=1` is set, 4.6 models fall through to the existing `budget_tokens` path with `thinking: { type: "enabled", budget_tokens: N }` instead of `thinking: { type: "adaptive" }`.

- No behavior change when the env var is unset (default)
- Includes test case

## Changes

- `agent/anthropic_adapter.py`: Add env var check to `_supports_adaptive_thinking`
- `tests/agent/test_anthropic_adapter.py`: Add test for the new behavior

## Test plan

- [x] Existing tests pass (no change to default behavior)
- [x] New test verifies budget thinking is used when env var is set
- [ ] Manual verification with Opus 4.6 confirming thinking stream always appears