### PR TITLE
fix(streaming): don't suppress final response when commentary message is sent

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -609,12 +609,15 @@ class GatewayStreamConsumer:
                 content=text,
                 metadata=self.metadata,
             )
-            if result.success:
-                self._already_sent = True
-                return True
+            # Note: do NOT set _already_sent = True here.
+            # Commentary messages are interim status updates (e.g. "Using browser
+            # tool..."), not the final response. Setting already_sent would cause
+            # the final response to be incorrectly suppressed when there are
+            # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
+            return result.success
         except Exception as e:
             logger.error("Commentary send error: %s", e)
-        return False
+            return False
 
     async def _send_or_edit(self, text: str) -> bool:
         """Send or edit the streaming message.


### PR DESCRIPTION
## Summary

Salvage of PR #10530 by richard950825-sys (LehaoLin). Cherry-picked onto current main.

Commentary messages (interim assistant status updates like "Using browser tool...") are sent via `_send_commentary()`, which was incorrectly setting `_already_sent = True` on success. This caused the final response to be suppressed when there were multiple tool calls, because the gateway checks `already_sent` to decide whether to skip re-sending the response.

## Fix

In `gateway/stream_consumer.py`, the `_send_commentary()` method no longer sets `self._already_sent = True` on successful send. Commentary messages are interim status updates, not the final response — the `already_sent` flag should only be set when actual response content is delivered.

Bug was introduced in commit 97b0cd51e (PR #7978) when the commentary feature was added.

## Test plan

- [x] `tests/gateway/test_stream_consumer.py` — 57 passed
- [x] Full gateway suite — no new failures

Fixes #10454
Closes #10530