### PR TITLE
fix(agent): inject turn-level live time context

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -167,6 +167,15 @@ def _install_safe_stdio() -> None:
             setattr(sys, stream_name, _SafeWriter(stream))
 
 
+def _build_live_time_context() -> str:
+    """Return turn-scoped live wall-clock context for the current API call."""
+    from hermes_time import now as _hermes_now, get_timezone as _get_tz
+
+    turn_now = _hermes_now()
+    tz_name = str(_get_tz() or "server-local")
+    return f"Current time: {turn_now.strftime('%Y-%m-%d %H:%M')} ({tz_name})"
+
+
 class IterationBudget:
     """Thread-safe iteration counter for an agent.
 
@@ -3310,6 +3319,18 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(p.strip() for p in prompt_parts if p.strip())
+
+    def _build_turn_scoped_system_prompt(self, base_system_prompt: Optional[str]) -> str:
+        """Build the non-persistent system prompt used for a single API call.
+
+        Live time belongs here instead of ``_build_system_prompt()`` so the
+        session-cached prompt stays stable for prefix caching and history reuse
+        while each turn still gets an accurate sense of "now".
+        """
+        effective_system = (base_system_prompt or "").strip()
+        if self.ephemeral_system_prompt:
+            effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+        return (effective_system + "\n\n" + _build_live_time_context()).strip()
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -7673,9 +7694,7 @@ class AIAgent:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 
-            effective_system = self._cached_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            effective_system = self._build_turn_scoped_system_prompt(self._cached_system_prompt)
             if effective_system:
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
             if self.prefill_messages:
@@ -8250,9 +8269,7 @@ class AIAgent:
             # Ephemeral additions are API-call-time only (not persisted to session DB).
             # External recall context is injected into the user message, not the system
             # prompt, so the stable cache prefix remains unchanged.
-            effective_system = active_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            effective_system = self._build_turn_scoped_system_prompt(active_system_prompt)
             # NOTE: Plugin context from pre_llm_call hooks is injected into the
             # user message (see injection block above), NOT the system prompt.
             # This is intentional — system prompt modifications break the prompt

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -668,6 +668,10 @@ class TestBuildSystemPrompt:
         # Should contain current date info like "Conversation started:"
         assert "Conversation started:" in prompt
 
+    def test_excludes_turn_level_live_time_marker(self, agent):
+        prompt = agent._build_system_prompt()
+        assert "Current time:" not in prompt
+
     def test_includes_nous_subscription_prompt(self, agent, monkeypatch):
         monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda tool_names: "NOUS SUBSCRIPTION BLOCK")
         prompt = agent._build_system_prompt()
@@ -1656,6 +1660,25 @@ class TestHandleMaxIterations:
         kwargs = agent.client.chat.completions.create.call_args.kwargs
         assert "reasoning" not in kwargs.get("extra_body", {})
 
+    def test_summary_injects_turn_level_live_time_context(self, agent, monkeypatch):
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+        monkeypatch.setattr(
+            run_agent,
+            "_build_live_time_context",
+            lambda: "Current time: 2026-04-16 09:30 (Asia/Shanghai)",
+        )
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        assert kwargs["messages"][0]["role"] == "system"
+        assert "You are helpful." in kwargs["messages"][0]["content"]
+        assert "Current time: 2026-04-16 09:30 (Asia/Shanghai)" in kwargs["messages"][0]["content"]
+
 
 class TestRunConversation:
     """Tests for the main run_conversation method.
@@ -1684,6 +1707,35 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_injects_turn_level_live_time_context_into_system_prompt(self, agent, monkeypatch):
+        self._setup_agent(agent)
+        captured = {}
+        monkeypatch.setattr(
+            run_agent,
+            "_build_live_time_context",
+            lambda: "Current time: 2026-04-16 09:30 (Asia/Shanghai)",
+        )
+
+        def _capture_api_call(api_kwargs):
+            captured["api_kwargs"] = api_kwargs
+            return _mock_response(content="Final answer", finish_reason="stop")
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Final answer"
+        system_message = captured["api_kwargs"]["messages"][0]
+        assert system_message["role"] == "system"
+        assert "You are helpful." in system_message["content"]
+        assert "Current time: 2026-04-16 09:30 (Asia/Shanghai)" in system_message["content"]
+        assert "Current time:" not in agent._cached_system_prompt
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -471,6 +471,30 @@ def test_run_conversation_codex_plain_text(monkeypatch):
     assert result["messages"][-1]["content"] == "OK"
 
 
+def test_run_conversation_codex_injects_turn_level_live_time_context(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._cached_system_prompt = "You are Hermes."
+    captured = {}
+    monkeypatch.setattr(
+        run_agent,
+        "_build_live_time_context",
+        lambda: "Current time: 2026-04-16 09:30 (Asia/Shanghai)",
+    )
+
+    def _capture_api_call(api_kwargs):
+        captured["api_kwargs"] = api_kwargs
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "OK"
+    assert "You are Hermes." in captured["api_kwargs"]["instructions"]
+    assert "Current time: 2026-04-16 09:30 (Asia/Shanghai)" in captured["api_kwargs"]["instructions"]
+
+
 def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
     """Regression: empty response.output + valid output_text should succeed,
     not trigger retry/fallback. The validation stage must defer to


### PR DESCRIPTION
## Summary

Hermes currently has a session-level `Conversation started: ...` timestamp, but it does not provide a reliable turn-level live sense of "now" for each API call.

This PR adds a turn-scoped `Current time: YYYY-MM-DD HH:MM (TZ)` hint at API-call time instead of baking live time into the cached session prompt.

## What changed

- add `_build_live_time_context()` in `run_agent.py`
- add `_build_turn_scoped_system_prompt()` so live time is injected per API call, not into `_build_system_prompt()`
- use that helper in both:
  - `run_conversation()`
  - `_handle_max_iterations()`
- add targeted tests for:
  - cached system prompt stays free of `Current time:`
  - chat-completions run path injects live time
  - max-iteration summary path injects live time
  - codex responses path injects live time

## Why this shape

This is intentionally aligned with the request in #10421:

- live time is turn-scoped
- it is injected at API-call time
- it does not mutate the session-cached system prompt
- it works for both chat-completions and codex-responses paths

## Relation to other work

This PR is intentionally narrower than #10061.

- #10061 focuses on timezone propagation to prompts and terminal environments
- this PR only addresses turn-level live current-time injection

They are adjacent, but not the same fix.

## Repro verified

I re-verified the gap locally on:

- latest stable `v0.9.0` released on April 13, 2026
- current `main` at `422f2866` on April 16, 2026

In both cases, Hermes still had only the session-start timestamp and no turn-level live `Current time:` context.

## How to test

```bash
python -m pytest tests/run_agent/test_run_agent.py -k 'turn_level_live_time or excludes_turn_level or summary_injects'
python -m pytest tests/run_agent/test_run_agent_codex_responses.py -k 'turn_level_live_time'
```

Refs #10421
