### PR TITLE
fix(skills): narrow mcporter description to stop shadowing native MCP (#10341)

### DIFF
--- a/skills/mcp/mcporter/SKILL.md
+++ b/skills/mcp/mcporter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcporter
-description: Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation.
+description: "mcporter CLI tool — manage mcporter-specific config, OAuth auth for mcporter-managed servers, ad-hoc server connections, and generate CLI wrappers or TypeScript types. Only use when the user explicitly asks for mcporter by name. For general MCP server queries (listing configured servers, available tools), use native-mcp instead."
 version: 1.0.0
 author: community
 license: MIT
@@ -15,6 +15,8 @@ prerequisites:
 # mcporter
 
 Use `mcporter` to discover, call, and manage [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) servers and tools directly from the terminal.
+
+> **When NOT to use this skill:** Do not use mcporter for general MCP questions like "list my configured MCP servers", "what MCP tools do I have?", or "show my MCP setup". Those queries should be answered using Hermes's native MCP client (see the `native-mcp` skill). Only use mcporter when the user explicitly asks for the `mcporter` CLI by name, or needs ad-hoc server connections not configured in `config.yaml`.
 
 ## Prerequisites
 

--- a/tests/skills/test_mcp_skill_routing.py
+++ b/tests/skills/test_mcp_skill_routing.py
@@ -1,0 +1,68 @@
+"""Verify that native-mcp outranks mcporter for generic MCP queries (#10341).
+
+The mcporter skill should only be selected when the user explicitly asks for
+the mcporter CLI.  General MCP questions ("list my MCP servers", "what MCP
+tools do you have?") must route to native-mcp.
+"""
+from tools.skills_hub import ClawHubSource, SkillMeta
+
+
+def _make_meta(name: str, description: str) -> SkillMeta:
+    return SkillMeta(
+        name=name,
+        description=description,
+        source="official",
+        identifier=f"mcp/{name}",
+        trust_level="builtin",
+    )
+
+
+# Read current descriptions from the actual SKILL.md files so the test
+# stays in sync with the repo.
+def _load_description(skill_path: str) -> str:
+    import yaml, pathlib
+
+    text = pathlib.Path(skill_path).read_text()
+    # Extract YAML frontmatter between --- markers
+    parts = text.split("---", 2)
+    if len(parts) >= 3:
+        fm = yaml.safe_load(parts[1])
+        return fm.get("description", "")
+    return ""
+
+
+_NATIVE_DESC = _load_description("skills/mcp/native-mcp/SKILL.md")
+_MCPORTER_DESC = _load_description("skills/mcp/mcporter/SKILL.md")
+
+
+class TestMcpSkillRouting:
+    """native-mcp must outscore mcporter for generic MCP queries."""
+
+    def _scores(self, query: str):
+        native = _make_meta("native-mcp", _NATIVE_DESC)
+        mcporter = _make_meta("mcporter", _MCPORTER_DESC)
+        return (
+            ClawHubSource._search_score(query, native),
+            ClawHubSource._search_score(query, mcporter),
+        )
+
+    def test_list_mcp_servers(self):
+        native, mcporter = self._scores("list my configured MCP servers")
+        assert native > mcporter, f"native={native} should beat mcporter={mcporter}"
+
+    def test_what_mcp_tools(self):
+        native, mcporter = self._scores("what MCP tools do you have")
+        assert native > mcporter, f"native={native} should beat mcporter={mcporter}"
+
+    def test_show_mcp_setup(self):
+        native, mcporter = self._scores("show my MCP setup")
+        assert native > mcporter, f"native={native} should beat mcporter={mcporter}"
+
+    def test_mcporter_explicit(self):
+        """When the user explicitly asks for mcporter, mcporter should win."""
+        native, mcporter = self._scores("mcporter")
+        assert mcporter > native, f"mcporter={mcporter} should beat native={native}"
+
+    def test_mcporter_cli_explicit(self):
+        native, mcporter = self._scores("use mcporter to list servers")
+        assert mcporter > native, f"mcporter={mcporter} should beat native={native}"


### PR DESCRIPTION
## Summary

- Narrowed the `mcporter` skill description to only match when the user explicitly asks for the mcporter CLI by name
- Added a "When NOT to use" callout block in the skill body to guide the LLM away from selecting mcporter for generic MCP queries
- Generic MCP questions ("list my MCP servers", "what MCP tools do you have?") now correctly route to `native-mcp`

Fixes #10341

## Changes

**`skills/mcp/mcporter/SKILL.md`**
- Replaced broad description ("list, configure, auth, and call MCP servers/tools directly") with scoped description that emphasizes mcporter-specific operations and explicitly defers generic queries to native-mcp
- Added blockquote guidance section: "When NOT to use this skill"

**`tests/skills/test_mcp_skill_routing.py`** (new)
- 5 test cases verifying `_search_score` routing:
  - `native-mcp` outscores `mcporter` for "list my configured MCP servers"
  - `native-mcp` outscores `mcporter` for "what MCP tools do you have"
  - `native-mcp` outscores `mcporter` for "show my MCP setup"
  - `mcporter` still wins for explicit "mcporter" query
  - `mcporter` still wins for "use mcporter to list servers"

## Test plan

- [x] `uv run pytest tests/skills/test_mcp_skill_routing.py -v` — 5/5 pass
- [ ] Manual: ask Hermes "list my configured MCP servers" and verify native-mcp handles it
- [ ] Manual: ask Hermes "use mcporter to list" and verify mcporter handles it

🤖 Generated with [Claude Code](https://claude.com/claude-code)