### PR TITLE
fix(gateway): honor slack.reply_in_thread from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -546,6 +546,8 @@ def load_gateway_config() -> GatewayConfig:
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
+                if "reply_in_thread" in platform_cfg:
+                    bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -310,3 +310,31 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     import os as _os
     assert _os.environ["SLACK_REQUIRE_MENTION"] == "false"
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
+
+
+def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  reply_in_thread: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+
+    assert config is not None
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.extra.get("reply_in_thread") is False
+
+    adapter = SlackAdapter(slack_config)
+    assert adapter._resolve_thread_ts(reply_to="171.000", metadata={}) is None
+    assert adapter._resolve_thread_ts(
+        reply_to="171.000",
+        metadata={"thread_id": "171.000"},
+    ) == "171.000"


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway config bridge bug where `slack.reply_in_thread: false` in `config.yaml` was silently ignored. Slack already reads `reply_in_thread` from `PlatformConfig.extra`, but `load_gateway_config()` never forwarded the top-level YAML key into that extra dict, so Slack DMs always kept the default threaded behavior.

This is the smallest safe fix because it only adds the missing bridge in `gateway/config.py` and adds a regression test that exercises the existing Slack adapter behavior.

## Related Issue

Fixes #7532

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py`
  Added `reply_in_thread` to the existing top-level platform-key bridge that feeds `PlatformConfig.extra`.
- `tests/gateway/test_slack_mention.py`
  Added a regression test proving that `slack.reply_in_thread: false` is loaded into Slack platform config and disables top-level thread anchoring while preserving replies inside an existing thread.

## How to Test

1. Create a config with:
   ```yaml
   slack:
     reply_in_thread: false
   ```
2. Ensure `SLACK_BOT_TOKEN` is set and load gateway config.
3. Confirm `config.platforms[Platform.SLACK].extra["reply_in_thread"]` is `False`.
4. Confirm Slack top-level messages resolve to direct replies, while messages already inside a thread still use that thread.

Validation I ran locally on macOS 26.5:

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_slack_mention.py -q -n0
python -m pytest tests/gateway/test_slack_mention.py tests/gateway/test_config.py -q -n0
python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_config.py -q -n0
python -m py_compile gateway/config.py tests/gateway/test_slack_mention.py
git diff --check
python - <<'PY'
from pathlib import Path
import tempfile, os
from gateway.config import load_gateway_config, Platform
from gateway.platforms.slack import SlackAdapter

with tempfile.TemporaryDirectory() as td:
    home = Path(td) / '.hermes'
    home.mkdir()
    (home / 'config.yaml').write_text('slack:\n  reply_in_thread: false\n', encoding='utf-8')
    os.environ['HERMES_HOME'] = str(home)
    os.environ['SLACK_BOT_TOKEN'] = 'xoxb-test'
    cfg = load_gateway_config()
    slack = cfg.platforms[Platform.SLACK]
    print(slack.extra)
    adapter = SlackAdapter(slack)
    print(adapter._resolve_thread_ts(reply_to='171.000', metadata={}))
    print(adapter._resolve_thread_ts(reply_to='171.000', metadata={'thread_id': '171.000'}))
PY
```

Observed results:
- `tests/gateway/test_slack_mention.py`: `26 passed`
- `tests/gateway/test_slack_mention.py tests/gateway/test_config.py`: `44 passed`
- `tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_config.py`: `169 passed`
- `py_compile` and `git diff --check`: clean
- Manual reproducer before fix produced `extra = {}` on `origin/main`; after fix it produces `{'reply_in_thread': False}`, with `None` for top-level replies and the existing thread id preserved for threaded replies.

I also ran the repo's CI-aligned local command from `.github/workflows/tests.yml` after aligning the venv with `uv pip install -e ".[all,dev]"`:

```bash
python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
```

That command is not clean on this macOS machine on current `main` either; it still reports many unrelated failures in Discord, Telegram, CLI new-session, transcription, and auxiliary-client areas that this PR does not touch. I left those out of scope and focused validation on the affected Slack/gateway surfaces.

No separate standalone lint command is documented in repo docs, so I did not invent one.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No UI screenshots needed for this config bridge fix.
