### PR TITLE
feat(gateway): add multi-account telegram routing

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -8,6 +8,7 @@ action="list" and for resolving human-friendly channel names to numeric IDs.
 
 import json
 import logging
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,7 @@ from utils import atomic_json_write
 logger = logging.getLogger(__name__)
 
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+_TELEGRAM_ACCOUNT_KEY_RE = re.compile(r"^telegram\[([a-z0-9_-]+)\]$", re.IGNORECASE)
 
 
 def _normalize_channel_query(value: str) -> str:
@@ -31,6 +33,46 @@ def _channel_target_name(platform_name: str, channel: Dict[str, Any]) -> str:
     if platform_name != "discord" and channel.get("type"):
         return f"{name} ({channel['type']})"
     return name
+
+
+def _normalize_platform_key(platform_name: Any) -> str:
+    """Normalize adapter/directory platform identifiers to lowercase string keys."""
+    raw = getattr(platform_name, "value", platform_name)
+    return str(raw).strip().lower()
+
+
+def _base_platform_name(platform_name: str) -> str:
+    """Collapse account-qualified platform names like telegram[devteam] to telegram."""
+    match = _TELEGRAM_ACCOUNT_KEY_RE.fullmatch(platform_name.strip().lower())
+    if match:
+        return "telegram"
+    return platform_name.strip().lower()
+
+
+def _platform_account_id(platform_name: str) -> Optional[str]:
+    """Extract the account_id from a platform key like telegram[devteam]."""
+    match = _TELEGRAM_ACCOUNT_KEY_RE.fullmatch(platform_name.strip().lower())
+    if match:
+        return match.group(1)
+    return None
+
+
+def _merge_channel_lists(*channel_lists: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Merge directory entries while preserving order and deduplicating by id/name/account."""
+    merged: List[Dict[str, Any]] = []
+    seen: set[tuple[str, str, Optional[str]]] = set()
+    for channels in channel_lists:
+        for channel in channels or []:
+            key = (
+                str(channel.get("id", "")),
+                str(channel.get("name", "")),
+                channel.get("account_id"),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(channel)
+    return merged
 
 
 def _session_entry_id(origin: Dict[str, Any]) -> Optional[str]:
@@ -69,12 +111,23 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
 
     for platform, adapter in adapters.items():
         try:
-            if platform == Platform.DISCORD:
-                platforms["discord"] = _build_discord(adapter)
-            elif platform == Platform.SLACK:
-                platforms["slack"] = _build_slack(adapter)
+            platform_key = _normalize_platform_key(platform)
+            base_platform = _base_platform_name(platform_key)
+            account_id = _platform_account_id(platform_key) or getattr(adapter, "account_id", None)
+
+            if base_platform == Platform.DISCORD.value:
+                channels = _build_discord(adapter)
+            elif base_platform == Platform.SLACK.value:
+                channels = _build_slack(adapter)
+            else:
+                continue
+
+            if account_id:
+                channels = [dict(ch, account_id=account_id) for ch in channels]
+                platforms[platform_key] = _merge_channel_lists(platforms.get(platform_key, []), channels)
+            platforms[base_platform] = _merge_channel_lists(platforms.get(base_platform, []), channels)
         except Exception as e:
-            logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
+            logger.warning("Channel directory: failed to build %s: %s", _normalize_platform_key(platform), e)
 
     # Platforms that don't support direct channel enumeration get session-based
     # discovery automatically.  Skip infrastructure entries that aren't messaging
@@ -201,7 +254,10 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     - Slack: "engineering", "#engineering"
     """
     directory = load_directory()
-    channels = directory.get("platforms", {}).get(platform_name, [])
+    normalized_platform = _normalize_platform_key(platform_name)
+    channels = directory.get("platforms", {}).get(normalized_platform, [])
+    if not channels:
+        channels = directory.get("platforms", {}).get(_base_platform_name(normalized_platform), [])
     if not channels:
         return None
 
@@ -211,7 +267,7 @@ def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
     for ch in channels:
         if _normalize_channel_query(ch["name"]) == query:
             return ch["id"]
-        if _normalize_channel_query(_channel_target_name(platform_name, ch)) == query:
+        if _normalize_channel_query(_channel_target_name(_base_platform_name(normalized_platform), ch)) == query:
             return ch["id"]
 
     # 2. Guild-qualified match for Discord ("GuildName/channel")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,7 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import re
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
@@ -156,6 +157,7 @@ class PlatformConfig:
     
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
+    account_id: Optional[str] = None
     
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -163,6 +165,8 @@ class PlatformConfig:
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
         }
+        if self.account_id:
+            result["account_id"] = self.account_id
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -184,7 +188,77 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             extra=data.get("extra", {}),
+            account_id=data.get("account_id"),
         )
+
+
+def _normalize_account_id(value: Any) -> Optional[str]:
+    """Normalize account IDs to a compact stable token or None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", text.lower()).strip("-_")
+    return normalized or None
+
+
+def _telegram_env_accounts() -> List[tuple[Optional[str], str]]:
+    """Return Telegram tokens from env as (account_id, token), preserving legacy behavior."""
+    accounts: List[tuple[Optional[str], str]] = []
+
+    primary = os.getenv("TELEGRAM_BOT_TOKEN")
+    if primary:
+        accounts.append((None, primary))
+
+    prefix = "TELEGRAM_BOT_TOKEN_"
+    for key, value in sorted(os.environ.items()):
+        if not key.startswith(prefix) or not value:
+            continue
+        suffix = key[len(prefix):].strip()
+        account_id = _normalize_account_id(suffix)
+        if not account_id:
+            continue
+        accounts.append((account_id, value))
+
+    return accounts
+
+
+def _apply_telegram_account_overrides(config: "GatewayConfig") -> None:
+    """Apply Telegram env overrides, including optional multi-account support."""
+    telegram_accounts = _telegram_env_accounts()
+    if not telegram_accounts:
+        return
+
+    primary_config = config.platforms.get(Platform.TELEGRAM)
+    if primary_config is None:
+        primary_config = PlatformConfig()
+        config.platforms[Platform.TELEGRAM] = primary_config
+
+    primary_config.enabled = True
+    primary_config.token = telegram_accounts[0][1]
+    primary_config.account_id = _normalize_account_id(primary_config.account_id)
+
+    accounts_map: Dict[str, Dict[str, Any]] = {}
+    existing_accounts = primary_config.extra.get("telegram_accounts", {})
+    if isinstance(existing_accounts, dict):
+        for raw_account_id, account_data in existing_accounts.items():
+            account_id = _normalize_account_id(raw_account_id)
+            if not account_id or not isinstance(account_data, dict):
+                continue
+            accounts_map[account_id] = dict(account_data)
+
+    for account_id, token in telegram_accounts[1:]:
+        if not account_id:
+            continue
+        account_cfg = dict(accounts_map.get(account_id, {}))
+        account_cfg["enabled"] = True
+        account_cfg["token"] = token
+        account_cfg["account_id"] = account_id
+        accounts_map[account_id] = account_cfg
+
+    if accounts_map:
+        primary_config.extra["telegram_accounts"] = accounts_map
 
 
 @dataclass
@@ -752,12 +826,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
     
     # Telegram
-    telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
-    if telegram_token:
-        if Platform.TELEGRAM not in config.platforms:
-            config.platforms[Platform.TELEGRAM] = PlatformConfig()
-        config.platforms[Platform.TELEGRAM].enabled = True
-        config.platforms[Platform.TELEGRAM].token = telegram_token
+    _apply_telegram_account_overrides(config)
     
     # Reply threading mode for Telegram (off/first/all)
     telegram_reply_mode = os.getenv("TELEGRAM_REPLY_TO_MODE", "").lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -242,6 +242,8 @@ from gateway.config import (
     Platform,
     GatewayConfig,
     load_gateway_config,
+    PlatformConfig,
+    _normalize_account_id,
 )
 from gateway.session import (
     SessionStore,
@@ -1733,16 +1735,56 @@ class GatewayRunner:
         enabled_platform_count = 0
         startup_nonretryable_errors: list[str] = []
         startup_retryable_errors: list[str] = []
+
+        def _iter_platform_instances():
+            for platform, platform_config in self.config.platforms.items():
+                if platform != Platform.TELEGRAM:
+                    yield platform, platform_config, platform.value
+                    continue
+
+                yield platform, platform_config, platform.value
+
+                extra_accounts = {}
+                if hasattr(platform_config, "extra") and isinstance(platform_config.extra, dict):
+                    extra_accounts = platform_config.extra.get("telegram_accounts", {})
+                if not isinstance(extra_accounts, dict):
+                    continue
+
+                for raw_account_id, account_data in sorted(extra_accounts.items()):
+                    account_id = _normalize_account_id(raw_account_id)
+                    if not account_id or not isinstance(account_data, dict):
+                        continue
+                    merged_extra = dict(platform_config.extra)
+                    merged_extra.pop("telegram_accounts", None)
+                    account_extra = account_data.get("extra", {})
+                    if isinstance(account_extra, dict):
+                        merged_extra.update(account_extra)
+                    account_config = PlatformConfig(
+                        enabled=bool(account_data.get("enabled", True)),
+                        token=account_data.get("token"),
+                        api_key=account_data.get("api_key", platform_config.api_key),
+                        home_channel=platform_config.home_channel,
+                        reply_to_mode=account_data.get("reply_to_mode", platform_config.reply_to_mode),
+                        extra=merged_extra,
+                        account_id=account_id,
+                    )
+                    if "home_channel" in account_data and isinstance(account_data["home_channel"], dict):
+                        try:
+                            from gateway.config import HomeChannel
+                            account_config.home_channel = HomeChannel.from_dict(account_data["home_channel"])
+                        except Exception:
+                            pass
+                    yield platform, account_config, f"telegram[{account_id}]"
         
         # Initialize and connect each configured platform
-        for platform, platform_config in self.config.platforms.items():
+        for platform, platform_config, platform_label in _iter_platform_instances():
             if not platform_config.enabled:
                 continue
             enabled_platform_count += 1
             
             adapter = self._create_adapter(platform, platform_config)
             if not adapter:
-                logger.warning("No adapter available for %s", platform.value)
+                logger.warning("No adapter available for %s", platform_label)
                 continue
             
             # Set up message + fatal error handlers
@@ -1752,9 +1794,9 @@ class GatewayRunner:
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             
             # Try to connect
-            logger.info("Connecting to %s...", platform.value)
+            logger.info("Connecting to %s...", platform_label)
             self._update_platform_runtime_status(
-                platform.value,
+                platform_label,
                 platform_state="connecting",
                 error_code=None,
                 error_message=None,
@@ -1762,21 +1804,21 @@ class GatewayRunner:
             try:
                 success = await adapter.connect()
                 if success:
-                    self.adapters[platform] = adapter
+                    self.adapters[platform_label] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
-                        platform.value,
+                        platform_label,
                         platform_state="connected",
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
+                    logger.info("✓ %s connected", platform_label)
                 else:
-                    logger.warning("✗ %s failed to connect", platform.value)
+                    logger.warning("✗ %s failed to connect", platform_label)
                     if adapter.has_fatal_error:
                         self._update_platform_runtime_status(
-                            platform.value,
+                            platform_label,
                             platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
                             error_code=adapter.fatal_error_code,
                             error_message=adapter.fatal_error_message,
@@ -1787,42 +1829,45 @@ class GatewayRunner:
                             else startup_nonretryable_errors
                         )
                         target.append(
-                            f"{platform.value}: {adapter.fatal_error_message}"
+                            f"{platform_label}: {adapter.fatal_error_message}"
                         )
                         # Queue for reconnection if the error is retryable
                         if adapter.fatal_error_retryable:
-                            self._failed_platforms[platform] = {
+                            self._failed_platforms[platform_label] = {
+                                "platform": platform,
                                 "config": platform_config,
                                 "attempts": 1,
                                 "next_retry": time.monotonic() + 30,
                             }
                     else:
                         self._update_platform_runtime_status(
-                            platform.value,
+                            platform_label,
                             platform_state="retrying",
                             error_code=None,
                             error_message="failed to connect",
                         )
                         startup_retryable_errors.append(
-                            f"{platform.value}: failed to connect"
+                            f"{platform_label}: failed to connect"
                         )
                         # No fatal error info means likely a transient issue — queue for retry
-                        self._failed_platforms[platform] = {
+                        self._failed_platforms[platform_label] = {
+                            "platform": platform,
                             "config": platform_config,
                             "attempts": 1,
                             "next_retry": time.monotonic() + 30,
                         }
             except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
+                logger.error("✗ %s error: %s", platform_label, e)
                 self._update_platform_runtime_status(
-                    platform.value,
+                    platform_label,
                     platform_state="retrying",
                     error_code=None,
                     error_message=str(e),
                 )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
+                startup_retryable_errors.append(f"{platform_label}: {e}")
                 # Unexpected exceptions are typically transient — queue for retry
-                self._failed_platforms[platform] = {
+                self._failed_platforms[platform_label] = {
+                    "platform": platform,
                     "config": platform_config,
                     "attempts": 1,
                     "next_retry": time.monotonic() + 30,
@@ -1862,7 +1907,10 @@ class GatewayRunner:
         if hook_count:
             logger.info("%s hook(s) loaded", hook_count)
         await self.hooks.emit("gateway:startup", {
-            "platforms": [p.value for p in self.adapters.keys()],
+            "platforms": [
+                p.value if hasattr(p, "value") else str(p)
+                for p in self.adapters.keys()
+            ],
         })
         
         if connected_count > 0:
@@ -2055,29 +2103,30 @@ class GatewayRunner:
                     if not self._running:
                         return
                     await asyncio.sleep(1)
-                continue
-
-            now = time.monotonic()
-            for platform in list(self._failed_platforms.keys()):
-                if not self._running:
-                    return
-                info = self._failed_platforms[platform]
-                if now < info["next_retry"]:
-                    continue  # not time yet
-
-                if info["attempts"] >= _MAX_ATTEMPTS:
-                    logger.warning(
-                        "Giving up reconnecting %s after %d attempts",
-                        platform.value, info["attempts"],
-                    )
-                    del self._failed_platforms[platform]
+            for platform_label, info in list(self._failed_platforms.items()):
+                if time.monotonic() < info.get("next_retry", 0):
                     continue
 
+                attempt = info.get("attempts", 0) + 1
+                platform = info.get("platform") or platform_label
                 platform_config = info["config"]
-                attempt = info["attempts"] + 1
+                if attempt > _MAX_ATTEMPTS:
+                    self._update_platform_runtime_status(
+                        platform_label,
+                        platform_state="fatal",
+                        error_code="reconnect_exhausted",
+                        error_message=f"failed after {_MAX_ATTEMPTS} retry attempts",
+                    )
+                    logger.error(
+                        "Reconnect %s: exceeded max retries (%d), giving up",
+                        platform_label, _MAX_ATTEMPTS,
+                    )
+                    del self._failed_platforms[platform_label]
+                    continue
+
                 logger.info(
-                    "Reconnecting %s (attempt %d/%d)...",
-                    platform.value, attempt, _MAX_ATTEMPTS,
+                    "Reconnect %s: attempt %d/%d",
+                    platform_label, attempt, _MAX_ATTEMPTS,
                 )
 
                 try:
@@ -2085,9 +2134,9 @@ class GatewayRunner:
                     if not adapter:
                         logger.warning(
                             "Reconnect %s: adapter creation returned None, removing from retry queue",
-                            platform.value,
+                            platform_label,
                         )
-                        del self._failed_platforms[platform]
+                        del self._failed_platforms[platform_label]
                         continue
 
                     adapter.set_message_handler(self._handle_message)
@@ -2097,17 +2146,17 @@ class GatewayRunner:
 
                     success = await adapter.connect()
                     if success:
-                        self.adapters[platform] = adapter
+                        self.adapters[platform_label] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
                         self.delivery_router.adapters = self.adapters
-                        del self._failed_platforms[platform]
+                        del self._failed_platforms[platform_label]
                         self._update_platform_runtime_status(
-                            platform.value,
+                            platform_label,
                             platform_state="connected",
                             error_code=None,
                             error_message=None,
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
+                        logger.info("✓ %s reconnected successfully", platform_label)
 
                         # Rebuild channel directory with the new adapter
                         try:
@@ -2119,19 +2168,19 @@ class GatewayRunner:
                         # Check if the failure is non-retryable
                         if adapter.has_fatal_error and not adapter.fatal_error_retryable:
                             self._update_platform_runtime_status(
-                                platform.value,
+                                platform_label,
                                 platform_state="fatal",
                                 error_code=adapter.fatal_error_code,
                                 error_message=adapter.fatal_error_message,
                             )
                             logger.warning(
                                 "Reconnect %s: non-retryable error (%s), removing from retry queue",
-                                platform.value, adapter.fatal_error_message,
+                                platform_label, adapter.fatal_error_message,
                             )
-                            del self._failed_platforms[platform]
+                            del self._failed_platforms[platform_label]
                         else:
                             self._update_platform_runtime_status(
-                                platform.value,
+                                platform_label,
                                 platform_state="retrying",
                                 error_code=adapter.fatal_error_code,
                                 error_message=adapter.fatal_error_message or "failed to reconnect",
@@ -2141,11 +2190,11 @@ class GatewayRunner:
                             info["next_retry"] = time.monotonic() + backoff
                             logger.info(
                                 "Reconnect %s failed, next retry in %ds",
-                                platform.value, backoff,
+                                platform_label, backoff,
                             )
                 except Exception as e:
                     self._update_platform_runtime_status(
-                        platform.value,
+                        platform_label,
                         platform_state="retrying",
                         error_code=None,
                         error_message=str(e),
@@ -2155,7 +2204,7 @@ class GatewayRunner:
                     info["next_retry"] = time.monotonic() + backoff
                     logger.warning(
                         "Reconnect %s error: %s, next retry in %ds",
-                        platform.value, e, backoff,
+                        platform_label, e, backoff,
                     )
 
             # Check every 10 seconds for platforms that need reconnection
@@ -2324,7 +2373,12 @@ class GatewayRunner:
             if not check_telegram_requirements():
                 logger.warning("Telegram: python-telegram-bot not installed")
                 return None
-            return TelegramAdapter(config)
+            adapter = TelegramAdapter(config)
+            account_id = _normalize_account_id(getattr(config, "account_id", None))
+            if account_id:
+                setattr(adapter, "account_id", account_id)
+                adapter.name = f"telegram[{account_id}]"
+            return adapter
         
         elif platform == Platform.DISCORD:
             from gateway.platforms.discord import DiscordAdapter, check_discord_requirements

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -154,6 +154,21 @@ class TestResolveChannelName:
             assert resolve_channel_name("telegram", "Dev Group (group)") == "456"
             assert resolve_channel_name("telegram", "Coaching Chat / topic 17585 (group)") == "-1001:17585"
 
+    def test_account_specific_platform_key_resolves_first(self, tmp_path):
+        platforms = {
+            "telegram": [
+                {"id": "123", "name": "Shared Room", "type": "group"},
+            ],
+            "telegram[devteam]": [
+                {"id": "999", "name": "Shared Room", "type": "group", "account_id": "devteam"},
+                {"id": "1001:7", "name": "Alerts Topic", "type": "group", "account_id": "devteam"},
+            ],
+        }
+        with self._setup(tmp_path, platforms):
+            assert resolve_channel_name("telegram[devteam]", "Shared Room") == "999"
+            assert resolve_channel_name("telegram[devteam]", "Alerts Topic (group)") == "1001:7"
+            assert resolve_channel_name("telegram[ops]", "Shared Room") == "123"
+
 
 class TestBuildFromSessions:
     def _write_sessions(self, tmp_path, sessions_data):
@@ -261,6 +276,9 @@ class TestFormatDirectoryForDisplay:
                 {"id": "123", "name": "Alice", "type": "dm"},
                 {"id": "456", "name": "Dev Group", "type": "group"},
                 {"id": "-1001:17585", "name": "Coaching Chat / topic 17585", "type": "group"},
+            ],
+            "telegram[devteam]": [
+                {"id": "999", "name": "Dev Team Room", "type": "group", "account_id": "devteam"},
             ]
         })
         with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
@@ -270,6 +288,7 @@ class TestFormatDirectoryForDisplay:
         assert "telegram:Alice" in result
         assert "telegram:Dev Group" in result
         assert "telegram:Coaching Chat / topic 17585" in result
+        assert "telegram[devteam]:Dev Team Room" in result
 
     def test_discord_grouped_by_guild(self, tmp_path):
         cache_file = _write_directory(tmp_path, {

--- a/tests/gateway/test_telegram_multi_account.py
+++ b/tests/gateway/test_telegram_multi_account.py
@@ -1,0 +1,115 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner
+
+
+class _FakeTelegramAdapter:
+    def __init__(self, config):
+        self.config = config
+        self.platform = Platform.TELEGRAM
+        self.name = "telegram"
+        self.account_id = getattr(config, "account_id", None)
+        self.has_fatal_error = False
+        self.fatal_error_retryable = False
+        self.fatal_error_code = None
+        self.fatal_error_message = None
+
+    def set_message_handler(self, handler):
+        self._message_handler = handler
+
+    def set_fatal_error_handler(self, handler):
+        self._fatal_handler = handler
+
+    def set_session_store(self, store):
+        self._session_store = store
+
+    def set_busy_session_handler(self, handler):
+        self._busy_handler = handler
+
+    async def connect(self):
+        return True
+
+
+class _FakeHooks:
+    loaded_hooks = []
+
+    def discover_and_load(self):
+        return None
+
+    async def emit(self, *_args, **_kwargs):
+        return None
+
+
+class _FakeDeliveryRouter:
+    def __init__(self):
+        self.adapters = {}
+
+
+def _make_runner(config):
+    runner = object.__new__(GatewayRunner)
+    runner.config = config
+    runner.adapters = {}
+    runner.delivery_router = _FakeDeliveryRouter()
+    runner.session_store = object()
+    runner.hooks = _FakeHooks()
+    runner._failed_platforms = {}
+    runner._running = False
+    runner._restart_requested = False
+    runner._exit_reason = None
+    runner._sync_voice_mode_state_to_adapter = lambda adapter: None
+    runner._update_platform_runtime_status = lambda *args, **kwargs: None
+    runner._update_runtime_status = lambda *args, **kwargs: None
+    runner._handle_message = lambda *args, **kwargs: None
+    runner._handle_adapter_fatal_error = lambda *args, **kwargs: None
+    runner._handle_active_session_busy_message = lambda *args, **kwargs: None
+    runner._increment_restart_failure_counts = lambda *args, **kwargs: None
+    runner._send_update_notification = AsyncMock(return_value=False)
+    runner._schedule_update_notification_watch = lambda *args, **kwargs: None
+    runner._send_restart_notification = AsyncMock(return_value=None)
+    runner._suspend_stuck_loop_sessions = lambda *args, **kwargs: 0
+    return runner
+
+
+def test_create_adapter_sets_account_id_and_name_for_telegram():
+    runner = _make_runner(GatewayConfig())
+    config = PlatformConfig(enabled=True, token="tok", account_id="devteam")
+
+    with patch("gateway.run.check_telegram_requirements", return_value=True, create=True), \
+         patch("gateway.platforms.telegram.check_telegram_requirements", return_value=True), \
+         patch("gateway.platforms.telegram.TelegramAdapter", _FakeTelegramAdapter):
+        adapter = runner._create_adapter(Platform.TELEGRAM, config)
+
+    assert adapter is not None
+    assert adapter.account_id == "devteam"
+    assert adapter.name == "telegram[devteam]"
+
+
+@pytest.mark.asyncio
+async def test_start_connects_primary_and_extra_telegram_accounts():
+    cfg = GatewayConfig(platforms={
+        Platform.TELEGRAM: PlatformConfig(
+            enabled=True,
+            token="primary-token",
+            extra={
+                "telegram_accounts": {
+                    "devteam": {"enabled": True, "token": "dev-token"},
+                    "alerts": {"enabled": True, "token": "alerts-token"},
+                }
+            },
+        )
+    })
+    runner = _make_runner(cfg)
+
+    with patch.object(GatewayRunner, "_create_adapter", side_effect=lambda platform, config: _FakeTelegramAdapter(config)), \
+         patch("gateway.channel_directory.build_channel_directory", return_value={"platforms": {}}), \
+         patch.object(GatewayRunner, "_session_expiry_watcher", return_value=None), \
+         patch.object(GatewayRunner, "_platform_reconnect_watcher", return_value=None):
+        result = await GatewayRunner.start(runner)
+
+    assert result is True
+    assert set(runner.adapters.keys()) == {"telegram", "telegram[alerts]", "telegram[devteam]"}
+    assert runner.adapters["telegram"].config.token == "primary-token"
+    assert runner.adapters["telegram[devteam]"].config.account_id == "devteam"
+    assert runner.adapters["telegram[alerts]"].config.account_id == "alerts"

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -364,6 +364,33 @@ class TestConfigFallbackIps:
             "149.154.167.220", "149.154.167.221",
         ]
 
+    def test_multi_account_env_tokens_populate_extra_accounts(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "primary-token")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN_DEVTEAM", "dev-token")
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN_ALERTS", "alerts-token")
+        config = GatewayConfig(platforms={})
+        _apply_env_overrides(config)
+
+        telegram_cfg = config.platforms[Platform.TELEGRAM]
+        assert telegram_cfg.enabled is True
+        assert telegram_cfg.token == "primary-token"
+        assert telegram_cfg.extra["telegram_accounts"]["devteam"]["token"] == "dev-token"
+        assert telegram_cfg.extra["telegram_accounts"]["alerts"]["token"] == "alerts-token"
+
+    def test_multi_account_env_without_primary_still_creates_legacy_telegram_platform(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN_DEVTEAM", "dev-token")
+        config = GatewayConfig(platforms={})
+        _apply_env_overrides(config)
+
+        telegram_cfg = config.platforms[Platform.TELEGRAM]
+        assert telegram_cfg.enabled is True
+        assert telegram_cfg.token == "dev-token"
+
     def test_env_var_creates_platform_if_missing(self, monkeypatch):
         from gateway.config import GatewayConfig, Platform, _apply_env_overrides
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -233,6 +233,79 @@ class TestSendMessageTool:
             media_files=[],
         )
 
+    def test_account_qualified_telegram_numeric_target_uses_account_config(self):
+        config, telegram_cfg = _make_config()
+        telegram_cfg.extra = {
+            "telegram_accounts": {
+                "devteam": {"enabled": True, "token": "dev-token"}
+            }
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:devteam:-1001:17585",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        sent_config = send_mock.await_args.args[1]
+        assert sent_config.token == "dev-token"
+        assert sent_config.account_id == "devteam"
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            sent_config,
+            "-1001",
+            "hello",
+            thread_id="17585",
+            media_files=[],
+        )
+
+    def test_account_qualified_telegram_label_resolves_via_account_directory(self):
+        config, telegram_cfg = _make_config()
+        telegram_cfg.extra = {
+            "telegram_accounts": {
+                "devteam": {"enabled": True, "token": "dev-token"}
+            }
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", side_effect=["-1009:88"]), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:devteam:Alerts Room",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        sent_config = send_mock.await_args.args[1]
+        assert sent_config.account_id == "devteam"
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            sent_config,
+            "-1009",
+            "hello",
+            thread_id="88",
+            media_files=[],
+        )
+        mirror_mock.assert_called_once_with("telegram", "-1009", "hello", source_label="cli", thread_id="88")
+
     def test_display_label_target_resolves_via_channel_directory(self, tmp_path):
         config, telegram_cfg = _make_config()
         cache_file = tmp_path / "channel_directory.json"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -5,6 +5,7 @@ Sends a message to a user or channel on any connected messaging platform
 human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
+import copy
 import json
 import logging
 import os
@@ -17,6 +18,7 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
+_TELEGRAM_ACCOUNT_TARGET_RE = re.compile(r"^\s*([a-z0-9_-]+)\s*:(.+)$", re.IGNORECASE)
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -111,27 +113,33 @@ def _handle_send(args):
     target_ref = parts[1].strip() if len(parts) > 1 else None
     chat_id = None
     thread_id = None
+    account_id = None
 
     if target_ref:
-        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+        account_id, parsed_target_ref = _parse_account_qualified_target(platform_name, target_ref)
+        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, parsed_target_ref)
     else:
+        parsed_target_ref = None
         is_explicit = False
 
     # Resolve human-friendly channel names to numeric IDs
-    if target_ref and not is_explicit:
+    if parsed_target_ref and not is_explicit:
         try:
             from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_name, target_ref)
+            lookup_platform_name = _platform_delivery_key(platform_name, account_id)
+            resolved = resolve_channel_name(lookup_platform_name, parsed_target_ref)
+            if not resolved and account_id:
+                resolved = resolve_channel_name(platform_name, parsed_target_ref)
             if resolved:
                 chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
             else:
                 return json.dumps({
-                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    "error": f"Could not resolve '{parsed_target_ref}' on {lookup_platform_name}. "
                     f"Use send_message(action='list') to see available targets."
                 })
         except Exception:
             return json.dumps({
-                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                "error": f"Could not resolve '{parsed_target_ref}' on {_platform_delivery_key(platform_name, account_id)}. "
                 f"Try using a numeric channel ID instead."
             })
 
@@ -170,8 +178,11 @@ def _handle_send(args):
         return tool_error(f"Unknown platform: {platform_name}. Available: {avail}")
 
     pconfig = config.platforms.get(platform)
+    if account_id:
+        pconfig = _resolve_account_platform_config(platform, pconfig, account_id)
     if not pconfig or not pconfig.enabled:
-        return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+        target_platform_name = _platform_delivery_key(platform_name, account_id)
+        return tool_error(f"Platform '{target_platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
 
     from gateway.platforms.base import BasePlatformAdapter
 
@@ -180,18 +191,21 @@ def _handle_send(args):
 
     used_home_channel = False
     if not chat_id:
-        home = config.get_home_channel(platform)
+        home = pconfig.home_channel if getattr(pconfig, "home_channel", None) else config.get_home_channel(platform)
         if home:
             chat_id = home.chat_id
+            if not thread_id:
+                thread_id = getattr(home, "thread_id", None)
             used_home_channel = True
         else:
+            target_platform_name = _platform_delivery_key(platform_name, account_id)
             return json.dumps({
-                "error": f"No home channel set for {platform_name} to determine where to send the message. "
-                f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
+                "error": f"No home channel set for {target_platform_name} to determine where to send the message. "
+                f"Either specify a channel directly with '{target_platform_name}:CHANNEL_NAME', "
                 f"or set a home channel via: hermes config set {platform_name.upper()}_HOME_CHANNEL <channel_id>"
             })
 
-    duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
+    duplicate_skip = _maybe_skip_cron_duplicate_send(_platform_delivery_key(platform_name, account_id), chat_id, thread_id)
     if duplicate_skip:
         return json.dumps(duplicate_skip)
 
@@ -208,7 +222,7 @@ def _handle_send(args):
             )
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
-            result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+            result["note"] = f"Sent to {_platform_delivery_key(platform_name, account_id)} home channel (chat_id: {chat_id})"
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:
@@ -226,6 +240,79 @@ def _handle_send(args):
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _getattr_or_default(obj, name: str, default=None):
+    """Return an attribute if present, otherwise a default value."""
+    return getattr(obj, name, default)
+
+
+def _parse_account_qualified_target(platform_name: str, target_ref: str):
+    """Extract an optional account qualifier from targets like devteam:-1001 or devteam:My Group."""
+    if platform_name != "telegram":
+        return None, target_ref
+
+    match = _TELEGRAM_ACCOUNT_TARGET_RE.fullmatch(target_ref)
+    if not match:
+        return None, target_ref
+
+    account_id = match.group(1).strip().lower()
+    remainder = match.group(2).strip()
+    if not account_id or not remainder:
+        return None, target_ref
+
+    if _TELEGRAM_TOPIC_TARGET_RE.fullmatch(account_id):
+        return None, target_ref
+
+    return account_id, remainder
+
+
+def _platform_delivery_key(platform_name: str, account_id: str | None = None) -> str:
+    """Return normalized platform label, including Telegram account suffix when present."""
+    if platform_name == "telegram" and account_id:
+        return f"telegram[{account_id}]"
+    return platform_name
+
+
+def _resolve_account_platform_config(platform, pconfig, account_id: str):
+    """Resolve an account-specific platform config while preserving base settings."""
+    from gateway.config import Platform
+
+    if platform != Platform.TELEGRAM or not pconfig:
+        return pconfig
+
+    extra_accounts = {}
+    if isinstance(getattr(pconfig, "extra", None), dict):
+        extra_accounts = pconfig.extra.get("telegram_accounts", {})
+    if not isinstance(extra_accounts, dict):
+        return None
+
+    account_data = extra_accounts.get(account_id)
+    if not isinstance(account_data, dict):
+        return None
+
+    resolved = copy.deepcopy(pconfig)
+    resolved.enabled = bool(account_data.get("enabled", True))
+    resolved.token = account_data.get("token", _getattr_or_default(resolved, "token"))
+    resolved.api_key = account_data.get("api_key", _getattr_or_default(resolved, "api_key"))
+    resolved.reply_to_mode = account_data.get("reply_to_mode", _getattr_or_default(resolved, "reply_to_mode"))
+    resolved.account_id = account_id
+
+    merged_extra = dict(getattr(pconfig, "extra", {}) or {})
+    merged_extra.pop("telegram_accounts", None)
+    account_extra = account_data.get("extra", {})
+    if isinstance(account_extra, dict):
+        merged_extra.update(account_extra)
+    resolved.extra = merged_extra
+
+    if isinstance(account_data.get("home_channel"), dict):
+        try:
+            from gateway.config import HomeChannel
+            resolved.home_channel = HomeChannel.from_dict(account_data["home_channel"])
+        except Exception:
+            pass
+
+    return resolved
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):


### PR DESCRIPTION
  ## What does this PR do?

  Adds backward-compatible multi-account Telegram support to Hermes gateway and `send_message`.

  Today Hermes assumes a single Telegram bot/account. This PR makes it possible to configure and run multiple Telegram bot identities at once, and to route outbound messages explicitly through the intended account.

  This is useful for setups that run separate assistant/dev/team Telegram bots in parallel.

  ## Related Issue

  Fixes #<ISSUE_NUMBER>

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added multi-account Telegram env/config support in `gateway/config.py`
    - supports extra accounts via `TELEGRAM_BOT_TOKEN_<ACCOUNT>`
    - preserves existing `TELEGRAM_BOT_TOKEN` behavior for the primary/default account

  - Updated gateway startup in `gateway/run.py`
    - starts one Telegram adapter per configured account
    - labels account-specific adapters as `telegram[account_id]`
    - updates reconnect/runtime bookkeeping to support string adapter labels

  - Updated channel directory behavior in `gateway/channel_directory.py`
    - supports account-qualified namespaces like `telegram[devteam]`
    - resolves account-specific channel labels first, then falls back to base `telegram`

  - Updated outbound routing in `tools/send_message_tool.py`
    - supports account-qualified targets such as:
      - `telegram:devteam:-1001234567890`
      - `telegram:devteam:-1001234567890:17585`
      - `telegram:devteam:Alerts Room`
    - resolves and sends with the correct account-specific Telegram config/token

  - Added/updated tests:
    - `tests/gateway/test_telegram_network.py`
    - `tests/gateway/test_telegram_multi_account.py`
    - `tests/gateway/test_channel_directory.py`
    - `tests/tools/test_send_message_tool.py`

  ## How to Test

  1. Configure Telegram env vars, for example:
     - `TELEGRAM_BOT_TOKEN=<primary token>`
     - `TELEGRAM_BOT_TOKEN_DEVTEAM=<secondary token>`

  2. Run the relevant tests:
     - `pytest tests/gateway/test_telegram_network.py tests/gateway/test_telegram_multi_account.py tests/gateway/test_channel_directory.py tests/tools/test_send_message_tool.py -q`

  3. Verify behavior:
     - existing single-account targets still work, e.g. `telegram:<chat_id>`
     - account-qualified targets work, e.g.:
       - `telegram:devteam:<chat_id>`
       - `telegram:devteam:<chat_id>:<thread_id>`
       - `telegram:devteam:<channel label>`

  4. Optionally verify live behavior by sending through two distinct Telegram bot accounts and confirming messages arrive from the expected bot identity.

  ## Checklist

  ### Code

  - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Targeted local test result:
  - `109 passed`

  Live validation:
  - verified successful outbound sends through two distinct Telegram bot identities
  - confirmed messages arrived from both configured bots
  ```