### PR TITLE
fix: disambiguate duplicate display names in model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -787,6 +787,7 @@ def list_authenticated_providers(
 
     results: List[dict] = []
     seen_slugs: set = set()
+    seen_display_names: dict[str, str] = {}  # display_name -> hermes_id
 
     data = fetch_models_dev()
 
@@ -827,6 +828,19 @@ def list_authenticated_providers(
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
         display_name = pinfo.name if pinfo else mdev_id
+
+        # Disambiguate duplicate display names (e.g., kimi-coding vs kimi-coding-cn)
+        if display_name in seen_display_names:
+            # Append region hint based on hermes_id suffix
+            if hermes_id.endswith("-cn"):
+                display_name = f"{display_name} (China)"
+            elif "-" in hermes_id:
+                # Use last segment as disambiguator
+                suffix = hermes_id.split("-")[-1].upper()
+                display_name = f"{display_name} ({suffix})"
+            else:
+                display_name = f"{display_name} ({hermes_id})"
+        seen_display_names[pinfo.name if pinfo else mdev_id] = hermes_id
 
         results.append({
             "slug": slug,


### PR DESCRIPTION
## Summary
Fixes duplicate "Kimi For Coding" entries in the TUI model picker when both `kimi-coding` and `kimi-coding-cn` providers are configured.

## Root Cause
Both `kimi-coding` and `kimi-coding-cn` map to the same models.dev ID (`kimi-for-coding`), so they resolve to the same display name without disambiguation.

## Fix
- Track seen display names in `list_authenticated_providers()`
- When a duplicate is detected, append a disambiguator:
  - "(China)" for `-cn` suffix
  - "(SUFFIX)" for other hyphenated IDs  
  - "(hermes_id)" as fallback

## Before
```
Kimi For Coding (6 models)
Kimi For Coding (4 models)  ← duplicate, confusing
```

## After
```
Kimi For Coding (6 models)
Kimi For Coding (China) (4 models)  ← disambiguated
```

## Test Plan
- [x] Duplicate providers now show disambiguated names
- [x] Single providers still show clean names
- [x] Import works without errors

Closes NousResearch/hermes-agent#10526