### PR TITLE
fix: activate WeCom callback message deduplication

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -258,6 +258,20 @@ class WecomCallbackAdapter(BasePlatformAdapter):
                 )
                 event = self._build_event(app, decrypted)
                 if event is not None:
+                    # Deduplicate: WeCom retries callbacks on timeout,
+                    # producing duplicate inbound messages (#10305).
+                    if event.message_id:
+                        now = time.time()
+                        if event.message_id in self._seen_messages:
+                            if now - self._seen_messages[event.message_id] < MESSAGE_DEDUP_TTL_SECONDS:
+                                logger.debug("[WecomCallback] Duplicate MsgId %s, skipping", event.message_id)
+                                return web.Response(text="success", content_type="text/plain")
+                            del self._seen_messages[event.message_id]
+                        self._seen_messages[event.message_id] = now
+                        # Prune expired entries when cache grows large
+                        if len(self._seen_messages) > 2000:
+                            cutoff = now - MESSAGE_DEDUP_TTL_SECONDS
+                            self._seen_messages = {k: v for k, v in self._seen_messages.items() if v > cutoff}
                     # Record which app this user belongs to.
                     if event.source and event.source.user_id:
                         map_key = self._user_app_key(


### PR DESCRIPTION
## Summary

Fixes #10305 — `WecomCallbackAdapter` declared a `_seen_messages` dict and `MESSAGE_DEDUP_TTL_SECONDS` constant but never checked them in `_handle_callback()`. WeCom retries callback deliveries on timeout, and each retry was treated as a fresh message.

## Fix

Added dedup check before `self._message_queue.put(event)`:

- Check if `event.message_id` was seen within TTL window → skip with 'success' response
- Track new message IDs with timestamp
- Prune expired entries when cache exceeds 2000

Uses the same TTL-aware pattern as the `MessageDeduplicator` fix from #10306.

14 lines added. 40 WeCom tests pass.