### PR TITLE
fix: complete ASCII-locale UnicodeEncodeError recovery for api_messages/reasoning_content (#6843)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,3 +105,4 @@ tesseracttars-creator <tesseracttars@gmail.com> <tesseracttars@gmail.com>
 xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
+MestreY0d4-Uninter <241404605+MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>

--- a/run_agent.py
+++ b/run_agent.py
@@ -457,6 +457,15 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                             if sanitized != fn_args:
                                 fn["arguments"] = sanitized
                                 found = True
+        # Sanitize any additional top-level string fields (e.g. reasoning_content)
+        for key, value in msg.items():
+            if key in {"content", "name", "tool_calls", "role"}:
+                continue
+            if isinstance(value, str):
+                sanitized = _strip_non_ascii(value)
+                if sanitized != value:
+                    msg[key] = sanitized
+                    found = True
     return found
 
 
@@ -9107,7 +9116,19 @@ class AIAgent:
                             # ASCII codec: the system encoding can't handle
                             # non-ASCII characters at all. Sanitize all
                             # non-ASCII content from messages/tool schemas and retry.
+                            # Sanitize both the canonical `messages` list and
+                            # `api_messages` (the API-copy built before the retry
+                            # loop, which may contain extra fields like
+                            # reasoning_content that are not in `messages`).
                             _messages_sanitized = _sanitize_messages_non_ascii(messages)
+                            if isinstance(api_messages, list):
+                                _sanitize_messages_non_ascii(api_messages)
+                            # Also sanitize the last api_kwargs if already built,
+                            # so a leftover non-ASCII value in a transformed field
+                            # (e.g. extra_body, reasoning_content) doesn't survive
+                            # into the next attempt via _build_api_kwargs cache paths.
+                            if isinstance(api_kwargs, dict):
+                                _sanitize_structure_non_ascii(api_kwargs)
                             _prefill_sanitized = False
                             if isinstance(getattr(self, "prefill_messages", None), list):
                                 _prefill_sanitized = _sanitize_messages_non_ascii(self.prefill_messages)

--- a/run_agent.py
+++ b/run_agent.py
@@ -9186,22 +9186,34 @@ class AIAgent:
                                         force=True,
                                     )
 
-                            if (
+                            # Always retry on ASCII codec detection —
+                            # _force_ascii_payload guarantees the full
+                            # api_kwargs payload is sanitized on the
+                            # next iteration (line ~8475).  Even when
+                            # per-component checks above find nothing
+                            # (e.g. non-ASCII only in api_messages'
+                            # reasoning_content), the flag catches it.
+                            # Bounded by _unicode_sanitization_passes < 2.
+                            self._unicode_sanitization_passes += 1
+                            _any_sanitized = (
                                 _messages_sanitized
                                 or _prefill_sanitized
                                 or _tools_sanitized
                                 or _system_sanitized
                                 or _headers_sanitized
                                 or _credential_sanitized
-                            ):
-                                self._unicode_sanitization_passes += 1
+                            )
+                            if _any_sanitized:
                                 self._vprint(
                                     f"{self.log_prefix}⚠️  System encoding is ASCII — stripped non-ASCII characters from request payload. Retrying...",
                                     force=True,
                                 )
-                                continue
-                        # Nothing to sanitize in any payload component.
-                        # Fall through to normal error path.
+                            else:
+                                self._vprint(
+                                    f"{self.log_prefix}⚠️  System encoding is ASCII — enabling full-payload sanitization for retry...",
+                                    force=True,
+                                )
+                            continue
 
                     status_code = getattr(api_error, "status_code", None)
                     error_context = self._extract_api_error_context(api_error)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -63,6 +63,7 @@ AUTHOR_MAP = {
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",
+    "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",

--- a/tests/run_agent/test_unicode_ascii_codec.py
+++ b/tests/run_agent/test_unicode_ascii_codec.py
@@ -268,9 +268,9 @@ class TestApiKeyClientSync:
             agent.client.api_key = _clean_key
 
         # All three locations should now hold the clean key
-        assert agent.api_key == "sk-proj-abcdef"
-        assert agent._client_kwargs["api_key"] == "sk-proj-abcdef"
-        assert agent.client.api_key == "sk-proj-abcdef"
+        assert agent.api_key == "***"
+        assert agent._client_kwargs["api_key"] == "***"
+        assert agent.client.api_key == "***"
         # The bad char should be gone from all of them
         assert "\u028b" not in agent.api_key
         assert "\u028b" not in agent._client_kwargs["api_key"]
@@ -294,3 +294,64 @@ class TestApiKeyClientSync:
 
         assert agent.api_key == "sk-proj-"
         assert agent.client is None  # should not have been touched
+
+
+class TestApiMessagesAndApiKwargsSanitized:
+    """Regression tests for #6843 follow-up: api_messages and api_kwargs must
+    be sanitized alongside messages during ASCII-codec recovery.
+
+    The original fix only sanitized the canonical `messages` list.
+    api_messages is a separate API-copy built before the retry loop; it may
+    carry extra fields (reasoning_content, extra_body) with non-ASCII chars
+    that are not present in `messages`.  Without sanitizing api_messages and
+    api_kwargs, the retry still raises UnicodeEncodeError even after the
+    'System encoding is ASCII — stripped...' log line appears.
+    """
+
+    def test_api_messages_with_reasoning_content_is_sanitized(self):
+        """api_messages may contain reasoning_content not in messages."""
+        api_messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Sure!",
+                # reasoning_content is injected by the API-copy builder and
+                # is NOT present in the canonical messages list
+                "reasoning_content": "Let me think \xab step by step \xbb",
+            },
+        ]
+        found = _sanitize_messages_non_ascii(api_messages)
+        assert found is True
+        assert "\xab" not in api_messages[2]["reasoning_content"]
+        assert "\xbb" not in api_messages[2]["reasoning_content"]
+
+    def test_api_kwargs_with_non_ascii_extra_body_is_sanitized(self):
+        """api_kwargs may contain non-ASCII in extra_body or other fields."""
+        api_kwargs = {
+            "model": "glm-5.1",
+            "messages": [{"role": "user", "content": "ok"}],
+            "extra_body": {
+                "system": "Think carefully \u2192 answer",
+            },
+        }
+        found = _sanitize_structure_non_ascii(api_kwargs)
+        assert found is True
+        assert "\u2192" not in api_kwargs["extra_body"]["system"]
+
+    def test_messages_clean_but_api_messages_dirty_both_get_sanitized(self):
+        """Even when canonical messages are clean, api_messages may be dirty."""
+        messages = [{"role": "user", "content": "hello"}]
+        api_messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning_content": "step \xab done",
+            },
+        ]
+        # messages sanitize returns False (nothing to clean)
+        assert _sanitize_messages_non_ascii(messages) is False
+        # api_messages sanitize must catch the dirty reasoning_content
+        assert _sanitize_messages_non_ascii(api_messages) is True
+        assert "\xab" not in api_messages[1]["reasoning_content"]

--- a/tests/run_agent/test_unicode_ascii_codec.py
+++ b/tests/run_agent/test_unicode_ascii_codec.py
@@ -268,9 +268,9 @@ class TestApiKeyClientSync:
             agent.client.api_key = _clean_key
 
         # All three locations should now hold the clean key
-        assert agent.api_key == "***"
-        assert agent._client_kwargs["api_key"] == "***"
-        assert agent.client.api_key == "***"
+        assert agent.api_key == "sk-proj-abcdef"
+        assert agent._client_kwargs["api_key"] == "sk-proj-abcdef"
+        assert agent.client.api_key == "sk-proj-abcdef"
         # The bad char should be gone from all of them
         assert "\u028b" not in agent.api_key
         assert "\u028b" not in agent._client_kwargs["api_key"]
@@ -355,3 +355,18 @@ class TestApiMessagesAndApiKwargsSanitized:
         # api_messages sanitize must catch the dirty reasoning_content
         assert _sanitize_messages_non_ascii(api_messages) is True
         assert "\xab" not in api_messages[1]["reasoning_content"]
+
+    def test_reasoning_field_in_canonical_messages_is_sanitized(self):
+        """The canonical messages list stores reasoning as 'reasoning', not
+        'reasoning_content'.  The extra-fields loop must catch it."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "assistant",
+                "content": "ok",
+                "reasoning": "Let me think \xab carefully \xbb",
+            },
+        ]
+        assert _sanitize_messages_non_ascii(messages) is True
+        assert "\xab" not in messages[1]["reasoning"]
+        assert "\xbb" not in messages[1]["reasoning"]


### PR DESCRIPTION
## Summary

Completes the ASCII-locale UnicodeEncodeError recovery path for issue #6843. Three PRs were already merged fixing the most common cases (message sanitization, API key sanitization, client key sync), but a gap remained: non-ASCII in `reasoning_content` within `api_messages` caused the recovery to fall through without retrying.

Salvaged from PR #9778 by @MestreY0d4-Uninter — contributor commits cherry-picked with authorship preserved.

## What changed

### From PR #9778 (MestreY0d4-Uninter):
- **`_sanitize_messages_non_ascii()`** now walks all extra top-level string fields in each message dict (any key not in `{content, name, tool_calls, role}`), catching `reasoning_content`, `reasoning`, and future extras
- **Recovery block** now explicitly sanitizes `api_messages` and `api_kwargs` alongside the canonical `messages` list
- **.mailmap + AUTHOR_MAP** entry for contributor

### Follow-up fix (ours):
- **Recovery block always retries** on ASCII codec detection — previously gated on per-component sanitization results, which meant the recovery fell through to the error path when non-ASCII lived only in `api_messages` (e.g. `reasoning_content` built from `messages['reasoning']` at line ~8336). The `_force_ascii_payload` flag guarantees full payload sanitization on the next iteration.
- **Added test** for `reasoning` field on canonical messages

## The gap that was open

At line ~8332, the agent copies `messages[i]['reasoning']` into `api_messages[i]['reasoning_content']`. But `_sanitize_messages_non_ascii()` only checked `content`, `name`, and `tool_calls` — never `reasoning`. On multi-turn sessions with non-English models (GLM, Qwen), reasoning often contains non-ASCII. The recovery block:

1. Set `_force_ascii_payload = True`  
2. Sanitized `messages` → found nothing (`reasoning` not checked) → `_messages_sanitized = False`  
3. All other checks clean → fell through to error path  
4. Burned a retry attempt despite the flag being set  

This is exactly what @BKLronin reported in the issue thread — seeing `System encoding is ASCII — stripped...` but the retry still failing.

## Test plan

- 29 unit tests pass (`tests/run_agent/test_unicode_ascii_codec.py`)
- E2E validation with real imports confirming:
  - `reasoning_content` in `api_messages` gets sanitized
  - `reasoning` in canonical `messages` gets sanitized  
  - `_sanitize_structure_non_ascii(api_kwargs)` covers the full payload recursively
  - Recovery bounded at 2 passes (no infinite loop)

Fixes #6843