### PR TITLE
fix(streaming): don't suppress final response when commentary message is sent

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -609,12 +609,15 @@ class GatewayStreamConsumer:
                 content=text,
                 metadata=self.metadata,
             )
-            if result.success:
-                self._already_sent = True
-                return True
+            # Note: do NOT set _already_sent = True here.
+            # Commentary messages are interim status updates (e.g. "Using browser
+            # tool..."), not the final response. Setting already_sent would cause
+            # the final response to be incorrectly suppressed when there are
+            # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
+            return result.success
         except Exception as e:
             logger.error("Commentary send error: %s", e)
-        return False
+            return False
 
     async def _send_or_edit(self, text: str) -> bool:
         """Send or edit the streaming message.


### PR DESCRIPTION
## Summary

Commentary messages (interim assistant status updates like "Using browser tool...") are sent via `_send_commentary()`, which was incorrectly setting `_already_sent = True` on success. This caused the final response to be suppressed when there were multiple tool calls, because the gateway checks `already_sent` to decide whether to skip re-sending the response.

The fix: commentary messages are interim status updates, not the final response, so `_already_sent` should not be set when they succeed. This ensures the final response is always delivered regardless of how many commentary messages were sent during the turn.

## Fix

In `gateway/stream_consumer.py`, the `_send_commentary()` method no longer sets `self._already_sent = True` on successful send. This is correct because:

- Commentary messages are interim status updates (e.g. "Using browser tool..."), not the final response
- The `already_sent` flag is used to prevent duplicate sends of the final response
- Setting it for commentary messages would incorrectly suppress the final response when there are multiple tool calls

## Test plan

- [x] Verify Feishu messages are no longer dropped when there are multiple tool calls (api_calls > 1) ✅
- [ ] Verify Telegram messages are no longer dropped when there are multiple tool calls
- [x] Verify interim commentary messages still work correctly ✅

## Test Results

Feishu testing confirmed (2026-04-16):
- Before fix: api_calls > 1 → no "Sending response" log (message dropped)
- After fix: api_calls > 1 → "Sending response" log present (message delivered)
- Test case: Complex query with 8 tool calls, 2201 char response → delivered successfully

Fixes #10454