### PR TITLE
feat: per-channel ephemeral prompts (Discord, Telegram, Slack, Mattermost)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -554,7 +554,7 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
-                if plat == Platform.DISCORD and "channel_prompts" in platform_cfg:
+                if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -554,6 +554,12 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.DISCORD and "channel_prompts" in platform_cfg:
+                    channel_prompts = platform_cfg["channel_prompts"]
+                    if isinstance(channel_prompts, dict):
+                        bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
+                    else:
+                        bridged["channel_prompts"] = channel_prompts
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -682,6 +682,10 @@ class MessageEvent:
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
+
+    # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
+    # Applied at API call time and never persisted to transcript history.
+    channel_prompt: Optional[str] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -780,6 +780,36 @@ _RETRYABLE_ERROR_PATTERNS = (
 MessageHandler = Callable[[MessageEvent], Awaitable[Optional[str]]]
 
 
+def resolve_channel_prompt(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> str | None:
+    """Resolve a per-channel ephemeral prompt from platform config.
+
+    Looks up ``channel_prompts`` in the adapter's ``config.extra`` dict.
+    Prefers an exact match on *channel_id*; falls back to *parent_id*
+    (useful for forum threads / child channels inheriting a parent prompt).
+
+    Returns the prompt string, or None if no match is found.  Blank/whitespace-
+    only prompts are treated as absent.
+    """
+    prompts = config_extra.get("channel_prompts") or {}
+    if not isinstance(prompts, dict):
+        return None
+
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        prompt = prompts.get(key)
+        if prompt is None:
+            continue
+        prompt = str(prompt).strip()
+        if prompt:
+            return prompt
+    return None
+
+
 class BasePlatformAdapter(ABC):
     """
     Base class for platform adapters.

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1992,11 +1992,14 @@ class DiscordAdapter(BasePlatformAdapter):
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
+        channel_id = str(interaction.channel_id)
+        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         return MessageEvent(
             text=text,
             message_type=msg_type,
             source=source,
             raw_message=interaction,
+            channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
         )
 
     # ------------------------------------------------------------------
@@ -2067,14 +2070,17 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
         )
 
-        _parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
+        _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
+        _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
             source=source,
             raw_message=interaction,
             auto_skill=_skills,
+            channel_prompt=_channel_prompt,
         )
         await self.handle_message(event)
 
@@ -2101,6 +2107,34 @@ class DiscordAdapter(BasePlatformAdapter):
                     return [skills]
                 if isinstance(skills, list) and skills:
                     return list(dict.fromkeys(skills))  # dedup, preserve order
+        return None
+
+    def _resolve_channel_prompt(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Resolve a Discord per-channel prompt, preferring the exact channel over its parent.
+
+        Config format (in platform extra):
+            channel_prompts:
+              "123456": "Prompt text"
+
+        Forum/thread messages inherit the parent forum/channel prompt when the
+        thread itself has no explicit override.
+        """
+        prompts = self.config.extra.get("channel_prompts") or {}
+        if not isinstance(prompts, dict):
+            return None
+        prompts = {str(k): v for k, v in prompts.items()}
+
+        for key in (channel_id, parent_id):
+            if not key:
+                continue
+            prompt = prompts.get(key)
+            if prompt is None:
+                prompt = prompts.get(str(key))
+            if prompt is None:
+                continue
+            prompt = str(prompt).strip()
+            if prompt:
+                return prompt
         return None
 
     def _thread_parent_channel(self, channel: Any) -> Any:
@@ -2654,6 +2688,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_chan, "parent_id", "") or "")
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
+        _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
 
         reply_to_id = None
         reply_to_text = None
@@ -2674,6 +2709,7 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_text=reply_to_text,
             timestamp=message.created_at,
             auto_skill=_skills,
+            channel_prompt=_channel_prompt,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2122,14 +2122,11 @@ class DiscordAdapter(BasePlatformAdapter):
         prompts = self.config.extra.get("channel_prompts") or {}
         if not isinstance(prompts, dict):
             return None
-        prompts = {str(k): v for k, v in prompts.items()}
 
         for key in (channel_id, parent_id):
             if not key:
                 continue
             prompt = prompts.get(key)
-            if prompt is None:
-                prompt = prompts.get(str(key))
             if prompt is None:
                 continue
             prompt = str(prompt).strip()

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2110,29 +2110,9 @@ class DiscordAdapter(BasePlatformAdapter):
         return None
 
     def _resolve_channel_prompt(self, channel_id: str, parent_id: str | None = None) -> str | None:
-        """Resolve a Discord per-channel prompt, preferring the exact channel over its parent.
-
-        Config format (in platform extra):
-            channel_prompts:
-              "123456": "Prompt text"
-
-        Forum/thread messages inherit the parent forum/channel prompt when the
-        thread itself has no explicit override.
-        """
-        prompts = self.config.extra.get("channel_prompts") or {}
-        if not isinstance(prompts, dict):
-            return None
-
-        for key in (channel_id, parent_id):
-            if not key:
-                continue
-            prompt = prompts.get(key)
-            if prompt is None:
-                continue
-            prompt = str(prompt).strip()
-            if prompt:
-                return prompt
-        return None
+        """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
+        from gateway.platforms.base import resolve_channel_prompt
+        return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -718,6 +718,12 @@ class MattermostAdapter(BasePlatformAdapter):
             thread_id=thread_id,
         )
 
+        # Per-channel ephemeral prompt
+        from gateway.platforms.base import resolve_channel_prompt
+        _channel_prompt = resolve_channel_prompt(
+            self.config.extra, channel_id, None,
+        )
+
         msg_event = MessageEvent(
             text=message_text,
             message_type=msg_type,
@@ -726,6 +732,7 @@ class MattermostAdapter(BasePlatformAdapter):
             message_id=post_id,
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
+            channel_prompt=_channel_prompt,
         )
 
         await self.handle_message(msg_event)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1167,6 +1167,12 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=thread_ts,
         )
 
+        # Per-channel ephemeral prompt
+        from gateway.platforms.base import resolve_channel_prompt
+        _channel_prompt = resolve_channel_prompt(
+            self.config.extra, channel_id, None,
+        )
+
         msg_event = MessageEvent(
             text=text,
             message_type=msg_type,
@@ -1176,6 +1182,7 @@ class SlackAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             reply_to_message_id=thread_ts if thread_ts != ts else None,
+            channel_prompt=_channel_prompt,
         )
 
         # Only react when bot is directly addressed (DM or @mention).

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2775,6 +2775,15 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_id = str(message.reply_to_message.message_id)
             reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
 
+        # Per-channel/topic ephemeral prompt
+        from gateway.platforms.base import resolve_channel_prompt
+        _chat_id_str = str(chat.id)
+        _channel_prompt = resolve_channel_prompt(
+            self.config.extra,
+            thread_id_str or _chat_id_str,
+            _chat_id_str if thread_id_str else None,
+        )
+
         return MessageEvent(
             text=message.text or "",
             message_type=msg_type,
@@ -2784,6 +2793,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
+            channel_prompt=_channel_prompt,
             timestamp=message.date,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2891,6 +2891,7 @@ class GatewayRunner:
                         message_type=_MT.TEXT,
                         source=event.source,
                         message_id=event.message_id,
+                        channel_prompt=getattr(event, "channel_prompt", None),
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "Queued for the next turn."
@@ -3868,6 +3869,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
+                channel_prompt=getattr(event, "channel_prompt", None),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -5089,6 +5091,7 @@ class GatewayRunner:
             message_type=MessageType.TEXT,
             source=source,
             raw_message=event.raw_message,
+            channel_prompt=getattr(event, "channel_prompt", None),
         )
         
         # Let the normal message handler process it
@@ -8069,6 +8072,7 @@ class GatewayRunner:
         session_key: str = None,
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
+        channel_prompt: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -8423,8 +8427,12 @@ class GatewayRunner:
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
             
-            # Combine platform context with user-configured ephemeral system prompt
+            # Combine platform context, per-channel context, and the user-configured
+            # ephemeral system prompt.
             combined_ephemeral = context_prompt or ""
+            event_channel_prompt = (channel_prompt or "").strip()
+            if event_channel_prompt:
+                combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             if self._ephemeral_system_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
 
@@ -9376,6 +9384,7 @@ class GatewayRunner:
                     session_key=session_key,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
+                    channel_prompt=getattr(pending_event, "channel_prompt", None),
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2891,7 +2891,7 @@ class GatewayRunner:
                         message_type=_MT.TEXT,
                         source=event.source,
                         message_id=event.message_id,
-                        channel_prompt=getattr(event, "channel_prompt", None),
+                        channel_prompt=event.channel_prompt,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "Queued for the next turn."
@@ -3869,7 +3869,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
                 session_key=session_key,
                 event_message_id=event.message_id,
-                channel_prompt=getattr(event, "channel_prompt", None),
+                channel_prompt=event.channel_prompt,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -5091,7 +5091,7 @@ class GatewayRunner:
             message_type=MessageType.TEXT,
             source=source,
             raw_message=event.raw_message,
-            channel_prompt=getattr(event, "channel_prompt", None),
+            channel_prompt=event.channel_prompt,
         )
         
         # Let the normal message handler process it
@@ -9384,7 +9384,7 @@ class GatewayRunner:
                     session_key=session_key,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
-                    channel_prompt=getattr(pending_event, "channel_prompt", None),
+                    channel_prompt=pending_event.channel_prompt,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -638,6 +638,7 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
     },
 
     # WhatsApp platform settings (gateway mode)
@@ -703,7 +704,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -649,6 +649,21 @@ DEFAULT_CONFIG = {
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
     },
 
+    # Telegram platform settings (gateway mode)
+    "telegram": {
+        "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+    },
+
+    # Slack platform settings (gateway mode)
+    "slack": {
+        "channel_prompts": {},         # Per-channel ephemeral system prompts
+    },
+
+    # Mattermost platform settings (gateway mode)
+    "mattermost": {
+        "channel_prompts": {},         # Per-channel ephemeral system prompts
+    },
+
     # Approval mode for dangerous commands:
     #   manual — always prompt the user (default)
     #   smart  — use auxiliary LLM to auto-approve low-risk commands, prompt for high-risk

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,6 +81,7 @@ AUTHOR_MAP = {
     "brooklyn.bb.nicholson@gmail.com": "brooklynnicholson",
     "4317663+helix4u@users.noreply.github.com": "helix4u",
     "331214+counterposition@users.noreply.github.com": "counterposition",
+    "blspear@gmail.com": "BrennerSpear",
     "gpickett00@gmail.com": "gpickett00",
     "mcosma@gmail.com": "wakamex",
     "clawdia.nash@proton.me": "clawdia-nash",

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -214,6 +214,46 @@ class TestLoadGatewayConfig:
             "456": "Therapist mode",
         }
 
+    def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  channel_prompts:\n"
+            '    "-1001234567": Research assistant\n'
+            "    789: Creative writing\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["channel_prompts"] == {
+            "-1001234567": "Research assistant",
+            "789": "Creative writing",
+        }
+
+    def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  channel_prompts:\n"
+            '    "C01ABC": Code review mode\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["channel_prompts"] == {
+            "C01ABC": "Code review mode",
+        }
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -193,6 +193,27 @@ class TestLoadGatewayConfig:
 
         assert config.thread_sessions_per_user is False
 
+    def test_bridges_discord_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_prompts:\n"
+            "    \"123\": Research mode\n"
+            "    456: Therapist mode\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["channel_prompts"] == {
+            "123": "Research mode",
+            "456": "Therapist mode",
+        }
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -8,6 +8,26 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = types.ModuleType("discord")
+    discord_mod.Intents = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Interaction = object
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
 import gateway.run as gateway_run
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent
@@ -37,6 +57,7 @@ def _install_fake_agent(monkeypatch):
 
 
 def _make_adapter():
+    _ensure_discord_mock()
     from gateway.platforms.discord import DiscordAdapter
 
     adapter = object.__new__(DiscordAdapter)

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -91,10 +91,19 @@ class TestResolveChannelPrompts:
         adapter.config.extra = {"channel_prompts": {"100": "Research mode"}}
         assert adapter._resolve_channel_prompt("100") == "Research mode"
 
-    def test_match_by_numeric_channel_id_key(self):
+    def test_numeric_yaml_keys_normalized_at_config_load(self):
+        """Numeric YAML keys are normalized to strings by config bridging.
+
+        The resolver itself expects string keys (config.py handles normalization),
+        so raw numeric keys will not match — this is intentional.
+        """
         adapter = _make_adapter()
-        adapter.config.extra = {"channel_prompts": {100: "Research mode"}}
+        # Simulates post-bridging state: keys are already strings
+        adapter.config.extra = {"channel_prompts": {"100": "Research mode"}}
         assert adapter._resolve_channel_prompt("100") == "Research mode"
+        # Pre-bridging numeric key would not match (bridging is responsible)
+        adapter.config.extra = {"channel_prompts": {100: "Research mode"}}
+        assert adapter._resolve_channel_prompt("100") is None
 
     def test_match_by_parent_id(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -1,0 +1,229 @@
+"""Tests for Discord channel_prompts resolution and injection."""
+
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_adapter():
+    from gateway.platforms.discord import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    return adapter
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = "Global prompt"
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._smart_model_routing = {}
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(streaming=None)
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="12345",
+        chat_type="thread",
+        user_id="user-1",
+    )
+
+
+class TestResolveChannelPrompts:
+    def test_no_prompt_returns_none(self):
+        adapter = _make_adapter()
+        assert adapter._resolve_channel_prompt("123") is None
+
+    def test_match_by_channel_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"100": "Research mode"}}
+        assert adapter._resolve_channel_prompt("100") == "Research mode"
+
+    def test_match_by_numeric_channel_id_key(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {100: "Research mode"}}
+        assert adapter._resolve_channel_prompt("100") == "Research mode"
+
+    def test_match_by_parent_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"200": "Forum prompt"}}
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Forum prompt"
+
+    def test_exact_channel_overrides_parent(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_prompts": {
+                "999": "Thread override",
+                "200": "Forum prompt",
+            }
+        }
+        assert adapter._resolve_channel_prompt("999", parent_id="200") == "Thread override"
+
+    def test_build_message_event_sets_channel_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"321": "Command prompt"}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_prompt == "Command prompt"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_thread_session_inherits_parent_channel_prompt(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"200": "Parent prompt"}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.handle_message = AsyncMock()
+
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(name="Wetlands"),
+            channel=SimpleNamespace(id=200, parent=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.channel_prompt == "Parent prompt"
+
+    def test_blank_prompts_are_ignored(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_prompts": {"100": "   "}}
+        assert adapter._resolve_channel_prompt("100") is None
+
+
+@pytest.mark.asyncio
+async def test_retry_preserves_channel_prompt(monkeypatch):
+    runner = _make_runner()
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1", last_prompt_tokens=10),
+        load_transcript=lambda session_id: [
+            {"role": "user", "content": "original message"},
+            {"role": "assistant", "content": "old reply"},
+        ],
+        rewrite_transcript=MagicMock(),
+    )
+    runner._handle_message = AsyncMock(return_value="ok")
+
+    event = MessageEvent(
+        text="/retry",
+        message_type=gateway_run.MessageType.COMMAND,
+        source=_make_source(),
+        raw_message=SimpleNamespace(),
+        channel_prompt="Channel prompt",
+    )
+
+    result = await runner._handle_retry_command(event)
+
+    assert result == "ok"
+    retried_event = runner._handle_message.await_args.args[0]
+    assert retried_event.channel_prompt == "Channel prompt"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    (tmp_path / "config.yaml").write_text("agent:\n  system_prompt: Global prompt\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    event = MessageEvent(
+        text="hi",
+        source=_make_source(),
+        message_id="m1",
+        channel_prompt="Channel prompt",
+    )
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:discord:thread:12345",
+        channel_prompt=event.channel_prompt,
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["ephemeral_system_prompt"] == (
+        "Context prompt\n\nChannel prompt\n\nGlobal prompt"
+    )

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -459,7 +459,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -606,6 +606,26 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == 18
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True
+
+
+class TestDiscordChannelPromptsConfig:
+    def test_default_config_includes_discord_channel_prompts(self):
+        assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}
+
+    def test_migrate_adds_discord_channel_prompts_default(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump({"_config_version": 17, "discord": {"auto_thread": True}}),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 18
+        assert raw["discord"]["auto_thread"] is True
+        assert raw["discord"]["channel_prompts"] == {}

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 17
+        assert DEFAULT_CONFIG["_config_version"] == 18

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -297,6 +297,7 @@ discord:
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
+  channel_prompts: {}             # Per-channel ephemeral system prompts
 
 # Session isolation (applies to all gateway platforms, not just Discord)
 group_sessions_per_user: true     # Isolate sessions per user in shared channels
@@ -380,6 +381,28 @@ discord:
 ```
 
 Useful for channels dedicated to bot interaction where threads would add unnecessary noise.
+
+#### `discord.channel_prompts`
+
+**Type:** mapping — **Default:** `{}`
+
+Per-channel ephemeral system prompts that are injected on every turn in the matching Discord channel or thread without being persisted to transcript history.
+
+```yaml
+discord:
+  channel_prompts:
+    "1234567890": |
+      This channel is for research tasks. Prefer deep comparisons,
+      citations, and concise synthesis.
+    "9876543210": |
+      This forum is for therapy-style support. Be warm, grounded,
+      and non-judgmental.
+```
+
+Behavior:
+- Exact thread/channel ID matches win.
+- If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
+- Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
 
 #### `group_sessions_per_user`
 

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -281,6 +281,23 @@ If this returns your bot's user info, the token is valid. If it returns an error
 
 **Fix**: Add your User ID to `MATTERMOST_ALLOWED_USERS` in `~/.hermes/.env` and restart the gateway. Remember: the User ID is a 26-character alphanumeric string, not your `@username`.
 
+## Per-Channel Prompts
+
+Assign ephemeral system prompts to specific Mattermost channels. The prompt is injected at runtime on every turn — never persisted to transcript history — so changes take effect immediately.
+
+```yaml
+mattermost:
+  channel_prompts:
+    "channel_id_abc123": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "channel_id_def456": |
+      Code review mode. Be precise about edge cases and
+      performance implications.
+```
+
+Keys are Mattermost channel IDs (find them in the channel URL or via the API). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
+
 ## Security
 
 :::warning

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -418,6 +418,23 @@ Hermes supports voice on Slack:
 
 ---
 
+## Per-Channel Prompts
+
+Assign ephemeral system prompts to specific Slack channels. The prompt is injected at runtime on every turn — never persisted to transcript history — so changes take effect immediately.
+
+```yaml
+slack:
+  channel_prompts:
+    "C01RESEARCH": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "C02ENGINEERING": |
+      Code review mode. Be precise about edge cases and
+      performance implications.
+```
+
+Keys are Slack channel IDs (find them via channel details → "About" → scroll to bottom). All messages in the matching channel get the prompt injected as an ephemeral system instruction.
+
 ## Troubleshooting
 
 | Problem | Solution |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -526,6 +526,29 @@ Unlike Discord (where reactions are additive), Telegram's Bot API replaces all b
 If the bot doesn't have permission to add reactions in a group, the reaction calls fail silently and message processing continues normally.
 :::
 
+## Per-Channel Prompts
+
+Assign ephemeral system prompts to specific Telegram groups or forum topics. The prompt is injected at runtime on every turn — never persisted to transcript history — so changes take effect immediately.
+
+```yaml
+telegram:
+  channel_prompts:
+    "-1001234567890": |
+      You are a research assistant. Focus on academic sources,
+      citations, and concise synthesis.
+    "42":  |
+      This topic is for creative writing feedback. Be warm and
+      constructive.
+```
+
+Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, topic-level prompts override the group-level prompt:
+
+- Message in topic `42` inside group `-1001234567890` → uses topic `42`'s prompt
+- Message in topic `99` (no explicit entry) → falls back to group `-1001234567890`'s prompt
+- Message in a group with no entry → no channel prompt applied
+
+Numeric YAML keys are automatically normalized to strings.
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
## Summary

Salvage of PR #9254 by @BrennerSpear ([NOUS]), extended to all major messaging platforms.

Adds `channel_prompts` config — per-channel ephemeral system prompts that are injected at runtime and never persisted to transcript history. Changes take effect immediately on the next message.

## Supported Platforms

| Platform | Key type | Parent fallback |
|----------|----------|----------------|
| **Discord** | Channel/thread/forum ID | Forum threads inherit parent forum prompt |
| **Telegram** | Chat ID or forum topic ID | Topics inherit parent group prompt |
| **Slack** | Channel ID | — |
| **Mattermost** | Channel ID | — |

## Architecture

`resolve_channel_prompt()` — shared helper in `gateway/platforms/base.py`. All four adapters delegate to it. Exact ID match wins; falls back to parent ID if provided. The gateway runner (`_run_agent`) injects the resolved prompt as an ephemeral system instruction, stacking with platform context and the global `system_prompt`.

## Config Example

```yaml
discord:
  channel_prompts:
    "1234567890": "Research mode — cite sources"
telegram:
  channel_prompts:
    "-1001234567": "Creative writing coach"
    "42": "This topic overrides the group prompt"
slack:
  channel_prompts:
    "C01RESEARCH": "Code review mode"
mattermost:
  channel_prompts:
    "abc123": "Focus on architecture decisions"
```

Numeric YAML keys are auto-normalized to strings.

## Changes
- `gateway/platforms/base.py`: Add `resolve_channel_prompt()` shared helper
- `gateway/platforms/discord.py`: Refactor to use shared helper, wire into all event paths
- `gateway/platforms/telegram.py`: Wire channel_prompts (chat_id + topic fallback)
- `gateway/platforms/slack.py`: Wire channel_prompts (channel_id)
- `gateway/platforms/mattermost.py`: Wire channel_prompts (channel_id)
- `gateway/config.py`: Remove Discord-only gate on channel_prompts bridging
- `gateway/run.py`: Propagate channel_prompt through queue/retry/interrupt paths
- `hermes_cli/config.py`: Add defaults for telegram/slack/mattermost, bump config version 17→18
- Docs: Per-channel prompts section on all four platform pages
- Tests: 110 passing (Discord prompts, slash commands, config bridging for all platforms)

## Test Evidence
- `test_discord_channel_prompts.py`: **10 passed**
- `test_discord_slash_commands.py`: **24 passed** (no regression)
- `test_config.py` (gateway + cli): **69 passed** (includes new Telegram/Slack bridging tests)
- `test_browser_camofox_state.py`: **7 passed**

## Credit
Original Discord implementation by @BrennerSpear in #9254 — authorship preserved via cherry-pick. Also closes duplicate #5751 by @luojiesi (submitted earlier with similar approach).