### PR TITLE
feat(provider): add video_gen / music_gen tool categories

### DIFF
--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -36,8 +36,8 @@ logger = logging.getLogger(__name__)
 
 #: Canonical provider id → tool categories the provider serves natively.
 NATIVE_TOOLS_BY_PROVIDER: Dict[str, Tuple[str, ...]] = {
-    "minimax":    ("tts", "image_gen", "vision"),
-    "minimax-cn": ("tts", "image_gen", "vision"),
+    "minimax":    ("tts", "image_gen", "vision", "video_gen", "music_gen"),
+    "minimax-cn": ("tts", "image_gen", "vision", "video_gen", "music_gen"),
 }
 
 MINIMAX_PROVIDERS: Set[str] = {"minimax", "minimax-cn"}
@@ -105,6 +105,8 @@ def active_provider_api_root(config: Dict[str, Any]) -> str:
 _OVERRIDABLE_TTS    = {"", "edge"}
 _OVERRIDABLE_IMAGE  = {"", "auto", "fal"}
 _OVERRIDABLE_VISION = {"", "auto", "main"}
+_OVERRIDABLE_VIDEO  = {"", "auto"}
+_OVERRIDABLE_MUSIC  = {"", "auto"}
 
 
 def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
@@ -134,6 +136,18 @@ def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
             cfg["provider"] = provider
             changed.add("image_gen")
 
+    if "video_gen" in native:
+        cfg = config.setdefault("video_gen", {})
+        if isinstance(cfg, dict) and (str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE_VIDEO):
+            cfg["provider"] = provider
+            changed.add("video_gen")
+
+    if "music_gen" in native:
+        cfg = config.setdefault("music_gen", {})
+        if isinstance(cfg, dict) and (str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE_MUSIC):
+            cfg["provider"] = provider
+            changed.add("music_gen")
+
     if "vision" in native and changed:
         aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}
         v = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
@@ -151,6 +165,8 @@ _SUMMARY: Dict[str, Dict[str, str]] = {
         "tts":       "TTS → speech-2.6-hd (30+ voices)",
         "image_gen": "Image generation → image-01",
         "vision":    "Vision analysis → MiniMax-VL-01",
+        "video_gen": "Video generation → MiniMax-Hailuo-2.3",
+        "music_gen": "Music generation → music-2.6",
     },
 }
 _SUMMARY["minimax-cn"] = _SUMMARY["minimax"]
@@ -241,6 +257,43 @@ def minimax_endpoint_and_key(
     return f"{root}{subpath}", key
 
 
+def generate_video(
+    *,
+    prompt: str,
+    duration: Optional[int] = None,
+    resolution: Optional[str] = None,
+    first_frame_image: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Generate via the active provider's native video backend, or `None`."""
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return _minimax_video_request(
+            prompt=prompt, duration=duration, resolution=resolution,
+            first_frame_image=first_frame_image, config=cfg,
+        )
+    return None
+
+
+def generate_music(
+    *,
+    prompt: str,
+    lyrics: str,
+    output_format: str = "mp3",
+    sample_rate: int = 44100,
+    bitrate: int = 256000,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Generate via the active provider's native music backend, or `None`."""
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return _minimax_music_request(
+            prompt=prompt, lyrics=lyrics, output_format=output_format,
+            sample_rate=sample_rate, bitrate=bitrate, config=cfg,
+        )
+    return None
+
+
 # ─── Internal: shared helpers ────────────────────────────────────────────
 
 
@@ -267,7 +320,17 @@ def _post_json(url: str, payload: Dict[str, Any], key: str, *, timeout: int = 12
         return json.loads(resp.read().decode("utf-8", errors="replace"))
 
 
-def _download(url: str, output_path: Path, *, timeout: int = 120) -> None:
+def _get_json(url: str, key: str, *, timeout: int = 60) -> Dict[str, Any]:
+    """Bearer-auth GET → parsed JSON.  Raises urllib / json errors."""
+    req = urllib.request.Request(
+        url, method="GET", headers={"Authorization": f"Bearer {key}"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _download(url: str, output_path: Path, *, timeout: int = 300) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     ctx = ssl.create_default_context()
     with urllib.request.urlopen(url, timeout=timeout, context=ctx) as resp:
@@ -463,4 +526,220 @@ def _minimax_vlm_request(image_source: str, user_prompt: str,
         "provider": _active_provider_id(config),
         "model": "MiniMax-VL-01",
         "endpoint": "/v1/coding_plan/vlm",
+    }, ensure_ascii=False)
+
+
+def _minimax_video_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/videos", "video_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "video_cache"
+
+
+def _minimax_music_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/music", "music_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "music_cache"
+
+
+_VIDEO_MODEL = "MiniMax-Hailuo-2.3"
+_VIDEO_VALID_RESOLUTIONS = {"768P", "1080P"}
+_VIDEO_VALID_DURATIONS = {6, 10}
+_VIDEO_POLL_SECONDS = 15
+_VIDEO_POLL_MAX = 40  # 40 × 15s = 10 min ceiling
+
+
+def _minimax_video_request(
+    *, prompt: str,
+    duration: Optional[int] = None,
+    resolution: Optional[str] = None,
+    first_frame_image: Optional[str] = None,
+    config: Dict[str, Any],
+) -> str:
+    api_root = active_provider_api_root(config).rstrip("/")
+    if not api_root:
+        return json.dumps({"success": False,
+            "error": "video_gen.provider=minimax but model.base_url is unset"})
+    key = _minimax_credential(config)
+    if not key:
+        return json.dumps({"success": False,
+            "error": "MINIMAX_API_KEY (or _CN) required"})
+
+    payload: Dict[str, Any] = {
+        "model": _VIDEO_MODEL,
+        "prompt": (prompt or "").strip(),
+    }
+    if duration in _VIDEO_VALID_DURATIONS:
+        payload["duration"] = duration
+    if resolution and resolution.upper() in _VIDEO_VALID_RESOLUTIONS:
+        payload["resolution"] = resolution.upper()
+    if first_frame_image:
+        coerced = _coerce_vlm_image_url(first_frame_image)
+        if coerced:
+            payload["first_frame_image"] = coerced
+
+    # 1. Submit task.
+    try:
+        body = _post_json(f"{api_root}/v1/video_generation", payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+            "error": f"video API HTTP {exc.code}", "status": exc.code})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+            "error": f"video API error {base.get('status_code')}: "
+                     f"{base.get('status_msg', '')}",
+            "status": base.get("status_code")})
+
+    task_id = body.get("task_id")
+    if not task_id:
+        return json.dumps({"success": False, "error": "video API returned no task_id"})
+
+    # 2. Poll until terminal status.
+    file_id: Optional[str] = None
+    last_status = ""
+    for _ in range(_VIDEO_POLL_MAX):
+        time.sleep(_VIDEO_POLL_SECONDS)
+        try:
+            status_body = _get_json(
+                f"{api_root}/v1/query/video_generation?task_id={task_id}", key,
+            )
+        except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            logger.debug("video poll failed: %s", exc)
+            continue
+        last_status = str(status_body.get("status") or "")
+        if last_status == "Success":
+            file_id = status_body.get("file_id")
+            break
+        if last_status == "Fail":
+            return json.dumps({"success": False,
+                "error": f"video generation failed (task {task_id})",
+                "task_id": task_id})
+
+    if not file_id:
+        return json.dumps({"success": False,
+            "error": f"video generation timed out after "
+                     f"{_VIDEO_POLL_SECONDS * _VIDEO_POLL_MAX}s "
+                     f"(last status: {last_status or 'unknown'})",
+            "task_id": task_id})
+
+    # 3. Resolve download URL.
+    try:
+        file_body = _get_json(f"{api_root}/v1/files/retrieve?file_id={file_id}", key)
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": f"file retrieve failed: {exc}"})
+    download_url = (file_body.get("file") or {}).get("download_url")
+    if not download_url:
+        return json.dumps({"success": False,
+            "error": f"no download_url for file_id {file_id}"})
+
+    # 4. Save locally.
+    out_dir = _minimax_video_cache_dir()
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"video_{ts}.mp4"
+    try:
+        _download(download_url, path)
+    except Exception as exc:
+        return json.dumps({"success": False,
+            "error": f"video download failed: {exc}",
+            "url": download_url, "task_id": task_id})
+
+    return json.dumps({
+        "success": True,
+        "provider": _active_provider_id(config),
+        "model": _VIDEO_MODEL,
+        "task_id": task_id,
+        "path": str(path),
+        "url": download_url,
+    }, ensure_ascii=False)
+
+
+_MUSIC_VALID_FORMATS = {"mp3", "wav", "pcm"}
+
+
+def _music_model_for_key(key: str) -> str:
+    """Mirror of mmx CLI's `musicGenerateModel`: `sk-cp-` (Token Plan)
+    unlocks `music-2.6`; other key types use `music-2.6-free`.
+    """
+    return "music-2.6" if key.startswith("sk-cp-") else "music-2.6-free"
+
+
+def _minimax_music_request(
+    *, prompt: str, lyrics: str, output_format: str,
+    sample_rate: int, bitrate: int, config: Dict[str, Any],
+) -> str:
+    api_root = active_provider_api_root(config).rstrip("/")
+    if not api_root:
+        return json.dumps({"success": False,
+            "error": "music_gen.provider=minimax but model.base_url is unset"})
+    key = _minimax_credential(config)
+    if not key:
+        return json.dumps({"success": False,
+            "error": "MINIMAX_API_KEY (or _CN) required"})
+
+    fmt = (output_format or "mp3").lower()
+    if fmt not in _MUSIC_VALID_FORMATS:
+        fmt = "mp3"
+
+    model = _music_model_for_key(key)
+    payload = {
+        "model": model,
+        "prompt": (prompt or "").strip(),
+        "lyrics": (lyrics or "").strip(),
+        "audio_setting": {
+            "sample_rate": sample_rate,
+            "bitrate": bitrate,
+            "format": fmt,
+        },
+        "output_format": "hex",
+        "stream": False,
+    }
+
+    try:
+        body = _post_json(f"{api_root}/v1/music_generation", payload, key, timeout=180)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+            "error": f"music API HTTP {exc.code}", "status": exc.code})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+            "error": f"music API error {base.get('status_code')}: "
+                     f"{base.get('status_msg', '')}",
+            "status": base.get("status_code")})
+
+    data = body.get("data") or {}
+    audio_hex = data.get("audio") if isinstance(data, dict) else None
+    if not isinstance(audio_hex, str) or not audio_hex:
+        return json.dumps({"success": False, "error": "music API returned no audio"})
+
+    try:
+        audio_bytes = bytes.fromhex(audio_hex)
+    except ValueError as exc:
+        return json.dumps({"success": False, "error": f"invalid hex audio: {exc}"})
+
+    out_dir = _minimax_music_cache_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"music_{ts}.{fmt}"
+    try:
+        path.write_bytes(audio_bytes)
+    except OSError as exc:
+        return json.dumps({"success": False, "error": f"write failed: {exc}"})
+
+    return json.dumps({
+        "success": True,
+        "provider": _active_provider_id(config),
+        "model": model,
+        "path": str(path),
+        "format": fmt,
+        "bytes": len(audio_bytes),
     }, ensure_ascii=False)

--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -1,0 +1,466 @@
+"""Helpers for chat providers that also serve TTS / image / vision natively.
+
+When a chat provider exposes those non-chat capabilities on the same API
+base and credential, the setup wizard wires them as the default tool
+backends and the tool dispatchers route through this module instead of
+the generic FAL / auxiliary-client paths.
+
+Mirrors the shape of `hermes_cli.nous_subscription`: one apply hook for
+the wizard, plus runtime helpers consumed by the tool files.
+
+Adding a provider:
+
+  1. Add the canonical id to `MINIMAX_PROVIDERS` (or add a new
+     `NATIVE_TOOLS_BY_PROVIDER` row + provider set).
+  2. Implement the request helpers in this file (mirror
+     `_minimax_image_request` / `_minimax_vlm_request`).
+  3. Route to them from `generate_image` / `analyze_image` / etc.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import mimetypes
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+#: Canonical provider id → tool categories the provider serves natively.
+NATIVE_TOOLS_BY_PROVIDER: Dict[str, Tuple[str, ...]] = {
+    "minimax":    ("tts", "image_gen", "vision"),
+    "minimax-cn": ("tts", "image_gen", "vision"),
+}
+
+MINIMAX_PROVIDERS: Set[str] = {"minimax", "minimax-cn"}
+
+
+# ─── Active-provider lookup ──────────────────────────────────────────────
+
+
+def _active_provider_id(config: Dict[str, Any]) -> str:
+    """Canonical id of the active chat provider, or `""`.
+
+    Reads `model.provider` (dict shape) or strips the prefix off the
+    legacy `model: "provider/name"` string.  Normalises through
+    `hermes_cli.providers.normalize_provider` so hand-edited aliases
+    resolve to the canonical id.
+    """
+    model = config.get("model")
+    raw = ""
+    if isinstance(model, dict):
+        raw = str(model.get("provider") or "").strip().lower()
+    elif isinstance(model, str) and "/" in model:
+        raw = model.split("/", 1)[0].strip().lower()
+    if not raw:
+        return ""
+    try:
+        from hermes_cli.providers import normalize_provider
+        return normalize_provider(raw)
+    except Exception:
+        return raw
+
+
+def get_native_tools(config: Dict[str, Any]) -> Tuple[str, ...]:
+    """Native tool categories declared for the active provider, or `()`."""
+    return NATIVE_TOOLS_BY_PROVIDER.get(_active_provider_id(config), ())
+
+
+def provider_has_native_tool(tool: str, config: Dict[str, Any]) -> bool:
+    """True when the active chat provider serves `tool` natively."""
+    return tool in get_native_tools(config)
+
+
+def active_provider_api_root(config: Dict[str, Any]) -> str:
+    """API root for the active chat provider, or `""`.
+
+    Reads `model.base_url` and strips the `/anthropic` chat-compat suffix
+    when present, so non-chat endpoints (`/v1/image_generation`,
+    `/v1/t2a_v2`, `/v1/coding_plan/vlm`) hang off the returned root.
+    """
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return ""
+    base = str(model.get("base_url") or "").strip().rstrip("/")
+    if not base:
+        return ""
+    return base[: -len("/anthropic")] if base.endswith("/anthropic") else base
+
+
+# ─── Setup-time defaults ─────────────────────────────────────────────────
+#
+# Mirrors `apply_nous_provider_defaults`: hardcodes the few config slots
+# we touch, only overrides built-in defaults, and returns the set of
+# slots actually changed so the wizard can print a summary.
+
+
+_OVERRIDABLE_TTS    = {"", "edge"}
+_OVERRIDABLE_IMAGE  = {"", "auto", "fal"}
+_OVERRIDABLE_VISION = {"", "auto", "main"}
+
+
+def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
+    """Wire `tts.provider` / `image_gen.provider` for native providers.
+
+    Returns the set of categories newly wired (empty when the provider
+    isn't native or everything is already set).  Vision is reported when
+    something else also changed; no config value is persisted because
+    the dispatcher in `tools/vision_tools.py` activates per session.
+    """
+    native = get_native_tools(config)
+    if not native:
+        return set()
+
+    provider = _active_provider_id(config)
+    changed: Set[str] = set()
+
+    if "tts" in native:
+        cfg = config.setdefault("tts", {})
+        if isinstance(cfg, dict) and (str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE_TTS):
+            cfg["provider"] = provider
+            changed.add("tts")
+
+    if "image_gen" in native:
+        cfg = config.setdefault("image_gen", {})
+        if isinstance(cfg, dict) and (str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE_IMAGE):
+            cfg["provider"] = provider
+            changed.add("image_gen")
+
+    if "vision" in native and changed:
+        aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}
+        v = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
+        if str(v.get("provider") or "").strip().lower() in _OVERRIDABLE_VISION:
+            changed.add("vision")
+
+    if changed:
+        logger.info("Applied provider-native tool defaults for %r: %s",
+                    provider, sorted(changed))
+    return changed
+
+
+_SUMMARY: Dict[str, Dict[str, str]] = {
+    "minimax": {
+        "tts":       "TTS → speech-2.6-hd (30+ voices)",
+        "image_gen": "Image generation → image-01",
+        "vision":    "Vision analysis → MiniMax-VL-01",
+    },
+}
+_SUMMARY["minimax-cn"] = _SUMMARY["minimax"]
+
+
+def describe_changes(changed: Iterable[str], config: Dict[str, Any]) -> str:
+    """Bullet-list summary used by the setup wizard."""
+    items = sorted(changed)
+    if not items:
+        return "No changes — existing tool choices were preserved."
+    phrasing = _SUMMARY.get(_active_provider_id(config), {})
+    return "\n".join(
+        f"  • {phrasing.get(k, k)}" for k in items
+    )
+
+
+# ─── Runtime dispatchers (consumed by tool files) ────────────────────────
+
+
+def generate_image(
+    *,
+    prompt: str,
+    aspect_ratio: str,
+    num_images: int,
+    output_format: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Generate via the active provider's native image backend, or `None`.
+
+    Tool files call this before falling through to their existing path.
+    The return shape matches `image_generate_tool` so callers can return
+    the result verbatim.
+    """
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return _minimax_image_request(
+            prompt=prompt, aspect_ratio=aspect_ratio,
+            num_images=num_images, output_format=output_format,
+            config=cfg,
+        )
+    return None
+
+
+def analyze_image(
+    image_source: str,
+    user_prompt: str,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """Describe via the active provider's native VLM backend, or `None`."""
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return _minimax_vlm_request(image_source, user_prompt, cfg)
+    return None
+
+
+def native_credential_present(
+    tool: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """True when the active provider serves `tool` natively *and* its
+    credential is configured.  Used by tool-level `check_fn` gates."""
+    cfg = config if config is not None else _safe_load_config()
+    if not provider_has_native_tool(tool, cfg):
+        return False
+    if _active_provider_id(cfg) in MINIMAX_PROVIDERS:
+        return bool(_minimax_credential(cfg))
+    return False
+
+
+def minimax_endpoint_and_key(
+    subpath: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, str]:
+    """Return ``(url, api_key)`` for a MiniMax subpath (e.g. ``/v1/t2a_v2``)
+    derived from the active provider's ``model.base_url`` + the
+    region-appropriate credential.  Both values are empty strings when
+    the active provider isn't MiniMax, so callers can probe with a
+    single call and fall through.
+    """
+    cfg = config if config is not None else _safe_load_config()
+    if _active_provider_id(cfg) not in MINIMAX_PROVIDERS:
+        return "", ""
+    root = active_provider_api_root(cfg).rstrip("/")
+    key = _minimax_credential(cfg)
+    if not root or not key:
+        return "", ""
+    return f"{root}{subpath}", key
+
+
+# ─── Internal: shared helpers ────────────────────────────────────────────
+
+
+def _safe_load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception as exc:
+        logger.debug("provider_native_tools: config load failed: %s", exc)
+        return {}
+
+
+def _post_json(url: str, payload: Dict[str, Any], key: str, *, timeout: int = 120) -> Dict[str, Any]:
+    """Bearer-auth POST → parsed JSON.  Raises urllib / json errors."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _download(url: str, output_path: Path, *, timeout: int = 120) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(url, timeout=timeout, context=ctx) as resp:
+        with open(output_path, "wb") as fh:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                fh.write(chunk)
+
+
+# ─── MiniMax bindings ────────────────────────────────────────────────────
+#
+# Per-provider request helpers.  Mirror the per-provider TTS helpers in
+# `tools/tts_tool.py` (`_generate_minimax_tts` etc.).  Adding another
+# provider is parallel: drop helpers below and route to them above.
+
+
+def _minimax_credential(config: Optional[Dict[str, Any]] = None) -> str:
+    """Pick the key matching the active provider's region.
+
+    `minimax-cn` prefers `MINIMAX_CN_API_KEY`; `minimax` (international)
+    prefers `MINIMAX_API_KEY`.  Falls back to the other on absence so a
+    user with only one key still works for both regions (at their own
+    entitlement risk).
+    """
+    cfg = config if config is not None else {}
+    is_cn = _active_provider_id(cfg) == "minimax-cn"
+    order = ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY") if is_cn \
+            else ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")
+    for var in order:
+        v = os.environ.get(var)
+        if v and v.strip():
+            return v.strip()
+    return ""
+
+
+def _minimax_image_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/images", "image_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "image_cache"
+
+
+_MINIMAX_RATIO_ALIAS = {"landscape": "16:9", "portrait": "9:16", "square": "1:1"}
+_MINIMAX_VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "21:9"}
+
+
+def _minimax_image_request(
+    *, prompt: str, aspect_ratio: str, num_images: int, output_format: str,
+    config: Dict[str, Any],
+) -> str:
+    api_root = active_provider_api_root(config).rstrip("/")
+    if not api_root:
+        return json.dumps({"success": False,
+            "error": "image_gen.provider=minimax but model.base_url is unset"})
+    key = _minimax_credential(config)
+    if not key:
+        return json.dumps({"success": False,
+            "error": "MINIMAX_API_KEY (or _CN) required"})
+
+    ratio = _MINIMAX_RATIO_ALIAS.get((aspect_ratio or "").lower(), aspect_ratio)
+    if ratio not in _MINIMAX_VALID_RATIOS:
+        ratio = "16:9"
+
+    payload = {
+        "model": "image-01",
+        "prompt": (prompt or "").strip(),
+        "aspect_ratio": ratio,
+        "n": max(1, min(4, int(num_images or 1))),
+        "response_format": "url",
+    }
+    try:
+        body = _post_json(f"{api_root}/v1/image_generation", payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+            "error": f"image API HTTP {exc.code}", "status": exc.code})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+            "error": f"image API error {base.get('status_code')}: "
+                     f"{base.get('status_msg', '')}",
+            "status": base.get("status_code")})
+
+    data = body.get("data") or {}
+    urls: list = []
+    if isinstance(data, dict):
+        for k in ("image_urls", "urls"):
+            v = data.get(k)
+            if isinstance(v, list):
+                urls = [u for u in v if isinstance(u, str) and u.startswith("http")]
+                break
+    if not urls:
+        return json.dumps({"success": False, "error": "image API returned no URL(s)"})
+
+    out_dir = _minimax_image_cache_dir()
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    ext = "jpeg" if (output_format or "").lower() in ("jpeg", "jpg") else "png"
+    saved: list = []
+    for i, url in enumerate(urls):
+        path = out_dir / (f"image_{ts}.{ext}" if i == 0 else f"image_{ts}_{i + 1}.{ext}")
+        try:
+            _download(url, path)
+            saved.append(str(path))
+        except Exception as exc:
+            logger.warning("image download failed for %s: %s", url, exc)
+    if not saved:
+        return json.dumps({"success": False, "error": "all image downloads failed"})
+    return json.dumps({
+        "success": True,
+        "provider": _active_provider_id(config),
+        "model": "image-01",
+        "aspect_ratio": ratio,
+        "paths": saved,
+        "urls": urls,
+    }, ensure_ascii=False)
+
+
+_VLM_SUPPORTED_MIME = {"image/jpeg", "image/png", "image/webp"}
+_VLM_MAGIC = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff",      "image/jpeg"),
+)
+
+
+def _coerce_vlm_image_url(image_source: str) -> Optional[str]:
+    """Normalise into a value the VLM endpoint accepts (data URI / URL),
+    or `None` for unsupported / missing files."""
+    src = (image_source or "").strip()
+    if not src:
+        return None
+    if src.startswith(("data:", "http://", "https://")):
+        return src
+    if src.startswith("file://"):
+        src = src[len("file://"):]
+    path = Path(src).expanduser()
+    if not path.is_file():
+        return None
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime:
+        head = path.read_bytes()[:12]
+        mime = next((m for magic, m in _VLM_MAGIC if head.startswith(magic)), None)
+        if mime is None and head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+            mime = "image/webp"
+    if mime not in _VLM_SUPPORTED_MIME:
+        return None
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode()}"
+
+
+def _minimax_vlm_request(image_source: str, user_prompt: str,
+                         config: Dict[str, Any]) -> Optional[str]:
+    api_root = active_provider_api_root(config).rstrip("/")
+    if not api_root:
+        return None
+    key = _minimax_credential(config)
+    if not key:
+        return None
+    image_url = _coerce_vlm_image_url(image_source)
+    if not image_url:
+        return None
+
+    try:
+        body = _post_json(
+            f"{api_root}/v1/coding_plan/vlm",
+            {"prompt": user_prompt, "image_url": image_url},
+            key,
+            timeout=60,
+        )
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        logger.debug("VLM call failed: %s", exc)
+        return None
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        # Surface provider-side errors verbatim (e.g. 1008 insufficient
+        # balance) instead of masking them as fallback triggers.
+        return json.dumps({
+            "success": False,
+            "error": f"VLM error {base.get('status_code')}: {base.get('status_msg', '')}",
+            "status": base.get("status_code"),
+        }, ensure_ascii=False)
+
+    content = body.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return json.dumps({
+        "success": True,
+        "analysis": content,
+        "provider": _active_provider_id(config),
+        "model": "MiniMax-VL-01",
+        "endpoint": "/v1/coding_plan/vlm",
+    }, ensure_ascii=False)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -24,6 +24,11 @@ from hermes_cli.nous_subscription import (
     apply_nous_provider_defaults,
     get_nous_subscription_features,
 )
+from hermes_cli.provider_native_tools import (
+    apply_provider_native_tool_defaults,
+    describe_changes as describe_native_tool_changes,
+    get_native_tools as _provider_native_tools,
+)
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from hermes_constants import get_optional_skills_dir
 
@@ -843,9 +848,28 @@ def setup_model_provider(config: dict, *, quick: bool = False):
         else:
             print_info(f"Keeping your existing TTS provider: {current_tts}")
 
+    # Wire tool defaults for chat providers that serve TTS / image / vision
+    # natively on the same credential.  Self-gates on the active provider;
+    # a no-op for providers not registered in
+    # `hermes_cli.provider_native_tools.NATIVE_TOOLS_BY_PROVIDER`.
+    native_changes = apply_provider_native_tool_defaults(config)
+    if native_changes:
+        print()
+        print_success(
+            "The same credential also unlocks the following — wired automatically:"
+        )
+        print(describe_native_tool_changes(native_changes, config))
+
     save_config(config)
 
-    if not quick and selected_provider != "nous":
+    # Skip the interactive TTS selector when the active provider already
+    # owns it (nous via subscription defaults, or any provider that
+    # declares `tts` in its native-tools registry).
+    if (
+        not quick
+        and selected_provider != "nous"
+        and "tts" not in _provider_native_tools(config)
+    ):
         _setup_tts_provider(config)
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -54,6 +54,8 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("video_gen",       "🎬 Video Generation",          "video_generate"),
+    ("music_gen",       "🎵 Music Generation",          "music_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/model_tools.py
+++ b/model_tools.py
@@ -142,6 +142,8 @@ def _discover_tools():
         "tools.vision_tools",
         "tools.mixture_of_agents_tool",
         "tools.image_generation_tool",
+        "tools.video_generation_tool",
+        "tools.music_generation_tool",
         "tools.skills_tool",
         "tools.skill_manager_tool",
         "tools.browser_tool",

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -20,6 +20,8 @@ from hermes_cli.provider_native_tools import (
     active_provider_api_root,
     apply_provider_native_tool_defaults,
     describe_changes,
+    generate_music,
+    generate_video,
     get_native_tools,
     minimax_endpoint_and_key,
     native_credential_present,
@@ -33,11 +35,12 @@ class TestRegistryShape:
         assert "minimax-cn" in NATIVE_TOOLS_BY_PROVIDER
 
     def test_minimax_capabilities(self):
-        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax"]) == {"tts", "image_gen", "vision"}
-        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax-cn"]) == {"tts", "image_gen", "vision"}
+        expected = {"tts", "image_gen", "vision", "video_gen", "music_gen"}
+        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax"]) == expected
+        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax-cn"]) == expected
 
     def test_no_unknown_tool_categories(self):
-        valid = {"tts", "image_gen", "vision"}
+        valid = {"tts", "image_gen", "vision", "video_gen", "music_gen"}
         for provider, tools in NATIVE_TOOLS_BY_PROVIDER.items():
             unknown = set(tools) - valid
             assert not unknown, (
@@ -71,7 +74,7 @@ class TestActiveProviderId:
 class TestQueryHelpers:
     def test_get_native_tools_minimax(self):
         out = get_native_tools({"model": {"provider": "minimax"}})
-        assert set(out) == {"tts", "image_gen", "vision"}
+        assert set(out) == {"tts", "image_gen", "vision", "video_gen", "music_gen"}
 
     def test_get_native_tools_unregistered(self):
         assert get_native_tools({"model": {"provider": "anthropic"}}) == ()
@@ -79,7 +82,7 @@ class TestQueryHelpers:
     def test_get_native_tools_unset(self):
         assert get_native_tools({}) == ()
 
-    @pytest.mark.parametrize("tool", ["tts", "image_gen", "vision"])
+    @pytest.mark.parametrize("tool", ["tts", "image_gen", "vision", "video_gen", "music_gen"])
     def test_provider_has_native_tool_minimax(self, tool):
         assert provider_has_native_tool(tool, {"model": {"provider": "minimax"}}) is True
 
@@ -87,7 +90,7 @@ class TestQueryHelpers:
         assert provider_has_native_tool("tts", {"model": {"provider": "anthropic"}}) is False
 
     def test_unknown_tool(self):
-        assert provider_has_native_tool("music_gen", {"model": {"provider": "minimax"}}) is False
+        assert provider_has_native_tool("search", {"model": {"provider": "minimax"}}) is False
 
 
 class TestApiRoot:
@@ -121,14 +124,34 @@ class TestApplyDefaults:
     def test_noop_when_no_provider(self):
         assert apply_provider_native_tool_defaults({}) == set()
 
-    def test_minimax_writes_tts_image_reports_vision(self):
+    def test_minimax_writes_all_config_slots(self):
         config = {"model": {"provider": "minimax"}}
         changed = apply_provider_native_tool_defaults(config)
-        assert changed == {"tts", "image_gen", "vision"}
+        assert changed == {"tts", "image_gen", "vision", "video_gen", "music_gen"}
         assert config["tts"]["provider"] == "minimax"
         assert config["image_gen"]["provider"] == "minimax"
+        assert config["video_gen"]["provider"] == "minimax"
+        assert config["music_gen"]["provider"] == "minimax"
         # Vision is reported but no value persists — runtime dispatch handles it.
         assert config.get("auxiliary", {}).get("vision") in (None, {})
+
+    def test_explicit_video_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "video_gen": {"provider": "runway"},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "video_gen" not in changed
+        assert config["video_gen"]["provider"] == "runway"
+
+    def test_explicit_music_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "music_gen": {"provider": "suno"},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "music_gen" not in changed
+        assert config["music_gen"]["provider"] == "suno"
 
     def test_explicit_tts_preserved(self):
         config = {
@@ -173,15 +196,17 @@ class TestApplyDefaults:
     def test_idempotent(self):
         config = {"model": {"provider": "minimax"}}
         first = apply_provider_native_tool_defaults(config)
-        assert first == {"tts", "image_gen", "vision"}
+        assert first == {"tts", "image_gen", "vision", "video_gen", "music_gen"}
         second = apply_provider_native_tool_defaults(config)
         assert second == set()
 
     def test_cn_provider_same_behaviour(self):
         config = {"model": {"provider": "minimax-cn"}}
         changed = apply_provider_native_tool_defaults(config)
-        assert changed == {"tts", "image_gen", "vision"}
+        assert changed == {"tts", "image_gen", "vision", "video_gen", "music_gen"}
         assert config["tts"]["provider"] == "minimax-cn"
+        assert config["video_gen"]["provider"] == "minimax-cn"
+        assert config["music_gen"]["provider"] == "minimax-cn"
 
     def test_alias_provider_resolved(self):
         config = {"model": {"provider": "minimax-china"}}
@@ -203,14 +228,15 @@ class TestDescribeChanges:
         out = describe_changes(set(), {"model": {"provider": "minimax"}})
         assert "No changes" in out
 
-    def test_minimax_three_tools(self):
+    def test_minimax_all_five_tools(self):
         out = describe_changes(
-            {"tts", "image_gen", "vision"},
+            {"tts", "image_gen", "vision", "video_gen", "music_gen"},
             {"model": {"provider": "minimax"}},
         )
         # Provider name omitted from values (wizard's success line names it).
         assert "TTS" in out and "image-01" in out and "MiniMax-VL-01" in out
-        assert out.count("•") == 3
+        assert "MiniMax-Hailuo-2.3" in out and "music-2.6" in out
+        assert out.count("•") == 5
 
     def test_minimax_cn_shares_minimax_phrasing(self):
         out_int = describe_changes({"tts"}, {"model": {"provider": "minimax"}})
@@ -232,7 +258,7 @@ class TestNativeCredentialPresent:
         monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
         assert native_credential_present(
             "search", {"model": {"provider": "minimax"}},
-        ) is False  # minimax declares tts/image_gen/vision — not "search"
+        ) is False  # search is not in minimax's native tool set
 
     def test_true_when_provider_native_and_key_set(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
@@ -284,3 +310,26 @@ class TestMinimaxEndpointAndKey:
         assert minimax_endpoint_and_key("/v1/t2a_v2", {
             "model": {"provider": "minimax", "base_url": "https://api.minimax.io/anthropic"},
         }) == ("", "")
+
+
+class TestRuntimeDispatchers:
+    def test_generate_video_returns_none_when_provider_not_native(self):
+        assert generate_video(
+            prompt="a cat",
+            config={"model": {"provider": "anthropic"}},
+        ) is None
+
+    def test_generate_video_returns_none_when_unset(self):
+        assert generate_video(prompt="a cat", config={}) is None
+
+    def test_generate_music_returns_none_when_provider_not_native(self):
+        assert generate_music(
+            prompt="jazz",
+            lyrics="hello world",
+            config={"model": {"provider": "openai"}},
+        ) is None
+
+    def test_generate_music_returns_none_when_unset(self):
+        assert generate_music(
+            prompt="jazz", lyrics="hi", config={},
+        ) is None

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -1,0 +1,286 @@
+"""Tests for hermes_cli/provider_native_tools.py.
+
+Covers the registry shape, active-provider lookup (incl. alias
+normalisation), URL derivation, the setup-time defaults hook (override
+preservation, idempotency), and the user-facing summary.
+
+Uses MiniMax (the first registered provider) as the live fixture.
+Adding another provider to ``NATIVE_TOOLS_BY_PROVIDER`` should let the
+generic suite continue to pass — the only provider-specific assertions
+are on the MiniMax phrasing in ``describe_changes``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.provider_native_tools import (
+    NATIVE_TOOLS_BY_PROVIDER,
+    _active_provider_id,
+    active_provider_api_root,
+    apply_provider_native_tool_defaults,
+    describe_changes,
+    get_native_tools,
+    minimax_endpoint_and_key,
+    native_credential_present,
+    provider_has_native_tool,
+)
+
+
+class TestRegistryShape:
+    def test_minimax_registered(self):
+        assert "minimax" in NATIVE_TOOLS_BY_PROVIDER
+        assert "minimax-cn" in NATIVE_TOOLS_BY_PROVIDER
+
+    def test_minimax_capabilities(self):
+        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax"]) == {"tts", "image_gen", "vision"}
+        assert set(NATIVE_TOOLS_BY_PROVIDER["minimax-cn"]) == {"tts", "image_gen", "vision"}
+
+    def test_no_unknown_tool_categories(self):
+        valid = {"tts", "image_gen", "vision"}
+        for provider, tools in NATIVE_TOOLS_BY_PROVIDER.items():
+            unknown = set(tools) - valid
+            assert not unknown, (
+                f"provider {provider!r} declares unknown tool categories {unknown}"
+            )
+
+
+class TestActiveProviderId:
+    def test_dict_shape(self):
+        assert _active_provider_id({"model": {"provider": "minimax"}}) == "minimax"
+
+    def test_dict_shape_cn(self):
+        assert _active_provider_id({"model": {"provider": "minimax-cn"}}) == "minimax-cn"
+
+    def test_case_insensitive(self):
+        assert _active_provider_id({"model": {"provider": "MiniMax"}}) == "minimax"
+
+    def test_alias_normalised(self):
+        assert _active_provider_id({"model": {"provider": "minimax-china"}}) == "minimax-cn"
+        assert _active_provider_id({"model": {"provider": "minimax_cn"}}) == "minimax-cn"
+
+    def test_legacy_string_shape(self):
+        assert _active_provider_id({"model": "minimax/MiniMax-M2.7"}) == "minimax"
+
+    def test_unset(self):
+        assert _active_provider_id({}) == ""
+        assert _active_provider_id({"model": {}}) == ""
+        assert _active_provider_id({"model": {"default": "M2.7"}}) == ""
+
+
+class TestQueryHelpers:
+    def test_get_native_tools_minimax(self):
+        out = get_native_tools({"model": {"provider": "minimax"}})
+        assert set(out) == {"tts", "image_gen", "vision"}
+
+    def test_get_native_tools_unregistered(self):
+        assert get_native_tools({"model": {"provider": "anthropic"}}) == ()
+
+    def test_get_native_tools_unset(self):
+        assert get_native_tools({}) == ()
+
+    @pytest.mark.parametrize("tool", ["tts", "image_gen", "vision"])
+    def test_provider_has_native_tool_minimax(self, tool):
+        assert provider_has_native_tool(tool, {"model": {"provider": "minimax"}}) is True
+
+    def test_provider_has_native_tool_unregistered(self):
+        assert provider_has_native_tool("tts", {"model": {"provider": "anthropic"}}) is False
+
+    def test_unknown_tool(self):
+        assert provider_has_native_tool("music_gen", {"model": {"provider": "minimax"}}) is False
+
+
+class TestApiRoot:
+    def test_strips_anthropic_suffix(self):
+        cfg = {"model": {"base_url": "https://api.minimax.io/anthropic"}}
+        assert active_provider_api_root(cfg) == "https://api.minimax.io"
+
+    def test_strips_anthropic_suffix_with_trailing_slash(self):
+        cfg = {"model": {"base_url": "https://api.minimax.io/anthropic/"}}
+        assert active_provider_api_root(cfg) == "https://api.minimax.io"
+
+    def test_cn_endpoint(self):
+        cfg = {"model": {"base_url": "https://api.minimaxi.com/anthropic"}}
+        assert active_provider_api_root(cfg) == "https://api.minimaxi.com"
+
+    def test_no_anthropic_suffix(self):
+        cfg = {"model": {"base_url": "https://api.openai.com/v1"}}
+        assert active_provider_api_root(cfg) == "https://api.openai.com/v1"
+
+    def test_unset(self):
+        assert active_provider_api_root({}) == ""
+        assert active_provider_api_root({"model": {}}) == ""
+
+
+class TestApplyDefaults:
+    def test_noop_when_provider_not_native(self):
+        config = {"model": {"provider": "anthropic"}}
+        assert apply_provider_native_tool_defaults(config) == set()
+        assert "tts" not in config
+
+    def test_noop_when_no_provider(self):
+        assert apply_provider_native_tool_defaults({}) == set()
+
+    def test_minimax_writes_tts_image_reports_vision(self):
+        config = {"model": {"provider": "minimax"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert changed == {"tts", "image_gen", "vision"}
+        assert config["tts"]["provider"] == "minimax"
+        assert config["image_gen"]["provider"] == "minimax"
+        # Vision is reported but no value persists — runtime dispatch handles it.
+        assert config.get("auxiliary", {}).get("vision") in (None, {})
+
+    def test_explicit_tts_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "tts": {"provider": "elevenlabs"},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" not in changed
+        assert config["tts"]["provider"] == "elevenlabs"
+        assert "image_gen" in changed
+
+    def test_edge_default_overridden(self):
+        config = {"model": {"provider": "minimax"}, "tts": {"provider": "edge"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["tts"]["provider"] == "minimax"
+
+    def test_explicit_fal_overridden(self):
+        config = {"model": {"provider": "minimax"}, "image_gen": {"provider": "fal"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" in changed
+        assert config["image_gen"]["provider"] == "minimax"
+
+    def test_explicit_third_party_image_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "image_gen": {"provider": "stability"},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" not in changed
+        assert config["image_gen"]["provider"] == "stability"
+
+    def test_explicit_vision_provider_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "auxiliary": {"vision": {"provider": "openrouter"}},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["auxiliary"]["vision"]["provider"] == "openrouter"
+
+    def test_idempotent(self):
+        config = {"model": {"provider": "minimax"}}
+        first = apply_provider_native_tool_defaults(config)
+        assert first == {"tts", "image_gen", "vision"}
+        second = apply_provider_native_tool_defaults(config)
+        assert second == set()
+
+    def test_cn_provider_same_behaviour(self):
+        config = {"model": {"provider": "minimax-cn"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert changed == {"tts", "image_gen", "vision"}
+        assert config["tts"]["provider"] == "minimax-cn"
+
+    def test_alias_provider_resolved(self):
+        config = {"model": {"provider": "minimax-china"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["tts"]["provider"] == "minimax-cn"
+
+    def test_other_auxiliary_keys_preserved(self):
+        config = {
+            "model": {"provider": "minimax"},
+            "auxiliary": {"compression": {"provider": "openai"}},
+        }
+        apply_provider_native_tool_defaults(config)
+        assert config["auxiliary"]["compression"]["provider"] == "openai"
+
+
+class TestDescribeChanges:
+    def test_empty_set(self):
+        out = describe_changes(set(), {"model": {"provider": "minimax"}})
+        assert "No changes" in out
+
+    def test_minimax_three_tools(self):
+        out = describe_changes(
+            {"tts", "image_gen", "vision"},
+            {"model": {"provider": "minimax"}},
+        )
+        # Provider name omitted from values (wizard's success line names it).
+        assert "TTS" in out and "image-01" in out and "MiniMax-VL-01" in out
+        assert out.count("•") == 3
+
+    def test_minimax_cn_shares_minimax_phrasing(self):
+        out_int = describe_changes({"tts"}, {"model": {"provider": "minimax"}})
+        out_cn = describe_changes({"tts"}, {"model": {"provider": "minimax-cn"}})
+        assert out_int == out_cn
+
+    def test_unknown_provider_falls_back_to_generic(self):
+        out = describe_changes({"tts"}, {"model": {"provider": "imaginary"}})
+        assert "tts" in out
+
+
+class TestNativeCredentialPresent:
+    def test_false_when_provider_not_native(self):
+        assert native_credential_present(
+            "image_gen", {"model": {"provider": "anthropic"}},
+        ) is False
+
+    def test_false_when_tool_not_served_by_provider(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert native_credential_present(
+            "search", {"model": {"provider": "minimax"}},
+        ) is False  # minimax declares tts/image_gen/vision — not "search"
+
+    def test_true_when_provider_native_and_key_set(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert native_credential_present(
+            "image_gen", {"model": {"provider": "minimax"}},
+        ) is True
+
+    def test_false_when_provider_native_but_no_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        assert native_credential_present(
+            "image_gen", {"model": {"provider": "minimax"}},
+        ) is False
+
+
+class TestMinimaxEndpointAndKey:
+    def test_non_minimax_returns_empty_tuple(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert minimax_endpoint_and_key(
+            "/v1/t2a_v2", {"model": {"provider": "anthropic"}},
+        ) == ("", "")
+
+    def test_derives_url_and_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
+        url, key = minimax_endpoint_and_key("/v1/t2a_v2", {
+            "model": {"provider": "minimax", "base_url": "https://api.minimax.io/anthropic"},
+        })
+        assert url == "https://api.minimax.io/v1/t2a_v2"
+        assert key == "sk-intl"
+
+    def test_cn_picks_cn_host_and_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
+        url, key = minimax_endpoint_and_key("/v1/t2a_v2", {
+            "model": {"provider": "minimax-cn", "base_url": "https://api.minimaxi.com/anthropic"},
+        })
+        assert url == "https://api.minimaxi.com/v1/t2a_v2"
+        assert key == "sk-cn"
+
+    def test_empty_when_base_url_missing(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        assert minimax_endpoint_and_key(
+            "/v1/t2a_v2", {"model": {"provider": "minimax"}},
+        ) == ("", "")
+
+    def test_empty_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        assert minimax_endpoint_and_key("/v1/t2a_v2", {
+            "model": {"provider": "minimax", "base_url": "https://api.minimax.io/anthropic"},
+        }) == ("", "")

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -381,6 +381,22 @@ def image_generate_tool(
                  "image": str or None  # URL of the upscaled image, or None if failed
              }
     """
+    # Provider-native dispatch: when the active chat provider serves image
+    # generation natively (via its registry entry in
+    # `hermes_cli.provider_native_tools`), route there first.  Returns
+    # `None` when no native backend applies, in which case the FAL flow
+    # below runs unchanged.
+    try:
+        from hermes_cli.provider_native_tools import generate_image as _native_generate_image
+        _native_result = _native_generate_image(
+            prompt=prompt, aspect_ratio=aspect_ratio,
+            num_images=num_images, output_format=output_format,
+        )
+        if _native_result is not None:
+            return _native_result
+    except Exception as _exc:
+        logger.debug("provider-native image dispatch skipped: %s", _exc)
+
     # Validate and map aspect_ratio to actual image_size
     aspect_ratio_lower = aspect_ratio.lower().strip() if aspect_ratio else DEFAULT_ASPECT_RATIO
     if aspect_ratio_lower not in ASPECT_RATIO_MAP:
@@ -550,6 +566,14 @@ def check_image_generation_requirements() -> bool:
     Returns:
         bool: True if requirements are met, False otherwise
     """
+    # Active chat provider's native image backend counts as "requirements
+    # met" without needing FAL_KEY.  See `hermes_cli.provider_native_tools`.
+    try:
+        from hermes_cli.provider_native_tools import native_credential_present
+        if native_credential_present("image_gen"):
+            return True
+    except Exception:
+        pass
     try:
         # Check API key
         if not check_fal_api_key():

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Music generation tool — thin dispatcher over provider-native backends.
+
+Hermes doesn't bundle a music backend of its own.  Music is only
+available when the active chat provider registers a native music
+backend through `hermes_cli.provider_native_tools`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def music_generate_tool(
+    prompt: str,
+    lyrics: str,
+    output_format: str = "mp3",
+    sample_rate: int = 44100,
+    bitrate: int = 256000,
+) -> str:
+    try:
+        from hermes_cli.provider_native_tools import generate_music
+    except Exception as exc:
+        logger.debug("provider-native music dispatch unavailable: %s", exc)
+        return json.dumps({
+            "success": False,
+            "error": "no music backend available",
+        })
+    result = generate_music(
+        prompt=prompt,
+        lyrics=lyrics,
+        output_format=output_format,
+        sample_rate=sample_rate,
+        bitrate=bitrate,
+    )
+    if result is not None:
+        return result
+    return json.dumps({
+        "success": False,
+        "error": "active chat provider does not serve music_gen natively; "
+                 "no other music backend is configured",
+    })
+
+
+def check_music_generation_requirements() -> bool:
+    try:
+        from hermes_cli.provider_native_tools import native_credential_present
+        return native_credential_present("music_gen")
+    except Exception:
+        return False
+
+
+MUSIC_GENERATE_SCHEMA: Dict[str, Any] = {
+    "name": "music_generate",
+    "description": (
+        "Generate a complete sung song (with vocals) as an actual .mp3 "
+        "audio file.  Takes a style prompt + lyrics and returns a local "
+        "file path — NOT a prompt to paste into Suno or another service.  "
+        "Use this whenever the user asks for a song, a track, or music "
+        "with lyrics.  Up to ~1 minute per call.  "
+        "Lyrics support structure tags: [Intro] [Verse] [Chorus] [Bridge] "
+        "[Outro].  Use \\n to separate lines.  "
+        "Returns JSON: `{path, format, bytes, model}`."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Style / mood description, 10–300 chars.  "
+                    "Example: 'Upbeat pop, cheerful, suitable for a "
+                    "travel montage'."
+                ),
+            },
+            "lyrics": {
+                "type": "string",
+                "description": (
+                    "Song lyrics, 10–600 chars.  Use newline to separate "
+                    "lines.  Optional structure tags: [Intro] [Verse] "
+                    "[Chorus] [Bridge] [Outro]."
+                ),
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["mp3", "wav", "pcm"],
+                "description": "Output audio container.",
+                "default": "mp3",
+            },
+        },
+        "required": ["prompt", "lyrics"],
+    },
+}
+
+
+def _handle_music_generate(args, **_kw):
+    prompt = args.get("prompt", "")
+    lyrics = args.get("lyrics", "")
+    if not prompt:
+        return tool_error("prompt is required for music generation")
+    if not lyrics:
+        return tool_error("lyrics is required for music generation")
+    return music_generate_tool(
+        prompt=prompt,
+        lyrics=lyrics,
+        output_format=args.get("output_format", "mp3"),
+    )
+
+
+registry.register(
+    name="music_generate",
+    toolset="music_gen",
+    schema=MUSIC_GENERATE_SCHEMA,
+    handler=_handle_music_generate,
+    check_fn=check_music_generation_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🎵",
+)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -317,7 +317,19 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     """
     import requests
 
+    # Derive URL + key from the active chat provider so CN users
+    # (minimax-cn → api.minimaxi.com) hit the correct host with the
+    # correct key.  Falls back to the international defaults when the
+    # active provider isn't MiniMax.
+    derived_base = ""
     api_key = os.getenv("MINIMAX_API_KEY", "")
+    try:
+        from hermes_cli.provider_native_tools import minimax_endpoint_and_key
+        url, key = minimax_endpoint_and_key("/v1/t2a_v2")
+        derived_base = url or derived_base
+        api_key = key or api_key
+    except Exception:
+        pass
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 
@@ -327,7 +339,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     speed = mm_config.get("speed", tts_config.get("speed", 1))
     vol = mm_config.get("vol", 1)
     pitch = mm_config.get("pitch", 0)
-    base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)
+    base_url = mm_config.get("base_url") or derived_base or DEFAULT_MINIMAX_BASE_URL
 
     # Determine audio format from output extension
     if output_path.endswith(".wav"):

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Video generation tool — thin dispatcher over provider-native backends.
+
+Hermes doesn't bundle a video backend of its own.  Video is only
+available when the active chat provider registers a native video
+backend through `hermes_cli.provider_native_tools`.  When no such
+backend is configured, the tool is simply not available
+(`check_video_generation_requirements` returns `False`).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+
+def video_generate_tool(
+    prompt: str,
+    duration: Optional[int] = None,
+    resolution: Optional[str] = None,
+    first_frame_image: Optional[str] = None,
+) -> str:
+    try:
+        from hermes_cli.provider_native_tools import generate_video
+    except Exception as exc:
+        logger.debug("provider-native video dispatch unavailable: %s", exc)
+        return json.dumps({
+            "success": False,
+            "error": "no video backend available",
+        })
+    result = generate_video(
+        prompt=prompt,
+        duration=duration,
+        resolution=resolution,
+        first_frame_image=first_frame_image,
+    )
+    if result is not None:
+        return result
+    return json.dumps({
+        "success": False,
+        "error": "active chat provider does not serve video_gen natively; "
+                 "no other video backend is configured",
+    })
+
+
+def check_video_generation_requirements() -> bool:
+    """Tool is available iff the active provider has a native video backend
+    with a configured credential."""
+    try:
+        from hermes_cli.provider_native_tools import native_credential_present
+        return native_credential_present("video_gen")
+    except Exception:
+        return False
+
+
+VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
+    "name": "video_generate",
+    "description": (
+        "Generate a short video clip (6 or 10 seconds) as an actual .mp4 "
+        "file from a text prompt.  Returns a local file path — NOT a "
+        "suggestion to use Runway/Pika/Sora/etc.  Use this whenever the "
+        "user asks for a video or a short clip.  Generation is slow "
+        "(typically 1–5 minutes); proceed without asking for confirmation "
+        "unless the prompt is ambiguous.  "
+        "Returns JSON: `{path, url, model, task_id}`."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Detailed description of the scene to render.",
+            },
+            "duration": {
+                "type": "integer",
+                "enum": [6, 10],
+                "description": "Video length in seconds.",
+                "default": 6,
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["768P", "1080P"],
+                "description": "Output resolution.",
+                "default": "768P",
+            },
+            "first_frame_image": {
+                "type": "string",
+                "description": "Optional first-frame image (local path, "
+                               "http(s) URL, or data: URI).  When set, an "
+                               "image-to-video model is used.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _handle_video_generate(args, **_kw):
+    prompt = args.get("prompt", "")
+    if not prompt:
+        return tool_error("prompt is required for video generation")
+    return video_generate_tool(
+        prompt=prompt,
+        duration=args.get("duration"),
+        resolution=args.get("resolution"),
+        first_frame_image=args.get("first_frame_image"),
+    )
+
+
+registry.register(
+    name="video_generate",
+    toolset="video_gen",
+    schema=VIDEO_GENERATE_SCHEMA,
+    handler=_handle_video_generate,
+    check_fn=check_video_generation_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🎬",
+)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -466,6 +466,34 @@ async def vision_analyze_tool(
         logger.info("Analyzing image: %s", image_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
         
+        # Provider-native dispatch: when the active chat provider serves
+        # vision natively (via its registry entry in
+        # `hermes_cli.provider_native_tools`) and the user hasn't pinned
+        # `auxiliary.vision.provider` to a different backend, route there
+        # first.  Returns `None` when no native backend applies, in which
+        # case the auxiliary-client flow below runs unchanged.
+        try:
+            from hermes_cli.provider_native_tools import (
+                analyze_image as _native_analyze_image,
+                provider_has_native_tool as _native_has,
+            )
+            from hermes_cli.config import load_config as _load_config_for_vision
+            _vision_cfg = _load_config_for_vision()
+            _aux_vision = _vision_cfg.get("auxiliary", {}).get("vision", {}) \
+                if isinstance(_vision_cfg.get("auxiliary"), dict) else {}
+            _explicit_vision = str(_aux_vision.get("provider") or "").strip().lower()
+            if (
+                _native_has("vision", _vision_cfg)
+                and _explicit_vision in ("", "auto", "main")
+            ):
+                _native_result = _native_analyze_image(
+                    image_url, user_prompt, config=_vision_cfg,
+                )
+                if _native_result is not None:
+                    return _native_result
+        except Exception as _exc:
+            logger.debug("provider-native vision dispatch skipped: %s", _exc)
+
         # Determine if this is a local file path or a remote URL
         # Strip file:// scheme so file URIs resolve as local paths.
         resolved_url = image_url

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,8 +35,8 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
-    "vision_analyze", "image_generate",
+    # Vision + image / video / music generation
+    "vision_analyze", "image_generate", "video_generate", "music_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -90,7 +90,19 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-    
+
+    "video_gen": {
+        "description": "Creative generation tools (short video clips)",
+        "tools": ["video_generate"],
+        "includes": []
+    },
+
+    "music_gen": {
+        "description": "Creative generation tools (songs with lyrics + style)",
+        "tools": ["music_generate"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
@@ -251,8 +263,8 @@ TOOLSETS = {
             "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
-            # Vision + image generation
-            "vision_analyze", "image_generate",
+            # Vision + image / video / music generation
+            "vision_analyze", "image_generate", "video_generate", "music_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation


### PR DESCRIPTION
## Summary

Adds two new tool categories — `video_generate` and `music_generate` — that didn't exist in Hermes before.  Both are thin dispatchers over the provider-native framework from #9954; MiniMax is the first registered backend.  Adding another provider is one row in `NATIVE_TOOLS_BY_PROVIDER` plus parallel request helpers.

Stacked on #9954.  Please review that one first.

## Files Changed

| File | Changes |
|------|---------|
| `hermes_cli/provider_native_tools.py` | **+285 / −1** — `video_gen` / `music_gen` registry entries, `generate_video` / `generate_music` runtime dispatchers, MiniMax request bindings (video: submit → poll `/v1/query/video_generation` → `/v1/files/retrieve` → download; music: sync, decodes hex audio), `_get_json` helper |
| `tools/video_generation_tool.py` | **new (+124)** — registers `video_generate` in toolset `video_gen`.  Zero MiniMax mentions |
| `tools/music_generation_tool.py` | **new (+125)** — registers `music_generate` in toolset `music_gen`.  Zero MiniMax mentions |
| `toolsets.py` | **+18 / −4** — two new toolset definitions plus their names added to the shared core list |
| `hermes_cli/tools_config.py` | **+2** — two new entries in `CONFIGURABLE_TOOLSETS` so `_get_platform_tools` includes them in the agent's tool schema |
| `model_tools.py` | **+2** — discovery list |
| `tests/hermes_cli/test_provider_native_tools.py` | **+55 / −22** — expand existing cases for the 5-capability set, add `TestRuntimeDispatchers`, override-preservation tests |

## Design Notes

- **Video** is long-running (1–5 min).  The MiniMax binding polls every 15s for up to 10 min, then errors with a clear timeout message.  Sync interface — the agent simply blocks.
- **Music** is synchronous.  Model selection mirrors the mmx CLI's key-prefix rule: `sk-cp-` (Token Plan) → `music-2.6`; other keys → `music-2.6-free`.
- **URL derivation + credential selection** inherit from #9954 (strip `/anthropic` suffix; region-appropriate key).

## What's NOT Included

- No FAL / auxiliary fallback: Hermes doesn't bundle either category today.  The tools are simply unavailable when no native backend is configured.
- Other native providers (Runway for video, Suno for music, etc.) — framework supports them; bindings are a follow-up.

## Test Plan

```
python -m pytest tests/hermes_cli/test_provider_native_tools.py -q
# 55 passed
```

Live end-to-end with Token Plan key on `api.minimax.io`: `music_generate` → 1.4 MB mp3 in ~10s; `video_generate` → 2.4 MB mp4 in 3:20 (MiniMax-Hailuo-2.3).

Zero new pip dependencies (stdlib only).