### PR TITLE
fix(agent): strip whitespace from tool_call_id in sanitizer

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3351,21 +3351,21 @@ class AIAgent:
                 for tc in msg.get("tool_calls") or []:
                     cid = AIAgent._get_tool_call_id_static(tc)
                     if cid:
-                        surviving_call_ids.add(cid)
+                        surviving_call_ids.add(cid.strip())
 
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
                 cid = msg.get("tool_call_id")
                 if cid:
-                    result_call_ids.add(cid)
+                    result_call_ids.add(cid.strip() if isinstance(cid, str) else cid)
 
         # 1. Drop tool results with no matching assistant call
         orphaned_results = result_call_ids - surviving_call_ids
         if orphaned_results:
             messages = [
                 m for m in messages
-                if not (m.get("role") == "tool" and m.get("tool_call_id") in orphaned_results)
+                if not (m.get("role") == "tool" and (m.get("tool_call_id", "").strip() if isinstance(m.get("tool_call_id"), str) else m.get("tool_call_id")) in orphaned_results)
             ]
             logger.debug(
                 "Pre-call sanitizer: removed %d orphaned tool result(s)",
@@ -3381,7 +3381,7 @@ class AIAgent:
                 if msg.get("role") == "assistant":
                     for tc in msg.get("tool_calls") or []:
                         cid = AIAgent._get_tool_call_id_static(tc)
-                        if cid in missing_results:
+                        if cid and cid.strip() in missing_results:
                             patched.append({
                                 "role": "tool",
                                 "content": "[Result unavailable — see context summary above]",

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -108,6 +108,41 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         assert out[1]["tool_call_id"] == "c6"
 
+    def test_whitespace_tool_call_id_matched(self):
+        """Whitespace around tool_call_id should not cause orphan misclassification (#9999)."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("call_123")]},
+            tool_result("  call_123  "),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Should match: 1 assistant + 1 tool result (no stub, no drop)
+        assert len(out) == 2
+        assert out[0]["role"] == "assistant"
+        assert out[1]["role"] == "tool"
+        assert out[1]["tool_call_id"] == "  call_123  "  # original preserved, just matched correctly
+
+    def test_whitespace_in_assistant_tool_call_id_matched(self):
+        """Whitespace in assistant-side tool_call id should also match."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("  c7  ")]},
+            tool_result("c7"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2
+        assert out[0]["role"] == "assistant"
+        assert out[1]["role"] == "tool"
+
+    def test_both_sides_whitespace_matched(self):
+        """Whitespace on both assistant and result side should still match."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("  x  ")]},
+            tool_result("  x  "),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 2
+        assert out[0]["role"] == "assistant"
+        assert out[1]["role"] == "tool"
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls


### PR DESCRIPTION
## What
Strip whitespace from `tool_call_id` values in `_sanitize_api_messages()` to prevent false orphan detection.

## Why
Closes #9999. When `tool_call_id` has surrounding whitespace (e.g. `" call_123 "` vs `"call_123"`), the set comparison in the sanitizer fails. The tool result is incorrectly dropped as orphaned, and a stub result is injected for the "missing" call. This corrupts the conversation history.

## How
Added `.strip()` to all four locations in `_sanitize_api_messages()` where `tool_call_id` values are compared:
- Assistant-side ID collection (line ~3354)
- Tool-result-side ID collection (line ~3361)
- Orphan removal filter (line ~3368)
- Stub injection check (line ~3384)

This makes whitespace handling consistent with `_build_codex_input_items()` (line ~3530) which already strips.

## Testing
- Added 3 regression tests to `tests/run_agent/test_agent_guardrails.py`:
  - Whitespace on result-side `tool_call_id`
  - Whitespace on assistant-side `tool_call_id`
  - Whitespace on both sides simultaneously
- All 32 guardrail tests pass
- 377/378 `tests/run_agent/` tests pass (1 pre-existing failure in `test_provider_parity.py`, unrelated)
- Tested on Linux x86_64 (AMD 8745HS), Python 3.13