### PR TITLE
fix(gateway): recognize Windows absolute media paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1213,7 +1213,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/|[A-Za-z]:[\\/])\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -1255,9 +1255,10 @@ class BasePlatformAdapter(ABC):
 
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)
-        # (?:~/|/)    anchors to absolute or home-relative paths
+        # (?:~/|/|[A-Za-z]:[\\/]) anchors to Unix absolute, home-relative,
+        #                         or Windows drive-absolute paths
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.])(?:~/|/|[A-Za-z]:[\\/])(?:[\w.\-]+[\\/])*[\w.\-]+\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -104,6 +104,25 @@ class TestBasicDetection:
         paths, _ = _extract("File at /tmp/my-screenshot-2024.png done")
         assert paths == ["/tmp/my-screenshot-2024.png"]
 
+    def test_windows_absolute_paths(self):
+        text = (
+            r"Screenshot at C:\Users\Simba\Pictures\shot.png "
+            r"and clip at D:/Media/clip.mp4"
+        )
+        paths, cleaned = _extract(
+            text,
+            existing_files={
+                r"C:\Users\Simba\Pictures\shot.png",
+                "D:/Media/clip.mp4",
+            },
+        )
+        assert paths == [
+            r"C:\Users\Simba\Pictures\shot.png",
+            "D:/Media/clip.mp4",
+        ]
+        assert r"C:\Users\Simba\Pictures\shot.png" not in cleaned
+        assert "D:/Media/clip.mp4" not in cleaned
+
 
 # ---------------------------------------------------------------------------
 # Non-existent files are skipped
@@ -278,10 +297,14 @@ class TestEdgeCases:
         paths, _ = _extract("File at /tmp/my file.png here")
         assert paths == []
 
-    def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
-        paths, _ = _extract("See C:\\Users\\test\\image.png")
-        assert paths == []
+    def test_windows_path_matched(self):
+        """Windows-style absolute paths should be matched."""
+        paths, cleaned = _extract(
+            r"See C:\Users\test\image.png",
+            existing_files={r"C:\Users\test\image.png"},
+        )
+        assert paths == [r"C:\Users\test\image.png"]
+        assert r"C:\Users\test\image.png" not in cleaned
 
     def test_relative_path_not_matched(self):
         """Relative paths like ./image.png should not match."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -321,6 +321,18 @@ class TestExtractMedia:
         assert "Here" in cleaned
         assert "After" in cleaned
 
+    def test_media_tag_supports_windows_absolute_paths(self):
+        content = (
+            "MEDIA:C:/Users/Simba/Pictures/shot.png\n"
+            r"MEDIA:C:\Users\Simba\Music\voice.ogg"
+        )
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("C:/Users/Simba/Pictures/shot.png", False),
+            (r"C:\Users\Simba\Music\voice.ogg", False),
+        ]
+        assert cleaned == ""
+
 
 # ---------------------------------------------------------------------------
 # truncate_message


### PR DESCRIPTION
## Summary

Fix gateway media extraction so native media delivery also works with Windows absolute paths.

Before this change, the shared gateway extractors only recognized Unix-style absolute paths (`/...`) and home-relative paths (`~/...`). That meant Windows responses like `MEDIA:C:\Users\...\shot.png` or bare local paths like `C:\Users\...\clip.mp4` were left in the visible assistant text instead of being routed through native image/audio/video delivery.

## Problem

Hermes already supports native media delivery across gateway platforms, but the shared regexes in `gateway/platforms/base.py` were biased toward Unix path formats.

This caused two Windows-specific failures:

1. `MEDIA:` directives with Windows absolute paths were not extracted.
2. Bare Windows local media paths were not detected for native delivery.

User-visible effect:
- generated screenshots/audio/video on Windows could show up as plain text paths in chat
- native media upload/send behavior would be skipped for those outputs

## What changed

Updated the shared gateway path extractors in `gateway/platforms/base.py` to recognize Windows drive-absolute paths in addition to existing Unix-style paths.

Specifically:
- `extract_media()` now accepts `C:/...` and `C:\...` paths in `MEDIA:` directives
- `extract_local_files()` now detects Windows drive-absolute local image/video paths for native media delivery

The change is intentionally narrow and only touches the shared extractor logic plus focused regression tests.

## Tests

Added/updated regression coverage for:
- Windows `MEDIA:` extraction
- Windows bare local-file detection
- prior edge-case expectations that explicitly rejected Windows paths

Validated with:

- `uv run --extra dev python -m pytest tests/gateway/test_platform_base.py tests/gateway/test_extract_local_files.py -q`
  - `115 passed`
- `uv run --extra dev python -m pytest tests/gateway/test_send_image_file.py -q`
  - `23 passed`


## Why this is safe

- no architecture changes
- no tool/prompt/session behavior changes
- shared extractor behavior is extended, not rewritten
- covered by focused regression tests at the exact parsing layer that was broken

## Files changed

- `gateway/platforms/base.py`
- `tests/gateway/test_platform_base.py`
- `tests/gateway/test_extract_local_files.py`
