### PR TITLE
fix(terminal): prevent wrapper hang when command ends with &

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -346,6 +346,10 @@ class BaseEnvironment(ABC):
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")
+        # If the command ends with & (background), disown all jobs so the shell
+        # exits immediately instead of waiting for them — prevents stdin hang.
+        if command.strip().endswith("&"):
+            parts.append("jobs -p | xargs -r disown 2>/dev/null; disown -a 2>/dev/null || true")
         parts.append("__hermes_ec=$?")
 
         # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)


### PR DESCRIPTION
## Problem

Commands ending with `&` (background execution) cause the bash wrapper to hang indefinitely because bash waits for all background jobs before exiting, even after the foreground command completes.

## Fix

Add `disown` logic after `eval` to detach all background jobs immediately, allowing the wrapper to exit right away.

**Changes** (`tools/environments/base.py`):
```python
# If the command ends with & (background), disown all jobs so the shell
# exits immediately instead of waiting for them — prevents stdin hang.
if command.strip().endswith("&"):
    parts.append("jobs -p | xargs -r disown 2>/dev/null; disown -a 2>/dev/null || true")
```

**Root cause**: `_wrap_command()` executes `bash -c (hermes wrapper) → eval (user command)`. When the command ends with `&`, `eval` returns but bash still has background jobs, so `exit` never executes and the wrapper hangs waiting for stdin.

**Fixes**: #8340, #6658