### PR TITLE
[codex] canonicalize gateway transcript storage

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -1,25 +1,25 @@
-"""
-Session mirroring for cross-platform message delivery.
+"""Session mirroring for cross-platform message delivery.
 
 When a message is sent to a platform (via send_message or cron delivery),
 this module appends a "delivery-mirror" record to the target session's
 transcript so the receiving-side agent has context about what was sent.
 
 Standalone -- works from CLI, cron, and gateway contexts without needing
-the full SessionStore machinery.
+the full SessionStore machinery, but delegates transcript persistence to
+the canonical helpers in ``gateway.session``.
 """
 
-import json
 import logging
 from datetime import datetime
 from typing import Optional
 
-from hermes_cli.config import get_hermes_home
+from hermes_constants import get_hermes_home
+
+from gateway.session import append_transcript_message, find_matching_session_id
 
 logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = get_hermes_home() / "sessions"
-_SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
 
 
 def mirror_to_session(
@@ -33,7 +33,8 @@ def mirror_to_session(
     Append a delivery-mirror message to the target session's transcript.
 
     Finds the gateway session that matches the given platform + chat_id,
-    then writes a mirror entry to both the JSONL transcript and SQLite DB.
+    then persists the mirror entry through the canonical gateway session
+    storage path.
 
     Returns True if mirrored successfully, False if no matching session or error.
     All errors are caught -- this is never fatal.
@@ -52,8 +53,7 @@ def mirror_to_session(
             "mirror_source": source_label,
         }
 
-        _append_to_jsonl(session_id, mirror_msg)
-        _append_to_sqlite(session_id, mirror_msg)
+        _append_to_transcript(session_id, mirror_msg)
 
         logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
         return True
@@ -64,69 +64,28 @@ def mirror_to_session(
 
 
 def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = None) -> Optional[str]:
-    """
-    Find the active session_id for a platform + chat_id pair.
-
-    Scans sessions.json entries and matches where origin.chat_id == chat_id
-    on the right platform.  DM session keys don't embed the chat_id
-    (e.g. "agent:main:telegram:dm"), so we check the origin dict.
-    """
-    if not _SESSIONS_INDEX.exists():
-        return None
-
-    try:
-        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
-        return None
-
-    platform_lower = platform.lower()
-    best_match = None
-    best_updated = ""
-
-    for _key, entry in data.items():
-        origin = entry.get("origin") or {}
-        entry_platform = (origin.get("platform") or entry.get("platform", "")).lower()
-
-        if entry_platform != platform_lower:
-            continue
-
-        origin_chat_id = str(origin.get("chat_id", ""))
-        if origin_chat_id == str(chat_id):
-            origin_thread_id = origin.get("thread_id")
-            if thread_id is not None and str(origin_thread_id or "") != str(thread_id):
-                continue
-            updated = entry.get("updated_at", "")
-            if updated > best_updated:
-                best_updated = updated
-                best_match = entry.get("session_id")
-
-    return best_match
+    """Resolve a delivery target to the latest matching gateway session."""
+    return find_matching_session_id(
+        _SESSIONS_DIR,
+        platform,
+        str(chat_id),
+        thread_id=thread_id,
+    )
 
 
-def _append_to_jsonl(session_id: str, message: dict) -> None:
-    """Append a message to the JSONL transcript file."""
-    transcript_path = _SESSIONS_DIR / f"{session_id}.jsonl"
-    try:
-        with open(transcript_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(message, ensure_ascii=False) + "\n")
-    except Exception as e:
-        logger.debug("Mirror JSONL write failed: %s", e)
-
-
-def _append_to_sqlite(session_id: str, message: dict) -> None:
-    """Append a message to the SQLite session database."""
+def _append_to_transcript(session_id: str, message: dict) -> None:
+    """Append a mirror message through the canonical gateway transcript path."""
     db = None
     try:
         from hermes_state import SessionDB
         db = SessionDB()
-        db.append_message(
-            session_id=session_id,
-            role=message.get("role", "assistant"),
-            content=message.get("content"),
-        )
     except Exception as e:
-        logger.debug("Mirror SQLite write failed: %s", e)
+        logger.debug("Mirror SQLite unavailable: %s", e)
+
+    try:
+        append_transcript_message(_SESSIONS_DIR, db, session_id, message)
+    except Exception as e:
+        logger.debug("Mirror transcript write failed: %s", e)
     finally:
         if db is not None:
             db.close()

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -11,7 +11,7 @@ the canonical helpers in ``gateway.session``.
 
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 
@@ -28,6 +28,7 @@ def mirror_to_session(
     message_text: str,
     source_label: str = "cli",
     thread_id: Optional[str] = None,
+    db: Any = None,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
@@ -53,7 +54,7 @@ def mirror_to_session(
             "mirror_source": source_label,
         }
 
-        _append_to_transcript(session_id, mirror_msg)
+        _append_to_transcript(session_id, mirror_msg, db=db)
 
         logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
         return True
@@ -73,19 +74,20 @@ def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = Non
     )
 
 
-def _append_to_transcript(session_id: str, message: dict) -> None:
+def _append_to_transcript(session_id: str, message: dict, db: Any = None) -> None:
     """Append a mirror message through the canonical gateway transcript path."""
-    db = None
-    try:
-        from hermes_state import SessionDB
-        db = SessionDB()
-    except Exception as e:
-        logger.debug("Mirror SQLite unavailable: %s", e)
+    owns_db = db is None
+    if owns_db:
+        try:
+            from hermes_state import SessionDB
+            db = SessionDB()
+        except Exception as e:
+            logger.debug("Mirror SQLite unavailable: %s", e)
 
     try:
         append_transcript_message(_SESSIONS_DIR, db, session_id, message)
     except Exception as e:
         logger.debug("Mirror transcript write failed: %s", e)
     finally:
-        if db is not None:
+        if owns_db and db is not None:
             db.close()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4085,8 +4085,9 @@ class GatewayRunner:
                 else:
                     # The agent already persisted these messages to SQLite via
                     # _flush_messages_to_session_db(), so skip the DB write here
-                    # to prevent the duplicate-write bug (#860).  We still write
-                    # to JSONL for backward compatibility and as a backup.
+                    # to prevent the duplicate-write bug (#860). SessionStore
+                    # now treats SQLite as canonical, so skip_db=True means
+                    # "do not persist this message again here."
                     agent_persisted = self._session_db is not None
                     for msg in new_messages:
                         # Skip system messages (they're rebuilt each run)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4083,13 +4083,18 @@ class GatewayRunner:
                             {"role": "assistant", "content": response, "timestamp": ts}
                         )
                 else:
-                    # The agent already persisted these messages to SQLite via
-                    # _flush_messages_to_session_db(), so skip the DB write here
-                    # to prevent the duplicate-write bug (#860). SessionStore
-                    # now treats SQLite as canonical, so skip_db=True means
-                    # "do not persist this message again here."
-                    agent_persisted = self._session_db is not None
-                    for msg in new_messages:
+                    # The agent reports how many post-history messages actually
+                    # reached SQLite. Skip only that persisted prefix so a
+                    # partial DB flush can still be completed here without
+                    # duplicate writes or silent transcript loss.
+                    try:
+                        persisted_count = max(
+                            0,
+                            int(agent_result.get("session_db_persisted_count", 0) or 0),
+                        )
+                    except (TypeError, ValueError):
+                        persisted_count = 0
+                    for idx, msg in enumerate(new_messages):
                         # Skip system messages (they're rebuilt each run)
                         if msg.get("role") == "system":
                             continue
@@ -4097,7 +4102,7 @@ class GatewayRunner:
                         entry = {**msg, "timestamp": ts}
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
-                            skip_db=agent_persisted,
+                            skip_db=idx < persisted_count,
                         )
             
             # Token counts and model are now persisted by the agent directly.
@@ -8818,6 +8823,7 @@ class GatewayRunner:
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
+            _persisted_idx = getattr(_agent, "_last_flushed_db_idx", 0) if _agent else 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
@@ -8834,6 +8840,7 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "session_db_persisted_count": max(0, _persisted_idx - len(agent_history)),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -8925,6 +8932,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "session_db_persisted_count": max(0, _persisted_idx - _effective_history_offset),
             }
         
         # Start progress message sender if enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8823,7 +8823,7 @@ class GatewayRunner:
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
-            _persisted_idx = getattr(_agent, "_last_flushed_db_idx", 0) if _agent else 0
+            _persisted_count = getattr(_agent, "_last_session_db_persisted_count", 0) if _agent else 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
@@ -8840,7 +8840,7 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
-                    "session_db_persisted_count": max(0, _persisted_idx - len(agent_history)),
+                    "session_db_persisted_count": _persisted_count,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -8932,7 +8932,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
-                "session_db_persisted_count": max(0, _persisted_idx - _effective_history_offset),
+                "session_db_persisted_count": _persisted_count,
             }
         
         # Start progress message sender if enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8823,7 +8823,7 @@ class GatewayRunner:
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
-            _persisted_count = getattr(_agent, "_last_session_db_persisted_count", 0) if _agent else 0
+            _persisted_idx = getattr(_agent, "_last_flushed_db_idx", 0) if _agent else 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
@@ -8840,7 +8840,7 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
-                    "session_db_persisted_count": _persisted_count,
+                    "session_db_persisted_count": max(0, _persisted_idx - len(agent_history)),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -8932,7 +8932,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
-                "session_db_persisted_count": _persisted_count,
+                "session_db_persisted_count": max(0, _persisted_idx - _effective_history_offset),
             }
         
         # Start progress message sender if enabled

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -611,12 +611,135 @@ def _read_jsonl_transcript(sessions_dir: Path, session_id: str) -> List[Dict[str
     return jsonl_messages
 
 
+def _normalize_transcript_value(value: Any) -> Any:
+    """Normalize structured message fields for equality checks."""
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True, ensure_ascii=False)
+    return value
+
+
+def _message_signature(message: Dict[str, Any]) -> tuple:
+    """Return the transcript fields that both SQLite and JSONL can compare."""
+    return (
+        message.get("role"),
+        message.get("content"),
+        message.get("tool_name"),
+        message.get("tool_call_id"),
+        _normalize_transcript_value(message.get("tool_calls")),
+        _normalize_transcript_value(message.get("reasoning")),
+        _normalize_transcript_value(message.get("reasoning_details")),
+        _normalize_transcript_value(message.get("codex_reasoning_items")),
+    )
+
+
+def _messages_start_with(messages: List[Dict[str, Any]], prefix: List[Dict[str, Any]]) -> bool:
+    """Return True when *messages* begins with *prefix* under transcript equality."""
+    if len(prefix) > len(messages):
+        return False
+    for idx, prefix_msg in enumerate(prefix):
+        if _message_signature(messages[idx]) != _message_signature(prefix_msg):
+            return False
+    return True
+
+
+def _longest_overlap(left: List[Dict[str, Any]], right: List[Dict[str, Any]]) -> int:
+    """Return the max suffix/prefix overlap between two transcript sequences."""
+    max_overlap = min(len(left), len(right))
+    for size in range(max_overlap, 0, -1):
+        if all(
+            _message_signature(left[-size + idx]) == _message_signature(right[idx])
+            for idx in range(size)
+        ):
+            return size
+    return 0
+
+
+def _parse_message_timestamp(value: Any) -> Optional[float]:
+    """Best-effort parse of a stored transcript timestamp."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _jsonl_time_bounds(messages: List[Dict[str, Any]]) -> Optional[tuple[float, float]]:
+    """Return (min_ts, max_ts) when every JSONL message has a parseable timestamp."""
+    stamps = [_parse_message_timestamp(msg.get("timestamp")) for msg in messages]
+    if any(ts is None for ts in stamps):
+        return None
+    return (min(stamps), max(stamps))
+
+
+def _db_time_bounds(rows: List[Dict[str, Any]]) -> Optional[tuple[float, float]]:
+    """Return (min_ts, max_ts) for raw SQLite message rows."""
+    if not rows:
+        return None
+    stamps = [row.get("timestamp") for row in rows if row.get("timestamp") is not None]
+    if len(stamps) != len(rows):
+        return None
+    return (min(stamps), max(stamps))
+
+
+def _merge_transcript_histories(
+    jsonl_messages: List[Dict[str, Any]],
+    db_messages: List[Dict[str, Any]],
+    *,
+    db_rows: Optional[List[Dict[str, Any]]] = None,
+) -> tuple[List[Dict[str, Any]], bool]:
+    """Merge legacy JSONL and SQLite transcript histories without losing turns.
+
+    Returns ``(merged_messages, safe_to_persist)``.  When ``safe_to_persist`` is
+    False, the caller must treat the result as read-only and keep the legacy
+    JSONL file in place.
+    """
+    if not db_messages:
+        return jsonl_messages, True
+    if not jsonl_messages:
+        return db_messages, True
+
+    if _messages_start_with(db_messages, jsonl_messages):
+        return db_messages, True
+    if _messages_start_with(jsonl_messages, db_messages):
+        return jsonl_messages, True
+
+    overlap = _longest_overlap(jsonl_messages, db_messages)
+    if overlap:
+        return jsonl_messages + db_messages[overlap:], True
+
+    overlap = _longest_overlap(db_messages, jsonl_messages)
+    if overlap:
+        return db_messages + jsonl_messages[overlap:], True
+
+    jsonl_bounds = _jsonl_time_bounds(jsonl_messages)
+    db_bounds = _db_time_bounds(db_rows or [])
+    if jsonl_bounds and db_bounds:
+        jsonl_min, jsonl_max = jsonl_bounds
+        db_min, db_max = db_bounds
+        if jsonl_max <= db_min:
+            return jsonl_messages + db_messages, True
+        if db_max <= jsonl_min:
+            return db_messages + jsonl_messages, True
+
+    # Ambiguous divergence: keep storage untouched and fall back to the more
+    # complete-looking source for this load only.
+    if len(jsonl_messages) > len(db_messages):
+        return jsonl_messages, False
+    return db_messages, False
+
+
 def _migrate_legacy_jsonl_to_db(
     sessions_dir: Path,
     session_db: Any,
     session_id: str,
     *,
     db_messages: Optional[List[Dict[str, Any]]] = None,
+    db_rows: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     """Import a legacy JSONL transcript into SQLite and retire the file.
 
@@ -628,14 +751,26 @@ def _migrate_legacy_jsonl_to_db(
     if not jsonl_messages:
         return db_messages or []
 
-    if db_messages and len(db_messages) >= len(jsonl_messages):
+    merged_messages, safe_to_persist = _merge_transcript_histories(
+        jsonl_messages,
+        db_messages or [],
+        db_rows=db_rows,
+    )
+    if not safe_to_persist:
+        logger.debug(
+            "Legacy transcript %s diverged ambiguously; leaving JSONL read-only in place",
+            session_id,
+        )
+        return merged_messages
+
+    if merged_messages == (db_messages or []):
         _remove_legacy_transcript(sessions_dir, session_id)
-        return db_messages
+        return merged_messages
 
     try:
         session_db.ensure_session(session_id, source="gateway")
         session_db.clear_messages(session_id)
-        for msg in jsonl_messages:
+        for msg in merged_messages:
             _append_message_to_session_db(
                 session_db,
                 session_id,
@@ -644,10 +779,10 @@ def _migrate_legacy_jsonl_to_db(
             )
         _remove_legacy_transcript(sessions_dir, session_id)
         migrated = session_db.get_messages_as_conversation(session_id)
-        return migrated or jsonl_messages
+        return migrated or merged_messages
     except Exception as e:
         logger.debug("Failed to migrate legacy transcript %s: %s", session_id, e)
-        return db_messages or jsonl_messages
+        return merged_messages
 
 
 def append_transcript_message(
@@ -712,6 +847,7 @@ def load_transcript_messages(
     """Load transcript messages from SQLite, migrating legacy JSONL once."""
     if session_db:
         try:
+            db_rows = session_db.get_messages(session_id)
             db_messages = session_db.get_messages_as_conversation(session_id)
         except Exception as e:
             logger.debug("Could not load messages from DB, falling back to JSONL: %s", e)
@@ -724,6 +860,7 @@ def load_transcript_messages(
                 session_db,
                 session_id,
                 db_messages=db_messages,
+                db_rows=db_rows,
             )
         return db_messages
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -549,6 +549,7 @@ def _append_message_to_session_db(
     """Append a single transcript message to SQLite when available."""
     if not session_db:
         return
+    session_db.ensure_session(session_id, source="gateway")
 
     role = message.get("role", "unknown")
     content = message.get("content")
@@ -634,160 +635,36 @@ def _read_jsonl_transcript(sessions_dir: Path, session_id: str) -> List[Dict[str
     return jsonl_messages
 
 
-def _normalize_transcript_value(value: Any) -> Any:
-    """Normalize structured message fields for equality checks."""
-    if isinstance(value, (dict, list)):
-        return json.dumps(value, sort_keys=True, ensure_ascii=False)
-    return value
+def _migrate_legacy_transcripts(sessions_dir: Path, session_db: Any) -> None:
+    """Import legacy JSONL transcripts into SQLite before runtime access.
 
-
-def _message_signature(message: Dict[str, Any]) -> tuple:
-    """Return the transcript fields that both SQLite and JSONL can compare."""
-    content = message.get("content")
-    if message.get("role") == "session_meta" and content is None:
-        content = {
-            k: v
-            for k, v in message.items()
-            if k not in {"role", "timestamp"}
-        }
-    return (
-        message.get("role"),
-        _normalize_transcript_value(content),
-        message.get("tool_name"),
-        message.get("tool_call_id"),
-        _normalize_transcript_value(message.get("tool_calls")),
-        _normalize_transcript_value(message.get("reasoning")),
-        _normalize_transcript_value(message.get("reasoning_details")),
-        _normalize_transcript_value(message.get("codex_reasoning_items")),
-    )
-
-
-def _message_signatures(messages: List[Dict[str, Any]]) -> List[tuple]:
-    """Precompute comparable transcript signatures for a message sequence."""
-    return [_message_signature(msg) for msg in messages]
-
-
-def _longest_overlap(left: List[tuple], right: List[tuple]) -> int:
-    """Return the max suffix/prefix overlap between two signature sequences."""
-    max_overlap = min(len(left), len(right))
-    for size in range(max_overlap, 0, -1):
-        if left[-size:] == right[:size]:
-            return size
-    return 0
-
-
-def _parse_message_timestamp(value: Any) -> Optional[float]:
-    """Best-effort parse of a stored transcript timestamp."""
-    if value in (None, ""):
-        return None
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value).timestamp()
-        except ValueError:
-            return None
-    return None
-
-
-def _time_bounds(messages: List[Dict[str, Any]]) -> Optional[tuple[float, float]]:
-    """Return (min_ts, max_ts) when every message has a parseable timestamp."""
-    if not messages:
-        return None
-    stamps = [_parse_message_timestamp(msg.get("timestamp")) for msg in messages]
-    if any(ts is None for ts in stamps):
-        return None
-    return (min(stamps), max(stamps))
-
-
-def _merge_transcript_histories(
-    jsonl_messages: List[Dict[str, Any]],
-    db_messages: List[Dict[str, Any]],
-    *,
-    db_rows: Optional[List[Dict[str, Any]]] = None,
-) -> tuple[List[Dict[str, Any]], bool]:
-    """Merge legacy JSONL and SQLite transcript histories without losing turns.
-
-    Returns ``(merged_messages, safe_to_persist)``.  When ``safe_to_persist`` is
-    False, the caller must treat the result as read-only and keep the legacy
-    JSONL file in place.
+    This intentionally does not try to reconcile mixed SQLite+JSONL state. If a
+    session has both, that is treated as a migration conflict that must be
+    resolved explicitly instead of guessed at runtime.
     """
-    if not db_messages:
-        return jsonl_messages, True
-    if not jsonl_messages:
-        return db_messages, True
+    if not session_db:
+        return
 
-    db_sigs = _message_signatures(db_messages)
-    jsonl_sigs = _message_signatures(jsonl_messages)
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    for transcript_path in sorted(sessions_dir.glob("*.jsonl")):
+        session_id = transcript_path.stem
+        jsonl_messages = _read_jsonl_transcript(sessions_dir, session_id)
+        if not jsonl_messages:
+            _remove_legacy_transcript(sessions_dir, session_id)
+            continue
 
-    if db_sigs[:len(jsonl_sigs)] == jsonl_sigs:
-        return db_messages, True
-    if jsonl_sigs[:len(db_sigs)] == db_sigs:
-        return jsonl_messages, True
+        db_messages = session_db.get_messages_as_conversation(session_id)
+        if db_messages:
+            raise RuntimeError(
+                "Legacy transcript "
+                f"{transcript_path.name} conflicts with existing SQLite history for "
+                f"session {session_id}. Resolve the transcript manually and remove "
+                "the JSONL file before continuing."
+            )
 
-    overlap = _longest_overlap(jsonl_sigs, db_sigs)
-    if overlap:
-        return jsonl_messages + db_messages[overlap:], True
-
-    overlap = _longest_overlap(db_sigs, jsonl_sigs)
-    if overlap:
-        return db_messages + jsonl_messages[overlap:], True
-
-    jsonl_bounds = _time_bounds(jsonl_messages)
-    db_bounds = _time_bounds(db_rows or [])
-    if jsonl_bounds and db_bounds:
-        jsonl_min, jsonl_max = jsonl_bounds
-        db_min, db_max = db_bounds
-        if jsonl_max <= db_min:
-            return jsonl_messages + db_messages, True
-        if db_max <= jsonl_min:
-            return db_messages + jsonl_messages, True
-
-    # Ambiguous divergence: keep storage untouched and fall back to the more
-    # complete-looking source for this load only.
-    if len(jsonl_messages) > len(db_messages):
-        return jsonl_messages, False
-    return db_messages, False
-
-
-def _migrate_legacy_jsonl_to_db(
-    sessions_dir: Path,
-    session_db: Any,
-    session_id: str,
-    *,
-    db_messages: Optional[List[Dict[str, Any]]] = None,
-    db_rows: Optional[List[Dict[str, Any]]] = None,
-) -> List[Dict[str, Any]]:
-    """Import a legacy JSONL transcript into SQLite and retire the file.
-
-    This is a one-way migration path, not a second live backend. After a
-    successful migration (or when SQLite already has at least as much history),
-    the legacy JSONL file is removed so future loads only consult SQLite.
-    """
-    jsonl_messages = _read_jsonl_transcript(sessions_dir, session_id)
-    if not jsonl_messages:
-        return db_messages or []
-
-    merged_messages, safe_to_persist = _merge_transcript_histories(
-        jsonl_messages,
-        db_messages or [],
-        db_rows=db_rows,
-    )
-    if not safe_to_persist:
-        logger.debug(
-            "Legacy transcript %s diverged ambiguously; leaving JSONL read-only in place",
-            session_id,
-        )
-        return merged_messages
-
-    if merged_messages == (db_messages or []):
-        _remove_legacy_transcript(sessions_dir, session_id)
-        return merged_messages
-
-    try:
         session_db.ensure_session(session_id, source="gateway")
         session_db.clear_messages(session_id)
-        for msg in merged_messages:
+        for msg in jsonl_messages:
             _append_message_to_session_db(
                 session_db,
                 session_id,
@@ -795,11 +672,6 @@ def _migrate_legacy_jsonl_to_db(
                 include_reasoning=True,
             )
         _remove_legacy_transcript(sessions_dir, session_id)
-        migrated = session_db.get_messages_as_conversation(session_id)
-        return migrated or merged_messages
-    except Exception as e:
-        logger.debug("Failed to migrate legacy transcript %s: %s", session_id, e)
-        return merged_messages
 
 
 def append_transcript_message(
@@ -818,7 +690,8 @@ def append_transcript_message(
             _append_message_to_session_db(session_db, session_id, message)
             return
         except Exception as e:
-            logger.debug("Session DB operation failed, falling back to JSONL: %s", e)
+            logger.warning("Session DB operation failed: %s", e)
+            return
 
     _append_message_to_jsonl(sessions_dir, session_id, message)
 
@@ -831,11 +704,12 @@ def rewrite_transcript_messages(
 ) -> None:
     """Replace a session transcript in the canonical store.
 
-    SQLite is the primary store when available. JSONL remains only as a
-    fallback when SQLite is unavailable or write failures force a downgrade.
+    SQLite is the primary store when available. JSONL is used only when the
+    session store itself is unavailable.
     """
     if session_db:
         try:
+            session_db.ensure_session(session_id, source="gateway")
             session_db.clear_messages(session_id)
             for msg in messages:
                 _append_message_to_session_db(
@@ -847,7 +721,8 @@ def rewrite_transcript_messages(
             _remove_legacy_transcript(sessions_dir, session_id)
             return
         except Exception as e:
-            logger.debug("Failed to rewrite transcript in DB, falling back to JSONL: %s", e)
+            logger.warning("Failed to rewrite transcript in DB: %s", e)
+            return
 
     sessions_dir.mkdir(parents=True, exist_ok=True)
     transcript_path = get_transcript_path(sessions_dir, session_id)
@@ -861,25 +736,13 @@ def load_transcript_messages(
     session_db: Any,
     session_id: str,
 ) -> List[Dict[str, Any]]:
-    """Load transcript messages from SQLite, migrating legacy JSONL once."""
+    """Load transcript messages from the canonical store."""
     if session_db:
         try:
-            db_rows = session_db.get_messages(session_id)
-            db_messages = session_db.get_messages_as_conversation(session_id)
+            return session_db.get_messages_as_conversation(session_id)
         except Exception as e:
-            logger.debug("Could not load messages from DB, falling back to JSONL: %s", e)
-            return _read_jsonl_transcript(sessions_dir, session_id)
-
-        transcript_path = get_transcript_path(sessions_dir, session_id)
-        if transcript_path.exists():
-            return _migrate_legacy_jsonl_to_db(
-                sessions_dir,
-                session_db,
-                session_id,
-                db_messages=db_messages,
-                db_rows=db_rows,
-            )
-        return db_messages
+            logger.warning("Could not load messages from DB: %s", e)
+            return []
 
     return _read_jsonl_transcript(sessions_dir, session_id)
 
@@ -934,6 +797,9 @@ class SessionStore:
                             continue
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")
+
+        if self._db:
+            _migrate_legacy_transcripts(self.sessions_dir, self._db)
 
         self._loaded = True
     
@@ -1347,6 +1213,7 @@ class SessionStore:
                      the duplicate-write bug (#860). When SQLite is unavailable,
                      JSONL remains the fallback backend.
         """
+        self._ensure_loaded()
         append_transcript_message(
             self.sessions_dir,
             self._db,
@@ -1361,6 +1228,7 @@ class SessionStore:
         Used by /retry, /undo, and /compress to persist modified conversation history.
         SQLite is canonical when available; JSONL is only a fallback backend.
         """
+        self._ensure_loaded()
         rewrite_transcript_messages(self.sessions_dir, self._db, session_id, messages)
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
@@ -1368,6 +1236,7 @@ class SessionStore:
 
         Legacy JSONL files are imported into SQLite once and then retired.
         """
+        self._ensure_loaded()
         return load_transcript_messages(self.sessions_dir, self._db, session_id)
 
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -551,10 +551,33 @@ def _append_message_to_session_db(
         return
 
     role = message.get("role", "unknown")
+    content = message.get("content")
+    if role == "session_meta" and content is None:
+        payload = {
+            k: v
+            for k, v in message.items()
+            if k not in {
+                "role",
+                "content",
+                "timestamp",
+                "tool_name",
+                "tool_calls",
+                "tool_call_id",
+                "reasoning",
+                "reasoning_details",
+                "codex_reasoning_items",
+            }
+        }
+        if payload:
+            content = payload
     kwargs: Dict[str, Any] = {
         "session_id": session_id,
         "role": role,
-        "content": message.get("content"),
+        "content": (
+            json.dumps(content, sort_keys=True, ensure_ascii=False)
+            if role == "session_meta" and isinstance(content, (dict, list))
+            else content
+        ),
         "tool_name": message.get("tool_name"),
         "tool_calls": message.get("tool_calls"),
         "tool_call_id": message.get("tool_call_id"),
@@ -620,9 +643,16 @@ def _normalize_transcript_value(value: Any) -> Any:
 
 def _message_signature(message: Dict[str, Any]) -> tuple:
     """Return the transcript fields that both SQLite and JSONL can compare."""
+    content = message.get("content")
+    if message.get("role") == "session_meta" and content is None:
+        content = {
+            k: v
+            for k, v in message.items()
+            if k not in {"role", "timestamp"}
+        }
     return (
         message.get("role"),
-        message.get("content"),
+        _normalize_transcript_value(content),
         message.get("tool_name"),
         message.get("tool_call_id"),
         _normalize_transcript_value(message.get("tool_calls")),

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -491,6 +491,187 @@ def build_session_key(
     return ":".join(key_parts)
 
 
+def get_transcript_path(sessions_dir: Path, session_id: str) -> Path:
+    """Return the legacy JSONL transcript path for a session."""
+    return sessions_dir / f"{session_id}.jsonl"
+
+
+def find_matching_session_id(
+    sessions_dir: Path,
+    platform: str,
+    chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+) -> Optional[str]:
+    """Return the most recently updated session ID matching a delivery target."""
+    sessions_index = sessions_dir / "sessions.json"
+    if not sessions_index.exists():
+        return None
+
+    try:
+        with open(sessions_index, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return None
+
+    platform_lower = platform.lower()
+    best_match = None
+    best_updated = ""
+
+    for entry in data.values():
+        origin = entry.get("origin") or {}
+        entry_platform = (origin.get("platform") or entry.get("platform", "")).lower()
+        if entry_platform != platform_lower:
+            continue
+
+        if str(origin.get("chat_id", "")) != str(chat_id):
+            continue
+
+        origin_thread_id = origin.get("thread_id")
+        if thread_id is not None and str(origin_thread_id or "") != str(thread_id):
+            continue
+
+        updated = entry.get("updated_at", "")
+        if updated > best_updated:
+            best_updated = updated
+            best_match = entry.get("session_id")
+
+    return best_match
+
+
+def _append_message_to_session_db(
+    session_db: Any,
+    session_id: str,
+    message: Dict[str, Any],
+    *,
+    include_reasoning: bool = False,
+) -> None:
+    """Append a single transcript message to SQLite when available."""
+    if not session_db:
+        return
+
+    role = message.get("role", "unknown")
+    kwargs: Dict[str, Any] = {
+        "session_id": session_id,
+        "role": role,
+        "content": message.get("content"),
+        "tool_name": message.get("tool_name"),
+        "tool_calls": message.get("tool_calls"),
+        "tool_call_id": message.get("tool_call_id"),
+    }
+    if include_reasoning and role == "assistant":
+        kwargs["reasoning"] = message.get("reasoning")
+        kwargs["reasoning_details"] = message.get("reasoning_details")
+        kwargs["codex_reasoning_items"] = message.get("codex_reasoning_items")
+    session_db.append_message(**kwargs)
+
+
+def _append_message_to_jsonl(
+    sessions_dir: Path,
+    session_id: str,
+    message: Dict[str, Any],
+) -> None:
+    """Append a single transcript message to the legacy JSONL store."""
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    transcript_path = get_transcript_path(sessions_dir, session_id)
+    with open(transcript_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(message, ensure_ascii=False) + "\n")
+
+
+def _read_jsonl_transcript(sessions_dir: Path, session_id: str) -> List[Dict[str, Any]]:
+    """Load transcript messages from the legacy JSONL store."""
+    transcript_path = get_transcript_path(sessions_dir, session_id)
+    jsonl_messages: List[Dict[str, Any]] = []
+    if not transcript_path.exists():
+        return jsonl_messages
+
+    with open(transcript_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                jsonl_messages.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Skipping corrupt line in transcript %s: %s",
+                    session_id, line[:120],
+                )
+    return jsonl_messages
+
+
+def append_transcript_message(
+    sessions_dir: Path,
+    session_db: Any,
+    session_id: str,
+    message: Dict[str, Any],
+    *,
+    skip_db: bool = False,
+) -> None:
+    """Persist one transcript message via the canonical gateway storage path."""
+    if session_db and not skip_db:
+        try:
+            _append_message_to_session_db(session_db, session_id, message)
+        except Exception as e:
+            logger.debug("Session DB operation failed: %s", e)
+
+    _append_message_to_jsonl(sessions_dir, session_id, message)
+
+
+def rewrite_transcript_messages(
+    sessions_dir: Path,
+    session_db: Any,
+    session_id: str,
+    messages: List[Dict[str, Any]],
+) -> None:
+    """Replace a session transcript in both SQLite and legacy JSONL stores."""
+    if session_db:
+        try:
+            session_db.clear_messages(session_id)
+            for msg in messages:
+                _append_message_to_session_db(
+                    session_db,
+                    session_id,
+                    msg,
+                    include_reasoning=True,
+                )
+        except Exception as e:
+            logger.debug("Failed to rewrite transcript in DB: %s", e)
+
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    transcript_path = get_transcript_path(sessions_dir, session_id)
+    with open(transcript_path, "w", encoding="utf-8") as f:
+        for msg in messages:
+            f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+
+
+def load_transcript_messages(
+    sessions_dir: Path,
+    session_db: Any,
+    session_id: str,
+) -> List[Dict[str, Any]]:
+    """Load transcript messages, preferring the longer of SQLite and JSONL."""
+    db_messages: List[Dict[str, Any]] = []
+    if session_db:
+        try:
+            db_messages = session_db.get_messages_as_conversation(session_id)
+        except Exception as e:
+            logger.debug("Could not load messages from DB: %s", e)
+
+    jsonl_messages = _read_jsonl_transcript(sessions_dir, session_id)
+
+    if len(jsonl_messages) > len(db_messages):
+        if db_messages:
+            logger.debug(
+                "Session %s: JSONL has %d messages vs SQLite %d — "
+                "using JSONL (legacy session not yet fully migrated)",
+                session_id, len(jsonl_messages), len(db_messages),
+            )
+        return jsonl_messages
+
+    return db_messages
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -942,7 +1123,7 @@ class SessionStore:
     
     def get_transcript_path(self, session_id: str) -> Path:
         """Get the path to a session's legacy transcript file."""
-        return self.sessions_dir / f"{session_id}.jsonl"
+        return get_transcript_path(self.sessions_dir, session_id)
     
     def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
         """Append a message to a session's transcript (SQLite + legacy JSONL).
@@ -953,24 +1134,13 @@ class SessionStore:
                      via its own _flush_messages_to_session_db(), preventing
                      the duplicate-write bug (#860).
         """
-        # Write to SQLite (unless the agent already handled it)
-        if self._db and not skip_db:
-            try:
-                self._db.append_message(
-                    session_id=session_id,
-                    role=message.get("role", "unknown"),
-                    content=message.get("content"),
-                    tool_name=message.get("tool_name"),
-                    tool_calls=message.get("tool_calls"),
-                    tool_call_id=message.get("tool_call_id"),
-                )
-            except Exception as e:
-                logger.debug("Session DB operation failed: %s", e)
-        
-        # Also write legacy JSONL (keeps existing tooling working during transition)
-        transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(message, ensure_ascii=False) + "\n")
+        append_transcript_message(
+            self.sessions_dir,
+            self._db,
+            session_id,
+            message,
+            skip_db=skip_db,
+        )
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.
@@ -978,59 +1148,10 @@ class SessionStore:
         Used by /retry, /undo, and /compress to persist modified conversation history.
         Rewrites both SQLite and legacy JSONL storage.
         """
-        # SQLite: clear old messages and re-insert
-        if self._db:
-            try:
-                self._db.clear_messages(session_id)
-                for msg in messages:
-                    role = msg.get("role", "unknown")
-                    self._db.append_message(
-                        session_id=session_id,
-                        role=role,
-                        content=msg.get("content"),
-                        tool_name=msg.get("tool_name"),
-                        tool_calls=msg.get("tool_calls"),
-                        tool_call_id=msg.get("tool_call_id"),
-                        reasoning=msg.get("reasoning") if role == "assistant" else None,
-                        reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                        codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    )
-            except Exception as e:
-                logger.debug("Failed to rewrite transcript in DB: %s", e)
-        
-        # JSONL: overwrite the file
-        transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        rewrite_transcript_messages(self.sessions_dir, self._db, session_id, messages)
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""
-        db_messages = []
-        # Try SQLite first
-        if self._db:
-            try:
-                db_messages = self._db.get_messages_as_conversation(session_id)
-            except Exception as e:
-                logger.debug("Could not load messages from DB: %s", e)
-
-        # Load legacy JSONL transcript (may contain more history than SQLite
-        # for sessions created before the DB layer was introduced).
-        transcript_path = self.get_transcript_path(session_id)
-        jsonl_messages = []
-        if transcript_path.exists():
-            with open(transcript_path, "r", encoding="utf-8") as f:
-                for line in f:
-                    line = line.strip()
-                    if line:
-                        try:
-                            jsonl_messages.append(json.loads(line))
-                        except json.JSONDecodeError:
-                            logger.warning(
-                                "Skipping corrupt line in transcript %s: %s",
-                                session_id, line[:120],
-                            )
-
         # Prefer whichever source has more messages.
         #
         # Background: when a session pre-dates SQLite storage (or when the DB
@@ -1041,16 +1162,7 @@ class SessionStore:
         # turn load_transcript returns those few SQLite rows and ignores the
         # full JSONL history — the model sees a context of 1-4 messages instead
         # of hundreds.  Using the longer source prevents this silent truncation.
-        if len(jsonl_messages) > len(db_messages):
-            if db_messages:
-                logger.debug(
-                    "Session %s: JSONL has %d messages vs SQLite %d — "
-                    "using JSONL (legacy session not yet fully migrated)",
-                    session_id, len(jsonl_messages), len(db_messages),
-                )
-            return jsonl_messages
-
-        return db_messages
+        return load_transcript_messages(self.sessions_dir, self._db, session_id)
 
 
 def build_session_context(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -632,24 +632,16 @@ def _message_signature(message: Dict[str, Any]) -> tuple:
     )
 
 
-def _messages_start_with(messages: List[Dict[str, Any]], prefix: List[Dict[str, Any]]) -> bool:
-    """Return True when *messages* begins with *prefix* under transcript equality."""
-    if len(prefix) > len(messages):
-        return False
-    for idx, prefix_msg in enumerate(prefix):
-        if _message_signature(messages[idx]) != _message_signature(prefix_msg):
-            return False
-    return True
+def _message_signatures(messages: List[Dict[str, Any]]) -> List[tuple]:
+    """Precompute comparable transcript signatures for a message sequence."""
+    return [_message_signature(msg) for msg in messages]
 
 
-def _longest_overlap(left: List[Dict[str, Any]], right: List[Dict[str, Any]]) -> int:
-    """Return the max suffix/prefix overlap between two transcript sequences."""
+def _longest_overlap(left: List[tuple], right: List[tuple]) -> int:
+    """Return the max suffix/prefix overlap between two signature sequences."""
     max_overlap = min(len(left), len(right))
     for size in range(max_overlap, 0, -1):
-        if all(
-            _message_signature(left[-size + idx]) == _message_signature(right[idx])
-            for idx in range(size)
-        ):
+        if left[-size:] == right[:size]:
             return size
     return 0
 
@@ -668,20 +660,12 @@ def _parse_message_timestamp(value: Any) -> Optional[float]:
     return None
 
 
-def _jsonl_time_bounds(messages: List[Dict[str, Any]]) -> Optional[tuple[float, float]]:
-    """Return (min_ts, max_ts) when every JSONL message has a parseable timestamp."""
+def _time_bounds(messages: List[Dict[str, Any]]) -> Optional[tuple[float, float]]:
+    """Return (min_ts, max_ts) when every message has a parseable timestamp."""
+    if not messages:
+        return None
     stamps = [_parse_message_timestamp(msg.get("timestamp")) for msg in messages]
     if any(ts is None for ts in stamps):
-        return None
-    return (min(stamps), max(stamps))
-
-
-def _db_time_bounds(rows: List[Dict[str, Any]]) -> Optional[tuple[float, float]]:
-    """Return (min_ts, max_ts) for raw SQLite message rows."""
-    if not rows:
-        return None
-    stamps = [row.get("timestamp") for row in rows if row.get("timestamp") is not None]
-    if len(stamps) != len(rows):
         return None
     return (min(stamps), max(stamps))
 
@@ -703,21 +687,24 @@ def _merge_transcript_histories(
     if not jsonl_messages:
         return db_messages, True
 
-    if _messages_start_with(db_messages, jsonl_messages):
+    db_sigs = _message_signatures(db_messages)
+    jsonl_sigs = _message_signatures(jsonl_messages)
+
+    if db_sigs[:len(jsonl_sigs)] == jsonl_sigs:
         return db_messages, True
-    if _messages_start_with(jsonl_messages, db_messages):
+    if jsonl_sigs[:len(db_sigs)] == db_sigs:
         return jsonl_messages, True
 
-    overlap = _longest_overlap(jsonl_messages, db_messages)
+    overlap = _longest_overlap(jsonl_sigs, db_sigs)
     if overlap:
         return jsonl_messages + db_messages[overlap:], True
 
-    overlap = _longest_overlap(db_messages, jsonl_messages)
+    overlap = _longest_overlap(db_sigs, jsonl_sigs)
     if overlap:
         return db_messages + jsonl_messages[overlap:], True
 
-    jsonl_bounds = _jsonl_time_bounds(jsonl_messages)
-    db_bounds = _db_time_bounds(db_rows or [])
+    jsonl_bounds = _time_bounds(jsonl_messages)
+    db_bounds = _time_bounds(db_rows or [])
     if jsonl_bounds and db_bounds:
         jsonl_min, jsonl_max = jsonl_bounds
         db_min, db_max = db_bounds

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -566,6 +566,17 @@ def _append_message_to_session_db(
     session_db.append_message(**kwargs)
 
 
+def _remove_legacy_transcript(sessions_dir: Path, session_id: str) -> None:
+    """Delete a legacy JSONL transcript after SQLite becomes canonical."""
+    transcript_path = get_transcript_path(sessions_dir, session_id)
+    try:
+        transcript_path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.debug("Could not remove legacy transcript %s: %s", transcript_path, e)
+
+
 def _append_message_to_jsonl(
     sessions_dir: Path,
     session_id: str,
@@ -600,6 +611,45 @@ def _read_jsonl_transcript(sessions_dir: Path, session_id: str) -> List[Dict[str
     return jsonl_messages
 
 
+def _migrate_legacy_jsonl_to_db(
+    sessions_dir: Path,
+    session_db: Any,
+    session_id: str,
+    *,
+    db_messages: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Import a legacy JSONL transcript into SQLite and retire the file.
+
+    This is a one-way migration path, not a second live backend. After a
+    successful migration (or when SQLite already has at least as much history),
+    the legacy JSONL file is removed so future loads only consult SQLite.
+    """
+    jsonl_messages = _read_jsonl_transcript(sessions_dir, session_id)
+    if not jsonl_messages:
+        return db_messages or []
+
+    if db_messages and len(db_messages) >= len(jsonl_messages):
+        _remove_legacy_transcript(sessions_dir, session_id)
+        return db_messages
+
+    try:
+        session_db.ensure_session(session_id, source="gateway")
+        session_db.clear_messages(session_id)
+        for msg in jsonl_messages:
+            _append_message_to_session_db(
+                session_db,
+                session_id,
+                msg,
+                include_reasoning=True,
+            )
+        _remove_legacy_transcript(sessions_dir, session_id)
+        migrated = session_db.get_messages_as_conversation(session_id)
+        return migrated or jsonl_messages
+    except Exception as e:
+        logger.debug("Failed to migrate legacy transcript %s: %s", session_id, e)
+        return db_messages or jsonl_messages
+
+
 def append_transcript_message(
     sessions_dir: Path,
     session_db: Any,
@@ -609,11 +659,14 @@ def append_transcript_message(
     skip_db: bool = False,
 ) -> None:
     """Persist one transcript message via the canonical gateway storage path."""
-    if session_db and not skip_db:
+    if session_db:
+        if skip_db:
+            return
         try:
             _append_message_to_session_db(session_db, session_id, message)
+            return
         except Exception as e:
-            logger.debug("Session DB operation failed: %s", e)
+            logger.debug("Session DB operation failed, falling back to JSONL: %s", e)
 
     _append_message_to_jsonl(sessions_dir, session_id, message)
 
@@ -624,7 +677,11 @@ def rewrite_transcript_messages(
     session_id: str,
     messages: List[Dict[str, Any]],
 ) -> None:
-    """Replace a session transcript in both SQLite and legacy JSONL stores."""
+    """Replace a session transcript in the canonical store.
+
+    SQLite is the primary store when available. JSONL remains only as a
+    fallback when SQLite is unavailable or write failures force a downgrade.
+    """
     if session_db:
         try:
             session_db.clear_messages(session_id)
@@ -635,8 +692,10 @@ def rewrite_transcript_messages(
                     msg,
                     include_reasoning=True,
                 )
+            _remove_legacy_transcript(sessions_dir, session_id)
+            return
         except Exception as e:
-            logger.debug("Failed to rewrite transcript in DB: %s", e)
+            logger.debug("Failed to rewrite transcript in DB, falling back to JSONL: %s", e)
 
     sessions_dir.mkdir(parents=True, exist_ok=True)
     transcript_path = get_transcript_path(sessions_dir, session_id)
@@ -650,26 +709,25 @@ def load_transcript_messages(
     session_db: Any,
     session_id: str,
 ) -> List[Dict[str, Any]]:
-    """Load transcript messages, preferring the longer of SQLite and JSONL."""
-    db_messages: List[Dict[str, Any]] = []
+    """Load transcript messages from SQLite, migrating legacy JSONL once."""
     if session_db:
         try:
             db_messages = session_db.get_messages_as_conversation(session_id)
         except Exception as e:
-            logger.debug("Could not load messages from DB: %s", e)
+            logger.debug("Could not load messages from DB, falling back to JSONL: %s", e)
+            return _read_jsonl_transcript(sessions_dir, session_id)
 
-    jsonl_messages = _read_jsonl_transcript(sessions_dir, session_id)
-
-    if len(jsonl_messages) > len(db_messages):
-        if db_messages:
-            logger.debug(
-                "Session %s: JSONL has %d messages vs SQLite %d — "
-                "using JSONL (legacy session not yet fully migrated)",
-                session_id, len(jsonl_messages), len(db_messages),
+        transcript_path = get_transcript_path(sessions_dir, session_id)
+        if transcript_path.exists():
+            return _migrate_legacy_jsonl_to_db(
+                sessions_dir,
+                session_db,
+                session_id,
+                db_messages=db_messages,
             )
-        return jsonl_messages
+        return db_messages
 
-    return db_messages
+    return _read_jsonl_transcript(sessions_dir, session_id)
 
 
 class SessionStore:
@@ -1126,13 +1184,14 @@ class SessionStore:
         return get_transcript_path(self.sessions_dir, session_id)
     
     def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
-        """Append a message to a session's transcript (SQLite + legacy JSONL).
+        """Append a message to a session transcript.
 
         Args:
-            skip_db: When True, only write to JSONL and skip the SQLite write.
-                     Used when the agent already persisted messages to SQLite
-                     via its own _flush_messages_to_session_db(), preventing
-                     the duplicate-write bug (#860).
+            skip_db: When True and SQLite is available, skip persistence here
+                     because the agent already wrote the message to SQLite via
+                     its own _flush_messages_to_session_db() path, preventing
+                     the duplicate-write bug (#860). When SQLite is unavailable,
+                     JSONL remains the fallback backend.
         """
         append_transcript_message(
             self.sessions_dir,
@@ -1146,22 +1205,15 @@ class SessionStore:
         """Replace the entire transcript for a session with new messages.
         
         Used by /retry, /undo, and /compress to persist modified conversation history.
-        Rewrites both SQLite and legacy JSONL storage.
+        SQLite is canonical when available; JSONL is only a fallback backend.
         """
         rewrite_transcript_messages(self.sessions_dir, self._db, session_id, messages)
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
-        """Load all messages from a session's transcript."""
-        # Prefer whichever source has more messages.
-        #
-        # Background: when a session pre-dates SQLite storage (or when the DB
-        # layer was added while a long-lived session was already active), the
-        # first post-migration turn writes only the *new* messages to SQLite
-        # (because _flush_messages_to_session_db skips messages already in
-        # conversation_history, assuming they're persisted).  On the *next*
-        # turn load_transcript returns those few SQLite rows and ignores the
-        # full JSONL history — the model sees a context of 1-4 messages instead
-        # of hundreds.  Using the longer source prevents this silent truncation.
+        """Load all messages from a session transcript.
+
+        Legacy JSONL files are imported into SQLite once and then retired.
+        """
         return load_transcript_messages(self.sessions_dir, self._db, session_id)
 
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -898,7 +898,18 @@ class SessionDB:
             rows = cursor.fetchall()
         messages = []
         for row in rows:
-            msg = {"role": row["role"], "content": row["content"]}
+            if row["role"] == "session_meta" and row["content"]:
+                try:
+                    parsed = json.loads(row["content"])
+                except (json.JSONDecodeError, TypeError):
+                    msg = {"role": row["role"], "content": row["content"]}
+                else:
+                    if isinstance(parsed, dict):
+                        msg = {"role": row["role"], **parsed}
+                    else:
+                        msg = {"role": row["role"], "content": parsed}
+            else:
+                msg = {"role": row["role"], "content": row["content"]}
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:

--- a/model_tools.py
+++ b/model_tools.py
@@ -426,6 +426,7 @@ def handle_function_call(
     session_id: Optional[str] = None,
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    session_db: Any = None,
     skip_pre_tool_call_hook: bool = False,
 ) -> str:
     """
@@ -503,12 +504,14 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 enabled_tools=sandbox_enabled,
+                session_db=session_db,
             )
         else:
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                session_db=session_db,
             )
 
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2377,8 +2377,9 @@ class AIAgent:
         truly new messages — preventing the duplicate-write bug (#860).
         """
         if not self._session_db:
-            return
+            return 0
         self._apply_persist_user_message_override(messages)
+        start_idx = len(conversation_history) if conversation_history else 0
         try:
             # If create_session() failed at startup (e.g. transient lock), the
             # session row may not exist yet.  ensure_session() uses INSERT OR
@@ -2388,9 +2389,8 @@ class AIAgent:
                 source=self.platform or "cli",
                 model=self.model,
             )
-            start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
-            for msg in messages[flush_from:]:
+            for msg_idx, msg in enumerate(messages[flush_from:], start=flush_from):
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 tool_calls_data = None
@@ -2413,9 +2413,13 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                 )
-            self._last_flushed_db_idx = len(messages)
+                self._last_flushed_db_idx = msg_idx + 1
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
+        return max(
+            0,
+            min(len(messages), self._last_flushed_db_idx) - start_idx,
+        )
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
@@ -8027,7 +8031,6 @@ class AIAgent:
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
         self.iteration_budget = IterationBudget(self.max_iterations)
-
         # Log conversation turn start for debugging/observability
         _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
         _msg_preview = _msg_preview.replace("\n", " ")

--- a/run_agent.py
+++ b/run_agent.py
@@ -1107,7 +1107,6 @@ class AIAgent:
         self._session_db = session_db
         self._parent_session_id = parent_session_id
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
-        self._last_session_db_persisted_count = 0  # exact count persisted for the current turn
         if self._session_db:
             try:
                 self._session_db.create_session(
@@ -2364,15 +2363,11 @@ class AIAgent:
         Skipped when ``persist_session=False`` (ephemeral helper flows).
         """
         if not self.persist_session:
-            self._last_session_db_persisted_count = 0
             return 0
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
-        self._last_session_db_persisted_count = self._flush_messages_to_session_db(
-            messages, conversation_history
-        )
-        return self._last_session_db_persisted_count
+        return self._flush_messages_to_session_db(messages, conversation_history)
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
@@ -2382,7 +2377,6 @@ class AIAgent:
         truly new messages — preventing the duplicate-write bug (#860).
         """
         if not self._session_db:
-            self._last_session_db_persisted_count = 0
             return 0
         self._apply_persist_user_message_override(messages)
         start_idx = len(conversation_history) if conversation_history else 0
@@ -2422,11 +2416,10 @@ class AIAgent:
                 self._last_flushed_db_idx = msg_idx + 1
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
-        self._last_session_db_persisted_count = max(
+        return max(
             0,
             min(len(messages), self._last_flushed_db_idx) - start_idx,
         )
-        return self._last_session_db_persisted_count
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/run_agent.py
+++ b/run_agent.py
@@ -1107,6 +1107,7 @@ class AIAgent:
         self._session_db = session_db
         self._parent_session_id = parent_session_id
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+        self._last_session_db_persisted_count = 0  # exact count persisted for the current turn
         if self._session_db:
             try:
                 self._session_db.create_session(
@@ -2363,11 +2364,15 @@ class AIAgent:
         Skipped when ``persist_session=False`` (ephemeral helper flows).
         """
         if not self.persist_session:
+            self._last_session_db_persisted_count = 0
             return 0
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
-        return self._flush_messages_to_session_db(messages, conversation_history)
+        self._last_session_db_persisted_count = self._flush_messages_to_session_db(
+            messages, conversation_history
+        )
+        return self._last_session_db_persisted_count
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
@@ -2377,6 +2382,7 @@ class AIAgent:
         truly new messages — preventing the duplicate-write bug (#860).
         """
         if not self._session_db:
+            self._last_session_db_persisted_count = 0
             return 0
         self._apply_persist_user_message_override(messages)
         start_idx = len(conversation_history) if conversation_history else 0
@@ -2416,10 +2422,11 @@ class AIAgent:
                 self._last_flushed_db_idx = msg_idx + 1
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
-        return max(
+        self._last_session_db_persisted_count = max(
             0,
             min(len(messages), self._last_flushed_db_idx) - start_idx,
         )
+        return self._last_session_db_persisted_count
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/run_agent.py
+++ b/run_agent.py
@@ -1107,6 +1107,7 @@ class AIAgent:
         self._session_db = session_db
         self._parent_session_id = parent_session_id
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
+        self._last_session_db_persisted_count = 0  # exact count persisted for the current turn
         if self._session_db:
             try:
                 self._session_db.create_session(
@@ -2363,11 +2364,15 @@ class AIAgent:
         Skipped when ``persist_session=False`` (ephemeral helper flows).
         """
         if not self.persist_session:
-            return
+            self._last_session_db_persisted_count = 0
+            return 0
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
-        self._flush_messages_to_session_db(messages, conversation_history)
+        self._last_session_db_persisted_count = self._flush_messages_to_session_db(
+            messages, conversation_history
+        )
+        return self._last_session_db_persisted_count
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
@@ -2377,6 +2382,7 @@ class AIAgent:
         truly new messages — preventing the duplicate-write bug (#860).
         """
         if not self._session_db:
+            self._last_session_db_persisted_count = 0
             return 0
         self._apply_persist_user_message_override(messages)
         start_idx = len(conversation_history) if conversation_history else 0
@@ -2416,10 +2422,11 @@ class AIAgent:
                 self._last_flushed_db_idx = msg_idx + 1
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
-        return max(
+        self._last_session_db_persisted_count = max(
             0,
             min(len(messages), self._last_flushed_db_idx) - start_idx,
         )
+        return self._last_session_db_persisted_count
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """
@@ -7100,6 +7107,7 @@ class AIAgent:
                 tool_call_id=tool_call_id,
                 session_id=self.session_id or "",
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                session_db=self._session_db,
                 skip_pre_tool_call_hook=True,
             )
 
@@ -7636,6 +7644,7 @@ class AIAgent:
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        session_db=self._session_db,
                         skip_pre_tool_call_hook=True,
                     )
                     _spinner_result = function_result
@@ -7656,6 +7665,7 @@ class AIAgent:
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        session_db=self._session_db,
                         skip_pre_tool_call_hook=True,
                     )
                 except Exception as tool_error:
@@ -8031,6 +8041,7 @@ class AIAgent:
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
         self.iteration_budget = IterationBudget(self.max_iterations)
+        self._last_session_db_persisted_count = 0
         # Log conversation turn start for debugging/observability
         _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
         _msg_preview = _msg_preview.replace("\n", " ")

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -119,11 +119,7 @@ class TestAppendToTranscript:
             _append_to_transcript("sess_1", {"role": "assistant", "content": "Hello"})
 
         transcript = sessions_dir / "sess_1.jsonl"
-        lines = transcript.read_text().strip().splitlines()
-        assert len(lines) == 1
-        msg = json.loads(lines[0])
-        assert msg["role"] == "assistant"
-        assert msg["content"] == "Hello"
+        assert not transcript.exists()
         mock_db.append_message.assert_called_once()
 
     def test_appends_multiple_messages(self, tmp_path):
@@ -137,8 +133,8 @@ class TestAppendToTranscript:
             _append_to_transcript("sess_1", {"role": "assistant", "content": "msg2"})
 
         transcript = sessions_dir / "sess_1.jsonl"
-        lines = transcript.read_text().strip().splitlines()
-        assert len(lines) == 2
+        assert not transcript.exists()
+        assert mock_db.append_message.call_count == 2
 
 
 class TestMirrorToSession:
@@ -157,14 +153,8 @@ class TestMirrorToSession:
 
         assert result is True
 
-        # Check JSONL was written
         transcript = sessions_dir / "sess_abc.jsonl"
-        assert transcript.exists()
-        msg = json.loads(transcript.read_text().strip())
-        assert msg["content"] == "Hello!"
-        assert msg["role"] == "assistant"
-        assert msg["mirror"] is True
-        assert msg["mirror_source"] == "cli"
+        assert not transcript.exists()
 
     def test_successful_mirror_uses_thread_id(self, tmp_path):
         sessions_dir, _ = _setup_sessions(tmp_path, {
@@ -185,7 +175,7 @@ class TestMirrorToSession:
             result = mirror_to_session("telegram", "-1001", "Hello topic!", source_label="cron", thread_id="10")
 
         assert result is True
-        assert (sessions_dir / "sess_topic_a.jsonl").exists()
+        assert not (sessions_dir / "sess_topic_a.jsonl").exists()
         assert not (sessions_dir / "sess_topic_b.jsonl").exists()
 
     def test_no_matching_session(self, tmp_path):

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -1,14 +1,13 @@
 """Tests for gateway/mirror.py — session mirroring."""
 
 import json
-from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import gateway.mirror as mirror_mod
 from gateway.mirror import (
     mirror_to_session,
     _find_session_id,
-    _append_to_jsonl,
+    _append_to_transcript,
 )
 
 
@@ -23,7 +22,7 @@ def _setup_sessions(tmp_path, sessions_data):
 
 class TestFindSessionId:
     def test_finds_matching_session(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "agent:main:telegram:dm": {
                 "session_id": "sess_abc",
                 "origin": {"platform": "telegram", "chat_id": "12345"},
@@ -31,14 +30,13 @@ class TestFindSessionId:
             }
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
             result = _find_session_id("telegram", "12345")
 
         assert result == "sess_abc"
 
     def test_returns_most_recent(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "old": {
                 "session_id": "sess_old",
                 "origin": {"platform": "telegram", "chat_id": "12345"},
@@ -51,14 +49,13 @@ class TestFindSessionId:
             },
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
             result = _find_session_id("telegram", "12345")
 
         assert result == "sess_new"
 
     def test_thread_id_disambiguates_same_chat(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "topic_a": {
                 "session_id": "sess_topic_a",
                 "origin": {"platform": "telegram", "chat_id": "-1001", "thread_id": "10"},
@@ -71,14 +68,13 @@ class TestFindSessionId:
             },
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
             result = _find_session_id("telegram", "-1001", thread_id="10")
 
         assert result == "sess_topic_a"
 
     def test_no_match_returns_none(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "sess": {
                 "session_id": "sess_1",
                 "origin": {"platform": "discord", "chat_id": "999"},
@@ -86,19 +82,19 @@ class TestFindSessionId:
             }
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
             result = _find_session_id("telegram", "12345")
 
         assert result is None
 
     def test_missing_sessions_file(self, tmp_path):
-        with patch.object(mirror_mod, "_SESSIONS_INDEX", tmp_path / "nope.json"):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", tmp_path / "sessions"):
             result = _find_session_id("telegram", "12345")
 
         assert result is None
 
     def test_platform_case_insensitive(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "s1": {
                 "session_id": "sess_1",
                 "origin": {"platform": "Telegram", "chat_id": "123"},
@@ -106,19 +102,21 @@ class TestFindSessionId:
             }
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
             result = _find_session_id("telegram", "123")
 
         assert result == "sess_1"
 
 
-class TestAppendToJsonl:
+class TestAppendToTranscript:
     def test_appends_message(self, tmp_path):
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
+        mock_db = MagicMock()
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
-            _append_to_jsonl("sess_1", {"role": "assistant", "content": "Hello"})
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_transcript("sess_1", {"role": "assistant", "content": "Hello"})
 
         transcript = sessions_dir / "sess_1.jsonl"
         lines = transcript.read_text().strip().splitlines()
@@ -126,14 +124,17 @@ class TestAppendToJsonl:
         msg = json.loads(lines[0])
         assert msg["role"] == "assistant"
         assert msg["content"] == "Hello"
+        mock_db.append_message.assert_called_once()
 
     def test_appends_multiple_messages(self, tmp_path):
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
+        mock_db = MagicMock()
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
-            _append_to_jsonl("sess_1", {"role": "assistant", "content": "msg1"})
-            _append_to_jsonl("sess_1", {"role": "assistant", "content": "msg2"})
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_transcript("sess_1", {"role": "assistant", "content": "msg1"})
+            _append_to_transcript("sess_1", {"role": "assistant", "content": "msg2"})
 
         transcript = sessions_dir / "sess_1.jsonl"
         lines = transcript.read_text().strip().splitlines()
@@ -142,7 +143,7 @@ class TestAppendToJsonl:
 
 class TestMirrorToSession:
     def test_successful_mirror(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "s1": {
                 "session_id": "sess_abc",
                 "origin": {"platform": "telegram", "chat_id": "12345"},
@@ -151,8 +152,7 @@ class TestMirrorToSession:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
-             patch("gateway.mirror._append_to_sqlite"):
+             patch("hermes_state.SessionDB", return_value=MagicMock()):
             result = mirror_to_session("telegram", "12345", "Hello!", source_label="cli")
 
         assert result is True
@@ -167,7 +167,7 @@ class TestMirrorToSession:
         assert msg["mirror_source"] == "cli"
 
     def test_successful_mirror_uses_thread_id(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {
+        sessions_dir, _ = _setup_sessions(tmp_path, {
             "topic_a": {
                 "session_id": "sess_topic_a",
                 "origin": {"platform": "telegram", "chat_id": "-1001", "thread_id": "10"},
@@ -181,8 +181,7 @@ class TestMirrorToSession:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
-             patch("gateway.mirror._append_to_sqlite"):
+             patch("hermes_state.SessionDB", return_value=MagicMock()):
             result = mirror_to_session("telegram", "-1001", "Hello topic!", source_label="cron", thread_id="10")
 
         assert result is True
@@ -190,10 +189,9 @@ class TestMirrorToSession:
         assert not (sessions_dir / "sess_topic_b.jsonl").exists()
 
     def test_no_matching_session(self, tmp_path):
-        sessions_dir, index_file = _setup_sessions(tmp_path, {})
+        sessions_dir, _ = _setup_sessions(tmp_path, {})
 
-        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir):
             result = mirror_to_session("telegram", "99999", "Hello!")
 
         assert result is False
@@ -205,25 +203,27 @@ class TestMirrorToSession:
         assert result is False
 
 
-class TestAppendToSqlite:
+class TestMirrorDbLifecycle:
     def test_connection_is_closed_after_use(self, tmp_path):
-        """Verify _append_to_sqlite closes the SessionDB connection."""
-        from gateway.mirror import _append_to_sqlite
+        """Verify _append_to_transcript closes the SessionDB connection."""
+        sessions_dir = tmp_path / "sessions"
         mock_db = MagicMock()
 
-        with patch("hermes_state.SessionDB", return_value=mock_db):
-            _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_transcript("sess_1", {"role": "assistant", "content": "hello"})
 
         mock_db.append_message.assert_called_once()
         mock_db.close.assert_called_once()
 
     def test_connection_closed_even_on_error(self, tmp_path):
         """Verify connection is closed even when append_message raises."""
-        from gateway.mirror import _append_to_sqlite
+        sessions_dir = tmp_path / "sessions"
         mock_db = MagicMock()
         mock_db.append_message.side_effect = Exception("db error")
 
-        with patch("hermes_state.SessionDB", return_value=mock_db):
-            _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_transcript("sess_1", {"role": "assistant", "content": "hello"})
 
         mock_db.close.assert_called_once()

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -122,6 +122,19 @@ class TestAppendToTranscript:
         assert not transcript.exists()
         mock_db.append_message.assert_called_once()
 
+    def test_reuses_supplied_db_without_reopening(self, tmp_path):
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        mock_db = MagicMock()
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("hermes_state.SessionDB") as session_db_cls:
+            _append_to_transcript("sess_1", {"role": "assistant", "content": "Hello"}, db=mock_db)
+
+        session_db_cls.assert_not_called()
+        mock_db.append_message.assert_called_once()
+        mock_db.close.assert_not_called()
+
     def test_appends_multiple_messages(self, tmp_path):
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
@@ -177,6 +190,25 @@ class TestMirrorToSession:
         assert result is True
         assert not (sessions_dir / "sess_topic_a.jsonl").exists()
         assert not (sessions_dir / "sess_topic_b.jsonl").exists()
+
+    def test_successful_mirror_reuses_supplied_db(self, tmp_path):
+        sessions_dir, _ = _setup_sessions(tmp_path, {
+            "s1": {
+                "session_id": "sess_abc",
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        })
+        mock_db = MagicMock()
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch("hermes_state.SessionDB") as session_db_cls:
+            result = mirror_to_session("telegram", "12345", "Hello!", source_label="cli", db=mock_db)
+
+        assert result is True
+        session_db_cls.assert_not_called()
+        mock_db.append_message.assert_called_once()
+        mock_db.close.assert_not_called()
 
     def test_no_matching_session(self, tmp_path):
         sessions_dir, _ = _setup_sessions(tmp_path, {})

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -481,47 +481,57 @@ class TestLoadTranscriptLegacyMigration:
                 f.write(json.dumps(msg) + "\n")
         return transcript_path
 
+    def _append_db_message_at(self, store_with_db, sid, role, content, ts):
+        with patch("hermes_state.time.time", return_value=ts):
+            store_with_db._db.append_message(session_id=sid, role=role, content=content)
+
     def test_jsonl_longer_than_sqlite_migrates_into_sqlite(self, store_with_db):
-        """Legacy JSONL should overwrite a partial SQLite transcript once."""
+        """Legacy JSONL should preserve a newer SQLite-only tail during migration."""
         sid = "legacy_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         legacy_messages = [
-            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg-{i}"}
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"msg-{i}",
+                "timestamp": float(100 + i),
+            }
             for i in range(10)
         ]
         transcript_path = self._write_legacy_transcript(store_with_db, sid, legacy_messages)
-        store_with_db._db.append_message(session_id=sid, role="user", content="new-q")
-        store_with_db._db.append_message(session_id=sid, role="assistant", content="new-a")
+        self._append_db_message_at(store_with_db, sid, "user", "new-q", 1000.0)
+        self._append_db_message_at(store_with_db, sid, "assistant", "new-a", 1001.0)
 
         result = store_with_db.load_transcript(sid)
-        assert len(result) == 10
+        assert len(result) == 12
         assert result[0]["content"] == "msg-0"
+        assert result[-2]["content"] == "new-q"
+        assert result[-1]["content"] == "new-a"
         assert not transcript_path.exists()
-        assert len(store_with_db._db.get_messages_as_conversation(sid)) == 10
+        assert len(store_with_db._db.get_messages_as_conversation(sid)) == 12
 
-    def test_sqlite_longer_than_jsonl_keeps_sqlite_and_removes_legacy_file(self, store_with_db):
-        """If SQLite already has the fuller transcript, keep it and retire JSONL."""
+    def test_sqlite_longer_than_jsonl_still_preserves_older_legacy_prefix(self, store_with_db):
+        """A shorter legacy prefix should still be preserved ahead of a newer SQLite tail."""
         sid = "migrated_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         transcript_path = self._write_legacy_transcript(store_with_db, sid, [
-            {"role": "user", "content": "old-q"},
-            {"role": "assistant", "content": "old-a"},
+            {"role": "user", "content": "old-q", "timestamp": 100.0},
+            {"role": "assistant", "content": "old-a", "timestamp": 101.0},
         ])
         for i in range(4):
             role = "user" if i % 2 == 0 else "assistant"
-            store_with_db._db.append_message(session_id=sid, role=role, content=f"db-{i}")
+            self._append_db_message_at(store_with_db, sid, role, f"db-{i}", 1000.0 + i)
 
         result = store_with_db.load_transcript(sid)
-        assert len(result) == 4
-        assert result[0]["content"] == "db-0"
+        assert len(result) == 6
+        assert [m["content"] for m in result] == ["old-q", "old-a", "db-0", "db-1", "db-2", "db-3"]
         assert not transcript_path.exists()
 
     def test_sqlite_empty_imports_jsonl_once(self, store_with_db):
         """If SQLite has no rows, import legacy JSONL and retire the file."""
         sid = "no_db_rows"
         transcript_path = self._write_legacy_transcript(store_with_db, sid, [
-            {"role": "user", "content": "hello"},
-            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "hello", "timestamp": 100.0},
+            {"role": "assistant", "content": "hi", "timestamp": 101.0},
         ])
 
         result = store_with_db.load_transcript(sid)
@@ -530,26 +540,47 @@ class TestLoadTranscriptLegacyMigration:
         assert not transcript_path.exists()
         assert len(store_with_db._db.get_messages_as_conversation(sid)) == 2
 
+    def test_db_history_before_jsonl_tail_merges_without_losing_tail(self, store_with_db):
+        """Fallback JSONL writes after DB recovery should append to the canonical history."""
+        sid = "db_then_jsonl"
+        store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
+        self._append_db_message_at(store_with_db, sid, "user", "db-q", 100.0)
+        self._append_db_message_at(store_with_db, sid, "assistant", "db-a", 101.0)
+        transcript_path = self._write_legacy_transcript(store_with_db, sid, [
+            {"role": "user", "content": "jsonl-q", "timestamp": 1000.0},
+            {"role": "assistant", "content": "jsonl-a", "timestamp": 1001.0},
+        ])
+
+        result = store_with_db.load_transcript(sid)
+        assert [m["content"] for m in result] == ["db-q", "db-a", "jsonl-q", "jsonl-a"]
+        assert not transcript_path.exists()
+        assert [m["content"] for m in store_with_db._db.get_messages_as_conversation(sid)] == [
+            "db-q",
+            "db-a",
+            "jsonl-q",
+            "jsonl-a",
+        ]
+
     def test_both_empty_returns_empty(self, store_with_db):
         """Neither source has data — returns empty list."""
         result = store_with_db.load_transcript("nonexistent")
         assert result == []
 
-    def test_equal_length_prefers_sqlite_and_removes_legacy_file(self, store_with_db):
-        """Equal-length legacy files should not survive once SQLite is canonical."""
+    def test_ambiguous_equal_length_histories_stay_read_only(self, store_with_db):
+        """Conflicting equal-length histories should not trigger destructive migration."""
         sid = "equal_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         transcript_path = self._write_legacy_transcript(store_with_db, sid, [
             {"role": "user", "content": "jsonl-q"},
             {"role": "assistant", "content": "jsonl-a"},
         ])
-        store_with_db._db.append_message(session_id=sid, role="user", content="db-q")
-        store_with_db._db.append_message(session_id=sid, role="assistant", content="db-a")
+        self._append_db_message_at(store_with_db, sid, "user", "db-q", 1000.0)
+        self._append_db_message_at(store_with_db, sid, "assistant", "db-a", 1001.0)
 
         result = store_with_db.load_transcript(sid)
         assert len(result) == 2
         assert result[0]["content"] == "db-q"
-        assert not transcript_path.exists()
+        assert transcript_path.exists()
 
 
 class TestSessionStoreSwitchSession:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -583,6 +583,43 @@ class TestLoadTranscriptLegacyMigration:
         assert transcript_path.exists()
 
 
+class TestSessionMetaRoundTrip:
+    """Ensure transcript-only metadata survives the SQLite-backed path."""
+
+    def test_session_meta_preserves_top_level_payload_in_sqlite(self, tmp_path):
+        from hermes_state import SessionDB
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        store._loaded = True
+
+        sid = "session_meta_sqlite"
+        store._db.create_session(session_id=sid, source="gateway", model="m")
+
+        store.append_to_transcript(
+            sid,
+            {
+                "role": "session_meta",
+                "tools": [{"function": {"name": "terminal"}}],
+                "model": "test/model",
+                "platform": "telegram",
+                "timestamp": "2026-04-16T00:00:00",
+            },
+        )
+
+        result = store.load_transcript(sid)
+        assert result == [
+            {
+                "role": "session_meta",
+                "tools": [{"function": {"name": "terminal"}}],
+                "model": "test/model",
+                "platform": "telegram",
+            }
+        ]
+
+
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -458,13 +458,12 @@ class TestLoadTranscriptCorruptLines:
         assert messages[1]["content"] == "b"
 
 
-class TestLoadTranscriptPreferLongerSource:
-    """Regression: load_transcript must return whichever source (SQLite or JSONL)
-    has more messages to prevent silent truncation.  GH-3212."""
+class TestLoadTranscriptLegacyMigration:
+    """Regression: legacy JSONL transcripts should migrate into SQLite once."""
 
     @pytest.fixture()
     def store_with_db(self, tmp_path):
-        """SessionStore with both SQLite and JSONL active."""
+        """SessionStore with SQLite active and legacy JSONL available."""
         from hermes_state import SessionDB
 
         config = GatewayConfig()
@@ -474,36 +473,40 @@ class TestLoadTranscriptPreferLongerSource:
         s._loaded = True
         return s
 
-    def test_jsonl_longer_than_sqlite_returns_jsonl(self, store_with_db):
-        """Legacy session: JSONL has full history, SQLite has only recent turn."""
+    def _write_legacy_transcript(self, store_with_db, sid, messages):
+        transcript_path = store_with_db.get_transcript_path(sid)
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(transcript_path, "w", encoding="utf-8") as f:
+            for msg in messages:
+                f.write(json.dumps(msg) + "\n")
+        return transcript_path
+
+    def test_jsonl_longer_than_sqlite_migrates_into_sqlite(self, store_with_db):
+        """Legacy JSONL should overwrite a partial SQLite transcript once."""
         sid = "legacy_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
-        # JSONL has 10 messages (legacy history — written before SQLite existed)
-        for i in range(10):
-            role = "user" if i % 2 == 0 else "assistant"
-            store_with_db.append_to_transcript(
-                sid, {"role": role, "content": f"msg-{i}"}, skip_db=True,
-            )
-        # SQLite has only 2 messages (recent turn after migration)
+        legacy_messages = [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg-{i}"}
+            for i in range(10)
+        ]
+        transcript_path = self._write_legacy_transcript(store_with_db, sid, legacy_messages)
         store_with_db._db.append_message(session_id=sid, role="user", content="new-q")
         store_with_db._db.append_message(session_id=sid, role="assistant", content="new-a")
 
         result = store_with_db.load_transcript(sid)
         assert len(result) == 10
         assert result[0]["content"] == "msg-0"
+        assert not transcript_path.exists()
+        assert len(store_with_db._db.get_messages_as_conversation(sid)) == 10
 
-    def test_sqlite_longer_than_jsonl_returns_sqlite(self, store_with_db):
-        """Fully migrated session: SQLite has more (JSONL stopped growing)."""
+    def test_sqlite_longer_than_jsonl_keeps_sqlite_and_removes_legacy_file(self, store_with_db):
+        """If SQLite already has the fuller transcript, keep it and retire JSONL."""
         sid = "migrated_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
-        # JSONL has 2 old messages
-        store_with_db.append_to_transcript(
-            sid, {"role": "user", "content": "old-q"}, skip_db=True,
-        )
-        store_with_db.append_to_transcript(
-            sid, {"role": "assistant", "content": "old-a"}, skip_db=True,
-        )
-        # SQLite has 4 messages (superset after migration)
+        transcript_path = self._write_legacy_transcript(store_with_db, sid, [
+            {"role": "user", "content": "old-q"},
+            {"role": "assistant", "content": "old-a"},
+        ])
         for i in range(4):
             role = "user" if i % 2 == 0 else "assistant"
             store_with_db._db.append_message(session_id=sid, role=role, content=f"db-{i}")
@@ -511,45 +514,42 @@ class TestLoadTranscriptPreferLongerSource:
         result = store_with_db.load_transcript(sid)
         assert len(result) == 4
         assert result[0]["content"] == "db-0"
+        assert not transcript_path.exists()
 
-    def test_sqlite_empty_falls_back_to_jsonl(self, store_with_db):
-        """No SQLite rows — falls back to JSONL (original behavior preserved)."""
+    def test_sqlite_empty_imports_jsonl_once(self, store_with_db):
+        """If SQLite has no rows, import legacy JSONL and retire the file."""
         sid = "no_db_rows"
-        store_with_db.append_to_transcript(
-            sid, {"role": "user", "content": "hello"}, skip_db=True,
-        )
-        store_with_db.append_to_transcript(
-            sid, {"role": "assistant", "content": "hi"}, skip_db=True,
-        )
+        transcript_path = self._write_legacy_transcript(store_with_db, sid, [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ])
 
         result = store_with_db.load_transcript(sid)
         assert len(result) == 2
         assert result[0]["content"] == "hello"
+        assert not transcript_path.exists()
+        assert len(store_with_db._db.get_messages_as_conversation(sid)) == 2
 
     def test_both_empty_returns_empty(self, store_with_db):
         """Neither source has data — returns empty list."""
         result = store_with_db.load_transcript("nonexistent")
         assert result == []
 
-    def test_equal_length_prefers_sqlite(self, store_with_db):
-        """When both have same count, SQLite wins (has richer fields like reasoning)."""
+    def test_equal_length_prefers_sqlite_and_removes_legacy_file(self, store_with_db):
+        """Equal-length legacy files should not survive once SQLite is canonical."""
         sid = "equal_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
-        # Write 2 messages to JSONL only
-        store_with_db.append_to_transcript(
-            sid, {"role": "user", "content": "jsonl-q"}, skip_db=True,
-        )
-        store_with_db.append_to_transcript(
-            sid, {"role": "assistant", "content": "jsonl-a"}, skip_db=True,
-        )
-        # Write 2 different messages to SQLite only
+        transcript_path = self._write_legacy_transcript(store_with_db, sid, [
+            {"role": "user", "content": "jsonl-q"},
+            {"role": "assistant", "content": "jsonl-a"},
+        ])
         store_with_db._db.append_message(session_id=sid, role="user", content="db-q")
         store_with_db._db.append_message(session_id=sid, role="assistant", content="db-a")
 
         result = store_with_db.load_transcript(sid)
         assert len(result) == 2
-        # Should be the SQLite version (equal count → prefers SQLite)
         assert result[0]["content"] == "db-q"
+        assert not transcript_path.exists()
 
 
 class TestSessionStoreSwitchSession:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -369,14 +369,16 @@ class TestSessionStoreRewriteTranscript:
 
     @pytest.fixture()
     def store(self, tmp_path):
+        from hermes_state import SessionDB
+
         config = GatewayConfig()
         with patch("gateway.session.SessionStore._ensure_loaded"):
             s = SessionStore(sessions_dir=tmp_path, config=config)
-        s._db = None  # no SQLite for these tests
+        s._db = SessionDB(db_path=tmp_path / "state.db")
         s._loaded = True
         return s
 
-    def test_rewrite_replaces_jsonl(self, store, tmp_path):
+    def test_rewrite_replaces_transcript(self, store, tmp_path):
         session_id = "test_session_1"
         # Write initial transcript
         for msg in [
@@ -408,178 +410,63 @@ class TestSessionStoreRewriteTranscript:
         assert reloaded == []
 
 
-class TestLoadTranscriptCorruptLines:
-    """Regression: corrupt JSONL lines (e.g. from mid-write crash) must be
-    skipped instead of crashing the entire transcript load.  GH-1193."""
-
-    @pytest.fixture()
-    def store(self, tmp_path):
-        config = GatewayConfig()
-        with patch("gateway.session.SessionStore._ensure_loaded"):
-            s = SessionStore(sessions_dir=tmp_path, config=config)
-        s._db = None
-        s._loaded = True
-        return s
-
-    def test_corrupt_line_skipped(self, store, tmp_path):
-        session_id = "corrupt_test"
-        transcript_path = store.get_transcript_path(session_id)
-        transcript_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(transcript_path, "w") as f:
-            f.write('{"role": "user", "content": "hello"}\n')
-            f.write('{"role": "assistant", "content": "hi th')  # truncated
-            f.write("\n")
-            f.write('{"role": "user", "content": "goodbye"}\n')
-
-        messages = store.load_transcript(session_id)
-        assert len(messages) == 2
-        assert messages[0]["content"] == "hello"
-        assert messages[1]["content"] == "goodbye"
-
-    def test_all_lines_corrupt_returns_empty(self, store, tmp_path):
-        session_id = "all_corrupt"
-        transcript_path = store.get_transcript_path(session_id)
-        transcript_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(transcript_path, "w") as f:
-            f.write("not json at all\n")
-            f.write("{truncated\n")
-
-        messages = store.load_transcript(session_id)
-        assert messages == []
-
-    def test_valid_transcript_unaffected(self, store, tmp_path):
-        session_id = "valid_test"
-        store.append_to_transcript(session_id, {"role": "user", "content": "a"})
-        store.append_to_transcript(session_id, {"role": "assistant", "content": "b"})
-
-        messages = store.load_transcript(session_id)
-        assert len(messages) == 2
-        assert messages[0]["content"] == "a"
-        assert messages[1]["content"] == "b"
-
-
-class TestLoadTranscriptLegacyMigration:
-    """Regression: legacy JSONL transcripts should migrate into SQLite once."""
+class TestLegacyTranscriptMigration:
+    """Legacy JSONL is imported once; mixed state is explicit."""
 
     @pytest.fixture()
     def store_with_db(self, tmp_path):
-        """SessionStore with SQLite active and legacy JSONL available."""
         from hermes_state import SessionDB
 
         config = GatewayConfig()
         with patch("gateway.session.SessionStore._ensure_loaded"):
             s = SessionStore(sessions_dir=tmp_path, config=config)
         s._db = SessionDB(db_path=tmp_path / "state.db")
-        s._loaded = True
+        s._loaded = False
         return s
 
-    def _write_legacy_transcript(self, store_with_db, sid, messages):
+    def _write_legacy_transcript(self, store_with_db, sid, lines):
         transcript_path = store_with_db.get_transcript_path(sid)
         transcript_path.parent.mkdir(parents=True, exist_ok=True)
         with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg) + "\n")
+            for line in lines:
+                f.write(line)
         return transcript_path
 
-    def _append_db_message_at(self, store_with_db, sid, role, content, ts):
-        with patch("hermes_state.time.time", return_value=ts):
-            store_with_db._db.append_message(session_id=sid, role=role, content=content)
-
-    def test_jsonl_longer_than_sqlite_migrates_into_sqlite(self, store_with_db):
-        """Legacy JSONL should preserve a newer SQLite-only tail during migration."""
+    def test_pure_legacy_transcript_imports_once(self, store_with_db):
         sid = "legacy_session"
-        store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
-        legacy_messages = [
-            {
-                "role": "user" if i % 2 == 0 else "assistant",
-                "content": f"msg-{i}",
-                "timestamp": float(100 + i),
-            }
-            for i in range(10)
-        ]
-        transcript_path = self._write_legacy_transcript(store_with_db, sid, legacy_messages)
-        self._append_db_message_at(store_with_db, sid, "user", "new-q", 1000.0)
-        self._append_db_message_at(store_with_db, sid, "assistant", "new-a", 1001.0)
-
-        result = store_with_db.load_transcript(sid)
-        assert len(result) == 12
-        assert result[0]["content"] == "msg-0"
-        assert result[-2]["content"] == "new-q"
-        assert result[-1]["content"] == "new-a"
-        assert not transcript_path.exists()
-        assert len(store_with_db._db.get_messages_as_conversation(sid)) == 12
-
-    def test_sqlite_longer_than_jsonl_still_preserves_older_legacy_prefix(self, store_with_db):
-        """A shorter legacy prefix should still be preserved ahead of a newer SQLite tail."""
-        sid = "migrated_session"
-        store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
         transcript_path = self._write_legacy_transcript(store_with_db, sid, [
-            {"role": "user", "content": "old-q", "timestamp": 100.0},
-            {"role": "assistant", "content": "old-a", "timestamp": 101.0},
-        ])
-        for i in range(4):
-            role = "user" if i % 2 == 0 else "assistant"
-            self._append_db_message_at(store_with_db, sid, role, f"db-{i}", 1000.0 + i)
-
-        result = store_with_db.load_transcript(sid)
-        assert len(result) == 6
-        assert [m["content"] for m in result] == ["old-q", "old-a", "db-0", "db-1", "db-2", "db-3"]
-        assert not transcript_path.exists()
-
-    def test_sqlite_empty_imports_jsonl_once(self, store_with_db):
-        """If SQLite has no rows, import legacy JSONL and retire the file."""
-        sid = "no_db_rows"
-        transcript_path = self._write_legacy_transcript(store_with_db, sid, [
-            {"role": "user", "content": "hello", "timestamp": 100.0},
-            {"role": "assistant", "content": "hi", "timestamp": 101.0},
+            json.dumps({"role": "user", "content": "hello", "timestamp": 100.0}) + "\n",
+            json.dumps({"role": "assistant", "content": "hi", "timestamp": 101.0}) + "\n",
         ])
 
         result = store_with_db.load_transcript(sid)
-        assert len(result) == 2
-        assert result[0]["content"] == "hello"
+        assert [m["content"] for m in result] == ["hello", "hi"]
         assert not transcript_path.exists()
-        assert len(store_with_db._db.get_messages_as_conversation(sid)) == 2
+        assert [m["content"] for m in store_with_db._db.get_messages_as_conversation(sid)] == ["hello", "hi"]
 
-    def test_db_history_before_jsonl_tail_merges_without_losing_tail(self, store_with_db):
-        """Fallback JSONL writes after DB recovery should append to the canonical history."""
-        sid = "db_then_jsonl"
-        store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
-        self._append_db_message_at(store_with_db, sid, "user", "db-q", 100.0)
-        self._append_db_message_at(store_with_db, sid, "assistant", "db-a", 101.0)
+    def test_corrupt_legacy_lines_are_skipped_during_import(self, store_with_db):
+        sid = "corrupt_session"
         transcript_path = self._write_legacy_transcript(store_with_db, sid, [
-            {"role": "user", "content": "jsonl-q", "timestamp": 1000.0},
-            {"role": "assistant", "content": "jsonl-a", "timestamp": 1001.0},
+            '{"role": "user", "content": "hello"}\n',
+            '{"role": "assistant", "content": "hi th\n',
+            '{"role": "assistant", "content": "goodbye"}\n',
         ])
 
         result = store_with_db.load_transcript(sid)
-        assert [m["content"] for m in result] == ["db-q", "db-a", "jsonl-q", "jsonl-a"]
+        assert [m["content"] for m in result] == ["hello", "goodbye"]
         assert not transcript_path.exists()
-        assert [m["content"] for m in store_with_db._db.get_messages_as_conversation(sid)] == [
-            "db-q",
-            "db-a",
-            "jsonl-q",
-            "jsonl-a",
-        ]
 
-    def test_both_empty_returns_empty(self, store_with_db):
-        """Neither source has data — returns empty list."""
-        result = store_with_db.load_transcript("nonexistent")
-        assert result == []
-
-    def test_ambiguous_equal_length_histories_stay_read_only(self, store_with_db):
-        """Conflicting equal-length histories should not trigger destructive migration."""
-        sid = "equal_session"
+    def test_mixed_sqlite_and_jsonl_state_raises(self, store_with_db):
+        sid = "mixed_session"
         store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
+        store_with_db._db.append_message(session_id=sid, role="user", content="db-q")
         transcript_path = self._write_legacy_transcript(store_with_db, sid, [
-            {"role": "user", "content": "jsonl-q"},
-            {"role": "assistant", "content": "jsonl-a"},
+            json.dumps({"role": "user", "content": "jsonl-q"}) + "\n",
+            json.dumps({"role": "assistant", "content": "jsonl-a"}) + "\n",
         ])
-        self._append_db_message_at(store_with_db, sid, "user", "db-q", 1000.0)
-        self._append_db_message_at(store_with_db, sid, "assistant", "db-a", 1001.0)
 
-        result = store_with_db.load_transcript(sid)
-        assert len(result) == 2
-        assert result[0]["content"] == "db-q"
+        with pytest.raises(RuntimeError, match="conflicts with existing SQLite history"):
+            store_with_db.load_transcript(sid)
         assert transcript_path.exists()
 
 

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -162,6 +162,46 @@ class TestFlushDeduplication:
             old_rows = db.get_messages(old_session)
             assert len(old_rows) == 2
 
+    def test_partial_flush_tracks_persisted_prefix_count(self):
+        """A partial DB failure should report the durable prefix length."""
+        from hermes_state import SessionDB
+
+        class FlakySessionDB:
+            def __init__(self, wrapped):
+                self._wrapped = wrapped
+                self._append_calls = 0
+
+            def create_session(self, *args, **kwargs):
+                return self._wrapped.create_session(*args, **kwargs)
+
+            def ensure_session(self, *args, **kwargs):
+                return self._wrapped.ensure_session(*args, **kwargs)
+
+            def append_message(self, *args, **kwargs):
+                self._append_calls += 1
+                if self._append_calls == 2:
+                    raise sqlite3.OperationalError("database is locked")
+                return self._wrapped.append_message(*args, **kwargs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            real_db = SessionDB(db_path=db_path)
+            flaky_db = FlakySessionDB(real_db)
+
+            agent = self._make_agent(flaky_db)
+            messages = [
+                {"role": "user", "content": "new question"},
+                {"role": "assistant", "content": "new answer"},
+            ]
+
+            persisted = agent._flush_messages_to_session_db(messages, [])
+
+            rows = real_db.get_messages(agent.session_id)
+            assert persisted == 1
+            assert agent._last_flushed_db_idx == 1
+            assert len(rows) == 1
+            assert rows[0]["content"] == "new question"
+
 
 # ---------------------------------------------------------------------------
 # Test: append_to_transcript skip_db parameter
@@ -248,6 +288,41 @@ class TestAppendToTranscriptSkipDb:
 
         rows = db.get_messages(session_id)
         assert len(rows) == 1
+
+    def test_partial_agent_flush_can_be_completed_without_duplicates(self, tmp_path):
+        """Gateway can persist only the unflushed tail after a partial DB write."""
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "test_partial.db"
+        db = SessionDB(db_path=db_path)
+
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        session_id = "test-partial-write"
+        db.create_session(session_id=session_id, source="test")
+        db.append_message(session_id=session_id, role="user", content="hello")
+
+        new_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+        persisted_count = 1
+        for idx, msg in enumerate(new_messages):
+            store.append_to_transcript(
+                session_id,
+                {**msg, "timestamp": "2026-04-16T00:00:00"},
+                skip_db=idx < persisted_count,
+            )
+
+        rows = db.get_messages_as_conversation(session_id)
+        assert [row["content"] for row in rows] == ["hello", "world"]
+        assert not store.get_transcript_path(session_id).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -3,7 +3,7 @@
 Verifies that:
 1. _flush_messages_to_session_db uses _last_flushed_db_idx to avoid re-writing
 2. Multiple _persist_session calls don't duplicate messages
-3. append_to_transcript(skip_db=True) skips SQLite but writes JSONL
+3. append_to_transcript(skip_db=True) avoids duplicate SQLite writes
 4. The gateway doesn't double-write messages the agent already persisted
 """
 
@@ -168,7 +168,7 @@ class TestFlushDeduplication:
 # ---------------------------------------------------------------------------
 
 class TestAppendToTranscriptSkipDb:
-    """Verify skip_db=True writes JSONL but not SQLite."""
+    """Verify skip_db=True avoids duplicate SQLite writes."""
 
     @pytest.fixture()
     def store(self, tmp_path):
@@ -177,17 +177,16 @@ class TestAppendToTranscriptSkipDb:
         config = GatewayConfig()
         with patch("gateway.session.SessionStore._ensure_loaded"):
             s = SessionStore(sessions_dir=tmp_path, config=config)
-        s._db = None  # no SQLite for these JSONL-focused tests
+        s._db = None  # force legacy fallback mode
         s._loaded = True
         return s
 
-    def test_skip_db_writes_jsonl_only(self, store, tmp_path):
-        """With skip_db=True, message appears in JSONL but not SQLite."""
+    def test_skip_db_uses_jsonl_fallback_without_sqlite(self, store, tmp_path):
+        """Without SQLite, JSONL remains the fallback transcript backend."""
         session_id = "test-skip-db"
         msg = {"role": "assistant", "content": "hello world"}
         store.append_to_transcript(session_id, msg, skip_db=True)
 
-        # JSONL should have the message
         jsonl_path = store.get_transcript_path(session_id)
         assert jsonl_path.exists()
         with open(jsonl_path) as f:
@@ -197,7 +196,7 @@ class TestAppendToTranscriptSkipDb:
         assert parsed["content"] == "hello world"
 
     def test_skip_db_prevents_sqlite_write(self, tmp_path):
-        """With skip_db=True and a real DB, message does NOT appear in SQLite."""
+        """With skip_db=True and a real DB, SessionStore writes nowhere."""
         from gateway.config import GatewayConfig
         from gateway.session import SessionStore
         from hermes_state import SessionDB
@@ -217,18 +216,14 @@ class TestAppendToTranscriptSkipDb:
         msg = {"role": "assistant", "content": "hello world"}
         store.append_to_transcript(session_id, msg, skip_db=True)
 
-        # SQLite should NOT have the message
         rows = db.get_messages(session_id)
         assert len(rows) == 0, f"Expected 0 DB rows with skip_db=True, got {len(rows)}"
 
-        # But JSONL should have it
         jsonl_path = store.get_transcript_path(session_id)
-        with open(jsonl_path) as f:
-            lines = f.readlines()
-        assert len(lines) == 1
+        assert not jsonl_path.exists()
 
-    def test_default_writes_both(self, tmp_path):
-        """Without skip_db, message appears in both JSONL and SQLite."""
+    def test_default_writes_sqlite_only_when_db_available(self, tmp_path):
+        """Without skip_db, SQLite is canonical and JSONL stays untouched."""
         from gateway.config import GatewayConfig
         from gateway.session import SessionStore
         from hermes_state import SessionDB
@@ -248,13 +243,9 @@ class TestAppendToTranscriptSkipDb:
         msg = {"role": "user", "content": "test message"}
         store.append_to_transcript(session_id, msg)
 
-        # JSONL should have the message
         jsonl_path = store.get_transcript_path(session_id)
-        with open(jsonl_path) as f:
-            lines = f.readlines()
-        assert len(lines) == 1
+        assert not jsonl_path.exists()
 
-        # SQLite should also have the message
         rows = db.get_messages(session_id)
         assert len(rows) == 1
 

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -199,7 +199,6 @@ class TestFlushDeduplication:
             rows = real_db.get_messages(agent.session_id)
             assert persisted == 1
             assert agent._last_flushed_db_idx == 1
-            assert agent._last_session_db_persisted_count == 1
             assert len(rows) == 1
             assert rows[0]["content"] == "new question"
 

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -199,6 +199,7 @@ class TestFlushDeduplication:
             rows = real_db.get_messages(agent.session_id)
             assert persisted == 1
             assert agent._last_flushed_db_idx == 1
+            assert agent._last_session_db_persisted_count == 1
             assert len(rows) == 1
             assert rows[0]["content"] == "new question"
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 from gateway.config import Platform
 from tools.send_message_tool import (
@@ -134,7 +134,7 @@ class TestSendMessageTool:
             thread_id=None,
             media_files=[],
         )
-        mirror_mock.assert_called_once_with("telegram", "-1002", "hello", source_label="cli", thread_id=None)
+        mirror_mock.assert_called_once_with("telegram", "-1002", "hello", source_label="cli", thread_id=None, db=None)
 
     def test_cron_same_chat_different_thread_still_sends(self):
         config, telegram_cfg = _make_config()
@@ -173,7 +173,7 @@ class TestSendMessageTool:
             thread_id="99999",
             media_files=[],
         )
-        mirror_mock.assert_called_once_with("telegram", "-1001", "hello", source_label="cli", thread_id="99999")
+        mirror_mock.assert_called_once_with("telegram", "-1001", "hello", source_label="cli", thread_id="99999", db=None)
 
     def test_sends_to_explicit_telegram_topic_target(self):
         config, telegram_cfg = _make_config()
@@ -202,7 +202,7 @@ class TestSendMessageTool:
             thread_id="17585",
             media_files=[],
         )
-        mirror_mock.assert_called_once_with("telegram", "-1001", "hello", source_label="cli", thread_id="17585")
+        mirror_mock.assert_called_once_with("telegram", "-1001", "hello", source_label="cli", thread_id="17585", db=None)
 
     def test_resolved_telegram_topic_name_preserves_thread_id(self):
         config, telegram_cfg = _make_config()
@@ -304,6 +304,37 @@ class TestSendMessageTool:
             "[Sent audio attachment]",
             source_label="cli",
             thread_id=None,
+            db=None,
+        )
+
+    def test_passes_shared_session_db_to_mirror(self):
+        config, _telegram_cfg = _make_config()
+        shared_db = MagicMock()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:-1001",
+                        "message": "hello",
+                    },
+                    session_db=shared_db,
+                )
+            )
+
+        assert result["success"] is True
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "-1001",
+            "hello",
+            source_label="cli",
+            thread_id=None,
+            db=shared_db,
         )
 
     def test_top_level_send_failure_redacts_query_token(self):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -87,7 +87,7 @@ def send_message_tool(args, **kw):
     if action == "list":
         return _handle_list()
 
-    return _handle_send(args)
+    return _handle_send(args, session_db=kw.get("session_db"))
 
 
 def _handle_list():
@@ -99,7 +99,7 @@ def _handle_list():
         return json.dumps(_error(f"Failed to load channel directory: {e}"))
 
 
-def _handle_send(args):
+def _handle_send(args, session_db=None):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
@@ -216,7 +216,14 @@ def _handle_send(args):
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
                 source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
-                if mirror_to_session(platform_name, chat_id, mirror_text, source_label=source_label, thread_id=thread_id):
+                if mirror_to_session(
+                    platform_name,
+                    chat_id,
+                    mirror_text,
+                    source_label=source_label,
+                    thread_id=thread_id,
+                    db=session_db,
+                ):
                     result["mirrored"] = True
             except Exception:
                 pass


### PR DESCRIPTION
## What changed

This PR removes duplicate gateway transcript persistence paths and makes `gateway/session.py` the single owner of transcript storage behavior.

Specifically:

- `gateway/mirror.py` now routes transcript writes through the canonical session helpers instead of maintaining its own JSONL and SQLite write logic.
- SQLite is now the canonical gateway transcript store.
- Legacy JSONL transcripts are no longer live-written when SQLite is available.
- Legacy JSONL files are only used as a one-time migration or fallback path.
- Legacy transcript migration now preserves SQLite-only tails and JSONL-only tails when their ordering is knowable.
- Ambiguous transcript divergence is treated conservatively: the code avoids destructive migration and leaves the legacy JSONL file in place as a read-only fallback.
- `session_meta` payloads now survive the canonical SQLite transcript path instead of being flattened away.
- The old runtime "whichever source is longer wins" heuristic is gone.

## Why it changed

The gateway had multiple independent ways to persist the same transcript data:

- normal session traffic through `SessionStore`
- mirrored delivery traffic through `gateway/mirror.py`
- a permanent SQLite + JSONL dual-write/read model in `gateway/session.py`

That split ownership increased drift risk and bug surface in one of the most state-sensitive parts of the gateway.

## User and developer impact

Gateway session history now has one canonical persistence path when SQLite is available. That makes transcript behavior easier to reason about and reduces the chance that mirrored messages or resumed sessions diverge from normal session behavior.

For older sessions, legacy JSONL history is imported into SQLite only when it can be merged safely. If the histories diverge ambiguously, the code leaves the JSONL transcript in place rather than risking data loss.

The canonical SQLite path also now preserves transcript-only `session_meta` payloads, so the replacement backend is closer to the behavior of the legacy JSONL transcript.

## Root cause

Transcript persistence had grown into a multi-path design where JSONL stopped being just a migration shim and effectively became a second live backend. That forced reconciliation logic, duplicate writes, and sidecar behavior outside the main session store.

## Validation

Focused validation passed:

- `source venv/bin/activate && venv/bin/python -m pytest -o addopts='' tests/gateway/test_session.py tests/gateway/test_mirror.py tests/run_agent/test_860_dedup.py -q`
- `source venv/bin/activate && venv/bin/python -m pytest -o addopts='' tests/gateway/test_retry_replacement.py tests/gateway/test_session_dm_thread_seeding.py tests/run_agent/test_session_meta_filtering.py -q`
