### PR TITLE
feat(agent): add microcompaction and rehydration to context compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -59,6 +59,14 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 _CHARS_PER_TOKEN = 4
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
+# Microcompaction: large tool outputs above this char threshold are saved
+# to disk and replaced with a summary + disk reference.  This prevents
+# single large outputs (test suites, big file reads, etc.) from dominating
+# the context window.  Applied BEFORE compression, including in the tail.
+_MICROCOMPACTION_THRESHOLD = 15_000  # chars (~3750 tokens)
+_MICROCOMPACTION_KEEP_HEAD = 1500    # chars kept inline from the start
+_MICROCOMPACTION_KEEP_TAIL = 500     # chars kept inline from the end
+
 
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
@@ -325,6 +333,88 @@ class ContextCompressor(ContextEngine):
                 )
             return False
         return True
+
+    # ------------------------------------------------------------------
+    # Microcompaction: save oversized tool outputs to disk
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _microcompact_large_outputs(
+        messages: List[Dict[str, Any]],
+    ) -> tuple[List[Dict[str, Any]], int]:
+        """Replace oversized tool results with a truncated version + disk reference.
+
+        Unlike the pruning pass (which only targets old/non-tail messages),
+        microcompaction applies to ALL tool results — including the
+        protected tail — because a single 200-line test output or 3000-line
+        file read can burn through context budget at any position.
+
+        The full output is saved to ``~/.hermes/compaction_cache/`` so the
+        model can reference it if needed.  Inline, we keep the first/last
+        few lines plus a 1-line summary.
+
+        Returns (messages_copy, compacted_count).
+        """
+        import os
+        from pathlib import Path
+        try:
+            from hermes_constants import get_hermes_home
+            cache_dir = get_hermes_home() / "compaction_cache"
+        except ImportError:
+            cache_dir = Path.home() / ".hermes" / "compaction_cache"
+
+        result = [m.copy() for m in messages]
+        compacted = 0
+
+        # Build tool_call_id -> (tool_name, arguments) index for summaries
+        call_index: Dict[str, tuple] = {}
+        for msg in result:
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    if isinstance(tc, dict):
+                        cid = tc.get("id", "")
+                        fn = tc.get("function", {})
+                        call_index[cid] = (fn.get("name", ""), fn.get("arguments", ""))
+
+        for i, msg in enumerate(result):
+            if msg.get("role") != "tool":
+                continue
+            content = msg.get("content") or ""
+            if not isinstance(content, str):
+                continue
+            if len(content) < _MICROCOMPACTION_THRESHOLD:
+                continue
+
+            # Save full output to disk
+            try:
+                cache_dir.mkdir(parents=True, exist_ok=True)
+                content_hash = hashlib.md5(content.encode("utf-8", errors="replace")).hexdigest()[:12]
+                cache_file = cache_dir / f"{content_hash}.txt"
+                if not cache_file.exists():
+                    cache_file.write_text(content, encoding="utf-8")
+                disk_path = str(cache_file)
+            except Exception:
+                disk_path = None
+
+            # Generate summary line
+            tool_id = msg.get("tool_call_id", "")
+            tool_name, tool_args = call_index.get(tool_id, ("unknown", ""))
+            summary_line = _summarize_tool_result(tool_name, tool_args, content)
+
+            # Build truncated replacement
+            head = content[:_MICROCOMPACTION_KEEP_HEAD]
+            tail = content[-_MICROCOMPACTION_KEEP_TAIL:]
+            omitted = len(content) - _MICROCOMPACTION_KEEP_HEAD - _MICROCOMPACTION_KEEP_TAIL
+            disk_note = f"\n[Full output saved to: {disk_path}]" if disk_path else ""
+            replacement = (
+                f"{head}\n\n"
+                f"... [{omitted:,} chars omitted — {summary_line}]{disk_note}\n\n"
+                f"{tail}"
+            )
+            result[i] = {**msg, "content": replacement}
+            compacted += 1
+
+        return result, compacted
 
     # ------------------------------------------------------------------
     # Tool output pruning (cheap pre-pass, no LLM call)
@@ -955,6 +1045,13 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             return messages
 
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
+
+        # Phase 0: Microcompaction — save oversized tool outputs to disk
+        # Applied before everything else, including tail protection, because
+        # a single huge output can dominate context at any position.
+        messages, mc_count = self._microcompact_large_outputs(messages)
+        if mc_count and not self.quiet_mode:
+            logger.info("Microcompaction: saved %d oversized tool output(s) to disk", mc_count)
 
         # Phase 1: Prune old tool results (cheap, no LLM call)
         messages, pruned_count = self._prune_old_tool_results(

--- a/run_agent.py
+++ b/run_agent.py
@@ -6818,6 +6818,62 @@ class AIAgent:
         if todo_snapshot:
             compressed.append({"role": "user", "content": todo_snapshot})
 
+        # ------------------------------------------------------------------
+        # Rehydration: auto-reload recently edited files after compression.
+        #
+        # Inspired by Claude Code — after compaction the model loses the
+        # actual content of files it was just working on.  Re-reading the
+        # most recently touched files keeps the model grounded in the
+        # current codebase state and prevents drift.
+        #
+        # Budget: up to 5 files, ~5K chars each, ~50K total.
+        # ------------------------------------------------------------------
+        _REHYDRATE_MAX_FILES = 5
+        _REHYDRATE_CHARS_PER_FILE = 5000
+        try:
+            from tools.file_tools import get_recent_files
+            recent = get_recent_files(task_id, limit=_REHYDRATE_MAX_FILES)
+            if recent:
+                rehydrated_parts = []
+                for fpath, _mtime in recent:
+                    try:
+                        p = Path(fpath)
+                        if not p.is_file() or p.stat().st_size > 500_000:
+                            continue  # skip missing/huge files
+                        # Skip binary-looking files
+                        if p.suffix.lower() in {
+                            ".png", ".jpg", ".jpeg", ".gif", ".webp", ".ico",
+                            ".woff", ".woff2", ".ttf", ".otf", ".eot",
+                            ".zip", ".tar", ".gz", ".bz2", ".7z",
+                            ".pyc", ".pyo", ".so", ".dll", ".exe",
+                            ".db", ".sqlite", ".sqlite3",
+                            ".pdf", ".mp3", ".mp4", ".ogg", ".wav",
+                        }:
+                            continue
+                        raw = p.read_text(errors="replace")
+                        snippet = raw[:_REHYDRATE_CHARS_PER_FILE]
+                        if len(raw) > _REHYDRATE_CHARS_PER_FILE:
+                            snippet += f"\n... [{len(raw) - _REHYDRATE_CHARS_PER_FILE:,} more chars truncated]"
+                        rehydrated_parts.append(f"### {fpath}\n```\n{snippet}\n```")
+                    except Exception:
+                        continue  # skip unreadable files
+
+                if rehydrated_parts:
+                    header = (
+                        "[FILES REHYDRATED after context compression]\n"
+                        "The following files were recently read or edited in this session. "
+                        "They are re-loaded automatically so you stay aligned with the "
+                        "current codebase state.\n\n"
+                    )
+                    rehydration_msg = header + "\n\n".join(rehydrated_parts)
+                    compressed.append({"role": "user", "content": rehydration_msg})
+                    logger.info(
+                        "Rehydration: injected %d file(s) into compressed context",
+                        len(rehydrated_parts),
+                    )
+        except Exception as e:
+            logger.debug("Rehydration skipped: %s", e)
+
         self._invalidate_system_prompt()
         new_system_prompt = self._build_system_prompt(system_message)
         self._cached_system_prompt = new_system_prompt

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -489,6 +489,26 @@ def notify_other_tool_call(task_id: str = "default"):
             task_data["consecutive"] = 0
 
 
+def get_recent_files(task_id: str = "default", limit: int = 5) -> list[tuple[str, float]]:
+    """Return the most recently accessed files for a task, sorted by mtime descending.
+
+    Used by the rehydration pass after context compression to know which
+    files to re-read into the compressed context.
+
+    Returns a list of (resolved_path, mtime) tuples.
+    """
+    with _read_tracker_lock:
+        task_data = _read_tracker.get(task_id)
+        if not task_data:
+            return []
+        timestamps = task_data.get("read_timestamps", {})
+        if not timestamps:
+            return []
+        # Sort by mtime descending (most recently touched first)
+        sorted_files = sorted(timestamps.items(), key=lambda x: x[1], reverse=True)
+        return sorted_files[:limit]
+
+
 def _update_read_timestamp(filepath: str, task_id: str) -> None:
     """Record the file's current modification time after a successful write.
 


### PR DESCRIPTION
## Summary

- Add microcompaction (Phase 0) to save oversized tool outputs to disk before compression
- Add post-compression rehydration to auto-reload recently edited files
- Add `get_recent_files()` helper to expose file read timestamps for rehydration

## Motivation

Long coding sessions accumulate large tool outputs (test suites, file reads) that dominate the context window, and after compression the model loses the actual content of files it was just editing. These two features address both problems:

1. **Microcompaction** catches oversized outputs (>15K chars) early — before any other compression phase — saving them to `~/.hermes/compaction_cache/` and keeping only head/tail excerpts inline.
2. **Rehydration** (inspired by Claude Code) re-reads the 5 most recently touched files after compaction, keeping the model grounded in the current codebase state.

## Changes

### `agent/context_compressor.py` (+97 lines)
- Add `_MICROCOMPACTION_THRESHOLD` (15K chars), `_MICROCOMPACTION_KEEP_HEAD` (1500), `_MICROCOMPACTION_KEEP_TAIL` (500) constants
- Add `_microcompact_large_outputs()` static method: saves full output to disk via content hash, replaces inline with head/tail + summary
- Insert Phase 0 call in `compress()` before Phase 1 (tool pruning)

### `run_agent.py` (+56 lines)
- Add rehydration block after todo snapshot injection in `_compress_context()`
- Reads up to 5 recent files (5K chars each) via `get_recent_files()`
- Skips binary files, missing files, and files >500KB
- Injects as a `[FILES REHYDRATED]` user message

### `tools/file_tools.py` (+20 lines)
- Add `get_recent_files(task_id, limit)` function
- Returns `(path, mtime)` tuples sorted by recency from the existing `_read_tracker`

## Test Plan

- [x] All compression-related tests pass (118 tests across agent/, tools/, run_agent/, gateway/, cli/)
- [x] Full test suite passes (分批执行，避免OOM)
- [x] No schema changes required
- [x] All features wrapped in try/except — graceful degradation on any failure

## Platforms Tested

- Ubuntu 24.04 (Azure VM)

## Notes for Reviewers

- Microcompaction uses `hashlib.md5` for cache filenames (not security-sensitive, just dedup)
- Rehydration budget is conservative: 5 files × 5K chars = ~25K chars max injection
- Both features are independent — either can be reverted without affecting the other
- No new dependencies, no config changes, no schema migrations