### PR TITLE
fix(mcp): honor stdio cwd/workdir config

### DIFF
--- a/tests/tools/test_mcp_stdio_workdir.py
+++ b/tests/tools/test_mcp_stdio_workdir.py
@@ -1,0 +1,73 @@
+"""End-to-end coverage for stdio MCP subprocess working directories."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import textwrap
+
+import pytest
+
+
+pytest.importorskip("mcp.server.fastmcp")
+
+
+def test_real_stdio_server_uses_configured_cwd(tmp_path, monkeypatch):
+    """The configured cwd reaches the real MCP child process."""
+    from tools import mcp_tool
+
+    server_script = tmp_path / "cwd_probe_server.py"
+    server_script.write_text(
+        textwrap.dedent(
+            """
+            import os
+
+            from mcp.server.fastmcp import FastMCP
+
+            mcp = FastMCP("cwd-probe")
+
+            @mcp.tool()
+            def report_cwd() -> str:
+                return os.getcwd()
+
+            if __name__ == "__main__":
+                mcp.run(transport="stdio")
+            """
+        ),
+        encoding="utf-8",
+    )
+    configured_cwd = tmp_path / "configured-cwd"
+    configured_cwd.mkdir()
+
+    # Keep this regression hermetic: the subprocess and MCP transport are real,
+    # while network malware checks and process-wide orphan cleanup are not part
+    # of the behavior under test.
+    monkeypatch.setattr(
+        "tools.osv_check.check_package_for_malware",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(mcp_tool, "_kill_orphaned_mcp_children", lambda: None)
+
+    async def drive_server():
+        server = mcp_tool.MCPServerTask("cwd-probe")
+        try:
+            await asyncio.wait_for(
+                server.start(
+                    {
+                        "command": sys.executable,
+                        "args": [str(server_script)],
+                        "cwd": str(configured_cwd),
+                        "connect_timeout": 5,
+                    }
+                ),
+                timeout=10,
+            )
+            result = await asyncio.wait_for(
+                server.session.call_tool("report_cwd", {}),
+                timeout=5,
+            )
+            assert result.content[0].text == str(configured_cwd)
+        finally:
+            await server.shutdown()
+
+    asyncio.run(drive_server())

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1214,6 +1214,37 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    @pytest.mark.parametrize(
+        ("config_key", "config_value", "expected_cwd"),
+        [
+            ("workdir", "~/repo", os.path.expanduser("~/repo")),
+            ("cwd", "/tmp/mcp-server", "/tmp/mcp-server"),
+        ],
+    )
+    def test_stdio_honors_configured_workdir(self, config_key, config_value, expected_cwd):
+        """Stdio MCP servers pass configured workdir/cwd through to the SDK."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                await server.start({"command": "node", config_key: config_value})
+
+                call_kwargs = mock_params.call_args
+                assert call_kwargs.kwargs.get("cwd") == expected_cwd
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
     def test_shutdown_signals_task_exit(self):
         """shutdown() signals the event and waits for task completion."""
         from tools.mcp_tool import MCPServerTask

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -5,6 +5,7 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 
 import asyncio
 import json
+import os
 import threading
 import time
 from types import SimpleNamespace
@@ -1215,13 +1216,17 @@ class TestMCPServerTask:
         asyncio.run(_test())
 
     @pytest.mark.parametrize(
-        ("config_key", "config_value", "expected_cwd"),
+        ("workdir_config", "expected_cwd"),
         [
-            ("workdir", "~/repo", os.path.expanduser("~/repo")),
-            ("cwd", "/tmp/mcp-server", "/tmp/mcp-server"),
+            ({"workdir": "~/repo"}, os.path.expanduser("~/repo")),
+            ({"cwd": "/tmp/mcp-server"}, "/tmp/mcp-server"),
+            (
+                {"cwd": "/tmp/canonical", "workdir": "/tmp/compat-alias"},
+                "/tmp/canonical",
+            ),
         ],
     )
-    def test_stdio_honors_configured_workdir(self, config_key, config_value, expected_cwd):
+    def test_stdio_honors_configured_workdir(self, workdir_config, expected_cwd):
         """Stdio MCP servers pass configured workdir/cwd through to the SDK."""
         from tools.mcp_tool import MCPServerTask
 
@@ -1236,7 +1241,7 @@ class TestMCPServerTask:
         async def _test():
             with patch("tools.mcp_tool.StdioServerParameters") as mock_params, p_stdio, p_cs:
                 server = MCPServerTask("srv")
-                await server.start({"command": "node", config_key: config_value})
+                await server.start({"command": "node", **workdir_config})
 
                 call_kwargs = mock_params.call_args
                 assert call_kwargs.kwargs.get("cwd") == expected_cwd

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -516,6 +516,37 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    @pytest.mark.parametrize(
+        ("config_key", "config_value", "expected_cwd"),
+        [
+            ("workdir", "~/repo", os.path.expanduser("~/repo")),
+            ("cwd", "/tmp/mcp-server", "/tmp/mcp-server"),
+        ],
+    )
+    def test_stdio_honors_configured_workdir(self, config_key, config_value, expected_cwd):
+        """Stdio MCP servers pass configured workdir/cwd through to the SDK."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, p_stdio, p_cs:
+                server = MCPServerTask("srv")
+                await server.start({"command": "node", config_key: config_value})
+
+                call_kwargs = mock_params.call_args
+                assert call_kwargs.kwargs.get("cwd") == expected_cwd
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
     def test_shutdown_signals_task_exit(self):
         """shutdown() signals the event and waits for task completion."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2018,6 +2018,7 @@ class MCPServerTask:
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
+        workdir = config.get("workdir") or config.get("cwd")
 
         if not command:
             raise ValueError(
@@ -2026,6 +2027,8 @@ class MCPServerTask:
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
+        if workdir:
+            workdir = os.path.expanduser(str(workdir))
 
         # Check package against OSV malware database before spawning.
         # Run off the event loop (the urllib HTTPS call is blocking) and bound
@@ -2069,6 +2072,7 @@ class MCPServerTask:
             command=command,
             args=args,
             env=safe_env if safe_env else None,
+            cwd=workdir,
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2018,7 +2018,7 @@ class MCPServerTask:
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
-        workdir = config.get("workdir") or config.get("cwd")
+        workdir = config.get("cwd") or config.get("workdir")
 
         if not command:
             raise ValueError(

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -892,6 +892,7 @@ class MCPServerTask:
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
+        workdir = config.get("workdir") or config.get("cwd")
 
         if not command:
             raise ValueError(
@@ -900,6 +901,8 @@ class MCPServerTask:
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
+        if workdir:
+            workdir = os.path.expanduser(str(workdir))
 
         # Check package against OSV malware database before spawning
         from tools.osv_check import check_package_for_malware
@@ -913,6 +916,7 @@ class MCPServerTask:
             command=command,
             args=args,
             env=safe_env if safe_env else None,
+            cwd=workdir,
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -20,6 +20,8 @@ mcp_servers:
     command: "..."      # stdio servers
     args: []
     env: {}
+    cwd: "/path/to/server"
+    # workdir: "/path/to/server"  # compatibility alias for cwd
 
     # OR
     url: "..."          # HTTP servers
@@ -48,6 +50,8 @@ mcp_servers:
 | `command` | string | stdio | Executable to launch |
 | `args` | list | stdio | Arguments for the subprocess |
 | `env` | mapping | stdio | Environment passed to the subprocess |
+| `cwd` | string | stdio | Working directory for the subprocess. `~` is expanded. Takes precedence if both working-directory keys are set |
+| `workdir` | string | stdio | Compatibility alias for `cwd` |
 | `url` | string | HTTP | Remote MCP endpoint |
 | `headers` | mapping | HTTP | Headers for remote server requests |
 | `ssl_verify` | bool or string | HTTP | TLS verification. `true` (default) uses system CAs, `false` disables verification (insecure), or a string path to a custom CA bundle (PEM) |


### PR DESCRIPTION
## Summary
- read `workdir` and `cwd` from stdio MCP server config
- expand `~` in configured working directories
- pass the resolved directory to `StdioServerParameters`
- add regression coverage for both config keys

## Why
This makes Hermes honor the configured working directory for stdio MCP servers instead of silently ignoring it. It should address the class of failures reported in #5467, while remaining backward compatible with users who configured either `workdir` or `cwd`.

## Testing
- `/Users/masonjames/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_tool.py -q -o 'addopts='nnRefs