### PR TITLE
[codex] defer background review notifications

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1845,6 +1845,16 @@ class BasePlatformAdapter(ABC):
             except Exception:
                 pass  # Last resort — don't let error reporting crash the handler
         finally:
+            # If the gateway handler deferred background-review notifications
+            # for this turn, release them only after the main response path
+            # completed (send, stream, or error handling).
+            try:
+                _handler_owner = getattr(self._message_handler, "__self__", None)
+                _release_bg = getattr(_handler_owner, "_release_deferred_background_reviews", None)
+                if callable(_release_bg):
+                    _release_bg(session_key)
+            except Exception:
+                pass
             # Stop typing indicator
             typing_task.cancel()
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -633,11 +633,48 @@ class GatewayRunner:
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        # Deferred background-review notification releases keyed by session.
+        # The review itself can run immediately, but its user-visible
+        # "💾 Skill created" / "💾 Memory updated" notification should not race
+        # ahead of the main assistant reply for the turn.
+        self._deferred_bg_review_releases: Dict[str, Any] = {}
+        self._deferred_bg_review_lock = threading.Lock()
 
 
 
 
     # -- Setup skill availability ----------------------------------------
+
+    def _register_deferred_background_review_release(
+        self, session_key: Optional[str], release_fn: Optional[callable]
+    ) -> None:
+        """Register a one-shot release hook for deferred background-review notifications."""
+        if not session_key or release_fn is None:
+            return
+        if not hasattr(self, "_deferred_bg_review_releases"):
+            self._deferred_bg_review_releases = {}
+        if not hasattr(self, "_deferred_bg_review_lock"):
+            self._deferred_bg_review_lock = threading.Lock()
+        with self._deferred_bg_review_lock:
+            self._deferred_bg_review_releases[session_key] = release_fn
+
+    def _release_deferred_background_reviews(self, session_key: Optional[str]) -> None:
+        """Release any queued background-review notifications for *session_key*."""
+        if not session_key:
+            return
+        release_fn = None
+        if hasattr(self, "_deferred_bg_review_releases"):
+            lock = getattr(self, "_deferred_bg_review_lock", None)
+            if lock is None:
+                release_fn = self._deferred_bg_review_releases.pop(session_key, None)
+            else:
+                with lock:
+                    release_fn = self._deferred_bg_review_releases.pop(session_key, None)
+        if release_fn is not None:
+            try:
+                release_fn()
+            except Exception as exc:
+                logger.debug("Deferred background review release failed: %s", exc)
 
     def _has_setup_skill(self) -> bool:
         """Check if the hermes-agent-setup skill is installed."""
@@ -8508,8 +8545,11 @@ class GatewayRunner:
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
 
-            # Background review delivery — send "💾 Memory updated" etc. to user
-            def _bg_review_send(message: str) -> None:
+            _bg_review_release = threading.Event()
+            _bg_review_pending: list[str] = []
+            _bg_review_pending_lock = threading.Lock()
+
+            def _deliver_bg_review_message(message: str) -> None:
                 if not _status_adapter:
                     return
                 try:
@@ -8524,7 +8564,30 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("background_review_callback error: %s", _e)
 
+            def _release_bg_review_messages() -> None:
+                _bg_review_release.set()
+                with _bg_review_pending_lock:
+                    pending = list(_bg_review_pending)
+                    _bg_review_pending.clear()
+                for queued in pending:
+                    _deliver_bg_review_message(queued)
+
+            # Background review delivery — send "💾 Memory updated" etc. to user
+            def _bg_review_send(message: str) -> None:
+                if not _status_adapter:
+                    return
+                if not _bg_review_release.is_set():
+                    with _bg_review_pending_lock:
+                        if not _bg_review_release.is_set():
+                            _bg_review_pending.append(message)
+                            return
+                _deliver_bg_review_message(message)
+
             agent.background_review_callback = _bg_review_send
+            self._register_deferred_background_review_release(
+                session_key,
+                _release_bg_review_messages,
+            )
 
             # Store agent reference for interrupt support
             agent_holder[0] = agent
@@ -9252,6 +9315,7 @@ class GatewayRunner:
                             )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
+                    self._release_deferred_background_reviews(session_key)
                 # else: interrupted — discard the interrupted response ("Operation
                 # interrupted." is just noise; the user already knows they sent a
                 # new message).

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1,5 +1,6 @@
 """Tests for topic-aware gateway progress updates."""
 
+import asyncio
 import importlib
 import sys
 import time
@@ -415,6 +416,21 @@ class QueuedCommentaryAgent:
         }
 
 
+class BackgroundReviewAgent:
+    def __init__(self, **kwargs):
+        self.background_review_callback = kwargs.get("background_review_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.background_review_callback:
+            self.background_review_callback("💾 Skill 'prospect-scanner' created.")
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class VerboseAgent:
     """Agent that emits a tool call with args whose JSON exceeds 200 chars."""
     LONG_CODE = "x" * 300
@@ -666,6 +682,68 @@ async def test_run_agent_queued_message_does_not_treat_commentary_as_final(monke
     assert result["final_response"] == "final response 2"
     assert "I'll inspect the repo first." in sent_texts
     assert "final response 1" in sent_texts
+
+
+@pytest.mark.asyncio
+async def test_run_agent_defers_background_review_notification_until_release(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        BackgroundReviewAgent,
+        session_id="sess-bg-review-order",
+        config_data={"display": {"interim_assistant_messages": True}},
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+
+
+class DeferredReleaseHandler:
+    def __init__(self, adapter):
+        self.adapter = adapter
+        self.released = []
+
+    async def handle(self, event):
+        return "done"
+
+    def _release_deferred_background_reviews(self, session_key):
+        self.released.append(session_key)
+        self.adapter.sent.append(
+            {
+                "chat_id": "bg-review",
+                "content": "💾 Skill 'prospect-scanner' created.",
+                "reply_to": None,
+                "metadata": None,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_base_processing_releases_deferred_background_reviews_after_main_send():
+    adapter = ProgressCaptureAdapter()
+    handler = DeferredReleaseHandler(adapter)
+    adapter.set_message_handler(handler.handle)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    event = MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-1",
+    )
+    session_key = "agent:main:telegram:group:-1001:17585"
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    await adapter._process_message_background(event, session_key)
+
+    sent_texts = [call["content"] for call in adapter.sent]
+    assert sent_texts == ["done", "💾 Skill 'prospect-scanner' created."]
+    assert handler.released == [session_key]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

This defers gateway background-review notifications until after the main assistant reply has been delivered for the turn.

- queue background-review notifications per session inside `GatewayRunner`
- release queued notifications only after the primary response path completes
- keep the background review/save itself asynchronous; only defer the user-visible `💾 ...` notification
- add regression coverage for both the `_run_agent` deferral and the adapter-level release ordering

## Why

A background review could emit messages like `💾 Skill 'prospect-scanner' created.` before the main assistant reply reached the user. In chat, that looks like Hermes searched, created the skill, and then just stopped.

## Root cause

`run_conversation()` starts the background review before the gateway has actually delivered the main reply. The gateway's `background_review_callback` sent those notifications immediately, so the side-channel message could race ahead of the real answer.

## Impact

Users now see the main reply first, followed by any background-review notification for that turn. The save behavior is unchanged; only notification ordering changes.

## Validation

- `uv run pytest tests/gateway/test_run_progress_topics.py -q`

## Attribution

This fixes the gateway-side race surfaced in the recent report from @spoofydude and Teknium around web-search/prospect-scanner sessions appearing to stop after the search phase.
