### PR TITLE
fix: close api server response store on aiohttp app cleanup

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -602,6 +602,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        self._response_store_closed = False
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -681,6 +682,34 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         return "*" in self._cors_origins or origin in self._cors_origins
+
+    def _ensure_response_store(self) -> None:
+        """Reopen the response store if it was closed during app cleanup."""
+        if self._response_store_closed:
+            self._response_store = ResponseStore()
+            self._response_store_closed = False
+
+    def _close_response_store(self) -> None:
+        """Close the response store exactly once per adapter lifecycle."""
+        if self._response_store_closed:
+            return
+        self._response_store_closed = True
+        try:
+            self._response_store.close()
+        except Exception:
+            pass
+
+    async def _on_app_cleanup(self, app: "web.Application") -> None:
+        """Release response-store resources when the aiohttp app is cleaned up."""
+        self._close_response_store()
+
+    def bind_app(self, app: "web.Application") -> "web.Application":
+        """Bind adapter lifecycle hooks to an aiohttp app used by the API server."""
+        self._ensure_response_store()
+        app["api_server_adapter"] = self
+        if self._on_app_cleanup not in app.on_cleanup:
+            app.on_cleanup.append(self._on_app_cleanup)
+        return app
 
     # ------------------------------------------------------------------
     # Auth helper
@@ -3339,8 +3368,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
-            self._app["api_server_adapter"] = self
+            self._app = self.bind_app(
+                web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
+            )
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)
@@ -3444,6 +3474,7 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._app = None
+        self._close_response_store()
         logger.info("[%s] API server stopped", self.name)
 
     async def send(

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -583,6 +583,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        self._response_store_closed = False
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -656,6 +657,34 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         return "*" in self._cors_origins or origin in self._cors_origins
+
+    def _ensure_response_store(self) -> None:
+        """Reopen the response store if it was closed during app cleanup."""
+        if self._response_store_closed:
+            self._response_store = ResponseStore()
+            self._response_store_closed = False
+
+    def _close_response_store(self) -> None:
+        """Close the response store exactly once per adapter lifecycle."""
+        if self._response_store_closed:
+            return
+        self._response_store_closed = True
+        try:
+            self._response_store.close()
+        except Exception:
+            pass
+
+    async def _on_app_cleanup(self, app: "web.Application") -> None:
+        """Release response-store resources when the aiohttp app is cleaned up."""
+        self._close_response_store()
+
+    def bind_app(self, app: "web.Application") -> "web.Application":
+        """Bind adapter lifecycle hooks to an aiohttp app used by the API server."""
+        self._ensure_response_store()
+        app["api_server_adapter"] = self
+        if self._on_app_cleanup not in app.on_cleanup:
+            app.on_cleanup.append(self._on_app_cleanup)
+        return app
 
     # ------------------------------------------------------------------
     # Auth helper
@@ -2615,8 +2644,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
-            self._app["api_server_adapter"] = self
+            self._app = self.bind_app(web.Application(middlewares=mws))
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)
@@ -2717,6 +2745,7 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._app = None
+        self._close_response_store()
         logger.info("[%s] API server stopped", self.name)
 
     async def send(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -350,8 +350,7 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app = adapter.bind_app(web.Application(middlewares=mws))
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
@@ -415,6 +414,33 @@ class TestAgentExecution:
 
 
 class TestHealthEndpoint:
+    @pytest.mark.asyncio
+    async def test_test_client_cleanup_closes_response_store(self, adapter):
+        """Closing the aiohttp test app should close the adapter response store."""
+        original_close = adapter._response_store.close
+        with patch.object(adapter._response_store, "close", wraps=original_close) as mock_close:
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/health")
+                assert resp.status == 200
+        assert mock_close.call_count == 1
+        assert adapter._response_store_closed is True
+
+    @pytest.mark.asyncio
+    async def test_create_app_reopens_response_store_after_cleanup(self, adapter):
+        """A reused adapter should reopen its response store for a later app lifecycle."""
+        first_app = _create_app(adapter)
+        async with TestClient(TestServer(first_app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+        assert adapter._response_store_closed is True
+
+        second_app = _create_app(adapter)
+        async with TestClient(TestServer(second_app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+        assert adapter._response_store_closed is True
+
     @pytest.mark.asyncio
     async def test_security_headers_present(self, adapter):
         """Responses should include basic security headers."""
@@ -1913,21 +1939,22 @@ class TestResponsesStreaming:
                     },
                 )
                 body = await resp.text()
+                response_id = None
+                for line in body.splitlines():
+                    if line.startswith("data: "):
+                        try:
+                            payload = json.loads(line[len("data: "):])
+                        except json.JSONDecodeError:
+                            continue
+                        if payload.get("type") == "response.completed":
+                            response_id = payload["response"]["id"]
+                            break
+
+                assert response_id
+                stored_history = adapter._response_store.get(response_id)["conversation_history"]
 
         assert resp.status == 200
-        response_id = None
-        for line in body.splitlines():
-            if line.startswith("data: "):
-                try:
-                    payload = json.loads(line[len("data: "):])
-                except json.JSONDecodeError:
-                    continue
-                if payload.get("type") == "response.completed":
-                    response_id = payload["response"]["id"]
-                    break
-
         assert response_id
-        stored_history = adapter._response_store.get(response_id)["conversation_history"]
         assert stored_history == expected_history
         assert stored_history.count(prior_history[0]) == 1
         assert stored_history.count({"role": "user", "content": "Now add 1 more"}) == 1

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -308,8 +308,7 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app = adapter.bind_app(web.Application(middlewares=mws))
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
@@ -337,6 +336,33 @@ def auth_adapter():
 
 
 class TestHealthEndpoint:
+    @pytest.mark.asyncio
+    async def test_test_client_cleanup_closes_response_store(self, adapter):
+        """Closing the aiohttp test app should close the adapter response store."""
+        original_close = adapter._response_store.close
+        with patch.object(adapter._response_store, "close", wraps=original_close) as mock_close:
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/health")
+                assert resp.status == 200
+        assert mock_close.call_count == 1
+        assert adapter._response_store_closed is True
+
+    @pytest.mark.asyncio
+    async def test_create_app_reopens_response_store_after_cleanup(self, adapter):
+        """A reused adapter should reopen its response store for a later app lifecycle."""
+        first_app = _create_app(adapter)
+        async with TestClient(TestServer(first_app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+        assert adapter._response_store_closed is True
+
+        second_app = _create_app(adapter)
+        async with TestClient(TestServer(second_app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+        assert adapter._response_store_closed is True
+
     @pytest.mark.asyncio
     async def test_security_headers_present(self, adapter):
         """Responses should include basic security headers."""

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -50,8 +50,7 @@ def _make_adapter(api_key: str = "") -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app with jobs routes registered."""
-    app = web.Application(middlewares=[cors_middleware])
-    app["api_server_adapter"] = adapter
+    app = adapter.bind_app(web.Application(middlewares=[cors_middleware]))
     # Register only job routes (plus health for sanity)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/api/jobs", adapter._handle_list_jobs)


### PR DESCRIPTION
## 背景

此前 `tests/gateway/test_api_server.py` 相关链路会在长序列
`TestClient(TestServer(app))` 运行后出现资源耗尽，表现为：

- `Errno 24`
- `Too many open files`

排查后确认主嫌疑链路为：

- `APIServerAdapter` 持有的 `ResponseStore`
- 未被统一挂到 aiohttp app lifecycle cleanup
- 测试 helper 的 `_create_app(adapter)` 路径绕过 `connect()`
- 生产路径与测试路径的资源释放合同发生分叉

本 PR 的目标是做**最小生命周期统一修复**，而不是大规模 app builder 重构。

## 变更

### 生产代码

- `gateway/platforms/api_server.py`
  - 新增 `bind_app()`
  - 将 adapter 生命周期统一绑定到 aiohttp app
  - 新增 cleanup 相关逻辑，确保 app 退出时关闭 `ResponseStore`
  - 在后续重新建 app 时支持 reopen / 重建必要资源
  - `connect()` / `disconnect()` 统一走同一生命周期合同

### 测试代码

- `tests/gateway/test_api_server.py`
- `tests/gateway/test_api_server_jobs.py`

将测试中的 app 构造 helper 切换为复用同一生命周期绑定入口，避免：

- 只修 `connect()` 不修测试路径
- 或只修测试 helper 造成“测试绿了但生产合同没修”

## 验证

已完成以下验证：

### 定向验证
- `tests/gateway/test_api_server.py`
- `tests/gateway/test_api_server_jobs.py`

结果：

- **144 passed**

### bind guard 验证
- `tests/gateway/test_api_server_bind_guard.py`

结果：

- **17 passed**

### 串联验证
- `tests/gateway/test_api_server.py`
- `tests/gateway/test_api_server_jobs.py`
- `tests/gateway/test_api_server_bind_guard.py`
- `tests/agent/test_context_references.py::test_expand_file_range_and_folder_listing`

结果：

- **162 passed**

### 更长串联验证
- `tests/gateway/test_api_server.py`
- `tests/gateway/test_api_server_jobs.py`
- `tests/gateway/test_api_server_bind_guard.py`
- `tests/agent/test_context_references.py::test_expand_file_range_and_folder_listing`
- `tests/cron`
- `tests/e2e`
- `tests/environments`

结果：

- **385 passed**

## 变更范围

本 PR 仅包含以下 3 个文件：

- `gateway/platforms/api_server.py`
- `tests/gateway/test_api_server.py`
- `tests/gateway/test_api_server_jobs.py`

当前 scoped diff：

- **60 insertions / 6 deletions**

## 结论

本 PR 之后：

- `ResponseStore` 生命周期已绑定到 aiohttp app cleanup
- `Errno 24` / `Too many open files` 主嫌疑链路已被压下
- 测试路径与生产路径共享同一 cleanup 合同

## 风险与说明

- 本 PR 不处理 gateway 里其他与 `Errno 24` 无关的独立失败
- 后续其余 gateway 基线问题应单独拆分处理
