### PR TITLE
fix(gateway): use profile aware Hermes paths in runtime hints

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4971,6 +4971,7 @@ class GatewayRunner:
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         import yaml
+        from hermes_constants import display_hermes_home
 
         args = event.get_command_args().strip().lower()
         config_path = _hermes_home / 'config.yaml'
@@ -4988,7 +4989,7 @@ class GatewayRunner:
             personalities = {}
 
         if not personalities:
-            return "No personalities configured in `~/.hermes/config.yaml`"
+            return f"No personalities configured in `{display_hermes_home()}/config.yaml`"
 
         if not args:
             lines = ["🎭 **Available Personalities**\n"]

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -301,6 +301,8 @@ def build_session_context_prompt(
     lines.append("")
     lines.append("**Delivery options for scheduled tasks:**")
     
+    from hermes_constants import display_hermes_home
+
     # Origin delivery
     if context.source.platform == Platform.LOCAL:
         lines.append("- `\"origin\"` → Local output (saved to files)")
@@ -309,9 +311,11 @@ def build_session_context_prompt(
             _hash_chat_id(context.source.chat_id) if redact_pii else context.source.chat_id
         )
         lines.append(f"- `\"origin\"` → Back to this chat ({_origin_label})")
-    
+
     # Local always available
-    lines.append("- `\"local\"` → Save to local files only (~/.hermes/cron/output/)")
+    lines.append(
+        f"- `\"local\"` → Save to local files only ({display_hermes_home()}/cron/output/)"
+    )
     
     # Platform home channels
     for platform, home in context.home_channels.items():

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "balyan.sid@gmail.com": "balyansid",
     "oluwadareab12@gmail.com": "bennytimz",
     "simon@simonmarcus.org": "simon-marcus",
+    "xowiekk@gmail.com": "Xowiek",
     "1243352777@qq.com": "zons-zhaozhy",
     # ── bulk addition: 75 emails resolved via API, PR salvage bodies, noreply
     #    crossref, and GH contributor list matching (April 2026 audit) ──

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -144,6 +144,18 @@ class TestGatewayPersonalityNone:
 
         assert "none" in result.lower()
 
+    @pytest.mark.asyncio
+    async def test_empty_personality_list_uses_profile_display_path(self, tmp_path):
+        runner = self._make_runner(personalities={})
+        (tmp_path / "config.yaml").write_text(yaml.dump({"agent": {"personalities": {}}}))
+
+        with patch("gateway.run._hermes_home", tmp_path), \
+             patch("hermes_constants.display_hermes_home", return_value="~/.hermes/profiles/coder"):
+            event = self._make_event("")
+            result = await runner._handle_personality_command(event)
+
+        assert result == "No personalities configured in `~/.hermes/profiles/coder/config.yaml`"
+
 
 class TestPersonalityDictFormat:
     """Test dict-format custom personalities with description, tone, style."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -283,6 +283,19 @@ class TestBuildSessionContextPrompt:
         assert "Local" in prompt
         assert "machine running this agent" in prompt
 
+    def test_local_delivery_path_uses_display_hermes_home(self):
+        config = GatewayConfig()
+        source = SessionSource(
+            platform=Platform.LOCAL, chat_id="cli",
+            chat_name="CLI terminal", chat_type="dm",
+        )
+        ctx = build_session_context(source, config)
+
+        with patch("hermes_constants.display_hermes_home", return_value="~/.hermes/profiles/coder"):
+            prompt = build_session_context_prompt(ctx)
+
+        assert "~/.hermes/profiles/coder/cron/output/" in prompt
+
     def test_whatsapp_prompt(self):
         config = GatewayConfig(
             platforms={


### PR DESCRIPTION
## Summary

This fixes two remaining gateway runtime strings that still hardcode ~/.hermes instead of using the active profile-aware display path.

## What changed

Updated the gateway session context prompt so "local" scheduled task delivery points to display_hermes_home()/cron/output/
Updated the gateway /personality command so the "No personalities configured" message points to display_hermes_home()/config.yaml
Added focused regression tests for both cases

## Why

Hermes profile support requires user-facing and agent-facing path guidance to reflect the active HERMES_HOME. These two runtime hints were still showing the default path even when running inside a profile such as ~/.hermes/profiles/coder.

This keeps the fix tightly scoped and consistent with recent profile-safe path cleanup already merged elsewhere in the codebase.

## Files changed

gateway/session.py
gateway/run.py
tests/gateway/test_session.py
tests/cli/test_personality_none.py

## Tests

Passed:

Bash

python -m pytest -n 0 --basetemp .pytest-basetemp tests/gateway/test_session.py::TestBuildSessionContextPrompt::test_local_delivery_path_uses_display_hermes_home tests/cli/test_personality_none.py::TestGatewayPersonalityNone::test_empty_personality_list_uses_profile_display_path -q



## Additional context

Broader nearby test run reached 67 passed, 14 failed

The 14 failures were environment-related CLI import failures caused by missing prompt_toolkit, not by this change

