### PR TITLE
fix(gateway): preserve top-level platform config keys

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -176,6 +176,21 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
+
+        known_keys = {
+            "enabled",
+            "token",
+            "api_key",
+            "home_channel",
+            "reply_to_mode",
+            "extra",
+        }
+        extra = {
+            key: value for key, value in data.items() if key not in known_keys
+        }
+        raw_extra = data.get("extra", {})
+        if isinstance(raw_extra, dict):
+            extra.update(raw_extra)
         
         return cls(
             enabled=data.get("enabled", False),
@@ -183,7 +198,7 @@ class PlatformConfig:
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -191,6 +191,11 @@ class PlatformConfig:
         raw_extra = data.get("extra", {})
         if isinstance(raw_extra, dict):
             extra.update(raw_extra)
+        elif "extra" in data:
+            logger.warning(
+                "Ignoring invalid platform config 'extra' value of type %s; expected a mapping",
+                type(raw_extra).__name__,
+            )
         
         return cls(
             enabled=data.get("enabled", False),

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -52,6 +52,23 @@ class TestPlatformConfigRoundtrip:
         assert restored.enabled is False
         assert restored.token is None
 
+    def test_from_dict_promotes_unknown_top_level_keys_to_extra(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "port": 9100,
+                "host": "0.0.0.0",
+                "extra": {"secret": "top-secret"},
+            }
+        )
+
+        assert restored.enabled is True
+        assert restored.extra == {
+            "port": 9100,
+            "host": "0.0.0.0",
+            "secret": "top-secret",
+        }
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -139,6 +156,28 @@ class TestGatewayConfigRoundtrip:
 
 
 class TestLoadGatewayConfig:
+    def test_bridges_top_level_platform_keys_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  webhook:\n"
+            "    enabled: true\n"
+            "    host: 0.0.0.0\n"
+            "    port: 9100\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        webhook_config = config.platforms[Platform.WEBHOOK]
+        assert webhook_config.enabled is True
+        assert webhook_config.extra["host"] == "0.0.0.0"
+        assert webhook_config.extra["port"] == 9100
+
     def test_bridges_quick_commands_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,6 +1,7 @@
 """Tests for gateway configuration management."""
 
 import os
+import logging
 from unittest.mock import patch
 
 from gateway.config import (
@@ -68,6 +69,19 @@ class TestPlatformConfigRoundtrip:
             "host": "0.0.0.0",
             "secret": "top-secret",
         }
+
+    def test_from_dict_warns_when_extra_is_not_a_mapping(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            restored = PlatformConfig.from_dict(
+                {
+                    "enabled": True,
+                    "port": 9100,
+                    "extra": "not-a-mapping",
+                }
+            )
+
+        assert restored.extra == {"port": 9100}
+        assert "Ignoring invalid platform config 'extra' value of type str" in caplog.text
 
 
 class TestGetConnectedPlatforms:


### PR DESCRIPTION
## What does this PR do?

Fixes `gateway/config.py` so top-level platform settings under `config.yaml` are preserved instead of being silently dropped during `PlatformConfig.from_dict()`.

The bug is that `load_gateway_config()` correctly deep-merges `platforms.<name>` blocks from `config.yaml`, but `PlatformConfig.from_dict()` only kept a fixed allowlist of fields and discarded everything else unless it was nested under `extra:`. Adapters like `webhook` and `api_server` read their settings from `config.extra`, so shorthand config such as `platforms.webhook.port: 9100` never reached the adapter.

This stays narrow at the parser boundary:
- unknown top-level platform keys are folded into `extra`
- explicit nested `extra` mappings remain backward compatible and still take precedence on overlap
- invalid non-mapping `extra` values are ignored with a warning instead of being passed through silently

## Related Issue

Fixes #10206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/config.py` so `PlatformConfig.from_dict()` copies unknown top-level platform keys into `extra`
- Preserved backward compatibility for explicit nested `extra` values when both shorthand and `extra` forms are present
- Added a warning when `extra` is present but not a mapping, so adapters do not silently receive an invalid shape
- Added regression coverage in `tests/gateway/test_config.py` for:
  - parser-level promotion of unknown top-level keys into `extra`
  - invalid non-mapping `extra` values being ignored with a warning
  - `load_gateway_config()` loading `platforms.webhook.host` / `platforms.webhook.port` from `config.yaml`

## How to Test

1. Add this to `~/.hermes/config.yaml`:
   ```yaml
   platforms:
     webhook:
       enabled: true
       host: 0.0.0.0
       port: 9100
   ```
2. Run `hermes gateway` (or load config through `gateway.config.load_gateway_config()`).
3. Confirm the webhook adapter now sees `host=0.0.0.0` and `port=9100` instead of falling back to defaults.
4. Optional validation edge case:
   ```yaml
   platforms:
     webhook:
       enabled: true
       extra: not-a-mapping
       port: 9100
   ```
   Confirm config loading still preserves `port=9100` and logs a warning about the invalid `extra` value.

## Validation

Focused and adjacent checks run locally:

- `source /Users/magic/Documents/Code/hermes-agent/venv/bin/activate && python -m pytest tests/gateway/test_config.py -q` → `20 passed`
- `source /Users/magic/Documents/Code/hermes-agent/venv/bin/activate && python -m pytest tests/gateway/test_api_server.py -q` → `114 passed`
- `git diff --check` → passed
- `source /Users/magic/Documents/Code/hermes-agent/venv/bin/activate && python -m py_compile gateway/config.py tests/gateway/test_config.py` → passed

I also ran the repo’s documented broad local test command:

- `source /Users/magic/Documents/Code/hermes-agent/venv/bin/activate && python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`

That command is not clean in this checkout: it ended with `98 failed, 11309 passed, 93 skipped, 60 errors`, including missing optional dependencies (`acp`, `fastapi`, `faster_whisper`) and unrelated failures in ACP, web server, Discord, Telegram, and other areas outside this patch.

No separate standalone lint command appears in the repo docs, so I did not invent one.

Tested locally on macOS `26.5` with Python `3.11`.

Adjacent surfaces checked:

- `gateway/platforms/webhook.py` reads `host` / `port` from `config.extra`
- `gateway/platforms/api_server.py` reads `host` / `port` from `config.extra`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS `26.5`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
