### PR TITLE
[codex] narrow reasoning replay for chat completions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6120,6 +6120,23 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
+    @staticmethod
+    def _assistant_reasoning_content_for_api(msg: dict) -> Optional[str]:
+        """Return replayable reasoning text for an assistant history message.
+
+        Only tool-call turns replay plain ``reasoning_content``. Normal
+        assistant text turns can carry low-quality hidden thoughts that should
+        not be fed back into later chat-completions requests.
+        """
+        if not isinstance(msg, dict):
+            return None
+        if msg.get("role") != "assistant" or not msg.get("tool_calls"):
+            return None
+        reasoning_text = msg.get("reasoning")
+        if isinstance(reasoning_text, str) and reasoning_text:
+            return reasoning_text
+        return None
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -8219,13 +8236,17 @@ class AIAgent:
                         if isinstance(_base, str):
                             api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
 
-                # For ALL assistant messages, pass reasoning back to the API
-                # This ensures multi-turn reasoning context is preserved
-                if msg.get("role") == "assistant":
-                    reasoning_text = msg.get("reasoning")
-                    if reasoning_text:
-                        # Add reasoning_content for API compatibility (Moonshot AI, Novita, OpenRouter)
-                        api_msg["reasoning_content"] = reasoning_text
+                # Only replay plain reasoning_content on assistant tool-call
+                # turns. General assistant turns already preserve structured
+                # reasoning_details for providers that support multi-turn
+                # reasoning continuity. Replaying unstructured reasoning on
+                # every assistant turn can poison weaker chat-completions
+                # models with low-quality hidden thoughts from prior turns.
+                reasoning_text = self._assistant_reasoning_content_for_api(msg)
+                if reasoning_text:
+                    # Add reasoning_content for API compatibility on
+                    # providers/routes that expect it for tool-call turns.
+                    api_msg["reasoning_content"] = reasoning_text
 
                 # Remove 'reasoning' field - it's for trajectory storage only
                 # We've copied it to 'reasoning_content' for the API above

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -140,6 +140,36 @@ class TestBuildApiKwargsOpenRouter:
         assert messages[1]["tool_calls"][0]["response_item_id"] == "fc_123"
         assert "codex_reasoning_items" in messages[1]
 
+    def test_plain_assistant_turn_does_not_replay_reasoning_content(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        msg = {
+            "role": "assistant",
+            "content": "Hello!",
+            "reasoning": "We should greet the user politely.",
+        }
+
+        assert agent._assistant_reasoning_content_for_api(msg) is None
+
+    def test_tool_call_turn_replays_reasoning_content(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "I should inspect the workspace before answering.",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{\"command\":\"pwd\"}"},
+                }
+            ],
+        }
+
+        assert (
+            agent._assistant_reasoning_content_for_api(msg)
+            == "I should inspect the workspace before answering."
+        )
+
     def test_should_sanitize_tool_calls_codex_vs_chat(self, monkeypatch):
         """Codex API should NOT sanitize, all other APIs should sanitize."""
         # Codex mode should NOT need sanitization


### PR DESCRIPTION
## What changed

This narrows assistant reasoning replay for chat-completions requests.

- add `_assistant_reasoning_content_for_api()` to centralize the replay decision
- replay plain `reasoning_content` only for assistant tool-call turns
- stop replaying free-form prior assistant reasoning on normal assistant text turns
- add provider-parity regression tests for both cases

## Why

`main` was replaying stored assistant `reasoning` back into later chat-completions requests for every assistant turn. That is safe for some structured reasoning flows, but it can poison weaker chat-completions models when their hidden reasoning is low-quality or garbled.

In practice this showed up as bad prior hidden reasoning leaking into later turns, especially on weaker OpenRouter models.

## Impact

This keeps the existing tool-call compatibility path, while reducing the chance that prior hidden reasoning contaminates follow-up turns.

Structured reasoning continuity is still preserved through the existing structured fields where supported.

## Root cause

The broad replay behavior came from expanding the earlier reasoning preservation path from assistant tool-call turns to all assistant turns.

## Validation

- `uv run pytest tests/run_agent/test_provider_parity.py -q -k 'plain_assistant_turn_does_not_replay_reasoning_content or tool_call_turn_replays_reasoning_content'`

## Attribution

This PR narrows the reasoning-preservation behavior introduced in commit `e114f09f` by Teknium. The original work added broader multi-format reasoning extraction/preservation; this patch keeps that intent for tool-call continuity while removing the over-broad replay path for generic chat-completions turns.
