### PR TITLE
fix: use POSIX ps -A instead of BSD -ax for Docker compat

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -222,7 +222,7 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "eww", "-ax", "-o", "pid=,command="],
+                ["ps", "-A", "eww", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,


### PR DESCRIPTION
## Summary

Fixes #9723 — `ps eww -ax` fails in Docker containers with procps-ng 4.0.4, causing `find_gateway_pids()` to return empty and `hermes gateway status` to falsely report the gateway as not running.

## Fix

Replace `ps eww -ax` with `ps -A eww`. `-A` is the POSIX equivalent of BSD `-ax` (select all processes). The `eww` modifiers (show environment + wide output) still work alongside the POSIX flag, preserving the `HERMES_HOME=` environment visibility needed for profile-aware PID matching.

1 line changed.