### PR TITLE
fix: handle cross-device shutil.move failure in tirith auto-install

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -360,7 +360,21 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
 
         src = os.path.join(tmpdir, "tirith")
         dest = os.path.join(_hermes_bin_dir(), "tirith")
-        shutil.move(src, dest)
+        try:
+            shutil.move(src, dest)
+        except OSError:
+            # Cross-device move (common in Docker, NFS): shutil.move() falls
+            # back to copy2 + unlink, but copy2's metadata step can raise
+            # PermissionError.  Use plain copy + manual chmod instead.
+            try:
+                shutil.copy(src, dest)
+            except OSError:
+                # Clean up partial dest to prevent a non-executable retry loop
+                try:
+                    os.unlink(dest)
+                except OSError:
+                    pass
+                return None, "cross_device_copy_failed"
         os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
         verification = "cosign + SHA-256" if cosign_verified else "SHA-256 only"


### PR DESCRIPTION
## Summary

Fixes #10127 — `_install_tirith()` crashes with `PermissionError` when `/tmp` and `~/.hermes/bin` are on different filesystems (common in Docker, NFS, certain Linux distros).

## Root Cause

`shutil.move(src, dest)` at line 363 is inside a `try/finally` that only cleans the tmpdir. When `/tmp` and the destination are on different devices:

1. `shutil.move()` tries `os.rename()` → fails with `errno 18` (cross-device link)
2. Falls back to `shutil.copy2()` + `os.remove()`
3. `copy2()`'s metadata/xattr step raises `PermissionError`
4. Exception propagates through `_resolve_tirith_path()` → `check_command_security()` — BEFORE the `try/except OSError` that handles fail_open (line 619)

**Secondary issue:** A failed partial install leaves `~/.hermes/bin/tirith` as a non-executable file. `_resolve_tirith_path()` checks `os.access(hermes_bin, os.X_OK)`, which fails, triggering auto-install again → retry loop on every terminal command.

## Fix

```python
try:
    shutil.move(src, dest)
except OSError:
    try:
        shutil.copy(src, dest)    # No metadata step
    except OSError:
        os.unlink(dest)           # Clean up partial file
        return None, "cross_device_copy_failed"
```

- `shutil.copy()` (not `copy2()`) skips the metadata/xattr step that causes the failure
- If even `copy()` fails, the partial dest is cleaned up to prevent the retry loop
- Returns `(None, reason)` so the failure routes through the existing install caching and fail_open logic

## Tests

63 existing tirith security tests pass, 0 failures.

E2E verified:
- Normal same-filesystem move ✓
- Cross-device fallback via shutil.copy ✓
- Both fail → partial dest cleaned up ✓