### PR TITLE
fix: extract tool calls from reasoning/thinking blocks (GLM-5.x, Qwen3.5)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -39,6 +39,105 @@ from utils import base_url_host_matches, base_url_hostname, env_int
 logger = logging.getLogger(__name__)
 
 
+def extract_tool_calls_from_reasoning(
+    reasoning_text: str,
+    valid_tool_names: set | None = None,
+) -> list:
+    """Extract tool calls embedded inside reasoning/thinking content.
+
+    Some models (notably GLM-5.x and Qwen3.5 variants) emit tool calls inside
+    ``reasoning_content`` / ``<thinking>`` blocks instead of the standard
+    ``delta.tool_calls`` stream field.  Scan common JSON/XML shapes and return
+    OpenAI-compatible tool-call dictionaries that the agent loop can execute.
+    """
+    if not reasoning_text or not str(reasoning_text).strip():
+        return []
+
+    results = []
+    seen_ids = set()
+    call_counter = 0
+
+    def _append(tool_name: str, args_str: str) -> None:
+        nonlocal call_counter
+        if not tool_name:
+            return
+        if valid_tool_names and tool_name not in valid_tool_names:
+            return
+        call_id = f"reasoning_tc_{call_counter}"
+        call_counter += 1
+        if call_id in seen_ids:
+            return
+        seen_ids.add(call_id)
+        results.append({
+            "id": call_id,
+            "type": "function",
+            "function": {"name": tool_name, "arguments": args_str},
+        })
+
+    json_pattern = re.compile(
+        r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"'
+        r'(?:arguments|parameters)'
+        r'"\s*:\s*(\{[^}]*\})'
+        r'\s*\}',
+        re.DOTALL,
+    )
+    for match in json_pattern.finditer(reasoning_text):
+        tool_name = match.group(1)
+        args_str = match.group(2)
+        try:
+            json.loads(args_str)
+        except json.JSONDecodeError:
+            args_str = json.dumps({"_raw": args_str})
+        _append(tool_name, args_str)
+
+    xml_pattern = re.compile(
+        r'<tool_call[^>]*\bname\s*=\s*"([^"]+)"[^>]*>'
+        r'(.*?)</tool_call\s*>',
+        re.DOTALL | re.IGNORECASE,
+    )
+    for match in xml_pattern.finditer(reasoning_text):
+        tool_name = match.group(1)
+        body = match.group(2).strip()
+        args_str = body if body else "{}"
+        try:
+            args_str = json.dumps(json.loads(args_str))
+        except json.JSONDecodeError:
+            args_str = "{}"
+        _append(tool_name, args_str)
+
+    fc_pattern = re.compile(
+        r'<function_call>\s*(\{.*?\})\s*</function_call\s*>',
+        re.DOTALL | re.IGNORECASE,
+    )
+    for match in fc_pattern.finditer(reasoning_text):
+        body = match.group(1).strip()
+        try:
+            obj = json.loads(body)
+        except json.JSONDecodeError:
+            continue
+        tool_name = obj.get("name", "")
+        args = obj.get("arguments") or obj.get("parameters") or {}
+        _append(tool_name, json.dumps(args))
+
+    if results:
+        unique = []
+        seen = set()
+        for result in results:
+            key = (result["function"]["name"], result["function"]["arguments"])
+            if key in seen:
+                continue
+            seen.add(key)
+            unique.append(result)
+        results = unique
+        logger.info(
+            "Extracted %d tool call(s) from reasoning content (names: %s)",
+            len(results),
+            [r["function"]["name"] for r in results],
+        )
+
+    return results
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -1972,6 +2071,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     ),
                 ))
 
+        full_reasoning = "".join(reasoning_parts) or None
+        if not mock_tool_calls and full_reasoning:
+            recovered = extract_tool_calls_from_reasoning(
+                full_reasoning,
+                valid_tool_names=getattr(agent, "valid_tool_names", None) or None,
+            )
+            if recovered:
+                mock_tool_calls = [
+                    SimpleNamespace(
+                        id=tc["id"],
+                        type=tc["type"],
+                        extra_content=None,
+                        function=SimpleNamespace(
+                            name=tc["function"]["name"],
+                            arguments=tc["function"]["arguments"],
+                        ),
+                    )
+                    for tc in recovered
+                ]
+                finish_reason = "tool_calls"
+
         # Zero-chunk guard: stream yielded nothing usable — a provider/upstream
         # error or malformed SSE, not a legitimate empty completion. Raise so the
         # retry machinery handles it instead of fabricating a successful turn.
@@ -1990,7 +2110,6 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         if has_truncated_tool_args:
             effective_finish_reason = "length"
 
-        full_reasoning = "".join(reasoning_parts) or None
         mock_message = SimpleNamespace(
             role=role,
             content=full_content,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1378,6 +1378,15 @@ class AIAgent:
         from agent.agent_runtime_helpers import extract_reasoning
         return extract_reasoning(self, assistant_message)
 
+    def _extract_tool_calls_from_reasoning(
+        self,
+        reasoning_text: str,
+        valid_tool_names: set = None,
+    ) -> list:
+        """Forwarder — see ``agent.chat_completion_helpers.extract_tool_calls_from_reasoning``."""
+        from agent.chat_completion_helpers import extract_tool_calls_from_reasoning
+        return extract_tool_calls_from_reasoning(reasoning_text, valid_tool_names=valid_tool_names)
+
     def _cleanup_task_resources(self, task_id: str) -> None:
         """Forwarder — see ``agent.chat_completion_helpers.cleanup_task_resources``."""
         from agent.chat_completion_helpers import cleanup_task_resources

--- a/run_agent.py
+++ b/run_agent.py
@@ -2125,6 +2125,159 @@ class AIAgent:
         
         return None
 
+    def _extract_tool_calls_from_reasoning(
+        self,
+        reasoning_text: str,
+        valid_tool_names: set = None,
+    ) -> list:
+        """Extract tool calls embedded inside reasoning/thinking content.
+
+        Some models (notably GLM-5.x via Z.AI) emit tool calls inside
+        ``reasoning_content`` or ``<thinking>`` blocks instead of the
+        standard ``delta.tool_calls`` SSE field.  The Hermes streaming
+        parser accumulates reasoning text but never inspects it for tool
+        calls, causing the model's intended tool calls to be silently
+        dropped.
+
+        This method scans reasoning text for tool-call-like patterns and
+        returns a list of dicts matching the internal tool_calls_acc
+        schema::
+
+            {"id": ..., "type": "function", "function": {"name": ..., "arguments": ...}}
+
+        Recognised formats (case-insensitive):
+
+        1. **JSON objects** containing ``"name"`` and ``"arguments"``
+           (or ``"parameters"``) keys — common in GLM-5.x reasoning.
+        2. **XML-style tags** like ``<tool_call name="...">`` or
+           ``<function_call>`` with JSON bodies — common in Qwen
+           thinking blocks.
+
+        Args:
+            reasoning_text: The raw reasoning/thinking content string.
+            valid_tool_names: Set of valid tool names to filter against.
+                If None, all extracted calls are returned.
+
+        Returns:
+            List of tool-call dicts.  Empty list if nothing found.
+        """
+        if not reasoning_text or not reasoning_text.strip():
+            return []
+
+        results = []
+        seen_ids = set()
+        call_counter = 0
+
+        # --- Pattern 1: JSON objects with "name" and "arguments"/"parameters" ---
+        # Matches {"name": "tool_name", "arguments": {...}} and variations.
+        # Use a loose scan: find all top-level {...} that look like tool calls.
+        json_pattern = re.compile(
+            r'\{\s*"name"\s*:\s*"([^"]+)"\s*,\s*"'
+            r'(?:arguments|parameters)'
+            r'"\s*:\s*(\{[^}]*\})'
+            r'\s*\}',
+            re.DOTALL,
+        )
+        for match in json_pattern.finditer(reasoning_text):
+            tool_name = match.group(1)
+            args_str = match.group(2)
+            if valid_tool_names and tool_name not in valid_tool_names:
+                continue
+            call_id = f"reasoning_tc_{call_counter}"
+            call_counter += 1
+            if call_id in seen_ids:
+                continue
+            seen_ids.add(call_id)
+            # Ensure arguments is valid JSON
+            try:
+                json.loads(args_str)
+            except json.JSONDecodeError:
+                # Try wrapping fix — sometimes the inner JSON is truncated
+                args_str = json.dumps({"_raw": args_str})
+            results.append({
+                "id": call_id,
+                "type": "function",
+                "function": {"name": tool_name, "arguments": args_str},
+            })
+
+        # --- Pattern 2: XML-style <tool_call name="..."> with JSON body ---
+        xml_pattern = re.compile(
+            r'<tool_call[^>]*\bname\s*=\s*"([^"]+)"[^>]*>'
+            r'(.*?)</tool_call\s*>',
+            re.DOTALL | re.IGNORECASE,
+        )
+        for match in xml_pattern.finditer(reasoning_text):
+            tool_name = match.group(1)
+            body = match.group(2).strip()
+            if valid_tool_names and tool_name not in valid_tool_names:
+                continue
+            call_id = f"reasoning_tc_{call_counter}"
+            call_counter += 1
+            if call_id in seen_ids:
+                continue
+            seen_ids.add(call_id)
+            # Body might be the arguments JSON directly
+            args_str = body if body else "{}"
+            try:
+                parsed = json.loads(args_str)
+                args_str = json.dumps(parsed)
+            except json.JSONDecodeError:
+                args_str = "{}"
+            results.append({
+                "id": call_id,
+                "type": "function",
+                "function": {"name": tool_name, "arguments": args_str},
+            })
+
+        # --- Pattern 3: <function_call> JSON wrapper ---
+        fc_pattern = re.compile(
+            r'<function_call>\s*(\{.*?\})\s*</function_call\s*>',
+            re.DOTALL | re.IGNORECASE,
+        )
+        for match in fc_pattern.finditer(reasoning_text):
+            body = match.group(1).strip()
+            try:
+                obj = json.loads(body)
+                tool_name = obj.get("name", "")
+                if not tool_name:
+                    continue
+                if valid_tool_names and tool_name not in valid_tool_names:
+                    continue
+                args = obj.get("arguments") or obj.get("parameters") or {}
+                call_id = f"reasoning_tc_{call_counter}"
+                call_counter += 1
+                if call_id in seen_ids:
+                    continue
+                seen_ids.add(call_id)
+                results.append({
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name, "arguments": json.dumps(args)},
+                })
+            except json.JSONDecodeError:
+                continue
+
+        if results:
+            # Deduplicate by (tool_name, arguments) — multiple patterns
+            # can match the same embedded tool call.
+            _seen = set()
+            _unique = []
+            for r in results:
+                _key = (r["function"]["name"], r["function"]["arguments"])
+                if _key not in _seen:
+                    _seen.add(_key)
+                    _unique.append(r)
+            results = _unique
+
+            logger.info(
+                "Extracted %d tool call(s) from reasoning content "
+                "(names: %s) — model emitted tool calls inside thinking block",
+                len(results),
+                [r["function"]["name"] for r in results],
+            )
+
+        return results
+
     def _cleanup_task_resources(self, task_id: str) -> None:
         """Clean up VM and browser resources for a given task.
 
@@ -5289,11 +5442,45 @@ class AIAgent:
                         ),
                     ))
 
+            # --- Reasoning-embedded tool call recovery ---
+            # Some models (GLM-5.x, Qwen3.5) emit tool calls inside
+            # reasoning_content / <thinking> blocks instead of the
+            # standard delta.tool_calls field.  When mock_tool_calls
+            # is empty but reasoning contains tool-call-like structures,
+            # extract and promote them so the agent loop can execute them.
+            full_reasoning = "".join(reasoning_parts) or None
+            if not mock_tool_calls and full_reasoning:
+                _recovered = self._extract_tool_calls_from_reasoning(
+                    full_reasoning,
+                    valid_tool_names=self.valid_tool_names or None,
+                )
+                if _recovered:
+                    mock_tool_calls = []
+                    for tc_dict in _recovered:
+                        mock_tool_calls.append(SimpleNamespace(
+                            id=tc_dict["id"],
+                            type=tc_dict["type"],
+                            extra_content=None,
+                            function=SimpleNamespace(
+                                name=tc_dict["function"]["name"],
+                                arguments=tc_dict["function"]["arguments"],
+                            ),
+                        ))
+                    # Model intended a tool call — override finish_reason
+                    # so the agent loop takes the tool-call branch.
+                    finish_reason = "tool_calls"
+                    self._vprint(
+                        f"{self.log_prefix}🔧 Recovered {len(mock_tool_calls)} tool "
+                        f"call(s) from reasoning content (model emitted inside "
+                        f"thinking block)",
+                        force=True,
+                    )
+
             effective_finish_reason = finish_reason or "stop"
             if has_truncated_tool_args:
                 effective_finish_reason = "length"
 
-            full_reasoning = "".join(reasoning_parts) or None
+            # full_reasoning already set above (reasoning-embedded recovery)
             mock_message = SimpleNamespace(
                 role=role,
                 content=full_content,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -115,6 +115,7 @@ AUTHOR_MAP = {
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
+    "krishna@padilha.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
     "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",

--- a/tests/run_agent/test_reasoning_tool_call_extraction.py
+++ b/tests/run_agent/test_reasoning_tool_call_extraction.py
@@ -1,0 +1,228 @@
+"""Tests for _extract_tool_calls_from_reasoning — recovery of tool calls
+that models (GLM-5.x, Qwen3.5) emit inside reasoning/thinking blocks."""
+
+import json
+import pytest
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent(tools=None):
+    """Create a minimal AIAgent with optional tool definitions."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.valid_tool_names = set()
+    if tools:
+        agent.valid_tool_names = {t["function"]["name"] for t in tools}
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Pattern 1: JSON objects with "name" + "arguments"
+# ---------------------------------------------------------------------------
+
+class TestJsonPattern:
+    """Pattern 1: bare JSON tool calls inside reasoning."""
+
+    def test_simple_json_tool_call(self):
+        agent = _make_agent(tools=[
+            {"function": {"name": "web_search"}},
+            {"function": {"name": "terminal"}},
+        ])
+        reasoning = (
+            'The user wants to search. I should use the search tool.\n'
+            '{"name": "web_search", "arguments": {"query": "python flask"}}'
+        )
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 1
+        assert result[0]["function"]["name"] == "web_search"
+        args = json.loads(result[0]["function"]["arguments"])
+        assert args == {"query": "python flask"}
+
+    def test_multiple_json_tool_calls(self):
+        agent = _make_agent(tools=[
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "write_file"}},
+        ])
+        reasoning = (
+            'First I will read, then write.\n'
+            '{"name": "read_file", "arguments": {"path": "/tmp/a.txt"}}\n'
+            'After reading, I write:\n'
+            '{"name": "write_file", "arguments": {"path": "/tmp/b.txt", "content": "hello"}}'
+        )
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 2
+        assert result[0]["function"]["name"] == "read_file"
+        assert result[1]["function"]["name"] == "write_file"
+
+    def test_json_with_parameters_key(self):
+        """Some models use 'parameters' instead of 'arguments'."""
+        agent = _make_agent(tools=[
+            {"function": {"name": "terminal"}},
+        ])
+        reasoning = '{"name": "terminal", "parameters": {"command": "ls"}}'
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 1
+        assert result[0]["function"]["name"] == "terminal"
+
+    def test_invalid_tool_name_filtered(self):
+        """Unknown tool names are filtered when valid_tool_names is provided."""
+        agent = _make_agent(tools=[
+            {"function": {"name": "web_search"}},
+        ])
+        reasoning = '{"name": "nonexistent_tool", "arguments": {"x": 1}}'
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 0
+
+    def test_no_filter_when_names_none(self):
+        """Without valid_tool_names, all extractions are returned."""
+        agent = _make_agent()
+        reasoning = '{"name": "any_tool", "arguments": {"x": 1}}'
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=None,
+        )
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pattern 2: XML <tool_call name="..."> tags
+# ---------------------------------------------------------------------------
+
+class TestXmlPattern:
+    """Pattern 2: XML-style tool call tags inside reasoning."""
+
+    def test_tool_call_xml_tag(self):
+        agent = _make_agent(tools=[
+            {"function": {"name": "read_file"}},
+        ])
+        reasoning = (
+            'I need to read the file.\n'
+            '<tool_call name="read_file">{"path": "/etc/hosts"}</tool_call'
+            '>'
+        )
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 1
+        assert result[0]["function"]["name"] == "read_file"
+        args = json.loads(result[0]["function"]["arguments"])
+        assert args == {"path": "/etc/hosts"}
+
+    def test_tool_call_xml_empty_body(self):
+        agent = _make_agent(tools=[
+            {"function": {"name": "web_search"}},
+        ])
+        reasoning = '<tool_call name="web_search"></tool_call'
+        reasoning += '>'
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 1
+        assert result[0]["function"]["arguments"] == "{}"
+
+    def test_tool_call_xml_case_insensitive(self):
+        agent = _make_agent(tools=[
+            {"function": {"name": "terminal"}},
+        ])
+        reasoning = '<TOOL_CALL name="terminal">{"command": "pwd"}</TOOL_CALL>'
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Pattern 3: <function_call> JSON wrapper
+# ---------------------------------------------------------------------------
+
+class TestFunctionCallPattern:
+    """Pattern 3: <function_call>{JSON}</function_call> tags."""
+
+    def test_function_call_tag(self):
+        agent = _make_agent(tools=[
+            {"function": {"name": "write_file"}},
+        ])
+        reasoning = (
+            '<function_call>{"name": "write_file", "arguments": '
+            '{"path": "/tmp/x", "content": "test"}}</function_call>'
+        )
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 1
+        assert result[0]["function"]["name"] == "write_file"
+
+    def test_function_call_invalid_json_ignored(self):
+        reasoning = '<function_call>{not valid json}</function_call>'
+        agent = _make_agent()
+        result = agent._extract_tool_calls_from_reasoning(reasoning)
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_empty_reasoning(self):
+        agent = _make_agent()
+        assert agent._extract_tool_calls_from_reasoning("") == []
+        assert agent._extract_tool_calls_from_reasoning(None) == []
+
+    def test_whitespace_only(self):
+        agent = _make_agent()
+        assert agent._extract_tool_calls_from_reasoning("   \n  ") == []
+
+    def test_no_tool_calls_in_reasoning(self):
+        agent = _make_agent()
+        reasoning = "Just thinking about the problem. No tool calls needed."
+        assert agent._extract_tool_calls_from_reasoning(reasoning) == []
+
+    def test_dedup_by_id(self):
+        """Each extracted call gets a unique ID."""
+        agent = _make_agent(tools=[
+            {"function": {"name": "web_search"}},
+        ])
+        reasoning = (
+            '{"name": "web_search", "arguments": {"query": "a"}}\n'
+            '{"name": "web_search", "arguments": {"query": "b"}}'
+        )
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 2
+        ids = [r["id"] for r in result]
+        assert len(set(ids)) == 2  # all unique
+
+    def test_mixed_formats(self):
+        """All three patterns can be extracted from the same reasoning."""
+        agent = _make_agent(tools=[
+            {"function": {"name": "web_search"}},
+            {"function": {"name": "read_file"}},
+            {"function": {"name": "terminal"}},
+        ])
+        reasoning = (
+            'JSON: {"name": "web_search", "arguments": {"query": "x"}}\n'
+            'XML: <tool_call name="read_file">{"path": "/a"}</tool_call'
+            '>\n'
+            'FC: <function_call>{"name": "terminal", "arguments": '
+            '{"command": "ls"}}</function_call>'
+        )
+        result = agent._extract_tool_calls_from_reasoning(
+            reasoning, valid_tool_names=agent.valid_tool_names,
+        )
+        assert len(result) == 3
+        names = {r["function"]["name"] for r in result}
+        assert names == {"web_search", "read_file", "terminal"}


### PR DESCRIPTION
## What does this PR do?

Fixes dropped tool calls for models that emit them inside reasoning/thinking content instead of the standard streaming `delta.tool_calls` field.

This affects models such as GLM-5.x and Qwen thinking mode. Hermes already accumulates reasoning text, but before this patch it never inspected that reasoning content for embedded tool-call structures. As a result, intended tool invocations were silently lost and the turn was treated as plain text.

## Related Issue

No tracked issue. This was found in real tool-use failures with reasoning-heavy models, especially GLM-5.x via Z.AI and Qwen3.5 thinking mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_extract_tool_calls_from_reasoning()` to `AIAgent`.
- Implemented extraction for three embedded formats:
  - JSON objects
  - XML-style `<tool_call ...>` tags
  - `<function_call>...</function_call>` wrappers
- Promoted extracted calls when standard streaming tool calls are absent.
- Forced `finish_reason="tool_calls"` in the recovery path so the normal agent loop executes the recovered tool calls.
- Added filtering by valid tool names.
- Added deduplication by `(name, arguments)`.
- Added comprehensive coverage in `tests/run_agent/test_reasoning_tool_call_extraction.py`.

## How to Test

1. Run:
   - `pytest tests/run_agent/test_reasoning_tool_call_extraction.py -q`
2. Verify all tests pass (`15 passed` locally when validated).
3. Confirm that reasoning-embedded tool-call payloads are recovered and executed only when standard `delta.tool_calls` are absent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
pytest tests/run_agent/test_reasoning_tool_call_extraction.py -q
15 passed
```
