### PR TITLE
fix(mattermost): pass channel display name to agent session context

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -710,8 +710,10 @@ class MattermostAdapter(BasePlatformAdapter):
             elif media_types:
                 msg_type = MessageType.DOCUMENT
 
+        channel_name = data.get("channel_display_name") or None
         source = self.build_source(
             chat_id=channel_id,
+            chat_name=channel_name,
             chat_type=chat_type,
             user_id=sender_id,
             user_name=sender_name,


### PR DESCRIPTION
## Summary

The Mattermost WebSocket `posted` event includes `channel_display_name` in its data payload, but this field was never forwarded to `build_source()`. As a result, the agent only sees the raw channel ID (e.g. `oktymcrgu3dq8nk9ssm5wgrmao`) instead of the human-readable name (e.g. `Soporte General`) in its session context.

This extracts `channel_display_name` from the WS event data and passes it as `chat_name` to `build_source()`, matching what Discord and Telegram already do for their respective adapters.

**Before:** `**Source:** Mattermost (channel: oktymcrgu3dq8nk9ssm5wgrmao)`
**After:** `**Source:** Mattermost (channel: Soporte General)`

## Changes

- `gateway/platforms/mattermost.py`: Extract `channel_display_name` from WS event `data` dict and pass as `chat_name` parameter to `build_source()`

## Test plan

- [x] Verified on live Mattermost instance — agent now reports channel name correctly in session context
- [x] Confirmed `channel_display_name` is present in Mattermost WS `posted` events (both public and private channels)
- [x] Falls back gracefully to `None` (existing behavior) if field is absent