### PR TITLE
Unify config.yaml loading across CLI and gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -210,6 +210,12 @@ def load_cli_config() -> Dict[str, Any]:
     else:
         config_path = project_config_path
 
+    from hermes_cli.config import (
+        _expand_env_vars,
+        load_config as _shared_load_config,
+        read_raw_config as _read_raw_config,
+    )
+
     # Default configuration
     defaults = {
         "model": {
@@ -313,79 +319,41 @@ def load_cli_config() -> Dict[str, Any]:
     # When using defaults (no config file / no terminal section), we should NOT
     # overwrite env vars that were already set by .env -- only a user's config
     # file should be authoritative.
-    _file_has_terminal_config = False
+    file_config = _read_raw_config(config_path=config_path)
+    _file_has_terminal_config = "terminal" in file_config
 
-    # Load from file if exists
-    if config_path.exists():
-        try:
-            with open(config_path, "r", encoding="utf-8") as f:
-                file_config = yaml.safe_load(f) or {}
-            
-            _file_has_terminal_config = "terminal" in file_config
+    try:
+        defaults = _shared_load_config(config_path=config_path, defaults=defaults)
+    except Exception as e:
+        logger.warning("Failed to load cli config from %s: %s", config_path, e)
+        defaults = _expand_env_vars(defaults)
 
-            # Handle model config - can be string (new format) or dict (old format)
-            if "model" in file_config:
-                if isinstance(file_config["model"], str):
-                    # New format: model is just a string, convert to dict structure
-                    defaults["model"]["default"] = file_config["model"]
-                elif isinstance(file_config["model"], dict):
-                    # Old format: model is a dict with default/base_url
-                    defaults["model"].update(file_config["model"])
-                    # If the user config sets model.model but not model.default,
-                    # promote model.model to model.default so the user's explicit
-                    # choice isn't shadowed by the hardcoded default.  Without this,
-                    # profile configs that only set "model:" (not "default:") silently
-                    # fall back to claude-opus because the merge preserves the
-                    # hardcoded default and HermesCLI.__init__ checks "default" first.
-                    if "model" in file_config["model"] and "default" not in file_config["model"]:
-                        defaults["model"]["default"] = file_config["model"]["model"]
+    # HermesCLI still expects the legacy nested model + agent fields.
+    model_config = defaults.get("model", {})
+    if isinstance(model_config, str):
+        defaults["model"] = {
+            "default": model_config,
+            "base_url": "",
+            "provider": "auto",
+        }
+    elif isinstance(model_config, dict):
+        defaults["model"] = {
+            "default": model_config.get("default") or model_config.get("model") or "",
+            "base_url": model_config.get("base_url", ""),
+            "provider": model_config.get("provider", "auto"),
+            **model_config,
+        }
 
-            # Legacy root-level provider/base_url fallback.
-            # Some users (or old code) put provider: / base_url: at the
-            # config root instead of inside the model: section.  These are
-            # only used as a FALLBACK when model.provider / model.base_url
-            # is not already set — never as an override.  The canonical
-            # location is model.provider (written by `hermes model`).
-            if not defaults["model"].get("provider"):
-                root_provider = file_config.get("provider")
-                if root_provider:
-                    defaults["model"]["provider"] = root_provider
-            if not defaults["model"].get("base_url"):
-                root_base_url = file_config.get("base_url")
-                if root_base_url:
-                    defaults["model"]["base_url"] = root_base_url
-            
-            # Deep merge file_config into defaults.
-            # First: merge keys that exist in both (deep-merge dicts, overwrite scalars)
-            for key in defaults:
-                if key == "model":
-                    continue  # Already handled above
-                if key in file_config:
-                    if isinstance(defaults[key], dict) and isinstance(file_config[key], dict):
-                        defaults[key].update(file_config[key])
-                    else:
-                        defaults[key] = file_config[key]
-            
-            # Second: carry over keys from file_config that aren't in defaults
-            # (e.g. platform_toolsets, provider_routing, memory, honcho, etc.)
-            for key in file_config:
-                if key not in defaults and key != "model":
-                    defaults[key] = file_config[key]
-            
-            # Handle legacy root-level max_turns (backwards compat) - copy to
-            # agent.max_turns whenever the nested key is missing.
-            agent_file_config = file_config.get("agent")
-            if "max_turns" in file_config and not (
-                isinstance(agent_file_config, dict)
-                and agent_file_config.get("max_turns") is not None
-            ):
-                defaults["agent"]["max_turns"] = file_config["max_turns"]
-        except Exception as e:
-            logger.warning("Failed to load cli-config.yaml: %s", e)
-
-    # Expand ${ENV_VAR} references in config values before bridging to env vars.
-    from hermes_cli.config import _expand_env_vars
-    defaults = _expand_env_vars(defaults)
+    agent_config = defaults.get("agent", {})
+    if isinstance(agent_config, dict):
+        if not agent_config.get("prefill_messages_file") and defaults.get("prefill_messages_file"):
+            agent_config["prefill_messages_file"] = defaults["prefill_messages_file"]
+        root_personalities = defaults.get("personalities")
+        if isinstance(root_personalities, dict) and root_personalities:
+            merged_personalities = dict(agent_config.get("personalities") or {})
+            merged_personalities.update(root_personalities)
+            agent_config["personalities"] = merged_personalities
+        defaults["agent"] = agent_config
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
     terminal_config = defaults.get("terminal", {})

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -82,6 +82,7 @@ _hermes_home = get_hermes_home()
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
 from dotenv import load_dotenv  # backward-compat for tests that monkeypatch this symbol
+from hermes_cli.config import load_config as _shared_load_config, read_raw_config as _read_raw_config
 from hermes_cli.env_loader import load_hermes_dotenv
 _env_path = _hermes_home / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve().parents[1] / '.env')
@@ -91,20 +92,25 @@ load_hermes_dotenv(hermes_home=_hermes_home, project_env=Path(__file__).resolve(
 _config_path = _hermes_home / 'config.yaml'
 if _config_path.exists():
     try:
-        import yaml as _yaml
-        with open(_config_path, encoding="utf-8") as _f:
-            _cfg = _yaml.safe_load(_f) or {}
-        # Expand ${ENV_VAR} references before bridging to env vars.
-        from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        _cfg = _shared_load_config()
+        _raw_cfg = _read_raw_config()
         # Top-level simple values (fallback only — don't override .env)
-        for _key, _val in _cfg.items():
+        for _key in _raw_cfg:
+            _val = _cfg.get(_key)
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:
                 os.environ[_key] = str(_val)
         # Terminal config is nested — bridge to TERMINAL_* env vars.
         # config.yaml overrides .env for these since it's the documented config path.
-        _terminal_cfg = _cfg.get("terminal", {})
-        if _terminal_cfg and isinstance(_terminal_cfg, dict):
+        _raw_terminal_cfg = _raw_cfg.get("terminal", {})
+        _terminal_cfg = dict(_cfg.get("terminal", {}) or {})
+        if "backend" in _terminal_cfg:
+            _terminal_cfg["env_type"] = _terminal_cfg["backend"]
+        elif "env_type" in _terminal_cfg:
+            _terminal_cfg["backend"] = _terminal_cfg["env_type"]
+        if _raw_terminal_cfg and isinstance(_raw_terminal_cfg, dict):
+            _explicit_terminal_keys = set(_raw_terminal_cfg.keys())
+            if "env_type" in _explicit_terminal_keys:
+                _explicit_terminal_keys.add("backend")
             _terminal_env_map = {
                 "backend": "TERMINAL_ENV",
                 "cwd": "TERMINAL_CWD",
@@ -128,7 +134,7 @@ if _config_path.exists():
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
-                if _cfg_key in _terminal_cfg:
+                if _cfg_key in _explicit_terminal_keys and _cfg_key in _terminal_cfg:
                     _val = _terminal_cfg[_cfg_key]
                     if isinstance(_val, list):
                         os.environ[_env_var] = json.dumps(_val)
@@ -176,34 +182,37 @@ if _config_path.exists():
                     os.environ[_env_map["base_url"]] = _base_url
                 if _api_key:
                     os.environ[_env_map["api_key"]] = _api_key
+        _raw_agent_cfg = _raw_cfg.get("agent", {})
         _agent_cfg = _cfg.get("agent", {})
-        if _agent_cfg and isinstance(_agent_cfg, dict):
-            if "max_turns" in _agent_cfg:
+        if isinstance(_raw_agent_cfg, dict) and _raw_agent_cfg and isinstance(_agent_cfg, dict):
+            if "max_turns" in _raw_agent_cfg:
                 os.environ["HERMES_MAX_ITERATIONS"] = str(_agent_cfg["max_turns"])
             # Bridge agent.gateway_timeout → HERMES_AGENT_TIMEOUT env var.
             # Env var from .env takes precedence (already in os.environ).
-            if "gateway_timeout" in _agent_cfg and "HERMES_AGENT_TIMEOUT" not in os.environ:
+            if "gateway_timeout" in _raw_agent_cfg and "HERMES_AGENT_TIMEOUT" not in os.environ:
                 os.environ["HERMES_AGENT_TIMEOUT"] = str(_agent_cfg["gateway_timeout"])
-            if "gateway_timeout_warning" in _agent_cfg and "HERMES_AGENT_TIMEOUT_WARNING" not in os.environ:
+            if "gateway_timeout_warning" in _raw_agent_cfg and "HERMES_AGENT_TIMEOUT_WARNING" not in os.environ:
                 os.environ["HERMES_AGENT_TIMEOUT_WARNING"] = str(_agent_cfg["gateway_timeout_warning"])
-            if "gateway_notify_interval" in _agent_cfg and "HERMES_AGENT_NOTIFY_INTERVAL" not in os.environ:
+            if "gateway_notify_interval" in _raw_agent_cfg and "HERMES_AGENT_NOTIFY_INTERVAL" not in os.environ:
                 os.environ["HERMES_AGENT_NOTIFY_INTERVAL"] = str(_agent_cfg["gateway_notify_interval"])
-            if "restart_drain_timeout" in _agent_cfg and "HERMES_RESTART_DRAIN_TIMEOUT" not in os.environ:
+            if "restart_drain_timeout" in _raw_agent_cfg and "HERMES_RESTART_DRAIN_TIMEOUT" not in os.environ:
                 os.environ["HERMES_RESTART_DRAIN_TIMEOUT"] = str(_agent_cfg["restart_drain_timeout"])
+        _raw_display_cfg = _raw_cfg.get("display", {})
         _display_cfg = _cfg.get("display", {})
-        if _display_cfg and isinstance(_display_cfg, dict):
-            if "busy_input_mode" in _display_cfg and "HERMES_GATEWAY_BUSY_INPUT_MODE" not in os.environ:
+        if isinstance(_raw_display_cfg, dict) and isinstance(_display_cfg, dict):
+            if "busy_input_mode" in _raw_display_cfg and "HERMES_GATEWAY_BUSY_INPUT_MODE" not in os.environ:
                 os.environ["HERMES_GATEWAY_BUSY_INPUT_MODE"] = str(_display_cfg["busy_input_mode"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         # HERMES_TIMEZONE from .env takes precedence (already in os.environ).
         _tz_cfg = _cfg.get("timezone", "")
-        if _tz_cfg and isinstance(_tz_cfg, str) and "HERMES_TIMEZONE" not in os.environ:
+        if "timezone" in _raw_cfg and _tz_cfg and isinstance(_tz_cfg, str) and "HERMES_TIMEZONE" not in os.environ:
             os.environ["HERMES_TIMEZONE"] = _tz_cfg.strip()
         # Security settings
+        _raw_security_cfg = _raw_cfg.get("security", {})
         _security_cfg = _cfg.get("security", {})
-        if isinstance(_security_cfg, dict):
+        if isinstance(_raw_security_cfg, dict) and isinstance(_security_cfg, dict):
             _redact = _security_cfg.get("redact_secrets")
-            if _redact is not None:
+            if "redact_secrets" in _raw_security_cfg and _redact is not None:
                 os.environ["HERMES_REDACT_SECRETS"] = str(_redact).lower()
     except Exception:
         pass  # Non-fatal; gateway can still run with .env values
@@ -427,13 +436,9 @@ def _platform_config_key(platform: "Platform") -> str:
 
 
 def _load_gateway_config() -> dict:
-    """Load and parse ~/.hermes/config.yaml, returning {} on any error."""
+    """Load gateway config through the shared Hermes config loader."""
     try:
-        config_path = _hermes_home / 'config.yaml'
-        if config_path.exists():
-            import yaml
-            with open(config_path, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f) or {}
+        return _shared_load_config()
     except Exception:
         logger.debug("Could not load gateway config from %s", _hermes_home / 'config.yaml')
     return {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2470,7 +2470,13 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 
-def read_raw_config() -> Dict[str, Any]:
+def _read_config_file(config_path: Path) -> Dict[str, Any]:
+    """Read a YAML config file and return its parsed object."""
+    with open(config_path, encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def read_raw_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
 
     Returns the raw YAML dict, or ``{}`` if the file doesn't exist or can't
@@ -2479,27 +2485,30 @@ def read_raw_config() -> Dict[str, Any]:
     + migration pipeline.
     """
     try:
-        config_path = get_config_path()
+        config_path = Path(config_path) if config_path is not None else get_config_path()
         if config_path.exists():
-            with open(config_path, encoding="utf-8") as f:
-                return yaml.safe_load(f) or {}
+            return _read_config_file(config_path)
     except Exception:
         pass
     return {}
 
 
-def load_config() -> Dict[str, Any]:
-    """Load configuration from ~/.hermes/config.yaml."""
+def load_config(
+    config_path: Optional[Path] = None,
+    *,
+    defaults: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Load configuration from a YAML file, merging into *defaults* when given."""
     import copy
+
     ensure_hermes_home()
-    config_path = get_config_path()
-    
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    
+    config_path = Path(config_path) if config_path is not None else get_config_path()
+
+    config = copy.deepcopy(DEFAULT_CONFIG if defaults is None else defaults)
+
     if config_path.exists():
         try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
+            user_config = _read_config_file(config_path)
 
             if "max_turns" in user_config:
                 agent_user_config = dict(user_config.get("agent") or {})

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -345,3 +345,44 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestSharedConfigLoaderCompatibility:
+    def test_string_model_is_normalized_to_cli_model_dict(self, tmp_path, monkeypatch):
+        import yaml
+        import cli
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump({"model": "openai/gpt-4.1-mini"}), encoding="utf-8")
+
+        monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+
+        cfg = cli.load_cli_config()
+
+        assert cfg["model"]["default"] == "openai/gpt-4.1-mini"
+        assert cfg["model"]["provider"] == "auto"
+        assert cfg["model"]["base_url"] == ""
+
+    def test_root_prefill_and_personalities_are_mapped_for_cli(self, tmp_path, monkeypatch):
+        import yaml
+        import cli
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "prefill_messages_file": "examples/prefill.json",
+                    "personalities": {
+                        "codereviewer": "Review code carefully.",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+
+        cfg = cli.load_cli_config()
+
+        assert cfg["agent"]["prefill_messages_file"] == "examples/prefill.json"
+        assert cfg["agent"]["personalities"]["codereviewer"] == "Review code carefully."

--- a/tests/gateway/test_run_config_loader.py
+++ b/tests/gateway/test_run_config_loader.py
@@ -1,0 +1,30 @@
+import yaml
+
+import gateway.run as gateway_run
+
+
+def test_load_gateway_config_uses_shared_normalized_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "provider": "openrouter",
+                "model": {
+                    "default": "openai/gpt-4.1-mini",
+                },
+                "max_turns": 41,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    cfg = gateway_run._load_gateway_config()
+
+    assert cfg["model"]["provider"] == "openrouter"
+    assert cfg["agent"]["max_turns"] == 41
+    assert cfg["terminal"]["backend"] == "local"


### PR DESCRIPTION
﻿## Summary

This PR removes duplicated `config.yaml` parsing paths between the CLI and gateway and routes both through the shared loader in `hermes_cli.config`.

## What changed

- added shared config file helpers so callers can load normalized config from an explicit path
- updated `cli.py` to use the shared loader instead of maintaining its own separate YAML parsing logic
- kept CLI-specific compatibility behavior for legacy `model` and `agent` field shapes
- updated `gateway/run.py` to load normalized config through the shared loader
- preserved gateway env-bridging behavior so only explicitly configured keys are pushed into environment variables
- added regression tests for CLI compatibility and gateway shared-loader behavior

## Why

Previously, Hermes read the same `config.yaml` in different ways in different parts of the app. That could lead to one mode understanding a setting while another ignored or misread it. This change makes config interpretation more consistent and reduces maintenance risk when new config keys are added.

## Testing

- added focused tests for CLI config compatibility
- added focused tests for gateway shared config loading
- could not run pytest in this environment because no accessible Python interpreter/venv is available in the sandboxed session
