### PR TITLE
fix: surface vision auth setup hints for image fallback

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7345,11 +7345,20 @@ class GatewayRunner:
                         f"image_url: {path} ~]"
                     )
                 else:
-                    enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
-                        "this time (>_<) You can try looking at it yourself "
-                        f"with vision_analyze using image_url: {path}]"
-                    )
+                    failure_detail = str(result.get("analysis") or result.get("error") or "").strip()
+                    if failure_detail:
+                        enriched_parts.append(
+                            "[The user sent an image but I couldn't quite see it "
+                            "this time (>_<) "
+                            f"Auto-analysis said: {failure_detail} "
+                            f"You can try looking at it yourself with vision_analyze using image_url: {path}]"
+                        )
+                    else:
+                        enriched_parts.append(
+                            "[The user sent an image but I couldn't quite see it "
+                            "this time (>_<) You can try looking at it yourself "
+                            f"with vision_analyze using image_url: {path}]"
+                        )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
                 enriched_parts.append(

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -315,6 +315,36 @@ class TestErrorLoggingExcInfo:
             assert any(r.exc_info and r.exc_info[0] is not None for r in error_records)
 
     @pytest.mark.asyncio
+    async def test_authentication_error_mentions_env_hint(self, tmp_path):
+        async def fake_download(url, dest, max_retries=3):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"\xff\xd8\xff" + b"\x00" * 16)
+            return dest
+
+        with (
+            patch("tools.vision_tools._validate_image_url", return_value=True),
+            patch("tools.vision_tools._download_image", side_effect=fake_download),
+            patch("tools.vision_tools._detect_image_mime_type", return_value="image/jpeg"),
+            patch("tools.vision_tools._image_to_base64_data_url", return_value="data:image/jpeg;base64,abc"),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                side_effect=Exception("Error code: 401 - Missing Authentication header"),
+            ),
+        ):
+            result = json.loads(
+                await vision_analyze_tool(
+                    "https://example.com/img.jpg",
+                    "describe this",
+                    "test/model",
+                )
+            )
+
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["analysis"]
+        assert "AUXILIARY_VISION_API_KEY" in result["analysis"]
+
+    @pytest.mark.asyncio
     async def test_cleanup_error_logs_exc_info(self, tmp_path, caplog):
         """Temp file cleanup failure should log warning with exc_info."""
         # Create a real temp file that will be "downloaded"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -632,6 +632,16 @@ async def vision_analyze_tool(
                 f"API provider account and try again. Error: {e}"
             )
         elif any(hint in err_str for hint in (
+            "401", "unauthorized", "missing authentication header", "authentication header",
+        )):
+            analysis = (
+                "Vision authentication failed. Add a vision-capable API key to "
+                "~/.hermes/.env, usually OPENROUTER_API_KEY, or explicitly set "
+                "AUXILIARY_VISION_PROVIDER / AUXILIARY_VISION_MODEL / "
+                "AUXILIARY_VISION_API_KEY if you use a separate vision backend. "
+                f"Error: {e}"
+            )
+        elif any(hint in err_str for hint in (
             "does not support", "not support image",
             "content_policy", "multimodal",
             "unrecognized request argument", "image input",


### PR DESCRIPTION
Summary:
- show a concrete ~/.hermes/.env hint when vision fails with 401 / missing authentication
- include the auto-analysis failure detail in the Telegram/gateway fallback text instead of dropping it
- add a regression test for the 401 auth-hint path

Why:
- users currently get a generic 'couldn't quite see it this time' message even when the real issue is just missing vision auth
- the screenshot case reproduced a 401 Missing Authentication header from the auxiliary vision path

Validation:
- python -m pytest tests/tools/test_vision_tools.py -q
- python -m pytest tests/gateway/test_duplicate_reply_suppression.py -q
- python -m compileall tools/vision_tools.py gateway/run.py