### PR TITLE
fix: hide gateway internal telemetry by default

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    "internal_status": False,
 }
 
 # ---------------------------------------------------------------------------
@@ -50,6 +51,7 @@ _TIER_HIGH = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,  # follow global
+    "internal_status": False,
 }
 
 _TIER_MEDIUM = {
@@ -57,6 +59,7 @@ _TIER_MEDIUM = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": None,
+    "internal_status": False,
 }
 
 _TIER_LOW = {
@@ -64,6 +67,7 @@ _TIER_LOW = {
     "show_reasoning": False,
     "tool_preview_length": 40,
     "streaming": False,
+    "internal_status": False,
 }
 
 _TIER_MINIMAL = {
@@ -71,6 +75,7 @@ _TIER_MINIMAL = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": False,
+    "internal_status": False,
 }
 
 _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
@@ -182,7 +187,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in ("show_reasoning", "streaming"):
+    if setting in ("show_reasoning", "streaming", "internal_status"):
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26,7 +26,7 @@ import threading
 import time
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Callable
 
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
@@ -1413,30 +1413,11 @@ class GatewayRunner:
 
         self._busy_ack_ts[session_key] = now
 
-        # Build a status-rich acknowledgment
-        status_parts = []
-        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
-            try:
-                summary = running_agent.get_activity_summary()
-                iteration = summary.get("api_call_count", 0)
-                max_iter = summary.get("max_iterations", 0)
-                current_tool = summary.get("current_tool")
-                start_ts = self._running_agents_ts.get(session_key, 0)
-                if start_ts:
-                    elapsed_min = int((now - start_ts) / 60)
-                    if elapsed_min > 0:
-                        status_parts.append(f"{elapsed_min} min elapsed")
-                if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
-                if current_tool:
-                    status_parts.append(f"running: {current_tool}")
-            except Exception:
-                pass
-
-        status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
-        message = (
-            f"⚡ Interrupting current task{status_detail}. "
-            f"I'll respond to your message shortly."
+        message = self._build_busy_ack_message(
+            source=event.source,
+            running_agent=running_agent,
+            session_key=session_key,
+            now=now,
         )
 
         thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
@@ -2560,6 +2541,104 @@ class GatewayRunner:
             return QQAdapter(config)
 
         return None
+
+    def _internal_status_enabled(self, source: SessionSource) -> bool:
+        """Return True only when internal gateway telemetry is explicitly enabled."""
+        try:
+            from gateway.display_config import resolve_display_setting
+
+            user_config = _load_gateway_config()
+            platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
+            return bool(resolve_display_setting(user_config, platform_key, "internal_status", False))
+        except Exception:
+            return False
+
+    def _build_busy_ack_message(
+        self,
+        source: SessionSource,
+        running_agent: Any,
+        session_key: str,
+        now: float,
+    ) -> str:
+        if not self._internal_status_enabled(source):
+            return "One sec, finishing the previous reply and then I'll handle this."
+
+        status_parts = []
+        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                summary = running_agent.get_activity_summary()
+                iteration = summary.get("api_call_count", 0)
+                max_iter = summary.get("max_iterations", 0)
+                current_tool = summary.get("current_tool")
+                start_ts = self._running_agents_ts.get(session_key, 0)
+                if start_ts:
+                    elapsed_min = int((now - start_ts) / 60)
+                    if elapsed_min > 0:
+                        status_parts.append(f"{elapsed_min} min elapsed")
+                if max_iter:
+                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                if current_tool:
+                    status_parts.append(f"running: {current_tool}")
+            except Exception:
+                pass
+
+        status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+        return (
+            f"⚡ Interrupting current task{status_detail}. "
+            f"I'll respond to your message shortly."
+        )
+
+    def _build_internal_status_callback(
+        self,
+        source: SessionSource,
+        adapter: Any,
+        chat_id: str,
+        metadata: Optional[dict[str, Any]],
+        loop: asyncio.AbstractEventLoop,
+    ) -> Optional[Callable[[str, str], None]]:
+        if not adapter or not self._internal_status_enabled(source):
+            return None
+
+        def _status_callback_sync(event_type: str, message: str) -> None:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    adapter.send(
+                        chat_id,
+                        message,
+                        metadata=metadata,
+                    ),
+                    loop,
+                )
+            except Exception as _e:
+                logger.debug("status_callback error (%s): %s", event_type, _e)
+
+        return _status_callback_sync
+
+    def _build_background_review_callback(
+        self,
+        source: SessionSource,
+        adapter: Any,
+        chat_id: str,
+        metadata: Optional[dict[str, Any]],
+        loop: asyncio.AbstractEventLoop,
+    ) -> Optional[Callable[[str], None]]:
+        if not adapter or not self._internal_status_enabled(source):
+            return None
+
+        def _bg_review_send(message: str) -> None:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    adapter.send(
+                        chat_id,
+                        message,
+                        metadata=metadata,
+                    ),
+                    loop,
+                )
+            except Exception as _e:
+                logger.debug("background_review_callback error: %s", _e)
+
+        return _bg_review_send
 
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
@@ -8383,25 +8462,17 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("agent:step hook error: %s", _e)
 
-        # Bridge sync status_callback → async adapter.send for context pressure
+        # Bridge sync status_callback → async adapter.send for optional internal telemetry
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
-
-        def _status_callback_sync(event_type: str, message: str) -> None:
-            if not _status_adapter:
-                return
-            try:
-                asyncio.run_coroutine_threadsafe(
-                    _status_adapter.send(
-                        _status_chat_id,
-                        message,
-                        metadata=_status_thread_metadata,
-                    ),
-                    _loop_for_step,
-                )
-            except Exception as _e:
-                logger.debug("status_callback error (%s): %s", event_type, _e)
+        _status_callback_sync = self._build_internal_status_callback(
+            source=source,
+            adapter=_status_adapter,
+            chat_id=_status_chat_id,
+            metadata=_status_thread_metadata,
+            loop=_loop_for_step,
+        )
 
         def run_sync():
             # The conditional re-assignment of `message` further below
@@ -8608,23 +8679,14 @@ class GatewayRunner:
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
 
-            # Background review delivery — send "💾 Memory updated" etc. to user
-            def _bg_review_send(message: str) -> None:
-                if not _status_adapter:
-                    return
-                try:
-                    asyncio.run_coroutine_threadsafe(
-                        _status_adapter.send(
-                            _status_chat_id,
-                            message,
-                            metadata=_status_thread_metadata,
-                        ),
-                        _loop_for_step,
-                    )
-                except Exception as _e:
-                    logger.debug("background_review_callback error: %s", _e)
-
-            agent.background_review_callback = _bg_review_send
+            # Background review delivery is disabled by default for gateway chats.
+            agent.background_review_callback = self._build_background_review_callback(
+                source=source,
+                adapter=_status_adapter,
+                chat_id=_status_chat_id,
+                metadata=_status_thread_metadata,
+                loop=_loop_for_step,
+            )
 
             # Store agent reference for interrupt support
             agent_holder[0] = agent

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -504,6 +504,7 @@ DEFAULT_CONFIG = {
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
+        "internal_status": False,  # Gateway: expose reconnect/memory/interrupt telemetry only when explicitly enabled
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)

--- a/tests/gateway/test_internal_status_visibility.py
+++ b/tests/gateway/test_internal_status_visibility.py
@@ -1,0 +1,138 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.run import GatewayRunner
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def _bind_internal_status_methods(runner: GatewayRunner) -> None:
+    for name in (
+        "_internal_status_enabled",
+        "_build_busy_ack_message",
+        "_build_internal_status_callback",
+        "_build_background_review_callback",
+    ):
+        setattr(runner, name, getattr(GatewayRunner, name).__get__(runner, GatewayRunner))
+
+
+@pytest.mark.asyncio
+async def test_busy_ack_for_end_users_is_neutral(monkeypatch):
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {"display": {}})
+    runner, adapter = make_restart_runner()
+    _bind_internal_status_methods(runner)
+    runner._busy_ack_ts = {}
+
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {
+        "api_call_count": 7,
+        "max_iterations": 60,
+        "current_tool": "search_files",
+    }
+    runner._running_agents["session"] = running_agent
+    runner._running_agents_ts["session"] = 0
+
+    event = MagicMock()
+    event.text = "new message"
+    event.message_id = "42"
+    event.source = make_restart_source()
+
+    await runner._handle_active_session_busy_message(event, "session")
+
+    assert adapter.sent == ["One sec, finishing the previous reply and then I'll handle this."]
+    assert "Interrupting current task" not in adapter.sent[0]
+    assert "iteration" not in adapter.sent[0]
+    assert "running:" not in adapter.sent[0]
+
+
+def test_detailed_busy_ack_requires_explicit_internal_status_config(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"display": {"internal_status": True}},
+    )
+    runner, _adapter = make_restart_runner()
+    _bind_internal_status_methods(runner)
+
+    running_agent = MagicMock()
+    running_agent.get_activity_summary.return_value = {
+        "api_call_count": 7,
+        "max_iterations": 60,
+        "current_tool": "search_files",
+    }
+    runner._running_agents_ts["session"] = 0
+
+    message = runner._build_busy_ack_message(
+        source=make_restart_source(),
+        running_agent=running_agent,
+        session_key="session",
+        now=120.0,
+    )
+
+    assert "Interrupting current task" in message
+    assert "iteration 7/60" in message
+    assert "running: search_files" in message
+
+
+@pytest.mark.asyncio
+async def test_internal_callbacks_are_disabled_by_default(monkeypatch):
+    monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {"display": {}})
+    runner, adapter = make_restart_runner()
+    _bind_internal_status_methods(runner)
+    loop = asyncio.get_running_loop()
+
+    status_cb = runner._build_internal_status_callback(
+        source=make_restart_source(),
+        adapter=adapter,
+        chat_id="123456",
+        metadata=None,
+        loop=loop,
+    )
+    review_cb = runner._build_background_review_callback(
+        source=make_restart_source(),
+        adapter=adapter,
+        chat_id="123456",
+        metadata=None,
+        loop=loop,
+    )
+
+    assert status_cb is None
+    assert review_cb is None
+
+
+@pytest.mark.asyncio
+async def test_internal_callbacks_send_when_explicitly_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_config",
+        lambda: {"display": {"internal_status": True}},
+    )
+    runner, adapter = make_restart_runner()
+    _bind_internal_status_methods(runner)
+    loop = asyncio.get_running_loop()
+
+    status_cb = runner._build_internal_status_callback(
+        source=make_restart_source(),
+        adapter=adapter,
+        chat_id="123456",
+        metadata=None,
+        loop=loop,
+    )
+    review_cb = runner._build_background_review_callback(
+        source=make_restart_source(),
+        adapter=adapter,
+        chat_id="123456",
+        metadata=None,
+        loop=loop,
+    )
+
+    assert status_cb is not None
+    assert review_cb is not None
+
+    status_cb("lifecycle", "⚠️ Connection to provider dropped")
+    review_cb("💾 User profile updated")
+    await asyncio.sleep(0.05)
+
+    assert adapter.sent == [
+        "⚠️ Connection to provider dropped",
+        "💾 User profile updated",
+    ]


### PR DESCRIPTION
## Summary
- hide busy interrupt details behind a new `display.internal_status` config that defaults to `false`
- stop forwarding lifecycle status and background memory/profile review messages to gateway chats unless that config is explicitly enabled
- add regression tests covering neutral busy acks and disabled internal callbacks by default

## Test Plan
- `/home/felipealvarenga/.hermes/hermes-agent/venv/bin/pytest tests/gateway/test_internal_status_visibility.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_drain.py -q`
