### PR TITLE
fix: remove 'q' alias from /quit so /queue's 'q' alias works

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -164,7 +164,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",
-               cli_only=True, aliases=("exit", "q")),
+               cli_only=True, aliases=("exit",)),
 ]
 
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -97,7 +97,7 @@ class TestResolveCommand:
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
         assert resolve_command("reset").name == "new"
-        assert resolve_command("q").name == "quit"
+        assert resolve_command("q").name == "queue"
         assert resolve_command("exit").name == "quit"
         assert resolve_command("gateway").name == "platforms"
         assert resolve_command("set-home").name == "sethome"


### PR DESCRIPTION
## Summary

Fixes #10467 — Both `/queue` and `/quit` registered `"q"` as an alias. Since `/quit` appeared later in `COMMAND_REGISTRY`, `_build_command_lookup()` silently overwrote `/queue`'s claim. The documented `/q` shorthand for queueing prompts was unusable — it always quit instead.

## Fix

Removed `"q"` from `/quit`'s aliases tuple. `/quit` still has `"exit"` as an alias plus the full `/quit` command. `/queue` has no other short alias so it needs `"q"`.

2 files, 2 lines changed. 108 command tests pass.