### PR TITLE
feat(memory): add per-user scoping to holographic memory plugin

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -662,6 +662,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        # Per-user memory scoping: callers pass X-Hermes-User-Id so
+        # memory plugins (holographic, mem0, honcho) isolate facts per
+        # user.  When absent, all facts are visible (CLI behaviour).
+        provided_user_id = request.headers.get(
+            "X-Hermes-User-Id", ""
+        ).strip() or None
+
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
         #
@@ -772,6 +779,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
+                user_id=provided_user_id,
             ))
 
             return await self._write_sse_chat_completion(
@@ -786,6 +794,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                user_id=provided_user_id,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1484,6 +1493,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if body.get("truncation") == "auto" and len(conversation_history) > 100:
             conversation_history = conversation_history[-100:]
 
+        # Per-user memory scoping (same header as chat completions)
+        resp_user_id = request.headers.get(
+            "X-Hermes-User-Id", ""
+        ).strip() or None
+
         # Reuse session from previous_response_id chain so the dashboard
         # groups the entire conversation under one session entry.
         session_id = stored_session_id or str(uuid.uuid4())
@@ -1539,6 +1553,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=_on_tool_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
+                user_id=resp_user_id,
                 agent_ref=agent_ref,
             ))
 
@@ -1568,6 +1583,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                user_id=resp_user_id,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1992,6 +2008,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
+        user_id: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2014,6 +2031,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
+                user_id=user_id,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -2176,6 +2194,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or stored_session_id or run_id
         ephemeral_system_prompt = instructions
+        stream_user_id = request.headers.get(
+            "X-Hermes-User-Id", ""
+        ).strip() or None
 
         async def _run_and_close():
             try:
@@ -2184,6 +2205,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    user_id=stream_user_id,
                 )
                 def _run_sync():
                     r = agent.run_conversation(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -517,6 +517,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        user_id: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -553,6 +554,7 @@ class APIServerAdapter(BasePlatformAdapter):
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
             platform="api_server",
+            user_id=user_id,
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -170,7 +170,17 @@ class HolographicMemoryProvider(MemoryProvider):
         hrr_weight = float(self._config.get("hrr_weight", 0.3))
         temporal_decay = int(self._config.get("temporal_decay_half_life", 0))
 
-        self._store = MemoryStore(db_path=db_path, default_trust=default_trust, hrr_dim=hrr_dim)
+        # Per-user scoping: gateway platforms pass user_id so each
+        # user's facts are isolated.  CLI sessions (user_id=None)
+        # see all facts (backwards-compatible).
+        user_scope = kwargs.get("user_id")
+
+        self._store = MemoryStore(
+            db_path=db_path,
+            default_trust=default_trust,
+            hrr_dim=hrr_dim,
+            user_scope=user_scope,
+        )
         self._retriever = FactRetriever(
             store=self._store,
             temporal_decay_half_life=temporal_decay,
@@ -183,9 +193,17 @@ class HolographicMemoryProvider(MemoryProvider):
         if not self._store:
             return ""
         try:
-            total = self._store._conn.execute(
-                "SELECT COUNT(*) FROM facts"
-            ).fetchone()[0]
+            if self._store.user_scope is not None:
+                total = self._store._conn.execute(
+                    "SELECT COUNT(*) FROM facts "
+                    "WHERE user_scope IS NULL "
+                    "OR user_scope = ?",
+                    (self._store.user_scope,),
+                ).fetchone()[0]
+            else:
+                total = self._store._conn.execute(
+                    "SELECT COUNT(*) FROM facts"
+                ).fetchone()[0]
         except Exception:
             total = 0
         if total == 0:
@@ -241,7 +259,7 @@ class HolographicMemoryProvider(MemoryProvider):
         self._auto_extract_facts(messages)
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
-        """Mirror built-in memory writes as facts."""
+        """Mirror built-in memory writes as facts (user-scoped)."""
         if action == "add" and self._store and content:
             try:
                 category = "user_pref" if target == "user" else "general"

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -154,6 +154,10 @@ class FactRetriever:
         # Score against individual fact vectors directly
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
+        scope_sql, scope_params = self.store.scope_clause()
+        if scope_sql:
+            where += " " + scope_sql
+            params.extend(scope_params)
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -214,6 +218,10 @@ class FactRetriever:
         # Get all facts with vectors
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
+        scope_sql, scope_params = self.store.scope_clause()
+        if scope_sql:
+            where += " " + scope_sql
+            params.extend(scope_params)
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -293,6 +301,10 @@ class FactRetriever:
         # Get all facts with vectors
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
+        scope_sql, scope_params = self.store.scope_clause()
+        if scope_sql:
+            where += " " + scope_sql
+            params.extend(scope_params)
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -358,6 +370,10 @@ class FactRetriever:
         # Get all facts with vectors and their linked entities
         where = "WHERE f.hrr_vector IS NOT NULL"
         params: list = []
+        scope_sql, scope_params = self.store.scope_clause("f")
+        if scope_sql:
+            where += " " + scope_sql
+            params.extend(scope_params)
         if category:
             where += " AND f.category = ?"
             params.append(category)
@@ -452,6 +468,10 @@ class FactRetriever:
 
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
+        scope_sql, scope_params = self.store.scope_clause()
+        if scope_sql:
+            where += " " + scope_sql
+            params.extend(scope_params)
         if category:
             where += " AND category = ?"
             params.append(category)
@@ -507,14 +527,19 @@ class FactRetriever:
 
         where_sql = " AND ".join(where_clauses)
 
+        # Per-user scoping
+        scope_sql, scope_params = self.store.scope_clause("f")
+
         sql = f"""
             SELECT f.*, facts_fts.rank as fts_rank_raw
             FROM facts_fts
             JOIN facts f ON f.fact_id = facts_fts.rowid
             WHERE {where_sql}
+            {scope_sql}
             ORDER BY facts_fts.rank
             LIMIT ?
         """
+        params.extend(scope_params)
         params.append(limit)
 
         try:

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -16,7 +16,7 @@ except ImportError:
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS facts (
     fact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    content         TEXT NOT NULL UNIQUE,
+    content         TEXT NOT NULL,
     category        TEXT DEFAULT 'general',
     tags            TEXT DEFAULT '',
     trust_score     REAL DEFAULT 0.5,
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS facts (
     helpful_count   INTEGER DEFAULT 0,
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    hrr_vector      BLOB
+    hrr_vector      BLOB,
+    user_scope      TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS entities (
@@ -41,8 +42,12 @@ CREATE TABLE IF NOT EXISTS fact_entities (
     PRIMARY KEY (fact_id, entity_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_facts_trust    ON facts(trust_score DESC);
-CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_content_user
+    ON facts(content, COALESCE(user_scope, ''));
+
+CREATE INDEX IF NOT EXISTS idx_facts_trust      ON facts(trust_score DESC);
+CREATE INDEX IF NOT EXISTS idx_facts_category   ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_facts_user_scope ON facts(user_scope);
 CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
@@ -103,6 +108,7 @@ class MemoryStore:
         db_path: "str | Path | None" = None,
         default_trust: float = 0.5,
         hrr_dim: int = 1024,
+        user_scope: "str | None" = None,
     ) -> None:
         if db_path is None:
             from hermes_constants import get_hermes_home
@@ -111,6 +117,7 @@ class MemoryStore:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.default_trust = _clamp_trust(default_trust)
         self.hrr_dim = hrr_dim
+        self.user_scope = user_scope
         self._hrr_available = hrr._HAS_NUMPY
         self._conn: sqlite3.Connection = sqlite3.connect(
             str(self.db_path),
@@ -129,10 +136,18 @@ class MemoryStore:
         """Create tables, indexes, and triggers if they do not exist. Enable WAL mode."""
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.executescript(_SCHEMA)
-        # Migrate: add hrr_vector column if missing (safe for existing databases)
+        # Migrate: add columns if missing (safe for existing databases)
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
         if "hrr_vector" not in columns:
             self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        if "user_scope" not in columns:
+            self._conn.execute("ALTER TABLE facts ADD COLUMN user_scope TEXT DEFAULT NULL")
+            # Replace the old UNIQUE constraint on content with a
+            # composite unique index that includes user_scope.
+            self._conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_content_user "
+                "ON facts(content, COALESCE(user_scope, ''))"
+            )
         self._conn.commit()
 
     # ------------------------------------------------------------------
@@ -147,9 +162,9 @@ class MemoryStore:
     ) -> int:
         """Insert a fact and return its fact_id.
 
-        Deduplicates by content (UNIQUE constraint). On duplicate, returns
-        the existing fact_id without modifying the row. Extracts entities from
-        the content and links them to the fact.
+        Deduplicates by (content, user_scope). On duplicate, returns
+        the existing fact_id without modifying the row. Extracts entities
+        from the content and links them to the fact.
         """
         with self._lock:
             content = content.strip()
@@ -159,17 +174,21 @@ class MemoryStore:
             try:
                 cur = self._conn.execute(
                     """
-                    INSERT INTO facts (content, category, tags, trust_score)
-                    VALUES (?, ?, ?, ?)
+                    INSERT INTO facts (content, category, tags,
+                                       trust_score, user_scope)
+                    VALUES (?, ?, ?, ?, ?)
                     """,
-                    (content, category, tags, self.default_trust),
+                    (content, category, tags,
+                     self.default_trust, self.user_scope),
                 )
                 self._conn.commit()
                 fact_id: int = cur.lastrowid  # type: ignore[assignment]
             except sqlite3.IntegrityError:
-                # Duplicate content — return existing id
+                # Duplicate content for this user — return existing id
                 row = self._conn.execute(
-                    "SELECT fact_id FROM facts WHERE content = ?", (content,)
+                    "SELECT fact_id FROM facts WHERE content = ? "
+                    "AND COALESCE(user_scope, '') = ?",
+                    (content, self.user_scope or ""),
                 ).fetchone()
                 return int(row["fact_id"])
 
@@ -195,6 +214,8 @@ class MemoryStore:
 
         Returns a list of fact dicts ordered by FTS5 rank, then trust_score
         descending. Also increments retrieval_count for matched facts.
+        When ``user_scope`` is set, only facts belonging to that scope
+        (or global facts with NULL user_scope) are returned.
         """
         with self._lock:
             query = query.strip()
@@ -202,6 +223,13 @@ class MemoryStore:
                 return []
 
             params: list = [query, min_trust]
+            scope_clause = ""
+            if self.user_scope is not None:
+                scope_clause = (
+                    "AND (f.user_scope IS NULL "
+                    "OR f.user_scope = ?)"
+                )
+                params.append(self.user_scope)
             category_clause = ""
             if category is not None:
                 category_clause = "AND f.category = ?"
@@ -216,6 +244,7 @@ class MemoryStore:
                 JOIN facts_fts fts ON fts.rowid = f.fact_id
                 WHERE facts_fts MATCH ?
                   AND f.trust_score >= ?
+                  {scope_clause}
                   {category_clause}
                 ORDER BY fts.rank, f.trust_score DESC
                 LIMIT ?
@@ -325,9 +354,18 @@ class MemoryStore:
         """Browse facts ordered by trust_score descending.
 
         Optionally filter by category and minimum trust score.
+        When ``user_scope`` is set, only matching or global facts
+        are returned.
         """
         with self._lock:
             params: list = [min_trust]
+            scope_clause = ""
+            if self.user_scope is not None:
+                scope_clause = (
+                    "AND (user_scope IS NULL "
+                    "OR user_scope = ?)"
+                )
+                params.append(self.user_scope)
             category_clause = ""
             if category is not None:
                 category_clause = "AND category = ?"
@@ -336,9 +374,11 @@ class MemoryStore:
 
             sql = f"""
                 SELECT fact_id, content, category, tags, trust_score,
-                       retrieval_count, helpful_count, created_at, updated_at
+                       retrieval_count, helpful_count, created_at,
+                       updated_at
                 FROM facts
                 WHERE trust_score >= ?
+                  {scope_clause}
                   {category_clause}
                 ORDER BY trust_score DESC
                 LIMIT ?
@@ -558,6 +598,27 @@ class MemoryStore:
     # ------------------------------------------------------------------
     # Utilities
     # ------------------------------------------------------------------
+
+    def scope_clause(
+        self, alias: str = "", column: str = "user_scope"
+    ) -> "tuple[str, list]":
+        """Return a SQL fragment and params that restrict queries to
+        the current ``user_scope`` (or all rows when unscoped).
+
+        Usage::
+
+            clause, params = store.scope_clause("f")
+            sql = f"SELECT ... FROM facts f WHERE ... {clause}"
+            cursor.execute(sql, [...] + params)
+        """
+        prefix = f"{alias}." if alias else ""
+        if self.user_scope is not None:
+            return (
+                f"AND ({prefix}{column} IS NULL "
+                f"OR {prefix}{column} = ?)",
+                [self.user_scope],
+            )
+        return ("", [])
 
     def _row_to_dict(self, row: sqlite3.Row) -> dict:
         """Convert a sqlite3.Row to a plain dict."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",
     # contributors (manual mapping from git names)
+    "nericervin@gmail.com": "nericervin",
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",


### PR DESCRIPTION
## Summary

Adds per-user fact scoping to the Holographic memory plugin, allowing multi-tenant deployments where each user's memories are isolated.

Replaces #7256 (rebased on current main to resolve conflicts).

## Changes

- **`plugins/memory/holographic/store.py`**: Add `user_scope` column to facts table, filter queries by user when provided
- **`plugins/memory/holographic/retrieval.py`**: Pass `user_scope` through retrieval pipeline
- **`plugins/memory/holographic/__init__.py`**: Accept `user_id` parameter in memory plugin interface
- **`gateway/platforms/api_server.py`**: 
  - Read `X-Hermes-User-Id` header for per-user memory scoping
  - Pass `user_id` through `_create_agent` and `_run_agent` to the memory plugin
  - Compatible with new streaming SSE callbacks (tool_start/tool_complete)

## Use case

When Hermes serves multiple users via the API server (e.g. from an Odoo Discuss integration), each user's holographic memories should be isolated. Without this, all users share the same fact store, leading to cross-contamination of context.

The `X-Hermes-User-Id` header is set by the client (e.g. Odoo webhook) to identify the user.

## Test plan

- [x] Verified on live multi-user deployment — facts are correctly scoped per user
- [x] Backwards compatible — when no `X-Hermes-User-Id` header is sent, behavior is unchanged (global scope)
- [x] No impact on other memory providers (Mem0, Honcho)