### PR TITLE
fix: parse string schedules in cron update_job()

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -501,6 +501,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if schedule_changed:
             updated_schedule = updated["schedule"]
+            # The API may pass schedule as a raw string (e.g. "every 10m")
+            # instead of a pre-parsed dict.  Normalize it the same way
+            # create_job() does so downstream code can call .get() safely.
+            if isinstance(updated_schedule, str):
+                updated_schedule = parse_schedule(updated_schedule)
+                updated["schedule"] = updated_schedule
             updated["schedule_display"] = updates.get(
                 "schedule_display",
                 updated_schedule.get("display", updated.get("schedule_display")),


### PR DESCRIPTION
## Summary

Fixes #10129 — `update_job()` crashes with `AttributeError: 'str' object has no attribute 'get'` when the schedule is passed as a string (e.g. `"every 10m"`) instead of a pre-parsed dict.

## Root Cause

`update_job()` at line 506 calls `updated_schedule.get("display", ...)` assuming the schedule is always a dict. The create path calls `parse_schedule()` to convert strings to dicts, but the update path skips this normalization — the API handler passes the raw string through.

## Fix

Added `isinstance(updated_schedule, str)` check + `parse_schedule()` call, matching the create path's pattern:

```python
if isinstance(updated_schedule, str):
    updated_schedule = parse_schedule(updated_schedule)
    updated["schedule"] = updated_schedule
```

6 lines added to `cron/jobs.py`.

## E2E Verification

Tested all four schedule formats through the update path:
- `"every 10m"` → parsed to interval dict ✓
- Pre-parsed dict → still works (no regression) ✓
- `"2026-12-25T09:00:00"` → parsed to one-shot ✓
- `"0 */2 * * *"` → parsed to cron ✓

## Tests

170 existing cron tests pass, 0 failures.

## Related PRs

Supersedes #10152, #10185, #10197 which targeted the same issue.