### PR TITLE
docs: document Telegram ignored threads

### DIFF
--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -169,6 +169,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_WEBHOOK_PORT` | Local listen port for webhook server (default: `8443`) |
 | `TELEGRAM_WEBHOOK_SECRET` | Secret token for verifying updates come from Telegram |
 | `TELEGRAM_REACTIONS` | Enable emoji reactions on messages during processing (default: `false`) |
+| `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_HOME_CHANNEL` | Default Discord channel for cron delivery |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -228,6 +228,7 @@ Hermes Agent works in Telegram group chats with a few considerations:
   - replies to one of the bot's messages
   - `@botusername` mentions
   - matches for one of your configured regex wake words in `telegram.mention_patterns`
+- Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
 - If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
 
 ### Example group trigger configuration
@@ -239,9 +240,13 @@ telegram:
   require_mention: true
   mention_patterns:
     - "^\\s*chompy\\b"
+  ignored_threads:
+    - 31
+    - "42"
 ```
 
 This example allows all the usual direct triggers plus messages that begin with `chompy`, even if they do not use an `@mention`.
+Messages in Telegram topics `31` and `42` are always ignored before the mention and free-response checks run.
 
 ### Notes on `mention_patterns`
 


### PR DESCRIPTION
## Summary
- document `telegram.ignored_threads` in the Telegram group chat guide
- add `TELEGRAM_IGNORED_THREADS` to the environment variable reference

## Context
`ignored_threads` support was added for Telegram topic filtering, including the config bridge to `TELEGRAM_IGNORED_THREADS`, but the user-facing docs still only described `require_mention` and `mention_patterns`.

## Testing
- `git diff --check`

## Notes
- I attempted `npm run typecheck` after `npm ci`; it is currently blocked by a pre-existing missing generated module: `website/src/data/skills.json`.
- I attempted `npm run lint:diagrams`; it is currently blocked because `ascii-guard` is not available from the installed package set.