### PR TITLE
fix: _load_skill_payload rebuilds wrong skill_dir for external skills

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -71,8 +71,15 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
 
     skill_name = str(loaded_skill.get("name") or normalized)
     skill_path = str(loaded_skill.get("path") or "")
+    # Prefer absolute skill_dir from skill_view if available (fixes external skills)
     skill_dir = None
-    if skill_path:
+    skill_dir_str = loaded_skill.get("skill_dir")
+    if skill_dir_str:
+        try:
+            skill_dir = Path(skill_dir_str)
+        except Exception:
+            skill_dir = None
+    elif skill_path:
         try:
             skill_dir = SKILLS_DIR / Path(skill_path).parent
         except Exception:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1263,6 +1263,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             "related_skills": related_skills,
             "content": content,
             "path": rel_path,
+            "skill_dir": str(skill_dir) if skill_dir else None,
             "linked_files": linked_files if linked_files else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files


### PR DESCRIPTION
## Summary
_load_skill_payload() reconstructs skill_dir using SKILLS_DIR / Path(skill_path).parent, which produces a wrong path for external skills registered via skills.external_dirs.

## Root Cause
skill_view() returns path as a relative path. _load_skill_payload() rebuilds the absolute skill directory using SKILLS_DIR, which fails for external skills.

## Fix
1. Have skill_view() include the absolute skill_dir in its result dict
2. In _load_skill_payload(), prefer the absolute skill_dir from skill_view over the reconstructed path

## Test Plan
- [x] External skills now return correct absolute skill_dir
- [x] Builtin skills continue to work as before

Closes NousResearch/hermes-agent#10313