### PR TITLE
fix: GitHub Copilot provider returns empty base URL when resolved via credential pool

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -167,6 +167,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        base_url = base_url or "https://api.githubcopilot.com"
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider


### PR DESCRIPTION
## Summary
When using the GitHub Copilot provider, Hermes fails to start with empty base URL error when resolved via credential pool.

## Root Cause
In hermes_cli/runtime_provider.py, the copilot branch sets api_mode but never provides a fallback base_url. When the credential pool path wins, the pool entry's base_url is None and there is no fallback.

## Fix
Add a default base URL fallback in the copilot branch, mirroring the pattern used by anthropic, openrouter, and qwen-oauth providers.

## Test Plan
- [x] Verified that resolve_runtime_provider returns correct base_url

Closes NousResearch/hermes-agent#10223