### PR TITLE
fix: install.sh fails on macOS due to unquoted spaces in Python path

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -255,7 +255,7 @@ check_python() {
         if command -v python >/dev/null 2>&1; then
             PYTHON_PATH="$(command -v python)"
             if "$PYTHON_PATH" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
-                PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+                PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
                 log_success "Python found: $PYTHON_FOUND_VERSION"
                 return 0
             fi
@@ -264,7 +264,7 @@ check_python() {
         log_info "Installing Python via pkg..."
         pkg install -y python >/dev/null
         PYTHON_PATH="$(command -v python)"
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python installed: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -275,7 +275,7 @@ check_python() {
     # First check if a suitable Python is already available
     if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -284,7 +284,7 @@ check_python() {
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
     if $UV_CMD python install "$PYTHON_VERSION"; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python installed: $PYTHON_FOUND_VERSION"
     else
         log_error "Failed to install Python $PYTHON_VERSION"


### PR DESCRIPTION
## Summary
The install.sh script exits prematurely on macOS when the Python interpreter path contains spaces.

## Root Cause
PYTHON_PATH variable was not quoted when used in command substitutions.

## Fix
Quote all PYTHON_PATH expansions in check_python() function.

## Test Plan
- [x] Script handles Python paths with spaces correctly

Closes NousResearch/hermes-agent#10009