### PR TITLE
fix(kimi): include kimi-coding-cn in Kimi base URL resolution

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2384,7 +2384,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id == "kimi-coding":
+    if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url
@@ -2470,7 +2470,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id == "kimi-coding":
+    if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif provider_id == "zai":
         base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -526,7 +526,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
     ProviderEntry("xai",            "xAI",                      "xAI (Grok models — direct API)"),
     ProviderEntry("zai",            "Z.AI / GLM",               "Z.AI / GLM (Zhipu AI direct API)"),
-    ProviderEntry("kimi-coding",    "Kimi / Moonshot",          "Kimi / Moonshot (Moonshot AI direct API)"),
+    ProviderEntry("kimi-coding",    "Kimi / Kimi Coding Plan",  "Kimi Coding Plan (api.kimi.com) & Moonshot API"),
     ProviderEntry("kimi-coding-cn", "Kimi / Moonshot (China)",  "Kimi / Moonshot China (Moonshot CN direct API)"),
     ProviderEntry("minimax",        "MiniMax",                  "MiniMax (global direct API)"),
     ProviderEntry("minimax-cn",     "MiniMax (China)",          "MiniMax China (domestic direct API)"),


### PR DESCRIPTION
## Summary

Salvaged from PR #10525 by @kkikione999. Kept the correct parts, dropped the broken ones.

### What's included:
- Route `kimi-coding-cn` through `_resolve_kimi_base_url()` in both `get_api_key_provider_status()` and `resolve_api_key_provider_credentials()` — CN users with `sk-kimi-` prefixed keys now get auto-detected to the Kimi Coding Plan endpoint
- Updated `kimi-coding` display label to accurately reflect dual-endpoint setup

### What was dropped from #10525:
- **Credential pool fallback** — wrong import path (`hermes_cli.credential_pool` doesn't exist), wrong function name (`get_credential_pool` vs `load_pool`), wrong data structure access (`_entries.values()` on a list), wrong attribute name (`provider_id` vs `provider`). All wrapped in bare except, so silently dead code.
- **`_model_flow_kimi` routing for kimi-coding-cn** — `_model_flow_kimi` hardcodes `provider_id = "kimi-coding"` at line 2341, so CN users would get their config silently saved as the non-CN provider.

### Test plan
- 22 kimi-specific tests pass
- Full `test_api_key_providers.py` suite: 126 pass, 1 pre-existing copilot failure
- E2E verified: CN default URL preserved for normal keys, coding plan URL auto-detected for sk-kimi- keys, env override wins in all cases

Closes #10525