### PR TITLE
feat(docker): add docker-compose.yml and Ollama config example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,110 @@
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: unless-stopped
+    networks:
+      ollama-net:
+        aliases:
+          - ollama
+    volumes:
+      - ollama_data:/root/.ollama
+    # Uncomment for NVIDIA GPU support:
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  hermes:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: hermes-agent
+    pull_policy: never
+    container_name: hermes
+    restart: unless-stopped
+    depends_on:
+      - ollama
+    networks:
+      - ollama-net
+    volumes:
+      - hermes_data:/opt/data
+      - ./docker/config-ollama.yaml:/opt/data/config.yaml:ro
+    stdin_open: true
+    tty: true
+    command: chat
+
+  gateway:
+    image: hermes-agent
+    pull_policy: never
+    container_name: hermes-gateway
+    restart: unless-stopped
+    depends_on:
+      - hermes
+    networks:
+      - ollama-net
+    env_file:
+      - .env
+    volumes:
+      - hermes_data:/opt/data
+      - ./docker/config-ollama.yaml:/opt/data/config.yaml:ro
+    ports:
+      - "8642:8642"
+    command: gateway
+
+  # api-server is a gateway platform adapter, not a standalone service.
+  # Enable it via the gateway by setting API_SERVER_ENABLED=true in .env
+
+  whatsapp-bridge:
+    image: hermes-agent
+    pull_policy: never
+    container_name: hermes-whatsapp
+    profiles: [whatsapp]
+    restart: unless-stopped
+    depends_on:
+      - hermes
+    networks:
+      - ollama-net
+    volumes:
+      - hermes_data:/opt/data
+    ports:
+      - "3010:3000"
+    entrypoint: ["node", "/opt/hermes/scripts/whatsapp-bridge/bridge.js"]
+
+  acp-adapter:
+    image: hermes-agent
+    pull_policy: never
+    container_name: hermes-acp
+    restart: unless-stopped
+    depends_on:
+      - hermes
+    networks:
+      - ollama-net
+    volumes:
+      - hermes_data:/opt/data
+    ports:
+      - "8081:8080"
+    entrypoint: ["/opt/venv/bin/python", "-m", "acp_adapter"]
+
+  website:
+    image: hermes-agent
+    pull_policy: never
+    container_name: hermes-website
+    restart: "no"
+    ports:
+      - "3002:3000"
+    networks:
+      - ollama-net
+    entrypoint: ["sh", "-c", "cd /opt/hermes/website && npm install && npm start"]
+
+networks:
+  ollama-net:
+    external: true
+
+volumes:
+  ollama_data:
+    external: true
+  hermes_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - hermes_data:/opt/data
     ports:
       - "8081:8080"
-    entrypoint: ["/opt/venv/bin/python", "-m", "acp_adapter"]
+    entrypoint: ["/opt/hermes/.venv/bin/python", "-m", "acp_adapter"]
 
   website:
     image: hermes-agent

--- a/docker/config-ollama.yaml
+++ b/docker/config-ollama.yaml
@@ -1,0 +1,18 @@
+# Hermes config — uses OpenRouter free tier by default.
+# Swap provider/model to use local Ollama instead (see comments below).
+
+model:
+  # Free OpenRouter models (no cost, require OPENROUTER_API_KEY in .env):
+  #   meta-llama/llama-3.1-8b-instruct:free
+  #   deepseek/deepseek-r1:free
+  #   google/gemma-3-12b-it:free
+  #   mistralai/mistral-7b-instruct:free
+  default: "gemma4-e4b"
+  provider: "custom"
+  base_url: "http://ollama:11434/v1"
+  api_key: "ollama"
+
+  # To use OpenRouter instead, comment out above and uncomment below:
+  # default: "qwen/qwen3-coder:free"
+  # provider: "openrouter"
+  # base_url: "https://openrouter.ai/api/v1"


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` — full stack (Ollama + Hermes + Gateway + optional WhatsApp bridge). NVIDIA GPU passthrough included as a commented-out block.
- Add `docker/config-ollama.yaml` — ready-to-use config pointing Hermes at a local Ollama instance, with comments showing how to swap to OpenRouter free tier.

## Why

No `docker-compose.yml` exists in the repo. Users running a self-hosted stack have to write their own from scratch. These two files give a working reference for the most common local deployment.

## Test plan

- [x] Stack starts with `docker compose up -d`
- [x] Gateway connects to Telegram (polling mode)
- [x] Gateway connects to WhatsApp (Baileys bridge)
- [x] Ollama responds through the gateway
- [x] NVIDIA GPU passthrough verified on RTX 4050

 Generated with [Claude Code](https://claude.com/claude-code)