### PR TITLE
fix: use absolute skill_dir for external skills

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -72,7 +72,14 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
     skill_name = str(loaded_skill.get("name") or normalized)
     skill_path = str(loaded_skill.get("path") or "")
     skill_dir = None
-    if skill_path:
+    # Prefer the absolute skill_dir returned by skill_view() — this is
+    # correct for both local and external skills.  Fall back to the old
+    # SKILLS_DIR-relative reconstruction only when skill_dir is absent
+    # (e.g. legacy skill_view responses).
+    abs_skill_dir = loaded_skill.get("skill_dir")
+    if abs_skill_dir:
+        skill_dir = Path(abs_skill_dir)
+    elif skill_path:
         try:
             skill_dir = SKILLS_DIR / Path(skill_path).parent
         except Exception:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1263,6 +1263,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             "related_skills": related_skills,
             "content": content,
             "path": rel_path,
+            "skill_dir": str(skill_dir) if skill_dir else None,
             "linked_files": linked_files if linked_files else None,
             "usage_hint": "To view linked files, call skill_view(name, file_path) where file_path is e.g. 'references/api.md' or 'assets/config.yaml'"
             if linked_files


### PR DESCRIPTION
## Summary

Fixes #10313 — `_load_skill_payload()` reconstructed `skill_dir` as `SKILLS_DIR / Path(relative_path).parent`, which produces wrong paths for external skills registered via `skills.external_dirs`. Those skills live outside `SKILLS_DIR` entirely, so their scripts and linked files failed to load.

## Fix

Two changes:

1. **`skill_view()`** now includes `"skill_dir": str(absolute_path)` in the result dict (it already had the value internally, just wasn't exposing it)

2. **`_load_skill_payload()`** prefers the absolute `skill_dir` from the result. Falls back to the old SKILLS_DIR-relative reconstruction only when `skill_dir` is absent (backward compat with any code that caches or mocks skill_view responses)

9 lines added across 2 files. 100 skill tests pass.