### PR TITLE
feat: add strategic re-evaluation guidance to system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -185,6 +185,21 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
     "without acting are not acceptable."
 )
 
+# Strategic re-evaluation guidance — prevents agents from getting stuck in
+# fix-loops by forcing a step back after repeated failures.
+# Ported from google-gemini/gemini-cli#25062.
+STRATEGIC_REEVALUATION_GUIDANCE = (
+    "# Strategic re-evaluation\n"
+    "If you have attempted to fix a failing implementation more than 3 times "
+    "without success, you must:\n"
+    "1. Stop and re-read the original task description carefully.\n"
+    "2. List your current assumptions and identify which ones might be wrong.\n"
+    "3. Propose a fundamentally different approach rather than continuing to "
+    "patch the current one.\n"
+    "Do not keep applying small variations of the same fix. Step back, "
+    "reconsider the problem from scratch, and try a different strategy."
+)
+
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
 TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok")

--- a/run_agent.py
+++ b/run_agent.py
@@ -94,7 +94,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE, STRATEGIC_REEVALUATION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -3349,6 +3349,13 @@ class AIAgent:
                 # prerequisite checks, verification, anti-hallucination).
                 if "gpt" in _model_lower or "codex" in _model_lower:
                     prompt_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+
+        # Strategic re-evaluation guidance — injected for all models with
+        # tools, not just enforcement targets.  Prevents fix-loops where the
+        # agent applies small variations of a failing approach forever.
+        # Ported from google-gemini/gemini-cli#25062.
+        if self.valid_tool_names:
+            prompt_parts.append(STRATEGIC_REEVALUATION_GUIDANCE)
 
         # so it can refer the user to them rather than reinventing answers.
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -24,6 +24,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    STRATEGIC_REEVALUATION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     PLATFORM_HINTS,
@@ -1027,6 +1028,40 @@ class TestOpenAIModelExecutionGuidance:
     def test_guidance_is_string(self):
         assert isinstance(OPENAI_MODEL_EXECUTION_GUIDANCE, str)
         assert len(OPENAI_MODEL_EXECUTION_GUIDANCE) > 100
+
+
+# =========================================================================
+# Strategic re-evaluation guidance
+# (ported from google-gemini/gemini-cli#25062)
+# =========================================================================
+
+
+class TestStrategicReevaluationGuidance:
+    """Tests for the strategic re-evaluation guidance constant."""
+
+    def test_guidance_is_string(self):
+        assert isinstance(STRATEGIC_REEVALUATION_GUIDANCE, str)
+        assert len(STRATEGIC_REEVALUATION_GUIDANCE) > 50
+
+    def test_guidance_mentions_3_attempts(self):
+        """Should trigger after 3 failed attempts."""
+        assert "3 times" in STRATEGIC_REEVALUATION_GUIDANCE
+
+    def test_guidance_requires_reread_task(self):
+        """Step 1: re-read the original task."""
+        assert "original task" in STRATEGIC_REEVALUATION_GUIDANCE.lower()
+
+    def test_guidance_requires_questioning_assumptions(self):
+        """Step 2: question current assumptions."""
+        assert "assumptions" in STRATEGIC_REEVALUATION_GUIDANCE.lower()
+
+    def test_guidance_requires_different_approach(self):
+        """Step 3: propose a fundamentally different approach."""
+        assert "different approach" in STRATEGIC_REEVALUATION_GUIDANCE.lower()
+
+    def test_guidance_discourages_small_variations(self):
+        """Should tell the agent not to keep doing the same thing."""
+        assert "small variations" in STRATEGIC_REEVALUATION_GUIDANCE.lower()
 
 
 # =========================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -705,6 +705,14 @@ class TestBuildSystemPrompt:
         assert mock_skills.call_args.kwargs["available_tools"] == set(toolset_map)
         assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
+    def test_strategic_reevaluation_guidance_present_when_tools_loaded(self, agent):
+        """Strategic re-evaluation guidance should appear for any agent with tools."""
+        from agent.prompt_builder import STRATEGIC_REEVALUATION_GUIDANCE
+
+        prompt = agent._build_system_prompt()
+        assert "Strategic re-evaluation" in prompt
+        assert "3 times" in prompt
+
 
 class TestToolUseEnforcementConfig:
     """Tests for the agent.tool_use_enforcement config option."""


### PR DESCRIPTION
## Summary

Port from [google-gemini/gemini-cli#25062](https://github.com/google-gemini/gemini-cli/pull/25062): **Strategic Re-evaluation guidance** — a system prompt addition that prevents agents from getting stuck in fix-loops.

### Problem
When an agent fails to fix a bug or implementation issue, it often applies small variations of the same failing approach repeatedly, burning iterations without making progress. This is one of the most common agent failure modes.

### Solution
Adds a concise `STRATEGIC_REEVALUATION_GUIDANCE` block to the system prompt, injected for **all models with tools** (not just enforcement-target models). After 3 failed fix attempts, the agent must:

1. Stop and re-read the original task description
2. List current assumptions and identify which might be wrong
3. Propose a fundamentally different approach

The guidance explicitly discourages applying small variations of the same fix.

### Changes
- `agent/prompt_builder.py` — New `STRATEGIC_REEVALUATION_GUIDANCE` constant
- `run_agent.py` — Import + inject the guidance in `_build_system_prompt()` after the tool-use enforcement block
- `tests/agent/test_prompt_builder.py` — 6 tests for constant content
- `tests/run_agent/test_run_agent.py` — 1 integration test verifying presence in system prompt

### Test results
```
368 passed in 11.93s (test_prompt_builder.py + test_run_agent.py)
```

### Source
Gemini CLI adds this same guidance to all their prompt variants. Their finding: agents that re-evaluate after repeated failures find the correct fix much faster than those that keep patching.