### PR TITLE
fix(mcp): seed protocol header before HTTP initialize

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1029,6 +1029,92 @@ class TestHTTPConfig:
 
         asyncio.run(_test())
 
+    def test_http_seeds_initial_protocol_header(self):
+        from tools.mcp_tool import LATEST_PROTOCOL_VERSION, MCPServerTask
+
+        server = MCPServerTask("remote")
+        captured = {}
+
+        class DummyAsyncClient:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummyTransportCtx:
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class DummySession:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def initialize(self):
+                return None
+
+        class DummyLegacyTransportCtx:
+            def __init__(self, **kwargs):
+                captured["legacy_headers"] = kwargs.get("headers")
+
+            async def __aenter__(self):
+                return MagicMock(), MagicMock(), (lambda: None)
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def _discover_tools(self):
+            self._shutdown_event.set()
+
+        async def _run(config, *, new_http):
+            captured.clear()
+            with patch("tools.mcp_tool._MCP_HTTP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._MCP_NEW_HTTP", new_http), \
+                 patch("httpx.AsyncClient", DummyAsyncClient), \
+                 patch("tools.mcp_tool.streamable_http_client", return_value=DummyTransportCtx()), \
+                 patch("tools.mcp_tool.streamablehttp_client", side_effect=lambda url, **kwargs: DummyLegacyTransportCtx(**kwargs)), \
+                 patch("tools.mcp_tool.ClientSession", DummySession), \
+                 patch.object(MCPServerTask, "_discover_tools", _discover_tools):
+                await server._run_http(config)
+
+        asyncio.run(_run({"url": "https://example.com/mcp"}, new_http=True))
+        assert captured["headers"]["mcp-protocol-version"] == LATEST_PROTOCOL_VERSION
+
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"mcp-protocol-version": "custom-version"},
+        }, new_http=True))
+        assert captured["headers"]["mcp-protocol-version"] == "custom-version"
+
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"MCP-Protocol-Version": "custom-version"},
+        }, new_http=True))
+        assert captured["headers"]["MCP-Protocol-Version"] == "custom-version"
+        assert "mcp-protocol-version" not in captured["headers"]
+
+        asyncio.run(_run({"url": "https://example.com/mcp"}, new_http=False))
+        assert captured["legacy_headers"]["mcp-protocol-version"] == LATEST_PROTOCOL_VERSION
+
+        asyncio.run(_run({
+            "url": "https://example.com/mcp",
+            "headers": {"MCP-Protocol-Version": "custom-version"},
+        }, new_http=False))
+        assert captured["legacy_headers"]["MCP-Protocol-Version"] == "custom-version"
+        assert "mcp-protocol-version" not in captured["legacy_headers"]
+
 
 # ---------------------------------------------------------------------------
 # Reconnection logic

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -93,6 +93,10 @@ _MCP_HTTP_AVAILABLE = False
 _MCP_SAMPLING_TYPES = False
 _MCP_NOTIFICATION_TYPES = False
 _MCP_MESSAGE_HANDLER_SUPPORTED = False
+# Conservative fallback for SDK builds that don't export LATEST_PROTOCOL_VERSION.
+# Streamable HTTP was introduced by 2025-03-26, so this remains valid for the
+# HTTP transport path even on older-but-supported SDK versions.
+LATEST_PROTOCOL_VERSION = "2025-03-26"
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
@@ -109,6 +113,10 @@ try:
         _MCP_NEW_HTTP = True
     except ImportError:
         _MCP_NEW_HTTP = False
+    try:
+        from mcp.types import LATEST_PROTOCOL_VERSION
+    except ImportError:
+        logger.debug("mcp.types.LATEST_PROTOCOL_VERSION not available -- using fallback protocol version")
     # Sampling types -- separated so older SDK versions don't break MCP support
     try:
         from mcp.types import (
@@ -949,6 +957,12 @@ class MCPServerTask:
 
         url = config["url"]
         headers = dict(config.get("headers") or {})
+        # Some MCP servers require MCP-Protocol-Version on the initial
+        # initialize request and reject session-less POSTs otherwise.
+        # Seed it as a client-level default, but treat user overrides as
+        # case-insensitive so conventional casing is preserved.
+        if not any(key.lower() == "mcp-protocol-version" for key in headers):
+            headers["mcp-protocol-version"] = LATEST_PROTOCOL_VERSION
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
 
         # OAuth 2.1 PKCE: build httpx.Auth handler using the MCP SDK.


### PR DESCRIPTION
## What does this PR do?

Fixes a StreamableHTTP MCP interoperability bug where Hermes fails to connect to stricter HTTP MCP servers that require `MCP-Protocol-Version` on the very first `initialize` request.

This seeds a client-level default protocol-version header before `initialize`, while preserving any user-supplied override case-insensitively so `MCP-Protocol-Version` and `mcp-protocol-version` do not get duplicated.

## Related Issue

None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Root Cause

Hermes only sent the protocol header after negotiation, which breaks strict servers that refuse to create a session until the header is already present on the initial request.

The original patch fixed the missing default header but still added a duplicate fallback header when users configured `MCP-Protocol-Version` with conventional casing, because the override check was case-sensitive on a plain Python dict.

## Changes Made

- seeded `mcp-protocol-version` before the first HTTP MCP initialize call in `tools/mcp_tool.py`
- added a conservative fallback when `mcp.types.LATEST_PROTOCOL_VERSION` is unavailable
- preserved explicit user config case-insensitively across both new and legacy HTTP transport paths
- added regression coverage in `tests/tools/test_mcp_tool.py` for:
  - default header seeding
  - lowercase override preservation
  - conventional-case override preservation without duplicate header insertion
  - legacy HTTP transport behavior

## How to Test

1. Create and activate a local virtual environment:
   ```bash
   uv venv venv --python 3.11
   source venv/bin/activate
   uv pip install -e ".[dev]"
   ```
2. Run the focused MCP regression coverage:
   ```bash
   python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py -q
   ```
3. Confirm the suite passes and the HTTP transport tests cover both lowercase and conventional-case `MCP-Protocol-Version` overrides without inserting a duplicate fallback header.

## Validation Performed

- Focused automated coverage:
  - `python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_dynamic_discovery.py -q`
  - Result: `177 passed`
- Manual validation:
  - reviewed the HTTP header construction path in `MCPServerTask._run_http`
  - verified the seeded default happens before `session.initialize()`
  - verified mixed-case user overrides are preserved without adding a second protocol-version header

## Tested Platform

- macOS
- Python 3.11

## Checklist

- [x] I’ve read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [x] I’ve added tests for my changes
- [x] I’ve tested on my platform: macOS, Python 3.11
- [x] I’ve considered cross-platform impact — low risk because this change is limited to HTTP header construction, not OS-specific process or file handling
- [x] I’ve updated relevant documentation or determined it is N/A
- [x] I’ve updated `cli-config.yaml.example` if needed — N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if needed — N/A
- [x] I’ve updated tool descriptions/schemas if needed — N/A
