### PR TITLE
fix(model): prefer direct providers over OpenRouter fallback

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1599,18 +1599,176 @@ def detect_provider_for_model(
 
     Priority:
     0. Bare provider name → switch to that provider's default model
-    1. Direct provider static catalog match
-    2. OpenRouter catalog match
+    1. Direct provider with credentials (highest)
+    2. Direct provider without credentials → remap to OpenRouter slug
+    3. OpenRouter catalog match
     """
     name = (model_name or "").strip()
     if not name:
         return None
 
-    static_match = detect_static_provider_for_model(name, current_provider)
-    if static_match:
-        return static_match
-    if _model_in_provider_catalog(name.lower(), _provider_keys(current_provider)):
+    current_provider = normalize_provider(current_provider)
+    current_keys = _provider_keys(current_provider)
+    name_lower = name.lower()
+
+    alias_match = _resolve_static_model_alias(name_lower, current_keys)
+    if alias_match:
+        return alias_match
+
+    # Preserve the static bare-provider shortcut before doing credential-aware
+    # model lookup.
+    resolved_provider = _PROVIDER_ALIASES.get(name_lower, name_lower)
+    if resolved_provider not in {"custom", "openrouter"}:
+        default_models = _PROVIDER_MODELS.get(resolved_provider, [])
+        if (
+            resolved_provider in _PROVIDER_LABELS
+            and default_models
+            and resolved_provider not in current_keys
+        ):
+            return (resolved_provider, default_models[0])
+
+    prefix_provider = ""
+    stripped_name = name
+    stripped_lower = name_lower
+    if "/" in name:
+        raw_prefix, remainder = name.split("/", 1)
+        prefix_provider = normalize_provider(raw_prefix.strip())
+        if remainder.strip():
+            stripped_name = remainder.strip()
+            stripped_lower = stripped_name.lower()
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY, has_usable_secret, _load_auth_store
+    except Exception:
+        PROVIDER_REGISTRY = {}
+        _load_auth_store = None
+
+        def has_usable_secret(value: object, *, min_length: int = 4) -> bool:
+            return isinstance(value, str) and len(value.strip()) >= min_length
+
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+    except Exception:
+        get_compatible_custom_providers = None
+        load_config = None
+
+    try:
+        from agent.credential_pool import load_pool
+    except Exception:
+        load_pool = None
+
+    matching_prefix_strip_providers = {
+        "zai", "kimi-coding", "minimax", "minimax-cn",
+        "alibaba", "qwen-oauth", "xiaomi", "custom",
+    }
+    custom_provider_keys: Optional[set[str]] = None
+
+    def _model_matches_catalog(models: list[str], provider_id: str) -> Optional[str]:
+        if any(name_lower == model.lower() for model in models):
+            return name
+        if (
+            prefix_provider
+            and provider_id in matching_prefix_strip_providers
+            and any(stripped_lower == model.lower() for model in models)
+        ):
+            return stripped_name
         return None
+
+    def _provider_has_routable_credentials(provider_id: str) -> bool:
+        pconfig = PROVIDER_REGISTRY.get(provider_id)
+        if pconfig:
+            for env_var in pconfig.api_key_env_vars:
+                if has_usable_secret(os.getenv(env_var, "").strip()):
+                    return True
+
+        if load_pool is not None:
+            try:
+                pool = load_pool(provider_id)
+                if pool.has_credentials():
+                    return True
+            except Exception:
+                pass
+
+        if _load_auth_store is not None:
+            try:
+                store = _load_auth_store()
+                if (
+                    provider_id in store.get("providers", {})
+                    or provider_id in store.get("credential_pool", {})
+                ):
+                    return True
+            except Exception:
+                pass
+
+        nonlocal custom_provider_keys
+        if custom_provider_keys is None:
+            custom_provider_keys = set()
+            if get_compatible_custom_providers and load_config:
+                try:
+                    for entry in get_compatible_custom_providers(load_config()):
+                        if not isinstance(entry, dict):
+                            continue
+                        key_candidates = [
+                            normalize_provider(str(entry.get("provider_key", "") or "").strip()),
+                            normalize_provider(str(entry.get("name", "") or "").strip()),
+                        ]
+                        api_key = str(entry.get("api_key", "") or "").strip()
+                        key_env = str(entry.get("key_env", "") or "").strip()
+                        has_secret = has_usable_secret(api_key)
+                        if not has_secret and key_env:
+                            has_secret = has_usable_secret(os.getenv(key_env, "").strip())
+                        if has_secret:
+                            custom_provider_keys.update(
+                                candidate
+                                for candidate in key_candidates
+                                if candidate and candidate != "custom"
+                            )
+                except Exception:
+                    custom_provider_keys = set()
+        return provider_id in custom_provider_keys
+
+    # If the model belongs to the current provider's catalog, don't suggest switching
+    if any(
+        _model_matches_catalog(_PROVIDER_MODELS.get(provider, []), provider)
+        for provider in current_keys
+    ):
+        return None
+
+    # --- Step 1: check static provider catalogs for a direct match ---
+    direct_matches: list[tuple[str, str]] = []
+    seen_providers: set[str] = set()
+    for pid, models in _PROVIDER_MODELS.items():
+        canonical_provider = normalize_provider(pid)
+        if canonical_provider in current_keys or canonical_provider in seen_providers:
+            continue
+        if canonical_provider in _AGGREGATOR_PROVIDERS:
+            continue
+        matched_name = _model_matches_catalog(models, canonical_provider)
+        if matched_name:
+            direct_matches.append((canonical_provider, matched_name))
+            seen_providers.add(canonical_provider)
+
+    if direct_matches:
+        credentialed_matches = [
+            (provider_id, matched_name)
+            for provider_id, matched_name in direct_matches
+            if _provider_has_routable_credentials(provider_id)
+        ]
+
+        if credentialed_matches:
+            if prefix_provider:
+                for provider_id, matched_name in credentialed_matches:
+                    if provider_id == prefix_provider:
+                        return (provider_id, matched_name)
+            return credentialed_matches[0]
+
+        # No direct creds — try to find this model on OpenRouter instead
+        or_slug = _find_openrouter_slug(name)
+        if or_slug:
+            return ("openrouter", or_slug)
+        # Still return the direct provider — credential resolution will
+        # give a clear error rather than silently using the wrong provider
+        return direct_matches[0]
 
     # --- Step 2: check OpenRouter catalog ---
     # First try exact match (handles provider/model format)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -302,6 +302,52 @@ class TestDetectProviderForModel:
         assert result is not None
         assert result[0] not in ("nous",)  # nous has claude models but shouldn't be suggested
 
+    def test_prefers_credentialed_sibling_direct_provider_over_openrouter(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "cn-key")
+        live_models = LIVE_OPENROUTER_MODELS + [("minimax/minimax-m2.7", "")]
+
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=live_models):
+            result = detect_provider_for_model("minimax-m2.7", "openai-codex")
+
+        assert result is not None
+        assert result[0] == "minimax-cn"
+        assert result[1].lower() == "minimax-m2.7"
+
+    def test_vendor_prefixed_direct_model_strips_prefix_for_matching_provider(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "cn-key")
+        live_models = LIVE_OPENROUTER_MODELS + [("minimax/minimax-m2.7", "")]
+
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=live_models):
+            result = detect_provider_for_model("minimax/minimax-m2.7", "openai-codex")
+
+        assert result is not None
+        assert result[0] == "minimax-cn"
+        assert result[1].lower() == "minimax-m2.7"
+
+    def test_prefixed_custom_provider_secret_beats_openrouter_fallback(self, monkeypatch):
+        for env_var in ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"):
+            monkeypatch.delenv(env_var, raising=False)
+
+        live_models = LIVE_OPENROUTER_MODELS + [("z-ai/glm-5-turbo", "")]
+        config = {
+            "providers": {
+                "zai": {
+                    "name": "Z.AI",
+                    "base_url": "https://api.z.ai/api/paas/v4",
+                    "api_key": "zai-config-key",
+                }
+            }
+        }
+
+        with patch("hermes_cli.models.fetch_openrouter_models", return_value=live_models), \
+             patch("hermes_cli.config.load_config", return_value=config):
+            result = detect_provider_for_model("z-ai/glm-5-turbo", "openai-codex")
+
+        assert result is not None
+        assert result == ("zai", "glm-5-turbo")
+
 
 class TestIsNousFreeTier:
     """Tests for is_nous_free_tier — account tier detection."""


### PR DESCRIPTION
Fixes #10300

## Summary
- prefer the credentialed direct provider when multiple native providers expose the same model family (for example `minimax` vs `minimax-cn`)
- recognize vendor-prefixed native model names like `minimax/minimax-m2.7` and `z-ai/glm-5-turbo` instead of falling through to OpenRouter
- honor saved `providers` / `custom_providers` API keys when deciding whether a prefixed direct model can stay on its native provider

## Root Cause
Latest `main` still has two gaps in `/model` provider detection for direct providers. First, it stops at the first direct-provider catalog hit, so `minimax-m2.7` can resolve to `minimax` even when only `minimax-cn` is configured. Second, `vendor/model` inputs like `minimax/minimax-m2.7` and `z-ai/glm-5-turbo` do not match native provider catalogs, so they fall through to OpenRouter instead of staying on the direct provider. When that direct provider is configured only through saved `providers` / `custom_providers` secrets, current detection also misses that credential signal.

## Validation
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_models.py -q`
