### PR TITLE
fix: stream vision downloads before size checks

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -24,6 +24,33 @@ from tools.vision_tools import (
 )
 
 
+class _FakeStreamResponse:
+    def __init__(
+        self, *, url="https://example.com/image.png", headers=None, chunks=()
+    ):
+        self.url = url
+        self.headers = headers or {}
+        self._chunks = list(chunks)
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeAsyncStream:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 # ---------------------------------------------------------------------------
 # _validate_image_url — urlparse-based validation
 # ---------------------------------------------------------------------------
@@ -272,10 +299,10 @@ class TestErrorLoggingExcInfo:
         from tools.vision_tools import _download_image
 
         with patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
+            mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(side_effect=ConnectionError("network down"))
+            mock_client.stream.side_effect = ConnectionError("network down")
             mock_client_cls.return_value = mock_client
 
             dest = tmp_path / "image.jpg"
@@ -475,28 +502,82 @@ class TestVisionSafetyGuards:
                 }
             raise AssertionError(f"unexpected URL checked: {url}")
 
-        class FakeResponse:
-            url = "https://blocked.test/final.png"
-            headers = {"content-length": "24"}
-            content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
-
-            def raise_for_status(self):
-                return None
-
         with (
             patch("tools.vision_tools.check_website_access", side_effect=fake_check),
             patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
             pytest.raises(PermissionError, match="Blocked by website policy"),
         ):
-            mock_client = AsyncMock()
+            mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=FakeResponse())
+            mock_client.stream.return_value = _FakeAsyncStream(
+                _FakeStreamResponse(
+                    url="https://blocked.test/final.png",
+                    headers={"content-length": "24"},
+                    chunks=[b"\x89PNG\r\n\x1a\n" + b"\x00" * 16],
+                )
+            )
             mock_client_cls.return_value = mock_client
 
-            await _download_image("https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1)
+            await _download_image(
+                "https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1
+            )
 
         assert not (tmp_path / "cat.png").exists()
+
+    @pytest.mark.asyncio
+    async def test_download_enforces_size_cap_while_streaming(self, tmp_path):
+        from tools.vision_tools import _download_image
+
+        with (
+            patch("tools.vision_tools._VISION_MAX_DOWNLOAD_BYTES", 10),
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+            pytest.raises(ValueError, match="Image too large"),
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream.return_value = _FakeAsyncStream(
+                _FakeStreamResponse(
+                    headers={},
+                    chunks=[b"12345", b"678901"],
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            await _download_image(
+                "https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1
+            )
+
+        assert not (tmp_path / "cat.png").exists()
+        assert not list(tmp_path.glob(".cat.png.*.tmp"))
+
+    @pytest.mark.asyncio
+    async def test_download_ignores_malformed_content_length(self, tmp_path):
+        from tools.vision_tools import _download_image
+
+        body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        dest = tmp_path / "cat.png"
+
+        with (
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream.return_value = _FakeAsyncStream(
+                _FakeStreamResponse(
+                    headers={"content-length": "not-a-number"},
+                    chunks=[body[:4], body[4:]],
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            await _download_image("https://allowed.test/cat.png", dest, max_retries=1)
+
+        assert dest.read_bytes() == body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -24,6 +24,33 @@ from tools.vision_tools import (
 )
 
 
+class _FakeStreamResponse:
+    def __init__(
+        self, *, url="https://example.com/image.png", headers=None, chunks=()
+    ):
+        self.url = url
+        self.headers = headers or {}
+        self._chunks = list(chunks)
+
+    def raise_for_status(self):
+        return None
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeAsyncStream:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
 # ---------------------------------------------------------------------------
 # _validate_image_url — urlparse-based validation
 # ---------------------------------------------------------------------------
@@ -272,10 +299,10 @@ class TestErrorLoggingExcInfo:
         from tools.vision_tools import _download_image
 
         with patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls:
-            mock_client = AsyncMock()
+            mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(side_effect=ConnectionError("network down"))
+            mock_client.stream.side_effect = ConnectionError("network down")
             mock_client_cls.return_value = mock_client
 
             dest = tmp_path / "image.jpg"
@@ -415,28 +442,82 @@ class TestVisionSafetyGuards:
                 }
             raise AssertionError(f"unexpected URL checked: {url}")
 
-        class FakeResponse:
-            url = "https://blocked.test/final.png"
-            headers = {"content-length": "24"}
-            content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
-
-            def raise_for_status(self):
-                return None
-
         with (
             patch("tools.vision_tools.check_website_access", side_effect=fake_check),
             patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
             pytest.raises(PermissionError, match="Blocked by website policy"),
         ):
-            mock_client = AsyncMock()
+            mock_client = MagicMock()
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
             mock_client.__aexit__ = AsyncMock(return_value=False)
-            mock_client.get = AsyncMock(return_value=FakeResponse())
+            mock_client.stream.return_value = _FakeAsyncStream(
+                _FakeStreamResponse(
+                    url="https://blocked.test/final.png",
+                    headers={"content-length": "24"},
+                    chunks=[b"\x89PNG\r\n\x1a\n" + b"\x00" * 16],
+                )
+            )
             mock_client_cls.return_value = mock_client
 
-            await _download_image("https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1)
+            await _download_image(
+                "https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1
+            )
 
         assert not (tmp_path / "cat.png").exists()
+
+    @pytest.mark.asyncio
+    async def test_download_enforces_size_cap_while_streaming(self, tmp_path):
+        from tools.vision_tools import _download_image
+
+        with (
+            patch("tools.vision_tools._VISION_MAX_DOWNLOAD_BYTES", 10),
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+            pytest.raises(ValueError, match="Image too large"),
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream.return_value = _FakeAsyncStream(
+                _FakeStreamResponse(
+                    headers={},
+                    chunks=[b"12345", b"678901"],
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            await _download_image(
+                "https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1
+            )
+
+        assert not (tmp_path / "cat.png").exists()
+        assert not list(tmp_path.glob(".cat.png.*.tmp"))
+
+    @pytest.mark.asyncio
+    async def test_download_ignores_malformed_content_length(self, tmp_path):
+        from tools.vision_tools import _download_image
+
+        body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+        dest = tmp_path / "cat.png"
+
+        with (
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.stream.return_value = _FakeAsyncStream(
+                _FakeStreamResponse(
+                    headers={"content-length": "not-a-number"},
+                    chunks=[body[:4], body[4:]],
+                )
+            )
+            mock_client_cls.return_value = mock_client
+
+            await _download_image("https://allowed.test/cat.png", dest, max_retries=1)
+
+        assert dest.read_bytes() == body
 
 
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -168,43 +168,73 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
             if blocked:
                 raise PermissionError(blocked["message"])
 
-            # Download the image with appropriate headers using async httpx
-            # Enable follow_redirects to handle image CDNs that redirect (e.g., Imgur, Picsum)
-            # SSRF: event_hooks validates each redirect target against private IP ranges
+            # Download the image with appropriate headers using async httpx.
+            # Enable follow_redirects to handle image CDNs that redirect (e.g., Imgur, Picsum).
+            # SSRF: event_hooks validates each redirect target against private IP ranges.
             async with httpx.AsyncClient(
                 timeout=_VISION_DOWNLOAD_TIMEOUT,
                 follow_redirects=True,
                 event_hooks={"response": [_ssrf_redirect_guard]},
             ) as client:
-                response = await client.get(
+                async with client.stream(
+                    "GET",
                     image_url,
                     headers={
                         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
                         "Accept": "image/*,*/*;q=0.8",
                     },
-                )
-                response.raise_for_status()
+                ) as response:
+                    response.raise_for_status()
 
-                # Reject overly large images early via Content-Length header.
-                cl = response.headers.get("content-length")
-                if cl and int(cl) > _VISION_MAX_DOWNLOAD_BYTES:
-                    raise ValueError(
-                        f"Image too large ({int(cl)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
-                    )
+                    # Reject overly large images early via Content-Length header
+                    # when it is present and valid. Still enforce the cap while
+                    # streaming because servers can omit or lie about it.
+                    cl = response.headers.get("content-length")
+                    if cl:
+                        try:
+                            declared_size = int(cl)
+                        except ValueError:
+                            declared_size = None
+                        if (
+                            declared_size is not None
+                            and declared_size > _VISION_MAX_DOWNLOAD_BYTES
+                        ):
+                            raise ValueError(
+                                f"Image too large ({declared_size} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
+                            )
 
-                final_url = str(response.url)
-                blocked = check_website_access(final_url)
-                if blocked:
-                    raise PermissionError(blocked["message"])
-                
-                # Save the image content (double-check actual size)
-                body = response.content
-                if len(body) > _VISION_MAX_DOWNLOAD_BYTES:
-                    raise ValueError(
-                        f"Image too large ({len(body)} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
+                    final_url = str(response.url)
+                    blocked = check_website_access(final_url)
+                    if blocked:
+                        raise PermissionError(blocked["message"])
+
+                    tmp_destination = destination.with_name(
+                        f".{destination.name}.{uuid.uuid4().hex}.tmp"
                     )
-                destination.write_bytes(body)
-            
+                    bytes_written = 0
+                    try:
+                        with tmp_destination.open("wb") as f:
+                            async for chunk in response.aiter_bytes():
+                                if not chunk:
+                                    continue
+                                bytes_written += len(chunk)
+                                if bytes_written > _VISION_MAX_DOWNLOAD_BYTES:
+                                    raise ValueError(
+                                        f"Image too large ({bytes_written} bytes, max {_VISION_MAX_DOWNLOAD_BYTES})"
+                                    )
+                                f.write(chunk)
+                        tmp_destination.replace(destination)
+                    except Exception:
+                        try:
+                            tmp_destination.unlink(missing_ok=True)
+                        except OSError:
+                            logger.debug(
+                                "Could not delete partial image download: %s",
+                                tmp_destination,
+                                exc_info=True,
+                            )
+                        raise
+
             return destination
         except Exception as e:
             last_error = e


### PR DESCRIPTION
## Summary
- stream remote vision downloads into a temporary file instead of buffering `response.content`
- enforce `_VISION_MAX_DOWNLOAD_BYTES` chunk-by-chunk and delete partial files on failure
- keep `Content-Length` as an early rejection, but ignore malformed values and rely on the streaming cap

## Tests
- `source venv/bin/activate && pytest tests/tools/test_vision_tools.py -q`
- `source venv/bin/activate && python -m compileall tools/vision_tools.py tests/tools/test_vision_tools.py`
- `git diff --check`