### PR TITLE
docs: update openai-codex setup reference

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -16,7 +16,7 @@ model:
   #   "nous"         - Nous Portal OAuth (requires: hermes login)
   #   "nous-api"     - Nous Portal API key (requires: NOUS_API_KEY)
   #   "anthropic"    - Direct Anthropic API (requires: ANTHROPIC_API_KEY)
-  #   "openai-codex" - OpenAI Codex (requires: hermes login --provider openai-codex)
+  #   "openai-codex" - OpenAI Codex (requires: hermes auth)
   #   "copilot"      - GitHub Copilot / GitHub Models (requires: GITHUB_TOKEN)
   #   "gemini"      - Use Google AI Studio direct (requires: GOOGLE_API_KEY or GEMINI_API_KEY)
   #   "zai"         - Use z.ai / ZhipuAI GLM models (requires: GLM_API_KEY)


### PR DESCRIPTION
## Summary
- Replace the stale `hermes login --provider openai-codex` reference in `cli-config.yaml.example` with the current `hermes auth → Codex` flow.

## Verification
- `git diff --check`
