### PR TITLE
fix: prevent agent hang when backgrounding processes via terminal tool

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -83,6 +83,7 @@ AUTHOR_MAP = {
     "4317663+helix4u@users.noreply.github.com": "helix4u",
     "331214+counterposition@users.noreply.github.com": "counterposition",
     "blspear@gmail.com": "BrennerSpear",
+    "239876380+handsdiff@users.noreply.github.com": "handsdiff",
     "gpickett00@gmail.com": "gpickett00",
     "mcosma@gmail.com": "wakamex",
     "clawdia.nash@proton.me": "clawdia-nash",

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -334,7 +334,7 @@ class ProcessRegistry:
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", command],
+                    [user_shell, "-lic", f"set +m; {command}"],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -375,7 +375,7 @@ class ProcessRegistry:
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
         proc = subprocess.Popen(
-            [user_shell, "-lic", command],
+            [user_shell, "-lic", f"set +m; {command}"],
             text=True,
             cwd=session.cwd,
             env=bg_env,


### PR DESCRIPTION
## Summary

Salvage of PR #9924 by @handsdiff. Cherry-picked onto current main.

When the agent runs a command that backgrounds a process (e.g. `python3 -m http.server 8000 &`), the terminal tool hangs forever. The root cause: `spawn_local()` uses `bash -lic` — the `-i` flag forces interactive mode which enables job control (`set -m`). With job control enabled, bash waits for all background jobs to complete before exiting.

Fix: prefix `set +m;` to disable job control while preserving interactive shell benefits (bashrc sourcing, alias expansion). Applied to both PTY and non-PTY spawn paths in `process_registry.py`.

## Investigation

Also evaluated PR #10425 (Edviin42) which targets `environments/base.py` with a `disown` approach. That code path uses `bash -c` (no `-i`), so non-interactive bash doesn't enable job control — the hang doesn't occur there. PR #9924 targets the correct code path.

## Changes
- `tools/process_registry.py`: Add `set +m;` prefix to both PTY and non-PTY spawn commands
- `scripts/release.py`: Add handsdiff to AUTHOR_MAP

## Test Evidence
- `test_process_registry.py`: **42 passed**

## Credit
Original work by @handsdiff in #9924 — authorship preserved via cherry-pick.