### PR TITLE
fix: MessageDeduplicator TTL never expires unless cache exceeds max_size

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -49,7 +49,11 @@ class MessageDeduplicator:
             return False
         now = time.time()
         if msg_id in self._seen:
-            return True
+            # Check if entry is still within TTL
+            if self._seen[msg_id] > now - self._ttl:
+                return True
+            # Entry expired, remove it
+            del self._seen[msg_id]
         self._seen[msg_id] = now
         if len(self._seen) > self._max_size:
             cutoff = now - self._ttl


### PR DESCRIPTION
## Summary
MessageDeduplicator.is_duplicate() says it is TTL-based, but an entry never expires unless the cache also grows past max_size.

## Root Cause
The implementation returned True for any previously seen ID without checking its age. Expired entries were only purged during size-based compaction.

## Fix
Check entry timestamp against TTL before returning True, and delete expired entries inline.

## Test Plan
- [x] Expired entries are now properly removed and not considered duplicates

Closes NousResearch/hermes-agent#10306