### PR TITLE
fix: recompute Copilot api_mode after model switch

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -452,6 +452,7 @@ def switch_model(
         ModelSwitchResult with all information the caller needs.
     """
     from hermes_cli.models import (
+        copilot_model_api_mode,
         detect_provider_for_model,
         validate_requested_model,
         opencode_model_api_mode,
@@ -708,6 +709,10 @@ def switch_model(
     # Apply auto-correction if validation found a closer match
     if validation.get("corrected_model"):
         new_model = validation["corrected_model"]
+
+    # --- Provider-specific api_mode overrides ---
+    if target_provider in {"copilot", "github-copilot"}:
+        api_mode = copilot_model_api_mode(new_model, api_key=api_key)
 
     # --- OpenCode api_mode override ---
     if target_provider in {"opencode-zen", "opencode-go", "opencode", "opencode-go"}:
@@ -1086,5 +1091,3 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
-

--- a/tests/hermes_cli/test_model_switch_copilot_api_mode.py
+++ b/tests/hermes_cli/test_model_switch_copilot_api_mode.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_same_provider_copilot_switch_recomputes_api_mode():
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "gh-token",
+                 "base_url": "https://api.githubcopilot.com",
+                 "api_mode": "codex_responses",
+             },
+         ), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+        result = switch_model(
+            raw_input="claude-opus-4.6",
+            current_provider="copilot",
+            current_model="gpt-5.4",
+        )
+
+    assert result.success, f"switch_model failed: {result.error_message}"
+    assert result.new_model == "claude-opus-4.6"
+    assert result.target_provider == "copilot"
+    assert result.api_mode == "chat_completions"
+
+
+def test_explicit_copilot_switch_uses_selected_model_api_mode():
+    with patch("hermes_cli.model_switch.resolve_alias", return_value=None), \
+         patch("hermes_cli.model_switch.list_provider_models", return_value=[]), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "gh-token",
+                 "base_url": "https://api.githubcopilot.com",
+                 "api_mode": "codex_responses",
+             },
+         ), \
+         patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION), \
+         patch("hermes_cli.model_switch.get_model_info", return_value=None), \
+         patch("hermes_cli.model_switch.get_model_capabilities", return_value=None), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None):
+        result = switch_model(
+            raw_input="claude-opus-4.6",
+            current_provider="openrouter",
+            current_model="anthropic/claude-sonnet-4.6",
+            explicit_provider="copilot",
+        )
+
+    assert result.success, f"switch_model failed: {result.error_message}"
+    assert result.new_model == "claude-opus-4.6"
+    assert result.target_provider == "github-copilot"
+    assert result.api_mode == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

Recomputes GitHub Copilot `api_mode` from the selected model in the shared `/model` switch path.

Before this change, Copilot could carry a stale `codex_responses` mode forward from a GPT-5 selection into a later Claude model switch. That led to Copilot Claude requests going out through the Responses API and failing with `unsupported_api_for_model` errors like `model claude-opus-4.6 does not support Responses API.`

This fixes the switch seam by recalculating Copilot transport after the new model name is finalized, the same way OpenCode already does provider-specific transport overrides.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Recompute Copilot `api_mode` in `hermes_cli/model_switch.py` after the selected model has been normalized and validated
- Apply that override for both `copilot` and `github-copilot` provider slugs used across the switch/runtime layers
- Add regression tests covering same-provider and explicit-provider switches from GPT/Codex flows into Copilot Claude models

## How to Test

1. Configure GitHub Copilot and select a GPT-5 model so Copilot is using `codex_responses`
2. Switch to `claude-opus-4.6` or another Claude model via the shared `/model` flow with provider `copilot`
3. Confirm the switched model uses `chat_completions` instead of `codex_responses`, and that the Claude request no longer fails with `unsupported_api_for_model`
4. Run:
   `python -m pytest tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/hermes_cli/test_model_validation.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted passes:
  - `python -m pytest tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/hermes_cli/test_model_validation.py -q` → `65 passed`
  - `python -m pytest tests/hermes_cli/test_model_provider_persistence.py tests/gateway/test_model_switch_persistence.py -q` → `19 passed`
- Full suite:
  - `python -m pytest tests/ -q -n 4` → `46 failed, 11709 passed, 34 skipped, 10 errors`
- The broad-suite failures are not clustered around this switch seam. I spot-checked the nearest Copilot failure (`tests/hermes_cli/test_api_key_providers.py::TestRuntimeProviderResolution::test_runtime_copilot_uses_gh_cli_token`) and it is a separate runtime/base_url default issue, not this Claude api_mode-switch bug.
