### PR TITLE
fix(gateway): prevent Telegram startup race on concurrent gateway instances

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -270,7 +270,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # giving up, so the old session has time to expire.
         self._polling_conflict_count += 1
 
-        MAX_CONFLICT_RETRIES = 3
+        MAX_CONFLICT_RETRIES = 5
         RETRY_DELAY = 10  # seconds
 
         if self._polling_conflict_count <= MAX_CONFLICT_RETRIES:
@@ -501,7 +501,35 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         
         try:
-            if not self._acquire_platform_lock('telegram-bot-token', self.config.token, 'Telegram bot token'):
+            # Retry lock acquisition to handle startup races where multiple
+            # gateway instances (launchd + agent-spawned nohup) compete for
+            # the same Telegram bot token.  The competing gateway will either
+            # complete startup and claim the token (we lose gracefully) or
+            # exit after its own startup conflict (we acquire the lock on retry).
+            _LOCK_MAX_RETRIES = 5
+            _LOCK_RETRY_DELAY = 5.0
+            _lock_acquired = False
+            for _lock_attempt in range(_LOCK_MAX_RETRIES):
+                # Clear any fatal error from a previous lock attempt so the
+                # adapter isn't permanently marked as broken.
+                self._fatal_error_code = None
+                self._fatal_error_message = None
+                self._fatal_error_retryable = False
+                if self._acquire_platform_lock('telegram-bot-token', self.config.token, 'Telegram bot token'):
+                    _lock_acquired = True
+                    break
+                if _lock_attempt < _LOCK_MAX_RETRIES - 1:
+                    logger.warning(
+                        "[%s] Telegram bot token lock busy (attempt %d/%d), retrying in %.0fs…",
+                        self.name, _lock_attempt + 1, _LOCK_MAX_RETRIES, _LOCK_RETRY_DELAY,
+                    )
+                    await asyncio.sleep(_LOCK_RETRY_DELAY)
+            if not _lock_acquired:
+                # Make the lock failure retryable so the gateway stays alive
+                # for background reconnection instead of exiting immediately.
+                # During startup races (launchd + agent nohup), the competing
+                # gateway will eventually release the lock.
+                self._fatal_error_retryable = True
                 return False
 
             # Build the application

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9406,6 +9406,47 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     existing_pid = get_running_pid()
     if existing_pid is not None and existing_pid != os.getpid():
         if replace:
+            # ── Freshness guard ──────────────────────────────────────
+            # If the PID file was written very recently, the existing gateway
+            # is likely a brand-new instance started by launchd or another
+            # orchestrator.  Killing it creates a race: the orchestrator
+            # respawns another gateway, which competes with us for the
+            # Telegram bot token lock.  Instead of killing a fresh gateway,
+            # wait briefly for it to finish startup.  If it's still alive
+            # after the grace period, proceed with the replace as normal.
+            _FRESHNESS_THRESHOLD = 30  # seconds
+            _pid_path = get_hermes_home() / "gateway.pid"
+            try:
+                _pid_mtime = _pid_path.stat().st_mtime
+                _pid_age = _time.time() - _pid_mtime
+            except (OSError, AttributeError):
+                _pid_age = float("inf")  # can't determine age — don't skip replace
+
+            if 0 < _pid_age < _FRESHNESS_THRESHOLD:
+                logger.info(
+                    "Existing gateway (PID %d) started just %.0fs ago — "
+                    "deferring replace to avoid startup race. "
+                    "Waiting up to %.0fs for it to finish startup.",
+                    existing_pid, _pid_age, _FRESHNESS_THRESHOLD - _pid_age,
+                )
+                # Wait for the remaining freshness window to expire
+                _wait = _FRESHNESS_THRESHOLD - _pid_age
+                for _ in range(int(_wait) + 1):
+                    _time.sleep(1.0)
+                    # Recheck — the new gateway may have crashed/exited
+                    try:
+                        os.kill(existing_pid, 0)
+                    except (ProcessLookupError, PermissionError):
+                        logger.info("Existing gateway (PID %d) exited during wait.", existing_pid)
+                        remove_pid_file()
+                        break
+                else:
+                    # Still alive after the grace period — proceed with replace
+                    logger.info(
+                        "Existing gateway (PID %d) is still alive after grace period. Proceeding with replace.",
+                        existing_pid,
+                    )
+
             logger.info(
                 "Replacing existing gateway instance (PID %d) with --replace.",
                 existing_pid,


### PR DESCRIPTION
## Problem

When `hermes gateway restart` (or `gateway run --replace`) is triggered, launchd's `KeepAlive: SuccessfulExit=false` **also** restarts the gateway. This creates 2-3 concurrent gateway instances that race for the Telegram bot token lock. The loser gets `"Telegram bot token already in use"` as a **non-retryable** fatal error, permanently losing Telegram connectivity until manual restart.

**Typical sequence:**
1. Agent triggers `nohup ... gateway run --replace &` (via terminal tool or restart command)
2. Old gateway exits → launchd immediately respawns another gateway
3. Now **two** new gateway instances start simultaneously
4. Both call `_acquire_platform_lock('telegram-bot-token', ...)`
5. First one wins; second gets non-retryable "bot token already in use" → gateway exits
6. Launchd restarts again → same race → loop until one instance survives alone

## Changes

### 1. Telegram lock retry loop (`gateway/platforms/telegram.py`)
Wrap `_acquire_platform_lock()` in a retry loop (5 retries, 5s delay = 25s total). Between retries, clear any fatal error from the previous attempt so the adapter isn't permanently marked as broken.

### 2. retryable=True on final lock failure (`gateway/platforms/telegram.py`)
Even after all 5 retries fail, mark the error as `retryable=True` so the 30-second `_reconnect_failed_platforms` loop can retry Telegram connection in the background. Previously `retryable=False` caused immediate gateway exit.

### 3. PID freshness guard (`gateway/run.py`)
In the `--replace` path: if the existing gateway's PID file was written within the last 30 seconds, defer the replace and wait for the new instance to either stabilize or exit. This prevents killing a brand-new gateway that launchd just started, which would trigger another restart race.

### 4. Increase MAX_CONFLICT_RETRIES 3→5 (`gateway/platforms/telegram.py`)
More tolerance for transient 409 polling conflicts during `--replace` handoffs.

## Testing

- Applied locally on a production gateway that was hitting this race every restart
- Gateway has been running stably with zero errors after the fix
- The freshness guard correctly defers when PID file is recent
- Lock retry loop succeeds on 2nd-3rd attempt when a competing instance exits during the retry window

## Files Changed

- `gateway/platforms/telegram.py` — Lock retry loop + retryable=True + MAX_CONFLICT_RETRIES=5
- `gateway/run.py` — PID freshness guard in `--replace` path
