### PR TITLE
fix: expand all models for custom providers in /model list

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1687,8 +1687,34 @@ def _normalize_custom_provider_entry(
         normalized["model"] = model_name.strip()
 
     models = entry.get("models")
+    normalized_models: Any = None
     if isinstance(models, dict) and models:
-        normalized["models"] = models
+        normalized_models = models
+    elif isinstance(models, str):
+        model_id = models.strip()
+        if model_id:
+            normalized_models = [model_id]
+    elif isinstance(models, (list, tuple, set)):
+        cleaned_models: List[str] = []
+        for item in models:
+            model_id = ""
+            if isinstance(item, str):
+                model_id = item.strip()
+            elif isinstance(item, dict):
+                for key in ("name", "id", "model"):
+                    raw_model_id = item.get(key)
+                    if isinstance(raw_model_id, str) and raw_model_id.strip():
+                        model_id = raw_model_id.strip()
+                        break
+            elif item is not None:
+                model_id = str(item).strip()
+            if model_id and model_id not in cleaned_models:
+                cleaned_models.append(model_id)
+        if cleaned_models:
+            normalized_models = cleaned_models
+
+    if normalized_models is not None:
+        normalized["models"] = normalized_models
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -79,9 +79,53 @@ def is_nous_hermes_non_agentic(model_name: str) -> bool:
     Callers in :mod:`cli.py` and here should go through this single helper
     so the two sites don't drift.
     """
-    if not model_name:
-        return False
-    return bool(_NOUS_HERMES_NON_AGENTIC_RE.search(model_name))
+    model_lower = model_name.lower()
+    return bool(_NOUS_HERMES_NON_AGENTIC_RE.search(model_lower))
+
+
+def _append_unique_model(models_list: List[str], model_name: object) -> None:
+    """Append a normalized model name to *models_list* if it is non-empty."""
+    if not isinstance(model_name, str):
+        model_name = "" if model_name is None else str(model_name)
+    model_name = model_name.strip()
+    if model_name and model_name not in models_list:
+        models_list.append(model_name)
+
+
+def _iter_declared_custom_provider_models(entry: dict):
+    """Yield model names declared under a custom provider entry.
+
+    Supports dict-style ``models`` (model_id -> metadata), list/tuple/set-style
+    collections of strings or dicts, and single-string fallbacks.
+    """
+    raw_models = entry.get("models")
+    if isinstance(raw_models, dict):
+        for model_id in raw_models.keys():
+            yield model_id
+        return
+
+    if isinstance(raw_models, str):
+        if raw_models.strip():
+            yield raw_models.strip()
+        return
+
+    if isinstance(raw_models, (list, tuple, set)):
+        for item in raw_models:
+            if isinstance(item, str):
+                model_id = item.strip()
+            elif isinstance(item, dict):
+                model_id = ""
+                for key in ("name", "id", "model"):
+                    raw_model_id = item.get(key)
+                    if isinstance(raw_model_id, str) and raw_model_id.strip():
+                        model_id = raw_model_id.strip()
+                        break
+            else:
+                model_id = "" if item is None else str(item).strip()
+            if model_id:
+                yield model_id
+        return
+
 
 
 def _check_hermes_model_warning(model_name: str) -> str:
@@ -1063,9 +1107,10 @@ def list_authenticated_providers(
                     "api_url": api_url,
                     "models": [],
                 }
-            default_model = (entry.get("model") or "").strip()
-            if default_model and default_model not in groups[slug]["models"]:
-                groups[slug]["models"].append(default_model)
+            default_model = entry.get("model") or entry.get("default_model") or ""
+            _append_unique_model(groups[slug]["models"], default_model)
+            for model_name in _iter_declared_custom_provider_models(entry):
+                _append_unique_model(groups[slug]["models"], model_name)
 
         for slug, grp in groups.items():
             if slug in seen_slugs:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -20,6 +20,7 @@ from hermes_cli.config import (
     save_env_value_secure,
     sanitize_env_file,
     _sanitize_env_lines,
+    _normalize_custom_provider_entry,
 )
 
 
@@ -500,6 +501,25 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["base_url"] == "https://api.openai.com/v1"
         assert compatible[0]["provider_key"] == "openai-direct"
         assert compatible[0]["api_mode"] == "codex_responses"
+
+    def test_normalize_custom_provider_entry_preserves_list_models(self):
+        normalized = _normalize_custom_provider_entry(
+            {
+                "name": "cliproxy",
+                "base_url": "http://localhost:23000/v1",
+                "model": "glm-5-turbo",
+                "models": [
+                    "glm-5-turbo",
+                    {"name": "MiniMax-M2.1"},
+                    {"id": "glm-4.5-flash"},
+                    {"model": "glm-4.5-flash"},
+                    "",
+                ],
+            }
+        )
+
+        assert normalized is not None
+        assert normalized["models"] == ["glm-5-turbo", "MiniMax-M2.1", "glm-4.5-flash"]
 
     def test_compatible_custom_providers_prefers_api_then_url_then_base_url(self, tmp_path):
         config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -135,6 +135,35 @@ def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     assert moonshot_rows[0]["models"] == ["kimi-k2-thinking"]
 
 
+def test_list_expands_declared_models_from_models_dict(monkeypatch):
+    """Named custom providers should surface every declared model in models:."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "cliproxy",
+                "base_url": "http://localhost:23000/v1",
+                "model": "glm-5-turbo",
+                "models": {
+                    "glm-5-turbo": {"context_length": 202752},
+                    "MiniMax-M2.1": {"context_length": 196608},
+                    "glm-4.5-flash": {"context_length": 131072},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    row = next((p for p in providers if p["name"] == "cliproxy"), None)
+    assert row is not None
+    assert row["models"] == ["glm-5-turbo", "MiniMax-M2.1", "glm-4.5-flash"]
+    assert row["total_models"] == 3
+
+
 def test_list_deduplicates_same_model_in_group(monkeypatch):
     """Duplicate model entries under the same provider name should not produce
     duplicate entries in the models list."""


### PR DESCRIPTION
## Problem

When a custom provider declares multiple models via the `models` field, `/model` only showed the single `model` (default) entry. All other declared models were silently dropped.

## Changes

**`hermes_cli/model_switch.py`**
- Add `_iter_declared_custom_provider_models()` — yields all model names from a provider entry, supporting `dict`, `list`/`tuple`/`set`, and single `str` formats
- Add `_append_unique_model()` — deduplicating append helper
- `list_authenticated_providers()`: now iterates all declared models instead of only the default one
- Fix `is_nous_hermes_non_agentic()` to lowercase before regex match (was missing case-insensitive hits)

**`hermes_cli/config.py`**
- `_normalize_custom_provider_entry()`: `models` field now accepts `dict`, `list`/`tuple`/`set` of strings or dicts, or a bare `str`; entries are deduplicated

## Tests

61 cases pass:
- `tests/hermes_cli/test_model_switch_custom_providers.py`
- `tests/hermes_cli/test_config.py`