### PR TITLE
fix(run_agent): use DASHSCOPE_API_KEY hint for alibaba provider

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -168,7 +168,7 @@ def _install_safe_stdio() -> None:
 
 
 def _provider_api_key_hint(provider_id: str) -> str:
-    """Return the primary API key env var hint for a configured provider."""
+    """Return the primary API key env var hint for API-key providers only."""
     normalized = (provider_id or "").strip().lower()
     if not normalized:
         return ""
@@ -179,8 +179,11 @@ def _provider_api_key_hint(provider_id: str) -> str:
         PROVIDER_REGISTRY = {}
 
     provider_config = PROVIDER_REGISTRY.get(normalized)
-    if provider_config and provider_config.api_key_env_vars:
-        return provider_config.api_key_env_vars[0]
+    if provider_config is not None:
+        api_key_env_vars = getattr(provider_config, "api_key_env_vars", ()) or ()
+        if api_key_env_vars:
+            return api_key_env_vars[0]
+        return ""
 
     return f"{normalized.upper()}_API_KEY"
 
@@ -970,10 +973,16 @@ class AIAgent:
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
                         env_var_hint = _provider_api_key_hint(_explicit)
+                        if env_var_hint:
+                            raise RuntimeError(
+                                f"Provider '{_explicit}' is set in config.yaml but no API key "
+                                f"was found. Set the {env_var_hint} environment "
+                                f"variable, or switch to a different provider with `hermes model`."
+                            )
                         raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {env_var_hint} environment "
-                            f"variable, or switch to a different provider with `hermes model`."
+                            f"Provider '{_explicit}' is set in config.yaml but no credentials "
+                            f"were found. Complete authentication for this provider, or switch "
+                            f"to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key
                     client_kwargs = {

--- a/run_agent.py
+++ b/run_agent.py
@@ -167,6 +167,24 @@ def _install_safe_stdio() -> None:
             setattr(sys, stream_name, _SafeWriter(stream))
 
 
+def _provider_api_key_hint(provider_id: str) -> str:
+    """Return the primary API key env var hint for a configured provider."""
+    normalized = (provider_id or "").strip().lower()
+    if not normalized:
+        return ""
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+    except Exception:
+        PROVIDER_REGISTRY = {}
+
+    provider_config = PROVIDER_REGISTRY.get(normalized)
+    if provider_config and provider_config.api_key_env_vars:
+        return provider_config.api_key_env_vars[0]
+
+    return f"{normalized.upper()}_API_KEY"
+
+
 class IterationBudget:
     """Thread-safe iteration counter for an agent.
 
@@ -951,9 +969,10 @@ class AIAgent:
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        env_var_hint = _provider_api_key_hint(_explicit)
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {env_var_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -163,6 +163,32 @@ def test_explicit_provider_missing_api_key_uses_provider_env_var_hint(monkeypatc
             )
 
 
+def test_explicit_provider_missing_oauth_credentials_omits_api_key_hint():
+    """Non-API-key providers should not invent env var hints in errors."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)),
+    ):
+        with pytest.raises(RuntimeError) as excinfo:
+            AIAgent(
+                model="gpt-5.3-codex",
+                provider="openai-codex",
+                api_key=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    message = str(excinfo.value)
+    assert "Complete authentication for this provider" in message
+    assert "API_KEY" not in message
+
+
 class TestProviderModelNormalization:
     def test_aiagent_strips_matching_native_provider_prefix(self):
         with (

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -138,6 +138,31 @@ def test_aiagent_reuses_existing_errors_log_handler():
             root_logger.addHandler(handler)
 
 
+def test_explicit_provider_missing_api_key_uses_provider_env_var_hint(monkeypatch):
+    """Explicit providers should use registry-backed env var hints in errors."""
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+    monkeypatch.delenv("ALIBABA_API_KEY", raising=False)
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)),
+    ):
+        with pytest.raises(RuntimeError, match="DASHSCOPE_API_KEY"):
+            AIAgent(
+                model="qwen-max",
+                provider="alibaba",
+                api_key=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+
 class TestProviderModelNormalization:
     def test_aiagent_strips_matching_native_provider_prefix(self):
         with (


### PR DESCRIPTION
## What does this PR do?

Fixes the explicit-provider missing-key error for Alibaba models so Hermes points users at the real credential env var, `DASHSCOPE_API_KEY`, instead of the non-existent `ALIBABA_API_KEY`.

Root cause: `AIAgent` was building the env-var hint with a naive `PROVIDER_API_KEY` pattern in the explicit-provider preflight path instead of consulting the provider metadata already defined in `hermes_cli.auth`.

This keeps the fix narrow: it only changes the error-message hint path, and adds one regression test for the current Alibaba/DashScope mapping.

## Related Issue

Fixes #9506

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: added `_provider_api_key_hint()` and used it in the explicit-provider missing-credentials error path
- `tests/run_agent/test_run_agent.py`: added a regression test that asserts `provider="alibaba"` errors mention `DASHSCOPE_API_KEY`
- Checked the adjacent provider metadata surface in `hermes_cli/auth.py` to ensure the fix matches the existing registry entry for Alibaba/DashScope

## How to Test

1. `source venv/bin/activate`
2. Unset `DASHSCOPE_API_KEY` and instantiate `AIAgent(model="qwen-max", provider="alibaba", api_key=None, quiet_mode=True, skip_context_files=True, skip_memory=True)`
3. Verify the raised `RuntimeError` mentions `DASHSCOPE_API_KEY`
4. Run `python -m pytest tests/run_agent/test_run_agent.py -q -k provider_env_var_hint -n 0`
5. Run `python -m pytest tests/hermes_cli/test_api_key_providers.py -q -n 0`

Validation I ran locally on April 15, 2026:

- `source venv/bin/activate && python -m py_compile run_agent.py tests/run_agent/test_run_agent.py`
- `git diff --check`
- `source venv/bin/activate && python -m pytest tests/run_agent/test_run_agent.py -q -k provider_env_var_hint -n 0` → `1 passed`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_api_key_providers.py -q -n 0` → `127 passed`
- `source venv/bin/activate && python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`
  - Note: this repo-aligned broad command is already red on untouched `origin/main` in my local environment (`76 failed, 11615 passed, 37 skipped`) and remains red on this branch (`74 failed, 11618 passed, 37 skipped`). I did not add a separate lint/typecheck gate because the repo docs do not define one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
