### PR TITLE
fix(profile): detect custom-root active profiles

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3897,17 +3897,15 @@ class HermesCLI:
     
     def _handle_profile_command(self):
         """Display active profile name and home directory."""
-        from hermes_constants import get_hermes_home, display_hermes_home
+        from hermes_constants import (
+            display_hermes_home,
+            get_active_profile_name,
+            get_hermes_home,
+        )
 
         home = get_hermes_home()
         display = display_hermes_home()
-
-        profiles_parent = Path.home() / ".hermes" / "profiles"
-        try:
-            rel = home.relative_to(profiles_parent)
-            profile_name = str(rel).split("/")[0]
-        except ValueError:
-            profile_name = None
+        profile_name = get_active_profile_name(home)
 
         print()
         if profile_name:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4374,20 +4374,15 @@ class GatewayRunner:
     
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""
-        from hermes_constants import get_hermes_home, display_hermes_home
-        from pathlib import Path
+        from hermes_constants import (
+            display_hermes_home,
+            get_active_profile_name,
+            get_hermes_home,
+        )
 
         home = get_hermes_home()
         display = display_hermes_home()
-
-        # Detect profile name from HERMES_HOME path
-        # Profile paths look like: ~/.hermes/profiles/<name>
-        profiles_parent = Path.home() / ".hermes" / "profiles"
-        try:
-            rel = home.relative_to(profiles_parent)
-            profile_name = str(rel).split("/")[0]
-        except ValueError:
-            profile_name = None
+        profile_name = get_active_profile_name(home)
 
         if profile_name:
             lines = [

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -56,6 +56,21 @@ def get_default_hermes_root() -> Path:
     return env_path
 
 
+def get_active_profile_name(hermes_home: Path | None = None) -> str | None:
+    """Return the active profile name for the given Hermes home, if any.
+
+    Supports both the standard ``~/.hermes/profiles/<name>`` layout and
+    custom-root deployments such as ``/opt/data/profiles/<name>``.
+    """
+    home = (hermes_home or get_hermes_home()).resolve()
+    profiles_root = (get_default_hermes_root() / "profiles").resolve()
+    try:
+        relative = home.relative_to(profiles_root)
+    except ValueError:
+        return None
+    return relative.parts[0] if relative.parts else None
+
+
 def get_optional_skills_dir(default: Path | None = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -188,6 +188,7 @@ AUTHOR_MAP = {
     "vorvul.danylo@gmail.com": "WorldInnovationsDepartment",
     "win4r@outlook.com": "win4r",
     "xush@xush.org": "KUSH42",
+    "xowiekk@gmail.com": "Xowiek",
     "yangzhi.see@gmail.com": "SeeYangZhi",
     "yongtenglei@gmail.com": "yongtenglei",
     "young@YoungdeMacBook-Pro.local": "YoungYang963",

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -1,5 +1,6 @@
 """Tests for CLI /status command behavior."""
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -83,3 +84,17 @@ def test_show_session_status_prints_gateway_style_summary():
     _, kwargs = cli_obj.console.print.call_args
     assert kwargs.get("highlight") is False
     assert kwargs.get("markup") is False
+
+
+def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path, capsys):
+    cli_obj = _make_cli()
+    profile_home = tmp_path / "profiles" / "coder"
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "unrelated-home")
+
+    cli_obj._handle_profile_command()
+
+    out = capsys.readouterr().out
+    assert "Profile: coder" in out
+    assert f"Home:    {profile_home}" in out

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -1,6 +1,7 @@
 """Tests for gateway /status behavior and token persistence."""
 
 from datetime import datetime
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -209,3 +210,25 @@ async def test_status_command_bypasses_active_session_guard():
     assert "Agent Running" in sent[0]
     assert not interrupt_event.is_set(), "/status incorrectly triggered an agent interrupt"
     assert session_key not in adapter._pending_messages, "/status was incorrectly queued"
+
+
+@pytest.mark.asyncio
+async def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    profile_home = tmp_path / "profiles" / "coder"
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "unrelated-home")
+
+    result = await runner._handle_profile_command(_make_event("/profile"))
+
+    assert "**Profile:** `coder`" in result
+    assert f"**Home:** `{profile_home}`" in result


### PR DESCRIPTION
## Summary

This fixes active profile detection for `/profile` in both the CLI and gateway when Hermes is running from a custom `HERMES_HOME`.

It also adds the missing contributor email mapping for `xowiekk@gmail.com` so the contributor attribution check passes for this branch.

## Problem

When `HERMES_HOME` points at a custom-root profile path such as `.../profiles/coder`, both CLI and gateway `/profile` could incorrectly report `default`.

The handlers were assuming profiles only lived under `~/.hermes/profiles/...` instead of using root-aware profile detection.

## Fix

- add a shared helper to resolve the active profile name from the current Hermes home
- switch CLI `/profile` to use the shared helper
- switch gateway `/profile` to use the shared helper
- add the missing `AUTHOR_MAP` entry for `xowiekk@gmail.com`

## Tests

Ran focused regression tests:

```bash
uv run --extra dev python -m pytest tests/cli/test_cli_status_command.py tests/gateway/test_status_command.py -q

Result:

11 passed