### PR TITLE
fix: show correct env var name in provider API key error

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -954,9 +954,20 @@ class AIAgent:
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
                     if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                        # Look up the actual env var name from the provider
+                        # config — some providers use non-standard names
+                        # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
+                        _env_hint = f"{_explicit.upper()}_API_KEY"
+                        try:
+                            from hermes_cli.auth import PROVIDER_REGISTRY
+                            _pcfg = PROVIDER_REGISTRY.get(_explicit)
+                            if _pcfg and _pcfg.api_key_env_vars:
+                                _env_hint = _pcfg.api_key_env_vars[0]
+                        except Exception:
+                            pass
                         raise RuntimeError(
                             f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_explicit.upper()}_API_KEY environment "
+                            f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
                     # Final fallback: try raw OpenRouter key


### PR DESCRIPTION
## Summary

Fixes #9506 — The error message for missing provider API keys dynamically constructed the env var name as `{PROVIDER}_API_KEY`. For alibaba this produced `ALIBABA_API_KEY`, but Hermes actually reads `DASHSCOPE_API_KEY`. Users following the error message set the wrong variable and got nowhere.

## Fix

Look up the actual env var from `PROVIDER_REGISTRY` before building the error. Falls back to the dynamic name if the registry import fails.

```
Before: Set the ALIBABA_API_KEY environment variable
After:  Set the DASHSCOPE_API_KEY environment variable
```

12 lines added to `run_agent.py`.