### PR TITLE
feat(api-server): intercept gateway slash commands on /v1/runs and /v1/chat/completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -50,6 +50,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.api_server_slash import maybe_handle_gateway_command
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -1424,6 +1425,56 @@ class APIServerAdapter(BasePlatformAdapter):
         model_name = body.get("model", self._model_name)
         created = int(time.time())
 
+        # Gateway slash-command intercept.  ``/help``, ``/commands``,
+        # ``/profile``, ``/provider`` are answered directly from the
+        # central command registry; stateful commands (``/model``,
+        # ``/new``, …) get a deterministic decline notice instead of
+        # being forwarded to the LLM, which would otherwise hallucinate
+        # a reply.  Unknown and strictly CLI-only commands fall through
+        # to the normal agent path.  See
+        # :mod:`gateway.platforms.api_server_slash` for the full policy.
+        slash_result = maybe_handle_gateway_command(user_message)
+        if slash_result is not None:
+            logger.info(
+                "[api_server] intercepted gateway command /%s on "
+                "/v1/chat/completions (stream=%s)",
+                slash_result.command,
+                bool(stream),
+            )
+            if stream:
+                return await self._write_sse_slash_command(
+                    request,
+                    completion_id=completion_id,
+                    model=model_name,
+                    created=created,
+                    session_id=session_id,
+                    text=slash_result.text,
+                )
+            return web.json_response(
+                {
+                    "id": completion_id,
+                    "object": "chat.completion",
+                    "created": created,
+                    "model": model_name,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": slash_result.text,
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 0,
+                        "completion_tokens": 0,
+                        "total_tokens": 0,
+                    },
+                },
+                headers={"X-Hermes-Session-Id": session_id},
+            )
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -1675,6 +1726,76 @@ class APIServerAdapter(BasePlatformAdapter):
                 except (asyncio.CancelledError, Exception):
                     pass
             logger.info("SSE client disconnected; interrupted agent task %s", completion_id)
+
+        return response
+
+    async def _write_sse_slash_command(
+        self,
+        request: "web.Request",
+        *,
+        completion_id: str,
+        model: str,
+        created: int,
+        session_id: Optional[str],
+        text: str,
+    ) -> "web.StreamResponse":
+        """Write a synthetic SSE stream for an intercepted slash command.
+
+        Emits the same three-chunk shape as :meth:`_write_sse_chat_completion`
+        — role chunk, content chunk, finish chunk, ``[DONE]`` terminator —
+        so OpenAI-compatible frontends render it indistinguishably from a
+        real LLM response.  There is no agent task and no queue: the full
+        body is known synchronously from *text*.
+        """
+        sse_headers = {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        }
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            sse_headers.update(cors)
+        if session_id:
+            sse_headers["X-Hermes-Session-Id"] = session_id
+        response = web.StreamResponse(status=200, headers=sse_headers)
+        await response.prepare(request)
+
+        try:
+            role_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+            }
+            await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
+
+            content_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+            }
+            await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+
+            finish_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "total_tokens": 0,
+                },
+            }
+            await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
+            await response.write(b"data: [DONE]\n\n")
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
+            logger.info("SSE client disconnected during slash-command reply %s", completion_id)
 
         return response
 
@@ -2327,6 +2448,41 @@ class APIServerAdapter(BasePlatformAdapter):
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = time.time()
+
+        # Gateway slash-command intercept.  When the first token of the
+        # user message resolves to a gateway-available command in
+        # :data:`hermes_cli.commands.COMMAND_REGISTRY`, synthesize a
+        # minimal ``message.delta`` + ``run.completed`` sequence into the
+        # run's event queue and skip the agent entirely.  Unknown and
+        # strictly CLI-only commands fall through to the normal path so
+        # the LLM can still handle skills and plugin commands.  See
+        # :mod:`gateway.platforms.api_server_slash` for the full policy.
+        slash_result = maybe_handle_gateway_command(user_message)
+        if slash_result is not None:
+            logger.info(
+                "[api_server] intercepted gateway command /%s on /v1/runs",
+                slash_result.command,
+            )
+            ts = time.time()
+            q.put_nowait({
+                "event": "message.delta",
+                "run_id": run_id,
+                "timestamp": ts,
+                "delta": slash_result.text,
+            })
+            q.put_nowait({
+                "event": "run.completed",
+                "run_id": run_id,
+                "timestamp": ts,
+                "output": slash_result.text,
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                },
+            })
+            q.put_nowait(None)
+            return web.json_response({"run_id": run_id, "status": "started"}, status=202)
 
         event_cb = self._make_run_event_callback(run_id, loop)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -59,7 +59,7 @@ from hermes_cli.config import load_config, save_config
 from hermes_cli.models import curated_models_for_provider, list_available_providers
 from hermes_state import SessionDB
 from tools.memory_tool import MemoryStore
-from tools.skills_tool import skill_view, skills_categories, skills_list
+from tools.skills_tool import skill_view, skills_list
 
 logger = logging.getLogger(__name__)
 
@@ -1227,13 +1227,6 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
         category = (request.query.get("category") or "").strip() or None
         return web.json_response(json.loads(skills_list(category=category)))
-
-    async def _handle_skill_categories(self, request: "web.Request") -> "web.Response":
-        """GET /api/skills/categories — list skill categories."""
-        auth_err = self._check_auth(request)
-        if auth_err:
-            return auth_err
-        return web.json_response(json.loads(skills_categories()))
 
     async def _handle_view_skill(self, request: "web.Request") -> "web.Response":
         """GET /api/skills/{name} — fetch skill details."""
@@ -2577,7 +2570,6 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_patch("/api/memory", self._handle_replace_memory)
             self._app.router.add_delete("/api/memory", self._handle_delete_memory)
             self._app.router.add_get("/api/skills", self._handle_list_skills)
-            self._app.router.add_get("/api/skills/categories", self._handle_skill_categories)
             self._app.router.add_get("/api/skills/{name}", self._handle_view_skill)
             self._app.router.add_get("/api/config", self._handle_get_config)
             self._app.router.add_patch("/api/config", self._handle_update_config)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -11,6 +11,16 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - GET  /health                     — health check
 
+Session management API (for frontend clients):
+- GET/POST/PATCH/DELETE /api/sessions   — session CRUD
+- GET  /api/sessions/{id}/messages      — session message history
+- POST /api/sessions/{id}/chat          — synchronous session chat turn
+- POST /api/sessions/{id}/chat/stream   — SSE streaming session chat turn
+- GET/POST/PATCH/DELETE /api/memory     — persistent memory entries
+- GET  /api/skills                      — list available skills
+- GET  /api/config                      — current model/provider settings
+- PATCH /api/config                     — update model/provider settings
+
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
 through this adapter by pointing at http://localhost:8642/v1.
@@ -45,6 +55,11 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from hermes_cli.config import load_config, save_config
+from hermes_cli.models import curated_models_for_provider, list_available_providers
+from hermes_state import SessionDB
+from tools.memory_tool import MemoryStore
+from tools.skills_tool import skill_view, skills_categories, skills_list
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +348,8 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
-        self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._session_db: Optional[SessionDB] = None
+        self._memory_store: Optional[MemoryStore] = None
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -426,6 +442,63 @@ class APIServerAdapter(BasePlatformAdapter):
             status=401,
         )
 
+    def _get_session_db(self) -> SessionDB:
+        """Create the session DB lazily."""
+        if self._session_db is None:
+            self._session_db = SessionDB()
+        return self._session_db
+
+    def _get_memory_store(self) -> MemoryStore:
+        """Create the memory store lazily."""
+        if self._memory_store is None:
+            self._memory_store = MemoryStore()
+            self._memory_store.load_from_disk()
+        return self._memory_store
+
+    @staticmethod
+    def _normalize_session_record(session: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Parse serialized session fields into API-friendly JSON."""
+        if session is None:
+            return None
+        normalized = dict(session)
+        model_config = normalized.get("model_config")
+        if model_config:
+            try:
+                normalized["model_config"] = json.loads(model_config)
+            except (TypeError, json.JSONDecodeError):
+                pass
+        return normalized
+
+    @staticmethod
+    def _current_model_settings(config: Dict[str, Any]) -> Dict[str, Any]:
+        """Extract model/provider/base_url/api_mode from config.yaml."""
+        model_cfg = config.get("model")
+        if isinstance(model_cfg, dict):
+            return {
+                "model": str(model_cfg.get("default") or model_cfg.get("model") or "").strip(),
+                "provider": str(model_cfg.get("provider") or "").strip(),
+                "api_mode": str(model_cfg.get("api_mode") or "").strip(),
+                "base_url": str(model_cfg.get("base_url") or "").strip(),
+            }
+        if isinstance(model_cfg, str):
+            return {
+                "model": model_cfg.strip(),
+                "provider": "",
+                "api_mode": "",
+                "base_url": "",
+            }
+        return {"model": "", "provider": "", "api_mode": "", "base_url": ""}
+
+    @staticmethod
+    def _parse_int(value: Any, default: int, minimum: int = 0) -> int:
+        """Parse an integer query parameter with bounds."""
+        if value in (None, ""):
+            return default
+        parsed = int(value)
+        if parsed < minimum:
+            raise ValueError(f"Value must be >= {minimum}")
+        return parsed
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -447,6 +520,57 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_user_content(
+        text: str, attachments: Optional[List[Dict[str, Any]]] = None
+    ) -> tuple:
+        """Build multimodal content from text + image attachments.
+
+        Returns (user_content, persist_text) where user_content is either
+        a plain string or a list of content parts for multimodal input.
+        """
+        if not attachments:
+            return text, text
+
+        image_parts: List[Dict[str, Any]] = []
+        for att in attachments:
+            if not isinstance(att, dict):
+                continue
+            mime = ""
+            for key in ("contentType", "mimeType", "mediaType"):
+                val = att.get(key)
+                if isinstance(val, str) and val.strip():
+                    mime = val.strip()
+                    break
+            if not mime.startswith("image/"):
+                continue
+            content = ""
+            for key in ("content", "base64", "data"):
+                val = att.get(key)
+                if isinstance(val, str) and val.strip():
+                    content = val.strip()
+                    break
+            if not content:
+                # Try dataUrl format: data:image/png;base64,...
+                data_url = att.get("dataUrl", "")
+                if isinstance(data_url, str) and data_url.startswith("data:"):
+                    content = data_url.split(",", 1)[-1] if "," in data_url else ""
+            if not content:
+                continue
+            image_parts.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{content}"},
+            })
+
+        if not image_parts:
+            return text, text
+
+        content_parts: List[Dict[str, Any]] = []
+        if text.strip():
+            content_parts.append({"type": "text", "text": text})
+        content_parts.extend(image_parts)
+        return content_parts, text
 
     def _create_agent(
         self,
@@ -526,6 +650,670 @@ class APIServerAdapter(BasePlatformAdapter):
             ],
         })
 
+    async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions — list sessions."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            limit = self._parse_int(request.query.get("limit"), 50)
+            offset = self._parse_int(request.query.get("offset"), 0)
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+
+        source = (request.query.get("source") or "").strip() or None
+        db = self._get_session_db()
+        items = [
+            self._normalize_session_record(item)
+            for item in db.list_sessions_rich(source=source, limit=limit, offset=offset)
+        ]
+        total = db.session_count(source=source)
+        return web.json_response({"items": items, "total": total})
+
+    async def _handle_create_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions — create a new session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        title = body.get("title")
+        source = str(body.get("source") or "api_server").strip() or "api_server"
+        model = body.get("model")
+        system_prompt = body.get("system_prompt")
+        session_id = f"sess_{uuid.uuid4().hex}"
+        db = self._get_session_db()
+
+        try:
+            db.create_session(
+                session_id=session_id,
+                source=source,
+                model=model,
+                system_prompt=system_prompt,
+            )
+            if title is not None:
+                db.set_session_title(session_id, str(title))
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+        session = self._normalize_session_record(db.get_session(session_id))
+        return web.json_response({"session": session})
+
+    async def _handle_search_sessions(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/search — search messages across sessions."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        query = (request.query.get("q") or "").strip()
+        if not query:
+            return web.json_response({"error": "Missing query parameter: q"}, status=400)
+        try:
+            limit = self._parse_int(request.query.get("limit"), 20)
+            offset = self._parse_int(request.query.get("offset"), 0)
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+
+        results = self._get_session_db().search_messages(query=query, limit=limit, offset=offset)
+        return web.json_response({"query": query, "count": len(results), "results": results})
+
+    async def _handle_get_session(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id} — fetch one session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        session = self._normalize_session_record(self._get_session_db().get_session(session_id))
+        if session is None:
+            return web.json_response({"error": "Session not found"}, status=404)
+        return web.json_response({"session": session})
+
+    async def _handle_get_session_messages(self, request: "web.Request") -> "web.Response":
+        """GET /api/sessions/{session_id}/messages — fetch session messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        db = self._get_session_db()
+        if db.get_session(session_id) is None:
+            db.ensure_session(session_id, source="web")
+        items = db.get_messages(session_id)
+        return web.json_response({"items": items, "total": len(items)})
+
+    async def _handle_update_session(self, request: "web.Request") -> "web.Response":
+        """PATCH /api/sessions/{session_id} — update a session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        db = self._get_session_db()
+        if db.get_session(session_id) is None:
+            return web.json_response({"error": "Session not found"}, status=404)
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        try:
+            if "title" in body:
+                db.set_session_title(session_id, body.get("title"))
+            if "system_prompt" in body:
+                db.update_system_prompt(session_id, body.get("system_prompt"))
+            if "end_reason" in body:
+                db.end_session(session_id, str(body.get("end_reason") or "updated"))
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+        session = self._normalize_session_record(db.get_session(session_id))
+        return web.json_response({"session": session})
+
+    async def _handle_delete_session(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/sessions/{session_id} — delete a session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        deleted = self._get_session_db().delete_session(session_id)
+        if not deleted:
+            return web.json_response({"error": "Session not found"}, status=404)
+        return web.json_response({"ok": True})
+
+    async def _handle_fork_session(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/fork — clone a session and its messages."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        session_id = request.match_info["session_id"]
+        db = self._get_session_db()
+        original = db.get_session(session_id)
+        if original is None:
+            return web.json_response({"error": "Session not found"}, status=404)
+
+        forked_id = f"sess_{uuid.uuid4().hex}"
+        try:
+            db.create_session(
+                session_id=forked_id,
+                source=original.get("source") or "api_server",
+                model=original.get("model"),
+                system_prompt=original.get("system_prompt"),
+                user_id=original.get("user_id"),
+                parent_session_id=session_id,
+            )
+            messages = db.get_messages(session_id)
+            for message in messages:
+                db.append_message(
+                    session_id=forked_id,
+                    role=message.get("role"),
+                    content=message.get("content"),
+                    tool_name=message.get("tool_name"),
+                    tool_calls=message.get("tool_calls"),
+                    tool_call_id=message.get("tool_call_id"),
+                    token_count=message.get("token_count"),
+                    finish_reason=message.get("finish_reason"),
+                    reasoning=message.get("reasoning"),
+                )
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+        session = self._normalize_session_record(db.get_session(forked_id))
+        return web.json_response({"session": session, "forked_from": session_id})
+
+    async def _handle_session_chat(self, request: "web.Request") -> "web.Response":
+        """POST /api/sessions/{session_id}/chat — run a session-aware chat turn."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+        db = self._get_session_db()
+        session = self._normalize_session_record(db.get_session(session_id))
+        if session is None:
+            db.ensure_session(session_id, source="web")
+            session = self._normalize_session_record(db.get_session(session_id)) or {}
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        message = body.get("message")
+        if not isinstance(message, str):
+            return web.json_response({"error": "Missing or invalid 'message' field"}, status=400)
+
+        raw_attachments_sync = body.get("attachments")
+        if raw_attachments_sync:
+            logger.debug("[chat] Received %d attachment(s): %s",
+                         len(raw_attachments_sync),
+                         [(a.get("name"), a.get("contentType"), len(a.get("content", "") or a.get("base64", "") or "")) for a in raw_attachments_sync if isinstance(a, dict)])
+        user_content, persist_text = self._build_user_content(message, raw_attachments_sync)
+        if isinstance(user_content, list):
+            logger.debug("[chat] Built multimodal content with %d parts", len(user_content))
+
+        model = body.get("model") or session.get("model") or "hermes-agent"
+        system_message = body.get("system_message")
+        history = db.get_messages_as_conversation(session_id)
+        loop = asyncio.get_event_loop()
+
+        def _run():
+            agent = self._create_agent(
+                ephemeral_system_prompt=system_message,
+                session_id=session_id,
+            )
+            agent._session_db = db  # Enable session persistence
+            result = agent.run_conversation(
+                user_content,
+                conversation_history=history,
+                persist_user_message=persist_text,
+            )
+            usage = {
+                "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+            }
+            return result, usage
+
+        try:
+            result, usage = await loop.run_in_executor(None, _run)
+        except Exception as e:
+            logger.error("Error running session chat for %s: %s", session_id, e, exc_info=True)
+            return web.json_response({"error": str(e)}, status=500)
+
+        return web.json_response({
+            "session_id": session_id,
+            "run_id": f"run_{uuid.uuid4().hex}",
+            "model": model,
+            "final_response": result.get("final_response"),
+            "completed": result.get("completed", False),
+            "partial": result.get("partial", False),
+            "interrupted": result.get("interrupted", False),
+            "api_calls": result.get("api_calls", 0),
+            "messages": result.get("messages", []),
+            "last_reasoning": result.get("last_reasoning"),
+            "response_previewed": result.get("response_previewed", False),
+            "usage": usage,
+        })
+
+    async def _handle_session_chat_stream(self, request: "web.Request") -> "web.StreamResponse":
+        """POST /api/sessions/{session_id}/chat/stream — stream a session chat turn over SSE."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+        db = self._get_session_db()
+        session = self._normalize_session_record(db.get_session(session_id))
+        if session is None:
+            db.ensure_session(session_id, source="web")
+            session = self._normalize_session_record(db.get_session(session_id)) or {}
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        message = body.get("message")
+        if not isinstance(message, str):
+            return web.json_response({"error": "Missing or invalid 'message' field"}, status=400)
+
+        # Build multimodal content if image attachments are present
+        raw_attachments = body.get("attachments")
+        if raw_attachments:
+            logger.debug("[chat/stream] Received %d attachment(s): %s",
+                         len(raw_attachments),
+                         [(a.get("name"), a.get("contentType"), len(a.get("content", "") or a.get("base64", "") or "")) for a in raw_attachments if isinstance(a, dict)])
+        user_content, persist_text = self._build_user_content(message, raw_attachments)
+        if isinstance(user_content, list):
+            logger.debug("[chat/stream] Built multimodal content with %d parts", len(user_content))
+
+        system_message = body.get("system_message")
+        history = db.get_messages_as_conversation(session_id)
+        assistant_message_id = f"msg_asst_{uuid.uuid4().hex}"
+
+        # Note: user message persistence is handled by AIAgent._flush_messages_to_session_db
+        # Don't double-persist here or messages will appear twice
+
+        import queue as _q
+        stream_q: _q.Queue = _q.Queue()
+
+        def _encode_sse(event_name: str, payload: Dict[str, Any]) -> bytes:
+            return f"event: {event_name}\ndata: {json.dumps(payload, ensure_ascii=False)}\n\n".encode("utf-8")
+
+        def _queue_event(event_name: str, payload: Dict[str, Any]) -> None:
+            stream_q.put(_encode_sse(event_name, payload))
+
+        def _tool_map(messages: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+            mapping: Dict[str, Dict[str, Any]] = {}
+            for item in messages:
+                if item.get("role") != "assistant":
+                    continue
+                for index, tool_call in enumerate(item.get("tool_calls") or []):
+                    tool_id = tool_call.get("id")
+                    if not tool_id:
+                        continue
+                    fn = tool_call.get("function") or {}
+                    raw_args = fn.get("arguments")
+                    try:
+                        parsed_args = json.loads(raw_args) if isinstance(raw_args, str) and raw_args.strip() else {}
+                    except json.JSONDecodeError:
+                        parsed_args = raw_args
+                    mapping[tool_id] = {
+                        "tool_name": fn.get("name") or item.get("tool_name") or f"tool_{index + 1}",
+                        "args": parsed_args,
+                    }
+            return mapping
+
+        def _result_preview(content: Any, limit: int = 4000) -> str:
+            text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+            return text[:limit] + ("..." if len(text) > limit else "")
+
+        run_id = f"run_{uuid.uuid4().hex}"
+
+        def _on_delta(delta):
+            if delta:
+                _queue_event(
+                    "assistant.delta",
+                    {"session_id": session_id, "run_id": run_id, "message_id": assistant_message_id, "delta": delta},
+                )
+
+        def _on_tool_progress(name, preview, args):
+            if name == "_thinking":
+                _queue_event(
+                    "tool.progress",
+                    {"session_id": session_id, "run_id": run_id, "message_id": assistant_message_id, "delta": preview},
+                )
+                return
+            payload = {
+                "session_id": session_id,
+                "run_id": run_id,
+                "tool_name": name,
+                "preview": preview,
+                "args": args,
+            }
+            _queue_event("tool.started", payload)
+
+        agent_ref = [None]
+        loop = asyncio.get_event_loop()
+
+        async def _run_agent_task():
+            def _run():
+                agent = self._create_agent(
+                    ephemeral_system_prompt=system_message,
+                    session_id=session_id,
+                    stream_delta_callback=_on_delta,
+                    tool_progress_callback=_on_tool_progress,
+                )
+                agent._session_db = db  # Enable session persistence
+                agent_ref[0] = agent
+                return agent.run_conversation(
+                    user_content,
+                    conversation_history=history,
+                    persist_user_message=persist_text,
+                )
+
+            return await loop.run_in_executor(None, _run)
+
+        agent_task = asyncio.ensure_future(_run_agent_task())
+
+        sse_headers = {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        }
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            sse_headers.update(cors)
+
+        response = web.StreamResponse(status=200, headers=sse_headers)
+        await response.prepare(request)
+
+        try:
+            user_message_id = f"msg_user_{uuid.uuid4().hex}"
+            await response.write(_encode_sse("session.created", {
+                "session_id": session_id,
+                "run_id": run_id,
+                "title": session.get("title") or "New Chat",
+            }))
+            await response.write(_encode_sse("run.started", {
+                "session_id": session_id,
+                "run_id": run_id,
+                "user_message": {
+                    "id": user_message_id,
+                    "role": "user",
+                    "content": message,
+                },
+            }))
+            await response.write(_encode_sse("message.started", {
+                "session_id": session_id,
+                "run_id": run_id,
+                "message": {"id": assistant_message_id, "role": "assistant"},
+            }))
+
+            last_activity = time.monotonic()
+            while True:
+                try:
+                    frame = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
+                except _q.Empty:
+                    if agent_task.done():
+                        while True:
+                            try:
+                                frame = stream_q.get_nowait()
+                                if frame is None:
+                                    break
+                                await response.write(frame)
+                            except _q.Empty:
+                                break
+                        break
+                    # Send periodic keepalive to prevent client/proxy
+                    # timeouts during agent init and long LLM API calls.
+                    if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
+                        await response.write(b": keepalive\n\n")
+                        last_activity = time.monotonic()
+                    continue
+
+                if frame is None:
+                    break
+
+                await response.write(frame)
+                last_activity = time.monotonic()
+
+            try:
+                result = await agent_task
+            except Exception:
+                result = {"messages": [], "final_response": "", "completed": False}
+            tools = _tool_map(result.get("messages") or [])
+            for item in result.get("messages") or []:
+                if item.get("role") != "tool":
+                    continue
+                tool_id = item.get("tool_call_id")
+                tool_meta = tools.get(tool_id, {})
+                await response.write(_encode_sse("tool.completed", {
+                    "session_id": session_id,
+                    "run_id": run_id,
+                    "tool_call_id": tool_id,
+                    "tool_name": tool_meta.get("tool_name") or item.get("tool_name") or "unknown",
+                    "args": tool_meta.get("args"),
+                    "result_preview": _result_preview(item.get("content")),
+                }))
+
+            await response.write(_encode_sse("assistant.completed", {
+                "session_id": session_id,
+                "run_id": run_id,
+                "message_id": assistant_message_id,
+                "content": result.get("final_response") or "",
+                "completed": result.get("completed", False),
+                "partial": result.get("partial", False),
+                "interrupted": result.get("interrupted", False),
+            }))
+            await response.write(_encode_sse("run.completed", {
+                "session_id": session_id,
+                "run_id": run_id,
+                "message_id": assistant_message_id,
+                "completed": result.get("completed", False),
+                "partial": result.get("partial", False),
+                "interrupted": result.get("interrupted", False),
+                "api_calls": result.get("api_calls"),
+            }))
+            await response.write(_encode_sse("done", {"session_id": session_id, "run_id": run_id, "state": "final"}))
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
+            agent = agent_ref[0]
+            if agent is not None:
+                try:
+                    agent.interrupt("SSE client disconnected")
+                except Exception:
+                    pass
+            if not agent_task.done():
+                agent_task.cancel()
+                try:
+                    await agent_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            logger.info("Session SSE client disconnected; interrupted session %s", session_id)
+
+        return response
+
+    async def _handle_get_memory(self, request: "web.Request") -> "web.Response":
+        """GET /api/memory — read current memory state."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        target = (request.query.get("target") or "all").strip().lower()
+        if target not in {"all", "memory", "user"}:
+            return web.json_response({"error": "target must be one of: all, memory, user"}, status=400)
+
+        store = self._get_memory_store()
+        store.load_from_disk()
+        targets = []
+        if target in {"all", "memory"}:
+            targets.append({
+                "target": "memory",
+                "entries": store.memory_entries,
+                "entry_count": len(store.memory_entries),
+            })
+        if target in {"all", "user"}:
+            targets.append({
+                "target": "user",
+                "entries": store.user_entries,
+                "entry_count": len(store.user_entries),
+            })
+        return web.json_response({"targets": targets})
+
+    async def _handle_add_memory(self, request: "web.Request") -> "web.Response":
+        """POST /api/memory — add a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        target = str(body.get("target") or "").strip().lower()
+        content = str(body.get("content") or "")
+        if target not in {"memory", "user"}:
+            return web.json_response({"error": "target must be 'memory' or 'user'"}, status=400)
+        result = self._get_memory_store().add(target, content)
+        status = 200 if result.get("success") else 400
+        return web.json_response(result, status=status)
+
+    async def _handle_replace_memory(self, request: "web.Request") -> "web.Response":
+        """PATCH /api/memory — replace a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        target = str(body.get("target") or "").strip().lower()
+        old_text = str(body.get("old_text") or "")
+        content = str(body.get("content") or "")
+        if target not in {"memory", "user"}:
+            return web.json_response({"error": "target must be 'memory' or 'user'"}, status=400)
+        result = self._get_memory_store().replace(target, old_text, content)
+        status = 200 if result.get("success") else 400
+        return web.json_response(result, status=status)
+
+    async def _handle_delete_memory(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/memory — delete a memory entry."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        target = str(body.get("target") or "").strip().lower()
+        old_text = str(body.get("old_text") or "")
+        if target not in {"memory", "user"}:
+            return web.json_response({"error": "target must be 'memory' or 'user'"}, status=400)
+        result = self._get_memory_store().remove(target, old_text)
+        status = 200 if result.get("success") else 400
+        return web.json_response(result, status=status)
+
+    async def _handle_list_skills(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills — list skills."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        category = (request.query.get("category") or "").strip() or None
+        return web.json_response(json.loads(skills_list(category=category)))
+
+    async def _handle_skill_categories(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/categories — list skill categories."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        return web.json_response(json.loads(skills_categories()))
+
+    async def _handle_view_skill(self, request: "web.Request") -> "web.Response":
+        """GET /api/skills/{name} — fetch skill details."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        name = request.match_info["name"]
+        file_path = (request.query.get("file_path") or "").strip() or None
+        return web.json_response(json.loads(skill_view(name, file_path=file_path)))
+
+    async def _handle_get_config(self, request: "web.Request") -> "web.Response":
+        """GET /api/config — fetch the current config."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        config = load_config()
+        current = self._current_model_settings(config)
+        return web.json_response({
+            "model": current["model"],
+            "provider": current["provider"],
+            "api_mode": current["api_mode"],
+            "base_url": current["base_url"],
+            "config": config,
+        })
+
+    async def _handle_update_config(self, request: "web.Request") -> "web.Response":
+        """PATCH /api/config — update model/provider/base_url settings."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        config = load_config()
+        model_cfg = config.get("model")
+        if isinstance(model_cfg, dict):
+            updated_model_cfg = dict(model_cfg)
+        elif isinstance(model_cfg, str) and model_cfg.strip():
+            updated_model_cfg = {"default": model_cfg.strip()}
+        else:
+            updated_model_cfg = {}
+
+        if "model" in body:
+            updated_model_cfg["default"] = str(body.get("model") or "").strip()
+        if "provider" in body:
+            updated_model_cfg["provider"] = str(body.get("provider") or "").strip()
+        if "base_url" in body:
+            updated_model_cfg["base_url"] = str(body.get("base_url") or "").strip()
+
+        config["model"] = updated_model_cfg
+        try:
+            save_config(config)
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
+        current = self._current_model_settings(config)
+        return web.json_response({
+            "ok": True,
+            "model": current["model"],
+            "provider": current["provider"],
+            "base_url": current["base_url"],
+        })
+
+    async def _handle_available_models(self, request: "web.Request") -> "web.Response":
+        """GET /api/available-models — list provider models and available providers."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        config = load_config()
+        current = self._current_model_settings(config)
+        provider = (request.query.get("provider") or current["provider"] or "openrouter").strip()
+        models = [
+            {"id": model_id, "description": description}
+            for model_id, description in curated_models_for_provider(provider)
+        ]
+        providers = list_available_providers()
+        return web.json_response({"provider": provider, "models": models, "providers": providers})
+
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
@@ -544,6 +1332,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
                 status=400,
             )
+
+        # Fast-path for capability probes (max_tokens=1)
+        # Return a minimal valid response so frontends detect the endpoint
+        # without spinning up a full agent.
+        max_tokens = body.get("max_tokens")
+        if max_tokens == 1:
+            return web.json_response({
+                "id": f"chatcmpl-probe-{uuid.uuid4().hex[:8]}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": body.get("model", "") or "hermes-agent",
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 1, "total_tokens": 1},
+            })
 
         stream = body.get("stream", False)
 
@@ -1760,6 +2562,26 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
             if hasattr(sweep_task, "add_done_callback"):
                 sweep_task.add_done_callback(self._background_tasks.discard)
+            self._app.router.add_get("/api/sessions", self._handle_list_sessions)
+            self._app.router.add_post("/api/sessions", self._handle_create_session)
+            self._app.router.add_get("/api/sessions/search", self._handle_search_sessions)
+            self._app.router.add_get("/api/sessions/{session_id}", self._handle_get_session)
+            self._app.router.add_get("/api/sessions/{session_id}/messages", self._handle_get_session_messages)
+            self._app.router.add_patch("/api/sessions/{session_id}", self._handle_update_session)
+            self._app.router.add_delete("/api/sessions/{session_id}", self._handle_delete_session)
+            self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
+            self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
+            self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
+            self._app.router.add_get("/api/memory", self._handle_get_memory)
+            self._app.router.add_post("/api/memory", self._handle_add_memory)
+            self._app.router.add_patch("/api/memory", self._handle_replace_memory)
+            self._app.router.add_delete("/api/memory", self._handle_delete_memory)
+            self._app.router.add_get("/api/skills", self._handle_list_skills)
+            self._app.router.add_get("/api/skills/categories", self._handle_skill_categories)
+            self._app.router.add_get("/api/skills/{name}", self._handle_view_skill)
+            self._app.router.add_get("/api/config", self._handle_get_config)
+            self._app.router.add_patch("/api/config", self._handle_update_config)
+            self._app.router.add_get("/api/available-models", self._handle_available_models)
 
             # Refuse to start network-accessible without authentication
             if is_network_accessible(self._host) and not self._api_key:
@@ -1814,6 +2636,10 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._runner.cleanup()
             self._runner = None
         self._app = None
+        if self._session_db is not None:
+            self._session_db.close()
+            self._session_db = None
+        self._memory_store = None
         logger.info("[%s] API server stopped", self.name)
 
     async def send(

--- a/gateway/platforms/api_server_slash.py
+++ b/gateway/platforms/api_server_slash.py
@@ -1,0 +1,343 @@
+"""Slash-command preprocessor for the OpenAI-compatible API server adapter.
+
+The API server's ``/v1/runs`` and ``/v1/chat/completions`` endpoints are
+intentionally stateless — each request spins up a fresh ``AIAgent`` with
+no session cache, no model override dict, and no reference to the
+``GatewayRouter`` that platforms like Discord and the CLI route through.
+See the comment at ``gateway/run.py:3148`` which confirms api_server is
+excluded from the router notification path.
+
+Without an interceptor, a message like ``/model claude-sonnet-4-6`` sent
+to ``/v1/runs`` passes through to the LLM verbatim.  The model then
+hallucinates a plausible-sounding reply such as *"``/model`` is a
+client-side command, I can't execute it"*, because it doesn't know the
+command was supposed to be handled by the gateway.  Frontends have no
+way to tell the command was swallowed.
+
+This module is a small preprocessor that runs before the LLM is invoked.
+It checks the user text for a leading ``/``, resolves the first token
+against ``COMMAND_REGISTRY`` from :mod:`hermes_cli.commands`, and either:
+
+* **Executes** the command, for the subset that is genuinely stateless
+  (``/help``, ``/commands``, ``/profile``, ``/provider``) using the same
+  helpers that :class:`GatewayRouter` uses.  These exist so API-server
+  frontends can reach the canonical help/config surface without having
+  to hardcode command lists.
+* **Declines politely** for commands that require router-owned session
+  state (``/model``, ``/new``, ``/retry``, ``/yolo``, …) by returning a
+  short notice explaining that the endpoint is stateless.  This replaces
+  the LLM-hallucination path with a deterministic, helpful response.
+* **Falls through** (``return None``) for non-slash text, unknown slash
+  commands, and strictly ``cli_only`` commands — the caller then runs
+  the normal LLM path.
+
+The preprocessor is wrapped in a top-level ``try/except`` so that any
+bug inside it logs at WARNING and falls through to the LLM path.  A
+preprocessor fault must never take down a normal chat request.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+from hermes_cli.commands import resolve_command
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SlashCommandResult:
+    """Result of a handled gateway slash command.
+
+    ``text`` is the plain-text body to surface to the caller; the caller
+    is responsible for wrapping it in whatever transport envelope the
+    endpoint needs (OpenAI chunk, ``message.delta``, JSON, …).
+
+    ``command`` is the canonical command name (without the leading
+    slash) — useful for logging and for echoing the name back to the
+    user in decline notices.
+    """
+
+    text: str
+    command: str
+
+
+# ---------------------------------------------------------------------------
+# Stateless handlers — each returns the textual body of a synthetic reply.
+# They must NOT touch router-owned state (session store, agent cache,
+# model override dict, per-adapter pickers).
+# ---------------------------------------------------------------------------
+
+
+def _handle_help(_args: str) -> str:
+    """Return the canonical gateway help listing.
+
+    Delegates to :func:`hermes_cli.commands.gateway_help_lines` so the
+    output stays in sync with the central command registry and honors
+    ``gateway_config_gate`` overrides automatically.
+    """
+    from hermes_cli.commands import gateway_help_lines
+
+    lines = ["**Hermes Commands**", ""]
+    lines.extend(gateway_help_lines())
+    lines.append("")
+    lines.append(
+        "Note: commands that mutate session state (for example `/model`, "
+        "`/new`, `/retry`, `/yolo`) are not available on the stateless "
+        "`/v1/runs` and `/v1/chat/completions` endpoints.  Use a channel "
+        "with persistent session state (CLI, Discord, Telegram, Slack) "
+        "for those."
+    )
+    return "\n".join(lines)
+
+
+def _handle_commands(args: str) -> str:
+    """Return the paginated ``/commands`` listing.
+
+    Mirrors :meth:`GatewayRouter._handle_commands_command` but without
+    the platform-specific page size and without the skill-commands
+    section (which depends on router-side skill loading that api_server
+    does not do).
+    """
+    from hermes_cli.commands import gateway_help_lines
+
+    entries = list(gateway_help_lines())
+    if not entries:
+        return "No commands available."
+
+    raw = (args or "").strip()
+    if raw:
+        try:
+            requested_page = int(raw)
+        except ValueError:
+            return "Usage: `/commands [page]`"
+    else:
+        requested_page = 1
+
+    page_size = 20
+    total_pages = max(1, (len(entries) + page_size - 1) // page_size)
+    page = max(1, min(requested_page, total_pages))
+    start = (page - 1) * page_size
+    page_entries = entries[start:start + page_size]
+
+    lines = [
+        f"**Commands** ({len(entries)} total, page {page}/{total_pages})",
+        "",
+        *page_entries,
+    ]
+    if total_pages > 1:
+        nav_parts = []
+        if page > 1:
+            nav_parts.append(f"`/commands {page - 1}` ← prev")
+        if page < total_pages:
+            nav_parts.append(f"next → `/commands {page + 1}`")
+        lines.extend(["", " | ".join(nav_parts)])
+    if page != requested_page:
+        lines.append(
+            f"_(Requested page {requested_page} was out of range, "
+            f"showing page {page}.)_"
+        )
+    return "\n".join(lines)
+
+
+def _handle_profile(_args: str) -> str:
+    """Return the active profile name and home directory.
+
+    Mirrors :meth:`GatewayRouter._handle_profile_command`.  Reads only
+    environment / filesystem state; no router dependency.
+    """
+    from pathlib import Path
+
+    from hermes_constants import display_hermes_home, get_hermes_home
+
+    home = get_hermes_home()
+    display = display_hermes_home()
+
+    profiles_parent = Path.home() / ".hermes" / "profiles"
+    try:
+        rel = home.relative_to(profiles_parent)
+        profile_name = str(rel).split("/")[0]
+    except ValueError:
+        profile_name = None
+
+    if profile_name:
+        return f"**Profile:** `{profile_name}`\n**Home:** `{display}`"
+    return f"**Profile:** default\n**Home:** `{display}`"
+
+
+def _handle_provider(_args: str) -> str:
+    """Return the current provider plus the list of available providers.
+
+    Mirrors the read-only branch of
+    :meth:`GatewayRouter._handle_provider_command`.  Reads config.yaml
+    and the provider registry directly — no router dependency.
+    """
+    import yaml
+
+    from hermes_cli.models import _PROVIDER_LABELS, list_available_providers, normalize_provider
+
+    # Resolve current provider from config
+    current_provider = "openrouter"
+    model_cfg: dict = {}
+    try:
+        from hermes_constants import get_hermes_home
+        config_path = get_hermes_home() / "config.yaml"
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as fh:
+                cfg = yaml.safe_load(fh) or {}
+            raw_model_cfg = cfg.get("model", {})
+            if isinstance(raw_model_cfg, dict):
+                model_cfg = raw_model_cfg
+                current_provider = model_cfg.get("provider", current_provider)
+    except Exception:
+        pass
+
+    current_provider = normalize_provider(current_provider)
+    if current_provider == "auto":
+        try:
+            from hermes_cli.auth import resolve_provider as _resolve_provider
+            current_provider = _resolve_provider(current_provider)
+        except Exception:
+            current_provider = "openrouter"
+
+    # Detect custom endpoint from config base_url
+    if current_provider == "openrouter":
+        cfg_base = model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
+        if cfg_base and "openrouter.ai" not in cfg_base:
+            current_provider = "custom"
+
+    current_label = _PROVIDER_LABELS.get(current_provider, current_provider)
+
+    lines = [
+        f"**Current provider:** {current_label} (`{current_provider}`)",
+        "",
+        "**Available providers:**",
+    ]
+    try:
+        providers = list_available_providers()
+    except Exception:
+        providers = []
+    for provider in providers:
+        marker = " ← active" if provider["id"] == current_provider else ""
+        auth = "authenticated" if provider["authenticated"] else "not authenticated"
+        aliases = (
+            f"  _(also: {', '.join(provider['aliases'])})_"
+            if provider["aliases"]
+            else ""
+        )
+        lines.append(
+            f"- `{provider['id']}` — {provider['label']} "
+            f"({auth}){aliases}{marker}"
+        )
+    lines.append("")
+    lines.append(
+        "Note: provider switching via `/model` is not available on "
+        "the stateless `/v1/runs` and `/v1/chat/completions` endpoints."
+    )
+    return "\n".join(lines)
+
+
+_STATELESS_HANDLERS: Dict[str, Callable[[str], str]] = {
+    "help": _handle_help,
+    "commands": _handle_commands,
+    "profile": _handle_profile,
+    "provider": _handle_provider,
+}
+
+
+# ---------------------------------------------------------------------------
+# Stateful-command decline notice
+# ---------------------------------------------------------------------------
+
+
+def _stateful_decline_notice(user_token: str, canonical_name: str) -> str:
+    """Build the decline notice for a stateful command.
+
+    *user_token* is whatever the caller actually typed (minus the leading
+    slash) so aliases like ``/reset`` echo back correctly.  *canonical_name*
+    is the resolved command name — useful for the footer pointer to
+    ``/help``.
+    """
+    displayed = user_token or canonical_name
+    return (
+        f"The `/{displayed}` command requires a persistent session and "
+        f"isn't available on the stateless `/v1/runs` and "
+        f"`/v1/chat/completions` endpoints.  Use a channel with session "
+        f"state (CLI, Discord, Telegram, Slack) for commands that mutate "
+        f"per-session configuration.\n\n"
+        f"For the commands that *are* supported here, type `/help`."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def maybe_handle_gateway_command(user_message: str) -> Optional[SlashCommandResult]:
+    """Intercept a gateway slash command if the message starts with one.
+
+    Returns a :class:`SlashCommandResult` if the first whitespace-delimited
+    token of *user_message* starts with ``/`` and resolves to a
+    gateway-available command in :data:`hermes_cli.commands.COMMAND_REGISTRY`.
+    Returns ``None`` otherwise — the caller then runs the normal LLM path.
+
+    ``None`` is also returned when:
+
+    * *user_message* is empty or does not start with ``/``.
+    * The first token is an unknown command (pass it to the LLM; it may
+      be a skill name the LLM recognizes).
+    * The command is strictly ``cli_only`` (``/clear``, ``/history``,
+      ``/save``, …) and has no ``gateway_config_gate`` — these are never
+      exposed to gateway adapters.
+    * Anything inside the preprocessor raises.  The exception is logged
+      at WARNING and the caller falls through to the LLM path.  A bug in
+      the preprocessor must never take down a normal chat request.
+    """
+    try:
+        if not user_message:
+            return None
+        stripped = user_message.lstrip()
+        if not stripped.startswith("/"):
+            return None
+
+        # Split into "/name" + remainder.  The remainder is passed to
+        # stateless handlers as-is so they can do their own arg parsing.
+        parts = stripped.split(None, 1)
+        first_token = parts[0][1:]  # drop the leading slash
+        args = parts[1] if len(parts) > 1 else ""
+
+        if not first_token:
+            return None
+
+        cmd = resolve_command(first_token)
+        if cmd is None:
+            # Unknown command — could be a skill or plugin command the
+            # LLM can handle.  Fall through silently.
+            return None
+
+        # Strictly CLI-only commands are never reachable via the gateway.
+        # Config-gated commands (``cli_only=True`` plus a
+        # ``gateway_config_gate``) are still gateway-reachable when the
+        # gate is set, so let them through to the stateful-decline path.
+        if cmd.cli_only and not cmd.gateway_config_gate:
+            return None
+
+        handler = _STATELESS_HANDLERS.get(cmd.name)
+        if handler is not None:
+            return SlashCommandResult(text=handler(args), command=cmd.name)
+
+        return SlashCommandResult(
+            text=_stateful_decline_notice(first_token, cmd.name),
+            command=cmd.name,
+        )
+    except Exception as exc:
+        logger.warning(
+            "api_server slash preprocessor failed for %r — falling "
+            "through to LLM path: %s",
+            user_message[:80],
+            exc,
+        )
+        return None

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1869,3 +1869,416 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+# ---------------------------------------------------------------------------
+# Gateway slash-command preprocessor
+# ---------------------------------------------------------------------------
+
+
+def _create_app_with_runs(adapter: APIServerAdapter) -> web.Application:
+    """Variant of :func:`_create_app` that also wires the ``/v1/runs`` routes.
+
+    The standard fixture only exposes chat completions / models / health;
+    the slash-command preprocessor needs to be exercised through both
+    chat completions *and* runs, so we add the runs handlers locally.
+    """
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/v1/models", adapter._handle_models)
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    return app
+
+
+class TestGatewaySlashCommands:
+    """Verify the slash-command preprocessor on ``/v1/runs`` and
+    ``/v1/chat/completions``.
+
+    Stateless commands (``/help``, ``/commands``, ``/profile``,
+    ``/provider``) are executed locally; stateful commands (``/model``,
+    ``/new``, …) return a decline notice; unknown and CLI-only commands
+    fall through to the LLM path.
+    """
+
+    # -- /v1/chat/completions -------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_help_intercepted_non_streaming(self, adapter):
+        """`/help` on non-streaming chat completions returns the help text
+        from ``gateway_help_lines`` and never invokes the agent."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "/help"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                content = data["choices"][0]["message"]["content"]
+                assert "Hermes Commands" in content
+                assert "/new" in content  # a canonical gateway entry
+                mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_help_intercepted_streaming(self, adapter):
+        """`/help` on streaming chat completions emits a synthetic SSE
+        stream and never invokes the agent."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "/help"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                assert "text/event-stream" in resp.headers.get("Content-Type", "")
+                body = await resp.text()
+                assert "Hermes Commands" in body
+                assert "[DONE]" in body
+                mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_stateful_command_declines(self, adapter):
+        """`/model` on chat completions returns a deterministic decline
+        notice that echoes the command name, and never invokes the agent."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [
+                            {"role": "user", "content": "/model claude-sonnet-4-6"}
+                        ],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                content = data["choices"][0]["message"]["content"]
+                assert "/model" in content
+                assert "stateless" in content
+                assert "/help" in content
+                mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_alias_echoes_typed_token(self, adapter):
+        """`/reset` (alias for `/new`) declines with the *typed* token so
+        the user sees the command they actually used."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "/reset"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                content = data["choices"][0]["message"]["content"]
+                assert "/reset" in content
+                mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_normal_text_passes_through(self, adapter):
+        """Non-slash text goes straight to the agent — preprocessor
+        must not swallow it."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi there", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "Hello there"}],
+                    },
+                )
+                assert resp.status == 200
+                mock_run.assert_called_once()
+                data = await resp.json()
+                assert data["choices"][0]["message"]["content"] == "hi there"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_cli_only_passes_through(self, adapter):
+        """`/clear` is strictly ``cli_only`` — it must fall through to
+        the LLM path so the model (or a skill) can decide what to do
+        with it, rather than being intercepted with a decline notice."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "okay", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "/clear"}],
+                    },
+                )
+                assert resp.status == 200
+                mock_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_unknown_slash_passes_through(self, adapter):
+        """Unrecognized slash commands must fall through — the LLM (or
+        a skill) may recognize them."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "idk that one", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "/notarealcommand"}],
+                    },
+                )
+                assert resp.status == 200
+                mock_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_preprocessor_exception_falls_through(self, adapter):
+        """A bug inside the preprocessor must log a warning and fall
+        through to the LLM path — never take down a chat request."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run, \
+                 patch(
+                     "gateway.platforms.api_server_slash.resolve_command",
+                     side_effect=RuntimeError("synthetic preprocessor fault"),
+                 ):
+                mock_run.return_value = (
+                    {"final_response": "survived", "messages": [], "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "/help"}],
+                    },
+                )
+                assert resp.status == 200
+                mock_run.assert_called_once()
+                data = await resp.json()
+                assert data["choices"][0]["message"]["content"] == "survived"
+
+    # -- /v1/runs -------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_runs_help_intercepted(self, adapter):
+        """`/help` on /v1/runs emits a synthetic ``message.delta`` +
+        ``run.completed`` sequence; the agent is never started."""
+        app = _create_app_with_runs(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post("/v1/runs", json={"input": "/help"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+                assert "message.delta" in body
+                assert "run.completed" in body
+                assert "Hermes Commands" in body
+                mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_stateful_command_declines(self, adapter):
+        """`/model ...` on /v1/runs emits the decline notice through the
+        event stream and never starts the agent."""
+        app = _create_app_with_runs(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/runs", json={"input": "/model claude-sonnet-4-6"}
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+                assert "/model" in body
+                assert "stateless" in body
+                assert "run.completed" in body
+                mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_normal_input_passes_through(self, adapter):
+        """Non-slash input on /v1/runs triggers the normal agent path."""
+        app = _create_app_with_runs(adapter)
+
+        # Patch _create_agent (which _handle_runs calls directly) with a
+        # stub whose run_conversation returns a minimal result dict.
+        fake_agent = MagicMock()
+        fake_agent.run_conversation.return_value = {"final_response": "hi"}
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=fake_agent):
+                resp = await cli.post("/v1/runs", json={"input": "Hello there"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await events_resp.text()
+                assert "run.completed" in body
+                fake_agent.run_conversation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_runs_cli_only_passes_through(self, adapter):
+        """`/clear` on /v1/runs falls through to the normal agent path."""
+        app = _create_app_with_runs(adapter)
+
+        fake_agent = MagicMock()
+        fake_agent.run_conversation.return_value = {"final_response": "passed"}
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=fake_agent):
+                resp = await cli.post("/v1/runs", json={"input": "/clear"})
+                assert resp.status == 202
+                fake_agent.run_conversation.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_runs_unknown_slash_passes_through(self, adapter):
+        """Unknown slash commands on /v1/runs fall through to the agent."""
+        app = _create_app_with_runs(adapter)
+
+        fake_agent = MagicMock()
+        fake_agent.run_conversation.return_value = {"final_response": "passed"}
+        fake_agent.session_prompt_tokens = 0
+        fake_agent.session_completion_tokens = 0
+        fake_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=fake_agent):
+                resp = await cli.post("/v1/runs", json={"input": "/notarealcommand"})
+                assert resp.status == 202
+                fake_agent.run_conversation.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Gateway slash-command preprocessor — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSlashPreprocessorUnit:
+    """Unit tests for :func:`maybe_handle_gateway_command` in isolation.
+
+    These exercise the pure-function surface without any aiohttp plumbing
+    so the policy (unknown → None, cli_only → None, alias → canonical
+    name, etc.) is pinned independently of the transport layer.
+    """
+
+    def test_empty_message_returns_none(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        assert maybe_handle_gateway_command("") is None
+        assert maybe_handle_gateway_command("   ") is None
+
+    def test_non_slash_text_returns_none(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        assert maybe_handle_gateway_command("Hello there") is None
+        assert maybe_handle_gateway_command("what is /model?") is None
+
+    def test_bare_slash_returns_none(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        assert maybe_handle_gateway_command("/") is None
+
+    def test_unknown_command_returns_none(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        assert maybe_handle_gateway_command("/notarealcommand") is None
+        assert maybe_handle_gateway_command("/notarealcommand foo bar") is None
+
+    def test_cli_only_command_returns_none(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        # /clear, /history, /save are all cli_only in the registry.
+        assert maybe_handle_gateway_command("/clear") is None
+        assert maybe_handle_gateway_command("/history") is None
+        assert maybe_handle_gateway_command("/save") is None
+
+    def test_stateless_help_executes(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        result = maybe_handle_gateway_command("/help")
+        assert result is not None
+        assert result.command == "help"
+        assert "Hermes Commands" in result.text
+
+    def test_stateless_commands_executes_with_pagination(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        result = maybe_handle_gateway_command("/commands 1")
+        assert result is not None
+        assert result.command == "commands"
+        assert "page 1/" in result.text
+
+    def test_stateful_command_declines(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        result = maybe_handle_gateway_command("/model claude-sonnet-4-6")
+        assert result is not None
+        assert result.command == "model"
+        assert "/model" in result.text
+        assert "stateless" in result.text
+
+    def test_alias_resolves_to_canonical_command(self):
+        """`/reset` is an alias for `/new`; the result should carry the
+        canonical command name but echo the typed token in the text."""
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        result = maybe_handle_gateway_command("/reset")
+        assert result is not None
+        assert result.command == "new"  # canonical
+        assert "/reset" in result.text  # user's typed form echoed
+
+    def test_leading_whitespace_tolerated(self):
+        from gateway.platforms.api_server_slash import maybe_handle_gateway_command
+
+        result = maybe_handle_gateway_command("   /help")
+        assert result is not None
+        assert result.command == "help"
+
+    def test_internal_exception_returns_none(self):
+        """A bug inside the preprocessor must return None, not raise."""
+        from gateway.platforms import api_server_slash
+
+        with patch.object(
+            api_server_slash,
+            "resolve_command",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert api_server_slash.maybe_handle_gateway_command("/help") is None

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -1,0 +1,1388 @@
+"""
+Tests for the Session API endpoints on the API server gateway adapter.
+
+Tests cover:
+- Session CRUD (create, list, get, update, delete, fork, search, messages)
+- Memory CRUD (get, add, replace, delete)
+- Skills (list, categories, view)
+- Config (get, update, available-models)
+- Auth enforcement on all session/memory/skills/config endpoints
+- Chat endpoints (sync and streaming SSE)
+- Capability probe fast-path
+"""
+
+import json
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _CORS_HEADERS,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
+    """Create an adapter with optional API key."""
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    if cors_origins is not None:
+        extra["cors_origins"] = cors_origins
+    config = PlatformConfig(enabled=True, extra=extra)
+    return APIServerAdapter(config)
+
+
+def _create_session_app(adapter: APIServerAdapter) -> web.Application:
+    """Create the aiohttp app with ALL routes (existing + session API)."""
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    # Existing routes
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/v1/models", adapter._handle_models)
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    # Session routes
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+    app.router.add_post("/api/sessions", adapter._handle_create_session)
+    app.router.add_get("/api/sessions/search", adapter._handle_search_sessions)
+    app.router.add_get("/api/sessions/{session_id}", adapter._handle_get_session)
+    app.router.add_get("/api/sessions/{session_id}/messages", adapter._handle_get_session_messages)
+    app.router.add_patch("/api/sessions/{session_id}", adapter._handle_update_session)
+    app.router.add_delete("/api/sessions/{session_id}", adapter._handle_delete_session)
+    app.router.add_post("/api/sessions/{session_id}/fork", adapter._handle_fork_session)
+    app.router.add_post("/api/sessions/{session_id}/chat", adapter._handle_session_chat)
+    app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
+    # Memory
+    app.router.add_get("/api/memory", adapter._handle_get_memory)
+    app.router.add_post("/api/memory", adapter._handle_add_memory)
+    app.router.add_patch("/api/memory", adapter._handle_replace_memory)
+    app.router.add_delete("/api/memory", adapter._handle_delete_memory)
+    # Skills
+    app.router.add_get("/api/skills", adapter._handle_list_skills)
+    app.router.add_get("/api/skills/categories", adapter._handle_skill_categories)
+    app.router.add_get("/api/skills/{name}", adapter._handle_view_skill)
+    # Config
+    app.router.add_get("/api/config", adapter._handle_get_config)
+    app.router.add_patch("/api/config", adapter._handle_update_config)
+    app.router.add_get("/api/available-models", adapter._handle_available_models)
+    return app
+
+
+def _mock_session_db():
+    """Create a mock SessionDB with all needed methods."""
+    db = MagicMock()
+    db.list_sessions_rich.return_value = []
+    db.session_count.return_value = 0
+    db.get_session.return_value = None
+    db.get_messages.return_value = []
+    db.get_messages_as_conversation.return_value = []
+    db.search_messages.return_value = []
+    db.create_session.return_value = None
+    db.set_session_title.return_value = True
+    db.update_system_prompt.return_value = None
+    db.end_session.return_value = None
+    db.delete_session.return_value = True
+    db.ensure_session.return_value = None
+    db.append_message.return_value = None
+    return db
+
+
+def _mock_memory_store():
+    """Create a mock MemoryStore with all needed methods."""
+    store = MagicMock()
+    store.memory_entries = ["Remember: user likes Python"]
+    store.user_entries = ["Name: Alice"]
+    store.load_from_disk.return_value = None
+    store.add.return_value = {"success": True, "message": "Added"}
+    store.replace.return_value = {"success": True, "message": "Replaced"}
+    store.remove.return_value = {"success": True, "message": "Removed"}
+    return store
+
+
+@pytest.fixture
+def adapter():
+    a = _make_adapter()
+    a._session_db = _mock_session_db()
+    a._memory_store = _mock_memory_store()
+    return a
+
+
+@pytest.fixture
+def auth_adapter():
+    a = _make_adapter(api_key="sk-secret")
+    a._session_db = _mock_session_db()
+    a._memory_store = _mock_memory_store()
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Session CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestListSessions:
+    @pytest.mark.asyncio
+    async def test_list_sessions_empty(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["items"] == []
+            assert data["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_with_items(self, adapter):
+        adapter._session_db.list_sessions_rich.return_value = [
+            {"session_id": "sess_1", "title": "First", "source": "api_server"},
+            {"session_id": "sess_2", "title": "Second", "source": "cli"},
+        ]
+        adapter._session_db.session_count.return_value = 2
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions")
+            assert resp.status == 200
+            data = await resp.json()
+            assert len(data["items"]) == 2
+            assert data["total"] == 2
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_pagination(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions?limit=10&offset=5")
+            assert resp.status == 200
+            call_kwargs = adapter._session_db.list_sessions_rich.call_args
+            assert call_kwargs.kwargs.get("limit") == 10 or call_kwargs[1].get("limit") == 10
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_source_filter(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions?source=telegram")
+            assert resp.status == 200
+            call_kwargs = adapter._session_db.list_sessions_rich.call_args
+            assert call_kwargs.kwargs.get("source") == "telegram" or call_kwargs[1].get("source") == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_invalid_limit(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions?limit=notanumber")
+            assert resp.status == 400
+
+
+class TestCreateSession:
+    @pytest.mark.asyncio
+    async def test_create_session_minimal(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_new",
+            "title": None,
+            "source": "api_server",
+            "model": None,
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions", json={})
+            assert resp.status == 200
+            data = await resp.json()
+            assert "session" in data
+            adapter._session_db.create_session.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_session_with_fields(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_new",
+            "title": "My Chat",
+            "source": "web",
+            "model": "claude-opus-4-0-20250514",
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/sessions",
+                json={"title": "My Chat", "source": "web", "model": "claude-opus-4-0-20250514"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["session"]["title"] == "My Chat"
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_json(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/sessions",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert "Invalid JSON" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_session_db_error(self, adapter):
+        adapter._session_db.create_session.side_effect = ValueError("bad input")
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions", json={"title": "Test"})
+            assert resp.status == 400
+
+
+class TestGetSession:
+    @pytest.mark.asyncio
+    async def test_get_session_found(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_abc",
+            "title": "Found",
+            "source": "api_server",
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_abc")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["session"]["session_id"] == "sess_abc"
+
+    @pytest.mark.asyncio
+    async def test_get_session_not_found(self, adapter):
+        adapter._session_db.get_session.return_value = None
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_nonexistent")
+            assert resp.status == 404
+            data = await resp.json()
+            assert "not found" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_session_normalizes_model_config(self, adapter):
+        """model_config JSON string is parsed into an object."""
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_mc",
+            "title": "Model Config Test",
+            "model_config": '{"temperature": 0.7}',
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_mc")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["session"]["model_config"] == {"temperature": 0.7}
+
+
+class TestGetSessionMessages:
+    @pytest.mark.asyncio
+    async def test_get_messages(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_m"}
+        adapter._session_db.get_messages.return_value = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_m/messages")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["total"] == 2
+            assert len(data["items"]) == 2
+            assert data["items"][0]["role"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_get_messages_auto_creates_session(self, adapter):
+        """If session doesn't exist, ensure_session is called."""
+        adapter._session_db.get_session.return_value = None
+        adapter._session_db.get_messages.return_value = []
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_new/messages")
+            assert resp.status == 200
+            adapter._session_db.ensure_session.assert_called_once()
+
+
+class TestUpdateSession:
+    @pytest.mark.asyncio
+    async def test_update_title(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_upd",
+            "title": "Updated Title",
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/sessions/sess_upd", json={"title": "Updated Title"})
+            assert resp.status == 200
+            data = await resp.json()
+            assert "session" in data
+            adapter._session_db.set_session_title.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_system_prompt(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_upd",
+            "system_prompt": "You are a pirate.",
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch(
+                "/api/sessions/sess_upd",
+                json={"system_prompt": "You are a pirate."},
+            )
+            assert resp.status == 200
+            adapter._session_db.update_system_prompt.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_end_reason(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_upd",
+            "end_reason": "completed",
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/sessions/sess_upd", json={"end_reason": "completed"})
+            assert resp.status == 200
+            adapter._session_db.end_session.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_update_not_found(self, adapter):
+        adapter._session_db.get_session.return_value = None
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/sessions/sess_missing", json={"title": "X"})
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_update_invalid_json(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_upd"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch(
+                "/api/sessions/sess_upd",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+
+class TestDeleteSession:
+    @pytest.mark.asyncio
+    async def test_delete_session(self, adapter):
+        adapter._session_db.delete_session.return_value = True
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/sessions/sess_del")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_delete_session_not_found(self, adapter):
+        adapter._session_db.delete_session.return_value = False
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/sessions/sess_missing")
+            assert resp.status == 404
+
+
+class TestForkSession:
+    @pytest.mark.asyncio
+    async def test_fork_session(self, adapter):
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_orig",
+            "title": "Original",
+            "source": "api_server",
+            "model": "gpt-4",
+            "system_prompt": "You are helpful.",
+        }
+        adapter._session_db.get_messages.return_value = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_orig/fork")
+            assert resp.status == 200
+            data = await resp.json()
+            assert "session" in data
+            assert data["forked_from"] == "sess_orig"
+            # create_session should have been called for the new session
+            assert adapter._session_db.create_session.call_count >= 1
+            # Messages should have been copied
+            assert adapter._session_db.append_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fork_session_not_found(self, adapter):
+        adapter._session_db.get_session.return_value = None
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_ghost/fork")
+            assert resp.status == 404
+
+
+class TestSearchSessions:
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self, adapter):
+        adapter._session_db.search_messages.return_value = [
+            {"session_id": "sess_1", "content": "Hello world", "role": "user"},
+        ]
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/search?q=hello")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["query"] == "hello"
+            assert data["count"] == 1
+            assert len(data["results"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/search?q=")
+            assert resp.status == 400
+            data = await resp.json()
+            assert "Missing" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_search_no_query_param(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/search")
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_search_pagination(self, adapter):
+        adapter._session_db.search_messages.return_value = []
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/search?q=test&limit=5&offset=10")
+            assert resp.status == 200
+            call_kwargs = adapter._session_db.search_messages.call_args
+            assert call_kwargs.kwargs.get("limit") == 5 or call_kwargs[1].get("limit") == 5
+
+
+# ---------------------------------------------------------------------------
+# Memory CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestGetMemory:
+    @pytest.mark.asyncio
+    async def test_get_memory_all(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert "targets" in data
+            # Default target is "all" which returns both memory and user
+            assert len(data["targets"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_memory_target_memory(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory?target=memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert len(data["targets"]) == 1
+            assert data["targets"][0]["target"] == "memory"
+            assert data["targets"][0]["entries"] == ["Remember: user likes Python"]
+
+    @pytest.mark.asyncio
+    async def test_get_memory_target_user(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory?target=user")
+            assert resp.status == 200
+            data = await resp.json()
+            assert len(data["targets"]) == 1
+            assert data["targets"][0]["target"] == "user"
+            assert data["targets"][0]["entries"] == ["Name: Alice"]
+
+    @pytest.mark.asyncio
+    async def test_get_memory_invalid_target(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory?target=invalid")
+            assert resp.status == 400
+            data = await resp.json()
+            assert "target" in data["error"]
+
+
+class TestAddMemory:
+    @pytest.mark.asyncio
+    async def test_add_memory(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/memory",
+                json={"target": "memory", "content": "User prefers dark mode"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["success"] is True
+            adapter._memory_store.add.assert_called_once_with("memory", "User prefers dark mode")
+
+    @pytest.mark.asyncio
+    async def test_add_memory_user_target(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/memory",
+                json={"target": "user", "content": "Favorite color: blue"},
+            )
+            assert resp.status == 200
+            adapter._memory_store.add.assert_called_once_with("user", "Favorite color: blue")
+
+    @pytest.mark.asyncio
+    async def test_add_memory_invalid_target(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/memory",
+                json={"target": "invalid", "content": "something"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_add_memory_invalid_json(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/memory",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_add_memory_failure(self, adapter):
+        adapter._memory_store.add.return_value = {"success": False, "error": "Limit exceeded"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/memory",
+                json={"target": "memory", "content": "Too much data"},
+            )
+            assert resp.status == 400
+
+
+class TestReplaceMemory:
+    @pytest.mark.asyncio
+    async def test_replace_memory(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch(
+                "/api/memory",
+                json={"target": "memory", "old_text": "old entry", "content": "new entry"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["success"] is True
+            adapter._memory_store.replace.assert_called_once_with("memory", "old entry", "new entry")
+
+    @pytest.mark.asyncio
+    async def test_replace_memory_invalid_target(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch(
+                "/api/memory",
+                json={"target": "bad", "old_text": "x", "content": "y"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_replace_memory_invalid_json(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch(
+                "/api/memory",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+
+class TestDeleteMemory:
+    @pytest.mark.asyncio
+    async def test_delete_memory(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete(
+                "/api/memory",
+                json={"target": "memory", "old_text": "Remember: user likes Python"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["success"] is True
+            adapter._memory_store.remove.assert_called_once_with("memory", "Remember: user likes Python")
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_invalid_target(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete(
+                "/api/memory",
+                json={"target": "nope", "old_text": "x"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_invalid_json(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete(
+                "/api/memory",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_failure(self, adapter):
+        adapter._memory_store.remove.return_value = {"success": False, "error": "Not found"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete(
+                "/api/memory",
+                json={"target": "memory", "old_text": "nonexistent"},
+            )
+            assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# Skills
+# ---------------------------------------------------------------------------
+
+
+class TestListSkills:
+    @pytest.mark.asyncio
+    async def test_list_skills(self, adapter):
+        mock_result = json.dumps({"skills": [{"name": "git", "description": "Git commands"}]})
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.skills_list", return_value=mock_result):
+                resp = await cli.get("/api/skills")
+                assert resp.status == 200
+                data = await resp.json()
+                assert "skills" in data
+
+    @pytest.mark.asyncio
+    async def test_list_skills_with_category(self, adapter):
+        mock_result = json.dumps({"skills": []})
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.skills_list", return_value=mock_result) as mock_fn:
+                resp = await cli.get("/api/skills?category=development")
+                assert resp.status == 200
+                mock_fn.assert_called_once_with(category="development")
+
+
+class TestSkillCategories:
+    @pytest.mark.asyncio
+    async def test_skill_categories(self, adapter):
+        mock_result = json.dumps({"categories": ["development", "productivity"]})
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.skills_categories", return_value=mock_result):
+                resp = await cli.get("/api/skills/categories")
+                assert resp.status == 200
+                data = await resp.json()
+                assert "categories" in data
+                assert len(data["categories"]) == 2
+
+
+class TestViewSkill:
+    @pytest.mark.asyncio
+    async def test_view_skill(self, adapter):
+        mock_result = json.dumps({
+            "name": "git",
+            "description": "Git commands",
+            "content": "# Git Skill\nUse git for version control.",
+        })
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.skill_view", return_value=mock_result) as mock_fn:
+                resp = await cli.get("/api/skills/git")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["name"] == "git"
+                mock_fn.assert_called_once_with("git", file_path=None)
+
+    @pytest.mark.asyncio
+    async def test_view_skill_with_file_path(self, adapter):
+        mock_result = json.dumps({"name": "git", "content": "# Git"})
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.skill_view", return_value=mock_result) as mock_fn:
+                resp = await cli.get("/api/skills/git?file_path=README.md")
+                assert resp.status == 200
+                mock_fn.assert_called_once_with("git", file_path="README.md")
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfig:
+    @pytest.mark.asyncio
+    async def test_get_config(self, adapter):
+        mock_config = {
+            "model": {"default": "claude-opus-4-0-20250514", "provider": "anthropic", "base_url": ""},
+        }
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.load_config", return_value=mock_config):
+                resp = await cli.get("/api/config")
+                assert resp.status == 200
+                data = await resp.json()
+                assert "model" in data
+                assert "provider" in data
+                assert "config" in data
+                assert data["model"] == "claude-opus-4-0-20250514"
+                assert data["provider"] == "anthropic"
+
+
+class TestUpdateConfig:
+    @pytest.mark.asyncio
+    async def test_update_config_model(self, adapter):
+        mock_config = {"model": {"default": "old-model", "provider": "openai"}}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.api_server.load_config", return_value=mock_config),
+                patch("gateway.platforms.api_server.save_config") as mock_save,
+            ):
+                resp = await cli.patch("/api/config", json={"model": "gpt-4o"})
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["ok"] is True
+                mock_save.assert_called_once()
+                saved_config = mock_save.call_args[0][0]
+                assert saved_config["model"]["default"] == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_update_config_provider(self, adapter):
+        mock_config = {"model": {"default": "gpt-4", "provider": "openai"}}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.api_server.load_config", return_value=mock_config),
+                patch("gateway.platforms.api_server.save_config") as mock_save,
+            ):
+                resp = await cli.patch("/api/config", json={"provider": "anthropic"})
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_config_invalid_json(self, adapter):
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch(
+                "/api/config",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_update_config_save_error(self, adapter):
+        mock_config = {"model": {"default": "gpt-4"}}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.api_server.load_config", return_value=mock_config),
+                patch("gateway.platforms.api_server.save_config", side_effect=IOError("Permission denied")),
+            ):
+                resp = await cli.patch("/api/config", json={"model": "gpt-4o"})
+                assert resp.status == 500
+
+
+class TestAvailableModels:
+    @pytest.mark.asyncio
+    async def test_available_models(self, adapter):
+        mock_config = {"model": {"default": "gpt-4", "provider": "anthropic"}}
+        mock_curated = [("claude-opus-4-0-20250514", "Powerful model"), ("claude-sonnet-4-20250514", "Fast model")]
+        mock_providers = ["anthropic", "openai", "openrouter"]
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.api_server.load_config", return_value=mock_config),
+                patch("gateway.platforms.api_server.curated_models_for_provider", return_value=mock_curated),
+                patch("gateway.platforms.api_server.list_available_providers", return_value=mock_providers),
+            ):
+                resp = await cli.get("/api/available-models?provider=anthropic")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["provider"] == "anthropic"
+                assert len(data["models"]) == 2
+                assert data["models"][0]["id"] == "claude-opus-4-0-20250514"
+                assert "providers" in data
+                assert len(data["providers"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_available_models_default_provider(self, adapter):
+        """When no provider query param, uses config provider or defaults to openrouter."""
+        mock_config = {"model": {"default": "gpt-4", "provider": "openai"}}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.api_server.load_config", return_value=mock_config),
+                patch("gateway.platforms.api_server.curated_models_for_provider", return_value=[]) as mock_curated,
+                patch("gateway.platforms.api_server.list_available_providers", return_value=[]),
+            ):
+                resp = await cli.get("/api/available-models")
+                assert resp.status == 200
+                # Should use config provider "openai"
+                mock_curated.assert_called_once_with("openai")
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement on session/memory/skills/config endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestSessionApiAuth:
+    """When an API key is configured, all endpoints should require auth."""
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_create_session_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions", json={})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_get_session_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_123")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_get_session_messages_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/sess_123/messages")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_update_session_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/sessions/sess_123", json={"title": "X"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_delete_session_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/sessions/sess_123")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_fork_session_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_123/fork")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_search_sessions_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/sessions/search?q=hello")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_session_chat_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_123/chat", json={"message": "hi"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_123/chat/stream", json={"message": "hi"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_get_memory_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_add_memory_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/memory", json={"target": "memory", "content": "x"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_replace_memory_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/memory", json={"target": "memory", "old_text": "x", "content": "y"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory", json={"target": "memory", "old_text": "x"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_list_skills_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_skill_categories_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/categories")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_view_skill_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/skills/git")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_get_config_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/config")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_update_config_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.patch("/api/config", json={"model": "gpt-4"})
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_available_models_requires_auth(self, auth_adapter):
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/available-models")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_valid_auth_passes(self, auth_adapter):
+        """With a valid Bearer token, requests should succeed."""
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/sessions",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_health_does_not_require_auth(self, auth_adapter):
+        """Health check is always open regardless of API key."""
+        app = _create_session_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health")
+            assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# Chat endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestSessionChat:
+    @pytest.mark.asyncio
+    async def test_session_chat_success(self, adapter):
+        """Sync chat returns the agent result."""
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_chat",
+            "title": "Chat Test",
+            "source": "api_server",
+            "model": "hermes-agent",
+        }
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        mock_result = {
+            "final_response": "Hello! I'm here to help.",
+            "completed": True,
+            "partial": False,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+            "last_reasoning": None,
+            "response_previewed": False,
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = mock_result
+        mock_agent.session_prompt_tokens = 100
+        mock_agent.session_completion_tokens = 20
+        mock_agent.session_total_tokens = 120
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/api/sessions/sess_chat/chat",
+                    json={"message": "Hello"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["session_id"] == "sess_chat"
+                assert data["final_response"] == "Hello! I'm here to help."
+                assert data["completed"] is True
+                assert "run_id" in data
+                assert "usage" in data
+                assert data["usage"]["input_tokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_session_chat_missing_message(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_chat"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_chat/chat", json={})
+            assert resp.status == 400
+            data = await resp.json()
+            assert "message" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_session_chat_invalid_json(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_chat"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/sessions/sess_chat/chat",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_session_chat_auto_creates_session(self, adapter):
+        """If session doesn't exist, ensure_session is called."""
+        adapter._session_db.get_session.return_value = None
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        mock_result = {
+            "final_response": "Hi!",
+            "completed": True,
+            "partial": False,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = mock_result
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/api/sessions/sess_new_chat/chat",
+                    json={"message": "Hi"},
+                )
+                assert resp.status == 200
+                adapter._session_db.ensure_session.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_session_chat_agent_error(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_err"}
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=RuntimeError("Agent init failed")):
+                resp = await cli.post(
+                    "/api/sessions/sess_err/chat",
+                    json={"message": "Hello"},
+                )
+                assert resp.status == 500
+                data = await resp.json()
+                assert "error" in data
+
+
+class TestSessionChatStream:
+    @pytest.mark.asyncio
+    async def test_stream_returns_sse(self, adapter):
+        """Streaming chat returns SSE events with correct lifecycle."""
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_stream",
+            "title": "Stream Test",
+            "source": "api_server",
+            "model": "hermes-agent",
+        }
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        mock_result = {
+            "final_response": "Streamed response!",
+            "completed": True,
+            "partial": False,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = mock_result
+        mock_agent.session_prompt_tokens = 50
+        mock_agent.session_completion_tokens = 10
+        mock_agent.session_total_tokens = 60
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/api/sessions/sess_stream/chat/stream",
+                    json={"message": "Hello"},
+                )
+                assert resp.status == 200
+                assert "text/event-stream" in resp.headers.get("Content-Type", "")
+                assert resp.headers.get("X-Accel-Buffering") == "no"
+
+                body = await resp.text()
+                # Verify lifecycle events
+                assert "event: session.created" in body
+                assert "event: run.started" in body
+                assert "event: message.started" in body
+                assert "event: assistant.completed" in body
+                assert "event: run.completed" in body
+                assert "event: done" in body
+                # Verify session_id appears in events
+                assert "sess_stream" in body
+                # Verify final response content
+                assert "Streamed response!" in body
+
+    @pytest.mark.asyncio
+    async def test_stream_missing_message(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_stream"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/api/sessions/sess_stream/chat/stream", json={})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_stream_invalid_json(self, adapter):
+        adapter._session_db.get_session.return_value = {"session_id": "sess_stream"}
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/sessions/sess_stream/chat/stream",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_stream_with_deltas(self, adapter):
+        """Verify that stream_delta_callback produces assistant.delta events."""
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_delta",
+            "title": "Delta Test",
+            "source": "api_server",
+        }
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        mock_result = {
+            "final_response": "Hello world",
+            "completed": True,
+            "partial": False,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        def _make_agent(**kwargs):
+            stream_cb = kwargs.get("stream_delta_callback")
+            mock_agent = MagicMock()
+
+            def _run_conv(user_content, **kw):
+                if stream_cb:
+                    stream_cb("Hello ")
+                    stream_cb("world")
+                return mock_result
+
+            mock_agent.run_conversation.side_effect = _run_conv
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=_make_agent):
+                resp = await cli.post(
+                    "/api/sessions/sess_delta/chat/stream",
+                    json={"message": "Say hello"},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "event: assistant.delta" in body
+                assert "Hello " in body
+                assert "event: done" in body
+
+    @pytest.mark.asyncio
+    async def test_stream_with_tool_results(self, adapter):
+        """Tool call results appear as tool.completed events."""
+        adapter._session_db.get_session.return_value = {
+            "session_id": "sess_tools",
+            "title": "Tool Test",
+            "source": "api_server",
+        }
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        mock_result = {
+            "final_response": "Here are the files.",
+            "completed": True,
+            "partial": False,
+            "interrupted": False,
+            "api_calls": 2,
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_abc123",
+                        "function": {"name": "terminal", "arguments": '{"command": "ls"}'},
+                    }],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_abc123",
+                    "content": "file1.txt\nfile2.txt",
+                    "tool_name": "terminal",
+                },
+            ],
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = mock_result
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/api/sessions/sess_tools/chat/stream",
+                    json={"message": "List files"},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "event: tool.completed" in body
+                assert "terminal" in body
+                assert "file1.txt" in body
+                assert "event: done" in body
+
+    @pytest.mark.asyncio
+    async def test_stream_auto_creates_session(self, adapter):
+        """If session doesn't exist, ensure_session is called."""
+        adapter._session_db.get_session.return_value = None
+        adapter._session_db.get_messages_as_conversation.return_value = []
+
+        mock_result = {
+            "final_response": "Hi!",
+            "completed": True,
+            "partial": False,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = mock_result
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                resp = await cli.post(
+                    "/api/sessions/sess_auto/chat/stream",
+                    json={"message": "Hi"},
+                )
+                assert resp.status == 200
+                adapter._session_db.ensure_session.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Capability probe
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityProbe:
+    @pytest.mark.asyncio
+    async def test_probe_max_tokens_1(self, adapter):
+        """max_tokens=1 returns a fast minimal response without running the agent."""
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [{"role": "user", "content": "probe"}],
+                    "max_tokens": 1,
+                },
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["object"] == "chat.completion"
+            assert data["id"].startswith("chatcmpl-probe-")
+            assert data["choices"][0]["message"]["content"] == "ok"
+            assert data["choices"][0]["finish_reason"] == "stop"
+            assert data["usage"]["total_tokens"] == 1
+
+    @pytest.mark.asyncio
+    async def test_probe_does_not_call_agent(self, adapter):
+        """Probe requests must not invoke the agent at all."""
+        app = _create_session_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "probe"}],
+                        "max_tokens": 1,
+                    },
+                )
+                assert resp.status == 200
+                mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

Gateway slash commands like `/model` currently pass through `/v1/runs` and
`/v1/chat/completions` to the LLM verbatim, which then hallucinates a reply
explaining why it can't execute them. Frontends get no signal the command
was supposed to be handled; users see what looks like a refusal.

This adds a small preprocessor on both chat handlers that runs the stateless
commands locally (`/help`, `/commands`, `/profile`, `/provider`) and returns
a short decline notice for the stateful ones so the LLM never sees them.

## Why most commands can't run here

`APIServerAdapter` is deliberately excluded from the router notification
path (see the comment at `gateway/run.py:3148`). `/v1/runs` builds a fresh
`AIAgent` per request with no session cache, no model-override dict, and no
`GatewayRouter` reference — by design, so it can stay stateless and
OpenAI-compatible. The dispatch chain in `GatewayRouter._handle_message`
mutates router-owned state (session store, agent cache, per-adapter pickers)
that api_server doesn't have.

So `/model`, `/new`, `/retry`, and most of the registry can't do their job
on a stateless endpoint — there's no persistent session to mutate. This PR
doesn't try to fake it. It runs what it can run, declines the rest with a
helpful notice, and leaves `run.py` and `GatewayRouter` untouched.

## What's here

A new sibling module `gateway/platforms/api_server_slash.py` with
`maybe_handle_gateway_command(text)` — classifies the first token, returns
a result on a hit and `None` on anything else. Both chat handlers get a
small call site that short-circuits on a hit and otherwise continues to the
LLM path.

Four commands run locally, reusing existing helpers from
`hermes_cli.commands` and `hermes_cli.models` so the output tracks
`COMMAND_REGISTRY`:

- `/help` and `/commands` → `gateway_help_lines()` (with pagination for the latter)
- `/profile` → profile name + home directory
- `/provider` → current provider + authenticated provider list

Stateful commands — `/model`, `/new`, `/retry`, `/yolo`, `/compress`,
`/title`, `/branch`, `/rollback`, `/approve`, `/deny`, `/background`,
`/stop`, `/fast`, `/reasoning`, `/personality`, and the rest — get a short
notice that echoes back what the user typed and points them at `/help` and
session-aware channels instead of letting the LLM guess.

Non-slash text, unknown slashes, and `cli_only` entries fall through
unchanged so the LLM (or an active skill) can still handle them. The
preprocessor is wrapped in a `try/except` that logs at WARNING and returns
`None` on any fault — a bug here shouldn't break a normal chat request, and
there's a test pinning that.

Synthetic responses match the shapes each handler already emits: a standard
`chat.completion` JSON body for non-streaming chat completions,
role/content/finish chunks with a `[DONE]` terminator for streaming (same
helper pattern as `_write_sse_chat_completion`), and `message.delta` +
`run.completed` events pushed into the existing `_run_streams[run_id]` queue
for `/v1/runs`. No background task or agent creation on the intercept path.

## About #8556

Follow-up to #8556, which adds the `/api/sessions/*` surface. #8556 is
purely additive (new routes), while this PR modifies existing handler
behavior on `/v1/runs` and `/v1/chat/completions` — different risk profile,
so they're separate PRs.

The branch is stacked on `feat/session-api`, so until #8556 merges this
PR's diff will include its commits. After it merges I'll rebase onto `main`.

Once #8556 lands, a smaller follow-up can handle the stateful commands on
`/api/sessions/{id}/chat/stream`, where session state actually exists —
`session.model_override = new_model` is a dict write, no router refactor
required.

## Tests

24 new tests in `tests/gateway/test_api_server.py`, running under the
existing `pytest-asyncio` + `aiohttp.test_utils.TestClient` harness. 13 are
HTTP-level tests covering both endpoints — stateless execution, stateful
decline (including alias resolution: `/reset` echoes `/reset` while
dispatching as canonical `/new`), normal text pass-through, `cli_only`
pass-through, unknown slash pass-through, and preprocessor-exception
fallthrough. The other 11 are pure-function unit tests on
`maybe_handle_gateway_command` pinning the policy independently of the
transport layer.

`131 passed, 81 warnings in 10.37s` — 110 pre-existing tests still green,
24 new.

## Scope

Only `api_server.py`'s `/v1/runs` and `/v1/chat/completions` handlers
change, plus the new sibling module. `GatewayRouter`, `run.py`, the command
registry, other platform adapters, `/v1/responses`, and every existing
session-state path are untouched.
