### PR TITLE
fix: run_agent sanitizer misclassifies tool results when tool_call_id has whitespace

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3331,8 +3331,8 @@ class AIAgent:
     def _get_tool_call_id_static(tc) -> str:
         """Extract call ID from a tool_call entry (dict or object)."""
         if isinstance(tc, dict):
-            return tc.get("id", "") or ""
-        return getattr(tc, "id", "") or ""
+            return (tc.get("id", "") or "").strip()
+        return (getattr(tc, "id", "") or "").strip()
 
     _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
 
@@ -3368,7 +3368,7 @@ class AIAgent:
         result_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "tool":
-                cid = msg.get("tool_call_id")
+                cid = msg.get("tool_call_id", "").strip()
                 if cid:
                     result_call_ids.add(cid)
 


### PR DESCRIPTION
## Summary
run_agent.py can misclassify a valid tool result as missing when tool_call_id contains leading or trailing whitespace.

## Root Cause
_sanitize_api_messages() compared raw tool_call_id strings without stripping whitespace.

## Fix
Strip whitespace in ID extraction (_get_tool_call_id_static) and when collecting result_call_ids from tool messages.

## Test Plan
- [x] Tool results with whitespace-padded IDs are correctly matched
- [x] Orphaned tool detection still works correctly

Closes NousResearch/hermes-agent#9999