### PR TITLE
fix: robust model/provider resolution for delegated subagents

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -115,6 +115,7 @@ AUTHOR_MAP = {
     "195255660+EvilHumphrey@users.noreply.github.com": "EvilHumphrey",
     "270604154+superearn-fisher@users.noreply.github.com": "superearn-fisher",
     "3540493+kpadilha@users.noreply.github.com": "kpadilha",
+    "krishna@padilha.com": "kpadilha",
     "40378218+chaconne67@users.noreply.github.com": "chaconne67",
     "Pluviobyte@users.noreply.github.com": "Pluviobyte",
     "sanghyuk_seo@nexcubecorp.com": "sanghyuk-seo-nexcube",

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -31,6 +31,7 @@ from tools.delegate_tool import (
     _extract_output_tail,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
+    _resolve_child_model_and_provider,
     _resolve_delegation_credentials,
 )
 
@@ -368,6 +369,31 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+
+    @patch("hermes_cli.config.load_config")
+    def test_child_resolves_blank_parent_model_and_provider_from_config(self, mock_load_config):
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "https://api.minimax.io/v1/"
+        parent.model = ""
+        parent.provider = ""
+
+        mock_load_config.return_value = {
+            "model": {
+                "default": "MiniMax-M2.7",
+                "provider": "minimax",
+                "base_url": "https://api.minimax.io/v1",
+            }
+        }
+
+        model, provider = _resolve_child_model_and_provider(
+            requested_model=None,
+            override_provider=None,
+            override_base_url=parent.base_url,
+            parent_agent=parent,
+        )
+
+        self.assertEqual(model, "MiniMax-M2.7")
+        self.assertEqual(provider, "minimax")
 
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -28,6 +28,7 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
+    _resolve_child_model_and_provider,
     _resolve_delegation_credentials,
 )
 
@@ -256,6 +257,31 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+
+    @patch("hermes_cli.config.load_config")
+    def test_child_resolves_blank_parent_model_and_provider_from_config(self, mock_load_config):
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "https://api.minimax.io/v1/"
+        parent.model = ""
+        parent.provider = ""
+
+        mock_load_config.return_value = {
+            "model": {
+                "default": "MiniMax-M2.7",
+                "provider": "minimax",
+                "base_url": "https://api.minimax.io/v1",
+            }
+        }
+
+        model, provider = _resolve_child_model_and_provider(
+            requested_model=None,
+            override_provider=None,
+            override_base_url=parent.base_url,
+            parent_agent=parent,
+        )
+
+        self.assertEqual(model, "MiniMax-M2.7")
+        self.assertEqual(provider, "minimax")
 
     def test_child_inherits_parent_print_fn(self):
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -594,6 +594,73 @@ _LEGACY_EVENT_MAP: Dict[str, DelegateEvent] = {
     "subagent_progress": DelegateEvent.TASK_PROGRESS,
 }
 
+def _infer_provider_from_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Best-effort provider inference from a resolved base_url."""
+    normalized = (base_url or "").strip().lower().rstrip("/")
+    if not normalized:
+        return None
+    if "minimax.io" in normalized:
+        return "minimax"
+    if "openrouter" in normalized:
+        return "openrouter"
+    if "chatgpt.com/backend-api/codex" in normalized or "api.openai.com" in normalized:
+        return "openai-codex"
+    if "api.anthropic.com" in normalized or normalized.endswith("/anthropic"):
+        return "anthropic"
+    if "api.z.ai" in normalized:
+        return "zai"
+    return None
+
+
+def _resolve_child_model_and_provider(
+    *,
+    requested_model: Optional[str],
+    override_provider: Optional[str],
+    override_base_url: Optional[str],
+    parent_agent,
+) -> tuple[str, str]:
+    """Resolve effective child model/provider robustly.
+
+    Parent agents created by some entry points can have a live client/base_url but
+    leave ``parent_agent.model`` / ``parent_agent.provider`` blank.  Subagents must
+    not inherit those blanks, otherwise they send requests with ``model=''``.
+    """
+    effective_model = (requested_model or getattr(parent_agent, "model", "") or "").strip()
+    effective_provider = (override_provider or getattr(parent_agent, "provider", "") or "").strip().lower()
+
+    full_cfg = {}
+    try:
+        from hermes_cli.config import load_config
+        full_cfg = load_config() or {}
+    except Exception:
+        full_cfg = {}
+
+    model_cfg = full_cfg.get("model", {}) if isinstance(full_cfg, dict) else {}
+    if not isinstance(model_cfg, dict):
+        model_cfg = {"default": str(model_cfg or "")}
+
+    cfg_model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+
+    if not effective_provider:
+        effective_provider = (
+            _infer_provider_from_base_url(override_base_url or getattr(parent_agent, "base_url", ""))
+            or cfg_provider
+            or ""
+        )
+
+    if not effective_model:
+        effective_model = cfg_model
+
+    if not effective_model and effective_provider:
+        try:
+            from hermes_cli.models import get_default_model_for_provider
+            effective_model = str(get_default_model_for_provider(effective_provider) or "").strip()
+        except Exception:
+            pass
+
+    return effective_model, effective_provider
+
 
 def check_delegate_requirements() -> bool:
     """Delegation has no external requirements -- always available."""
@@ -1051,10 +1118,16 @@ def _build_child_agent(
 
         child_thinking_cb = _child_thinking
 
-    # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
-    effective_provider = override_provider or getattr(parent_agent, "provider", None)
+    # Resolve effective credentials: config override > parent inherit.
+    # Important: parent_agent.model/provider may be blank even when the parent is
+    # live and authenticated via runtime provider resolution. Resolve robustly.
     effective_base_url = override_base_url or parent_agent.base_url
+    effective_model, effective_provider = _resolve_child_model_and_provider(
+        requested_model=model,
+        override_provider=override_provider,
+        override_base_url=effective_base_url,
+        parent_agent=parent_agent,
+    )
     effective_api_key = override_api_key or parent_api_key
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -82,6 +82,74 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
 
 
+def _infer_provider_from_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Best-effort provider inference from a resolved base_url."""
+    normalized = (base_url or "").strip().lower().rstrip("/")
+    if not normalized:
+        return None
+    if "minimax.io" in normalized:
+        return "minimax"
+    if "openrouter" in normalized:
+        return "openrouter"
+    if "chatgpt.com/backend-api/codex" in normalized or "api.openai.com" in normalized:
+        return "openai-codex"
+    if "api.anthropic.com" in normalized or normalized.endswith("/anthropic"):
+        return "anthropic"
+    if "api.z.ai" in normalized:
+        return "zai"
+    return None
+
+
+def _resolve_child_model_and_provider(
+    *,
+    requested_model: Optional[str],
+    override_provider: Optional[str],
+    override_base_url: Optional[str],
+    parent_agent,
+) -> tuple[str, str]:
+    """Resolve effective child model/provider robustly.
+
+    Parent agents created by some entry points can have a live client/base_url but
+    leave ``parent_agent.model`` / ``parent_agent.provider`` blank.  Subagents must
+    not inherit those blanks, otherwise they send requests with ``model=''``.
+    """
+    effective_model = (requested_model or getattr(parent_agent, "model", "") or "").strip()
+    effective_provider = (override_provider or getattr(parent_agent, "provider", "") or "").strip().lower()
+
+    full_cfg = {}
+    try:
+        from hermes_cli.config import load_config
+        full_cfg = load_config() or {}
+    except Exception:
+        full_cfg = {}
+
+    model_cfg = full_cfg.get("model", {}) if isinstance(full_cfg, dict) else {}
+    if not isinstance(model_cfg, dict):
+        model_cfg = {"default": str(model_cfg or "")}
+
+    cfg_model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+
+    if not effective_provider:
+        effective_provider = (
+            _infer_provider_from_base_url(override_base_url or getattr(parent_agent, "base_url", ""))
+            or cfg_provider
+            or ""
+        )
+
+    if not effective_model:
+        effective_model = cfg_model
+
+    if not effective_model and effective_provider:
+        try:
+            from hermes_cli.models import get_default_model_for_provider
+            effective_model = str(get_default_model_for_provider(effective_provider) or "").strip()
+        except Exception:
+            pass
+
+    return effective_model, effective_provider
+
+
 def check_delegate_requirements() -> bool:
     """Delegation has no external requirements -- always available."""
     return True
@@ -317,10 +385,16 @@ def _build_child_agent(
 
         child_thinking_cb = _child_thinking
 
-    # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
-    effective_provider = override_provider or getattr(parent_agent, "provider", None)
+    # Resolve effective credentials: config override > parent inherit.
+    # Important: parent_agent.model/provider may be blank even when the parent is
+    # live and authenticated via runtime provider resolution. Resolve robustly.
     effective_base_url = override_base_url or parent_agent.base_url
+    effective_model, effective_provider = _resolve_child_model_and_provider(
+        requested_model=model,
+        override_provider=override_provider,
+        override_base_url=effective_base_url,
+        parent_agent=parent_agent,
+    )
     effective_api_key = override_api_key or parent_api_key
     effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
     effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)


### PR DESCRIPTION
## What does this PR do?

Fixes delegated child-agent startup when the parent agent has live clients but blank `model` / `provider` attributes.

Without this fix, `delegate_task` can spawn a child that inherits `model=""` and `provider=""`, causing immediate provider errors such as `model not found`. The PR adds a robust resolution chain so the child always gets a valid model/provider pair.

## Related Issue

No tracked issue. This was found in real delegation flows using custom providers whose runtime resolution depended on `base_url` rather than explicit parent attributes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_infer_provider_from_base_url(base_url)` to map known provider URLs to provider names.
- Added `_resolve_child_model_and_provider(...)` with this resolution order:
  1. explicit overrides
  2. non-empty parent attributes
  3. config defaults (`model.default`, `model.provider`)
  4. URL-based provider inference
  5. provider default-model lookup
- Updated child-agent construction in `tools/delegate_tool.py` to use the new resolution path.
- Added regression coverage in `tests/tools/test_delegate.py` for blank-parent resolution.

## How to Test

1. Run:
   - `pytest tests/tools/test_delegate.py -q`
2. Verify the new test `test_child_resolves_blank_parent_model_and_provider_from_config` passes.
3. Reproduce delegation with a blank-parent custom-provider scenario and confirm the child resolves a valid model/provider instead of sending `model=""`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Targeted validation added in tests/tools/test_delegate.py:
- test_child_resolves_blank_parent_model_and_provider_from_config
```
