### PR TITLE
fix: /browser connect CDP override takes priority over Camofox

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -37,6 +37,18 @@ class TestCamofoxMode:
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         assert is_camofox_mode() is True
 
+    def test_cdp_override_takes_priority(self, monkeypatch):
+        """When BROWSER_CDP_URL is set (via /browser connect), CDP takes priority over Camofox."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
+        assert is_camofox_mode() is False
+
+    def test_cdp_override_blank_does_not_disable_camofox(self, monkeypatch):
+        """Empty/whitespace BROWSER_CDP_URL should not suppress Camofox."""
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.setenv("BROWSER_CDP_URL", "  ")
+        assert is_camofox_mode() is True
+
     def test_health_check_unreachable(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
         assert check_camofox_available() is False

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -54,7 +54,15 @@ def get_camofox_url() -> str:
 
 
 def is_camofox_mode() -> bool:
-    """True when Camofox backend is configured."""
+    """True when Camofox backend is configured and no CDP override is active.
+
+    When the user has explicitly connected to a live Chrome instance via
+    ``/browser connect`` (which sets ``BROWSER_CDP_URL``), the CDP connection
+    takes priority over Camofox so the browser tools operate on the real
+    browser instead of being silently routed to the Camofox backend.
+    """
+    if os.getenv("BROWSER_CDP_URL", "").strip():
+        return False
     return bool(get_camofox_url())
 
 


### PR DESCRIPTION
## Summary

When a user runs `/browser connect` to attach browser tools to their real Chrome instance via CDP, the `BROWSER_CDP_URL` env var is set. However, every browser tool function checks `_is_camofox_mode()` **first**, which short-circuits to the Camofox backend before `_get_session_info()` ever reaches the CDP override check.

**Result:** `/browser connect` confirms success but browser tools silently route to Camofox anyway.

## Fix

`is_camofox_mode()` in `tools/browser_camofox.py` now returns `False` when `BROWSER_CDP_URL` is set. This is one change in one place that covers all ~15 browser tool functions.

The logic: `/browser connect` is an explicit user override — they want their real Chrome, not Camofox. Empty/whitespace `BROWSER_CDP_URL` does not suppress Camofox (only a real value does).

## Files changed
- `tools/browser_camofox.py` — `is_camofox_mode()` checks for CDP override
- `tests/tools/test_browser_camofox.py` — 2 new tests for CDP priority behavior

## Test results
All 164 browser tests pass.

Reported by SkyLinx on Discord.