### PR TITLE
fix: resolve UnboundLocalError in post-tool empty response nudge path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10346,8 +10346,9 @@ class AIAgent:
                             #   tool(result) → assistant("(empty)") → user(nudge)
                             # Without this, we'd have tool → user which most
                             # APIs reject as an invalid sequence.
-                            assistant_msg["content"] = "(empty)"
-                            messages.append(assistant_msg)
+                            _nudge_msg = self._build_assistant_message(assistant_message, finish_reason)
+                            _nudge_msg["content"] = "(empty)"
+                            messages.append(_nudge_msg)
                             messages.append({
                                 "role": "user",
                                 "content": (


### PR DESCRIPTION
## Summary

- Fix `UnboundLocalError: cannot access local variable 'assistant_msg'` in the post-tool-call empty response nudge path

## Problem

When a model (e.g. GLM-5, GLM-4.5-Air) returns an empty response after executing tool calls, the agent enters a recovery path that appends a nudge message to prompt the model to continue. This path at line 10349 references `assistant_msg`, which is only assigned in the tool-calls branch (line 10098). In the no-tool-calls branch (where the empty response lands), this variable is never bound.

**Error reproduced:**
```
❌ Error during OpenAI-compatible API call #1: cannot access local variable 'assistant_msg' where it is not associated with a value
⚠️ Empty response from model — retrying (1/3)
⚠️ Empty response from model — retrying (2/3)  
⚠️ Empty response from model — retrying (3/3)
❌ Model returned no content after all retries. No fallback providers configured.
```

## Fix

Build a fresh assistant message dict via `self._build_assistant_message(assistant_message, finish_reason)` instead of reusing the unbound `assistant_msg` variable. This is consistent with the exhausted-retries path at line 10457 which does the same thing.

## Test plan

- [ ] Run a session with a model that returns empty responses after tool calls (e.g. GLM-5.1 on Z.AI coding plan)
- [ ] Verify the nudge path works without `UnboundLocalError`
- [ ] Verify the model recovers and continues processing after the nudge
- [ ] Run existing test suite to ensure no regressions