### PR TITLE
fix(gateway): close failed adapter on reconnect to prevent fd leak

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2191,6 +2191,13 @@ class GatewayRunner:
                         except Exception:
                             pass
                     else:
+                        # Release connection pools from the failed adapter to
+                        # prevent file-descriptor exhaustion on repeated retries.
+                        try:
+                            await adapter.disconnect()
+                        except Exception:
+                            pass
+
                         # Check if the failure is non-retryable
                         if adapter.has_fatal_error and not adapter.fatal_error_retryable:
                             self._update_platform_runtime_status(
@@ -2219,6 +2226,13 @@ class GatewayRunner:
                                 platform.value, backoff,
                             )
                 except Exception as e:
+                    # Clean up the adapter that failed during connect to avoid
+                    # leaking its HTTP connection-pool file descriptors.
+                    try:
+                        await adapter.disconnect()
+                    except Exception:
+                        pass
+
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",


### PR DESCRIPTION
## Summary

- When a Telegram adapter fails to reconnect, the newly created `HTTPXRequest` connection pools (2 × 512 FDs each) are never closed — the adapter is abandoned without calling `disconnect()`
- After enough reconnect cycles this exhausts the OS file descriptor limit, causing `[Errno 24] Too many open files` for all subsequent operations (config loads, script execution, etc.)
- This adds `adapter.disconnect()` on both the failed-connect and exception paths in the reconnect loop to release pools immediately

## Root Cause

`gateway/run.py` reconnect loop (`_reconnect_failed_platforms`):
1. New adapter created via `_create_adapter()` → initializes 2 `HTTPXRequest` objects with 512-connection pools each
2. `adapter.connect()` fails or throws → code updates retry state but **never calls `adapter.disconnect()`**
3. Adapter falls out of scope with open httpx `AsyncClient` pools → FDs leak
4. Repeat until OS limit hit

## Fix

Two insertions in the reconnect loop — call `await adapter.disconnect()` wrapped in try/except:
- After `connect()` returns `False` (before retry scheduling)
- In the `except Exception` handler (before retry scheduling)

Both paths already existed for the success case (old adapter disconnected in `_handle_adapter_fatal_error`), this just covers the failure paths.

## Test plan

- [ ] Run gateway with a Telegram bot token, kill network briefly to trigger reconnect cycle
- [ ] Monitor fd count (`lsof -p <pid> | wc -l`) across multiple reconnect attempts — should stay flat
- [ ] Verify successful reconnect still works after the fix (disconnect only on failure path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)