### PR TITLE
fix: Gateway fails to start with --config flag using json instead of yaml

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9725,9 +9725,9 @@ def main():
     
     config = None
     if args.config:
-        import json
+        import yaml
         with open(args.config, encoding="utf-8") as f:
-            data = json.load(f)
+            data = yaml.safe_load(f)
             config = GatewayConfig.from_dict(data)
     
     # Run the gateway - exit with code 1 if no platforms connected,


### PR DESCRIPTION
## Summary
Gateway fails to start with --config flag because it uses json.load() instead of yaml.safe_load() to parse the config file.

## Root Cause
In gateway/run.py, the main() function loads the --config file using json.load(), but the documented and expected config format is YAML.

## Fix
Replace json.load() with yaml.safe_load() to correctly parse YAML config files.

## Test Plan
- [x] Gateway starts successfully with YAML config file via --config flag

Closes NousResearch/hermes-agent#10216