### PR TITLE
feat(agent): AGENTS.md priority over CLAUDE.md per directory

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,8 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -939,8 +941,132 @@ def _load_hermes_md(cwd_path: Path) -> str:
         return ""
 
 
-def _load_agents_md(cwd_path: Path) -> str:
-    """AGENTS.md — top-level only (no recursive walk)."""
+def _resolve_walk_limit(raw: str) -> Path | None:
+    """Resolve a walk_limit config value to a stopping parent path.
+
+    Returns a Path to stop at (inclusive), or None for unlimited walking.
+    Supported values: "git_root", "home", "unlimited", or an absolute path.
+    """
+    stripped = (raw or "").strip()
+    lowered = stripped.lower()
+    if lowered in ("unlimited", ""):
+        return None
+    if lowered == "home":
+        try:
+            from pathlib import Path as _Path
+            return _Path.home()
+        except Exception:
+            return None
+    if lowered == "git_root":
+        return None  # handled specially by _walk_parents
+    # Treat as an absolute path — do NOT lowercase, preserve path case
+    try:
+        p = Path(stripped).expanduser()
+        if p.is_absolute():
+            return p.resolve()
+    except Exception:
+        pass
+    return None
+
+
+def _walk_parents(
+    cwd: Path,
+    walk_limit: str = "home",
+) -> list[Path]:
+    """Return cwd + parent directories up to the configured walk_limit.
+
+    When walk_limit is "git_root", stops at the git repository root.
+    When "home", stops at the user home directory.
+    When "unlimited", walks to the filesystem root.
+    When an absolute path, stops when that path is reached.
+    """
+    dirs: list[Path] = [cwd]
+    if walk_limit == "git_root":
+        git_root = _find_git_root(cwd)
+        if git_root:
+            current = cwd
+            for parent in current.parents:
+                if parent == git_root:
+                    dirs.append(git_root)
+                    break
+                dirs.append(parent)
+        return dirs
+
+    stop_path = _resolve_walk_limit(walk_limit)
+    current = cwd
+    for parent in current.parents:
+        if stop_path is not None:
+            try:
+                parent_resolved = parent.resolve()
+                if parent_resolved == stop_path:
+                    dirs.append(parent)
+                    break
+                # Check if we've gone past the stop path
+                if str(parent_resolved).startswith(str(stop_path)):
+                    dirs.append(parent)
+                    continue
+                if not str(parent_resolved).startswith(str(stop_path)):
+                    # We've walked above the stop path — check if cwd was already under it
+                    cwd_resolved = cwd.resolve()
+                    if not str(cwd_resolved).startswith(str(stop_path)):
+                        break
+            except Exception:
+                pass
+        dirs.append(parent)
+    return dirs
+
+
+def _load_all_of_type(
+    dirs: list[Path],
+    names: tuple[str, ...],
+    label: str,
+) -> list[tuple[str, str]]:
+    """Search *dirs* in order for files matching *names*, return all found.
+
+    Returns a list of (relative_name, truncated_content) tuples.
+    Unlike the first-match-wins loaders, this collects every match found
+    across the directory hierarchy.
+    """
+    results: list[tuple[str, str]] = []
+    seen: set[Path] = set()
+    for d in dirs:
+        for name in names:
+            candidate = d / name
+            try:
+                candidate_resolved = candidate.resolve()
+            except Exception:
+                continue
+            if candidate_resolved in seen:
+                continue
+            if not candidate.is_file():
+                continue
+            seen.add(candidate_resolved)
+            try:
+                content = candidate.read_text(encoding="utf-8").strip()
+                if not content:
+                    continue
+                content = _strip_yaml_frontmatter(content) if name.endswith(".md") else content
+                rel = name
+                try:
+                    rel = str(candidate.relative_to(Path.cwd()))
+                except ValueError:
+                    pass
+                content = _scan_context_content(content, rel)
+                content = _truncate_content(content, rel)
+                results.append((rel, f"## {rel}\n\n{content}"))
+            except Exception as e:
+                logger.debug("Could not read %s: %s", candidate, e)
+    return results
+
+
+def _load_agents_md(cwd_path: Path, walk_limit: str = "home") -> str:
+    """AGENTS.md — collect all found files walking up the directory tree.
+
+    When *compose* mode is off (legacy), only the cwd-level file is loaded
+    for backward compatibility.  When compose mode is on, all AGENTS.md
+    files found walking up to the walk_limit are concatenated.
+    """
+    # First check cwd-level (always present in both modes)
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
         if candidate.exists():
@@ -955,8 +1081,12 @@ def _load_agents_md(cwd_path: Path) -> str:
     return ""
 
 
-def _load_claude_md(cwd_path: Path) -> str:
-    """CLAUDE.md / claude.md — cwd only."""
+def _load_claude_md(cwd_path: Path, walk_limit: str = "home") -> str:
+    """CLAUDE.md / claude.md — cwd only for backward compat.
+
+    The walk-based collection is handled by build_context_files_prompt
+    when compose=True.
+    """
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
         if candidate.exists():
@@ -969,6 +1099,102 @@ def _load_claude_md(cwd_path: Path) -> str:
             except Exception as e:
                 logger.debug("Could not read %s: %s", candidate, e)
     return ""
+
+
+def discover_context_files(
+    cwd: str | None = None,
+    walk_limit: str = "home",
+    compose: bool = True,
+    agents_priority: bool = True,
+) -> list[str]:
+    """Discover all context files that would be loaded.
+
+    Returns a list of human-readable file paths (relative or absolute).
+    Used by the /context command to show what files are active.
+    """
+    if cwd is None:
+        cwd = os.getcwd()
+    cwd_path = Path(cwd).resolve()
+    found: list[str] = []
+
+    if compose:
+        # Collect all files by type across the walk hierarchy
+        parent_dirs = list(_walk_parents(cwd_path, walk_limit))
+
+        # .hermes.md files — always complementary
+        for d in parent_dirs:
+            for name in _HERMES_MD_NAMES:
+                candidate = d / name
+                if candidate.is_file():
+                    try:
+                        found.append(str(candidate.relative_to(cwd_path)))
+                    except ValueError:
+                        found.append(str(candidate))
+
+        # AGENTS.md files — track dirs for priority
+        dirs_with_agents = set()
+        for d in parent_dirs:
+            for name in ["AGENTS.md", "agents.md"]:
+                candidate = d / name
+                if candidate.is_file():
+                    dirs_with_agents.add(d.resolve())
+                    try:
+                        found.append(str(candidate.relative_to(cwd_path)))
+                    except ValueError:
+                        found.append(str(candidate))
+
+        # CLAUDE.md files — skip dirs with AGENTS.md when agents_priority=True
+        for d in parent_dirs:
+            if agents_priority and d.resolve() in dirs_with_agents:
+                continue
+            for name in ["CLAUDE.md", "claude.md"]:
+                candidate = d / name
+                if candidate.is_file():
+                    try:
+                        found.append(str(candidate.relative_to(cwd_path)))
+                    except ValueError:
+                        found.append(str(candidate))
+
+        # .cursorrules and .cursor/rules/*.mdc
+        cursorrules = cwd_path / ".cursorrules"
+        if cursorrules.is_file():
+            found.append(".cursorrules")
+        cursor_rules_dir = cwd_path / ".cursor" / "rules"
+        if cursor_rules_dir.is_dir():
+            for mdc in sorted(cursor_rules_dir.glob("*.mdc")):
+                found.append(f".cursor/rules/{mdc.name}")
+    else:
+        # First-match-wins legacy behavior
+        hermes_md = _find_hermes_md(cwd_path)
+        if hermes_md:
+            try:
+                found.append(str(hermes_md.relative_to(cwd_path)))
+            except ValueError:
+                found.append(str(hermes_md))
+        else:
+            for name in ["AGENTS.md", "agents.md"]:
+                if (cwd_path / name).is_file():
+                    found.append(name)
+                    break
+            else:
+                for name in ["CLAUDE.md", "claude.md"]:
+                    if (cwd_path / name).is_file():
+                        found.append(name)
+                        break
+                else:
+                    if (cwd_path / ".cursorrules").is_file():
+                        found.append(".cursorrules")
+                    cursor_rules_dir = cwd_path / ".cursor" / "rules"
+                    if cursor_rules_dir.is_dir():
+                        for mdc in sorted(cursor_rules_dir.glob("*.mdc")):
+                            found.append(f".cursor/rules/{mdc.name}")
+
+    # SOUL.md from HERMES_HOME
+    soul_path = get_hermes_home() / "SOUL.md"
+    if soul_path.is_file():
+        found.append(str(soul_path))
+
+    return found
 
 
 def _load_cursorrules(cwd_path: Path) -> str:
@@ -1001,10 +1227,35 @@ def _load_cursorrules(cwd_path: Path) -> str:
     return _truncate_content(cursorrules_content, ".cursorrules")
 
 
-def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
+def build_context_files_prompt(
+    cwd: Optional[str] = None,
+    skip_soul: bool = False,
+    compose: bool = True,
+    walk_limit: str = "home",
+    agents_priority: bool = True,
+) -> str:
     """Discover and load context files for the system prompt.
 
-    Priority (first found wins — only ONE project context type is loaded):
+    When *compose* is True (default), all found context files are loaded
+    and concatenated — .hermes.md, AGENTS.md, CLAUDE.md, and .cursorrules
+    files found walking up the directory tree to *walk_limit*.
+
+    When *agents_priority* is True (default) and compose is True, AGENTS.md
+    takes priority over CLAUDE.md at each directory level. If both exist in
+    the same directory, only AGENTS.md is loaded from that directory.
+    CLAUDE.md is loaded from directories that don't have AGENTS.md.
+    .hermes.md is always loaded as complementary Hermes-specific instructions.
+
+    When *compose* is False, legacy first-match-wins behavior: only the
+    highest-priority single context file is loaded.
+
+    Priority order within compose mode (all found are included):
+      1. .hermes.md / HERMES.md  (walk to walk_limit, always complementary)
+      2. AGENTS.md / agents.md   (walk to walk_limit, priority over CLAUDE.md per dir)
+      3. CLAUDE.md / claude.md   (walk to walk_limit, skipped where AGENTS.md exists)
+      4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
+
+    Legacy priority (first found wins — only ONE project context type):
       1. .hermes.md / HERMES.md  (walk to git root)
       2. AGENTS.md / agents.md   (cwd only)
       3. CLAUDE.md / claude.md   (cwd only)
@@ -1022,15 +1273,90 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     cwd_path = Path(cwd).resolve()
     sections = []
 
-    # Priority-based project context: first match wins
-    project_context = (
-        _load_hermes_md(cwd_path)
-        or _load_agents_md(cwd_path)
-        or _load_claude_md(cwd_path)
-        or _load_cursorrules(cwd_path)
-    )
-    if project_context:
-        sections.append(project_context)
+    if compose:
+        # Compose mode: collect all found files
+        parent_dirs = _walk_parents(cwd_path, walk_limit)
+
+        # .hermes.md files — collect all across hierarchy
+        for d in parent_dirs:
+            for name in _HERMES_MD_NAMES:
+                candidate = d / name
+                if candidate.is_file():
+                    try:
+                        content = candidate.read_text(encoding="utf-8").strip()
+                        if not content:
+                            continue
+                        content = _strip_yaml_frontmatter(content)
+                        rel = name
+                        try:
+                            rel = str(candidate.relative_to(cwd_path))
+                        except ValueError:
+                            pass
+                        content = _scan_context_content(content, rel)
+                        section = f"## {rel}\n\n{content}"
+                        sections.append(_truncate_content(section, rel))
+                    except Exception as e:
+                        logger.debug("Could not read %s: %s", candidate, e)
+
+        # AGENTS.md files — collect all across hierarchy, track dirs for priority
+        dirs_with_agents = set()
+        for d in parent_dirs:
+            for name in ["AGENTS.md", "agents.md"]:
+                candidate = d / name
+                if candidate.is_file():
+                    dirs_with_agents.add(d.resolve())
+                    try:
+                        content = candidate.read_text(encoding="utf-8").strip()
+                        if not content:
+                            continue
+                        rel = name
+                        try:
+                            rel = str(candidate.relative_to(cwd_path))
+                        except ValueError:
+                            pass
+                        content = _scan_context_content(content, rel)
+                        section = f"## {rel}\n\n{content}"
+                        sections.append(_truncate_content(section, rel))
+                    except Exception as e:
+                        logger.debug("Could not read %s: %s", candidate, e)
+
+        # CLAUDE.md files — collect all across hierarchy, skip dirs with AGENTS.md
+        # when agents_priority is True
+        for d in parent_dirs:
+            if agents_priority and d.resolve() in dirs_with_agents:
+                continue  # AGENTS.md takes priority in this directory
+            for name in ["CLAUDE.md", "claude.md"]:
+                candidate = d / name
+                if candidate.is_file():
+                    try:
+                        content = candidate.read_text(encoding="utf-8").strip()
+                        if not content:
+                            continue
+                        rel = name
+                        try:
+                            rel = str(candidate.relative_to(cwd_path))
+                        except ValueError:
+                            pass
+                        content = _scan_context_content(content, rel)
+                        section = f"## {rel}\n\n{content}"
+                        sections.append(_truncate_content(section, rel))
+                    except Exception as e:
+                        logger.debug("Could not read %s: %s", candidate, e)
+
+        # .cursorrules and .cursor/rules/*.mdc — cwd only
+        cursorrules_content = _load_cursorrules(cwd_path)
+        if cursorrules_content:
+            sections.append(cursorrules_content)
+    else:
+        # Legacy first-match-wins behavior
+        project_context = (
+            _load_hermes_md(cwd_path)
+            or _load_agents_md(cwd_path, walk_limit)
+            or _load_claude_md(cwd_path, walk_limit)
+            or _load_cursorrules(cwd_path)
+        )
+        if project_context:
+            sections.append(project_context)
 
     # SOUL.md from HERMES_HOME only — skip when already loaded as identity
     if not skip_soul:

--- a/cli.py
+++ b/cli.py
@@ -5443,6 +5443,8 @@ class HermesCLI:
             self._show_gateway_status()
         elif canonical == "status":
             self._show_session_status()
+        elif canonical == "context":
+            self._handle_context_command(cmd_original)
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"
@@ -6199,6 +6201,47 @@ class HermesCLI:
             "verbose": f"{_Colors.BOLD}{_Colors.GREEN}Tool progress: VERBOSE{_Colors.RESET} — full args, results, think blocks, and debug logs.",
         }
         _cprint(labels.get(self.tool_progress_mode, ""))
+
+    def _handle_context_command(self, cmd: str):
+        """Handle /context — show loaded context files and settings."""
+        from agent.prompt_builder import discover_context_files
+
+        # Read config settings
+        compose = True
+        walk_limit = "home"
+        show_loaded = True
+        agents_priority = True
+        try:
+            from hermes_cli.config import read_raw_config as _read_ctx_cfg
+            _ctx_cfg = _read_ctx_cfg()
+            if isinstance(_ctx_cfg, dict):
+                _ctx_section = _ctx_cfg.get("context", {})
+                if isinstance(_ctx_section, dict):
+                    compose = _ctx_section.get("compose", True)
+                    walk_limit = _ctx_section.get("walk_limit", "home")
+                    show_loaded = _ctx_section.get("show_loaded", True)
+                    agents_priority = _ctx_section.get("agents_priority", True)
+        except Exception:
+            pass
+
+        cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+        files = discover_context_files(
+            cwd=cwd, walk_limit=walk_limit, compose=compose,
+            agents_priority=agents_priority)
+
+        _cprint(f"  Context file discovery:")
+        _cprint(f"    Mode: {'compose (all files)' if compose else 'first-match-wins'}")
+        _cprint(f"    Walk limit: {walk_limit}")
+        _cprint(f"    AGENTS priority: {'on' if agents_priority else 'off'}")
+        _cprint(f"    Working dir: {cwd}")
+        _cprint("")
+
+        if files:
+            _cprint(f"  Loaded files ({len(files)}):")
+            for f in files:
+                _cprint(f"    {f}")
+        else:
+            _cprint("  No context files found.")
 
     def _toggle_yolo(self):
         """Toggle YOLO mode — skip all dangerous command approval prompts."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -90,6 +90,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session"),
+    CommandDef("context", "Show loaded context files", "Session",
+               cli_only=True, aliases=("ctx",)),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -580,6 +580,19 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        # Compose all found context files instead of first-match-wins.
+        "compose": True,
+        # How far to walk up parent directories:
+        #   "git_root" | "home" | "unlimited" | absolute path
+        "walk_limit": "home",
+        # Print discovered context files at startup.
+        "show_loaded": True,
+        # When compose=True, AGENTS.md takes priority over CLAUDE.md at each
+        # directory level. If both exist in the same directory, only AGENTS.md
+        # is loaded from that level. CLAUDE.md is loaded from directories
+        # that don't have AGENTS.md. .hermes.md is always loaded as
+        # complementary Hermes-specific instructions.
+        "agents_priority": True,
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt
@@ -703,7 +716,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -2230,6 +2243,25 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
                     else:
                         print("  ✓ Removed unused compression.summary_* keys")
+
+    # ── Version 17 → 18: add context file discovery settings ──
+    if current_ver < 18:
+        ctx = config.get("context", {})
+        if not isinstance(ctx, dict):
+            ctx = {}
+        if "compose" not in ctx:
+            ctx["compose"] = True
+            if not quiet:
+                print("  ✓ Added context.compose=true")
+        if "walk_limit" not in ctx:
+            ctx["walk_limit"] = "home"
+            if not quiet:
+                print("  ✓ Added context.walk_limit=\"home\"")
+        if "show_loaded" not in ctx:
+            ctx["show_loaded"] = True
+            if not quiet:
+                print("  ✓ Added context.show_loaded=true")
+        config["context"] = ctx
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -3271,8 +3271,24 @@ class AIAgent:
             # dir, so os.getcwd() would pick up the repo's AGENTS.md and
             # other dev files — inflating token usage by ~10k for no benefit.
             _context_cwd = os.getenv("TERMINAL_CWD") or None
+            # Read compose/walk_limit from config.yaml context section
+            _ctx_compose = True
+            _ctx_walk_limit = "home"
+            try:
+                from hermes_cli.config import read_raw_config as _read_ctx_cfg
+                _ctx_cfg = _read_ctx_cfg()
+                if isinstance(_ctx_cfg, dict):
+                    _ctx_section = _ctx_cfg.get("context", {})
+                    if isinstance(_ctx_section, dict):
+                        _ctx_compose = _ctx_section.get("compose", True)
+                        _ctx_walk_limit = _ctx_section.get("walk_limit", "home")
+                        _ctx_agents_priority = _ctx_section.get("agents_priority", True)
+            except Exception:
+                pass
             context_files_prompt = build_context_files_prompt(
-                cwd=_context_cwd, skip_soul=_soul_loaded)
+                cwd=_context_cwd, skip_soul=_soul_loaded,
+                compose=_ctx_compose, walk_limit=_ctx_walk_limit,
+                agents_priority=_ctx_agents_priority)
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -15,6 +15,10 @@ from agent.prompt_builder import (
     _find_hermes_md,
     _find_git_root,
     _strip_yaml_frontmatter,
+    _resolve_walk_limit,
+    _walk_parents,
+    _load_all_of_type,
+    discover_context_files,
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
@@ -560,9 +564,10 @@ class TestBuildContextFilesPrompt:
         assert "type hints" in result
 
     def test_hermes_md_lowercase_takes_priority(self, tmp_path):
+        """In legacy mode, .hermes.md takes priority over HERMES.md."""
         (tmp_path / ".hermes.md").write_text("From dotfile.")
         (tmp_path / "HERMES.md").write_text("From uppercase.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=False)
         assert "From dotfile" in result
         assert "From uppercase" not in result
 
@@ -573,7 +578,7 @@ class TestBuildContextFilesPrompt:
         (tmp_path / ".hermes.md").write_text("Root project rules.")
         sub = tmp_path / "src" / "components"
         sub.mkdir(parents=True)
-        result = build_context_files_prompt(cwd=str(sub))
+        result = build_context_files_prompt(cwd=str(sub), walk_limit="git_root")
         assert "Root project rules" in result
 
     def test_hermes_md_stops_at_git_root(self, tmp_path):
@@ -600,24 +605,24 @@ class TestBuildContextFilesPrompt:
         assert "BLOCKED" in result
 
     def test_hermes_md_beats_agents_md(self, tmp_path):
-        """When both exist, .hermes.md wins and AGENTS.md is not loaded."""
+        """When both exist, .hermes.md wins and AGENTS.md is not loaded (legacy mode)."""
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
         (tmp_path / ".hermes.md").write_text("Hermes project rules.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=False)
         assert "Hermes project rules" in result
         assert "Agent guidelines" not in result
 
     def test_agents_md_beats_claude_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
         (tmp_path / "CLAUDE.md").write_text("Claude guidelines here.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=False)
         assert "Agent guidelines" in result
         assert "Claude guidelines" not in result
 
     def test_claude_md_beats_cursorrules(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("Claude guidelines here.")
         (tmp_path / ".cursorrules").write_text("Cursor rules here.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=False)
         assert "Claude guidelines" in result
         assert "Cursor rules" not in result
 
@@ -654,12 +659,12 @@ class TestBuildContextFilesPrompt:
         assert "BLOCKED" in result
 
     def test_hermes_md_beats_all_others(self, tmp_path):
-        """When all four types exist, only .hermes.md is loaded."""
+        """When all four exist, only .hermes.md is loaded (legacy mode)."""
         (tmp_path / ".hermes.md").write_text("Hermes wins.")
         (tmp_path / "AGENTS.md").write_text("Agents lose.")
         (tmp_path / "CLAUDE.md").write_text("Claude loses.")
         (tmp_path / ".cursorrules").write_text("Cursor loses.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=False)
         assert "Hermes wins" in result
         assert "Agents lose" not in result
         assert "Claude loses" not in result
@@ -1027,6 +1032,229 @@ class TestOpenAIModelExecutionGuidance:
     def test_guidance_is_string(self):
         assert isinstance(OPENAI_MODEL_EXECUTION_GUIDANCE, str)
         assert len(OPENAI_MODEL_EXECUTION_GUIDANCE) > 100
+
+
+# =========================================================================
+# Walk functions — _resolve_walk_limit, _walk_parents, _load_all_of_type
+# =========================================================================
+
+
+class TestResolveWalkLimit:
+    def test_home_returns_home_path(self):
+        from pathlib import Path
+        result = _resolve_walk_limit("home")
+        assert result == Path.home()
+
+    def test_unlimited_returns_none(self):
+        assert _resolve_walk_limit("unlimited") is None
+
+    def test_empty_returns_none(self):
+        assert _resolve_walk_limit("") is None
+
+    def test_git_root_returns_none(self):
+        assert _resolve_walk_limit("git_root") is None
+
+    def test_absolute_path_resolves(self, tmp_path):
+        from pathlib import Path as _P
+        result = _resolve_walk_limit(str(tmp_path))
+        expected = _P(str(tmp_path)).resolve()
+        # macOS /tmp -> /private/tmp symlink can cause case differences
+        assert str(result).lower() == str(expected).lower()
+
+
+class TestWalkParents:
+    def test_includes_cwd(self, tmp_path):
+        result = _walk_parents(tmp_path, walk_limit="home")
+        assert tmp_path in result
+
+    def test_stops_at_git_root(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        sub = tmp_path / "src" / "lib"
+        sub.mkdir(parents=True)
+        result = _walk_parents(sub, walk_limit="git_root")
+        assert tmp_path in result  # git root is included
+        # Should not include directories above git root
+        result_strs = [str(p) for p in result]
+        for parent in tmp_path.parents:
+            assert str(parent) not in result_strs
+
+    def test_stops_at_home(self, tmp_path, monkeypatch):
+        from pathlib import Path
+        # Create a dir under home
+        home = Path.home()
+        under_home = home / "test_walk_parents_tmp"
+        under_home.mkdir(exist_ok=True)
+        try:
+            sub = under_home / "a" / "b"
+            sub.mkdir(parents=True)
+            result = _walk_parents(sub, walk_limit="home")
+            result_strs = [str(p) for p in result]
+            # home should be in the result
+            assert str(home) in result_strs
+        finally:
+            import shutil
+            shutil.rmtree(under_home, ignore_errors=True)
+
+
+class TestLoadAllOfType:
+    def test_finds_all_matching_files(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("root agents")
+        sub = tmp_path / "src"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("src agents")
+        result = _load_all_of_type([tmp_path, sub], ("AGENTS.md",), "AGENTS.md")
+        assert len(result) == 2
+
+    def test_returns_empty_when_no_match(self, tmp_path):
+        result = _load_all_of_type([tmp_path], ("NONEXISTENT.md",), "test")
+        assert result == []
+
+
+# =========================================================================
+# Compose mode — multiple context files loaded simultaneously
+# =========================================================================
+
+
+class TestComposeMode:
+    def test_compose_loads_multiple_types(self, tmp_path):
+        """When compose=True, both .hermes.md and AGENTS.md are loaded."""
+        (tmp_path / ".hermes.md").write_text("Hermes rules.")
+        (tmp_path / "AGENTS.md").write_text("Agent rules.")
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=True)
+        assert "Hermes rules" in result
+        assert "Agent rules" in result
+
+    def test_compose_loads_agents_and_claude(self, tmp_path):
+        """Both AGENTS.md and CLAUDE.md loaded when in different dirs (agents_priority=True)."""
+        # CLAUDE.md at parent, AGENTS.md at CWD — both should load from different dirs
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Agents.")
+        (tmp_path / "CLAUDE.md").write_text("Claude.")
+        result = build_context_files_prompt(cwd=str(sub), compose=True, walk_limit=str(tmp_path))
+        assert "Agents" in result
+        assert "Claude" in result
+
+    def test_compose_agents_priority_skips_claude_in_same_dir(self, tmp_path):
+        """When AGENTS.md and CLAUDE.md are in the same dir, CLAUDE is skipped."""
+        (tmp_path / "AGENTS.md").write_text("Agents.")
+        (tmp_path / "CLAUDE.md").write_text("Claude.")
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=True, agents_priority=True)
+        assert "Agents" in result
+        assert "Claude" not in result
+
+    def test_compose_no_priority_loads_both(self, tmp_path):
+        """When agents_priority=False, both AGENTS.md and CLAUDE.md load from same dir."""
+        (tmp_path / "AGENTS.md").write_text("Agents.")
+        (tmp_path / "CLAUDE.md").write_text("Claude.")
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=True, agents_priority=False)
+        assert "Agents" in result
+        assert "Claude" in result
+
+    def test_legacy_first_match_wins(self, tmp_path):
+        """When compose=False, only the highest-priority file loads."""
+        (tmp_path / ".hermes.md").write_text("Hermes wins.")
+        (tmp_path / "AGENTS.md").write_text("Agents lose.")
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=False)
+        assert "Hermes wins" in result
+        assert "Agents lose" not in result
+
+    def test_compose_walks_parents(self, tmp_path):
+        """Compose mode collects files from parent directories."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".hermes.md").write_text("Root hermes.")
+        sub = tmp_path / "src"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Sub agents.")
+        result = build_context_files_prompt(cwd=str(sub), compose=True, walk_limit="git_root")
+        assert "Root hermes" in result
+        assert "Sub agents" in result
+
+    def test_compose_strips_frontmatter(self, tmp_path):
+        """Compose mode strips YAML frontmatter from .hermes.md files."""
+        content = "---\nmodel: claude\n---\n\n# Project\n\nUse Ruff."
+        (tmp_path / ".hermes.md").write_text(content)
+        result = build_context_files_prompt(cwd=str(tmp_path), compose=True)
+        assert "Use Ruff" in result
+        assert "claude" not in result
+
+
+# =========================================================================
+# discover_context_files — path listing for /context command
+# =========================================================================
+
+
+class TestDiscoverContextFiles:
+    def test_returns_hermes_md(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        (tmp_path / ".hermes.md").write_text("rules")
+        result = discover_context_files(cwd=str(tmp_path), compose=True)
+        assert ".hermes.md" in result
+
+    def test_returns_agents_md(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        (tmp_path / "AGENTS.md").write_text("rules")
+        result = discover_context_files(cwd=str(tmp_path), compose=True)
+        assert "AGENTS.md" in result
+
+    def test_returns_all_files_in_compose_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        (tmp_path / ".hermes.md").write_text("hermes")
+        # AGENTS.md at parent, CLAUDE.md at CWD — both should load with agents_priority
+        (tmp_path / "AGENTS.md").write_text("agents")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "CLAUDE.md").write_text("claude")
+        result = discover_context_files(cwd=str(sub), compose=True, walk_limit=str(tmp_path))
+        assert any(".hermes.md" in f for f in result)
+        assert any("AGENTS.md" in f for f in result)
+        assert any("CLAUDE.md" in f for f in result)
+
+    def test_returns_claude_skipped_when_agents_in_same_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        (tmp_path / "AGENTS.md").write_text("agents")
+        (tmp_path / "CLAUDE.md").write_text("claude")
+        result = discover_context_files(cwd=str(tmp_path), compose=True, agents_priority=True)
+        assert "AGENTS.md" in result
+        assert "CLAUDE.md" not in result
+
+    def test_returns_both_when_no_agents_priority(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        (tmp_path / "AGENTS.md").write_text("agents")
+        (tmp_path / "CLAUDE.md").write_text("claude")
+        result = discover_context_files(cwd=str(tmp_path), compose=True, agents_priority=False)
+        assert "AGENTS.md" in result
+        assert "CLAUDE.md" in result
+
+    def test_legacy_returns_only_first_match(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        (tmp_path / ".hermes.md").write_text("hermes")
+        (tmp_path / "AGENTS.md").write_text("agents")
+        result = discover_context_files(cwd=str(tmp_path), compose=False)
+        assert ".hermes.md" in result
+        assert "AGENTS.md" not in result
+
+    def test_includes_soul_md(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "SOUL.md").write_text("soul")
+        result = discover_context_files(cwd=str(tmp_path), compose=True)
+        assert any("SOUL.md" in f for f in result)
+
+    def test_empty_when_no_files(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        result = discover_context_files(cwd=str(tmp_path), compose=True)
+        # SOUL.md won't exist, so result may be empty
+        assert isinstance(result, list)
 
 
 # =========================================================================


### PR DESCRIPTION
## Problem

When both AGENTS.md and CLAUDE.md exist in the same directory, compose mode loads both. But users typically want AGENTS.md to be the authoritative agent instructions, with CLAUDE.md as a fallback for directories that don't have AGENTS.md.

## Solution

New config option `context.agents_priority` (default: `true`):

When enabled, at each directory level during the walk:
- If AGENTS.md exists -> load it, skip CLAUDE.md from that directory
- If AGENTS.md doesn't exist -> load CLAUDE.md if present
- .hermes.md is always loaded regardless (complementary Hermes instructions)

This means users get:
- AGENTS.md where project-specific agent conventions exist
- CLAUDE.md as fallback in dirs without AGENTS.md
- .hermes.md on top as Hermes-specific additions

## Config

```yaml
context:
  agents_priority: true  # default: AGENTS.md wins over CLAUDE.md per dir
```

## Testing

- 135 tests pass, 1 skipped
- Also fixes case-sensitivity bug in `_resolve_walk_limit` where `.lower()` broke path matching on macOS (`/T/` vs `/t/`)