### PR TITLE
fix(cli): avoid duplicate subcommand help output

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6325,8 +6325,12 @@ Examples:
             sys.stderr = _io.StringIO()
             args = parser.parse_args(_processed_argv)
             sys.stderr = _saved_stderr
-        except SystemExit:
+        except SystemExit as exc:
             sys.stderr = _saved_stderr
+            # Successful argparse exits (for example `-h/--help`) have
+            # already printed the intended output. Re-parsing duplicates it.
+            if exc.code in (0, None):
+                raise
             # Subcommand name was consumed as a flag value (e.g. -c model).
             # Fall back to optional subparsers so argparse handles it normally.
             subparsers.required = False

--- a/tests/hermes_cli/test_subparser_routing_fallback.py
+++ b/tests/hermes_cli/test_subparser_routing_fallback.py
@@ -146,3 +146,17 @@ class TestSubparserRoutingFallback:
         assert args.yolo is True
         assert args.worktree is True
         assert args.skills == ["myskill"]
+
+
+def test_main_subcommand_help_prints_once(monkeypatch, capsys):
+    """`hermes <subcommand> -h` should not duplicate help output."""
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "dashboard", "-h"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main()
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert out.count("usage: hermes dashboard") == 1


### PR DESCRIPTION
## What does this PR do?

Fixes the duplicated help output from `hermes <subcommand> -h`.

`hermes dashboard -h` currently prints the same argparse help block twice. The root cause is the defensive subparser fallback in `hermes_cli/main.py`: when the first parse exits successfully via `SystemExit(0)` for `-h/--help`, Hermes falls through to a second `parse_args()` call and prints the same help text again.

This patch keeps the existing fallback for real parse failures, but lets successful argparse exits propagate immediately so help output is only emitted once.

This is intentionally narrow:
- 1 production file changed: `hermes_cli/main.py`
- 1 regression test added: `tests/hermes_cli/test_subparser_routing_fallback.py`
- no behavior changes outside the successful help path

## Related Issue

Fixes #10230

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`
  - preserve `SystemExit(0)` from argparse help/version paths instead of reparsing
  - keep the existing fallback for the `bpo-9338` subparser-routing workaround on real parse errors
- `tests/hermes_cli/test_subparser_routing_fallback.py`
  - add a regression test against the real `main()` entrypoint to verify `hermes dashboard -h` prints exactly one usage block

## How to Test

1. Activate the repo environment:
   - `source venv/bin/activate`
2. Reproduce before/after behavior:
   - `python -m hermes_cli.main dashboard -h`
   - expected after this patch: `usage: hermes dashboard ...` appears once, not twice
3. Run the focused regression tests:
   - `python -m pytest tests/hermes_cli/test_subparser_routing_fallback.py -q`
   - `python -m pytest tests/hermes_cli/test_argparse_flag_propagation.py -q`

## Validation

Passed locally:
- `source venv/bin/activate && python -m hermes_cli.main dashboard -h`
  - after the patch, `usage: hermes dashboard` appears exactly once
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_subparser_routing_fallback.py -q`
  - `14 passed in 2.03s`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_argparse_flag_propagation.py -q`
  - `15 passed in 3.65s`
- `git diff --check`
- `source venv/bin/activate && python -m py_compile hermes_cli/main.py tests/hermes_cli/test_subparser_routing_fallback.py`

Additional notes:
- The repo docs do not define a separate standalone lint command, so I did not invent one.
- I also ran the repo's broad CI-aligned local test command:
  - `source venv/bin/activate && python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`
  - On this local macOS environment, that command is currently red against many unrelated existing failures in gateway/agent/skills tests outside this change. This parser fix does not touch those areas.
- This PR touches `hermes_cli/main.py`, so it should trigger the upstream `Nix` workflow. `nix` is not installed in my local environment, so I could not run the closest local equivalent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Manual repro after the fix:

```text
returncode= 0
count_usage= 1
usage: hermes dashboard [-h] [--port PORT] [--host HOST] [--no-open]
                        [--insecure]
```
