### PR TITLE
fix(kimi): unify kimi-coding-cn provider flow

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -373,6 +373,17 @@ def _resolve_api_key_provider_secret(
         if has_usable_secret(val):
             return val, env_var
 
+    # Fallback: check credential pool (auth.json)
+    try:
+        from hermes_cli.credential_pool import get_credential_pool
+        pool = get_credential_pool()
+        if pool and pool.has_credentials():
+            for entry in pool._entries.values():
+                if entry.provider_id == provider_id and entry.runtime_api_key:
+                    return entry.runtime_api_key, "credential-pool"
+    except Exception:
+        pass
+
     return "", ""
 
 
@@ -2384,7 +2395,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id == "kimi-coding":
+    if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url
@@ -2470,7 +2481,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id == "kimi-coding":
+    if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif provider_id == "zai":
         base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1137,9 +1137,9 @@ def select_provider_and_model(args=None):
         _remove_custom_provider(config)
     elif selected_provider == "anthropic":
         _model_flow_anthropic(config, current_model)
-    elif selected_provider == "kimi-coding":
+    elif selected_provider in ("kimi-coding", "kimi-coding-cn"):
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("gemini", "deepseek", "xai", "zai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee"):
+    elif selected_provider in ("gemini", "deepseek", "xai", "zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
     # ── Post-switch cleanup: clear stale OPENAI_BASE_URL ──────────────

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -526,7 +526,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
-    ProviderEntry("kimi-coding",    "Kimi / Moonshot",          "Kimi / Moonshot (Moonshot AI direct API)"),
+    ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),
     ProviderEntry("kimi-coding-cn", "Kimi / Moonshot (China)",  "Kimi / Moonshot China (Moonshot CN direct API)"),
     ProviderEntry("minimax",        "MiniMax",                  "MiniMax (global direct API)"),
     ProviderEntry("minimax-cn",     "MiniMax (China)",          "MiniMax China (domestic direct API)"),


### PR DESCRIPTION
## Summary

- Route `kimi-coding-cn` through the Kimi-specific model selection flow (`_model_flow_kimi`) instead of the generic `_model_flow_api_key_provider`
- Add credential pool fallback in `_resolve_api_key_provider_secret` so API keys stored in `auth.json` credential pool are consulted
- Include `kimi-coding-cn` in the Kimi base URL resolution logic (both `get_api_key_provider_status` and `resolve_api_key_provider_credentials`)
- Update `kimi-coding` display label from "Kimi / Moonshot" to "Kimi / Kimi Coding Plan" to accurately reflect the Coding Plan + Moonshot API dual-endpoint setup

## Problem

Previously, `kimi-coding-cn` was treated as a generic API key provider:
- It skipped Kimi-specific base URL resolution
- Credential pool was not consulted for API key lookup
- It fell through to the generic model flow instead of the curated Kimi model picker

## Test plan

- [ ] Configure `KIMI_CN_API_KEY` and verify `kimi-coding-cn` appears in `/model` picker
- [ ] Switch to `kimi-coding-cn` and confirm models load correctly via Kimi model flow
- [ ] Verify base URL resolves properly for CN endpoint
- [ ] Confirm credential pool fallback works when env var is not set