### PR TITLE
fix(mcp): improve MCP timeout diagnostics

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -324,6 +324,43 @@ class TestRunOnMCPLoopInterrupts:
             mcp_mod._mcp_loop = old_loop
             mcp_mod._mcp_thread = old_thread
 
+    def test_timeout_reports_elapsed_and_configured_timeout(self):
+        import tools.mcp_tool as mcp_mod
+
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
+        cancelled = threading.Event()
+
+        async def _slow_call():
+            try:
+                await asyncio.sleep(5)
+                return "done"
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        old_loop = mcp_mod._mcp_loop
+        old_thread = mcp_mod._mcp_thread
+        mcp_mod._mcp_loop = loop
+        mcp_mod._mcp_thread = thread
+
+        try:
+            with pytest.raises(TimeoutError, match=r"MCP call timed out after .*configured timeout: 0.2s"):
+                mcp_mod._run_on_mcp_loop(_slow_call(), timeout=0.2)
+
+            deadline = time.time() + 2
+            while time.time() < deadline and not cancelled.is_set():
+                time.sleep(0.05)
+            assert cancelled.is_set()
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=2)
+            loop.close()
+            mcp_mod._mcp_loop = old_loop
+            mcp_mod._mcp_thread = old_thread
+
 
 # ---------------------------------------------------------------------------
 # Tool registration (discovery + register)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1250,7 +1250,8 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
     if loop is None or not loop.is_running():
         raise RuntimeError("MCP event loop is not running")
     future = asyncio.run_coroutine_threadsafe(coro, loop)
-    deadline = None if timeout is None else time.monotonic() + timeout
+    start_time = time.monotonic()
+    deadline = None if timeout is None else start_time + timeout
 
     while True:
         if is_interrupted():
@@ -1261,7 +1262,12 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
         if deadline is not None:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                return future.result(timeout=0)
+                future.cancel()
+                elapsed = time.monotonic() - start_time
+                raise TimeoutError(
+                    f"MCP call timed out after {elapsed:.1f}s "
+                    f"(configured timeout: {float(timeout):.1f}s)"
+                )
             wait_timeout = min(wait_timeout, remaining)
 
         try:


### PR DESCRIPTION
## Summary
- track elapsed wall time in `_run_on_mcp_loop`
- cancel the in-flight future when a timeout expires
- raise a descriptive `TimeoutError` that includes elapsed and configured timeout
- add regression coverage for the timeout diagnostic message

## Why
Long-running MCP tool calls currently fail with an empty `TimeoutError`, which makes it hard to tell whether Hermes is enforcing the configured timeout or whether a server is failing internally. This change makes timeout failures immediately actionable in logs and tool responses.

## Testing
- `/Users/masonjames/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_mcp_tool.py -q -o 'addopts='