### PR TITLE
fix(tools): overwrite MCP OAuth token files safely on Windows

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -67,6 +67,35 @@ class TestHermesTokenStorage:
         client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
         assert client_path.exists()
 
+    def test_set_tokens_overwrites_existing_file_without_path_rename(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-server")
+        import asyncio
+
+        first_token = MagicMock()
+        first_token.model_dump.return_value = {
+            "access_token": "first-token",
+            "token_type": "Bearer",
+        }
+        asyncio.run(storage.set_tokens(first_token))
+
+        second_token = MagicMock()
+        second_token.model_dump.return_value = {
+            "access_token": "second-token",
+            "token_type": "Bearer",
+        }
+
+        def _fail_if_rename_called(self, target):
+            raise AssertionError("Path.rename should not be used for OAuth token writes")
+
+        monkeypatch.setattr(Path, "rename", _fail_if_rename_called)
+
+        asyncio.run(storage.set_tokens(second_token))
+
+        token_path = tmp_path / "mcp-tokens" / "test-server.json"
+        data = json.loads(token_path.read_text())
+        assert data["access_token"] == "second-token"
+
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("test-server")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -161,7 +161,7 @@ def _write_json(path: Path, data: dict) -> None:
     try:
         tmp.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
         os.chmod(tmp, 0o600)
-        tmp.rename(path)
+        os.replace(tmp, path)
     except OSError:
         tmp.unlink(missing_ok=True)
         raise


### PR DESCRIPTION
This change fixes an overwrite bug in MCP OAuth file persistence.

The current write path in tools/mcp_oauth.py finalizes atomic JSON writes with Path.rename(). That is fine on POSIX, but it is not overwrite-safe on Windows when the destination file already exists.

In practice, that means the first successful OAuth write can succeed, while later writes to the same token or client-info file can fail during refresh or update flows.

## What changed:
- replaced the final Path.rename() step with os.replace()
- kept the existing temp-file atomic write pattern unchanged
- added a regression test covering repeated writes to the same target file

## Why this is the right fix:
- it keeps the current storage flow intact
- it only changes the final file replacement primitive
- os.replace() is the portable overwrite-safe operation intended for this exact case

## Regression coverage added:
- tests/tools/test_mcp_oauth.py::TestHermesTokenStorage::test_set_tokens_overwrites_existing_file_without_path_rename

## Validation:
- pytest tests/tools/test_mcp_oauth.py -q -k set_tokens_overwrites_existing_file_without_path_rename -> passed
- pytest tests/tools/test_mcp_oauth.py -q -k HermesTokenStorage -> 7 passed


## Files changed:
- tools/mcp_oauth.py
- tests/tools/test_mcp_oauth.py