### PR TITLE
fix(cli): guard interactive chat launch in non-tty sessions

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from dotenv import load_dotenv
-
 
 # Env var name suffixes that indicate credential values.  These are the
 # only env vars whose values we sanitize on load — we must not silently
@@ -32,6 +30,10 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    # Import lazily so tests or entrypoints that temporarily stub `dotenv`
+    # do not permanently capture a fake loader in this module.
+    from dotenv import load_dotenv
+
     try:
         load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
     except UnicodeDecodeError:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -45,10 +45,56 @@ Usage:
 
 import argparse
 import os
+import selectors
 import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
+
+def _has_interactive_stdio() -> bool:
+    """Return True when both stdin and stdout are usable terminals."""
+    for name in ("stdin", "stdout"):
+        stream = getattr(sys, name, None)
+        if stream is None:
+            return False
+        try:
+            if not stream.isatty():
+                return False
+        except Exception:
+            return False
+    return True
+
+
+def can_launch_chat_interactively() -> tuple[bool, Optional[str]]:
+    """Return whether prompt_toolkit can safely attach to the current terminal."""
+    if not _has_interactive_stdio():
+        return False, "Interactive chat needs a real stdin/stdout terminal."
+
+    stdin = getattr(sys, "stdin", None)
+    try:
+        fd = stdin.fileno()
+    except (AttributeError, OSError, ValueError):
+        return False, "stdin is not exposed as a usable terminal file descriptor."
+
+    try:
+        if not os.isatty(fd):
+            return False, "stdin is not attached to a usable terminal device."
+    except OSError:
+        return False, "stdin is not attached to a usable terminal device."
+
+    selector = None
+    try:
+        selector = selectors.DefaultSelector()
+        selector.register(fd, selectors.EVENT_READ)
+        selector.unregister(fd)
+    except OSError:
+        return False, "Your current terminal session cannot hand stdin to the interactive chat UI."
+    finally:
+        if selector is not None:
+            selector.close()
+
+    return True, None
+
 
 def _require_tty(command_name: str) -> None:
     """Exit with a clear error if stdin is not a terminal.
@@ -57,7 +103,7 @@ def _require_tty(command_name: str) -> None:
     curses or input() prompts that spin at 100% CPU when stdin is a pipe.
     This guard prevents accidental non-interactive invocation.
     """
-    if not sys.stdin.isatty():
+    if not _has_interactive_stdio():
         print(
             f"Error: 'hermes {command_name}' requires an interactive terminal.\n"
             f"It cannot be run through a pipe or non-interactive subprocess.\n"
@@ -738,6 +784,17 @@ def cmd_chat(args):
         prefetch_update_check()
     except Exception:
         pass
+
+    if not getattr(args, "query", None):
+        can_launch, reason = can_launch_chat_interactively()
+        if not can_launch:
+            print(
+                "Error: 'hermes chat' requires an interactive terminal.\n"
+                f"{reason}\n"
+                "Run it directly in your terminal, or pass -q/--query for single-query mode.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Sync bundled skills on every CLI launch (fast -- skips unchanged skills)
     try:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2978,6 +2978,17 @@ def _resolve_hermes_chat_argv() -> Optional[list[str]]:
 def _offer_launch_chat():
     """Prompt the user to jump straight into chat after setup."""
     print()
+
+    from hermes_cli.main import can_launch_chat_interactively
+
+    can_launch, reason = can_launch_chat_interactively()
+    if not can_launch:
+        print_info("Skipping automatic chat launch.")
+        if reason:
+            print_info(reason)
+        print_info("Run 'hermes chat' directly in your terminal when you're ready.")
+        return
+
     if not prompt_yes_no("Launch hermes chat now?", True):
         return
 

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -539,7 +539,7 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
 
     monkeypatch.setattr("hermes_cli.auth.resolve_provider", _resolve_provider)
     monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices, **kwargs: len(choices) - 1)
-    monkeypatch.setattr("sys.stdin", type("FakeTTY", (), {"isatty": lambda self: True})())
+    monkeypatch.setattr(hermes_main, "_require_tty", lambda *a: None)
 
     hermes_main.cmd_model(SimpleNamespace())
     output = capsys.readouterr().out

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -6,8 +6,11 @@ import types
 
 import pytest
 
-# Ensure dotenv doesn't interfere
-if "dotenv" not in sys.modules:
+# Import real dotenv when available. Only fall back to a stub in minimal
+# environments where python-dotenv is not installed.
+try:
+    import dotenv  # noqa: F401
+except ImportError:
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
     sys.modules["dotenv"] = fake_dotenv
@@ -131,7 +134,7 @@ PROVIDER_ENV_VARS = (
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
-    "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
+    "NOUS_API_KEY", "COPILOT_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
 )

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+import types
 from pathlib import Path
 
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -68,3 +69,27 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_env_loader_uses_live_dotenv_after_module_imported_under_stub(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("OPENAI_BASE_URL=https://new.example/v1\n", encoding="utf-8")
+
+    env_loader_module = importlib.import_module("hermes_cli.env_loader")
+    real_dotenv = importlib.import_module("dotenv")
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://old.example/v1")
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    importlib.reload(env_loader_module)
+    monkeypatch.setitem(sys.modules, "dotenv", real_dotenv)
+
+    try:
+        loaded = env_loader_module.load_hermes_dotenv(hermes_home=home)
+        assert loaded == [env_file]
+        assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
+    finally:
+        importlib.reload(env_loader_module)

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
     filter_nous_free_models, _NOUS_ALLOWED_FREE_MODELS,
@@ -16,6 +18,22 @@ LIVE_OPENROUTER_MODELS = [
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
 ]
 
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    for env_var in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
 
 
 class TestModelIds:

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -467,6 +467,7 @@ def test_offer_launch_chat_execs_fresh_process(monkeypatch):
 
     monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_mod, "_resolve_hermes_chat_argv", lambda: ["/usr/local/bin/hermes", "chat"])
+    monkeypatch.setattr("hermes_cli.main.can_launch_chat_interactively", lambda: (True, None))
 
     exec_calls = []
 
@@ -487,6 +488,7 @@ def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys
 
     monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(setup_mod, "_resolve_hermes_chat_argv", lambda: None)
+    monkeypatch.setattr("hermes_cli.main.can_launch_chat_interactively", lambda: (True, None))
 
     setup_mod._offer_launch_chat()
 

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -144,6 +144,44 @@ class TestNonInteractiveSetup:
         out = capsys.readouterr().out
         assert "hermes config set model.provider custom" in out
 
+    def test_chat_with_provider_exits_cleanly_when_interactive_ui_cannot_attach(self, capsys):
+        """Configured chat should fail gracefully instead of surfacing prompt_toolkit tracebacks."""
+        from hermes_cli.main import cmd_chat
+
+        args = _make_chat_args()
+
+        with (
+            patch("hermes_cli.main._has_any_provider_configured", return_value=True),
+            patch(
+                "hermes_cli.main.can_launch_chat_interactively",
+                return_value=(False, "Your current terminal session cannot hand stdin to the interactive chat UI."),
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cmd_chat(args)
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "requires an interactive terminal" in err
+        assert "single-query mode" in err
+
+    def test_offer_launch_chat_skips_auto_launch_when_chat_ui_cannot_attach(self, capsys):
+        """Setup should not prompt to launch chat when the interactive UI cannot start safely."""
+        from hermes_cli import setup as setup_mod
+
+        with (
+            patch(
+                "hermes_cli.main.can_launch_chat_interactively",
+                return_value=(False, "Your current terminal session cannot hand stdin to the interactive chat UI."),
+            ),
+            patch.object(setup_mod, "prompt_yes_no", side_effect=AssertionError("launch prompt should be skipped")),
+        ):
+            setup_mod._offer_launch_chat()
+
+        out = capsys.readouterr().out
+        assert "Skipping automatic chat launch." in out
+        assert "Run 'hermes chat' directly in your terminal" in out
+
     def test_returning_user_terminal_menu_choice_dispatches_terminal_section(self, tmp_path):
         """Returning-user menu should map Terminal Backend to the terminal setup, not TTS."""
         from hermes_cli import setup as setup_mod


### PR DESCRIPTION
## Summary
- guard `hermes chat` before prompt_toolkit attaches when stdin/stdout are not truly interactive
- skip setup auto-launch when interactive chat cannot safely start, while preserving fresh-process relaunch behavior
- harden env-loader and provider/model tests against leaked dotenv or provider env state
- update setup/provider tests for new launch guard behavior

## Testing
- `/Users/ea/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_chat_skills_flag.py tests/hermes_cli/test_env_loader.py tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_models.py tests/cli/test_cli_provider_resolution.py`