### PR TITLE
Fix Copilot pool base URL fallback

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -14,6 +14,7 @@ from agent.credential_pool import CredentialPool, PooledCredential, get_custom_p
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    DEFAULT_GITHUB_MODELS_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
     _agent_key_is_usable,
@@ -167,6 +168,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = "chat_completions"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        base_url = base_url or DEFAULT_GITHUB_MODELS_BASE_URL
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -57,6 +57,37 @@ def test_resolve_runtime_provider_anthropic_pool_respects_config_base_url(monkey
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
 
 
+
+
+def test_resolve_runtime_provider_copilot_pool_fills_default_base_url(monkeypatch):
+    class _Entry:
+        access_token = "pool-token"
+        source = "gh_cli"
+        base_url = ""
+        runtime_api_key = "pool-token"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "copilot", "default": "gpt-4.1-mini"},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="copilot")
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["base_url"] == "https://api.githubcopilot.com"
+    assert resolved["api_key"] == "pool-token"
+    assert resolved["credential_pool"] is not None
+
 def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeypatch):
     def _unexpected_pool(provider):
         raise AssertionError(f"load_pool should not be called for {provider}")


### PR DESCRIPTION
## Summary
- fill in the default GitHub Copilot base URL when a pooled Copilot credential has an empty base_url
- reuse the shared DEFAULT_GITHUB_MODELS_BASE_URL constant instead of a hardcoded string
- add a regression test covering pooled Copilot credentials without a base_url

## Testing
- python -m py_compile hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py
- pytest -q tests/hermes_cli/test_runtime_provider_resolution.py -k copilot_pool_fills_default_base_url -q
- hermes chat -Q -q "한 줄로만 대답해. 정식 패치 검증이야. 정상 작동이면 OK라고만 답해."