### PR TITLE
fix: terminal workdir validation for Windows paths

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -76,6 +76,7 @@ AUTHOR_MAP = {
     "abdullahfarukozden@gmail.com": "Farukest",
     "lovre.pesut@gmail.com": "rovle",
     "hakanerten02@hotmail.com": "teyrebaz33",
+    "ruzzgarcn@gmail.com": "Ruzzgar",
     "alireza78.crypto@gmail.com": "alireza78a",
     "brooklyn.bb.nicholson@gmail.com": "brooklynnicholson",
     "4317663+helix4u@users.noreply.github.com": "helix4u",

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -88,3 +88,18 @@ def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
 
     assert transformed == "echo ok && sudo -S -p '' whoami"
     assert sudo_stdin == "cached-pass\n"
+
+
+def test_validate_workdir_allows_windows_drive_paths():
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project") is None
+    assert terminal_tool._validate_workdir("C:/Users/Alice/project") is None
+
+
+def test_validate_workdir_allows_windows_unc_paths():
+    assert terminal_tool._validate_workdir(r"\\server\share\project") is None
+
+
+def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
+    assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
+    assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -148,9 +148,10 @@ def _check_all_guards(command: str, env_type: str) -> dict:
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
-# Covers alphanumeric, path separators, tilde, dot, hyphen, underscore, space,
-# plus, at, equals, and comma.  Everything else is rejected.
-_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/_\-.~ +@=,]+$')
+# Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
+# dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
+# else is rejected.
+_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/\\:_\-.~ +@=,]+$')
 
 
 def _validate_workdir(workdir: str) -> str | None:


### PR DESCRIPTION
## Summary

Salvage of PR #9953 by @Ruzzgar. Cherry-picked onto current main.

`_validate_workdir()` rejected valid Windows paths (`C:\Users\...`, `\\server\share\...`) because the regex allowlist didn't include `:` or `\\`. Expands the allowlist narrowly for Windows path syntax while keeping shell metacharacter protection.

## Changes
- `tools/terminal_tool.py`: Add `:` and `\\` to `_WORKDIR_SAFE_RE`
- `tests/tools/test_terminal_tool.py`: Tests for Windows drive paths, UNC paths, and blocked metacharacters in Windows-style paths
- `scripts/release.py`: AUTHOR_MAP entry for Ruzzgar

## Test Evidence
- `test_terminal_tool.py`: **10 passed**

## Credit
Original work by @Ruzzgar in #9953 — authorship preserved via cherry-pick.