### PR TITLE
feat: localize Hermes CLI user-facing copy to Korean

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1053,6 +1053,41 @@ def _accent_hex() -> str:
         return "#FFBF00"
 
 
+def _display_cell_width(text: str) -> int:
+    """Approximate terminal cell width for Unicode text, including CJK characters."""
+    import unicodedata
+
+    width = 0
+    for ch in text:
+        if unicodedata.combining(ch):
+            continue
+        width += 2 if unicodedata.east_asian_width(ch) in {"F", "W"} else 1
+    return width
+
+
+def _center_display_text(text: str, width: int) -> str:
+    """Center text by terminal display width, truncating safely when needed."""
+    import unicodedata
+
+    if width <= 0:
+        return ""
+
+    pieces: list[str] = []
+    used = 0
+    for ch in text:
+        ch_width = 0 if unicodedata.combining(ch) else (2 if unicodedata.east_asian_width(ch) in {"F", "W"} else 1)
+        if used + ch_width > width:
+            break
+        pieces.append(ch)
+        used += ch_width
+
+    trimmed = "".join(pieces)
+    pad = max(0, width - used)
+    left = pad // 2
+    right = pad - left
+    return (" " * left) + trimmed + (" " * right)
+
+
 def _rich_text_from_ansi(text: str) -> _RichText:
     """Safely render assistant/tool output that may contain ANSI escapes.
 
@@ -3738,15 +3773,13 @@ class HermesCLI:
 
         try:
             from hermes_cli.skin_engine import get_active_help_header
-            header = get_active_help_header("(^_^)? Available Commands")
+            header = get_active_help_header("(^_^) 사용 가능한 명령어")
         except Exception:
-            header = "(^_^)? Available Commands"
-        header = (header or "").strip() or "(^_^)? Available Commands"
+            header = "(^_^) 사용 가능한 명령어"
+        header = (header or "").strip() or "(^_^) 사용 가능한 명령어"
         inner_width = 55
-        if len(header) > inner_width:
-            header = header[:inner_width]
         _cprint(f"\n{_BOLD}+{'-' * inner_width}+{_RST}")
-        _cprint(f"{_BOLD}|{header:^{inner_width}}|{_RST}")
+        _cprint(f"{_BOLD}|{_center_display_text(header, inner_width)}|{_RST}")
         _cprint(f"{_BOLD}+{'-' * inner_width}+{_RST}")
 
         for category, commands in COMMANDS_BY_CATEGORY.items():
@@ -3763,12 +3796,12 @@ class HermesCLI:
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
 
-        _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
+        _cprint(f"\n  {_DIM}팁: 메시지를 바로 입력하면 Hermes와 대화할 수 있어요!{_RST}")
+        _cprint(f"  {_DIM}여러 줄 입력: Alt+Enter{_RST}")
         if _is_termux_environment():
-            _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")
+            _cprint(f"  {_DIM}이미지 첨부: /image {_termux_example_image_path()} 또는 프롬프트 시작에 로컬 이미지 경로 입력{_RST}\n")
         else:
-            _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")
+            _cprint(f"  {_DIM}이미지 붙여넣기: Alt+V (또는 /paste){_RST}\n")
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
@@ -7992,9 +8025,9 @@ class HermesCLI:
         else:
             try:
                 from hermes_cli.skin_engine import get_active_goodbye
-                goodbye = get_active_goodbye("Goodbye! ⚕")
+                goodbye = get_active_goodbye("안녕히 가세요! ⚕")
             except Exception:
-                goodbye = "Goodbye! ⚕"
+                goodbye = "안녕히 가세요! ⚕"
             print(goodbye)
 
     def _get_tui_prompt_symbols(self) -> tuple[str, str]:
@@ -8206,10 +8239,10 @@ class HermesCLI:
         try:
             from hermes_cli.skin_engine import get_active_skin
             _welcome_skin = get_active_skin()
-            _welcome_text = _welcome_skin.get_branding("welcome", "Welcome to Hermes Agent! Type your message or /help for commands.")
+            _welcome_text = _welcome_skin.get_branding("welcome", "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요.")
             _welcome_color = _welcome_skin.get_color("banner_text", "#FFF8DC")
         except Exception:
-            _welcome_text = "Welcome to Hermes Agent! Type your message or /help for commands."
+            _welcome_text = "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요."
             _welcome_color = "#FFF8DC"
         self.console.print(f"[{_welcome_color}]{_welcome_text}[/]")
         # Show a random tip to help users discover features

--- a/cli.py
+++ b/cli.py
@@ -3769,7 +3769,7 @@ class HermesCLI:
 
     def show_help(self):
         """Display help information with categorized commands."""
-        from hermes_cli.commands import COMMANDS_BY_CATEGORY
+        from hermes_cli.commands import COMMANDS_BY_CATEGORY, get_category_label
 
         try:
             from hermes_cli.skin_engine import get_active_help_header
@@ -3783,14 +3783,14 @@ class HermesCLI:
         _cprint(f"{_BOLD}+{'-' * inner_width}+{_RST}")
 
         for category, commands in COMMANDS_BY_CATEGORY.items():
-            _cprint(f"\n  {_BOLD}── {category} ──{_RST}")
+            _cprint(f"\n  {_BOLD}── {get_category_label(category)} ──{_RST}")
             for cmd, desc in commands.items():
                 if not self._command_available(cmd):
                     continue
                 ChatConsole().print(f"    [bold {_accent_hex()}]{cmd:<15}[/] [dim]-[/] {_escape(desc)}")
 
         if _skill_commands:
-            _cprint(f"\n  ⚡ {_BOLD}Skill Commands{_RST} ({len(_skill_commands)} installed):")
+            _cprint(f"\n  ⚡ {_BOLD}스킬 명령어{_RST} ({len(_skill_commands)}개 설치됨):")
             for cmd, info in sorted(_skill_commands.items()):
                 ChatConsole().print(
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -302,7 +302,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
-        print(f"[Email] Connected as {self._address}")
+        print(f"[이메일] {self._address} 계정으로 연결했어요")
         return True
 
     async def disconnect(self) -> None:
@@ -371,7 +371,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if "<" in sender_name:
                         sender_name = sender_name.split("<")[0].strip().strip('"')
 
-                    subject = _decode_header_value(msg.get("Subject", "(no subject)"))
+                    subject = _decode_header_value(msg.get("Subject", "(제목 없음)"))
                     message_id = msg.get("Message-ID", "")
                     in_reply_to = msg.get("In-Reply-To", "")
                     # Skip automated/noreply senders before any processing
@@ -422,7 +422,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Build message text: include subject as context
         text = body
         if subject and not subject.startswith("Re:"):
-            text = f"[Subject: {subject}]\n\n{body}"
+            text = f"[제목: {subject}]\n\n{body}"
 
         # Determine message type and media
         media_urls = []
@@ -450,7 +450,7 @@ class EmailAdapter(BasePlatformAdapter):
         )
 
         event = MessageEvent(
-            text=text or "(empty email)",
+            text=text or "(빈 이메일)",
             message_type=msg_type,
             source=source,
             message_id=msg_data["message_id"],
@@ -535,7 +535,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an image URL as part of an email body."""
         text = caption or ""
-        text += f"\n\nImage: {image_url}"
+        text += f"\n\n이미지: {image_url}"
         return await self.send(chat_id, text.strip(), reply_to)
 
     async def send_document(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4398,20 +4398,20 @@ class GatewayRunner:
         """Handle /help command - list available commands."""
         from hermes_cli.commands import gateway_help_lines
         lines = [
-            "📖 **Hermes Commands**\n",
+            "📖 **Hermes 명령어**\n",
             *gateway_help_lines(),
         ]
         try:
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
             if skill_cmds:
-                lines.append(f"\n⚡ **Skill Commands** ({len(skill_cmds)} active):")
+                lines.append(f"\n⚡ **스킬 명령어** ({len(skill_cmds)}개 활성):")
                 # Show first 10, then point to /commands for the rest
                 sorted_cmds = sorted(skill_cmds)
                 for cmd in sorted_cmds[:10]:
                     lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
                 if len(sorted_cmds) > 10:
-                    lines.append(f"\n... and {len(sorted_cmds) - 10} more. Use `/commands` for the full paginated list.")
+                    lines.append(f"\n... 외 {len(sorted_cmds) - 10}개가 더 있습니다. 전체 페이지 목록은 `/commands`를 사용하세요.")
         except Exception:
             pass
         return "\n".join(lines)
@@ -4425,7 +4425,7 @@ class GatewayRunner:
             try:
                 requested_page = int(raw_args)
             except ValueError:
-                return "Usage: `/commands [page]`"
+                return "사용법: `/commands [page]`"
         else:
             requested_page = 1
 
@@ -4436,15 +4436,15 @@ class GatewayRunner:
             skill_cmds = get_skill_commands()
             if skill_cmds:
                 entries.append("")
-                entries.append("⚡ **Skill Commands**:")
+                entries.append("⚡ **스킬 명령어**:")
                 for cmd in sorted(skill_cmds):
-                    desc = skill_cmds[cmd].get("description", "").strip() or "Skill command"
+                    desc = skill_cmds[cmd].get("description", "").strip() or "스킬 명령어"
                     entries.append(f"`{cmd}` — {desc}")
         except Exception:
             pass
 
         if not entries:
-            return "No commands available."
+            return "사용 가능한 명령어가 없습니다."
 
         from gateway.config import Platform
         page_size = 15 if event.source.platform == Platform.TELEGRAM else 20
@@ -4454,19 +4454,19 @@ class GatewayRunner:
         page_entries = entries[start:start + page_size]
 
         lines = [
-            f"📚 **Commands** ({len(entries)} total, page {page}/{total_pages})",
+            f"📚 **명령어** ({len(entries)}개, 페이지 {page}/{total_pages})",
             "",
             *page_entries,
         ]
         if total_pages > 1:
             nav_parts = []
             if page > 1:
-                nav_parts.append(f"`/commands {page - 1}` ← prev")
+                nav_parts.append(f"`/commands {page - 1}` ← 이전")
             if page < total_pages:
-                nav_parts.append(f"next → `/commands {page + 1}`")
+                nav_parts.append(f"다음 → `/commands {page + 1}`")
             lines.extend(["", " | ".join(nav_parts)])
         if page != requested_page:
-            lines.append(f"_(Requested page {requested_page} was out of range, showing page {page}.)_")
+            lines.append(f"_(요청한 페이지 {requested_page}는 범위를 벗어나 페이지 {page}를 표시합니다.)_")
         return "\n".join(lines)
     
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -502,12 +502,12 @@ def format_auth_error(error: Exception) -> str:
         return str(error)
 
     if error.relogin_required:
-        return f"{error} Run `hermes model` to re-authenticate."
+        return f"{error} 다시 인증하려면 `hermes model` 을 실행하세요."
 
     if error.code == "subscription_required":
         return (
-            "No active paid subscription found on Nous Portal. "
-            "Please purchase/activate a subscription, then retry."
+            "Nous Portal에서 활성화된 유료 구독을 찾지 못했어요. "
+            "구독을 구매하거나 활성화한 뒤 다시 시도해 주세요."
         )
 
     if error.code == "insufficient_credits":
@@ -2738,7 +2738,7 @@ def _prompt_model_selection(
         if idx < len(ordered):
             return ordered[idx]
         elif idx == len(ordered):
-            custom = input("Enter model name: ").strip()
+            custom = input("모델 이름 입력: ").strip()
             return custom if custom else None
         return None
     except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
@@ -2750,33 +2750,33 @@ def _prompt_model_selection(
     for i, mid in enumerate(ordered, 1):
         print(f"  {i:>{num_width}}. {_label(mid)}")
     n = len(ordered)
-    print(f"  {n + 1:>{num_width}}. Enter custom model name")
-    print(f"  {n + 2:>{num_width}}. Skip (keep current)")
+    print(f"  {n + 1:>{num_width}}. 사용자 지정 모델 이름 입력")
+    print(f"  {n + 2:>{num_width}}. 건너뛰기(현재 설정 유지)")
 
     if _unavailable:
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
         print()
-        print(f"  {_DIM}── Unavailable models (requires paid tier — upgrade at {_upgrade_url}) ──{_RESET}")
+        print(f"  {_DIM}── 사용할 수 없는 모델(유료 플랜 필요 — 업그레이드: {_upgrade_url}) ──{_RESET}")
         for mid in _unavailable:
             print(f"  {'':>{num_width}}  {_DIM}{_label(mid)}{_RESET}")
     print()
 
     while True:
         try:
-            choice = input(f"Choice [1-{n + 2}] (default: skip): ").strip()
+            choice = input(f"선택 [1-{n + 2}] (기본값: 건너뛰기): ").strip()
             if not choice:
                 return None
             idx = int(choice)
             if 1 <= idx <= n:
                 return ordered[idx - 1]
             elif idx == n + 1:
-                custom = input("Enter model name: ").strip()
+                custom = input("모델 이름 입력: ").strip()
                 return custom if custom else None
             elif idx == n + 2:
                 return None
-            print(f"Please enter 1-{n + 2}")
+            print(f"1-{n + 2} 사이의 번호를 입력해 주세요")
         except ValueError:
-            print("Please enter a number")
+            print("숫자를 입력해 주세요")
         except (KeyboardInterrupt, EOFError):
             return None
 
@@ -2800,9 +2800,9 @@ def _save_model_choice(model_id: str) -> None:
 
 def login_command(args) -> None:
     """Deprecated: use 'hermes model' or 'hermes setup' instead."""
-    print("The 'hermes login' command has been removed.")
-    print("Use 'hermes auth' to manage credentials,")
-    print("'hermes model' to select a provider, or 'hermes setup' for full setup.")
+    print("'hermes login' 명령은 제거되었어요.")
+    print("자격 증명 관리는 'hermes auth'를 사용하고,")
+    print("provider 선택은 'hermes model', 전체 설정은 'hermes setup'을 사용하세요.")
     raise SystemExit(0)
 
 
@@ -2818,29 +2818,29 @@ def _login_openai_codex(args, pconfig: ProviderConfig) -> None:
         # the user "Login successful!".
         _resolved_key = existing.get("api_key", "")
         if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(_resolved_key, 60):
-            print("Existing Codex credentials found in Hermes auth store.")
+            print("Hermes auth store에서 기존 Codex 자격 증명을 찾았어요.")
             try:
-                reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
+                reuse = input("기존 자격 증명을 사용할까요? [Y/n]: ").strip().lower()
             except (EOFError, KeyboardInterrupt):
                 reuse = "y"
             if reuse in ("", "y", "yes"):
                 config_path = _update_config_for_provider("openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL))
                 print()
-                print("Login successful!")
-                print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+                print("로그인에 성공했어요!")
+                print(f"  설정 업데이트: {config_path} (model.provider=openai-codex)")
                 return
         else:
-            print("Existing Codex credentials are expired. Starting fresh login...")
+            print("기존 Codex 자격 증명이 만료되었어요. 새 로그인을 시작할게요...")
     except AuthError:
         pass
 
     # Check for existing Codex CLI tokens we can import
     cli_tokens = _import_codex_cli_tokens()
     if cli_tokens:
-        print("Found existing Codex CLI credentials at ~/.codex/auth.json")
-        print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
+        print("~/.codex/auth.json 에서 기존 Codex CLI 자격 증명을 찾았어요")
+        print("Codex CLI / VS Code와 충돌하지 않도록 Hermes 전용 세션을 만들 거예요.")
         try:
-            do_import = input("Import these credentials? (a separate login is recommended) [y/N]: ").strip().lower()
+            do_import = input("이 자격 증명을 가져올까요? (별도 로그인 권장) [y/N]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             do_import = "n"
         if do_import in ("y", "yes"):
@@ -2848,15 +2848,15 @@ def _login_openai_codex(args, pconfig: ProviderConfig) -> None:
             base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
             config_path = _update_config_for_provider("openai-codex", base_url)
             print()
-            print("Credentials imported. Note: if Codex CLI refreshes its token,")
-            print("Hermes will keep working independently with its own session.")
-            print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+            print("자격 증명을 가져왔어요. 참고로 Codex CLI가 토큰을 갱신해도,")
+            print("Hermes는 자체 세션으로 계속 독립적으로 동작해요.")
+            print(f"  설정 업데이트: {config_path} (model.provider=openai-codex)")
             return
 
     # Run a fresh device code flow — Hermes gets its own OAuth session
     print()
-    print("Signing in to OpenAI Codex...")
-    print("(Hermes creates its own session — won't affect Codex CLI or VS Code)")
+    print("OpenAI Codex에 로그인하는 중...")
+    print("(Hermes 전용 세션을 만들며 Codex CLI나 VS Code에는 영향을 주지 않아요)")
     print()
 
     creds = _codex_device_code_login()
@@ -2865,10 +2865,10 @@ def _login_openai_codex(args, pconfig: ProviderConfig) -> None:
     _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
     config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
     print()
-    print("Login successful!")
+    print("로그인에 성공했어요!")
     from hermes_constants import display_hermes_home as _dhh
-    print(f"  Auth state: {_dhh()}/auth.json")
-    print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+    print(f"  인증 상태: {_dhh()}/auth.json")
+    print(f"  설정 업데이트: {config_path} (model.provider=openai-codex)")
 
 
 def _codex_device_code_login() -> Dict[str, Any]:
@@ -2910,12 +2910,12 @@ def _codex_device_code_login() -> Dict[str, Any]:
         )
 
     # Step 2: Show user the code
-    print("To continue, follow these steps:\n")
-    print("  1. Open this URL in your browser:")
+    print("계속하려면 다음 단계를 따라 주세요:\n")
+    print("  1. 브라우저에서 다음 URL을 여세요:")
     print(f"     \033[94m{issuer}/codex/device\033[0m\n")
-    print("  2. Enter this code:")
+    print("  2. 아래 코드를 입력하세요:")
     print(f"     \033[94m{user_code}\033[0m\n")
-    print("Waiting for sign-in... (press Ctrl+C to cancel)")
+    print("로그인을 기다리는 중... (취소하려면 Ctrl+C)")
 
     # Step 3: Poll for authorization code
     max_wait = 15 * 60  # 15 minutes
@@ -3052,9 +3052,9 @@ def _nous_device_code_login(
     print(f"Starting Hermes login via {pconfig.name}...")
     print(f"Portal: {portal_base_url}")
     if insecure:
-        print("TLS verification: disabled (--insecure)")
+        print("TLS 검증: 비활성화됨 (--insecure)")
     elif ca_bundle:
-        print(f"TLS verification: custom CA bundle ({ca_bundle})")
+        print(f"TLS 검증: 사용자 지정 CA 번들 사용 ({ca_bundle})")
 
     with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
         device_data = _request_device_code(
@@ -3070,19 +3070,19 @@ def _nous_device_code_login(
         interval = int(device_data["interval"])
 
         print()
-        print("To continue:")
-        print(f"  1. Open: {verification_url}")
-        print(f"  2. If prompted, enter code: {user_code}")
+        print("계속하려면:")
+        print(f"  1. 열기: {verification_url}")
+        print(f"  2. 필요하면 코드 입력: {user_code}")
 
         if open_browser:
             opened = webbrowser.open(verification_url)
             if opened:
-                print("  (Opened browser for verification)")
+                print("  (인증용 브라우저를 열었어요)")
             else:
-                print("  Could not open browser automatically — use the URL above.")
+                print("  브라우저를 자동으로 열지 못했어요 — 위 URL을 직접 사용해 주세요.")
 
         effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
-        print(f"Waiting for approval (polling every {effective_interval}s)...")
+        print(f"승인을 기다리는 중... ({effective_interval}초마다 확인)")
 
         token_data = _poll_for_token(
             client=client,
@@ -3139,10 +3139,10 @@ def _nous_device_code_login(
                 "portal_base_url", DEFAULT_NOUS_PORTAL_URL
             ).rstrip("/")
             print()
-            print("Your Nous Portal account does not have an active subscription.")
-            print(f"  Subscribe here: {portal_url}/billing")
+            print("Nous Portal 계정에 활성 구독이 없어요.")
+            print(f"  구독 페이지: {portal_url}/billing")
             print()
-            print("After subscribing, run `hermes model` again to finish setup.")
+            print("구독 후 `hermes model` 을 다시 실행해 설정을 마무리하세요.")
             raise SystemExit(1)
         raise
 
@@ -3178,8 +3178,8 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
             saved_to = _save_auth_store(auth_store)
 
         print()
-        print("Login successful!")
-        print(f"  Auth state: {saved_to}")
+        print("로그인에 성공했어요!")
+        print(f"  인증 상태: {saved_to}")
 
         # Resolve model BEFORE writing provider to config.yaml so we never
         # leave the config in a half-updated state (provider=nous but model
@@ -3213,7 +3213,7 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                     )
             _portal = auth_state.get("portal_base_url", "")
             if model_ids:
-                print(f"Showing {len(model_ids)} curated models — use \"Enter custom model name\" for others.")
+                print(f"큐레이션 모델 {len(model_ids)}개를 표시해요 — 다른 모델은 \"사용자 지정 모델 이름 입력\"을 사용하세요.")
                 selected_model = _prompt_model_selection(
                     model_ids, pricing=pricing,
                     unavailable_models=unavailable_models,
@@ -3221,14 +3221,14 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
                 )
             elif unavailable_models:
                 _url = (_portal or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
-                print("No free models currently available.")
-                print(f"Upgrade at {_url} to access paid models.")
+                print("현재 사용할 수 있는 무료 모델이 없어요.")
+                print(f"유료 모델을 사용하려면 업그레이드: {_url}")
             else:
-                print("No curated models available for Nous Portal.")
+                print("Nous Portal에서 사용할 수 있는 큐레이션 모델이 없어요.")
         except Exception as exc:
             message = format_auth_error(exc) if isinstance(exc, AuthError) else str(exc)
             print()
-            print(f"Login succeeded, but could not fetch available models. Reason: {message}")
+            print(f"로그인에는 성공했지만 사용 가능한 모델을 가져오지 못했어요. 이유: {message}")
 
         # Write provider + model atomically so config is never mismatched.
         config_path = _update_config_for_provider(
@@ -3236,14 +3236,14 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
         )
         if selected_model:
             _save_model_choice(selected_model)
-            print(f"Default model set to: {selected_model}")
-        print(f"  Config updated: {config_path} (model.provider=nous)")
+            print(f"기본 모델을 설정했어요: {selected_model}")
+        print(f"  설정 업데이트: {config_path} (model.provider=nous)")
 
     except KeyboardInterrupt:
-        print("\nLogin cancelled.")
+        print("\n로그인을 취소했어요.")
         raise SystemExit(130)
     except Exception as exc:
-        print(f"Login failed: {exc}")
+        print(f"로그인에 실패했어요: {exc}")
         raise SystemExit(1)
 
 
@@ -3259,17 +3259,17 @@ def logout_command(args) -> None:
     target = provider_id or active
 
     if not target:
-        print("No provider is currently logged in.")
+        print("현재 로그인된 provider가 없어요.")
         return
 
     provider_name = PROVIDER_REGISTRY[target].name if target in PROVIDER_REGISTRY else target
 
     if clear_provider_auth(target):
         _reset_config_provider()
-        print(f"Logged out of {provider_name}.")
+        print(f"{provider_name} 에서 로그아웃했어요.")
         if os.getenv("OPENROUTER_API_KEY"):
-            print("Hermes will use OpenRouter for inference.")
+            print("Hermes는 추론에 OpenRouter를 사용할 거예요.")
         else:
-            print("Run `hermes model` or configure an API key to use Hermes.")
+            print("Hermes를 사용하려면 `hermes model` 을 실행하거나 API key를 설정하세요.")
     else:
-        print(f"No auth state found for {provider_name}.")
+        print(f"{provider_name} 의 인증 상태를 찾지 못했어요.")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2672,14 +2672,14 @@ def _prompt_model_selection(
         else:
             base = mid
         if mid == current_model:
-            base += "  ← currently in use"
+            base += "  ← 현재 사용 중"
         return base
 
     # Default cursor on the current model (index 0 if it was reordered to top)
     default_idx = 0
 
     # Build a pricing header hint for the menu title
-    menu_title = "Select default model:"
+    menu_title = "기본 모델 선택:"
     if has_pricing:
         # Align the header with the model column.
         # Each choice is "  {label}" (2 spaces) and simple_term_menu prepends
@@ -2699,8 +2699,8 @@ def _prompt_model_selection(
         from simple_term_menu import TerminalMenu
 
         choices = [f"  {_label(mid)}" for mid in ordered]
-        choices.append("  Enter custom model name")
-        choices.append("  Skip (keep current)")
+        choices.append("  사용자 지정 모델 이름 입력")
+        choices.append("  건너뛰기(현재 설정 유지)")
 
         # Print the unavailable block BEFORE the menu via regular print().
         # simple_term_menu pads title lines to terminal width (causes wrapping),
@@ -2713,9 +2713,9 @@ def _prompt_model_selection(
             for mid in _unavailable:
                 print(f"{_DIM}     {_label(mid)}{_RESET}")
             print()
-            print(f"{_DIM}  ── Upgrade at {_upgrade_url} for paid models ──{_RESET}")
+            print(f"{_DIM}  ── 유료 모델을 사용하려면 업그레이드: {_upgrade_url} ──{_RESET}")
             print()
-            effective_title = "Available free models:"
+            effective_title = "사용 가능한 무료 모델:"
         else:
             effective_title = menu_title
 
@@ -2943,12 +2943,12 @@ def _codex_device_code_login() -> Dict[str, Any]:
                         provider="openai-codex", code="device_code_poll_error",
                     )
     except KeyboardInterrupt:
-        print("\nLogin cancelled.")
+        print("\n로그인을 취소했어요.")
         raise SystemExit(130)
 
     if code_resp is None:
         raise AuthError(
-            "Login timed out after 15 minutes.",
+            "15분 동안 로그인을 완료하지 못해 시간이 초과되었어요.",
             provider="openai-codex", code="device_code_timeout",
         )
 
@@ -3049,8 +3049,8 @@ def _nous_device_code_login(
     if _is_remote_session():
         open_browser = False
 
-    print(f"Starting Hermes login via {pconfig.name}...")
-    print(f"Portal: {portal_base_url}")
+    print(f"{pconfig.name}을(를) 통해 Hermes 로그인을 시작할게요...")
+    print(f"포털: {portal_base_url}")
     if insecure:
         print("TLS 검증: 비활성화됨 (--insecure)")
     elif ca_bundle:
@@ -3101,7 +3101,7 @@ def _nous_device_code_login(
         or requested_inference_url
     )
     if resolved_inference_url != requested_inference_url:
-        print(f"Using portal-provided inference URL: {resolved_inference_url}")
+        print(f"포털에서 제공한 inference URL을 사용할게요: {resolved_inference_url}")
 
     auth_state = {
         "portal_base_url": portal_base_url,
@@ -3252,7 +3252,7 @@ def logout_command(args) -> None:
     provider_id = getattr(args, "provider", None)
 
     if provider_id and provider_id not in PROVIDER_REGISTRY:
-        print(f"Unknown provider: {provider_id}")
+        print(f"알 수 없는 provider예요: {provider_id}")
         raise SystemExit(1)
 
     active = get_active_provider()

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -156,7 +156,7 @@ def auth_add_command(args) -> None:
         if not token:
             token = getpass("Paste your API key: ").strip()
         if not token:
-            raise SystemExit("No API key provided.")
+            raise SystemExit("API key가 제공되지 않았어요.")
         default_label = _api_key_default_label(len(pool.entries()) + 1)
         label = (getattr(args, "label", None) or "").strip()
         if not label:
@@ -311,8 +311,8 @@ def auth_remove_command(args) -> None:
         raise SystemExit(f"{error} Provider: {provider}.")
     removed = pool.remove_index(index)
     if removed is None:
-        raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
-    print(f"Removed {provider} credential #{index} ({removed.label})")
+        raise SystemExit(f'provider {provider} 에서 "{target}" 와(과) 일치하는 자격 증명을 찾지 못했어요.')
+    print(f"{provider} 자격 증명 #{index} ({removed.label}) 을(를) 제거했어요")
 
     # If this was an env-seeded credential, also clear the env var from .env
     # so it doesn't get re-seeded on the next load_pool() call.
@@ -337,34 +337,34 @@ def auth_remove_command(args) -> None:
             if isinstance(providers_dict, dict) and provider in providers_dict:
                 del providers_dict[provider]
                 _save_auth_store(auth_store)
-                print(f"Cleared {provider} OAuth tokens from auth store")
+                print(f"auth store에서 {provider} OAuth 토큰을 지웠어요")
 
     elif removed.source == "hermes_pkce" and provider == "anthropic":
         from hermes_constants import get_hermes_home
         oauth_file = get_hermes_home() / ".anthropic_oauth.json"
         if oauth_file.exists():
             oauth_file.unlink()
-            print("Cleared Hermes Anthropic OAuth credentials")
+            print("Hermes Anthropic OAuth 자격 증명을 지웠어요")
 
     elif removed.source == "claude_code" and provider == "anthropic":
         from hermes_cli.auth import suppress_credential_source
         suppress_credential_source(provider, "claude_code")
-        print("Suppressed claude_code credential — it will not be re-seeded.")
-        print("Note: Claude Code credentials still live in ~/.claude/.credentials.json")
-        print("Run `hermes auth add anthropic` to re-enable if needed.")
+        print("claude_code 자격 증명을 억제했어요 — 다시 자동 주입되지 않아요.")
+        print("참고: Claude Code 자격 증명 자체는 ~/.claude/.credentials.json 에 남아 있어요")
+        print("다시 활성화하려면 `hermes auth add anthropic` 를 실행하세요.")
 
 
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     pool = load_pool(provider)
     count = pool.reset_statuses()
-    print(f"Reset status on {count} {provider} credentials")
+    print(f"{provider} 자격 증명 {count}개의 상태를 초기화했어요")
 
 
 def _interactive_auth() -> None:
     """Interactive credential pool management when `hermes auth` is called bare."""
     # Show current pool status first
-    print("Credential Pool Status")
+    print("자격 증명 풀 상태")
     print("=" * 50)
 
     auth_list_command(SimpleNamespace(provider=None))
@@ -372,18 +372,18 @@ def _interactive_auth() -> None:
 
     # Main menu
     choices = [
-        "Add a credential",
-        "Remove a credential",
-        "Reset cooldowns for a provider",
-        "Set rotation strategy for a provider",
-        "Exit",
+        "자격 증명 추가",
+        "자격 증명 제거",
+        "provider 쿨다운 초기화",
+        "provider 회전 전략 설정",
+        "종료",
     ]
-    print("What would you like to do?")
+    print("무엇을 할까요?")
     for i, choice in enumerate(choices, 1):
         print(f"  {i}. {choice}")
 
     try:
-        raw = input("\nChoice: ").strip()
+        raw = input("\n선택: ").strip()
     except (EOFError, KeyboardInterrupt):
         return
 
@@ -406,10 +406,10 @@ def _pick_provider(prompt: str = "Provider") -> str:
     custom_names = _get_custom_provider_names()
     if custom_names:
         custom_display = [name for name, _key, _provider_key in custom_names]
-        print(f"\nKnown providers: {', '.join(known)}")
-        print(f"Custom endpoints: {', '.join(custom_display)}")
+        print(f"\n알려진 provider: {', '.join(known)}")
+        print(f"custom endpoint: {', '.join(custom_display)}")
     else:
-        print(f"\nKnown providers: {', '.join(known)}")
+        print(f"\n알려진 provider: {', '.join(known)}")
     try:
         raw = input(f"{prompt}: ").strip()
     except (EOFError, KeyboardInterrupt):
@@ -418,17 +418,17 @@ def _pick_provider(prompt: str = "Provider") -> str:
 
 
 def _interactive_add() -> None:
-    provider = _pick_provider("Provider to add credential for")
+    provider = _pick_provider("자격 증명을 추가할 provider")
     if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
         raise SystemExit(f"Unknown provider: {provider}")
 
     # For OAuth-capable providers, ask which type
     if provider in _OAUTH_CAPABLE_PROVIDERS:
-        print(f"\n{provider} supports both API keys and OAuth login.")
-        print("  1. API key (paste a key from the provider dashboard)")
-        print("  2. OAuth login (authenticate via browser)")
+        print(f"\n{provider} 는 API key와 OAuth 로그인을 모두 지원해요.")
+        print("  1. API key (provider 대시보드에서 key를 붙여넣기)")
+        print("  2. OAuth 로그인 (브라우저에서 인증)")
         try:
-            type_choice = input("Type [1/2]: ").strip()
+            type_choice = input("유형 [1/2]: ").strip()
         except (EOFError, KeyboardInterrupt):
             return
         if type_choice == "2":
@@ -440,7 +440,7 @@ def _interactive_add() -> None:
 
     label = None
     try:
-        typed_label = input("Label / account name (optional): ").strip()
+        typed_label = input("라벨 / 계정 이름(선택): ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if typed_label:
@@ -454,10 +454,10 @@ def _interactive_add() -> None:
 
 
 def _interactive_remove() -> None:
-    provider = _pick_provider("Provider to remove credential from")
+    provider = _pick_provider("자격 증명을 제거할 provider")
     pool = load_pool(provider)
     if not pool.has_credentials():
-        print(f"No credentials for {provider}.")
+        print(f"{provider} 용 자격 증명이 없어요.")
         return
 
     # Show entries with indices
@@ -466,7 +466,7 @@ def _interactive_remove() -> None:
         print(f"  #{i}  {e.label:25s} {e.auth_type:10s} {e.source}{exhausted} [id:{e.id}]")
 
     try:
-        raw = input("Remove #, id, or label (blank to cancel): ").strip()
+        raw = input("제거할 #, id, 또는 라벨(비워 두면 취소): ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if not raw:
@@ -476,30 +476,30 @@ def _interactive_remove() -> None:
 
 
 def _interactive_reset() -> None:
-    provider = _pick_provider("Provider to reset cooldowns for")
+    provider = _pick_provider("쿨다운을 초기화할 provider")
 
     auth_reset_command(SimpleNamespace(provider=provider))
 
 
 def _interactive_strategy() -> None:
-    provider = _pick_provider("Provider to set strategy for")
+    provider = _pick_provider("전략을 설정할 provider")
     current = get_pool_strategy(provider)
     strategies = [STRATEGY_FILL_FIRST, STRATEGY_ROUND_ROBIN, STRATEGY_LEAST_USED, STRATEGY_RANDOM]
 
-    print(f"\nCurrent strategy for {provider}: {current}")
+    print(f"\n{provider} 의 현재 전략: {current}")
     print()
     descriptions = {
-        STRATEGY_FILL_FIRST: "Use first key until exhausted, then next",
-        STRATEGY_ROUND_ROBIN: "Cycle through keys evenly",
-        STRATEGY_LEAST_USED: "Always pick the least-used key",
-        STRATEGY_RANDOM: "Random selection",
+        STRATEGY_FILL_FIRST: "첫 번째 key를 소진할 때까지 쓰고 다음 key로 이동",
+        STRATEGY_ROUND_ROBIN: "key를 고르게 순환 사용",
+        STRATEGY_LEAST_USED: "가장 적게 사용한 key를 항상 선택",
+        STRATEGY_RANDOM: "무작위 선택",
     }
     for i, s in enumerate(strategies, 1):
         marker = " ←" if s == current else ""
         print(f"  {i}. {s:15s} — {descriptions.get(s, '')}{marker}")
 
     try:
-        raw = input("\nStrategy [1-4]: ").strip()
+        raw = input("\n전략 [1-4]: ").strip()
     except (EOFError, KeyboardInterrupt):
         return
     if not raw:
@@ -509,7 +509,7 @@ def _interactive_strategy() -> None:
         idx = int(raw) - 1
         strategy = strategies[idx]
     except (ValueError, IndexError):
-        print("Invalid choice.")
+        print("올바르지 않은 선택이에요.")
         return
 
     from hermes_cli.config import load_config, save_config
@@ -520,7 +520,7 @@ def _interactive_strategy() -> None:
     pool_strategies[provider] = strategy
     cfg["credential_pool_strategies"] = pool_strategies
     save_config(cfg)
-    print(f"Set {provider} strategy to: {strategy}")
+    print(f"{provider} 전략을 다음으로 설정했어요: {strategy}")
 
 
 def auth_command(args) -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -138,7 +138,7 @@ def _format_exhausted_status(entry) -> str:
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
-        raise SystemExit(f"Unknown provider: {provider}")
+        raise SystemExit(f"알 수 없는 provider예요: {provider}")
 
     requested_type = str(getattr(args, "auth_type", "") or "").strip().lower()
     if requested_type in {AUTH_TYPE_API_KEY, "api-key"}:
@@ -154,13 +154,13 @@ def auth_add_command(args) -> None:
     if requested_type == AUTH_TYPE_API_KEY:
         token = (getattr(args, "api_key", None) or "").strip()
         if not token:
-            token = getpass("Paste your API key: ").strip()
+            token = getpass("API key를 붙여 넣어 주세요: ").strip()
         if not token:
             raise SystemExit("API key가 제공되지 않았어요.")
         default_label = _api_key_default_label(len(pool.entries()) + 1)
         label = (getattr(args, "label", None) or "").strip()
         if not label:
-            label = input(f"Label (optional, default: {default_label}): ").strip() or default_label
+            label = input(f"라벨(선택, 기본값: {default_label}): ").strip() or default_label
         entry = PooledCredential(
             provider=provider,
             id=uuid.uuid4().hex[:6],
@@ -172,7 +172,7 @@ def auth_add_command(args) -> None:
             base_url=_provider_base_url(provider),
         )
         pool.add_entry(entry)
-        print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')
+        print(f'{provider} 자격 증명 #{len(pool.entries())}을(를) 추가했어요: "{label}"')
         return
 
     if provider == "anthropic":
@@ -180,7 +180,7 @@ def auth_add_command(args) -> None:
 
         creds = anthropic_mod.run_hermes_oauth_login_pure()
         if not creds:
-            raise SystemExit("Anthropic OAuth login did not return credentials.")
+            raise SystemExit("Anthropic OAuth 로그인이 자격 증명을 반환하지 않았어요.")
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -198,7 +198,7 @@ def auth_add_command(args) -> None:
             base_url=_provider_base_url(provider),
         )
         pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        print(f'{provider} OAuth 자격 증명 #{len(pool.entries())}을(를) 추가했어요: "{entry.label}"')
         return
 
     if provider == "nous":
@@ -225,7 +225,7 @@ def auth_add_command(args) -> None:
             "base_url": creds.get("inference_base_url"),
         })
         pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        print(f'{provider} OAuth 자격 증명 #{len(pool.entries())}을(를) 추가했어요: "{entry.label}"')
         return
 
     if provider == "openai-codex":
@@ -247,7 +247,7 @@ def auth_add_command(args) -> None:
             last_refresh=creds.get("last_refresh"),
         )
         pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        print(f'{provider} OAuth 자격 증명 #{len(pool.entries())}을(를) 추가했어요: "{entry.label}"')
         return
 
     if provider == "qwen-oauth":
@@ -267,10 +267,10 @@ def auth_add_command(args) -> None:
             base_url=creds.get("base_url"),
         )
         pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        print(f'{provider} OAuth 자격 증명 #{len(pool.entries())}을(를) 추가했어요: "{entry.label}"')
         return
 
-    raise SystemExit(f"`hermes auth add {provider}` is not implemented for auth type {requested_type} yet.")
+    raise SystemExit(f"`hermes auth add {provider}` 명령은 auth type {requested_type}에 아직 구현되지 않았어요.")
 
 
 def auth_list_command(args) -> None:
@@ -322,7 +322,7 @@ def auth_remove_command(args) -> None:
             from hermes_cli.config import remove_env_value
             cleared = remove_env_value(env_var)
             if cleared:
-                print(f"Cleared {env_var} from .env")
+                print(f".env 에서 {env_var}를 삭제했어요")
 
     # If this was a singleton-seeded credential (OAuth device_code, hermes_pkce),
     # clear the underlying auth store / credential file so it doesn't get
@@ -420,7 +420,7 @@ def _pick_provider(prompt: str = "Provider") -> str:
 def _interactive_add() -> None:
     provider = _pick_provider("자격 증명을 추가할 provider")
     if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
-        raise SystemExit(f"Unknown provider: {provider}")
+        raise SystemExit(f"알 수 없는 provider예요: {provider}")
 
     # For OAuth-capable providers, ask which type
     if provider in _OAUTH_CAPABLE_PROVIDERS:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -116,7 +116,7 @@ def run_backup(args) -> None:
     hermes_root = get_default_hermes_root()
 
     if not hermes_root.is_dir():
-        print(f"Error: Hermes home directory not found at {hermes_root}")
+        print(f"오류: Hermes 홈 디렉터리를 찾지 못했어요: {hermes_root}")
         sys.exit(1)
 
     # Determine output path
@@ -138,7 +138,7 @@ def run_backup(args) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Collect files
-    print(f"Scanning {display_hermes_home()} ...")
+    print(f"{display_hermes_home()} 을(를) 스캔하는 중...")
     files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
     skipped_dirs = set()
 
@@ -172,12 +172,12 @@ def run_backup(args) -> None:
             files_to_add.append((fpath, rel))
 
     if not files_to_add:
-        print("No files to back up.")
+        print("백업할 파일이 없어요.")
         return
 
     # Create the zip
     file_count = len(files_to_add)
-    print(f"Backing up {file_count} files ...")
+    print(f"파일 {file_count}개를 백업하는 중...")
 
     total_bytes = 0
     errors = []
@@ -214,25 +214,25 @@ def run_backup(args) -> None:
 
     # Summary
     print()
-    print(f"Backup complete: {out_path}")
-    print(f"  Files:       {file_count}")
-    print(f"  Original:    {_format_size(total_bytes)}")
-    print(f"  Compressed:  {_format_size(zip_size)}")
-    print(f"  Time:        {elapsed:.1f}s")
+    print(f"백업 완료: {out_path}")
+    print(f"  파일 수:     {file_count}")
+    print(f"  원본 크기:   {_format_size(total_bytes)}")
+    print(f"  압축 크기:   {_format_size(zip_size)}")
+    print(f"  소요 시간:   {elapsed:.1f}s")
 
     if skipped_dirs:
-        print(f"\n  Excluded directories:")
+        print(f"\n  제외된 디렉터리:")
         for d in sorted(skipped_dirs):
             print(f"    {d}/")
 
     if errors:
-        print(f"\n  Warnings ({len(errors)} files skipped):")
+        print(f"\n  경고 ({len(errors)}개 파일 건너뜀):")
         for e in errors[:10]:
             print(e)
         if len(errors) > 10:
-            print(f"  ... and {len(errors) - 10} more")
+            print(f"  ... 그리고 {len(errors) - 10}개 더")
 
-    print(f"\nRestore with: hermes import {out_path.name}")
+    print(f"\n복원 명령: hermes import {out_path.name}")
 
 
 # ---------------------------------------------------------------------------
@@ -295,11 +295,11 @@ def run_import(args) -> None:
     zip_path = Path(args.zipfile).expanduser().resolve()
 
     if not zip_path.is_file():
-        print(f"Error: File not found: {zip_path}")
+        print(f"오류: 파일을 찾지 못했어요: {zip_path}")
         sys.exit(1)
 
     if not zipfile.is_zipfile(zip_path):
-        print(f"Error: Not a valid zip file: {zip_path}")
+        print(f"오류: 올바른 zip 파일이 아니에요: {zip_path}")
         sys.exit(1)
 
     hermes_root = get_default_hermes_root()
@@ -308,18 +308,18 @@ def run_import(args) -> None:
         # Validate
         ok, reason = _validate_backup_zip(zf)
         if not ok:
-            print(f"Error: {reason}")
+            print(f"오류: {reason}")
             sys.exit(1)
 
         prefix = _detect_prefix(zf)
         members = [n for n in zf.namelist() if not n.endswith("/")]
         file_count = len(members)
 
-        print(f"Backup contains {file_count} files")
-        print(f"Target: {display_hermes_home()}")
+        print(f"백업 안에 파일 {file_count}개가 들어 있어요")
+        print(f"대상 경로: {display_hermes_home()}")
 
         if prefix:
-            print(f"Detected archive prefix: {prefix!r} (will be stripped)")
+            print(f"아카이브 prefix를 감지했어요: {prefix!r} (제거 후 복원)")
 
         # Check for existing installation
         has_config = (hermes_root / "config.yaml").exists()
@@ -327,20 +327,20 @@ def run_import(args) -> None:
 
         if (has_config or has_env) and not args.force:
             print()
-            print("Warning: Target directory already has Hermes configuration.")
-            print("Importing will overwrite existing files with backup contents.")
+            print("경고: 대상 디렉터리에 이미 Hermes 설정이 있어요.")
+            print("가져오기를 진행하면 기존 파일을 백업 내용으로 덮어써요.")
             print()
             try:
-                answer = input("Continue? [y/N] ").strip().lower()
+                answer = input("계속할까요? [y/N] ").strip().lower()
             except (EOFError, KeyboardInterrupt):
-                print("\nAborted.")
+                print("\n중단했어요.")
                 sys.exit(1)
             if answer not in ("y", "yes"):
-                print("Aborted.")
+                print("중단했어요.")
                 return
 
         # Extract
-        print(f"\nImporting {file_count} files ...")
+        print(f"\n파일 {file_count}개를 가져오는 중...")
         hermes_root.mkdir(parents=True, exist_ok=True)
 
         errors = []
@@ -381,11 +381,11 @@ def run_import(args) -> None:
 
         # Summary
         print()
-        print(f"Import complete: {restored} files restored in {elapsed:.1f}s")
-        print(f"  Target: {display_hermes_home()}")
+        print(f"가져오기 완료: {restored}개 파일을 {elapsed:.1f}초 동안 복원했어요")
+        print(f"  대상 경로: {display_hermes_home()}")
 
         if errors:
-            print(f"\n  Warnings ({len(errors)} files skipped):")
+            print(f"\n  경고 ({len(errors)}개 파일 건너뜀):")
             for e in errors[:10]:
                 print(e)
             if len(errors) > 10:
@@ -419,32 +419,32 @@ def run_import(args) -> None:
                     created = [n for n, ok in restored_profiles if ok]
                     skipped = [n for n, ok in restored_profiles if not ok]
                     if created:
-                        print(f"\n  Profile aliases restored: {', '.join(created)}")
+                        print(f"\n  복원한 프로필 alias: {', '.join(created)}")
                     if skipped:
-                        print(f"  Profile aliases skipped:  {', '.join(skipped)}")
+                        print(f"  건너뛴 프로필 alias:  {', '.join(skipped)}")
                     if not _is_wrapper_dir_in_path():
-                        print(f"\n  Note: {_get_wrapper_dir()} is not in your PATH.")
-                        print('  Add to your shell config (~/.bashrc or ~/.zshrc):')
+                        print(f"\n  참고: {_get_wrapper_dir()} 가 PATH에 없어요.")
+                        print('  셸 설정(~/.bashrc 또는 ~/.zshrc)에 추가하세요:')
                         print('    export PATH="$HOME/.local/bin:$PATH"')
             except ImportError:
                 # hermes_cli.profiles might not be available (fresh install)
                 if any(profiles_dir.iterdir()):
-                    print(f"\n  Profiles detected but aliases could not be created.")
-                    print(f"  Run: hermes profile list  (after installing hermes)")
+                    print(f"\n  프로필은 감지했지만 alias를 만들지 못했어요.")
+                    print(f"  실행: hermes profile list  (hermes 설치 후)")
 
         # Guidance
         print()
         if not (hermes_root / "hermes-agent").is_dir():
-            print("Note: The hermes-agent codebase was not included in the backup.")
-            print("  If this is a fresh install, run: hermes update")
+            print("참고: 백업에는 hermes-agent 코드베이스가 포함되지 않았어요.")
+            print("  새로 설치한 환경이라면 실행: hermes update")
 
         if restored_profiles:
             gw_profiles = [n for n, _ in restored_profiles]
-            print("\nTo re-enable gateway services for profiles:")
+            print("\n프로필별 gateway 서비스를 다시 활성화하려면:")
             for pname in gw_profiles:
                 print(f"  hermes -p {pname} gateway install")
 
-        print("Done. Your Hermes configuration has been restored.")
+        print("완료됐어요. Hermes 설정을 복원했어요.")
 
 
 # ---------------------------------------------------------------------------
@@ -652,4 +652,4 @@ def run_quick_backup(args) -> None:
         print(f"  {len(snaps)} snapshot(s) stored in {display_hermes_home()}/state-snapshots/")
         print(f"  Restore with: /snapshot restore {snap_id}")
     else:
-        print("No state files found to snapshot.")
+        print("스냅샷할 상태 파일을 찾지 못했어요.")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -58,112 +58,112 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
-    CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
+    CommandDef("new", "새 세션 시작(새 세션 ID와 기록으로 초기화)", "Session",
                aliases=("reset",)),
-    CommandDef("clear", "Clear screen and start a new session", "Session",
+    CommandDef("clear", "화면을 지우고 새 세션 시작", "Session",
                cli_only=True),
-    CommandDef("history", "Show conversation history", "Session",
+    CommandDef("history", "대화 기록 표시", "Session",
                cli_only=True),
-    CommandDef("save", "Save the current conversation", "Session",
+    CommandDef("save", "현재 대화 저장", "Session",
                cli_only=True),
-    CommandDef("retry", "Retry the last message (resend to agent)", "Session"),
-    CommandDef("undo", "Remove the last user/assistant exchange", "Session"),
-    CommandDef("title", "Set a title for the current session", "Session",
+    CommandDef("retry", "마지막 메시지 다시 시도(에이전트에 재전송)", "Session"),
+    CommandDef("undo", "마지막 사용자/어시스턴트 교환 제거", "Session"),
+    CommandDef("title", "현재 세션 제목 설정", "Session",
                args_hint="[name]"),
-    CommandDef("branch", "Branch the current session (explore a different path)", "Session",
+    CommandDef("branch", "현재 세션에서 분기 생성(다른 경로 탐색)", "Session",
                aliases=("fork",), args_hint="[name]"),
-    CommandDef("compress", "Manually compress conversation context", "Session",
+    CommandDef("compress", "대화 컨텍스트를 수동으로 압축", "Session",
                args_hint="[focus topic]"),
-    CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
+    CommandDef("rollback", "파일시스템 체크포인트 목록 표시 또는 복원", "Session",
                args_hint="[number]"),
-    CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
+    CommandDef("snapshot", "Hermes 설정/상태 스냅샷 생성 또는 복원", "Session",
                aliases=("snap",), args_hint="[create|restore <id>|prune]"),
-    CommandDef("stop", "Kill all running background processes", "Session"),
-    CommandDef("approve", "Approve a pending dangerous command", "Session",
+    CommandDef("stop", "실행 중인 백그라운드 프로세스 모두 종료", "Session"),
+    CommandDef("approve", "대기 중인 위험 명령 승인", "Session",
                gateway_only=True, args_hint="[session|always]"),
-    CommandDef("deny", "Deny a pending dangerous command", "Session",
+    CommandDef("deny", "대기 중인 위험 명령 거부", "Session",
                gateway_only=True),
-    CommandDef("background", "Run a prompt in the background", "Session",
+    CommandDef("background", "프롬프트를 백그라운드에서 실행", "Session",
                aliases=("bg",), args_hint="<prompt>"),
-    CommandDef("btw", "Ephemeral side question using session context (no tools, not persisted)", "Session",
+    CommandDef("btw", "세션 컨텍스트를 이용한 임시 사이드 질문(도구 사용 없음, 저장 안 함)", "Session",
                args_hint="<question>"),
-    CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
+    CommandDef("queue", "다음 턴에 실행할 프롬프트 대기열에 추가(즉시 끼어들지 않음)", "Session",
                aliases=("q",), args_hint="<prompt>"),
-    CommandDef("status", "Show session info", "Session"),
-    CommandDef("profile", "Show active profile name and home directory", "Info"),
-    CommandDef("sethome", "Set this chat as the home channel", "Session",
+    CommandDef("status", "세션 정보 표시", "Session"),
+    CommandDef("profile", "현재 활성 프로필 이름과 홈 디렉터리 표시", "Info"),
+    CommandDef("sethome", "이 채팅을 홈 채널로 설정", "Session",
                gateway_only=True, aliases=("set-home",)),
-    CommandDef("resume", "Resume a previously-named session", "Session",
+    CommandDef("resume", "이전에 이름 붙인 세션 다시 열기", "Session",
                args_hint="[name]"),
 
     # Configuration
-    CommandDef("config", "Show current configuration", "Configuration",
+    CommandDef("config", "현재 설정 표시", "Configuration",
                cli_only=True),
-    CommandDef("model", "Switch model for this session", "Configuration", args_hint="[model] [--global]"),
-    CommandDef("provider", "Show available providers and current provider",
+    CommandDef("model", "이 세션에서 사용할 모델 전환", "Configuration", args_hint="[model] [--global]"),
+    CommandDef("provider", "사용 가능한 provider와 현재 provider 표시",
                "Configuration"),
 
-    CommandDef("personality", "Set a predefined personality", "Configuration",
+    CommandDef("personality", "미리 정의된 personality 설정", "Configuration",
                args_hint="[name]"),
-    CommandDef("statusbar", "Toggle the context/model status bar", "Configuration",
+    CommandDef("statusbar", "컨텍스트/모델 상태바 토글", "Configuration",
                cli_only=True, aliases=("sb",)),
-    CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
+    CommandDef("verbose", "도구 진행 표시 순환: off -> new -> all -> verbose",
                "Configuration", cli_only=True,
                gateway_config_gate="display.tool_progress_command"),
-    CommandDef("yolo", "Toggle YOLO mode (skip all dangerous command approvals)",
+    CommandDef("yolo", "YOLO 모드 토글(위험 명령 승인 전부 건너뜀)",
                "Configuration"),
-    CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
+    CommandDef("reasoning", "추론 강도와 표시 방식 관리", "Configuration",
                args_hint="[level|show|hide]",
                subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
-    CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
+    CommandDef("fast", "고속 모드 토글 — OpenAI Priority Processing / Anthropic Fast Mode", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),
-    CommandDef("skin", "Show or change the display skin/theme", "Configuration",
+    CommandDef("skin", "표시 스킨/테마 표시 또는 변경", "Configuration",
                cli_only=True, args_hint="[name]"),
-    CommandDef("voice", "Toggle voice mode", "Configuration",
+    CommandDef("voice", "음성 모드 토글", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
 
     # Tools & Skills
-    CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",
+    CommandDef("tools", "도구 관리: /tools [list|disable|enable] [name...]", "Tools & Skills",
                args_hint="[list|disable|enable] [name...]", cli_only=True),
-    CommandDef("toolsets", "List available toolsets", "Tools & Skills",
+    CommandDef("toolsets", "사용 가능한 toolset 목록 표시", "Tools & Skills",
                cli_only=True),
-    CommandDef("skills", "Search, install, inspect, or manage skills",
+    CommandDef("skills", "skill 검색, 설치, 미리보기 또는 관리",
                "Tools & Skills", cli_only=True,
                subcommands=("search", "browse", "inspect", "install")),
-    CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
+    CommandDef("cron", "예약 작업 관리", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
-    CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills"),
-    CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
+    CommandDef("reload", ".env 변수를 현재 세션에 다시 불러오기", "Tools & Skills"),
+    CommandDef("reload-mcp", "config에서 MCP 서버 다시 불러오기", "Tools & Skills",
                aliases=("reload_mcp",)),
-    CommandDef("browser", "Connect browser tools to your live Chrome via CDP", "Tools & Skills",
+    CommandDef("browser", "브라우저 도구를 실행 중인 Chrome에 CDP로 연결", "Tools & Skills",
                cli_only=True, args_hint="[connect|disconnect|status]",
                subcommands=("connect", "disconnect", "status")),
-    CommandDef("plugins", "List installed plugins and their status",
+    CommandDef("plugins", "설치된 plugin과 상태 목록 표시",
                "Tools & Skills", cli_only=True),
 
     # Info
-    CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
+    CommandDef("commands", "모든 명령어와 skill 목록을 페이지 단위로 표시", "Info",
                gateway_only=True, args_hint="[page]"),
-    CommandDef("help", "Show available commands", "Info"),
-    CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
+    CommandDef("help", "사용 가능한 명령어 표시", "Info"),
+    CommandDef("restart", "진행 중인 작업을 정리한 뒤 gateway를 안전하게 재시작", "Session",
                gateway_only=True),
-    CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
-    CommandDef("insights", "Show usage insights and analytics", "Info",
+    CommandDef("usage", "현재 세션의 토큰 사용량과 속도 제한 표시", "Info"),
+    CommandDef("insights", "사용량 인사이트와 분석 표시", "Info",
                args_hint="[days]"),
-    CommandDef("platforms", "Show gateway/messaging platform status", "Info",
+    CommandDef("platforms", "gateway/메시징 플랫폼 상태 표시", "Info",
                cli_only=True, aliases=("gateway",)),
-    CommandDef("paste", "Check clipboard for an image and attach it", "Info",
+    CommandDef("paste", "클립보드의 이미지를 확인해 다음 프롬프트에 첨부", "Info",
                cli_only=True),
-    CommandDef("image", "Attach a local image file for your next prompt", "Info",
+    CommandDef("image", "다음 프롬프트에 사용할 로컬 이미지 파일 첨부", "Info",
                cli_only=True, args_hint="<path>"),
-    CommandDef("update", "Update Hermes Agent to the latest version", "Info",
+    CommandDef("update", "Hermes Agent를 최신 버전으로 업데이트", "Info",
                gateway_only=True),
-    CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
+    CommandDef("debug", "디버그 리포트(시스템 정보 + 로그)를 업로드하고 공유 링크 생성", "Info"),
 
     # Exit
-    CommandDef("quit", "Exit the CLI", "Exit",
+    CommandDef("quit", "CLI 종료", "Exit",
                cli_only=True, aliases=("exit", "q")),
 ]
 
@@ -196,7 +196,7 @@ def resolve_command(name: str) -> CommandDef | None:
 def _build_description(cmd: CommandDef) -> str:
     """Build a CLI-facing description string including usage hint."""
     if cmd.args_hint:
-        return f"{cmd.description} (usage: /{cmd.name} {cmd.args_hint})"
+        return f"{cmd.description} (사용법: /{cmd.name} {cmd.args_hint})"
     return cmd.description
 
 
@@ -206,7 +206,7 @@ for _cmd in COMMAND_REGISTRY:
     if not _cmd.gateway_only:
         COMMANDS[f"/{_cmd.name}"] = _build_description(_cmd)
         for _alias in _cmd.aliases:
-            COMMANDS[f"/{_alias}"] = f"{_cmd.description} (alias for /{_cmd.name})"
+            COMMANDS[f"/{_alias}"] = f"{_cmd.description} (/{_cmd.name}의 별칭)"
 
 # Backwards-compatible categorized dict
 COMMANDS_BY_CATEGORY: dict[str, dict[str, str]] = {}
@@ -312,7 +312,7 @@ def gateway_help_lines() -> list[str]:
             if a.replace("-", "_") == cmd.name.replace("-", "_") and a != cmd.name:
                 continue
             alias_parts.append(f"`/{a}`")
-        alias_note = f" (alias: {', '.join(alias_parts)})" if alias_parts else ""
+        alias_note = f" (별칭: {', '.join(alias_parts)})" if alias_parts else ""
         lines.append(f"`/{cmd.name}{args}` -- {cmd.description}{alias_note}")
     return lines
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -218,6 +218,20 @@ for _cmd in COMMAND_REGISTRY:
             _cat[f"/{_alias}"] = COMMANDS[f"/{_alias}"]
 
 
+CATEGORY_LABELS: dict[str, str] = {
+    "Session": "세션",
+    "Configuration": "설정",
+    "Tools & Skills": "도구와 스킬",
+    "Info": "정보",
+    "Exit": "종료",
+}
+
+
+def get_category_label(category: str) -> str:
+    """Return the localized display label for a command category."""
+    return CATEGORY_LABELS.get(category, category)
+
+
 # Subcommands lookup: "/cmd" -> ["sub1", "sub2", ...]
 SUBCOMMANDS: dict[str, list[str]] = {}
 for _cmd in COMMAND_REGISTRY:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2510,7 +2510,7 @@ def load_config() -> Dict[str, Any]:
 
             config = _deep_merge(config, user_config)
         except Exception as e:
-            print(f"Warning: Failed to load config: {e}")
+            print(f"경고: config를 불러오지 못했어요: {e}")
     
     return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
 
@@ -3136,11 +3136,11 @@ def edit_config():
                 break
     
     if not editor:
-        print("No editor found. Config file is at:")
+        print("에디터를 찾지 못했어요. config 파일 위치:")
         print(f"  {config_path}")
         return
     
-    print(f"Opening {config_path} in {editor}...")
+    print(f"{editor}로 {config_path} 파일을 여는 중...")
     subprocess.run([editor, str(config_path)])
 
 
@@ -3249,9 +3249,9 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         if not key or value is None:
-            print("Usage: hermes config set <key> <value>")
+            print("사용법: hermes config set <key> <value>")
             print()
-            print("Examples:")
+            print("예시:")
             print("  hermes config set model anthropic/claude-sonnet-4")
             print("  hermes config set terminal.backend docker")
             print("  hermes config set OPENROUTER_API_KEY sk-or-...")
@@ -3361,8 +3361,8 @@ def config_command(args):
     else:
         print(f"Unknown config command: {subcmd}")
         print()
-        print("Available commands:")
-        print("  hermes config           Show current configuration")
+        print("사용 가능한 명령어:")
+        print("  hermes config           현재 설정 표시")
         print("  hermes config edit      Open config in editor")
         print("  hermes config set <key> <value>   Set a config value")
         print("  hermes config check     Check for missing/outdated config")

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -1,8 +1,8 @@
 """
-Cron subcommand for hermes CLI.
+hermes CLI용 cron 하위 명령.
 
-Handles standalone cron management commands like list, create, edit,
-pause/resume/run/remove, status, and tick.
+list, create, edit, pause/resume/run/remove, status, tick 같은
+독립형 cron 관리 명령을 처리합니다.
 """
 
 import json
@@ -45,13 +45,13 @@ def cron_list(show_all: bool = False):
     jobs = list_jobs(include_disabled=show_all)
 
     if not jobs:
-        print(color("No scheduled jobs.", Colors.DIM))
-        print(color("Create one with 'hermes cron create ...' or the /cron command in chat.", Colors.DIM))
+        print(color("예약된 작업이 없어요.", Colors.DIM))
+        print(color("'hermes cron create ...' 또는 채팅의 /cron 명령으로 만들어 보세요.", Colors.DIM))
         return
 
     print()
     print(color("┌─────────────────────────────────────────────────────────────────────────┐", Colors.CYAN))
-    print(color("│                         Scheduled Jobs                                  │", Colors.CYAN))
+    print(color("│                           예약 작업 목록                                 │", Colors.CYAN))
     print(color("└─────────────────────────────────────────────────────────────────────────┘", Colors.CYAN))
     print()
 
@@ -83,16 +83,16 @@ def cron_list(show_all: bool = False):
             status = color("[disabled]", Colors.RED)
 
         print(f"  {color(job_id, Colors.YELLOW)} {status}")
-        print(f"    Name:      {name}")
-        print(f"    Schedule:  {schedule}")
-        print(f"    Repeat:    {repeat_str}")
-        print(f"    Next run:  {next_run}")
-        print(f"    Deliver:   {deliver_str}")
+        print(f"    이름:      {name}")
+        print(f"    일정:      {schedule}")
+        print(f"    반복:      {repeat_str}")
+        print(f"    다음 실행: {next_run}")
+        print(f"    전달:      {deliver_str}")
         if skills:
-            print(f"    Skills:    {', '.join(skills)}")
+            print(f"    스킬:      {', '.join(skills)}")
         script = job.get("script")
         if script:
-            print(f"    Script:    {script}")
+            print(f"    스크립트:  {script}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -102,19 +102,19 @@ def cron_list(show_all: bool = False):
                 status_display = color("ok", Colors.GREEN)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
-            print(f"    Last run:  {last_run}  {status_display}")
+            print(f"    마지막 실행: {last_run}  {status_display}")
 
         delivery_err = job.get("last_delivery_error")
         if delivery_err:
-            print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
+            print(f"    {color('⚠ 전달 실패:', Colors.YELLOW)} {delivery_err}")
 
         print()
 
     from hermes_cli.gateway import find_gateway_pids
     if not find_gateway_pids():
-        print(color("  ⚠  Gateway is not running — jobs won't fire automatically.", Colors.YELLOW))
-        print(color("     Start it with: hermes gateway install", Colors.DIM))
-        print(color("                    sudo hermes gateway install --system  # Linux servers", Colors.DIM))
+        print(color("  ⚠  게이트웨이가 실행 중이 아니어서 작업이 자동 실행되지 않아요.", Colors.YELLOW))
+        print(color("     시작 명령: hermes gateway install", Colors.DIM))
+        print(color("                sudo hermes gateway install --system  # Linux 서버", Colors.DIM))
         print()
 
 
@@ -133,26 +133,26 @@ def cron_status():
 
     pids = find_gateway_pids()
     if pids:
-        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+        print(color("✓ 게이트웨이가 실행 중이어서 cron 작업이 자동으로 실행돼요", Colors.GREEN))
         print(f"  PID: {', '.join(map(str, pids))}")
     else:
-        print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
+        print(color("✗ 게이트웨이가 실행 중이 아니어서 cron 작업이 자동 실행되지 않아요", Colors.RED))
         print()
-        print("  To enable automatic execution:")
-        print("    hermes gateway install    # Install as a user service")
-        print("    sudo hermes gateway install --system  # Linux servers: boot-time system service")
-        print("    hermes gateway            # Or run in foreground")
+        print("  자동 실행을 켜려면:")
+        print("    hermes gateway install    # 사용자 서비스로 설치")
+        print("    sudo hermes gateway install --system  # Linux 서버: 부팅 시 시작되는 시스템 서비스")
+        print("    hermes gateway            # 또는 포그라운드 실행")
 
     print()
 
     jobs = list_jobs(include_disabled=False)
     if jobs:
         next_runs = [j.get("next_run_at") for j in jobs if j.get("next_run_at")]
-        print(f"  {len(jobs)} active job(s)")
+        print(f"  활성 작업 {len(jobs)}개")
         if next_runs:
-            print(f"  Next run: {min(next_runs)}")
+            print(f"  다음 실행: {min(next_runs)}")
     else:
-        print("  No active jobs")
+        print("  활성 작업이 없어요")
 
     print()
 
@@ -170,17 +170,17 @@ def cron_create(args):
         script=getattr(args, "script", None),
     )
     if not result.get("success"):
-        print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
+        print(color(f"작업을 만들지 못했어요: {result.get('error', '알 수 없는 오류')}", Colors.RED))
         return 1
-    print(color(f"Created job: {result['job_id']}", Colors.GREEN))
-    print(f"  Name: {result['name']}")
-    print(f"  Schedule: {result['schedule']}")
+    print(color(f"작업을 만들었어요: {result['job_id']}", Colors.GREEN))
+    print(f"  이름: {result['name']}")
+    print(f"  일정: {result['schedule']}")
     if result.get("skills"):
-        print(f"  Skills: {', '.join(result['skills'])}")
+        print(f"  스킬: {', '.join(result['skills'])}")
     job_data = result.get("job", {})
     if job_data.get("script"):
-        print(f"  Script: {job_data['script']}")
-    print(f"  Next run: {result['next_run_at']}")
+        print(f"  스크립트: {job_data['script']}")
+    print(f"  다음 실행: {result['next_run_at']}")
     return 0
 
 
@@ -189,7 +189,7 @@ def cron_edit(args):
 
     job = get_job(args.job_id)
     if not job:
-        print(color(f"Job not found: {args.job_id}", Colors.RED))
+        print(color(f"작업을 찾지 못했어요: {args.job_id}", Colors.RED))
         return 1
 
     existing_skills = list(job.get("skills") or ([] if not job.get("skill") else [job.get("skill")]))
@@ -220,33 +220,33 @@ def cron_edit(args):
         script=getattr(args, "script", None),
     )
     if not result.get("success"):
-        print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
+        print(color(f"작업을 업데이트하지 못했어요: {result.get('error', '알 수 없는 오류')}", Colors.RED))
         return 1
 
     updated = result["job"]
-    print(color(f"Updated job: {updated['job_id']}", Colors.GREEN))
-    print(f"  Name: {updated['name']}")
-    print(f"  Schedule: {updated['schedule']}")
+    print(color(f"작업을 업데이트했어요: {updated['job_id']}", Colors.GREEN))
+    print(f"  이름: {updated['name']}")
+    print(f"  일정: {updated['schedule']}")
     if updated.get("skills"):
-        print(f"  Skills: {', '.join(updated['skills'])}")
+        print(f"  스킬: {', '.join(updated['skills'])}")
     else:
-        print("  Skills: none")
+        print("  스킬: 없음")
     if updated.get("script"):
-        print(f"  Script: {updated['script']}")
+        print(f"  스크립트: {updated['script']}")
     return 0
 
 
 def _job_action(action: str, job_id: str, success_verb: str) -> int:
     result = _cron_api(action=action, job_id=job_id)
     if not result.get("success"):
-        print(color(f"Failed to {action} job: {result.get('error', 'unknown error')}", Colors.RED))
+        print(color(f"작업 {action}에 실패했어요: {result.get('error', '알 수 없는 오류')}", Colors.RED))
         return 1
     job = result.get("job") or result.get("removed_job") or {}
     print(color(f"{success_verb} job: {job.get('name', job_id)} ({job_id})", Colors.GREEN))
     if action in {"resume", "run"} and result.get("job", {}).get("next_run_at"):
-        print(f"  Next run: {result['job']['next_run_at']}")
+        print(f"  다음 실행: {result['job']['next_run_at']}")
     if action == "run":
-        print("  It will run on the next scheduler tick.")
+        print("  다음 scheduler tick에서 실행돼요.")
     return 0
 
 
@@ -274,17 +274,17 @@ def cron_command(args):
         return cron_edit(args)
 
     if subcmd == "pause":
-        return _job_action("pause", args.job_id, "Paused")
+        return _job_action("pause", args.job_id, "일시중지한")
 
     if subcmd == "resume":
-        return _job_action("resume", args.job_id, "Resumed")
+        return _job_action("resume", args.job_id, "재개한")
 
     if subcmd == "run":
-        return _job_action("run", args.job_id, "Triggered")
+        return _job_action("run", args.job_id, "실행 예약한")
 
     if subcmd in {"remove", "rm", "delete"}:
-        return _job_action("remove", args.job_id, "Removed")
+        return _job_action("remove", args.job_id, "제거한")
 
-    print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print(f"알 수 없는 cron 명령어예요: {subcmd}")
+    print("사용법: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
     sys.exit(1)

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -250,7 +250,7 @@ def run_debug_share(args):
     expiry = getattr(args, "expire", 7)
     local_only = getattr(args, "local", False)
 
-    print("Collecting debug report...")
+    print("디버그 리포트를 수집하는 중...")
 
     # Capture dump once — prepended to every paste for context.
     dump_text = _capture_dump()
@@ -269,17 +269,17 @@ def run_debug_share(args):
         print(report)
         if agent_log:
             print(f"\n\n{'=' * 60}")
-            print("FULL agent.log")
+            print("전체 agent.log")
             print(f"{'=' * 60}\n")
             print(agent_log)
         if gateway_log:
             print(f"\n\n{'=' * 60}")
-            print("FULL gateway.log")
+            print("전체 gateway.log")
             print(f"{'=' * 60}\n")
             print(gateway_log)
         return
 
-    print("Uploading...")
+    print("업로드하는 중...")
     urls: dict[str, str] = {}
     failures: list[str] = []
 
@@ -325,12 +325,12 @@ def run_debug(args):
         run_debug_share(args)
     else:
         # Default: show help
-        print("Usage: hermes debug share [--lines N] [--expire N] [--local]")
+        print("사용법: hermes debug share [--lines N] [--expire N] [--local]")
         print()
-        print("Commands:")
-        print("  share    Upload debug report to a paste service and print URL")
+        print("명령어:")
+        print("  share    디버그 리포트를 paste 서비스에 업로드하고 URL 출력")
         print()
-        print("Options:")
-        print("  --lines N    Number of log lines to include (default: 200)")
-        print("  --expire N   Paste expiry in days (default: 7)")
-        print("  --local      Print report locally instead of uploading")
+        print("옵션:")
+        print("  --lines N    포함할 로그 줄 수(기본값: 200)")
+        print("  --expire N   paste 만료 기간(일, 기본값: 7)")
+        print("  --local      업로드 대신 로컬에 리포트 출력")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -181,32 +181,32 @@ def run_doctor(args):
     # Check: Python version
     # =========================================================================
     print()
-    print(color("◆ Python Environment", Colors.CYAN, Colors.BOLD))
+    print(color("◆ Python 환경", Colors.CYAN, Colors.BOLD))
     
     py_version = sys.version_info
     if py_version >= (3, 11):
         check_ok(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}")
     elif py_version >= (3, 10):
         check_ok(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}")
-        check_warn("Python 3.11+ recommended for RL Training tools (tinker requires >= 3.11)")
+        check_warn("RL 학습 도구에는 Python 3.11+를 권장해요 (tinker는 3.11 이상 필요)")
     elif py_version >= (3, 8):
-        check_warn(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}", "(3.10+ recommended)")
+        check_warn(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}", "(3.10+ 권장)")
     else:
-        check_fail(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}", "(3.10+ required)")
-        issues.append("Upgrade Python to 3.10+")
+        check_fail(f"Python {py_version.major}.{py_version.minor}.{py_version.micro}", "(3.10+ 필요)")
+        issues.append("Python을 3.10 이상으로 업그레이드하세요")
     
     # Check if in virtual environment
     in_venv = sys.prefix != sys.base_prefix
     if in_venv:
-        check_ok("Virtual environment active")
+        check_ok("가상환경 활성화됨")
     else:
-        check_warn("Not in virtual environment", "(recommended)")
+        check_warn("가상환경 안에서 실행 중이 아님", "(권장)")
     
     # =========================================================================
     # Check: Required packages
     # =========================================================================
     print()
-    print(color("◆ Required Packages", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 필수 패키지", Colors.CYAN, Colors.BOLD))
     
     required_packages = [
         ("openai", "OpenAI SDK"),
@@ -227,71 +227,71 @@ def run_doctor(args):
             __import__(module)
             check_ok(name)
         except ImportError:
-            check_fail(name, "(missing)")
-            issues.append(f"Install {name}: {_python_install_cmd()} {module}")
+            check_fail(name, "(없음)")
+            issues.append(f"{name} 설치: {_python_install_cmd()} {module}")
     
     for module, name in optional_packages:
         try:
             __import__(module)
-            check_ok(name, "(optional)")
+            check_ok(name, "(선택 사항)")
         except ImportError:
-            check_warn(name, "(optional, not installed)")
+            check_warn(name, "(선택 사항, 설치되지 않음)")
     
     # =========================================================================
     # Check: Configuration files
     # =========================================================================
     print()
-    print(color("◆ Configuration Files", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 설정 파일", Colors.CYAN, Colors.BOLD))
     
     # Check ~/.hermes/.env (primary location for user config)
     env_path = HERMES_HOME / '.env'
     if env_path.exists():
-        check_ok(f"{_DHH}/.env file exists")
+        check_ok(f"{_DHH}/.env 파일이 있어요")
         
         # Check for common issues
         content = env_path.read_text()
         if _has_provider_env_config(content):
-            check_ok("API key or custom endpoint configured")
+            check_ok("API key 또는 custom endpoint가 설정되어 있어요")
         else:
-            check_warn(f"No API key found in {_DHH}/.env")
-            issues.append("Run 'hermes setup' to configure API keys")
+            check_warn(f"{_DHH}/.env에서 API key를 찾지 못했어요")
+            issues.append("API key를 설정하려면 'hermes setup'을 실행하세요")
     else:
         # Also check project root as fallback
         fallback_env = PROJECT_ROOT / '.env'
         if fallback_env.exists():
-            check_ok(".env file exists (in project directory)")
+            check_ok("프로젝트 디렉터리에 .env 파일이 있어요")
         else:
-            check_fail(f"{_DHH}/.env file missing")
+            check_fail(f"{_DHH}/.env 파일이 없어요")
             if should_fix:
                 env_path.parent.mkdir(parents=True, exist_ok=True)
                 env_path.touch()
-                check_ok(f"Created empty {_DHH}/.env")
-                check_info("Run 'hermes setup' to configure API keys")
+                check_ok(f"비어 있는 {_DHH}/.env 파일을 만들었어요")
+                check_info("API key를 설정하려면 'hermes setup'을 실행하세요")
                 fixed_count += 1
             else:
-                check_info("Run 'hermes setup' to create one")
-                issues.append("Run 'hermes setup' to create .env")
+                check_info("만들려면 'hermes setup'을 실행하세요")
+                issues.append(".env를 만들려면 'hermes setup'을 실행하세요")
     
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'
     if config_path.exists():
-        check_ok(f"{_DHH}/config.yaml exists")
+        check_ok(f"{_DHH}/config.yaml 파일이 있어요")
     else:
         fallback_config = PROJECT_ROOT / 'cli-config.yaml'
         if fallback_config.exists():
-            check_ok("cli-config.yaml exists (in project directory)")
+            check_ok("프로젝트 디렉터리에 cli-config.yaml이 있어요")
         else:
             example_config = PROJECT_ROOT / 'cli-config.yaml.example'
             if should_fix and example_config.exists():
                 config_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(str(example_config), str(config_path))
-                check_ok(f"Created {_DHH}/config.yaml from cli-config.yaml.example")
+                check_ok(f"cli-config.yaml.example로 {_DHH}/config.yaml을 만들었어요")
                 fixed_count += 1
             elif should_fix:
-                check_warn("config.yaml not found and no example to copy from")
-                manual_issues.append(f"Create {_DHH}/config.yaml manually")
+                check_warn("config.yaml이 없고 복사할 예제 파일도 없어요")
+                manual_issues.append(f"{_DHH}/config.yaml을 수동으로 만드세요")
             else:
-                check_warn("config.yaml not found", "(using defaults)")
+                check_warn("config.yaml이 없어요", "(기본값 사용 중)")
 
     # Check config version and stale keys
     config_path = HERMES_HOME / 'config.yaml'
@@ -301,21 +301,21 @@ def run_doctor(args):
             current_ver, latest_ver = check_config_version()
             if current_ver < latest_ver:
                 check_warn(
-                    f"Config version outdated (v{current_ver} → v{latest_ver})",
-                    "(new settings available)"
+                    f"설정 버전이 오래됐어요 (v{current_ver} → v{latest_ver})",
+                    "(새 설정을 사용할 수 있어요)"
                 )
                 if should_fix:
                     try:
                         migrate_config(interactive=False, quiet=False)
-                        check_ok("Config migrated to latest version")
+                        check_ok("설정을 최신 버전으로 마이그레이션했어요")
                         fixed_count += 1
                     except Exception as mig_err:
-                        check_warn(f"Auto-migration failed: {mig_err}")
-                        issues.append("Run 'hermes setup' to migrate config")
+                        check_warn(f"자동 마이그레이션에 실패했어요: {mig_err}")
+                        issues.append("설정을 마이그레이션하려면 'hermes setup'을 실행하세요")
                 else:
-                    issues.append("Run 'hermes doctor --fix' or 'hermes setup' to migrate config")
+                    issues.append("설정을 마이그레이션하려면 'hermes doctor --fix' 또는 'hermes setup'을 실행하세요")
             else:
-                check_ok(f"Config version up to date (v{current_ver})")
+                check_ok(f"설정 버전이 최신이에요 (v{current_ver})")
         except Exception:
             pass
 
@@ -327,8 +327,8 @@ def run_doctor(args):
             stale_root_keys = [k for k in ("provider", "base_url") if k in raw_config and isinstance(raw_config[k], str)]
             if stale_root_keys:
                 check_warn(
-                    f"Stale root-level config keys: {', '.join(stale_root_keys)}",
-                    "(should be under 'model:' section)"
+                    f"루트 레벨의 오래된 설정 키가 있어요: {', '.join(stale_root_keys)}",
+                    "('model:' 섹션 아래에 있어야 해요)"
                 )
                 if should_fix:
                     model_section = raw_config.setdefault("model", {})
@@ -339,10 +339,10 @@ def run_doctor(args):
                             raw_config.pop(k)
                     from utils import atomic_yaml_write
                     atomic_yaml_write(config_path, raw_config)
-                    check_ok("Migrated stale root-level keys into model section")
+                    check_ok("오래된 루트 레벨 키를 model 섹션으로 옮겼어요")
                     fixed_count += 1
                 else:
-                    issues.append("Stale root-level provider/base_url in config.yaml — run 'hermes doctor --fix'")
+                    issues.append("config.yaml에 오래된 루트 레벨 provider/base_url이 있어요 — 'hermes doctor --fix'를 실행하세요")
         except Exception:
             pass
 
@@ -352,7 +352,7 @@ def run_doctor(args):
             config_issues = validate_config_structure()
             if config_issues:
                 print()
-                print(color("◆ Config Structure", Colors.CYAN, Colors.BOLD))
+                print(color("◆ 설정 구조", Colors.CYAN, Colors.BOLD))
                 for ci in config_issues:
                     if ci.severity == "error":
                         check_fail(ci.message)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -369,62 +369,63 @@ def run_doctor(args):
     # Check: Auth providers
     # =========================================================================
     print()
-    print(color("◆ Auth Providers", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 인증 provider", Colors.CYAN, Colors.BOLD))
 
     try:
         from hermes_cli.auth import get_nous_auth_status, get_codex_auth_status
 
         nous_status = get_nous_auth_status()
         if nous_status.get("logged_in"):
-            check_ok("Nous Portal auth", "(logged in)")
+            check_ok("Nous Portal 인증", "(로그인됨)")
         else:
-            check_warn("Nous Portal auth", "(not logged in)")
+            check_warn("Nous Portal 인증", "(로그인 안 됨)")
 
         codex_status = get_codex_auth_status()
         if codex_status.get("logged_in"):
-            check_ok("OpenAI Codex auth", "(logged in)")
+            check_ok("OpenAI Codex 인증", "(로그인됨)")
         else:
-            check_warn("OpenAI Codex auth", "(not logged in)")
+            check_warn("OpenAI Codex 인증", "(로그인 안 됨)")
             if codex_status.get("error"):
                 check_info(codex_status["error"])
     except Exception as e:
-        check_warn("Auth provider status", f"(could not check: {e})")
+        check_warn("인증 provider 상태", f"(확인하지 못했어요: {e})")
 
     if shutil.which("codex"):
         check_ok("codex CLI")
     else:
-        check_warn("codex CLI not found", "(required for openai-codex login)")
+        check_warn("codex CLI를 찾지 못했어요", "(openai-codex 로그인에 필요)"
+        )
 
     # =========================================================================
     # Check: Directory structure
     # =========================================================================
     print()
-    print(color("◆ Directory Structure", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 디렉터리 구조", Colors.CYAN, Colors.BOLD))
     
     hermes_home = HERMES_HOME
     if hermes_home.exists():
-        check_ok(f"{_DHH} directory exists")
+        check_ok(f"{_DHH} 디렉터리가 있어요")
     else:
         if should_fix:
             hermes_home.mkdir(parents=True, exist_ok=True)
-            check_ok(f"Created {_DHH} directory")
+            check_ok(f"{_DHH} 디렉터리를 만들었어요")
             fixed_count += 1
         else:
-            check_warn(f"{_DHH} not found", "(will be created on first use)")
+            check_warn(f"{_DHH}를 찾지 못했어요", "(처음 사용할 때 만들어져요)")
     
     # Check expected subdirectories
     expected_subdirs = ["cron", "sessions", "logs", "skills", "memories"]
     for subdir_name in expected_subdirs:
         subdir_path = hermes_home / subdir_name
         if subdir_path.exists():
-            check_ok(f"{_DHH}/{subdir_name}/ exists")
+            check_ok(f"{_DHH}/{subdir_name}/ 디렉터리가 있어요")
         else:
             if should_fix:
                 subdir_path.mkdir(parents=True, exist_ok=True)
-                check_ok(f"Created {_DHH}/{subdir_name}/")
+                check_ok(f"{_DHH}/{subdir_name}/ 디렉터리를 만들었어요")
                 fixed_count += 1
             else:
-                check_warn(f"{_DHH}/{subdir_name}/ not found", "(will be created on first use)")
+                check_warn(f"{_DHH}/{subdir_name}/를 찾지 못했어요", "(처음 사용할 때 만들어져요)")
     
     # Check for SOUL.md persona file
     soul_path = hermes_home / "SOUL.md"
@@ -433,11 +434,11 @@ def run_doctor(args):
         # Check if it's just the template comments (no real content)
         lines = [l for l in content.splitlines() if l.strip() and not l.strip().startswith(("<!--", "-->", "#"))]
         if lines:
-            check_ok(f"{_DHH}/SOUL.md exists (persona configured)")
+            check_ok(f"{_DHH}/SOUL.md가 있어요 (persona 설정됨)")
         else:
-            check_info(f"{_DHH}/SOUL.md exists but is empty — edit it to customize personality")
+            check_info(f"{_DHH}/SOUL.md는 있지만 비어 있어요 — 수정해서 personality를 커스터마이즈하세요")
     else:
-        check_warn(f"{_DHH}/SOUL.md not found", "(create it to give Hermes a custom personality)")
+        check_warn(f"{_DHH}/SOUL.md를 찾지 못했어요", "(Hermes에 custom personality를 주려면 만들어 주세요)")
         if should_fix:
             soul_path.parent.mkdir(parents=True, exist_ok=True)
             soul_path.write_text(
@@ -446,30 +447,30 @@ def run_doctor(args):
                 "You are Hermes, a helpful AI assistant.\n",
                 encoding="utf-8",
             )
-            check_ok(f"Created {_DHH}/SOUL.md with basic template")
+            check_ok(f"기본 템플릿으로 {_DHH}/SOUL.md를 만들었어요")
             fixed_count += 1
     
     # Check memory directory
     memories_dir = hermes_home / "memories"
     if memories_dir.exists():
-        check_ok(f"{_DHH}/memories/ directory exists")
+        check_ok(f"{_DHH}/memories/ 디렉터리가 있어요")
         memory_file = memories_dir / "MEMORY.md"
         user_file = memories_dir / "USER.md"
         if memory_file.exists():
             size = len(memory_file.read_text(encoding="utf-8").strip())
-            check_ok(f"MEMORY.md exists ({size} chars)")
+            check_ok(f"MEMORY.md가 있어요 ({size}자)")
         else:
-            check_info("MEMORY.md not created yet (will be created when the agent first writes a memory)")
+            check_info("MEMORY.md는 아직 없어요 (에이전트가 처음 memory를 쓸 때 만들어져요)")
         if user_file.exists():
             size = len(user_file.read_text(encoding="utf-8").strip())
-            check_ok(f"USER.md exists ({size} chars)")
+            check_ok(f"USER.md가 있어요 ({size}자)")
         else:
-            check_info("USER.md not created yet (will be created when the agent first writes a memory)")
+            check_info("USER.md는 아직 없어요 (에이전트가 처음 memory를 쓸 때 만들어져요)")
     else:
-        check_warn(f"{_DHH}/memories/ not found", "(will be created on first use)")
+        check_warn(f"{_DHH}/memories/를 찾지 못했어요", "(처음 사용할 때 만들어져요)")
         if should_fix:
             memories_dir.mkdir(parents=True, exist_ok=True)
-            check_ok(f"Created {_DHH}/memories/")
+            check_ok(f"{_DHH}/memories/ 디렉터리를 만들었어요")
             fixed_count += 1
     
     # Check SQLite session store
@@ -481,11 +482,11 @@ def run_doctor(args):
             cursor = conn.execute("SELECT COUNT(*) FROM sessions")
             count = cursor.fetchone()[0]
             conn.close()
-            check_ok(f"{_DHH}/state.db exists ({count} sessions)")
+            check_ok(f"{_DHH}/state.db가 있어요 ({count}개 세션)")
         except Exception as e:
-            check_warn(f"{_DHH}/state.db exists but has issues: {e}")
+            check_warn(f"{_DHH}/state.db는 있지만 문제가 있어요: {e}")
     else:
-        check_info(f"{_DHH}/state.db not created yet (will be created on first session)")
+        check_info(f"{_DHH}/state.db는 아직 없어요 (첫 세션에서 만들어져요)")
 
     # Check WAL file size (unbounded growth indicates missed checkpoints)
     wal_path = hermes_home / "state.db-wal"
@@ -494,8 +495,8 @@ def run_doctor(args):
             wal_size = wal_path.stat().st_size
             if wal_size > 50 * 1024 * 1024:  # 50 MB
                 check_warn(
-                    f"WAL file is large ({wal_size // (1024*1024)} MB)",
-                    "(may indicate missed checkpoints)"
+                    f"WAL 파일이 커요 ({wal_size // (1024*1024)} MB)",
+                    "(체크포인트를 놓쳤을 수 있어요)"
                 )
                 if should_fix:
                     import sqlite3
@@ -503,12 +504,12 @@ def run_doctor(args):
                     conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
                     conn.close()
                     new_size = wal_path.stat().st_size if wal_path.exists() else 0
-                    check_ok(f"WAL checkpoint performed ({wal_size // 1024}K → {new_size // 1024}K)")
+                    check_ok(f"WAL 체크포인트를 수행했어요 ({wal_size // 1024}K → {new_size // 1024}K)")
                     fixed_count += 1
                 else:
-                    issues.append("Large WAL file — run 'hermes doctor --fix' to checkpoint")
+                    issues.append("WAL 파일이 커요 — 체크포인트를 수행하려면 'hermes doctor --fix'를 실행하세요")
             elif wal_size > 10 * 1024 * 1024:  # 10 MB
-                check_info(f"WAL file is {wal_size // (1024*1024)} MB (normal for active sessions)")
+                check_info(f"WAL 파일 크기는 {wal_size // (1024*1024)} MB예요 (활성 세션에서는 정상일 수 있어요)")
         except Exception:
             pass
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -136,7 +136,7 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
             is_linux,
         )
     except Exception as e:
-        check_warn("Gateway service linger", f"(could not import gateway helpers: {e})")
+        check_warn("Gateway 서비스 linger", f"(gateway helper를 불러오지 못했어요: {e})")
         return
 
     if not is_linux():
@@ -147,17 +147,17 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         return
 
     print()
-    print(color("◆ Gateway Service", Colors.CYAN, Colors.BOLD))
+    print(color("◆ Gateway 서비스", Colors.CYAN, Colors.BOLD))
 
     linger_enabled, linger_detail = get_systemd_linger_status()
     if linger_enabled is True:
-        check_ok("Systemd linger enabled", "(gateway service survives logout)")
+        check_ok("Systemd linger 활성화됨", "(로그아웃 후에도 gateway 서비스가 유지됨)")
     elif linger_enabled is False:
-        check_warn("Systemd linger disabled", "(gateway may stop after logout)")
-        check_info("Run: sudo loginctl enable-linger $USER")
+        check_warn("Systemd linger 비활성화됨", "(로그아웃 후 gateway가 중지될 수 있어요)")
+        check_info("실행: sudo loginctl enable-linger $USER")
         issues.append("Enable linger for the gateway user service: sudo loginctl enable-linger $USER")
     else:
-        check_warn("Could not verify systemd linger", f"({linger_detail})")
+        check_warn("Systemd linger 상태를 확인하지 못했어요", f"({linger_detail})")
 
 
 def run_doctor(args):

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -519,20 +519,20 @@ def run_doctor(args):
     # Check: External tools
     # =========================================================================
     print()
-    print(color("◆ External Tools", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 외부 도구", Colors.CYAN, Colors.BOLD))
     
     # Git
     if shutil.which("git"):
         check_ok("git")
     else:
-        check_warn("git not found", "(optional)")
+        check_warn("git을 찾지 못했어요", "(선택 사항)")
     
     # ripgrep (optional, for faster file search)
     if shutil.which("rg"):
-        check_ok("ripgrep (rg)", "(faster file search)")
+        check_ok("ripgrep (rg)", "(더 빠른 파일 검색)")
     else:
-        check_warn("ripgrep (rg) not found", "(file search uses grep fallback)")
-        check_info(f"Install for faster search: {_system_package_install_cmd('ripgrep')}")
+        check_warn("ripgrep (rg)를 찾지 못했어요", "(파일 검색은 grep 대체 경로를 사용해요)")
+        check_info(f"더 빠른 검색을 위해 설치하세요: {_system_package_install_cmd('ripgrep')}")
     
     # Docker (optional)
     terminal_env = os.getenv("TERMINAL_ENV", "local")
@@ -544,21 +544,22 @@ def run_doctor(args):
             except subprocess.TimeoutExpired:
                 result = None
             if result is not None and result.returncode == 0:
-                check_ok("docker", "(daemon running)")
+                check_ok("docker", "(daemon 실행 중)")
             else:
-                check_fail("docker daemon not running")
-                issues.append("Start Docker daemon")
+                check_fail("docker daemon이 실행 중이 아니에요")
+                issues.append("Docker daemon을 시작하세요")
         else:
-            check_fail("docker not found", "(required for TERMINAL_ENV=docker)")
-            issues.append("Install Docker or change TERMINAL_ENV")
+            check_fail("docker를 찾지 못했어요", "(TERMINAL_ENV=docker 에 필요)"
+            )
+            issues.append("Docker를 설치하거나 TERMINAL_ENV를 변경하세요")
     else:
         if shutil.which("docker"):
             check_ok("docker", "(optional)")
         else:
             if _is_termux():
-                check_info("Docker backend is not available inside Termux (expected on Android)")
+                check_info("Termux 내부에서는 Docker 백엔드를 사용할 수 없어요 (Android에서는 정상이에요)")
             else:
-                check_warn("docker not found", "(optional)")
+                check_warn("docker를 찾지 못했어요", "(선택 사항)")
     
     # SSH (if using ssh backend)
     if terminal_env == "ssh":
@@ -575,28 +576,30 @@ def run_doctor(args):
             except subprocess.TimeoutExpired:
                 result = None
             if result is not None and result.returncode == 0:
-                check_ok(f"SSH connection to {ssh_host}")
+                check_ok(f"{ssh_host}에 SSH 연결 가능")
             else:
-                check_fail(f"SSH connection to {ssh_host}")
-                issues.append(f"Check SSH configuration for {ssh_host}")
+                check_fail(f"{ssh_host}에 SSH 연결할 수 없어요")
+                issues.append(f"{ssh_host}의 SSH 설정을 확인하세요")
         else:
-            check_fail("TERMINAL_SSH_HOST not set", "(required for TERMINAL_ENV=ssh)")
-            issues.append("Set TERMINAL_SSH_HOST in .env")
+            check_fail("TERMINAL_SSH_HOST가 설정되지 않았어요", "(TERMINAL_ENV=ssh 에 필요)"
+            )
+            issues.append(".env에 TERMINAL_SSH_HOST를 설정하세요")
     
     # Daytona (if using daytona backend)
     if terminal_env == "daytona":
         daytona_key = os.getenv("DAYTONA_API_KEY")
         if daytona_key:
-            check_ok("Daytona API key", "(configured)")
+            check_ok("Daytona API key", "(설정됨)")
         else:
-            check_fail("DAYTONA_API_KEY not set", "(required for TERMINAL_ENV=daytona)")
-            issues.append("Set DAYTONA_API_KEY environment variable")
+            check_fail("DAYTONA_API_KEY가 설정되지 않았어요", "(TERMINAL_ENV=daytona 에 필요)"
+            )
+            issues.append("DAYTONA_API_KEY 환경 변수를 설정하세요")
         try:
             from daytona import Daytona  # noqa: F401 — SDK presence check
-            check_ok("daytona SDK", "(installed)")
+            check_ok("daytona SDK", "(설치됨)")
         except ImportError:
-            check_fail("daytona SDK not installed", "(pip install daytona)")
-            issues.append("Install daytona SDK: pip install daytona")
+            check_fail("daytona SDK가 설치되지 않았어요", "(pip install daytona)")
+            issues.append("daytona SDK를 설치하세요: pip install daytona")
 
     # Node.js + agent-browser (for browser automation tools)
     if shutil.which("node"):
@@ -604,25 +607,25 @@ def run_doctor(args):
         # Check if agent-browser is installed
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
         if agent_browser_path.exists():
-            check_ok("agent-browser (Node.js)", "(browser automation)")
+            check_ok("agent-browser (Node.js)", "(브라우저 자동화)")
         else:
             if _is_termux():
-                check_info("agent-browser is not installed (expected in the tested Termux path)")
-                check_info("Install it manually later with: npm install -g agent-browser && agent-browser install")
-                check_info("Termux browser setup:")
+                check_info("agent-browser가 설치되지 않았어요 (테스트된 Termux 경로에서는 정상이에요)")
+                check_info("나중에 수동으로 설치하세요: npm install -g agent-browser && agent-browser install")
+                check_info("Termux 브라우저 설정:")
                 for step in _termux_browser_setup_steps(node_installed=True):
                     check_info(step)
             else:
-                check_warn("agent-browser not installed", "(run: npm install)")
+                check_warn("agent-browser가 설치되지 않았어요", "(실행: npm install)")
     else:
         if _is_termux():
-            check_info("Node.js not found (browser tools are optional in the tested Termux path)")
-            check_info("Install Node.js on Termux with: pkg install nodejs")
-            check_info("Termux browser setup:")
+            check_info("Node.js를 찾지 못했어요 (테스트된 Termux 경로에서는 브라우저 도구가 선택 사항이에요)")
+            check_info("Termux에서 Node.js 설치: pkg install nodejs")
+            check_info("Termux 브라우저 설정:")
             for step in _termux_browser_setup_steps(node_installed=False):
                 check_info(step)
         else:
-            check_warn("Node.js not found", "(optional, needed for browser tools)")
+            check_warn("Node.js를 찾지 못했어요", "(선택 사항, 브라우저 도구에 필요)")
     
     # npm audit for all Node.js packages
     if shutil.which("npm"):
@@ -647,15 +650,15 @@ def run_doctor(args):
                 moderate = vuln_count.get("moderate", 0)
                 total = critical + high + moderate
                 if total == 0:
-                    check_ok(f"{label} deps", "(no known vulnerabilities)")
+                    check_ok(f"{label} 의존성", "(알려진 취약점 없음)")
                 elif critical > 0 or high > 0:
                     check_warn(
-                        f"{label} deps",
-                        f"({critical} critical, {high} high, {moderate} moderate — run: cd {npm_dir} && npm audit fix)"
+                        f"{label} 의존성",
+                        f"(critical {critical}, high {high}, moderate {moderate} — 실행: cd {npm_dir} && npm audit fix)"
                     )
-                    issues.append(f"{label} has {total} npm vulnerability(ies)")
+                    issues.append(f"{label}에 npm 취약점 {total}개가 있어요")
                 else:
-                    check_ok(f"{label} deps", f"({moderate} moderate vulnerability(ies))")
+                    check_ok(f"{label} 의존성", f"(moderate 취약점 {moderate}개)")
             except Exception:
                 pass
 
@@ -663,11 +666,11 @@ def run_doctor(args):
     # Check: API connectivity
     # =========================================================================
     print()
-    print(color("◆ API Connectivity", Colors.CYAN, Colors.BOLD))
+    print(color("◆ API 연결 상태", Colors.CYAN, Colors.BOLD))
     
     openrouter_key = os.getenv("OPENROUTER_API_KEY")
     if openrouter_key:
-        print("  Checking OpenRouter API...", end="", flush=True)
+        print("  OpenRouter API 확인 중...", end="", flush=True)
         try:
             import httpx
             response = httpx.get(
@@ -679,19 +682,19 @@ def run_doctor(args):
                 print(f"\r  {color('✓', Colors.GREEN)} OpenRouter API                          ")
             elif response.status_code == 401:
                 print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(invalid API key)', Colors.DIM)}                ")
-                issues.append("Check OPENROUTER_API_KEY in .env")
+                issues.append(".env의 OPENROUTER_API_KEY를 확인하세요")
             else:
                 print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'(HTTP {response.status_code})', Colors.DIM)}                ")
         except Exception as e:
             print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'({e})', Colors.DIM)}                ")
-            issues.append("Check network connectivity")
+            issues.append("네트워크 연결 상태를 확인하세요")
     else:
-        check_warn("OpenRouter API", "(not configured)")
+        check_warn("OpenRouter API", "(설정되지 않음)")
     
     from hermes_cli.auth import get_anthropic_key
     anthropic_key = get_anthropic_key()
     if anthropic_key:
-        print("  Checking Anthropic API...", end="", flush=True)
+        print("  Anthropic API 확인 중...", end="", flush=True)
         try:
             import httpx
             from agent.anthropic_adapter import _is_oauth_token, _COMMON_BETAS, _OAUTH_ONLY_BETAS
@@ -746,9 +749,9 @@ def run_doctor(args):
             _label = _pname.ljust(20)
             # Some providers (like MiniMax) don't support /models endpoint
             if not _supports_health_check:
-                print(f"  {color('✓', Colors.GREEN)} {_label} {color('(key configured)', Colors.DIM)}")
+                print(f"  {color('✓', Colors.GREEN)} {_label} {color('(key 설정됨)', Colors.DIM)}")
                 continue
-            print(f"  Checking {_pname} API...", end="", flush=True)
+            print(f"  {_pname} API 확인 중...", end="", flush=True)
             try:
                 import httpx
                 _base = os.getenv(_base_env, "") if _base_env else ""
@@ -773,7 +776,7 @@ def run_doctor(args):
                     print(f"\r  {color('✓', Colors.GREEN)} {_label}                          ")
                 elif _resp.status_code == 401:
                     print(f"\r  {color('✗', Colors.RED)} {_label} {color('(invalid API key)', Colors.DIM)}           ")
-                    issues.append(f"Check {_env_vars[0]} in .env")
+                    issues.append(f".env의 {_env_vars[0]} 값을 확인하세요")
                 else:
                     print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'(HTTP {_resp.status_code})', Colors.DIM)}           ")
             except Exception as _e:
@@ -783,7 +786,7 @@ def run_doctor(args):
     # Check: Submodules
     # =========================================================================
     print()
-    print(color("◆ Submodules", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 서브모듈", Colors.CYAN, Colors.BOLD))
     
     # tinker-atropos (RL training backend)
     tinker_dir = PROJECT_ROOT / "tinker-atropos"
@@ -791,21 +794,21 @@ def run_doctor(args):
         if py_version >= (3, 11):
             try:
                 __import__("tinker_atropos")
-                check_ok("tinker-atropos", "(RL training backend)")
+                check_ok("tinker-atropos", "(RL 학습 백엔드)")
             except ImportError:
                 install_cmd = f"{_python_install_cmd()} -e ./tinker-atropos"
-                check_warn("tinker-atropos found but not installed", f"(run: {install_cmd})")
-                issues.append(f"Install tinker-atropos: {install_cmd}")
+                check_warn("tinker-atropos는 있지만 설치되지 않았어요", f"(실행: {install_cmd})")
+                issues.append(f"tinker-atropos를 설치하세요: {install_cmd}")
         else:
-            check_warn("tinker-atropos requires Python 3.11+", f"(current: {py_version.major}.{py_version.minor})")
+            check_warn("tinker-atropos는 Python 3.11+가 필요해요", f"(현재: {py_version.major}.{py_version.minor})")
     else:
-        check_warn("tinker-atropos not found", "(run: git submodule update --init --recursive)")
+        check_warn("tinker-atropos를 찾지 못했어요", "(실행: git submodule update --init --recursive)")
     
     # =========================================================================
     # Check: Tool Availability
     # =========================================================================
     print()
-    print(color("◆ Tool Availability", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 도구 사용 가능 여부", Colors.CYAN, Colors.BOLD))
     
     try:
         # Add project root to path for imports
@@ -823,16 +826,16 @@ def run_doctor(args):
             env_vars = item.get("missing_vars") or item.get("env_vars") or []
             if env_vars:
                 vars_str = ", ".join(env_vars)
-                check_warn(item["name"], f"(missing {vars_str})")
+                check_warn(item["name"], f"({vars_str} 누락)")
             else:
-                check_warn(item["name"], "(system dependency not met)")
+                check_warn(item["name"], "(시스템 의존성을 충족하지 못함)")
 
         # Count disabled tools with API key requirements
         api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
         if api_disabled:
-            issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
+            issues.append("전체 도구 접근을 위해 누락된 API key를 설정하려면 'hermes setup'을 실행하세요")
     except Exception as e:
-        check_warn("Could not check tool availability", f"({e})")
+        check_warn("도구 사용 가능 여부를 확인하지 못했어요", f"({e})")
     
     # =========================================================================
     # Check: Skills Hub
@@ -842,35 +845,35 @@ def run_doctor(args):
 
     hub_dir = HERMES_HOME / "skills" / ".hub"
     if hub_dir.exists():
-        check_ok("Skills Hub directory exists")
+        check_ok("Skills Hub 디렉터리가 있어요")
         lock_file = hub_dir / "lock.json"
         if lock_file.exists():
             try:
                 import json
                 lock_data = json.loads(lock_file.read_text())
                 count = len(lock_data.get("installed", {}))
-                check_ok(f"Lock file OK ({count} hub-installed skill(s))")
+                check_ok(f"Lock 파일이 정상이에요 ({count}개 hub 설치 스킬)")
             except Exception:
-                check_warn("Lock file", "(corrupted or unreadable)")
+                check_warn("Lock 파일", "(손상되었거나 읽을 수 없어요)")
         quarantine = hub_dir / "quarantine"
         q_count = sum(1 for d in quarantine.iterdir() if d.is_dir()) if quarantine.exists() else 0
         if q_count > 0:
-            check_warn(f"{q_count} skill(s) in quarantine", "(pending review)")
+            check_warn(f"격리된 스킬 {q_count}개", "(검토 대기 중)")
     else:
-        check_warn("Skills Hub directory not initialized", "(run: hermes skills list)")
+        check_warn("Skills Hub 디렉터리가 초기화되지 않았어요", "(실행: hermes skills list)")
 
     from hermes_cli.config import get_env_value
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")
     if github_token:
-        check_ok("GitHub token configured (authenticated API access)")
+        check_ok("GitHub token이 설정되어 있어요 (인증된 API 접근 가능)")
     else:
-        check_warn("No GITHUB_TOKEN", f"(60 req/hr rate limit — set in {_DHH}/.env for better rates)")
+        check_warn("GITHUB_TOKEN이 없어요", f"(시간당 60회 제한 — 더 높은 한도를 원하면 {_DHH}/.env에 설정하세요)")
 
     # =========================================================================
     # Memory Provider (only check the active provider, if any)
     # =========================================================================
     print()
-    print(color("◆ Memory Provider", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 메모리 provider", Colors.CYAN, Colors.BOLD))
 
     _active_memory_provider = ""
     try:
@@ -884,7 +887,7 @@ def run_doctor(args):
         pass
 
     if not _active_memory_provider:
-        check_ok("Built-in memory active", "(no external provider configured — this is fine)")
+        check_ok("내장 메모리 활성화됨", "(외부 provider가 설정되지 않았어도 정상이에요)")
     elif _active_memory_provider == "honcho":
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
@@ -892,58 +895,58 @@ def run_doctor(args):
             _honcho_cfg_path = resolve_config_path()
 
             if not _honcho_cfg_path.exists():
-                check_warn("Honcho config not found", "run: hermes memory setup")
+                check_warn("Honcho 설정을 찾지 못했어요", "실행: hermes memory setup")
             elif not hcfg.enabled:
-                check_info(f"Honcho disabled (set enabled: true in {_honcho_cfg_path} to activate)")
+                check_info(f"Honcho가 비활성화되어 있어요 ({_honcho_cfg_path}에서 enabled: true로 설정하면 활성화돼요)")
             elif not (hcfg.api_key or hcfg.base_url):
-                check_fail("Honcho API key or base URL not set", "run: hermes memory setup")
-                issues.append("No Honcho API key — run 'hermes memory setup'")
+                check_fail("Honcho API key 또는 base URL이 설정되지 않았어요", "실행: hermes memory setup")
+                issues.append("Honcho API key가 없어요 — 'hermes memory setup'을 실행하세요")
             else:
                 from plugins.memory.honcho.client import get_honcho_client, reset_honcho_client
                 reset_honcho_client()
                 try:
                     get_honcho_client(hcfg)
                     check_ok(
-                        "Honcho connected",
+                        "Honcho 연결됨",
                         f"workspace={hcfg.workspace_id} mode={hcfg.recall_mode} freq={hcfg.write_frequency}",
                     )
                 except Exception as _e:
-                    check_fail("Honcho connection failed", str(_e))
-                    issues.append(f"Honcho unreachable: {_e}")
+                    check_fail("Honcho 연결에 실패했어요", str(_e))
+                    issues.append(f"Honcho에 연결할 수 없어요: {_e}")
         except ImportError:
-            check_fail("honcho-ai not installed", "pip install honcho-ai")
-            issues.append("Honcho is set as memory provider but honcho-ai is not installed")
+            check_fail("honcho-ai가 설치되지 않았어요", "pip install honcho-ai")
+            issues.append("메모리 provider가 Honcho로 설정되어 있지만 honcho-ai가 설치되지 않았어요")
         except Exception as _e:
-            check_warn("Honcho check failed", str(_e))
+            check_warn("Honcho 점검에 실패했어요", str(_e))
     elif _active_memory_provider == "mem0":
         try:
             from plugins.memory.mem0 import _load_config as _load_mem0_config
             mem0_cfg = _load_mem0_config()
             mem0_key = mem0_cfg.get("api_key", "")
             if mem0_key:
-                check_ok("Mem0 API key configured")
+                check_ok("Mem0 API key가 설정되어 있어요")
                 check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
             else:
-                check_fail("Mem0 API key not set", "(set MEM0_API_KEY in .env or run hermes memory setup)")
-                issues.append("Mem0 is set as memory provider but API key is missing")
+                check_fail("Mem0 API key가 설정되지 않았어요", "(.env에 MEM0_API_KEY를 설정하거나 hermes memory setup 실행)")
+                issues.append("메모리 provider가 Mem0로 설정되어 있지만 API key가 없어요")
         except ImportError:
-            check_fail("Mem0 plugin not loadable", "pip install mem0ai")
-            issues.append("Mem0 is set as memory provider but mem0ai is not installed")
+            check_fail("Mem0 플러그인을 불러올 수 없어요", "pip install mem0ai")
+            issues.append("메모리 provider가 Mem0로 설정되어 있지만 mem0ai가 설치되지 않았어요")
         except Exception as _e:
-            check_warn("Mem0 check failed", str(_e))
+            check_warn("Mem0 점검에 실패했어요", str(_e))
     else:
         # Generic check for other memory providers (openviking, hindsight, etc.)
         try:
             from plugins.memory import load_memory_provider
             _provider = load_memory_provider(_active_memory_provider)
             if _provider and _provider.is_available():
-                check_ok(f"{_active_memory_provider} provider active")
+                check_ok(f"{_active_memory_provider} provider 활성화됨")
             elif _provider:
-                check_warn(f"{_active_memory_provider} configured but not available", "run: hermes memory status")
+                check_warn(f"{_active_memory_provider}가 설정되어 있지만 사용할 수 없어요", "실행: hermes memory status")
             else:
-                check_warn(f"{_active_memory_provider} plugin not found", "run: hermes memory setup")
+                check_warn(f"{_active_memory_provider} 플러그인을 찾지 못했어요", "실행: hermes memory setup")
         except Exception as _e:
-            check_warn(f"{_active_memory_provider} check failed", str(_e))
+            check_warn(f"{_active_memory_provider} 점검에 실패했어요", str(_e))
 
     # =========================================================================
     # Profiles
@@ -955,23 +958,23 @@ def run_doctor(args):
         named_profiles = [p for p in list_profiles() if not p.is_default]
         if named_profiles:
             print()
-            print(color("◆ Profiles", Colors.CYAN, Colors.BOLD))
-            check_ok(f"{len(named_profiles)} profile(s) found")
+            print(color("◆ 프로필", Colors.CYAN, Colors.BOLD))
+            check_ok(f"프로필 {len(named_profiles)}개를 찾았어요")
             wrapper_dir = _get_wrapper_dir()
             for p in named_profiles:
                 parts = []
                 if p.gateway_running:
-                    parts.append("gateway running")
+                    parts.append("gateway 실행 중")
                 if p.model:
                     parts.append(p.model[:30])
                 if not (p.path / "config.yaml").exists():
-                    parts.append("⚠ missing config")
+                    parts.append("⚠ config 없음")
                 if not (p.path / ".env").exists():
-                    parts.append("no .env")
+                    parts.append(".env 없음")
                 wrapper = wrapper_dir / p.name
                 if not wrapper.exists():
-                    parts.append("no alias")
-                status = ", ".join(parts) if parts else "configured"
+                    parts.append("별칭 없음")
+                status = ", ".join(parts) if parts else "설정됨"
                 check_ok(f"  {p.name}: {status}")
 
             # Check for orphan wrappers
@@ -984,7 +987,7 @@ def run_doctor(args):
                         if "hermes -p" in content:
                             _m = _re.search(r"hermes -p (\S+)", content)
                             if _m and not profile_exists(_m.group(1)):
-                                check_warn(f"Orphan alias: {wrapper.name} → profile '{_m.group(1)}' no longer exists")
+                                check_warn(f"고아 alias: {wrapper.name} → profile '{_m.group(1)}' 이(가) 더 이상 없어요")
                     except Exception:
                         pass
     except ImportError:
@@ -999,9 +1002,9 @@ def run_doctor(args):
     remaining_issues = issues + manual_issues
     if should_fix and fixed_count > 0:
         print(color("─" * 60, Colors.GREEN))
-        print(color(f"  Fixed {fixed_count} issue(s).", Colors.GREEN, Colors.BOLD), end="")
+        print(color(f"  문제 {fixed_count}개를 수정했어요.", Colors.GREEN, Colors.BOLD), end="")
         if remaining_issues:
-            print(color(f" {len(remaining_issues)} issue(s) require manual intervention.", Colors.YELLOW, Colors.BOLD))
+            print(color(f" 수동 조치가 필요한 문제 {len(remaining_issues)}개가 남아 있어요.", Colors.YELLOW, Colors.BOLD))
         else:
             print()
         print()
@@ -1011,15 +1014,15 @@ def run_doctor(args):
             print()
     elif remaining_issues:
         print(color("─" * 60, Colors.YELLOW))
-        print(color(f"  Found {len(remaining_issues)} issue(s) to address:", Colors.YELLOW, Colors.BOLD))
+        print(color(f"  해결이 필요한 문제 {len(remaining_issues)}개를 찾았어요:", Colors.YELLOW, Colors.BOLD))
         print()
         for i, issue in enumerate(remaining_issues, 1):
             print(f"  {i}. {issue}")
         print()
         if not should_fix:
-            print(color("  Tip: run 'hermes doctor --fix' to auto-fix what's possible.", Colors.DIM))
+            print(color("  팁: 자동으로 고칠 수 있는 항목은 'hermes doctor --fix'를 실행하세요.", Colors.DIM))
     else:
         print(color("─" * 60, Colors.GREEN))
-        print(color("  All checks passed! 🎉", Colors.GREEN, Colors.BOLD))
+        print(color("  모든 점검을 통과했어요! 🎉", Colors.GREEN, Colors.BOLD))
     
     print()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -584,11 +584,11 @@ def _default_system_service_user() -> str | None:
 
 def prompt_linux_gateway_install_scope() -> str | None:
     choice = prompt_choice(
-        "  Choose how the gateway should run in the background:",
+        "  게이트웨이를 백그라운드에서 어떻게 실행할지 선택해 주세요:",
         [
-            "User service (no sudo; best for laptops/dev boxes; may need linger after logout)",
-            "System service (starts on boot; requires sudo; still runs as your user)",
-            "Skip service install for now",
+            "사용자 서비스 (sudo 불필요, 노트북/개발 환경에 적합, 로그아웃 후 linger 설정이 필요할 수 있음)",
+            "시스템 서비스 (부팅 시 시작, sudo 필요, 실제 실행은 현재 사용자 계정으로 진행)",
+            "지금은 서비스 설치 건너뛰기",
         ],
         default=0,
     )
@@ -603,12 +603,12 @@ def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, b
     if scope == "system":
         run_as_user = _default_system_service_user()
         if os.geteuid() != 0:
-            print_warning("  System service install requires sudo, so Hermes can't create it from this user session.")
+            print_warning("  시스템 서비스 설치에는 sudo가 필요해서, 현재 사용자 세션에서는 Hermes가 바로 생성할 수 없어요.")
             if run_as_user:
-                print_info(f"  After setup, run: sudo hermes gateway install --system --run-as-user {run_as_user}")
+                print_info(f"  설정이 끝난 뒤 다음 명령을 실행하세요: sudo hermes gateway install --system --run-as-user {run_as_user}")
             else:
-                print_info("  After setup, run: sudo hermes gateway install --system --run-as-user <your-user>")
-            print_info("  Then start it with: sudo hermes gateway start --system")
+                print_info("  설정이 끝난 뒤 다음 명령을 실행하세요: sudo hermes gateway install --system --run-as-user <your-user>")
+            print_info("  그다음 다음 명령으로 시작하세요: sudo hermes gateway start --system")
             return scope, False
 
         if not run_as_user:
@@ -617,7 +617,7 @@ def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, b
                 run_as_user = (run_as_user or "").strip()
                 if run_as_user:
                     break
-                print_error("  Enter a username.")
+                print_error("  사용자 이름을 입력해 주세요.")
 
         systemd_install(force=force, system=True, run_as_user=run_as_user)
         return scope, True
@@ -681,13 +681,13 @@ def print_systemd_linger_guidance() -> None:
     """Print the current linger status and the fix when it is disabled."""
     linger_enabled, linger_detail = get_systemd_linger_status()
     if linger_enabled is True:
-        print("✓ Systemd linger is enabled (service survives logout)")
+        print("✓ systemd linger가 활성화되어 있어요 (로그아웃 후에도 서비스가 유지돼요)")
     elif linger_enabled is False:
-        print("⚠ Systemd linger is disabled (gateway may stop when you log out)")
-        print("  Run: sudo loginctl enable-linger $USER")
+        print("⚠ systemd linger가 비활성화되어 있어요 (로그아웃하면 gateway가 멈출 수 있어요)")
+        print("  실행: sudo loginctl enable-linger $USER")
     else:
-        print(f"⚠ Could not verify systemd linger ({linger_detail})")
-        print("  If you want the gateway user service to survive logout, run:")
+        print(f"⚠ systemd linger 상태를 확인하지 못했어요 ({linger_detail})")
+        print("  로그아웃 후에도 gateway 사용자 서비스를 유지하려면 다음 명령을 실행하세요:")
         print("  sudo loginctl enable-linger $USER")
 
 def _launchd_user_home() -> Path:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -998,7 +998,7 @@ def _ensure_linger_enabled() -> None:
         _print_linger_enable_warning(username, linger_detail or "loginctl not found")
         return
 
-    print("Enabling linger so the gateway survives SSH logout...")
+    print("SSH 로그아웃 후에도 게이트웨이가 유지되도록 linger를 활성화하는 중...")
     try:
         result = subprocess.run(
             ["loginctl", "enable-linger", username],
@@ -1012,7 +1012,7 @@ def _ensure_linger_enabled() -> None:
         return
 
     if result.returncode == 0:
-        print("✓ Linger enabled — gateway will persist after logout")
+        print("✓ Linger를 활성화했어요 — 로그아웃 후에도 게이트웨이가 유지돼요")
         return
 
     detail = (result.stderr or result.stdout or f"exit {result.returncode}").strip()
@@ -1053,30 +1053,30 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
             _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
             print(f"✓ {_service_scope_label(system).capitalize()} service definition updated")
             return
-        print(f"Service already installed at: {unit_path}")
-        print("Use --force to reinstall")
+        print(f"서비스가 이미 설치되어 있어요: {unit_path}")
+        print("재설치하려면 --force 를 사용하세요")
         return
 
     unit_path.parent.mkdir(parents=True, exist_ok=True)
-    print(f"Installing {_service_scope_label(system)} systemd service to: {unit_path}")
+    print(f"{_service_scope_label(system)} systemd 서비스를 설치하는 중: {unit_path}")
     unit_path.write_text(generate_systemd_unit(system=system, run_as_user=run_as_user), encoding="utf-8")
 
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
 
     print()
-    print(f"✓ {_service_scope_label(system).capitalize()} service installed and enabled!")
+    print(f"✓ {_service_scope_label(system).capitalize()} 서비스를 설치하고 활성화했어요!")
     print()
-    print("Next steps:")
-    print(f"  {'sudo ' if system else ''}hermes gateway start{scope_flag}              # Start the service")
-    print(f"  {'sudo ' if system else ''}hermes gateway status{scope_flag}             # Check status")
-    print(f"  {'journalctl' if system else 'journalctl --user'} -u {get_service_name()} -f  # View logs")
+    print("다음 단계:")
+    print(f"  {'sudo ' if system else ''}hermes gateway start{scope_flag}              # 서비스 시작")
+    print(f"  {'sudo ' if system else ''}hermes gateway status{scope_flag}             # 상태 확인")
+    print(f"  {'journalctl' if system else 'journalctl --user'} -u {get_service_name()} -f  # 로그 보기")
     print()
 
     if system:
         configured_user = _read_systemd_user_from_unit(unit_path)
         if configured_user:
-            print(f"Configured to run as: {configured_user}")
+            print(f"실행 사용자: {configured_user}")
     else:
         _ensure_linger_enabled()
 
@@ -1094,10 +1094,10 @@ def systemd_uninstall(system: bool = False):
     unit_path = get_systemd_unit_path(system=system)
     if unit_path.exists():
         unit_path.unlink()
-        print(f"✓ Removed {unit_path}")
+        print(f"✓ 제거했어요: {unit_path}")
 
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
-    print(f"✓ {_service_scope_label(system).capitalize()} service uninstalled")
+    print(f"✓ {_service_scope_label(system).capitalize()} 서비스를 제거했어요")
 
 
 def systemd_start(system: bool = False):
@@ -1106,7 +1106,7 @@ def systemd_start(system: bool = False):
         _require_root_for_system_service("start")
     refresh_systemd_unit_if_needed(system=system)
     _run_systemctl(["start", get_service_name()], system=system, check=True, timeout=30)
-    print(f"✓ {_service_scope_label(system).capitalize()} service started")
+    print(f"✓ {_service_scope_label(system).capitalize()} 서비스를 시작했어요")
 
 
 
@@ -1115,7 +1115,7 @@ def systemd_stop(system: bool = False):
     if system:
         _require_root_for_system_service("stop")
     _run_systemctl(["stop", get_service_name()], system=system, check=True, timeout=90)
-    print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
+    print(f"✓ {_service_scope_label(system).capitalize()} 서비스를 중지했어요")
 
 
 
@@ -2824,7 +2824,7 @@ def gateway_setup():
                     print_info("  Run in foreground: hermes gateway run")
     else:
         print()
-        print_info("No platforms configured. Run 'hermes gateway setup' when ready.")
+        print_info("설정된 플랫폼이 없어요. 준비되면 'hermes gateway setup'를 실행하세요.")
 
     print()
 
@@ -2858,39 +2858,39 @@ def gateway_command(args):
         system = getattr(args, 'system', False)
         run_as_user = getattr(args, 'run_as_user', None)
         if is_termux():
-            print("Gateway service installation is not supported on Termux.")
-            print("Run manually: hermes gateway")
+            print("Termux에서는 게이트웨이 서비스를 설치할 수 없어요.")
+            print("수동 실행: hermes gateway")
             sys.exit(1)
         if supports_systemd_services():
             if is_wsl():
-                print_warning("WSL detected — systemd services may not survive WSL restarts.")
-                print_info("  Consider running in foreground instead: hermes gateway run")
-                print_info("  Or use tmux/screen for persistence: tmux new -s hermes 'hermes gateway run'")
+                print_warning("WSL이 감지되었어요 — systemd 서비스가 WSL 재시작 후 유지되지 않을 수 있어요.")
+                print_info("  대신 포그라운드 실행을 고려해 보세요: hermes gateway run")
+                print_info("  또는 tmux/screen으로 유지하세요: tmux new -s hermes 'hermes gateway run'")
                 print()
             systemd_install(force=force, system=system, run_as_user=run_as_user)
         elif is_macos():
             launchd_install(force)
         elif is_wsl():
-            print("WSL detected but systemd is not running.")
-            print("Either enable systemd (add systemd=true to /etc/wsl.conf and restart WSL)")
-            print("or run the gateway in foreground mode:")
+            print("WSL이 감지되었지만 systemd가 실행 중이 아니에요.")
+            print("systemd를 활성화(add systemd=true to /etc/wsl.conf 후 WSL 재시작)하거나")
+            print("게이트웨이를 포그라운드 모드로 실행하세요:")
             print()
-            print("  hermes gateway run                              # direct foreground")
-            print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
-            print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
+            print("  hermes gateway run                              # 직접 포그라운드 실행")
+            print("  tmux new -s hermes 'hermes gateway run'         # tmux로 유지")
+            print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # 백그라운드")
             sys.exit(1)
         elif is_container():
-            print("Service installation is not needed inside a Docker container.")
-            print("The container runtime is your service manager — use Docker restart policies instead:")
+            print("Docker 컨테이너 안에서는 서비스 설치가 필요하지 않아요.")
+            print("컨테이너 런타임이 서비스 관리자를 대신하므로 Docker 재시작 정책을 사용하세요:")
             print()
-            print("  docker run --restart unless-stopped ...   # auto-restart on crash/reboot")
-            print("  docker restart <container>                # manual restart")
+            print("  docker run --restart unless-stopped ...   # 크래시/재부팅 시 자동 재시작")
+            print("  docker restart <container>                # 수동 재시작")
             print()
-            print("To run the gateway: hermes gateway run")
+            print("게이트웨이 실행: hermes gateway run")
             sys.exit(0)
         else:
-            print("Service installation not supported on this platform.")
-            print("Run manually: hermes gateway run")
+            print("이 플랫폼에서는 서비스 설치를 지원하지 않아요.")
+            print("수동 실행: hermes gateway run")
             sys.exit(1)
     
     elif subcmd == "uninstall":
@@ -2899,55 +2899,55 @@ def gateway_command(args):
             return
         system = getattr(args, 'system', False)
         if is_termux():
-            print("Gateway service uninstall is not supported on Termux because there is no managed service to remove.")
-            print("Stop manual runs with: hermes gateway stop")
+            print("Termux에는 제거할 관리형 서비스가 없어서 게이트웨이 서비스 제거를 지원하지 않아요.")
+            print("수동 실행 중지: hermes gateway stop")
             sys.exit(1)
         if supports_systemd_services():
             systemd_uninstall(system=system)
         elif is_macos():
             launchd_uninstall()
         elif is_container():
-            print("Service uninstall is not applicable inside a Docker container.")
-            print("To stop the gateway, stop or remove the container:")
+            print("Docker 컨테이너 안에서는 서비스 제거가 해당되지 않아요.")
+            print("게이트웨이를 중지하려면 컨테이너를 중지하거나 제거하세요:")
             print()
             print("  docker stop <container>")
             print("  docker rm <container>")
             sys.exit(0)
         else:
-            print("Not supported on this platform.")
+            print("이 플랫폼에서는 지원하지 않아요.")
             sys.exit(1)
 
     elif subcmd == "start":
         system = getattr(args, 'system', False)
         if is_termux():
-            print("Gateway service start is not supported on Termux because there is no system service manager.")
-            print("Run manually: hermes gateway")
+            print("Termux에는 시스템 서비스 관리자가 없어서 게이트웨이 서비스 시작을 지원하지 않아요.")
+            print("수동 실행: hermes gateway")
             sys.exit(1)
         if supports_systemd_services():
             systemd_start(system=system)
         elif is_macos():
             launchd_start()
         elif is_wsl():
-            print("WSL detected but systemd is not available.")
-            print("Run the gateway in foreground mode instead:")
+            print("WSL이 감지되었지만 systemd를 사용할 수 없어요.")
+            print("대신 게이트웨이를 포그라운드 모드로 실행하세요:")
             print()
-            print("  hermes gateway run                              # direct foreground")
-            print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
-            print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
+            print("  hermes gateway run                              # 직접 포그라운드 실행")
+            print("  tmux new -s hermes 'hermes gateway run'         # tmux로 유지")
+            print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # 백그라운드")
             print()
-            print("To enable systemd: add systemd=true to /etc/wsl.conf and run 'wsl --shutdown' from PowerShell.")
+            print("systemd를 활성화하려면 /etc/wsl.conf 에 systemd=true 를 추가하고 PowerShell에서 'wsl --shutdown'을 실행하세요.")
             sys.exit(1)
         elif is_container():
-            print("Service start is not applicable inside a Docker container.")
-            print("The gateway runs as the container's main process.")
+            print("Docker 컨테이너 안에서는 서비스 시작이 해당되지 않아요.")
+            print("게이트웨이는 컨테이너의 메인 프로세스로 실행돼요.")
             print()
-            print("  docker start <container>     # start a stopped container")
-            print("  docker restart <container>   # restart a running container")
+            print("  docker start <container>     # 중지된 컨테이너 시작")
+            print("  docker restart <container>   # 실행 중인 컨테이너 재시작")
             print()
-            print("Or run the gateway directly: hermes gateway run")
+            print("또는 게이트웨이를 직접 실행하세요: hermes gateway run")
             sys.exit(0)
         else:
-            print("Not supported on this platform.")
+            print("이 플랫폼에서는 지원하지 않아요.")
             sys.exit(1)
 
     elif subcmd == "stop":
@@ -2972,9 +2972,9 @@ def gateway_command(args):
             killed = kill_gateway_processes(all_profiles=True)
             total = killed + (1 if service_available else 0)
             if total:
-                print(f"✓ Stopped {total} gateway process(es) across all profiles")
+                print(f"✓ 모든 프로필에서 게이트웨이 프로세스 {total}개를 중지했어요")
             else:
-                print("✗ No gateway processes found")
+                print("✗ 게이트웨이 프로세스를 찾지 못했어요")
         else:
             # Default: stop only the current profile's gateway
             service_available = False
@@ -2994,11 +2994,11 @@ def gateway_command(args):
             if not service_available:
                 # No systemd/launchd — use profile-scoped PID file
                 if stop_profile_gateway():
-                    print("✓ Stopped gateway for this profile")
+                    print("✓ 현재 프로필의 게이트웨이를 중지했어요")
                 else:
-                    print("✗ No gateway running for this profile")
+                    print("✗ 현재 프로필에서 실행 중인 게이트웨이가 없어요")
             else:
-                print(f"✓ Stopped {get_service_name()} service")
+                print(f"✓ {get_service_name()} 서비스를 중지했어요")
     
     elif subcmd == "restart":
         # Try service first, fall back to killing and restarting
@@ -3029,30 +3029,30 @@ def gateway_command(args):
                     import getpass
                     _username = getpass.getuser()
                     print()
-                    print("⚠ Cannot restart gateway as a service — linger is not enabled.")
-                    print("  The gateway user service requires linger to function on headless servers.")
+                    print("⚠ 서비스를 통해 게이트웨이를 재시작할 수 없어요 — linger가 활성화되어 있지 않아요.")
+                    print("  헤드리스 서버에서 게이트웨이 사용자 서비스가 동작하려면 linger가 필요해요.")
                     print()
-                    print(f"  Run:  sudo loginctl enable-linger {_username}")
+                    print(f"  실행:  sudo loginctl enable-linger {_username}")
                     print()
-                    print("  Then restart the gateway:")
+                    print("  그다음 게이트웨이를 다시 시작하세요:")
                     print("    hermes gateway restart")
                     return
 
             if service_configured:
                 print()
-                print("✗ Gateway service restart failed.")
-                print("  The service definition exists, but the service manager did not recover it.")
-                print("  Fix the service, then retry: hermes gateway start")
+                print("✗ 게이트웨이 서비스 재시작에 실패했어요.")
+                print("  서비스 정의는 존재하지만 서비스 관리자가 복구하지 못했어요.")
+                print("  서비스를 고친 뒤 다시 시도하세요: hermes gateway start")
                 sys.exit(1)
 
             # Manual restart: stop only this profile's gateway
             if stop_profile_gateway():
-                print("✓ Stopped gateway for this profile")
+                print("✓ 현재 프로필의 게이트웨이를 중지했어요")
 
             _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
 
             # Start fresh
-            print("Starting gateway...")
+            print("게이트웨이를 시작하는 중...")
             run_gateway(verbose=0)
     
     elif subcmd == "status":
@@ -3068,42 +3068,42 @@ def gateway_command(args):
             # Check for manually running processes
             pids = find_gateway_pids()
             if pids:
-                print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
-                print("  (Running manually, not as a system service)")
+                print(f"✓ 게이트웨이가 실행 중이에요 (PID: {', '.join(map(str, pids))})")
+                print("  (시스템 서비스가 아니라 수동으로 실행 중이에요)")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
                     print()
-                    print("Recent gateway health:")
+                    print("최근 게이트웨이 상태:")
                     for line in runtime_lines:
                         print(f"  {line}")
                 print()
                 if is_termux():
-                    print("Termux note:")
-                    print("  Android may stop background jobs when Termux is suspended")
+                    print("Termux 참고:")
+                    print("  Termux가 일시중지되면 Android가 백그라운드 작업을 멈출 수 있어요")
                 elif is_wsl():
-                    print("WSL note:")
-                    print("  The gateway is running in foreground/manual mode (recommended for WSL).")
-                    print("  Use tmux or screen for persistence across terminal closes.")
+                    print("WSL 참고:")
+                    print("  게이트웨이는 포그라운드/수동 모드로 실행 중이에요 (WSL 권장).")
+                    print("  터미널을 닫아도 유지하려면 tmux 또는 screen을 사용하세요.")
                 else:
-                    print("To install as a service:")
+                    print("서비스로 설치하려면:")
                     print("  hermes gateway install")
                     print("  sudo hermes gateway install --system")
             else:
-                print("✗ Gateway is not running")
+                print("✗ 게이트웨이가 실행 중이 아니에요")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
                     print()
-                    print("Recent gateway health:")
+                    print("최근 게이트웨이 상태:")
                     for line in runtime_lines:
                         print(f"  {line}")
                 print()
-                print("To start:")
-                print("  hermes gateway run      # Run in foreground")
+                print("시작하려면:")
+                print("  hermes gateway run      # 포그라운드 실행")
                 if is_termux():
-                    print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # Best-effort background start")
+                    print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # 최선의 백그라운드 시작")
                 elif is_wsl():
-                    print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
-                    print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
+                    print("  tmux new -s hermes 'hermes gateway run'         # tmux로 유지")
+                    print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # 백그라운드")
                 else:
-                    print("  hermes gateway install  # Install as user service")
-                    print("  sudo hermes gateway install --system  # Install as boot-time system service")
+                    print("  hermes gateway install  # 사용자 서비스로 설치")
+                    print("  sudo hermes gateway install --system  # 부팅 시 시작되는 시스템 서비스로 설치")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1635,19 +1635,19 @@ _PLATFORMS = [
         "emoji": "📱",
         "token_var": "TELEGRAM_BOT_TOKEN",
         "setup_instructions": [
-            "1. Open Telegram and message @BotFather",
-            "2. Send /newbot and follow the prompts to create your bot",
-            "3. Copy the bot token BotFather gives you",
-            "4. To find your user ID: message @userinfobot — it replies with your numeric ID",
+            "1. Telegram에서 @BotFather에게 메시지를 보냅니다",
+            "2. /newbot 을 보내고 안내에 따라 봇을 만듭니다",
+            "3. BotFather가 알려주는 봇 토큰을 복사합니다",
+            "4. 사용자 ID를 확인하려면 @userinfobot 에 메시지를 보내세요 — 숫자 ID를 답장해 줍니다",
         ],
         "vars": [
-            {"name": "TELEGRAM_BOT_TOKEN", "prompt": "Bot token", "password": True,
-             "help": "Paste the token from @BotFather (step 3 above)."},
-            {"name": "TELEGRAM_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated)", "password": False,
+            {"name": "TELEGRAM_BOT_TOKEN", "prompt": "Telegram 봇 토큰", "password": True,
+             "help": "위 3단계에서 받은 @BotFather 토큰을 붙여 넣으세요."},
+            {"name": "TELEGRAM_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분)", "password": False,
              "is_allowlist": True,
-             "help": "Paste your user ID from step 4 above."},
-            {"name": "TELEGRAM_HOME_CHANNEL", "prompt": "Home channel ID (for cron/notification delivery, or empty to set later with /set-home)", "password": False,
-             "help": "For DMs, this is your user ID. You can set it later by typing /set-home in chat."},
+             "help": "위 4단계에서 확인한 본인 사용자 ID를 붙여 넣으세요."},
+            {"name": "TELEGRAM_HOME_CHANNEL", "prompt": "홈 채널 ID (cron/알림 전달용, 비워 두면 나중에 /set-home으로 설정)", "password": False,
+             "help": "DM에서는 보통 본인 사용자 ID와 같습니다. 나중에 채팅에서 /set-home으로 설정할 수도 있습니다."},
         ],
     },
     {
@@ -1656,26 +1656,26 @@ _PLATFORMS = [
         "emoji": "💬",
         "token_var": "DISCORD_BOT_TOKEN",
         "setup_instructions": [
-            "1. Go to https://discord.com/developers/applications → New Application",
-            "2. Go to Bot → Reset Token → copy the bot token",
-            "3. Enable: Bot → Privileged Gateway Intents → Message Content Intent",
-            "4. Invite the bot to your server:",
-            "   OAuth2 → URL Generator → check BOTH scopes:",
+            "1. https://discord.com/developers/applications 로 이동 → New Application",
+            "2. Bot → Reset Token 으로 이동해 봇 토큰을 복사합니다",
+            "3. Bot → Privileged Gateway Intents → Message Content Intent 를 활성화합니다",
+            "4. 봇을 서버에 초대합니다:",
+            "   OAuth2 → URL Generator → 아래 두 scope를 모두 체크하세요:",
             "     - bot",
-            "     - applications.commands  (required for slash commands!)",
+            "     - applications.commands  (슬래시 명령어에 필수)",
             "   Bot Permissions: Send Messages, Read Message History, Attach Files",
-            "   Copy the URL and open it in your browser to invite.",
-            "5. Get your user ID: enable Developer Mode in Discord settings,",
-            "   then right-click your name → Copy ID",
+            "   생성된 URL을 복사해 브라우저에서 열고 초대하세요.",
+            "5. 사용자 ID 확인: Discord 설정에서 Developer Mode를 켠 뒤",
+            "   내 이름을 우클릭 → Copy ID",
         ],
         "vars": [
-            {"name": "DISCORD_BOT_TOKEN", "prompt": "Bot token", "password": True,
-             "help": "Paste the token from step 2 above."},
-            {"name": "DISCORD_ALLOWED_USERS", "prompt": "Allowed user IDs or usernames (comma-separated)", "password": False,
+            {"name": "DISCORD_BOT_TOKEN", "prompt": "Discord 봇 토큰", "password": True,
+             "help": "위 2단계에서 복사한 토큰을 붙여 넣으세요."},
+            {"name": "DISCORD_ALLOWED_USERS", "prompt": "허용할 사용자 ID 또는 사용자명 (쉼표로 구분)", "password": False,
              "is_allowlist": True,
-             "help": "Paste your user ID from step 5 above."},
-            {"name": "DISCORD_HOME_CHANNEL", "prompt": "Home channel ID (for cron/notification delivery, or empty to set later with /set-home)", "password": False,
-             "help": "Right-click a channel → Copy Channel ID (requires Developer Mode)."},
+             "help": "위 5단계에서 확인한 본인 사용자 ID를 붙여 넣으세요."},
+            {"name": "DISCORD_HOME_CHANNEL", "prompt": "홈 채널 ID (cron/알림 전달용, 비워 두면 나중에 /set-home으로 설정)", "password": False,
+             "help": "채널을 우클릭 → Copy Channel ID (Developer Mode 필요)."},
         ],
     },
     {
@@ -1684,29 +1684,29 @@ _PLATFORMS = [
         "emoji": "💼",
         "token_var": "SLACK_BOT_TOKEN",
         "setup_instructions": [
-            "1. Go to https://api.slack.com/apps → Create New App → From Scratch",
-            "2. Enable Socket Mode: Settings → Socket Mode → Enable",
-            "   Create an App-Level Token with scope: connections:write → copy xapp-... token",
-            "3. Add Bot Token Scopes: Features → OAuth & Permissions → Scopes",
-            "   Required: chat:write, app_mentions:read, channels:history, channels:read,",
+            "1. https://api.slack.com/apps → Create New App → From Scratch 로 이동합니다",
+            "2. Socket Mode 활성화: Settings → Socket Mode → Enable",
+            "   scope가 connections:write 인 App-Level Token을 만든 뒤 xapp-... 토큰을 복사하세요",
+            "3. Bot Token Scope 추가: Features → OAuth & Permissions → Scopes",
+            "   필수: chat:write, app_mentions:read, channels:history, channels:read,",
             "   groups:history, im:history, im:read, im:write, users:read, files:read, files:write",
-            "4. Subscribe to Events: Features → Event Subscriptions → Enable",
-            "   Required events: message.im, message.channels, app_mention",
-            "   Optional: message.groups (for private channels)",
-            "   ⚠ Without message.channels the bot will ONLY work in DMs!",
-            "5. Install to Workspace: Settings → Install App → copy xoxb-... token",
-            "6. Reinstall the app after any scope or event changes",
-            "7. Find your user ID: click your profile → three dots → Copy member ID",
-            "8. Invite the bot to channels: /invite @YourBot",
+            "4. 이벤트 구독: Features → Event Subscriptions → Enable",
+            "   필수 이벤트: message.im, message.channels, app_mention",
+            "   선택: message.groups (비공개 채널용)",
+            "   ⚠ message.channels 가 없으면 봇은 DM에서만 동작합니다!",
+            "5. 워크스페이스에 설치: Settings → Install App → xoxb-... 토큰 복사",
+            "6. scope나 이벤트를 바꾼 뒤에는 앱을 다시 설치하세요",
+            "7. 사용자 ID 확인: 프로필 클릭 → 점 세 개 메뉴 → Copy member ID",
+            "8. 채널에 봇 초대: /invite @YourBot",
         ],
         "vars": [
-            {"name": "SLACK_BOT_TOKEN", "prompt": "Bot Token (xoxb-...)", "password": True,
-             "help": "Paste the bot token from step 3 above."},
-            {"name": "SLACK_APP_TOKEN", "prompt": "App Token (xapp-...)", "password": True,
-             "help": "Paste the app-level token from step 4 above."},
-            {"name": "SLACK_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated)", "password": False,
+            {"name": "SLACK_BOT_TOKEN", "prompt": "Slack Bot Token (xoxb-...)", "password": True,
+             "help": "위 5단계에서 복사한 봇 토큰을 붙여 넣으세요."},
+            {"name": "SLACK_APP_TOKEN", "prompt": "Slack App Token (xapp-...)", "password": True,
+             "help": "위 2단계에서 만든 app-level 토큰을 붙여 넣으세요."},
+            {"name": "SLACK_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분)", "password": False,
              "is_allowlist": True,
-             "help": "Paste your member ID from step 7 above."},
+             "help": "위 7단계에서 확인한 member ID를 붙여 넣으세요."},
         ],
     },
     {
@@ -1715,27 +1715,27 @@ _PLATFORMS = [
         "emoji": "🔐",
         "token_var": "MATRIX_ACCESS_TOKEN",
         "setup_instructions": [
-            "1. Works with any Matrix homeserver (self-hosted Synapse/Conduit/Dendrite or matrix.org)",
-            "2. Create a bot user on your homeserver, or use your own account",
-            "3. Get an access token: Element → Settings → Help & About → Access Token",
-            "   Or via API: curl -X POST https://your-server/_matrix/client/v3/login \\",
+            "1. 어떤 Matrix homeserver와도 사용할 수 있습니다 (자체 호스팅 Synapse/Conduit/Dendrite 또는 matrix.org)",
+            "2. homeserver에 봇 계정을 만들거나 본인 계정을 사용할 수 있습니다",
+            "3. access token 확인: Element → Settings → Help & About → Access Token",
+            "   또는 API 사용: curl -X POST https://your-server/_matrix/client/v3/login \\",
             "     -d '{\"type\":\"m.login.password\",\"user\":\"@bot:server\",\"password\":\"...\"}'",
-            "4. Alternatively, provide user ID + password and Hermes will log in directly",
-            "5. For E2EE: set MATRIX_ENCRYPTION=true (requires pip install 'mautrix[encryption]')",
-            "6. To find your user ID: it's @username:your-server (shown in Element profile)",
+            "4. 또는 사용자 ID + 비밀번호를 입력하면 Hermes가 직접 로그인합니다",
+            "5. E2EE를 쓰려면 MATRIX_ENCRYPTION=true 로 설정하세요 (pip install 'mautrix[encryption]' 필요)",
+            "6. 사용자 ID는 @username:your-server 형식이며 Element 프로필에서 확인할 수 있습니다",
         ],
         "vars": [
-            {"name": "MATRIX_HOMESERVER", "prompt": "Homeserver URL (e.g. https://matrix.example.org)", "password": False,
-             "help": "Your Matrix homeserver URL. Works with any self-hosted instance."},
-            {"name": "MATRIX_ACCESS_TOKEN", "prompt": "Access token (leave empty to use password login instead)", "password": True,
-             "help": "Paste your access token, or leave empty and provide user ID + password below."},
-            {"name": "MATRIX_USER_ID", "prompt": "User ID (@bot:server — required for password login)", "password": False,
-             "help": "Full Matrix user ID, e.g. @hermes:matrix.example.org"},
-            {"name": "MATRIX_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated, e.g. @you:server)", "password": False,
+            {"name": "MATRIX_HOMESERVER", "prompt": "Matrix homeserver URL (예: https://matrix.example.org)", "password": False,
+             "help": "Matrix homeserver URL입니다. 어떤 자체 호스팅 인스턴스와도 사용할 수 있습니다."},
+            {"name": "MATRIX_ACCESS_TOKEN", "prompt": "Access token (비워 두면 대신 비밀번호 로그인 사용)", "password": True,
+             "help": "access token을 붙여 넣거나, 비워 두고 아래에 사용자 ID + 비밀번호를 입력하세요."},
+            {"name": "MATRIX_USER_ID", "prompt": "사용자 ID (@bot:server — 비밀번호 로그인 시 필수)", "password": False,
+             "help": "전체 Matrix 사용자 ID입니다. 예: @hermes:matrix.example.org"},
+            {"name": "MATRIX_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분, 예: @you:server)", "password": False,
              "is_allowlist": True,
-             "help": "Matrix user IDs who can interact with the bot."},
-            {"name": "MATRIX_HOME_ROOM", "prompt": "Home room ID (for cron/notification delivery, or empty to set later with /set-home)", "password": False,
-             "help": "Room ID (e.g. !abc123:server) for delivering cron results and notifications."},
+             "help": "봇과 상호작용할 수 있는 Matrix 사용자 ID 목록입니다."},
+            {"name": "MATRIX_HOME_ROOM", "prompt": "홈 룸 ID (cron/알림 전달용, 비워 두면 나중에 /set-home으로 설정)", "password": False,
+             "help": "cron 결과와 알림을 전달할 룸 ID입니다. 예: !abc123:server"},
         ],
     },
     {
@@ -1744,27 +1744,27 @@ _PLATFORMS = [
         "emoji": "💬",
         "token_var": "MATTERMOST_TOKEN",
         "setup_instructions": [
-            "1. In Mattermost: Integrations → Bot Accounts → Add Bot Account",
-            "   (System Console → Integrations → Bot Accounts must be enabled)",
-            "2. Give it a username (e.g. hermes) and copy the bot token",
-            "3. Works with any self-hosted Mattermost instance — enter your server URL",
-            "4. To find your user ID: click your avatar (top-left) → Profile",
-            "   Your user ID is displayed there — click it to copy.",
-            "   ⚠ This is NOT your username — it's a 26-character alphanumeric ID.",
-            "5. To get a channel ID: click the channel name → View Info → copy the ID",
+            "1. Mattermost에서 Integrations → Bot Accounts → Add Bot Account 로 이동합니다",
+            "   (System Console → Integrations → Bot Accounts 가 활성화되어 있어야 합니다)",
+            "2. 사용자명(예: hermes)을 지정하고 봇 토큰을 복사합니다",
+            "3. 어떤 자체 호스팅 Mattermost 인스턴스와도 사용할 수 있습니다 — 서버 URL을 입력하세요",
+            "4. 사용자 ID 확인: 아바타(좌상단) 클릭 → Profile",
+            "   화면에 사용자 ID가 표시되며 클릭하면 복사됩니다.",
+            "   ⚠ 이것은 사용자명이 아니라 26자리 영숫자 ID입니다.",
+            "5. 채널 ID 확인: 채널 이름 클릭 → View Info → ID 복사",
         ],
         "vars": [
-            {"name": "MATTERMOST_URL", "prompt": "Server URL (e.g. https://mm.example.com)", "password": False,
-             "help": "Your Mattermost server URL. Works with any self-hosted instance."},
-            {"name": "MATTERMOST_TOKEN", "prompt": "Bot token", "password": True,
-             "help": "Paste the bot token from step 2 above."},
-            {"name": "MATTERMOST_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated)", "password": False,
+            {"name": "MATTERMOST_URL", "prompt": "Mattermost 서버 URL (예: https://mm.example.com)", "password": False,
+             "help": "Mattermost 서버 URL입니다. 어떤 자체 호스팅 인스턴스와도 사용할 수 있습니다."},
+            {"name": "MATTERMOST_TOKEN", "prompt": "Mattermost 봇 토큰", "password": True,
+             "help": "위 2단계에서 복사한 봇 토큰을 붙여 넣으세요."},
+            {"name": "MATTERMOST_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분)", "password": False,
              "is_allowlist": True,
-             "help": "Your Mattermost user ID from step 4 above."},
-            {"name": "MATTERMOST_HOME_CHANNEL", "prompt": "Home channel ID (for cron/notification delivery, or empty to set later with /set-home)", "password": False,
-             "help": "Channel ID where Hermes delivers cron results and notifications."},
-            {"name": "MATTERMOST_REPLY_MODE", "prompt": "Reply mode — 'off' for flat messages, 'thread' for threaded replies (default: off)", "password": False,
-             "help": "off = flat channel messages, thread = replies nest under your message."},
+             "help": "위 4단계에서 확인한 Mattermost 사용자 ID를 입력하세요."},
+            {"name": "MATTERMOST_HOME_CHANNEL", "prompt": "홈 채널 ID (cron/알림 전달용, 비워 두면 나중에 /set-home으로 설정)", "password": False,
+             "help": "Hermes가 cron 결과와 알림을 전달할 채널 ID입니다."},
+            {"name": "MATTERMOST_REPLY_MODE", "prompt": "응답 모드 — 'off'는 일반 메시지, 'thread'는 스레드 응답 (기본값: off)", "password": False,
+             "help": "off = 채널에 일반 메시지로 응답, thread = 사용자의 메시지 아래 스레드로 응답합니다."},
         ],
     },
     {
@@ -1785,24 +1785,24 @@ _PLATFORMS = [
         "emoji": "📧",
         "token_var": "EMAIL_ADDRESS",
         "setup_instructions": [
-            "1. Use a dedicated email account for your Hermes agent",
-            "2. For Gmail: enable 2FA, then create an App Password at",
+            "1. Hermes 전용 이메일 계정을 사용하는 것을 권장합니다",
+            "2. Gmail은 2단계 인증을 켠 뒤 아래에서 앱 비밀번호를 만드세요",
             "   https://myaccount.google.com/apppasswords",
-            "3. For other providers: use your email password or app-specific password",
-            "4. IMAP must be enabled on your email account",
+            "3. 다른 제공자는 일반 비밀번호 또는 앱 전용 비밀번호를 사용하세요",
+            "4. 이메일 계정에서 IMAP가 활성화되어 있어야 합니다",
         ],
         "vars": [
-            {"name": "EMAIL_ADDRESS", "prompt": "Email address", "password": False,
-             "help": "The email address Hermes will use (e.g., hermes@gmail.com)."},
-            {"name": "EMAIL_PASSWORD", "prompt": "Email password (or app password)", "password": True,
-             "help": "For Gmail, use an App Password (not your regular password)."},
-            {"name": "EMAIL_IMAP_HOST", "prompt": "IMAP host", "password": False,
-             "help": "e.g., imap.gmail.com for Gmail, outlook.office365.com for Outlook."},
-            {"name": "EMAIL_SMTP_HOST", "prompt": "SMTP host", "password": False,
-             "help": "e.g., smtp.gmail.com for Gmail, smtp.office365.com for Outlook."},
-            {"name": "EMAIL_ALLOWED_USERS", "prompt": "Allowed sender emails (comma-separated)", "password": False,
+            {"name": "EMAIL_ADDRESS", "prompt": "이메일 주소", "password": False,
+             "help": "Hermes가 사용할 이메일 주소입니다. 예: hermes@gmail.com"},
+            {"name": "EMAIL_PASSWORD", "prompt": "이메일 비밀번호 (또는 앱 비밀번호)", "password": True,
+             "help": "Gmail은 일반 비밀번호 대신 앱 비밀번호를 사용하세요."},
+            {"name": "EMAIL_IMAP_HOST", "prompt": "IMAP 호스트", "password": False,
+             "help": "예: Gmail은 imap.gmail.com, Outlook은 outlook.office365.com"},
+            {"name": "EMAIL_SMTP_HOST", "prompt": "SMTP 호스트", "password": False,
+             "help": "예: Gmail은 smtp.gmail.com, Outlook은 smtp.office365.com"},
+            {"name": "EMAIL_ALLOWED_USERS", "prompt": "허용할 발신자 이메일 (쉼표로 구분)", "password": False,
              "is_allowlist": True,
-             "help": "Only emails from these addresses will be processed."},
+             "help": "이 주소들에서 온 이메일만 처리합니다."},
         ],
     },
     {
@@ -1811,25 +1811,25 @@ _PLATFORMS = [
         "emoji": "📱",
         "token_var": "TWILIO_ACCOUNT_SID",
         "setup_instructions": [
-            "1. Create a Twilio account at https://www.twilio.com/",
-            "2. Get your Account SID and Auth Token from the Twilio Console dashboard",
-            "3. Buy or configure a phone number capable of sending SMS",
-            "4. Set up your webhook URL for inbound SMS:",
-            "   Twilio Console → Phone Numbers → Active Numbers → your number",
+            "1. https://www.twilio.com/ 에서 Twilio 계정을 만듭니다",
+            "2. Twilio Console 대시보드에서 Account SID와 Auth Token을 확인합니다",
+            "3. SMS 발신이 가능한 전화번호를 구매하거나 설정합니다",
+            "4. 수신 SMS용 webhook URL을 설정합니다:",
+            "   Twilio Console → Phone Numbers → Active Numbers → 해당 번호",
             "   → Messaging → A MESSAGE COMES IN → Webhook → https://your-server:8080/webhooks/twilio",
         ],
         "vars": [
             {"name": "TWILIO_ACCOUNT_SID", "prompt": "Twilio Account SID", "password": False,
-             "help": "Found on the Twilio Console dashboard."},
+             "help": "Twilio Console 대시보드에서 확인할 수 있습니다."},
             {"name": "TWILIO_AUTH_TOKEN", "prompt": "Twilio Auth Token", "password": True,
-             "help": "Found on the Twilio Console dashboard (click to reveal)."},
-            {"name": "TWILIO_PHONE_NUMBER", "prompt": "Twilio phone number (E.164 format, e.g. +15551234567)", "password": False,
-             "help": "The Twilio phone number to send SMS from."},
-            {"name": "SMS_ALLOWED_USERS", "prompt": "Allowed phone numbers (comma-separated, E.164 format)", "password": False,
+             "help": "Twilio Console 대시보드에서 확인할 수 있습니다 (클릭하면 표시됨)."},
+            {"name": "TWILIO_PHONE_NUMBER", "prompt": "Twilio 전화번호 (E.164 형식, 예: +155****4567)", "password": False,
+             "help": "SMS를 발송할 Twilio 전화번호입니다."},
+            {"name": "SMS_ALLOWED_USERS", "prompt": "허용할 전화번호 (쉼표로 구분, E.164 형식)", "password": False,
              "is_allowlist": True,
-             "help": "Only messages from these phone numbers will be processed."},
-            {"name": "SMS_HOME_CHANNEL", "prompt": "Home channel phone number (for cron/notification delivery, or empty)", "password": False,
-             "help": "Phone number to deliver cron job results and notifications to."},
+             "help": "이 번호들에서 온 메시지만 처리합니다."},
+            {"name": "SMS_HOME_CHANNEL", "prompt": "홈 채널 전화번호 (cron/알림 전달용, 비워 둘 수 있음)", "password": False,
+             "help": "cron 결과와 알림을 전달할 전화번호입니다."},
         ],
     },
     {
@@ -1838,16 +1838,16 @@ _PLATFORMS = [
         "emoji": "💬",
         "token_var": "DINGTALK_CLIENT_ID",
         "setup_instructions": [
-            "1. Go to https://open-dev.dingtalk.com → Create Application",
-            "2. Under 'Credentials', copy the AppKey (Client ID) and AppSecret (Client Secret)",
-            "3. Enable 'Stream Mode' under the bot settings",
-            "4. Add the bot to a group chat or message it directly",
+            "1. https://open-dev.dingtalk.com 으로 이동 → Create Application",
+            "2. 'Credentials'에서 AppKey(Client ID)와 AppSecret(Client Secret)을 복사합니다",
+            "3. 봇 설정에서 'Stream Mode'를 활성화합니다",
+            "4. 봇을 그룹 채팅에 추가하거나 직접 메시지를 보냅니다",
         ],
         "vars": [
             {"name": "DINGTALK_CLIENT_ID", "prompt": "AppKey (Client ID)", "password": False,
-             "help": "The AppKey from your DingTalk application credentials."},
+             "help": "DingTalk 앱 자격 증명에 있는 AppKey입니다."},
             {"name": "DINGTALK_CLIENT_SECRET", "prompt": "AppSecret (Client Secret)", "password": True,
-             "help": "The AppSecret from your DingTalk application credentials."},
+             "help": "DingTalk 앱 자격 증명에 있는 AppSecret입니다."},
         ],
     },
     {
@@ -1856,27 +1856,27 @@ _PLATFORMS = [
         "emoji": "🪽",
         "token_var": "FEISHU_APP_ID",
         "setup_instructions": [
-            "1. Go to https://open.feishu.cn/ (or https://open.larksuite.com/ for Lark)",
-            "2. Create an app and copy the App ID and App Secret",
-            "3. Enable the Bot capability for the app",
-            "4. Choose WebSocket (recommended) or Webhook connection mode",
-            "5. Add the bot to a group chat or message it directly",
-            "6. Restrict access with FEISHU_ALLOWED_USERS for production use",
+            "1. https://open.feishu.cn/ (Lark는 https://open.larksuite.com/) 으로 이동합니다",
+            "2. 앱을 생성하고 App ID와 App Secret을 복사합니다",
+            "3. 앱에서 Bot 기능을 활성화합니다",
+            "4. WebSocket(권장) 또는 Webhook 연결 모드를 선택합니다",
+            "5. 봇을 그룹 채팅에 추가하거나 직접 메시지를 보냅니다",
+            "6. 운영 환경에서는 FEISHU_ALLOWED_USERS 로 접근을 제한하세요",
         ],
         "vars": [
             {"name": "FEISHU_APP_ID", "prompt": "App ID", "password": False,
-             "help": "The App ID from your Feishu/Lark application."},
+             "help": "Feishu/Lark 애플리케이션의 App ID입니다."},
             {"name": "FEISHU_APP_SECRET", "prompt": "App Secret", "password": True,
-             "help": "The App Secret from your Feishu/Lark application."},
-            {"name": "FEISHU_DOMAIN", "prompt": "Domain — feishu or lark (default: feishu)", "password": False,
-             "help": "Use 'feishu' for Feishu China, or 'lark' for Lark international."},
-            {"name": "FEISHU_CONNECTION_MODE", "prompt": "Connection mode — websocket or webhook (default: websocket)", "password": False,
-             "help": "websocket is recommended unless you specifically need webhook mode."},
-            {"name": "FEISHU_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated, or empty)", "password": False,
+             "help": "Feishu/Lark 애플리케이션의 App Secret입니다."},
+            {"name": "FEISHU_DOMAIN", "prompt": "도메인 — feishu 또는 lark (기본값: feishu)", "password": False,
+             "help": "중국 Feishu는 'feishu', 국제 Lark는 'lark'를 사용하세요."},
+            {"name": "FEISHU_CONNECTION_MODE", "prompt": "연결 모드 — websocket 또는 webhook (기본값: websocket)", "password": False,
+             "help": "특별한 이유가 없다면 websocket을 권장합니다."},
+            {"name": "FEISHU_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분, 비워 둘 수 있음)", "password": False,
              "is_allowlist": True,
-             "help": "Restrict which Feishu/Lark users can interact with the bot."},
-            {"name": "FEISHU_HOME_CHANNEL", "prompt": "Home chat ID (optional, for cron/notifications)", "password": False,
-             "help": "Chat ID for scheduled results and notifications."},
+             "help": "어떤 Feishu/Lark 사용자가 봇과 상호작용할 수 있는지 제한합니다."},
+            {"name": "FEISHU_HOME_CHANNEL", "prompt": "홈 채팅 ID (선택 사항, cron/알림용)", "password": False,
+             "help": "예약 실행 결과와 알림을 받을 채팅 ID입니다."},
         ],
     },
     {
@@ -1885,22 +1885,22 @@ _PLATFORMS = [
         "emoji": "💬",
         "token_var": "WECOM_BOT_ID",
         "setup_instructions": [
-            "1. Go to WeCom Admin Console → Applications → Create AI Bot",
-            "2. Copy the Bot ID and Secret from the bot's credentials page",
-            "3. The bot connects via WebSocket — no public endpoint needed",
-            "4. Add the bot to a group chat or message it directly in WeCom",
-            "5. Restrict access with WECOM_ALLOWED_USERS for production use",
+            "1. WeCom 관리자 콘솔 → Applications → Create AI Bot 으로 이동합니다",
+            "2. 봇 자격 증명 페이지에서 Bot ID와 Secret을 복사합니다",
+            "3. 봇은 WebSocket으로 연결되므로 공개 엔드포인트가 필요 없습니다",
+            "4. 봇을 그룹 채팅에 추가하거나 WeCom에서 직접 메시지를 보냅니다",
+            "5. 운영 환경에서는 WECOM_ALLOWED_USERS 로 접근을 제한하세요",
         ],
         "vars": [
             {"name": "WECOM_BOT_ID", "prompt": "Bot ID", "password": False,
-             "help": "The Bot ID from your WeCom AI Bot."},
+             "help": "WeCom AI Bot의 Bot ID입니다."},
             {"name": "WECOM_SECRET", "prompt": "Secret", "password": True,
-             "help": "The secret from your WeCom AI Bot."},
-            {"name": "WECOM_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated, or empty)", "password": False,
+             "help": "WeCom AI Bot의 secret입니다."},
+            {"name": "WECOM_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분, 비워 둘 수 있음)", "password": False,
              "is_allowlist": True,
-             "help": "Restrict which WeCom users can interact with the bot."},
-            {"name": "WECOM_HOME_CHANNEL", "prompt": "Home chat ID (optional, for cron/notifications)", "password": False,
-             "help": "Chat ID for scheduled results and notifications."},
+             "help": "어떤 WeCom 사용자가 봇과 상호작용할 수 있는지 제한합니다."},
+            {"name": "WECOM_HOME_CHANNEL", "prompt": "홈 채팅 ID (선택 사항, cron/알림용)", "password": False,
+             "help": "예약 실행 결과와 알림을 받을 채팅 ID입니다."},
         ],
     },
     {
@@ -1909,29 +1909,29 @@ _PLATFORMS = [
         "emoji": "💬",
         "token_var": "WECOM_CALLBACK_CORP_ID",
         "setup_instructions": [
-            "1. Go to WeCom Admin Console → Applications → Create Self-Built App",
-            "2. Note the Corp ID (top of admin console) and create a Corp Secret",
-            "3. Under Receive Messages, configure the callback URL to point to your server",
-            "4. Copy the Token and EncodingAESKey from the callback configuration",
-            "5. The adapter runs an HTTP server — ensure the port is reachable from WeCom",
-            "6. Restrict access with WECOM_CALLBACK_ALLOWED_USERS for production use",
+            "1. WeCom 관리자 콘솔 → Applications → Create Self-Built App 으로 이동합니다",
+            "2. Corp ID(관리자 콘솔 상단)를 확인하고 Corp Secret을 생성합니다",
+            "3. Receive Messages에서 callback URL을 서버 주소로 설정합니다",
+            "4. callback 설정에 있는 Token과 EncodingAESKey를 복사합니다",
+            "5. 이 어댑터는 HTTP 서버를 실행하므로 해당 포트가 WeCom에서 접근 가능해야 합니다",
+            "6. 운영 환경에서는 WECOM_CALLBACK_ALLOWED_USERS 로 접근을 제한하세요",
         ],
         "vars": [
             {"name": "WECOM_CALLBACK_CORP_ID", "prompt": "Corp ID", "password": False,
-             "help": "Your WeCom enterprise Corp ID."},
+             "help": "WeCom 엔터프라이즈 Corp ID입니다."},
             {"name": "WECOM_CALLBACK_CORP_SECRET", "prompt": "Corp Secret", "password": True,
-             "help": "The secret for your self-built application."},
+             "help": "Self-Built App용 secret입니다."},
             {"name": "WECOM_CALLBACK_AGENT_ID", "prompt": "Agent ID", "password": False,
-             "help": "The Agent ID of your self-built application."},
+             "help": "Self-Built App의 Agent ID입니다."},
             {"name": "WECOM_CALLBACK_TOKEN", "prompt": "Callback Token", "password": True,
-             "help": "The Token from your WeCom callback configuration."},
+             "help": "WeCom callback 설정에 있는 Token입니다."},
             {"name": "WECOM_CALLBACK_ENCODING_AES_KEY", "prompt": "Encoding AES Key", "password": True,
-             "help": "The EncodingAESKey from your WeCom callback configuration."},
-            {"name": "WECOM_CALLBACK_PORT", "prompt": "Callback server port (default: 8645)", "password": False,
-             "help": "Port for the HTTP callback server."},
-            {"name": "WECOM_CALLBACK_ALLOWED_USERS", "prompt": "Allowed user IDs (comma-separated, or empty)", "password": False,
+             "help": "WeCom callback 설정에 있는 EncodingAESKey입니다."},
+            {"name": "WECOM_CALLBACK_PORT", "prompt": "Callback 서버 포트 (기본값: 8645)", "password": False,
+             "help": "HTTP callback 서버가 사용할 포트입니다."},
+            {"name": "WECOM_CALLBACK_ALLOWED_USERS", "prompt": "허용할 사용자 ID (쉼표로 구분, 비워 둘 수 있음)", "password": False,
              "is_allowlist": True,
-             "help": "Restrict which WeCom users can interact with the app."},
+             "help": "어떤 WeCom 사용자가 앱과 상호작용할 수 있는지 제한합니다."},
         ],
     },
     {
@@ -1946,26 +1946,26 @@ _PLATFORMS = [
         "emoji": "💬",
         "token_var": "BLUEBUBBLES_SERVER_URL",
         "setup_instructions": [
-            "1. Install BlueBubbles on a Mac that will act as your iMessage server:",
+            "1. iMessage 서버 역할을 할 Mac에 BlueBubbles를 설치합니다:",
             "   https://bluebubbles.app/",
-            "2. Complete the BlueBubbles setup wizard — sign in with your Apple ID",
-            "3. In BlueBubbles Settings → API, note the Server URL and password",
-            "4. The server URL is typically http://<your-mac-ip>:1234",
-            "5. Hermes connects via the BlueBubbles REST API and receives",
-            "   incoming messages via a local webhook",
-            "6. To authorize users, use DM pairing: hermes pairing generate bluebubbles",
-            "   Share the code — the user sends it via iMessage to get approved",
+            "2. BlueBubbles 설정 마법사를 완료하고 Apple ID로 로그인합니다",
+            "3. BlueBubbles Settings → API 에서 Server URL과 비밀번호를 확인합니다",
+            "4. 서버 URL은 보통 http://<your-mac-ip>:1234 형식입니다",
+            "5. Hermes는 BlueBubbles REST API로 연결하고",
+            "   로컬 webhook을 통해 수신 메시지를 받습니다",
+            "6. 사용자 승인에는 DM 페어링을 사용하세요: hermes pairing generate bluebubbles",
+            "   생성된 코드를 공유하면 사용자가 iMessage로 보내 승인 요청을 할 수 있습니다",
         ],
         "vars": [
-            {"name": "BLUEBUBBLES_SERVER_URL", "prompt": "BlueBubbles server URL (e.g. http://192.168.1.10:1234)", "password": False,
-             "help": "The URL shown in BlueBubbles Settings → API."},
-            {"name": "BLUEBUBBLES_PASSWORD", "prompt": "BlueBubbles server password", "password": True,
-             "help": "The password shown in BlueBubbles Settings → API."},
-            {"name": "BLUEBUBBLES_ALLOWED_USERS", "prompt": "Pre-authorized phone numbers or iMessage IDs (comma-separated, or leave empty for DM pairing)", "password": False,
+            {"name": "BLUEBUBBLES_SERVER_URL", "prompt": "BlueBubbles 서버 URL (예: http://192.168.1.10:1234)", "password": False,
+             "help": "BlueBubbles Settings → API 에 표시되는 URL입니다."},
+            {"name": "BLUEBUBBLES_PASSWORD", "prompt": "BlueBubbles 서버 비밀번호", "password": True,
+             "help": "BlueBubbles Settings → API 에 표시되는 비밀번호입니다."},
+            {"name": "BLUEBUBBLES_ALLOWED_USERS", "prompt": "미리 허용할 전화번호 또는 iMessage ID (쉼표로 구분, DM 페어링을 쓰려면 비워 두기)", "password": False,
              "is_allowlist": True,
-             "help": "Optional — pre-authorize specific users. Leave empty to use DM pairing instead (recommended)."},
-            {"name": "BLUEBUBBLES_HOME_CHANNEL", "prompt": "Home channel (phone number or iMessage ID for cron/notifications, or empty)", "password": False,
-             "help": "Phone number or Apple ID to deliver cron results and notifications to."},
+             "help": "선택 사항입니다 — 특정 사용자를 미리 허용할 수 있습니다. 권장 방식은 비워 두고 DM 페어링을 사용하는 것입니다."},
+            {"name": "BLUEBUBBLES_HOME_CHANNEL", "prompt": "홈 채널 (cron/알림용 전화번호 또는 iMessage ID, 비워 둘 수 있음)", "password": False,
+             "help": "cron 결과와 알림을 받을 전화번호 또는 Apple ID입니다."},
         ],
     },
     {
@@ -1974,21 +1974,21 @@ _PLATFORMS = [
         "emoji": "🐧",
         "token_var": "QQ_APP_ID",
         "setup_instructions": [
-            "1. Register a QQ Bot application at q.qq.com",
-            "2. Note your App ID and App Secret from the application page",
-            "3. Enable the required intents (C2C, Group, Guild messages)",
-            "4. Configure sandbox or publish the bot",
+            "1. q.qq.com 에서 QQ Bot 애플리케이션을 등록합니다",
+            "2. 애플리케이션 페이지에서 App ID와 App Secret을 확인합니다",
+            "3. 필요한 intent(C2C, Group, Guild messages)를 활성화합니다",
+            "4. sandbox를 설정하거나 봇을 배포합니다",
         ],
         "vars": [
             {"name": "QQ_APP_ID", "prompt": "QQ Bot App ID", "password": False,
-             "help": "Your QQ Bot App ID from q.qq.com."},
+             "help": "q.qq.com 에 있는 QQ Bot App ID입니다."},
             {"name": "QQ_CLIENT_SECRET", "prompt": "QQ Bot App Secret", "password": True,
-             "help": "Your QQ Bot App Secret from q.qq.com."},
-            {"name": "QQ_ALLOWED_USERS", "prompt": "Allowed user OpenIDs (comma-separated, leave empty for open access)", "password": False,
+             "help": "q.qq.com 에 있는 QQ Bot App Secret입니다."},
+            {"name": "QQ_ALLOWED_USERS", "prompt": "허용할 사용자 OpenID (쉼표로 구분, 오픈 액세스를 원하면 비워 두기)", "password": False,
              "is_allowlist": True,
-             "help": "Optional — restrict DM access to specific user OpenIDs."},
-            {"name": "QQ_HOME_CHANNEL", "prompt": "Home channel (user/group OpenID for cron delivery, or empty)", "password": False,
-             "help": "OpenID to deliver cron results and notifications to."},
+             "help": "선택 사항입니다 — 특정 사용자 OpenID만 DM 접근을 허용할 수 있습니다."},
+            {"name": "QQ_HOME_CHANNEL", "prompt": "홈 채널 (cron 전달용 user/group OpenID, 비워 둘 수 있음)", "password": False,
+             "help": "cron 결과와 알림을 받을 OpenID입니다."},
         ],
     },
 ]
@@ -2006,45 +2006,45 @@ def _platform_status(platform: dict) -> str:
         if val and val.lower() == "true":
             session_file = get_hermes_home() / "whatsapp" / "session" / "creds.json"
             if session_file.exists():
-                return "configured + paired"
-            return "enabled, not paired"
-        return "not configured"
+                return "설정됨 + 페어링됨"
+            return "활성화됨, 아직 페어링 안 됨"
+        return "설정 안 됨"
     if platform.get("key") == "signal":
         account = get_env_value("SIGNAL_ACCOUNT")
         if val and account:
-            return "configured"
+            return "설정됨"
         if val or account:
-            return "partially configured"
-        return "not configured"
+            return "부분 설정됨"
+        return "설정 안 됨"
     if platform.get("key") == "email":
         pwd = get_env_value("EMAIL_PASSWORD")
         imap = get_env_value("EMAIL_IMAP_HOST")
         smtp = get_env_value("EMAIL_SMTP_HOST")
         if all([val, pwd, imap, smtp]):
-            return "configured"
+            return "설정됨"
         if any([val, pwd, imap, smtp]):
-            return "partially configured"
-        return "not configured"
+            return "부분 설정됨"
+        return "설정 안 됨"
     if platform.get("key") == "matrix":
         homeserver = get_env_value("MATRIX_HOMESERVER")
         password = get_env_value("MATRIX_PASSWORD")
         if (val or password) and homeserver:
             e2ee = get_env_value("MATRIX_ENCRYPTION")
             suffix = " + E2EE" if e2ee and e2ee.lower() in ("true", "1", "yes") else ""
-            return f"configured{suffix}"
+            return f"설정됨{suffix}"
         if val or password or homeserver:
-            return "partially configured"
-        return "not configured"
+            return "부분 설정됨"
+        return "설정 안 됨"
     if platform.get("key") == "weixin":
         token = get_env_value("WEIXIN_TOKEN")
         if val and token:
-            return "configured"
+            return "설정됨"
         if val or token:
-            return "partially configured"
-        return "not configured"
+            return "부분 설정됨"
+        return "설정 안 됨"
     if val:
-        return "configured"
-    return "not configured"
+        return "설정됨"
+    return "설정 안 됨"
 
 
 def _runtime_health_lines() -> list[str]:
@@ -2089,7 +2089,7 @@ def _setup_standard_platform(platform: dict):
     token_var = platform["token_var"]
 
     print()
-    print(color(f"  ─── {emoji} {label} Setup ───", Colors.CYAN))
+    print(color(f"  ─── {emoji} {label} 설정 ───", Colors.CYAN))
 
     # Show step-by-step setup instructions if this platform has them
     instructions = platform.get("setup_instructions")
@@ -2101,8 +2101,8 @@ def _setup_standard_platform(platform: dict):
     existing_token = get_env_value(token_var)
     if existing_token:
         print()
-        print_success(f"{label} is already configured.")
-        if not prompt_yes_no(f"  Reconfigure {label}?", False):
+        print_success(f"{label}: 이미 설정되어 있음")
+        if not prompt_yes_no(f"  {label}를 다시 설정할까요?", False):
             return
 
     allowed_val_set = None  # Track if user set an allowlist (for home channel offer)
@@ -2116,9 +2116,9 @@ def _setup_standard_platform(platform: dict):
 
         # Allowlist fields get special handling for the deny-by-default security model
         if var.get("is_allowlist"):
-            print_info("  The gateway DENIES all users by default for security.")
-            print_info("  Enter user IDs to create an allowlist, or leave empty")
-            print_info("  and you'll be asked about open access next.")
+            print_info("  보안을 위해 gateway는 기본적으로 모든 사용자를 거부합니다.")
+            print_info("  허용 목록을 만들려면 사용자 ID를 입력하세요.")
+            print_info("  비워 두면 다음 단계에서 오픈 액세스 여부를 물어봅니다.")
             value = prompt(f"  {var['prompt']}", password=False)
             if value:
                 cleaned = value.replace(" ", "")
@@ -2135,36 +2135,36 @@ def _setup_standard_platform(platform: dict):
                             parts.append(uid)
                     cleaned = ",".join(parts)
                 save_env_value(var["name"], cleaned)
-                print_success("  Saved — only these users can interact with the bot.")
+                print_success("  저장 완료 — 이 사용자들만 봇과 상호작용할 수 있습니다.")
                 allowed_val_set = cleaned
             else:
                 # No allowlist — ask about open access vs DM pairing
                 print()
                 access_choices = [
-                    "Enable open access (anyone can message the bot)",
-                    "Use DM pairing (unknown users request access, you approve with 'hermes pairing approve')",
-                    "Skip for now (bot will deny all users until configured)",
+                    "오픈 액세스 사용 (누구나 봇에 메시지를 보낼 수 있음)",
+                    "DM 페어링 사용 (알 수 없는 사용자가 접근 요청을 보내고, 'hermes pairing approve'로 승인)",
+                    "지금은 건너뛰기 (설정 전까지 모든 사용자 거부)",
                 ]
-                access_idx = prompt_choice("  How should unauthorized users be handled?", access_choices, 1)
+                access_idx = prompt_choice("  미승인 사용자를 어떻게 처리할까요?", access_choices, 1)
                 if access_idx == 0:
                     save_env_value("GATEWAY_ALLOW_ALL_USERS", "true")
-                    print_warning("  Open access enabled — anyone can use your bot!")
+                    print_warning("  오픈 액세스 활성화 — 누구나 봇을 사용할 수 있습니다!")
                 elif access_idx == 1:
-                    print_success("  DM pairing mode — users will receive a code to request access.")
-                    print_info("  Approve with: hermes pairing approve <platform> <code>")
+                    print_success("  DM 페어링 모드 — 사용자는 코드를 받아 접근을 요청할 수 있습니다.")
+                    print_info("  승인 명령: hermes pairing approve <platform> <code>")
                 else:
-                    print_info("  Skipped — configure later with 'hermes gateway setup'")
+                    print_info("  건너뜀 — 나중에 'hermes gateway setup'으로 설정할 수 있습니다")
             continue
 
         value = prompt(f"  {var['prompt']}", password=var.get("password", False))
         if value:
             save_env_value(var["name"], value)
-            print_success(f"  Saved {var['name']}")
+            print_success(f"  저장 완료: {var['name']}")
         elif var["name"] == token_var:
-            print_warning(f"  Skipped — {label} won't work without this.")
+            print_warning(f"  건너뜀 — {label}은(는) 이 값이 없으면 동작하지 않습니다.")
             return
         else:
-            print_info("  Skipped (can configure later)")
+            print_info("  건너뜀 (나중에 설정 가능)")
 
     # If an allowlist was set and home channel wasn't, offer to reuse
     # the first user ID (common for Telegram DMs).
@@ -2172,12 +2172,12 @@ def _setup_standard_platform(platform: dict):
     home_val = get_env_value(home_var)
     if allowed_val_set and not home_val and label == "Telegram":
         first_id = allowed_val_set.split(",")[0].strip()
-        if first_id and prompt_yes_no(f"  Use your user ID ({first_id}) as the home channel?", True):
+        if first_id and prompt_yes_no(f"  사용자 ID({first_id})를 홈 채널로 사용할까요?", True):
             save_env_value(home_var, first_id)
-            print_success(f"  Home channel set to {first_id}")
+            print_success(f"  홈 채널을 {first_id}(으)로 설정했습니다")
 
     print()
-    print_success(f"{emoji} {label} configured!")
+    print_success(f"{emoji} {label} 설정 완료!")
 
 
 def _setup_whatsapp():
@@ -2276,8 +2276,8 @@ def _setup_weixin():
     existing_token = get_env_value("WEIXIN_TOKEN")
     if existing_account and existing_token:
         print()
-        print_success("Weixin is already configured.")
-        if not prompt_yes_no("  Reconfigure Weixin?", False):
+        print_success("Weixin: 이미 설정되어 있음")
+        if not prompt_yes_no("  Weixin을 다시 설정할까요?", False):
             return
 
     try:
@@ -2330,7 +2330,7 @@ def _setup_weixin():
         "Only allow listed user IDs",
         "Disable direct messages",
     ]
-    access_idx = prompt_choice("  How should direct messages be authorized?", access_choices, 0)
+    access_idx = prompt_choice("  다이렉트 메시지 접근을 어떻게 승인할까요?", access_choices, 0)
     if access_idx == 0:
         save_env_value("WEIXIN_DM_POLICY", "pairing")
         save_env_value("WEIXIN_ALLOW_ALL_USERS", "false")
@@ -2361,11 +2361,11 @@ def _setup_weixin():
         "Allow all group chats",
         "Only allow listed group chat IDs",
     ]
-    group_idx = prompt_choice("  How should group chats be handled?", group_choices, 0)
+    group_idx = prompt_choice("  그룹 채팅을 어떻게 처리할까요?", group_choices, 0)
     if group_idx == 0:
         save_env_value("WEIXIN_GROUP_POLICY", "disabled")
         save_env_value("WEIXIN_GROUP_ALLOWED_USERS", "")
-        print_info("  Group chats disabled.")
+        print_info("  그룹 채팅을 비활성화했습니다.")
     elif group_idx == 1:
         save_env_value("WEIXIN_GROUP_POLICY", "open")
         save_env_value("WEIXIN_GROUP_ALLOWED_USERS", "")
@@ -2380,10 +2380,10 @@ def _setup_weixin():
         print()
         if prompt_yes_no(f"  Use your Weixin user ID ({user_id}) as the home channel?", True):
             save_env_value("WEIXIN_HOME_CHANNEL", user_id)
-            print_success(f"  Home channel set to {user_id}")
+            print_success(f"  홈 채널을 {user_id}(으)로 설정했습니다")
 
     print()
-    print_success("Weixin configured!")
+    print_success("Weixin 설정 완료!")
     print_info(f"  Account ID: {account_id}")
     if user_id:
         print_info(f"  User ID: {user_id}")
@@ -2398,8 +2398,8 @@ def _setup_feishu():
     existing_secret = get_env_value("FEISHU_APP_SECRET")
     if existing_app_id and existing_secret:
         print()
-        print_success("Feishu / Lark is already configured.")
-        if not prompt_yes_no("  Reconfigure Feishu / Lark?", False):
+        print_success("Feishu / Lark: 이미 설정되어 있음")
+        if not prompt_yes_no("  Feishu / Lark를 다시 설정할까요?", False):
             return
 
     # ── Choose setup method ──
@@ -2438,16 +2438,16 @@ def _setup_feishu():
     # ── Manual credential input ──
     if not credentials:
         print()
-        print_info("  Go to https://open.feishu.cn/ (or https://open.larksuite.com/ for Lark)")
-        print_info("  Create an app, enable the Bot capability, and copy the credentials.")
+        print_info("  https://open.feishu.cn/ (Lark는 https://open.larksuite.com/) 으로 이동하세요")
+        print_info("  앱을 만들고 Bot 기능을 활성화한 뒤 자격 증명을 복사하세요.")
         print()
         app_id = prompt("  App ID", password=False)
         if not app_id:
-            print_warning("  Skipped — Feishu / Lark won't work without an App ID.")
+            print_warning("  건너뜀 — Feishu / Lark는 App ID가 없으면 동작하지 않습니다.")
             return
         app_secret = prompt("  App Secret", password=True)
         if not app_secret:
-            print_warning("  Skipped — Feishu / Lark won't work without an App Secret.")
+            print_warning("  건너뜀 — Feishu / Lark는 App Secret이 없으면 동작하지 않습니다.")
             return
 
         domain_choices = ["feishu (China)", "lark (International)"]
@@ -2515,46 +2515,46 @@ def _setup_feishu():
         "Allow all direct messages",
         "Only allow listed user IDs",
     ]
-    access_idx = prompt_choice("  How should direct messages be authorized?", access_choices, 0)
+    access_idx = prompt_choice("  다이렉트 메시지 접근을 어떻게 승인할까요?", access_choices, 0)
     if access_idx == 0:
         save_env_value("FEISHU_ALLOW_ALL_USERS", "false")
         save_env_value("FEISHU_ALLOWED_USERS", "")
-        print_success("  DM pairing enabled.")
-        print_info("  Unknown users can request access; approve with `hermes pairing approve`.")
+        print_success("  DM 페어링을 활성화했습니다.")
+        print_info("  알 수 없는 사용자가 접근을 요청할 수 있으며 `hermes pairing approve`로 승인할 수 있습니다.")
     elif access_idx == 1:
         save_env_value("FEISHU_ALLOW_ALL_USERS", "true")
         save_env_value("FEISHU_ALLOWED_USERS", "")
-        print_warning("  Open DM access enabled for Feishu / Lark.")
+        print_warning("  Feishu / Lark의 오픈 DM 접근을 활성화했습니다.")
     else:
         save_env_value("FEISHU_ALLOW_ALL_USERS", "false")
         default_allow = open_id or ""
-        allowlist = prompt("  Allowed user IDs (comma-separated)", default_allow, password=False).replace(" ", "")
+        allowlist = prompt("  허용할 사용자 ID (쉼표로 구분)", default_allow, password=False).replace(" ", "")
         save_env_value("FEISHU_ALLOWED_USERS", allowlist)
-        print_success("  Allowlist saved.")
+        print_success("  허용 목록을 저장했습니다.")
 
     # ── Group policy ──
     print()
     group_choices = [
-        "Respond only when @mentioned in groups (recommended)",
-        "Disable group chats",
+        "그룹에서는 @멘션될 때만 응답 (권장)",
+        "그룹 채팅 비활성화",
     ]
-    group_idx = prompt_choice("  How should group chats be handled?", group_choices, 0)
+    group_idx = prompt_choice("  그룹 채팅을 어떻게 처리할까요?", group_choices, 0)
     if group_idx == 0:
         save_env_value("FEISHU_GROUP_POLICY", "open")
-        print_info("  Group chats enabled (bot must be @mentioned).")
+        print_info("  그룹 채팅을 활성화했습니다 (봇을 @멘션해야 응답).")
     else:
         save_env_value("FEISHU_GROUP_POLICY", "disabled")
-        print_info("  Group chats disabled.")
+        print_info("  그룹 채팅을 비활성화했습니다.")
 
     # ── Home channel ──
     print()
-    home_channel = prompt("  Home chat ID (optional, for cron/notifications)", password=False)
+    home_channel = prompt("  홈 채팅 ID (선택 사항, cron/알림용)", password=False)
     if home_channel:
         save_env_value("FEISHU_HOME_CHANNEL", home_channel)
-        print_success(f"  Home channel set to {home_channel}")
+        print_success(f"  홈 채널을 {home_channel}(으)로 설정했습니다")
 
     print()
-    print_success("🪽 Feishu / Lark configured!")
+    print_success("🪽 Feishu / Lark 설정 완료!")
     print_info(f"  App ID: {app_id}")
     print_info(f"  Domain: {domain}")
     if bot_name:
@@ -2572,8 +2572,8 @@ def _setup_signal():
     existing_account = get_env_value("SIGNAL_ACCOUNT")
     if existing_url and existing_account:
         print()
-        print_success("Signal is already configured.")
-        if not prompt_yes_no("  Reconfigure Signal?", False):
+        print_success("Signal: 이미 설정되어 있음")
+        if not prompt_yes_no("  Signal을 다시 설정할까요?", False):
             return
 
     # Check if signal-cli is available
@@ -2668,7 +2668,7 @@ def _setup_signal():
         save_env_value("SIGNAL_GROUP_ALLOWED_USERS", groups)
 
     print()
-    print_success("Signal configured!")
+    print_success("Signal 설정 완료!")
     print_info(f"  URL: {url}")
     print_info(f"  Account: {account}")
     print_info("  DM auth: via SIGNAL_ALLOWED_USERS + DM pairing")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2832,7 +2832,7 @@ def cmd_version(args):
         import openai
         print(f"OpenAI SDK: {openai.__version__}")
     except ImportError:
-        print("OpenAI SDK: Not installed")
+        print("OpenAI SDK: 설치되지 않음")
 
     # Show update status (synchronous — acceptable since user asked for version info)
     try:
@@ -2840,13 +2840,13 @@ def cmd_version(args):
         from hermes_cli.config import recommended_update_command
         behind = check_for_updates()
         if behind and behind > 0:
-            commits_word = "commit" if behind == 1 else "commits"
+            commits_word = "커밋" if behind == 1 else "커밋"
             print(
-                f"Update available: {behind} {commits_word} behind — "
-                f"run '{recommended_update_command()}'"
+                f"업데이트 가능: 최신 버전보다 {behind} {commits_word} 뒤처져 있어요 — "
+                f"'{recommended_update_command()}' 실행"
             )
         elif behind == 0:
-            print("Up to date")
+            print("최신 상태예요")
     except Exception:
         pass
 
@@ -2953,25 +2953,25 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     npm = shutil.which("npm")
     if not npm:
         if fatal:
-            print("Web UI frontend not built and npm is not available.")
-            print("Install Node.js, then run:  cd web && npm install && npm run build")
+            print("Web UI 프런트엔드가 빌드되지 않았고 npm도 사용할 수 없어요.")
+            print("Node.js를 설치한 뒤 다음을 실행하세요: cd web && npm install && npm run build")
         return not fatal
-    print("→ Building web UI...")
+    print("→ Web UI를 빌드하는 중...")
     r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
     if r1.returncode != 0:
-        print(f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
-              + ("" if fatal else " (hermes web will not be available)"))
+        print(f"  {'✗' if fatal else '⚠'} Web UI npm install에 실패했어요"
+              + ("" if fatal else " (hermes web을 사용할 수 없어요)"))
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            print("  수동 실행: cd web && npm install && npm run build")
         return False
     r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
     if r2.returncode != 0:
-        print(f"  {'✗' if fatal else '⚠'} Web UI build failed"
-              + ("" if fatal else " (hermes web will not be available)"))
+        print(f"  {'✗' if fatal else '⚠'} Web UI 빌드에 실패했어요"
+              + ("" if fatal else " (hermes web을 사용할 수 없어요)"))
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            print("  수동 실행: cd web && npm install && npm run build")
         return False
-    print("  ✓ Web UI built")
+    print("  ✓ Web UI 빌드 완료")
     return True
 
 
@@ -2989,13 +2989,13 @@ def _update_via_zip(args):
     branch = "main"
     zip_url = f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip"
     
-    print("→ Downloading latest version...")
+    print("→ 최신 버전을 다운로드하는 중...")
     try:
         tmp_dir = tempfile.mkdtemp(prefix="hermes-update-")
         zip_path = os.path.join(tmp_dir, f"hermes-agent-{branch}.zip")
         urlretrieve(zip_url, zip_path)
         
-        print("→ Extracting...")
+        print("→ 압축을 푸는 중...")
         with zipfile.ZipFile(zip_path, 'r') as zf:
             # Validate paths to prevent zip-slip (path traversal)
             tmp_dir_real = os.path.realpath(tmp_dir)
@@ -3031,19 +3031,19 @@ def _update_via_zip(args):
                 shutil.copy2(src, dst)
             update_count += 1
         
-        print(f"✓ Updated {update_count} items from ZIP")
+        print(f"✓ ZIP에서 {update_count}개 항목을 업데이트했어요")
         
         # Cleanup
         shutil.rmtree(tmp_dir, ignore_errors=True)
         
     except Exception as e:
-        print(f"✗ ZIP update failed: {e}")
+        print(f"✗ ZIP 업데이트에 실패했어요: {e}")
         sys.exit(1)
 
     # Clear stale bytecode after ZIP extraction
     removed = _clear_bytecode_cache(PROJECT_ROOT)
     if removed:
-        print(f"  ✓ Cleared {removed} stale __pycache__ director{'y' if removed == 1 else 'ies'}")
+        print(f"  ✓ 오래된 __pycache__ 디렉터리 {removed}개를 정리했어요")
     
     # Reinstall Python dependencies. Prefer .[all], but if one optional extra
     # breaks on this machine, keep base deps and reinstall the remaining extras

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4628,18 +4628,18 @@ def main():
     chat_parser.add_argument(
         "-v", "--verbose",
         action="store_true",
-        help="Verbose output"
+        help="상세 출력"
     )
     chat_parser.add_argument(
         "-Q", "--quiet",
         action="store_true",
-        help="Quiet mode for programmatic use: suppress banner, spinner, and tool previews. Only output the final response and session info."
+        help="프로그램용 조용한 모드: 배너, 스피너, 도구 미리보기를 숨기고 최종 응답과 세션 정보만 출력"
     )
     chat_parser.add_argument(
         "--resume", "-r",
         metavar="SESSION_ID",
         default=argparse.SUPPRESS,
-        help="Resume a previous session by ID (shown on exit)"
+        help="이전 세션을 ID로 이어서 열기(종료 시 표시됨)"
     )
     chat_parser.add_argument(
         "--continue", "-c",
@@ -4648,43 +4648,43 @@ def main():
         const=True,
         default=argparse.SUPPRESS,
         metavar="SESSION_NAME",
-        help="Resume a session by name, or the most recent if no name given"
+        help="이름으로 세션을 이어서 열고, 이름이 없으면 가장 최근 세션 열기"
     )
     chat_parser.add_argument(
         "--worktree", "-w",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Run in an isolated git worktree (for parallel agents on the same repo)"
+        help="격리된 git worktree에서 실행(같은 repo에서 병렬 에이전트용)"
     )
     chat_parser.add_argument(
         "--checkpoints",
         action="store_true",
         default=False,
-        help="Enable filesystem checkpoints before destructive file operations (use /rollback to restore)"
+        help="파괴적 파일 작업 전에 파일시스템 체크포인트 활성화(/rollback으로 복원 가능)"
     )
     chat_parser.add_argument(
         "--max-turns",
         type=int,
         default=None,
         metavar="N",
-        help="Maximum tool-calling iterations per conversation turn (default: 90, or agent.max_turns in config)"
+        help="대화 턴당 최대 도구 호출 반복 횟수(기본값: 90, 또는 config의 agent.max_turns)"
     )
     chat_parser.add_argument(
         "--yolo",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Bypass all dangerous command approval prompts (use at your own risk)"
+        help="위험 명령 승인 프롬프트를 모두 우회(사용자 책임)"
     )
     chat_parser.add_argument(
         "--pass-session-id",
         action="store_true",
         default=argparse.SUPPRESS,
-        help="Include the session ID in the agent's system prompt"
+        help="에이전트 시스템 프롬프트에 세션 ID 포함"
     )
     chat_parser.add_argument(
         "--source",
         default=None,
-        help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists."
+        help="필터링용 세션 source 태그(기본값: cli). 사용자 세션 목록에 보이면 안 되는 서드파티 연동은 'tool' 사용"
     )
     chat_parser.set_defaults(func=cmd_chat)
 
@@ -4698,41 +4698,41 @@ def main():
     )
     model_parser.add_argument(
         "--portal-url",
-        help="Portal base URL for Nous login (default: production portal)"
+        help="Nous 로그인용 portal 기본 URL(기본값: 운영 portal)"
     )
     model_parser.add_argument(
         "--inference-url",
-        help="Inference API base URL for Nous login (default: production inference API)"
+        help="Nous 로그인용 inference API 기본 URL(기본값: 운영 inference API)"
     )
     model_parser.add_argument(
         "--client-id",
         default=None,
-        help="OAuth client id to use for Nous login (default: hermes-cli)"
+        help="Nous 로그인에 사용할 OAuth client id(기본값: hermes-cli)"
     )
     model_parser.add_argument(
         "--scope",
         default=None,
-        help="OAuth scope to request for Nous login"
+        help="Nous 로그인에서 요청할 OAuth scope"
     )
     model_parser.add_argument(
         "--no-browser",
         action="store_true",
-        help="Do not attempt to open the browser automatically during Nous login"
+        help="Nous 로그인 중 브라우저를 자동으로 열지 않음"
     )
     model_parser.add_argument(
         "--timeout",
         type=float,
         default=15.0,
-        help="HTTP request timeout in seconds for Nous login (default: 15)"
+        help="Nous 로그인용 HTTP 요청 타임아웃(초, 기본값: 15)"
     )
     model_parser.add_argument(
         "--ca-bundle",
-        help="Path to CA bundle PEM file for Nous TLS verification"
+        help="Nous TLS 검증용 CA 번들 PEM 파일 경로"
     )
     model_parser.add_argument(
         "--insecure",
         action="store_true",
-        help="Disable TLS verification for Nous login (testing only)"
+        help="Nous 로그인용 TLS 검증 비활성화(테스트 전용)"
     )
     model_parser.set_defaults(func=cmd_model)
 
@@ -4747,44 +4747,44 @@ def main():
     gateway_subparsers = gateway_parser.add_subparsers(dest="gateway_command")
     
     # gateway run (default)
-    gateway_run = gateway_subparsers.add_parser("run", help="Run gateway in foreground (recommended for WSL, Docker, Termux)")
+    gateway_run = gateway_subparsers.add_parser("run", help="게이트웨이를 포그라운드에서 실행(WSL, Docker, Termux 권장)")
     gateway_run.add_argument("-v", "--verbose", action="count", default=0,
-                             help="Increase stderr log verbosity (-v=INFO, -vv=DEBUG)")
+                             help="stderr 로그 상세도 증가(-v=INFO, -vv=DEBUG)")
     gateway_run.add_argument("-q", "--quiet", action="store_true",
-                             help="Suppress all stderr log output")
+                             help="stderr 로그 출력을 모두 숨김")
     gateway_run.add_argument("--replace", action="store_true",
-                             help="Replace any existing gateway instance (useful for systemd)")
+                             help="기존 게이트웨이 인스턴스가 있으면 교체(systemd에서 유용)")
     
     # gateway start
-    gateway_start = gateway_subparsers.add_parser("start", help="Start the installed systemd/launchd background service")
-    gateway_start.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_start = gateway_subparsers.add_parser("start", help="설치된 systemd/launchd 백그라운드 서비스 시작")
+    gateway_start.add_argument("--system", action="store_true", help="Linux 시스템 레벨 게이트웨이 서비스 대상")
     
     # gateway stop
-    gateway_stop = gateway_subparsers.add_parser("stop", help="Stop gateway service")
-    gateway_stop.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
-    gateway_stop.add_argument("--all", action="store_true", help="Stop ALL gateway processes across all profiles")
+    gateway_stop = gateway_subparsers.add_parser("stop", help="게이트웨이 서비스 중지")
+    gateway_stop.add_argument("--system", action="store_true", help="Linux 시스템 레벨 게이트웨이 서비스 대상")
+    gateway_stop.add_argument("--all", action="store_true", help="모든 프로필의 게이트웨이 프로세스를 전부 중지")
     
     # gateway restart
-    gateway_restart = gateway_subparsers.add_parser("restart", help="Restart gateway service")
-    gateway_restart.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_restart = gateway_subparsers.add_parser("restart", help="게이트웨이 서비스 재시작")
+    gateway_restart.add_argument("--system", action="store_true", help="Linux 시스템 레벨 게이트웨이 서비스 대상")
     
     # gateway status
-    gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")
-    gateway_status.add_argument("--deep", action="store_true", help="Deep status check")
-    gateway_status.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_status = gateway_subparsers.add_parser("status", help="게이트웨이 상태 표시")
+    gateway_status.add_argument("--deep", action="store_true", help="심층 상태 점검")
+    gateway_status.add_argument("--system", action="store_true", help="Linux 시스템 레벨 게이트웨이 서비스 대상")
     
     # gateway install
-    gateway_install = gateway_subparsers.add_parser("install", help="Install gateway as a systemd/launchd background service")
-    gateway_install.add_argument("--force", action="store_true", help="Force reinstall")
-    gateway_install.add_argument("--system", action="store_true", help="Install as a Linux system-level service (starts at boot)")
-    gateway_install.add_argument("--run-as-user", dest="run_as_user", help="User account the Linux system service should run as")
+    gateway_install = gateway_subparsers.add_parser("install", help="게이트웨이를 systemd/launchd 백그라운드 서비스로 설치")
+    gateway_install.add_argument("--force", action="store_true", help="강제로 재설치")
+    gateway_install.add_argument("--system", action="store_true", help="Linux 시스템 레벨 서비스로 설치(부팅 시 시작)")
+    gateway_install.add_argument("--run-as-user", dest="run_as_user", help="Linux 시스템 서비스가 실행될 사용자 계정")
     
     # gateway uninstall
-    gateway_uninstall = gateway_subparsers.add_parser("uninstall", help="Uninstall gateway service")
-    gateway_uninstall.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_uninstall = gateway_subparsers.add_parser("uninstall", help="게이트웨이 서비스 제거")
+    gateway_uninstall.add_argument("--system", action="store_true", help="Linux 시스템 레벨 게이트웨이 서비스 대상")
 
     # gateway setup
-    gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
+    gateway_subparsers.add_parser("setup", help="메시징 플랫폼 설정")
 
     gateway_parser.set_defaults(func=cmd_gateway)
     
@@ -4802,17 +4802,17 @@ def main():
         nargs="?",
         choices=["model", "tts", "terminal", "gateway", "tools", "agent"],
         default=None,
-        help="Run a specific setup section instead of the full wizard"
+        help="전체 마법사 대신 특정 설정 섹션만 실행"
     )
     setup_parser.add_argument(
         "--non-interactive",
         action="store_true",
-        help="Non-interactive mode (use defaults/env vars)"
+        help="비대화형 모드(기본값/env var 사용)"
     )
     setup_parser.add_argument(
         "--reset",
         action="store_true",
-        help="Reset configuration to defaults"
+        help="설정을 기본값으로 초기화"
     )
     setup_parser.set_defaults(func=cmd_setup)
 
@@ -4838,45 +4838,45 @@ def main():
         "--provider",
         choices=["nous", "openai-codex"],
         default=None,
-        help="Provider to authenticate with (default: nous)"
+        help="인증할 provider(기본값: nous)"
     )
     login_parser.add_argument(
         "--portal-url",
-        help="Portal base URL (default: production portal)"
+        help="Portal 기본 URL(기본값: 운영 portal)"
     )
     login_parser.add_argument(
         "--inference-url",
-        help="Inference API base URL (default: production inference API)"
+        help="추론 API 기본 URL(기본값: 운영 inference API)"
     )
     login_parser.add_argument(
         "--client-id",
         default=None,
-        help="OAuth client id to use (default: hermes-cli)"
+        help="사용할 OAuth client id(기본값: hermes-cli)"
     )
     login_parser.add_argument(
         "--scope",
         default=None,
-        help="OAuth scope to request"
+        help="요청할 OAuth scope"
     )
     login_parser.add_argument(
         "--no-browser",
         action="store_true",
-        help="Do not attempt to open the browser automatically"
+        help="브라우저를 자동으로 열지 않음"
     )
     login_parser.add_argument(
         "--timeout",
         type=float,
         default=15.0,
-        help="HTTP request timeout in seconds (default: 15)"
+        help="HTTP 요청 타임아웃(초, 기본값: 15)"
     )
     login_parser.add_argument(
         "--ca-bundle",
-        help="Path to CA bundle PEM file for TLS verification"
+        help="TLS 검증용 CA 번들 PEM 파일 경로"
     )
     login_parser.add_argument(
         "--insecure",
         action="store_true",
-        help="Disable TLS verification (testing only)"
+        help="TLS 검증 비활성화(테스트 전용)"
     )
     login_parser.set_defaults(func=cmd_login)
 
@@ -4892,7 +4892,7 @@ def main():
         "--provider",
         choices=["nous", "openai-codex"],
         default=None,
-        help="Provider to log out from (default: active provider)"
+        help="로그아웃할 provider(기본값: 현재 활성 provider)"
     )
     logout_parser.set_defaults(func=cmd_logout)
 
@@ -4901,25 +4901,25 @@ def main():
         help="provider 풀 자격 증명 관리",
     )
     auth_subparsers = auth_parser.add_subparsers(dest="auth_action")
-    auth_add = auth_subparsers.add_parser("add", help="Add a pooled credential")
-    auth_add.add_argument("provider", help="Provider id (for example: anthropic, openai-codex, openrouter)")
-    auth_add.add_argument("--type", dest="auth_type", choices=["oauth", "api-key", "api_key"], help="Credential type to add")
-    auth_add.add_argument("--label", help="Optional display label")
-    auth_add.add_argument("--api-key", help="API key value (otherwise prompted securely)")
-    auth_add.add_argument("--portal-url", help="Nous portal base URL")
-    auth_add.add_argument("--inference-url", help="Nous inference base URL")
+    auth_add = auth_subparsers.add_parser("add", help="풀 자격 증명 추가")
+    auth_add.add_argument("provider", help="Provider id(예: anthropic, openai-codex, openrouter)")
+    auth_add.add_argument("--type", dest="auth_type", choices=["oauth", "api-key", "api_key"], help="추가할 자격 증명 유형")
+    auth_add.add_argument("--label", help="선택 표시 라벨")
+    auth_add.add_argument("--api-key", help="API key 값(없으면 안전하게 프롬프트 표시)")
+    auth_add.add_argument("--portal-url", help="Nous portal 기본 URL")
+    auth_add.add_argument("--inference-url", help="Nous inference 기본 URL")
     auth_add.add_argument("--client-id", help="OAuth client id")
-    auth_add.add_argument("--scope", help="OAuth scope override")
-    auth_add.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser for OAuth login")
-    auth_add.add_argument("--timeout", type=float, help="OAuth/network timeout in seconds")
-    auth_add.add_argument("--insecure", action="store_true", help="Disable TLS verification for OAuth login")
-    auth_add.add_argument("--ca-bundle", help="Custom CA bundle for OAuth login")
-    auth_list = auth_subparsers.add_parser("list", help="List pooled credentials")
-    auth_list.add_argument("provider", nargs="?", help="Optional provider filter")
-    auth_remove = auth_subparsers.add_parser("remove", help="Remove a pooled credential by index, id, or label")
+    auth_add.add_argument("--scope", help="OAuth scope 덮어쓰기")
+    auth_add.add_argument("--no-browser", action="store_true", help="OAuth 로그인 때 브라우저를 자동으로 열지 않음")
+    auth_add.add_argument("--timeout", type=float, help="OAuth/네트워크 타임아웃(초)")
+    auth_add.add_argument("--insecure", action="store_true", help="OAuth 로그인용 TLS 검증 비활성화")
+    auth_add.add_argument("--ca-bundle", help="OAuth 로그인용 사용자 지정 CA 번들")
+    auth_list = auth_subparsers.add_parser("list", help="풀 자격 증명 목록 표시")
+    auth_list.add_argument("provider", nargs="?", help="선택 provider 필터")
+    auth_remove = auth_subparsers.add_parser("remove", help="인덱스, id, 라벨로 풀 자격 증명 제거")
     auth_remove.add_argument("provider", help="Provider id")
-    auth_remove.add_argument("target", help="Credential index, entry id, or exact label")
-    auth_reset = auth_subparsers.add_parser("reset", help="Clear exhaustion status for all credentials for a provider")
+    auth_remove.add_argument("target", help="자격 증명 인덱스, 항목 id, 또는 정확한 라벨")
+    auth_reset = auth_subparsers.add_parser("reset", help="provider의 모든 자격 증명 소진 상태 초기화")
     auth_reset.add_argument("provider", help="Provider id")
     auth_parser.set_defaults(func=cmd_auth)
 
@@ -4934,12 +4934,12 @@ def main():
     status_parser.add_argument(
         "--all",
         action="store_true",
-        help="Show all details (redacted for sharing)"
+        help="모든 세부정보 표시(공유용으로 일부 가림)"
     )
     status_parser.add_argument(
         "--deep",
         action="store_true",
-        help="Run deep checks (may take longer)"
+        help="심층 점검 실행(시간이 더 걸릴 수 있음)"
     )
     status_parser.set_defaults(func=cmd_status)
     
@@ -4954,51 +4954,51 @@ def main():
     cron_subparsers = cron_parser.add_subparsers(dest="cron_command")
     
     # cron list
-    cron_list = cron_subparsers.add_parser("list", help="List scheduled jobs")
-    cron_list.add_argument("--all", action="store_true", help="Include disabled jobs")
+    cron_list = cron_subparsers.add_parser("list", help="예약 작업 목록 표시")
+    cron_list.add_argument("--all", action="store_true", help="비활성화된 작업도 포함")
 
     # cron create/add
-    cron_create = cron_subparsers.add_parser("create", aliases=["add"], help="Create a scheduled job")
-    cron_create.add_argument("schedule", help="Schedule like '30m', 'every 2h', or '0 9 * * *'")
-    cron_create.add_argument("prompt", nargs="?", help="Optional self-contained prompt or task instruction")
-    cron_create.add_argument("--name", help="Optional human-friendly job name")
-    cron_create.add_argument("--deliver", help="Delivery target: origin, local, telegram, discord, signal, or platform:chat_id")
-    cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
-    cron_create.add_argument("--skill", dest="skills", action="append", help="Attach a skill. Repeat to add multiple skills.")
-    cron_create.add_argument("--script", help="Path to a Python script whose stdout is injected into the prompt each run")
+    cron_create = cron_subparsers.add_parser("create", aliases=["add"], help="예약 작업 생성")
+    cron_create.add_argument("schedule", help="예: '30m', 'every 2h', '0 9 * * *' 형식의 일정")
+    cron_create.add_argument("prompt", nargs="?", help="선택: 독립 실행형 프롬프트 또는 작업 지시")
+    cron_create.add_argument("--name", help="선택: 사람이 읽기 쉬운 작업 이름")
+    cron_create.add_argument("--deliver", help="전달 대상: origin, local, telegram, discord, signal 또는 platform:chat_id")
+    cron_create.add_argument("--repeat", type=int, help="선택: 반복 횟수")
+    cron_create.add_argument("--skill", dest="skills", action="append", help="스킬 첨부. 여러 개를 붙이려면 반복 지정")
+    cron_create.add_argument("--script", help="실행마다 stdout을 프롬프트에 주입할 Python 스크립트 경로")
 
     # cron edit
-    cron_edit = cron_subparsers.add_parser("edit", help="Edit an existing scheduled job")
-    cron_edit.add_argument("job_id", help="Job ID to edit")
-    cron_edit.add_argument("--schedule", help="New schedule")
-    cron_edit.add_argument("--prompt", help="New prompt/task instruction")
-    cron_edit.add_argument("--name", help="New job name")
-    cron_edit.add_argument("--deliver", help="New delivery target")
-    cron_edit.add_argument("--repeat", type=int, help="New repeat count")
-    cron_edit.add_argument("--skill", dest="skills", action="append", help="Replace the job's skills with this set. Repeat to attach multiple skills.")
-    cron_edit.add_argument("--add-skill", dest="add_skills", action="append", help="Append a skill without replacing the existing list. Repeatable.")
-    cron_edit.add_argument("--remove-skill", dest="remove_skills", action="append", help="Remove a specific attached skill. Repeatable.")
-    cron_edit.add_argument("--clear-skills", action="store_true", help="Remove all attached skills from the job")
-    cron_edit.add_argument("--script", help="Path to a Python script whose stdout is injected into the prompt each run. Pass empty string to clear.")
+    cron_edit = cron_subparsers.add_parser("edit", help="기존 예약 작업 편집")
+    cron_edit.add_argument("job_id", help="편집할 작업 ID")
+    cron_edit.add_argument("--schedule", help="새 일정")
+    cron_edit.add_argument("--prompt", help="새 프롬프트/작업 지시")
+    cron_edit.add_argument("--name", help="새 작업 이름")
+    cron_edit.add_argument("--deliver", help="새 전달 대상")
+    cron_edit.add_argument("--repeat", type=int, help="새 반복 횟수")
+    cron_edit.add_argument("--skill", dest="skills", action="append", help="작업의 스킬 목록을 이 집합으로 교체. 여러 개를 붙이려면 반복 지정")
+    cron_edit.add_argument("--add-skill", dest="add_skills", action="append", help="기존 목록을 바꾸지 않고 스킬 추가. 반복 가능")
+    cron_edit.add_argument("--remove-skill", dest="remove_skills", action="append", help="첨부된 특정 스킬 제거. 반복 가능")
+    cron_edit.add_argument("--clear-skills", action="store_true", help="작업에 붙은 모든 스킬 제거")
+    cron_edit.add_argument("--script", help="실행마다 stdout을 프롬프트에 주입할 Python 스크립트 경로. 비우려면 빈 문자열 전달")
 
     # lifecycle actions
-    cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")
-    cron_pause.add_argument("job_id", help="Job ID to pause")
+    cron_pause = cron_subparsers.add_parser("pause", help="예약 작업 일시중지")
+    cron_pause.add_argument("job_id", help="일시중지할 작업 ID")
 
-    cron_resume = cron_subparsers.add_parser("resume", help="Resume a paused job")
-    cron_resume.add_argument("job_id", help="Job ID to resume")
+    cron_resume = cron_subparsers.add_parser("resume", help="일시중지된 작업 재개")
+    cron_resume.add_argument("job_id", help="재개할 작업 ID")
 
-    cron_run = cron_subparsers.add_parser("run", help="Run a job on the next scheduler tick")
-    cron_run.add_argument("job_id", help="Job ID to trigger")
+    cron_run = cron_subparsers.add_parser("run", help="다음 스케줄러 tick에서 작업 실행")
+    cron_run.add_argument("job_id", help="실행할 작업 ID")
 
-    cron_remove = cron_subparsers.add_parser("remove", aliases=["rm", "delete"], help="Remove a scheduled job")
-    cron_remove.add_argument("job_id", help="Job ID to remove")
+    cron_remove = cron_subparsers.add_parser("remove", aliases=["rm", "delete"], help="예약 작업 제거")
+    cron_remove.add_argument("job_id", help="제거할 작업 ID")
 
     # cron status
-    cron_subparsers.add_parser("status", help="Check if cron scheduler is running")
+    cron_subparsers.add_parser("status", help="크론 스케줄러 실행 상태 확인")
 
     # cron tick (mostly for debugging)
-    cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
+    cron_subparsers.add_parser("tick", help="실행 시각이 된 작업을 한 번 실행하고 종료")
 
     cron_parser.set_defaults(func=cmd_cron)
 
@@ -5012,24 +5012,24 @@ def main():
     )
     webhook_subparsers = webhook_parser.add_subparsers(dest="webhook_action")
 
-    wh_sub = webhook_subparsers.add_parser("subscribe", aliases=["add"], help="Create a webhook subscription")
-    wh_sub.add_argument("name", help="Route name (used in URL: /webhooks/<name>)")
-    wh_sub.add_argument("--prompt", default="", help="Prompt template with {dot.notation} payload refs")
-    wh_sub.add_argument("--events", default="", help="Comma-separated event types to accept")
-    wh_sub.add_argument("--description", default="", help="What this subscription does")
-    wh_sub.add_argument("--skills", default="", help="Comma-separated skill names to load")
-    wh_sub.add_argument("--deliver", default="log", help="Delivery target: log, telegram, discord, slack, etc.")
-    wh_sub.add_argument("--deliver-chat-id", default="", help="Target chat ID for cross-platform delivery")
-    wh_sub.add_argument("--secret", default="", help="HMAC secret (auto-generated if omitted)")
+    wh_sub = webhook_subparsers.add_parser("subscribe", aliases=["add"], help="웹훅 구독 생성")
+    wh_sub.add_argument("name", help="라우트 이름(URL에서 /webhooks/<name>에 사용)")
+    wh_sub.add_argument("--prompt", default="", help="{dot.notation} payload 참조를 포함한 프롬프트 템플릿")
+    wh_sub.add_argument("--events", default="", help="허용할 이벤트 유형(쉼표 구분)")
+    wh_sub.add_argument("--description", default="", help="이 구독의 용도 설명")
+    wh_sub.add_argument("--skills", default="", help="로드할 스킬 이름(쉼표 구분)")
+    wh_sub.add_argument("--deliver", default="log", help="전달 대상: log, telegram, discord, slack 등")
+    wh_sub.add_argument("--deliver-chat-id", default="", help="크로스플랫폼 전달 대상 chat ID")
+    wh_sub.add_argument("--secret", default="", help="HMAC 시크릿(생략 시 자동 생성)")
 
-    webhook_subparsers.add_parser("list", aliases=["ls"], help="List all dynamic subscriptions")
+    webhook_subparsers.add_parser("list", aliases=["ls"], help="동적 구독 전체 목록 표시")
 
-    wh_rm = webhook_subparsers.add_parser("remove", aliases=["rm"], help="Remove a subscription")
-    wh_rm.add_argument("name", help="Subscription name to remove")
+    wh_rm = webhook_subparsers.add_parser("remove", aliases=["rm"], help="구독 제거")
+    wh_rm.add_argument("name", help="제거할 구독 이름")
 
-    wh_test = webhook_subparsers.add_parser("test", help="Send a test POST to a webhook route")
-    wh_test.add_argument("name", help="Subscription name to test")
-    wh_test.add_argument("--payload", default="", help="JSON payload to send (default: test payload)")
+    wh_test = webhook_subparsers.add_parser("test", help="웹훅 라우트로 테스트 POST 전송")
+    wh_test.add_argument("name", help="테스트할 구독 이름")
+    wh_test.add_argument("--payload", default="", help="전송할 JSON payload(기본값: 테스트 payload)")
 
     webhook_parser.set_defaults(func=cmd_webhook)
 
@@ -5044,7 +5044,7 @@ def main():
     doctor_parser.add_argument(
         "--fix",
         action="store_true",
-        help="Attempt to fix issues automatically"
+        help="문제를 자동으로 수정 시도"
     )
     doctor_parser.set_defaults(func=cmd_doctor)
 
@@ -5060,7 +5060,7 @@ def main():
     dump_parser.add_argument(
         "--show-keys",
         action="store_true",
-        help="Show redacted API key prefixes (first/last 4 chars) instead of just set/not set"
+        help="단순 설정 여부 대신 API key 앞/뒤 4글자를 가려서 표시"
     )
     dump_parser.set_defaults(func=cmd_dump)
 
@@ -5075,29 +5075,29 @@ def main():
                     "공유 가능한 URL을 받을 수 있습니다.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
-Examples:
-    hermes debug share              Upload debug report and print URL
-    hermes debug share --lines 500  Include more log lines
-    hermes debug share --expire 30  Keep paste for 30 days
-    hermes debug share --local      Print report locally (no upload)
+예시:
+    hermes debug share              디버그 리포트를 업로드하고 URL 출력
+    hermes debug share --lines 500  더 많은 로그 줄 포함
+    hermes debug share --expire 30  paste를 30일간 유지
+    hermes debug share --local      로컬에만 리포트 출력(업로드 안 함)
 """,
     )
     debug_sub = debug_parser.add_subparsers(dest="debug_command")
     share_parser = debug_sub.add_parser(
         "share",
-        help="Upload debug report to a paste service and print a shareable URL",
+        help="디버그 리포트를 paste 서비스에 업로드하고 공유 URL 출력",
     )
     share_parser.add_argument(
         "--lines", type=int, default=200,
-        help="Number of log lines to include per log file (default: 200)",
+        help="로그 파일마다 포함할 줄 수(기본값: 200)",
     )
     share_parser.add_argument(
         "--expire", type=int, default=7,
-        help="Paste expiry in days (default: 7)",
+        help="paste 만료 기간(일, 기본값: 7)",
     )
     share_parser.add_argument(
         "--local", action="store_true",
-        help="Print the report locally instead of uploading",
+        help="업로드 대신 로컬에 리포트 출력",
     )
     debug_parser.set_defaults(func=cmd_debug)
 
@@ -5113,16 +5113,16 @@ Examples:
     )
     backup_parser.add_argument(
         "-o", "--output",
-        help="Output path for the zip file (default: ~/hermes-backup-<timestamp>.zip)"
+        help="zip 파일 출력 경로(기본값: ~/hermes-backup-<timestamp>.zip)"
     )
     backup_parser.add_argument(
         "-q", "--quick",
         action="store_true",
-        help="Quick snapshot: only critical state files (config, state.db, .env, auth, cron)"
+        help="빠른 스냅샷: 핵심 상태 파일만 포함(config, state.db, .env, auth, cron)"
     )
     backup_parser.add_argument(
         "-l", "--label",
-        help="Label for the snapshot (only used with --quick)"
+        help="스냅샷 라벨(--quick 사용 시에만 적용)"
     )
     backup_parser.set_defaults(func=cmd_backup)
 
@@ -5136,12 +5136,12 @@ Examples:
     )
     import_parser.add_argument(
         "zipfile",
-        help="Path to the backup zip file"
+        help="백업 zip 파일 경로"
     )
     import_parser.add_argument(
         "--force", "-f",
         action="store_true",
-        help="Overwrite existing files without confirmation"
+        help="확인 없이 기존 파일 덮어쓰기"
     )
     import_parser.set_defaults(func=cmd_import)
 
@@ -5156,27 +5156,27 @@ Examples:
     config_subparsers = config_parser.add_subparsers(dest="config_command")
     
     # config show (default)
-    config_subparsers.add_parser("show", help="Show current configuration")
+    config_subparsers.add_parser("show", help="현재 설정 표시")
     
     # config edit
-    config_subparsers.add_parser("edit", help="Open config file in editor")
+    config_subparsers.add_parser("edit", help="에디터에서 config 파일 열기")
     
     # config set
-    config_set = config_subparsers.add_parser("set", help="Set a configuration value")
-    config_set.add_argument("key", nargs="?", help="Configuration key (e.g., model, terminal.backend)")
-    config_set.add_argument("value", nargs="?", help="Value to set")
+    config_set = config_subparsers.add_parser("set", help="설정값 지정")
+    config_set.add_argument("key", nargs="?", help="설정 키(예: model, terminal.backend)")
+    config_set.add_argument("value", nargs="?", help="설정할 값")
     
     # config path
-    config_subparsers.add_parser("path", help="Print config file path")
+    config_subparsers.add_parser("path", help="config 파일 경로 출력")
     
     # config env-path
-    config_subparsers.add_parser("env-path", help="Print .env file path")
+    config_subparsers.add_parser("env-path", help=".env 파일 경로 출력")
     
     # config check
-    config_subparsers.add_parser("check", help="Check for missing/outdated config")
+    config_subparsers.add_parser("check", help="누락되었거나 오래된 config 점검")
     
     # config migrate
-    config_subparsers.add_parser("migrate", help="Update config with new options")
+    config_subparsers.add_parser("migrate", help="새 옵션으로 config 업데이트")
     
     config_parser.set_defaults(func=cmd_config)
     
@@ -5190,17 +5190,17 @@ Examples:
     )
     pairing_sub = pairing_parser.add_subparsers(dest="pairing_action")
 
-    pairing_sub.add_parser("list", help="Show pending + approved users")
+    pairing_sub.add_parser("list", help="대기 중 + 승인된 사용자 표시")
 
-    pairing_approve_parser = pairing_sub.add_parser("approve", help="Approve a pairing code")
-    pairing_approve_parser.add_argument("platform", help="Platform name (telegram, discord, slack, whatsapp)")
-    pairing_approve_parser.add_argument("code", help="Pairing code to approve")
+    pairing_approve_parser = pairing_sub.add_parser("approve", help="페어링 코드 승인")
+    pairing_approve_parser.add_argument("platform", help="플랫폼 이름(telegram, discord, slack, whatsapp)")
+    pairing_approve_parser.add_argument("code", help="승인할 페어링 코드")
 
-    pairing_revoke_parser = pairing_sub.add_parser("revoke", help="Revoke user access")
-    pairing_revoke_parser.add_argument("platform", help="Platform name")
-    pairing_revoke_parser.add_argument("user_id", help="User ID to revoke")
+    pairing_revoke_parser = pairing_sub.add_parser("revoke", help="사용자 접근 권한 철회")
+    pairing_revoke_parser.add_argument("platform", help="플랫폼 이름")
+    pairing_revoke_parser.add_argument("user_id", help="철회할 사용자 ID")
 
-    pairing_sub.add_parser("clear-pending", help="Clear all pending codes")
+    pairing_sub.add_parser("clear-pending", help="대기 중인 코드 모두 비우기")
 
     def cmd_pairing(args):
         from hermes_cli.pairing import pairing_command
@@ -5218,65 +5218,65 @@ Examples:
     )
     skills_subparsers = skills_parser.add_subparsers(dest="skills_action")
 
-    skills_browse = skills_subparsers.add_parser("browse", help="Browse all available skills (paginated)")
-    skills_browse.add_argument("--page", type=int, default=1, help="Page number (default: 1)")
-    skills_browse.add_argument("--size", type=int, default=20, help="Results per page (default: 20)")
+    skills_browse = skills_subparsers.add_parser("browse", help="사용 가능한 스킬 전체 둘러보기(페이지 단위)")
+    skills_browse.add_argument("--page", type=int, default=1, help="페이지 번호(기본값: 1)")
+    skills_browse.add_argument("--size", type=int, default=20, help="페이지당 결과 수(기본값: 20)")
     skills_browse.add_argument("--source", default="all",
                                choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"],
-                               help="Filter by source (default: all)")
+                               help="source로 필터링(기본값: all)")
 
-    skills_search = skills_subparsers.add_parser("search", help="Search skill registries")
-    skills_search.add_argument("query", help="Search query")
+    skills_search = skills_subparsers.add_parser("search", help="스킬 레지스트리 검색")
+    skills_search.add_argument("query", help="검색어")
     skills_search.add_argument("--source", default="all", choices=["all", "official", "skills-sh", "well-known", "github", "clawhub", "lobehub"])
-    skills_search.add_argument("--limit", type=int, default=10, help="Max results")
+    skills_search.add_argument("--limit", type=int, default=10, help="최대 결과 수")
 
-    skills_install = skills_subparsers.add_parser("install", help="Install a skill")
-    skills_install.add_argument("identifier", help="Skill identifier (e.g. openai/skills/skill-creator)")
-    skills_install.add_argument("--category", default="", help="Category folder to install into")
-    skills_install.add_argument("--force", action="store_true", help="Install despite blocked scan verdict")
-    skills_install.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt (needed in TUI mode)")
+    skills_install = skills_subparsers.add_parser("install", help="스킬 설치")
+    skills_install.add_argument("identifier", help="스킬 식별자(예: openai/skills/skill-creator)")
+    skills_install.add_argument("--category", default="", help="설치할 category 폴더")
+    skills_install.add_argument("--force", action="store_true", help="차단 스캔 판정이 있어도 설치")
+    skills_install.add_argument("--yes", "-y", action="store_true", help="확인 프롬프트 건너뛰기(TUI 모드에서 필요)")
 
-    skills_inspect = skills_subparsers.add_parser("inspect", help="Preview a skill without installing")
-    skills_inspect.add_argument("identifier", help="Skill identifier")
+    skills_inspect = skills_subparsers.add_parser("inspect", help="설치하지 않고 스킬 미리보기")
+    skills_inspect.add_argument("identifier", help="스킬 식별자")
 
-    skills_list = skills_subparsers.add_parser("list", help="List installed skills")
+    skills_list = skills_subparsers.add_parser("list", help="설치된 스킬 목록 표시")
     skills_list.add_argument("--source", default="all", choices=["all", "hub", "builtin", "local"])
 
-    skills_check = skills_subparsers.add_parser("check", help="Check installed hub skills for updates")
-    skills_check.add_argument("name", nargs="?", help="Specific skill to check (default: all)")
+    skills_check = skills_subparsers.add_parser("check", help="설치된 hub 스킬 업데이트 점검")
+    skills_check.add_argument("name", nargs="?", help="점검할 특정 스킬(기본값: 전체)")
 
-    skills_update = skills_subparsers.add_parser("update", help="Update installed hub skills")
-    skills_update.add_argument("name", nargs="?", help="Specific skill to update (default: all outdated skills)")
+    skills_update = skills_subparsers.add_parser("update", help="설치된 hub 스킬 업데이트")
+    skills_update.add_argument("name", nargs="?", help="업데이트할 특정 스킬(기본값: 오래된 스킬 전체)")
 
-    skills_audit = skills_subparsers.add_parser("audit", help="Re-scan installed hub skills")
-    skills_audit.add_argument("name", nargs="?", help="Specific skill to audit (default: all)")
+    skills_audit = skills_subparsers.add_parser("audit", help="설치된 hub 스킬 재스캔")
+    skills_audit.add_argument("name", nargs="?", help="감사할 특정 스킬(기본값: 전체)")
 
-    skills_uninstall = skills_subparsers.add_parser("uninstall", help="Remove a hub-installed skill")
-    skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall = skills_subparsers.add_parser("uninstall", help="hub 설치 스킬 제거")
+    skills_uninstall.add_argument("name", help="제거할 스킬 이름")
 
-    skills_publish = skills_subparsers.add_parser("publish", help="Publish a skill to a registry")
-    skills_publish.add_argument("skill_path", help="Path to skill directory")
-    skills_publish.add_argument("--to", default="github", choices=["github", "clawhub"], help="Target registry")
-    skills_publish.add_argument("--repo", default="", help="Target GitHub repo (e.g. openai/skills)")
+    skills_publish = skills_subparsers.add_parser("publish", help="레지스트리에 스킬 게시")
+    skills_publish.add_argument("skill_path", help="스킬 디렉터리 경로")
+    skills_publish.add_argument("--to", default="github", choices=["github", "clawhub"], help="대상 레지스트리")
+    skills_publish.add_argument("--repo", default="", help="대상 GitHub repo(예: openai/skills)")
 
-    skills_snapshot = skills_subparsers.add_parser("snapshot", help="Export/import skill configurations")
+    skills_snapshot = skills_subparsers.add_parser("snapshot", help="스킬 설정 내보내기/가져오기")
     snapshot_subparsers = skills_snapshot.add_subparsers(dest="snapshot_action")
-    snap_export = snapshot_subparsers.add_parser("export", help="Export installed skills to a file")
-    snap_export.add_argument("output", help="Output JSON file path (use - for stdout)")
-    snap_import = snapshot_subparsers.add_parser("import", help="Import and install skills from a file")
-    snap_import.add_argument("input", help="Input JSON file path")
-    snap_import.add_argument("--force", action="store_true", help="Force install despite caution verdict")
+    snap_export = snapshot_subparsers.add_parser("export", help="설치된 스킬을 파일로 내보내기")
+    snap_export.add_argument("output", help="출력 JSON 파일 경로(stdout은 - 사용)")
+    snap_import = snapshot_subparsers.add_parser("import", help="파일에서 스킬을 가져와 설치")
+    snap_import.add_argument("input", help="입력 JSON 파일 경로")
+    snap_import.add_argument("--force", action="store_true", help="주의 판정이 있어도 강제로 설치")
 
-    skills_tap = skills_subparsers.add_parser("tap", help="Manage skill sources")
+    skills_tap = skills_subparsers.add_parser("tap", help="스킬 source 관리")
     tap_subparsers = skills_tap.add_subparsers(dest="tap_action")
-    tap_subparsers.add_parser("list", help="List configured taps")
-    tap_add = tap_subparsers.add_parser("add", help="Add a GitHub repo as skill source")
-    tap_add.add_argument("repo", help="GitHub repo (e.g. owner/repo)")
-    tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
-    tap_rm.add_argument("name", help="Tap name to remove")
+    tap_subparsers.add_parser("list", help="설정된 tap 목록 표시")
+    tap_add = tap_subparsers.add_parser("add", help="GitHub repo를 스킬 source로 추가")
+    tap_add.add_argument("repo", help="GitHub repo(예: owner/repo)")
+    tap_rm = tap_subparsers.add_parser("remove", help="tap 제거")
+    tap_rm.add_argument("name", help="제거할 tap 이름")
 
     # config sub-action: interactive enable/disable
-    skills_subparsers.add_parser("config", help="Interactive skill configuration — enable/disable individual skills")
+    skills_subparsers.add_parser("config", help="대화형 스킬 설정 — 개별 스킬 활성화/비활성화")
 
     def cmd_skills(args):
         # Route 'config' action to skills_config module
@@ -5301,38 +5301,38 @@ Examples:
     plugins_subparsers = plugins_parser.add_subparsers(dest="plugins_action")
 
     plugins_install = plugins_subparsers.add_parser(
-        "install", help="Install a plugin from a Git URL or owner/repo"
+        "install", help="Git URL 또는 owner/repo로 플러그인 설치"
     )
     plugins_install.add_argument(
         "identifier",
-        help="Git URL or owner/repo shorthand (e.g. anpicasso/hermes-plugin-chrome-profiles)",
+        help="Git URL 또는 owner/repo 축약형(예: anpicasso/hermes-plugin-chrome-profiles)",
     )
     plugins_install.add_argument(
         "--force", "-f", action="store_true",
-        help="Remove existing plugin and reinstall",
+        help="기존 플러그인을 제거하고 재설치",
     )
 
     plugins_update = plugins_subparsers.add_parser(
-        "update", help="Pull latest changes for an installed plugin"
+        "update", help="설치된 플러그인의 최신 변경 사항 가져오기"
     )
-    plugins_update.add_argument("name", help="Plugin name to update")
+    plugins_update.add_argument("name", help="업데이트할 플러그인 이름")
 
     plugins_remove = plugins_subparsers.add_parser(
-        "remove", aliases=["rm", "uninstall"], help="Remove an installed plugin"
+        "remove", aliases=["rm", "uninstall"], help="설치된 플러그인 제거"
     )
-    plugins_remove.add_argument("name", help="Plugin directory name to remove")
+    plugins_remove.add_argument("name", help="제거할 플러그인 디렉터리 이름")
 
-    plugins_subparsers.add_parser("list", aliases=["ls"], help="List installed plugins")
+    plugins_subparsers.add_parser("list", aliases=["ls"], help="설치된 플러그인 목록 표시")
 
     plugins_enable = plugins_subparsers.add_parser(
-        "enable", help="Enable a disabled plugin"
+        "enable", help="비활성화된 플러그인 활성화"
     )
-    plugins_enable.add_argument("name", help="Plugin name to enable")
+    plugins_enable.add_argument("name", help="활성화할 플러그인 이름")
 
     plugins_disable = plugins_subparsers.add_parser(
-        "disable", help="Disable a plugin without removing it"
+        "disable", help="플러그인을 제거하지 않고 비활성화"
     )
-    plugins_disable.add_argument("name", help="Plugin name to disable")
+    plugins_disable.add_argument("name", help="비활성화할 플러그인 이름")
 
     def cmd_plugins(args):
         from hermes_cli.plugins_cmd import plugins_command
@@ -5374,9 +5374,9 @@ Examples:
         ),
     )
     memory_sub = memory_parser.add_subparsers(dest="memory_command")
-    memory_sub.add_parser("setup", help="Interactive provider selection and configuration")
-    memory_sub.add_parser("status", help="Show current memory provider config")
-    memory_sub.add_parser("off", help="Disable external provider (built-in only)")
+    memory_sub.add_parser("setup", help="대화형 provider 선택 및 설정")
+    memory_sub.add_parser("status", help="현재 memory provider 설정 표시")
+    memory_sub.add_parser("off", help="외부 provider 비활성화(내장만 사용)")
 
     def cmd_memory(args):
         sub = getattr(args, "memory_command", None)
@@ -5411,46 +5411,46 @@ Examples:
     tools_parser.add_argument(
         "--summary",
         action="store_true",
-        help="Print a summary of enabled tools per platform and exit"
+        help="플랫폼별 활성 도구 요약을 출력하고 종료"
     )
     tools_sub = tools_parser.add_subparsers(dest="tools_action")
 
     # hermes tools list [--platform cli]
     tools_list_p = tools_sub.add_parser(
         "list",
-        help="Show all tools and their enabled/disabled status",
+        help="모든 도구와 활성/비활성 상태 표시",
     )
     tools_list_p.add_argument(
         "--platform", default="cli",
-        help="Platform to show (default: cli)",
+        help="표시할 플랫폼(기본값: cli)",
     )
 
     # hermes tools disable <name...> [--platform cli]
     tools_disable_p = tools_sub.add_parser(
         "disable",
-        help="Disable toolsets or MCP tools",
+        help="toolset 또는 MCP 도구 비활성화",
     )
     tools_disable_p.add_argument(
         "names", nargs="+", metavar="NAME",
-        help="Toolset name (e.g. web) or MCP tool in server:tool form",
+        help="Toolset 이름(예: web) 또는 server:tool 형식의 MCP 도구",
     )
     tools_disable_p.add_argument(
         "--platform", default="cli",
-        help="Platform to apply to (default: cli)",
+        help="적용할 플랫폼(기본값: cli)",
     )
 
     # hermes tools enable <name...> [--platform cli]
     tools_enable_p = tools_sub.add_parser(
         "enable",
-        help="Enable toolsets or MCP tools",
+        help="toolset 또는 MCP 도구 활성화",
     )
     tools_enable_p.add_argument(
         "names", nargs="+", metavar="NAME",
-        help="Toolset name or MCP tool in server:tool form",
+        help="Toolset 이름 또는 server:tool 형식의 MCP 도구",
     )
     tools_enable_p.add_argument(
         "--platform", default="cli",
-        help="Platform to apply to (default: cli)",
+        help="적용할 플랫폼(기본값: cli)",
     )
 
     def cmd_tools(args):
@@ -5481,32 +5481,32 @@ Examples:
 
     mcp_serve_p = mcp_sub.add_parser(
         "serve",
-        help="Run Hermes as an MCP server (expose conversations to other agents)",
+        help="Hermes를 MCP 서버로 실행(대화를 다른 에이전트에 노출)",
     )
     mcp_serve_p.add_argument(
         "-v", "--verbose", action="store_true",
-        help="Enable verbose logging on stderr",
+        help="stderr에 자세한 로그 활성화",
     )
 
-    mcp_add_p = mcp_sub.add_parser("add", help="Add an MCP server (discovery-first install)")
-    mcp_add_p.add_argument("name", help="Server name (used as config key)")
-    mcp_add_p.add_argument("--url", help="HTTP/SSE endpoint URL")
-    mcp_add_p.add_argument("--command", help="Stdio command (e.g. npx)")
-    mcp_add_p.add_argument("--args", nargs="*", default=[], help="Arguments for stdio command")
-    mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
-    mcp_add_p.add_argument("--preset", help="Known MCP preset name")
-    mcp_add_p.add_argument("--env", nargs="*", default=[], help="Environment variables for stdio servers (KEY=VALUE)")
+    mcp_add_p = mcp_sub.add_parser("add", help="MCP 서버 추가(discovery-first 설치)")
+    mcp_add_p.add_argument("name", help="서버 이름(config 키로 사용)")
+    mcp_add_p.add_argument("--url", help="HTTP/SSE 엔드포인트 URL")
+    mcp_add_p.add_argument("--command", help="stdio 명령어(예: npx)")
+    mcp_add_p.add_argument("--args", nargs="*", default=[], help="stdio 명령어 인자")
+    mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="인증 방식")
+    mcp_add_p.add_argument("--preset", help="알려진 MCP preset 이름")
+    mcp_add_p.add_argument("--env", nargs="*", default=[], help="stdio 서버용 환경 변수(KEY=VALUE)")
 
-    mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
-    mcp_rm_p.add_argument("name", help="Server name to remove")
+    mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="MCP 서버 제거")
+    mcp_rm_p.add_argument("name", help="제거할 서버 이름")
 
-    mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
+    mcp_sub.add_parser("list", aliases=["ls"], help="설정된 MCP 서버 목록 표시")
 
-    mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
-    mcp_test_p.add_argument("name", help="Server name to test")
+    mcp_test_p = mcp_sub.add_parser("test", help="MCP 서버 연결 테스트")
+    mcp_test_p.add_argument("name", help="테스트할 서버 이름")
 
-    mcp_cfg_p = mcp_sub.add_parser("configure", aliases=["config"], help="Toggle tool selection")
-    mcp_cfg_p.add_argument("name", help="Server name to configure")
+    mcp_cfg_p = mcp_sub.add_parser("configure", aliases=["config"], help="도구 선택 토글")
+    mcp_cfg_p.add_argument("name", help="설정할 서버 이름")
 
     def cmd_mcp(args):
         from hermes_cli.mcp_config import mcp_command
@@ -5524,36 +5524,36 @@ Examples:
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
 
-    sessions_list = sessions_subparsers.add_parser("list", help="List recent sessions")
-    sessions_list.add_argument("--source", help="Filter by source (cli, telegram, discord, etc.)")
-    sessions_list.add_argument("--limit", type=int, default=20, help="Max sessions to show")
+    sessions_list = sessions_subparsers.add_parser("list", help="최근 세션 목록 표시")
+    sessions_list.add_argument("--source", help="source로 필터링(cli, telegram, discord 등)")
+    sessions_list.add_argument("--limit", type=int, default=20, help="표시할 최대 세션 수")
 
-    sessions_export = sessions_subparsers.add_parser("export", help="Export sessions to a JSONL file")
-    sessions_export.add_argument("output", help="Output JSONL file path (use - for stdout)")
-    sessions_export.add_argument("--source", help="Filter by source")
-    sessions_export.add_argument("--session-id", help="Export a specific session")
+    sessions_export = sessions_subparsers.add_parser("export", help="세션을 JSONL 파일로 내보내기")
+    sessions_export.add_argument("output", help="출력 JSONL 파일 경로(stdout은 - 사용)")
+    sessions_export.add_argument("--source", help="source로 필터링")
+    sessions_export.add_argument("--session-id", help="특정 세션 내보내기")
 
-    sessions_delete = sessions_subparsers.add_parser("delete", help="Delete a specific session")
-    sessions_delete.add_argument("session_id", help="Session ID to delete")
-    sessions_delete.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+    sessions_delete = sessions_subparsers.add_parser("delete", help="특정 세션 삭제")
+    sessions_delete.add_argument("session_id", help="삭제할 세션 ID")
+    sessions_delete.add_argument("--yes", "-y", action="store_true", help="확인 건너뛰기")
 
-    sessions_prune = sessions_subparsers.add_parser("prune", help="Delete old sessions")
-    sessions_prune.add_argument("--older-than", type=int, default=90, help="Delete sessions older than N days (default: 90)")
-    sessions_prune.add_argument("--source", help="Only prune sessions from this source")
-    sessions_prune.add_argument("--yes", "-y", action="store_true", help="Skip confirmation")
+    sessions_prune = sessions_subparsers.add_parser("prune", help="오래된 세션 삭제")
+    sessions_prune.add_argument("--older-than", type=int, default=90, help="N일보다 오래된 세션 삭제(기본값: 90)")
+    sessions_prune.add_argument("--source", help="이 source의 세션만 정리")
+    sessions_prune.add_argument("--yes", "-y", action="store_true", help="확인 건너뛰기")
 
-    sessions_subparsers.add_parser("stats", help="Show session store statistics")
+    sessions_subparsers.add_parser("stats", help="세션 저장소 통계 표시")
 
-    sessions_rename = sessions_subparsers.add_parser("rename", help="Set or change a session's title")
-    sessions_rename.add_argument("session_id", help="Session ID to rename")
-    sessions_rename.add_argument("title", nargs="+", help="New title for the session")
+    sessions_rename = sessions_subparsers.add_parser("rename", help="세션 제목 지정 또는 변경")
+    sessions_rename.add_argument("session_id", help="이름을 바꿀 세션 ID")
+    sessions_rename.add_argument("title", nargs="+", help="세션의 새 제목")
 
     sessions_browse = sessions_subparsers.add_parser(
         "browse",
-        help="Interactive session picker — browse, search, and resume sessions",
+        help="대화형 세션 선택기 — 탐색, 검색, 이어서 열기",
     )
-    sessions_browse.add_argument("--source", help="Filter by source (cli, telegram, discord, etc.)")
-    sessions_browse.add_argument("--limit", type=int, default=50, help="Max sessions to load (default: 50)")
+    sessions_browse.add_argument("--source", help="source로 필터링(cli, telegram, discord 등)")
+    sessions_browse.add_argument("--limit", type=int, default=50, help="불러올 최대 세션 수(기본값: 50)")
 
     def _confirm_prompt(prompt: str) -> bool:
         """Prompt for y/N confirmation, safe against non-TTY environments."""
@@ -5726,8 +5726,8 @@ Examples:
         help="사용량 인사이트와 분석 표시",
         description="세션 기록을 분석해 토큰 사용량, 비용, 도구 패턴, 활동 추세를 표시"
     )
-    insights_parser.add_argument("--days", type=int, default=30, help="Number of days to analyze (default: 30)")
-    insights_parser.add_argument("--source", help="Filter by platform (cli, telegram, discord, etc.)")
+    insights_parser.add_argument("--days", type=int, default=30, help="분석할 일 수(기본값: 30)")
+    insights_parser.add_argument("--source", help="플랫폼으로 필터링(cli, telegram, discord 등)")
 
     def cmd_insights(args):
         try:
@@ -5757,71 +5757,71 @@ Examples:
     # claw migrate
     claw_migrate = claw_subparsers.add_parser(
         "migrate",
-        help="Migrate from OpenClaw to Hermes",
-        description="Import settings, memories, skills, and API keys from an OpenClaw installation. "
-                    "Always shows a preview before making changes."
+        help="OpenClaw에서 Hermes로 마이그레이션",
+        description="OpenClaw 설치본에서 설정, memory, 스킬, API key를 가져옵니다. "
+                    "변경 전에 항상 미리보기를 보여줍니다."
     )
     claw_migrate.add_argument(
         "--source",
-        help="Path to OpenClaw directory (default: ~/.openclaw)"
+        help="OpenClaw 디렉터리 경로(기본값: ~/.openclaw)"
     )
     claw_migrate.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview only — stop after showing what would be migrated"
+        help="미리보기만 수행 — 무엇이 마이그레이션될지 보여준 뒤 중지"
     )
     claw_migrate.add_argument(
         "--preset",
         choices=["user-data", "full"],
         default="full",
-        help="Migration preset (default: full). 'user-data' excludes secrets"
+        help="마이그레이션 preset(기본값: full). 'user-data'는 시크릿 제외"
     )
     claw_migrate.add_argument(
         "--overwrite",
         action="store_true",
-        help="Overwrite existing files (default: skip conflicts)"
+        help="기존 파일 덮어쓰기(기본값: 충돌 시 건너뜀)"
     )
     claw_migrate.add_argument(
         "--migrate-secrets",
         action="store_true",
-        help="Include allowlisted secrets (TELEGRAM_BOT_TOKEN, API keys, etc.)"
+        help="허용 목록 시크릿 포함(TELEGRAM_BOT_TOKEN, API key 등)"
     )
     claw_migrate.add_argument(
         "--workspace-target",
-        help="Absolute path to copy workspace instructions into"
+        help="workspace 지침을 복사할 절대 경로"
     )
     claw_migrate.add_argument(
         "--skill-conflict",
         choices=["skip", "overwrite", "rename"],
         default="skip",
-        help="How to handle skill name conflicts (default: skip)"
+        help="스킬 이름 충돌 처리 방식(기본값: skip)"
     )
     claw_migrate.add_argument(
         "--yes", "-y",
         action="store_true",
-        help="Skip confirmation prompts"
+        help="확인 프롬프트 건너뛰기"
     )
 
     # claw cleanup
     claw_cleanup = claw_subparsers.add_parser(
         "cleanup",
         aliases=["clean"],
-        help="Archive leftover OpenClaw directories after migration",
-        description="Scan for and archive leftover OpenClaw directories to prevent state fragmentation"
+        help="마이그레이션 후 남은 OpenClaw 디렉터리 보관",
+        description="상태 분산을 막기 위해 남은 OpenClaw 디렉터리를 스캔하고 보관"
     )
     claw_cleanup.add_argument(
         "--source",
-        help="Path to a specific OpenClaw directory to clean up"
+        help="정리할 특정 OpenClaw 디렉터리 경로"
     )
     claw_cleanup.add_argument(
         "--dry-run",
         action="store_true",
-        help="Preview what would be archived without making changes"
+        help="변경 없이 무엇이 보관될지 미리보기"
     )
     claw_cleanup.add_argument(
         "--yes", "-y",
         action="store_true",
-        help="Skip confirmation prompts"
+        help="확인 프롬프트 건너뛰기"
     )
 
     def cmd_claw(args):
@@ -5864,12 +5864,12 @@ Examples:
     uninstall_parser.add_argument(
         "--full",
         action="store_true",
-        help="Full uninstall - remove everything including configs and data"
+        help="전체 제거 - 설정과 데이터까지 모두 삭제"
     )
     uninstall_parser.add_argument(
         "--yes", "-y",
         action="store_true",
-        help="Skip confirmation prompts"
+        help="확인 프롬프트 건너뛰기"
     )
     uninstall_parser.set_defaults(func=cmd_uninstall)
 
@@ -5903,49 +5903,49 @@ Examples:
     )
     profile_subparsers = profile_parser.add_subparsers(dest="profile_action")
 
-    profile_subparsers.add_parser("list", help="List all profiles")
-    profile_use = profile_subparsers.add_parser("use", help="Set sticky default profile")
-    profile_use.add_argument("profile_name", help="Profile name (or 'default')")
+    profile_subparsers.add_parser("list", help="모든 프로필 목록 표시")
+    profile_use = profile_subparsers.add_parser("use", help="고정 기본 프로필 지정")
+    profile_use.add_argument("profile_name", help="프로필 이름(또는 'default')")
 
-    profile_create = profile_subparsers.add_parser("create", help="Create a new profile")
-    profile_create.add_argument("profile_name", help="Profile name (lowercase, alphanumeric)")
+    profile_create = profile_subparsers.add_parser("create", help="새 프로필 생성")
+    profile_create.add_argument("profile_name", help="프로필 이름(소문자, 영숫자)")
     profile_create.add_argument("--clone", action="store_true",
-                                help="Copy config.yaml, .env, SOUL.md from active profile")
+                                help="활성 프로필의 config.yaml, .env, SOUL.md 복사")
     profile_create.add_argument("--clone-all", action="store_true",
-                                help="Full copy of active profile (all state)")
+                                help="활성 프로필 전체 복사(모든 상태 포함)")
     profile_create.add_argument("--clone-from", metavar="SOURCE",
-                                help="Source profile to clone from (default: active)")
+                                help="복사할 원본 프로필(기본값: 활성 프로필)")
     profile_create.add_argument("--no-alias", action="store_true",
-                                help="Skip wrapper script creation")
+                                help="래퍼 스크립트 생성 건너뛰기")
 
-    profile_delete = profile_subparsers.add_parser("delete", help="Delete a profile")
-    profile_delete.add_argument("profile_name", help="Profile to delete")
+    profile_delete = profile_subparsers.add_parser("delete", help="프로필 삭제")
+    profile_delete.add_argument("profile_name", help="삭제할 프로필")
     profile_delete.add_argument("-y", "--yes", action="store_true",
-                                help="Skip confirmation prompt")
+                                help="확인 프롬프트 건너뛰기")
 
-    profile_show = profile_subparsers.add_parser("show", help="Show profile details")
-    profile_show.add_argument("profile_name", help="Profile to show")
+    profile_show = profile_subparsers.add_parser("show", help="프로필 세부정보 표시")
+    profile_show.add_argument("profile_name", help="표시할 프로필")
 
-    profile_alias = profile_subparsers.add_parser("alias", help="Manage wrapper scripts")
-    profile_alias.add_argument("profile_name", help="Profile name")
+    profile_alias = profile_subparsers.add_parser("alias", help="래퍼 스크립트 관리")
+    profile_alias.add_argument("profile_name", help="프로필 이름")
     profile_alias.add_argument("--remove", action="store_true",
-                               help="Remove the wrapper script")
+                               help="래퍼 스크립트 제거")
     profile_alias.add_argument("--name", dest="alias_name", metavar="NAME",
-                               help="Custom alias name (default: profile name)")
+                               help="사용자 지정 alias 이름(기본값: 프로필 이름)")
 
-    profile_rename = profile_subparsers.add_parser("rename", help="Rename a profile")
-    profile_rename.add_argument("old_name", help="Current profile name")
-    profile_rename.add_argument("new_name", help="New profile name")
+    profile_rename = profile_subparsers.add_parser("rename", help="프로필 이름 변경")
+    profile_rename.add_argument("old_name", help="현재 프로필 이름")
+    profile_rename.add_argument("new_name", help="새 프로필 이름")
 
-    profile_export = profile_subparsers.add_parser("export", help="Export a profile to archive")
-    profile_export.add_argument("profile_name", help="Profile to export")
+    profile_export = profile_subparsers.add_parser("export", help="프로필을 아카이브로 내보내기")
+    profile_export.add_argument("profile_name", help="내보낼 프로필")
     profile_export.add_argument("-o", "--output", default=None,
-                                help="Output file (default: <name>.tar.gz)")
+                                help="출력 파일(기본값: <name>.tar.gz)")
 
-    profile_import = profile_subparsers.add_parser("import", help="Import a profile from archive")
-    profile_import.add_argument("archive", help="Path to .tar.gz archive")
+    profile_import = profile_subparsers.add_parser("import", help="아카이브에서 프로필 가져오기")
+    profile_import.add_argument("archive", help=".tar.gz 아카이브 경로")
     profile_import.add_argument("--name", dest="import_name", metavar="NAME",
-                                help="Profile name (default: inferred from archive)")
+                                help="프로필 이름(기본값: 아카이브에서 추론)")
 
     profile_parser.set_defaults(func=cmd_profile)
 
@@ -5958,7 +5958,7 @@ Examples:
     )
     completion_parser.add_argument(
         "shell", nargs="?", default="bash", choices=["bash", "zsh", "fish"],
-        help="Shell type (default: bash)",
+        help="셸 종류(기본값: bash)",
     )
     completion_parser.set_defaults(func=lambda args: cmd_completion(args, parser))
 
@@ -5970,12 +5970,12 @@ Examples:
         help="웹 UI 대시보드 시작",
         description="설정, API key, 세션 관리를 위한 Hermes Agent 웹 대시보드 실행",
     )
-    dashboard_parser.add_argument("--port", type=int, default=9119, help="Port (default 9119)")
-    dashboard_parser.add_argument("--host", default="127.0.0.1", help="Host (default 127.0.0.1)")
-    dashboard_parser.add_argument("--no-open", action="store_true", help="Don't open browser automatically")
+    dashboard_parser.add_argument("--port", type=int, default=9119, help="포트(기본값: 9119)")
+    dashboard_parser.add_argument("--host", default="127.0.0.1", help="호스트(기본값: 127.0.0.1)")
+    dashboard_parser.add_argument("--no-open", action="store_true", help="브라우저를 자동으로 열지 않음")
     dashboard_parser.add_argument(
         "--insecure", action="store_true",
-        help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
+        help="localhost가 아닌 주소 바인딩 허용(위험: 네트워크에 API key 노출 가능)",
     )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 
@@ -5988,46 +5988,46 @@ Examples:
         description="agent.log / errors.log / gateway.log 조회, tail, 필터링",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
-Examples:
-    hermes logs                    Show last 50 lines of agent.log
-    hermes logs -f                 Follow agent.log in real time
-    hermes logs errors             Show last 50 lines of errors.log
-    hermes logs gateway -n 100     Show last 100 lines of gateway.log
-    hermes logs --level WARNING    Only show WARNING and above
-    hermes logs --session abc123   Filter by session ID
-    hermes logs --component tools  Only show tool-related lines
-    hermes logs --since 1h         Lines from the last hour
-    hermes logs --since 30m -f     Follow, starting from 30 min ago
-    hermes logs list               List available log files with sizes
+예시:
+    hermes logs                    agent.log 최근 50줄 표시
+    hermes logs -f                 agent.log를 실시간으로 따라가기
+    hermes logs errors             errors.log 최근 50줄 표시
+    hermes logs gateway -n 100     gateway.log 최근 100줄 표시
+    hermes logs --level WARNING    WARNING 이상만 표시
+    hermes logs --session abc123   세션 ID로 필터링
+    hermes logs --component tools  도구 관련 줄만 표시
+    hermes logs --since 1h         최근 1시간의 줄만 표시
+    hermes logs --since 30m -f     최근 30분부터 시작해 따라가기
+    hermes logs list               사용 가능한 로그 파일과 크기 표시
 """,
     )
     logs_parser.add_argument(
         "log_name", nargs="?", default="agent",
-        help="Log to view: agent (default), errors, gateway, or 'list' to show available files",
+        help="볼 로그: agent(기본값), errors, gateway 또는 사용 가능한 파일 표시용 'list'",
     )
     logs_parser.add_argument(
         "-n", "--lines", type=int, default=50,
-        help="Number of lines to show (default: 50)",
+        help="표시할 줄 수(기본값: 50)",
     )
     logs_parser.add_argument(
         "-f", "--follow", action="store_true",
-        help="Follow the log in real time (like tail -f)",
+        help="로그를 실시간으로 따라가기(tail -f처럼)",
     )
     logs_parser.add_argument(
         "--level", metavar="LEVEL",
-        help="Minimum log level to show (DEBUG, INFO, WARNING, ERROR)",
+        help="표시할 최소 로그 레벨(DEBUG, INFO, WARNING, ERROR)",
     )
     logs_parser.add_argument(
         "--session", metavar="ID",
-        help="Filter lines containing this session ID substring",
+        help="이 세션 ID 부분 문자열이 포함된 줄만 필터링",
     )
     logs_parser.add_argument(
         "--since", metavar="TIME",
-        help="Show lines since TIME ago (e.g. 1h, 30m, 2d)",
+        help="TIME 전부터의 줄만 표시(예: 1h, 30m, 2d)",
     )
     logs_parser.add_argument(
         "--component", metavar="NAME",
-        help="Filter by component: gateway, agent, tools, cli, cron",
+        help="구성요소로 필터링: gateway, agent, tools, cli, cron",
     )
     logs_parser.set_defaults(func=cmd_logs)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1991,8 +1991,8 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             return f"{effort}  ← currently in use"
         return effort
 
-    disable_label = "Disable reasoning"
-    skip_label = "Skip (keep current)"
+    disable_label = "추론 비활성화"
+    skip_label = "건너뛰기(현재 설정 유지)"
 
     if current_effort == "none":
         default_idx = len(ordered)
@@ -2017,7 +2017,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             menu_highlight_style=("fg_green",),
             cycle_cursor=True,
             clear_screen=False,
-            title="Select reasoning effort:",
+            title="추론 강도 선택:",
         )
         idx = menu.show()
         from hermes_cli.curses_ui import flush_stdin
@@ -2033,7 +2033,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
     except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
         pass
 
-    print("Select reasoning effort:")
+    print("추론 강도 선택:")
     for i, effort in enumerate(ordered, 1):
         print(f"  {i}. {_label(effort)}")
     n = len(ordered)
@@ -2043,7 +2043,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
 
     while True:
         try:
-            choice = input(f"Choice [1-{n + 2}] (default: keep current): ").strip()
+            choice = input(f"선택 [1-{n + 2}] (기본값: 현재 설정 유지): ").strip()
             if not choice:
                 return None
             idx = int(choice)
@@ -2053,9 +2053,9 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
                 return "none"
             if idx == n + 2:
                 return None
-            print(f"Please enter 1-{n + 2}")
+            print(f"1-{n + 2} 사이의 번호를 입력해 주세요")
         except ValueError:
-            print("Please enter a number")
+            print("숫자를 입력해 주세요")
         except (KeyboardInterrupt, EOFError):
             return None
 
@@ -3203,21 +3203,21 @@ def _restore_stashed_changes(
 ) -> bool:
     if prompt_user:
         print()
-        print("⚠ Local changes were stashed before updating.")
-        print("  Restoring them may reapply local customizations onto the updated codebase.")
-        print("  Review the result afterward if Hermes behaves unexpectedly.")
-        print("Restore local changes now? [Y/n]")
+        print("⚠ 업데이트 전에 로컬 변경 사항을 git stash에 저장했어요.")
+        print("  지금 복원하면 업데이트된 코드베이스 위에 로컬 커스터마이징이 다시 적용될 수 있어요.")
+        print("  Hermes가 이상하게 동작하면 복원 후 결과를 꼭 확인해 주세요.")
+        print("지금 로컬 변경 사항을 복원할까요? [Y/n]")
         if input_fn is not None:
-            response = input_fn("Restore local changes now? [Y/n]", "y")
+            response = input_fn("지금 로컬 변경 사항을 복원할까요? [Y/n]", "y")
         else:
             response = input().strip().lower()
         if response not in ("", "y", "yes"):
-            print("Skipped restoring local changes.")
-            print("Your changes are still preserved in git stash.")
-            print(f"Restore manually with: git stash apply {stash_ref}")
+            print("로컬 변경 사항 복원을 건너뛰었어요.")
+            print("변경 사항은 아직 git stash에 안전하게 보관되어 있어요.")
+            print(f"수동 복원: git stash apply {stash_ref}")
             return False
 
-    print("→ Restoring local changes...")
+    print("→ 로컬 변경 사항을 복원하는 중...")
     restore = subprocess.run(
         git_cmd + ["stash", "apply", stash_ref],
         cwd=cwd,
@@ -3235,7 +3235,7 @@ def _restore_stashed_changes(
     has_conflicts = bool(unmerged.stdout.strip())
 
     if restore.returncode != 0 or has_conflicts:
-        print("✗ Update pulled new code, but restoring local changes hit conflicts.")
+        print("✗ 업데이트로 새 코드를 가져왔지만 로컬 변경 사항 복원 중 충돌이 발생했어요.")
         if restore.stdout.strip():
             print(restore.stdout.strip())
         if restore.stderr.strip():
@@ -3244,11 +3244,11 @@ def _restore_stashed_changes(
         # Show which files conflicted
         conflicted_files = unmerged.stdout.strip()
         if conflicted_files:
-            print("\nConflicted files:")
+            print("\n충돌한 파일:")
             for f in conflicted_files.splitlines():
                 print(f"  • {f}")
 
-        print("\nYour stashed changes are preserved — nothing is lost.")
+        print("\nstash에 저장된 변경 사항은 그대로 보존되어 있으니 잃어버린 내용은 없어요.")
         print(f"  Stash ref: {stash_ref}")
 
         # Always reset to clean state — leaving conflict markers in source
@@ -3259,8 +3259,8 @@ def _restore_stashed_changes(
             cwd=cwd,
             capture_output=True,
         )
-        print("Working tree reset to clean state.")
-        print(f"Restore your changes later with: git stash apply {stash_ref}")
+        print("작업 트리를 깨끗한 상태로 초기화했어요.")
+        print(f"나중에 변경 사항 복원: git stash apply {stash_ref}")
         # Don't sys.exit — the code update itself succeeded, only the stash
         # restore had conflicts.  Let cmd_update continue with pip install,
         # skill sync, and gateway restart.
@@ -3268,8 +3268,8 @@ def _restore_stashed_changes(
 
     stash_selector = _resolve_stash_selector(git_cmd, cwd, stash_ref)
     if stash_selector is None:
-        print("⚠ Local changes were restored, but Hermes couldn't find the stash entry to drop.")
-        print("  The stash was left in place. You can remove it manually after checking the result.")
+        print("⚠ 로컬 변경 사항은 복원됐지만 Hermes가 삭제할 stash 항목을 찾지 못했어요.")
+        print("  stash는 그대로 남겨두었어요. 결과를 확인한 뒤 수동으로 지울 수 있어요.")
         _print_stash_cleanup_guidance(stash_ref)
     else:
         drop = subprocess.run(
@@ -3279,16 +3279,16 @@ def _restore_stashed_changes(
             text=True,
         )
         if drop.returncode != 0:
-            print("⚠ Local changes were restored, but Hermes couldn't drop the saved stash entry.")
+            print("⚠ 로컬 변경 사항은 복원됐지만 Hermes가 저장된 stash 항목을 삭제하지 못했어요.")
             if drop.stdout.strip():
                 print(drop.stdout.strip())
             if drop.stderr.strip():
                 print(drop.stderr.strip())
-            print("  The stash was left in place. You can remove it manually after checking the result.")
+            print("  stash는 그대로 남겨두었어요. 결과를 확인한 뒤 수동으로 지울 수 있어요.")
             _print_stash_cleanup_guidance(stash_ref, stash_selector)
 
-    print("⚠ Local changes were restored on top of the updated codebase.")
-    print("  Review `git diff` / `git status` if Hermes behaves unexpectedly.")
+    print("⚠ 업데이트된 코드베이스 위에 로컬 변경 사항을 복원했어요.")
+    print("  Hermes가 이상하게 동작하면 `git diff` / `git status`를 확인해 주세요.")
     return True
 
 # =========================================================================
@@ -3436,7 +3436,7 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         print("  This means you may miss updates from NousResearch/hermes-agent.")
         print()
         try:
-            response = input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
+            response = input("공식 repo를 'upstream' remote로 추가할까요? [Y/n]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             print()
             response = "n"
@@ -3946,7 +3946,7 @@ def cmd_update(args):
             print()
             if gateway_mode:
                 response = _gateway_prompt(
-                    "Would you like to configure new options now? [Y/n]", "n"
+                    "지금 새 옵션을 설정할까요? [Y/n]", "n"
                 ).strip().lower()
             elif not (sys.stdin.isatty() and sys.stdout.isatty()):
                 print("  ℹ Non-interactive session — skipping config migration prompt.")
@@ -3954,7 +3954,7 @@ def cmd_update(args):
                 response = "n"
             else:
                 try:
-                    response = input("Would you like to configure them now? [Y/n]: ").strip().lower()
+                    response = input("지금 새 옵션을 설정할까요? [Y/n]: ").strip().lower()
                 except EOFError:
                     response = "n"
             
@@ -3971,7 +3971,7 @@ def cmd_update(args):
                     print("  ℹ API keys require manual entry: hermes config migrate")
             else:
                 print()
-                print("Skipped. Run 'hermes config migrate' later to configure.")
+                print("건너뛰었어요. 나중에 설정하려면 'hermes config migrate'를 실행하세요.")
         else:
             print("  ✓ Configuration is up to date")
         
@@ -4136,8 +4136,8 @@ def cmd_update(args):
             logger.debug("Gateway restart during update failed: %s", e)
         
         print()
-        print("Tip: You can now select a provider and model:")
-        print("  hermes model              # Select provider and model")
+        print("팁: 이제 provider와 모델을 선택할 수 있어요:")
+        print("  hermes model              # provider와 모델 선택")
         
     except subprocess.CalledProcessError as e:
         if sys.platform == "win32":
@@ -4228,7 +4228,7 @@ def cmd_profile(args):
         active = get_active_profile_name()
 
         if not profiles:
-            print("No profiles found.")
+            print("프로필이 없어요.")
             return
 
         # Header
@@ -4451,8 +4451,8 @@ def cmd_dashboard(args):
         import fastapi  # noqa: F401
         import uvicorn  # noqa: F401
     except ImportError:
-        print("Web UI dependencies not installed.")
-        print("Install them with:  pip install hermes-agent[web]")
+        print("Web UI 의존성이 설치되지 않았어요.")
+        print("설치 명령: pip install hermes-agent[web]")
         sys.exit(1)
 
     if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
@@ -5888,8 +5888,8 @@ def main():
             from acp_adapter.entry import main as acp_main
             acp_main()
         except ImportError:
-            print("ACP dependencies not installed.")
-            print("Install them with:  pip install -e '.[acp]'")
+            print("ACP 의존성이 설치되지 않았어요.")
+            print("설치 명령: pip install -e '.[acp]'")
             sys.exit(1)
 
     acp_parser.set_defaults(func=cmd_acp)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1,46 +1,27 @@
 #!/usr/bin/env python3
 """
-Hermes CLI - Main entry point.
+Hermes CLI - 메인 진입점.
 
-Usage:
-    hermes                     # Interactive chat (default)
-    hermes chat                # Interactive chat
-    hermes gateway             # Run gateway in foreground
-    hermes gateway start       # Start gateway as service
-    hermes gateway stop        # Stop gateway service
-    hermes gateway status      # Show gateway status
-    hermes gateway install     # Install gateway service
-    hermes gateway uninstall   # Uninstall gateway service
-    hermes setup               # Interactive setup wizard
-    hermes logout              # Clear stored authentication
-    hermes status              # Show status of all components
-    hermes cron                # Manage cron jobs
-    hermes cron list           # List cron jobs
-    hermes cron status         # Check if cron scheduler is running
-    hermes doctor              # Check configuration and dependencies
-    hermes honcho setup                    # Configure Honcho AI memory integration
-    hermes honcho status                   # Show Honcho config and connection status
-    hermes honcho sessions                 # List directory → session name mappings
-    hermes honcho map <name>               # Map current directory to a session name
-    hermes honcho peer                     # Show peer names and dialectic settings
-    hermes honcho peer --user NAME         # Set user peer name
-    hermes honcho peer --ai NAME           # Set AI peer name
-    hermes honcho peer --reasoning LEVEL   # Set dialectic reasoning level
-    hermes honcho mode                     # Show current memory mode
-    hermes honcho mode [hybrid|honcho|local]  # Set memory mode
-    hermes honcho tokens                   # Show token budget settings
-    hermes honcho tokens --context N       # Set session.context() token cap
-    hermes honcho tokens --dialectic N     # Set dialectic result char cap
-    hermes honcho identity                 # Show AI peer identity representation
-    hermes honcho identity <file>          # Seed AI peer identity from a file (SOUL.md etc.)
-    hermes honcho migrate                  # Step-by-step migration guide: OpenClaw native → Hermes + Honcho
-    hermes version             Show version
-    hermes update              Update to latest version
-    hermes uninstall           Uninstall Hermes Agent
-    hermes acp                 Run as an ACP server for editor integration
-    hermes sessions browse     Interactive session picker with search
+사용 예:
+    hermes                     # 대화형 채팅(기본값)
+    hermes chat                # 대화형 채팅
+    hermes gateway             # 게이트웨이를 포그라운드에서 실행
+    hermes gateway start       # 게이트웨이 서비스를 시작
+    hermes gateway stop        # 게이트웨이 서비스를 중지
+    hermes setup               # 설정 마법사 실행
+    hermes tools               # 활성화할 도구 설정
+    hermes model               # 기본 모델 설정
+    hermes status              # 시스템/provider 상태 표시
+    hermes config              # 현재 설정 표시
+    hermes cron                # 크론 작업 관리
+    hermes doctor              # 설정과 의존성 점검
+    hermes version             # 버전 표시
+    hermes update              # 최신 버전으로 업데이트
+    hermes uninstall           # Hermes Agent 제거
+    hermes acp                 # 에디터 연동용 ACP 서버로 실행
+    hermes sessions browse     # 검색 가능한 세션 선택기 실행
 
-    hermes claw migrate --dry-run  # Preview migration without changes
+    hermes claw migrate --dry-run  # 변경 없이 마이그레이션 미리보기
 """
 
 import argparse
@@ -59,9 +40,9 @@ def _require_tty(command_name: str) -> None:
     """
     if not sys.stdin.isatty():
         print(
-            f"Error: 'hermes {command_name}' requires an interactive terminal.\n"
-            f"It cannot be run through a pipe or non-interactive subprocess.\n"
-            f"Run it directly in your terminal instead.",
+            f"오류: 'hermes {command_name}' 명령은 대화형 터미널이 필요합니다.\n"
+            f"파이프나 비대화형 서브프로세스에서는 실행할 수 없습니다.\n"
+            f"터미널에서 직접 실행해 주세요.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -300,7 +281,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
     bug in tmux/iTerm when arrow keys are used.
     """
     if not sessions:
-        print("No sessions found.")
+        print("세션을 찾지 못했어요.")
         return None
 
     # Try curses-based picker first
@@ -362,7 +343,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                 if max_y < 5 or max_x < 40:
                     # Terminal too small
                     try:
-                        stdscr.addstr(0, 0, "Terminal too small")
+                        stdscr.addstr(0, 0, "터미널 크기가 너무 작습니다")
                     except curses.error:
                         pass
                     stdscr.refresh()
@@ -371,12 +352,12 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
 
                 # Header line
                 if search_text:
-                    header = f"  Browse sessions — filter: {search_text}█"
+                    header = f"  세션 탐색 — 필터: {search_text}█"
                     header_attr = curses.A_BOLD
                     if curses.has_colors():
                         header_attr |= curses.color_pair(3)
                 else:
-                    header = "  Browse sessions — ↑↓ navigate  Enter select  Type to filter  Esc quit"
+                    header = "  세션 탐색 — ↑↓ 이동  Enter 선택  입력으로 필터  Esc 종료"
                     header_attr = curses.A_BOLD
                     if curses.has_colors():
                         header_attr |= curses.color_pair(2)
@@ -388,7 +369,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                 # Column header line
                 fixed_cols = 3 + 12 + 6 + 18 + 6
                 name_width = max(20, max_x - fixed_cols)
-                col_header = f"   {'Title / Preview':<{name_width}}  {'Active':<10}  {'Src':<5} {'ID'}"
+                col_header = f"   {'제목 / 미리보기':<{name_width}}  {'최근 활동':<10}  {'출처':<5} {'ID'}"
                 try:
                     dim_attr = curses.color_pair(4) if curses.has_colors() else curses.A_DIM
                     stdscr.addnstr(1, 0, col_header, max_x - 1, dim_attr)
@@ -403,7 +384,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                 # Clamp cursor and scroll
                 if not filtered:
                     try:
-                        msg = "  No sessions match the filter."
+                        msg = "  필터와 일치하는 세션이 없습니다."
                         stdscr.addnstr(3, 0, msg, max_x - 1, curses.A_DIM)
                     except curses.error:
                         pass
@@ -440,11 +421,11 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                 # Footer
                 footer_y = max_y - 1
                 if filtered:
-                    footer = f"  {cursor + 1}/{len(filtered)} sessions"
+                    footer = f"  {cursor + 1}/{len(filtered)}개 세션"
                     if len(filtered) < len(sessions):
-                        footer += f" (filtered from {len(sessions)})"
+                        footer += f" (전체 {len(sessions)}개 중 필터됨)"
                 else:
-                    footer = f"  0/{len(sessions)} sessions"
+                    footer = f"  0/{len(sessions)}개 세션"
                 try:
                     stdscr.addnstr(footer_y, 0, footer, max_x - 1,
                                    curses.color_pair(4) if curses.has_colors() else curses.A_DIM)
@@ -499,7 +480,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
         pass
 
     # Fallback: numbered list (Windows without curses, etc.)
-    print("\n  Browse sessions  (enter number to resume, q to cancel)\n")
+    print("\n  세션 탐색  (번호를 입력하면 이어서 열고, q를 입력하면 취소)\n")
     for i, s in enumerate(sessions):
         title = (s.get("title") or "").strip()
         preview = (s.get("preview") or "").strip()
@@ -512,15 +493,15 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
 
     while True:
         try:
-            val = input(f"\n  Select [1-{len(sessions)}]: ").strip()
+            val = input(f"\n  선택 [1-{len(sessions)}]: ").strip()
             if not val or val.lower() in ("q", "quit", "exit"):
                 return None
             idx = int(val) - 1
             if 0 <= idx < len(sessions):
                 return sessions[idx]["id"]
-            print(f"  Invalid selection. Enter 1-{len(sessions)} or q to cancel.")
+            print(f"  잘못된 선택입니다. 1-{len(sessions)} 또는 q를 입력해 취소하세요.")
         except ValueError:
-            print("  Invalid input. Enter a number or q to cancel.")
+            print("  잘못된 입력입니다. 숫자 또는 q를 입력해 취소하세요.")
         except (KeyboardInterrupt, EOFError):
             print()
             return None
@@ -4495,40 +4476,40 @@ def main():
     """Main entry point for hermes CLI."""
     parser = argparse.ArgumentParser(
         prog="hermes",
-        description="Hermes Agent - AI assistant with tool-calling capabilities",
+        description="Hermes Agent - 도구 호출 기능을 갖춘 AI 어시스턴트",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Examples:
-    hermes                        Start interactive chat
-    hermes chat -q "Hello"        Single query mode
-    hermes -c                     Resume the most recent session
-    hermes -c "my project"        Resume a session by name (latest in lineage)
-    hermes --resume <session_id>  Resume a specific session by ID
-    hermes setup                  Run setup wizard
-    hermes logout                 Clear stored authentication
-    hermes auth add <provider>    Add a pooled credential
-    hermes auth list              List pooled credentials
-    hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
-    hermes auth reset <provider>  Clear exhaustion status for a provider
-    hermes model                  Select default model
-    hermes config                 View configuration
-    hermes config edit            Edit config in $EDITOR
-    hermes config set model gpt-4 Set a config value
-    hermes gateway                Run messaging gateway
+예시:
+    hermes                        대화형 채팅 시작
+    hermes chat -q \"안녕\"          단일 질의 모드
+    hermes -c                     가장 최근 세션 이어서 열기
+    hermes -c \"my project\"        이름으로 세션 이어서 열기(계보 기준 최신)
+    hermes --resume <session_id>  세션 ID로 특정 세션 이어서 열기
+    hermes setup                  설정 마법사 실행
+    hermes logout                 저장된 인증 정보 지우기
+    hermes auth add <provider>    풀 자격 증명 추가
+    hermes auth list              풀 자격 증명 목록 표시
+    hermes auth remove <p> <t>    인덱스, ID 또는 라벨로 풀 자격 증명 제거
+    hermes auth reset <provider>  provider의 소진 상태 초기화
+    hermes model                  기본 모델 선택
+    hermes config                 현재 설정 표시
+    hermes config edit            $EDITOR로 설정 파일 편집
+    hermes config set model gpt-4 설정값 저장
+    hermes gateway                메시징 게이트웨이 실행
     hermes -s hermes-agent-dev,github-auth
-    hermes -w                     Start in isolated git worktree
-    hermes gateway install        Install gateway background service
-    hermes sessions list          List past sessions
-    hermes sessions browse        Interactive session picker
-    hermes sessions rename ID T   Rename/title a session
-    hermes logs                   View agent.log (last 50 lines)
-    hermes logs -f                Follow agent.log in real time
-    hermes logs errors            View errors.log
-    hermes logs --since 1h        Lines from the last hour
-    hermes debug share             Upload debug report for support
-    hermes update                 Update to latest version
+    hermes -w                     격리된 git worktree에서 시작
+    hermes gateway install        게이트웨이 백그라운드 서비스 설치
+    hermes sessions list          지난 세션 목록 표시
+    hermes sessions browse        대화형 세션 선택기 실행
+    hermes sessions rename ID T   세션 이름/제목 변경
+    hermes logs                   agent.log 보기(최근 50줄)
+    hermes logs -f                agent.log 실시간 따라가기
+    hermes logs errors            errors.log 보기
+    hermes logs --since 1h        최근 1시간 로그만 표시
+    hermes debug share            지원용 디버그 리포트 업로드
+    hermes update                 최신 버전으로 업데이트
 
-For more help on a command:
+명령어별 자세한 도움말:
     hermes <command> --help
 """
     )
@@ -4536,13 +4517,13 @@ For more help on a command:
     parser.add_argument(
         "--version", "-V",
         action="store_true",
-        help="Show version and exit"
+        help="버전을 표시하고 종료"
     )
     parser.add_argument(
         "--resume", "-r",
         metavar="SESSION",
         default=None,
-        help="Resume a previous session by ID or title"
+        help="ID 또는 제목으로 이전 세션 이어서 열기"
     )
     parser.add_argument(
         "--continue", "-c",
@@ -4551,70 +4532,70 @@ For more help on a command:
         const=True,
         default=None,
         metavar="SESSION_NAME",
-        help="Resume a session by name, or the most recent if no name given"
+        help="이름으로 세션을 이어서 열거나, 이름이 없으면 가장 최근 세션 열기"
     )
     parser.add_argument(
         "--worktree", "-w",
         action="store_true",
         default=False,
-        help="Run in an isolated git worktree (for parallel agents)"
+        help="격리된 git worktree에서 실행(병렬 에이전트용)"
     )
     parser.add_argument(
         "--skills", "-s",
         action="append",
         default=None,
-        help="Preload one or more skills for the session (repeat flag or comma-separate)"
+        help="세션 시작 전에 스킬을 하나 이상 미리 로드(플래그 반복 또는 쉼표 구분)"
     )
     parser.add_argument(
         "--yolo",
         action="store_true",
         default=False,
-        help="Bypass all dangerous command approval prompts (use at your own risk)"
+        help="위험 명령 승인 프롬프트를 모두 건너뜀(주의해서 사용)"
     )
     parser.add_argument(
         "--pass-session-id",
         action="store_true",
         default=False,
-        help="Include the session ID in the agent's system prompt"
+        help="에이전트 시스템 프롬프트에 세션 ID 포함"
     )
     
-    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+    subparsers = parser.add_subparsers(dest="command", help="실행할 명령어")
     
     # =========================================================================
     # chat command
     # =========================================================================
     chat_parser = subparsers.add_parser(
         "chat",
-        help="Interactive chat with the agent",
-        description="Start an interactive chat session with Hermes Agent"
+        help="에이전트와 대화형 채팅 실행",
+        description="Hermes Agent와의 대화형 채팅 세션 시작"
     )
     chat_parser.add_argument(
         "-q", "--query",
-        help="Single query (non-interactive mode)"
+        help="단일 질의 실행(비대화형 모드)"
     )
     chat_parser.add_argument(
         "--image",
-        help="Optional local image path to attach to a single query"
+        help="단일 질의에 첨부할 로컬 이미지 경로(선택)"
     )
     chat_parser.add_argument(
         "-m", "--model",
-        help="Model to use (e.g., anthropic/claude-sonnet-4)"
+        help="사용할 모델(예: anthropic/claude-sonnet-4)"
     )
     chat_parser.add_argument(
         "-t", "--toolsets",
-        help="Comma-separated toolsets to enable"
+        help="활성화할 toolset 목록(쉼표 구분)"
     )
     chat_parser.add_argument(
         "-s", "--skills",
         action="append",
         default=argparse.SUPPRESS,
-        help="Preload one or more skills for the session (repeat flag or comma-separate)"
+        help="세션 시작 전에 스킬을 하나 이상 미리 로드(플래그 반복 또는 쉼표 구분)"
     )
     chat_parser.add_argument(
         "--provider",
         choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee"],
         default=None,
-        help="Inference provider (default: auto)"
+        help="추론 provider(기본값: auto)"
     )
     chat_parser.add_argument(
         "-v", "--verbose",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1988,7 +1988,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
 
     def _label(effort):
         if effort == current_effort:
-            return f"{effort}  ← currently in use"
+            return f"{effort}  ← 현재 사용 중"
         return effort
 
     disable_label = "추론 비활성화"
@@ -2086,7 +2086,7 @@ def _model_flow_copilot(config, current_model=""):
     source = creds.get("source", "")
 
     if not api_key:
-        print("No GitHub token configured for GitHub Copilot.")
+        print("GitHub Copilot용 GitHub 토큰이 설정되어 있지 않아요.")
         print()
         print("  지원하는 토큰 종류:")
         print("    → OAuth 토큰 (gho_*)              `copilot login` 또는 device code 흐름으로 발급")
@@ -3120,7 +3120,7 @@ def _update_via_zip(args):
         pass
     
     print()
-    print("✓ Update complete!")
+    print("✓ 업데이트가 완료되었어요!")
 
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
@@ -3145,13 +3145,13 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
         text=True,
     )
     if unmerged.stdout.strip():
-        print("→ Clearing unmerged index entries from a previous conflict...")
+        print("→ 이전 충돌에서 남은 병합되지 않은 index 항목을 정리하는 중...")
         subprocess.run(git_cmd + ["reset"], cwd=cwd, capture_output=True)
 
     from datetime import datetime, timezone
 
     stash_name = datetime.now(timezone.utc).strftime("hermes-update-autostash-%Y%m%d-%H%M%S")
-    print("→ Local changes detected — stashing before update...")
+    print("→ 로컬 변경 사항을 감지했어요. 업데이트 전에 stash에 저장할게요...")
     subprocess.run(
         git_cmd + ["stash", "push", "--include-untracked", "-m", stash_name],
         cwd=cwd,
@@ -3185,12 +3185,12 @@ def _resolve_stash_selector(git_cmd: list[str], cwd: Path, stash_ref: str) -> Op
 
 
 def _print_stash_cleanup_guidance(stash_ref: str, stash_selector: Optional[str] = None) -> None:
-    print("  Check `git status` first so you don't accidentally reapply the same change twice.")
-    print("  Find the saved entry with: git stash list --format='%gd %H %s'")
+    print("  같은 변경 사항을 중복 적용하지 않도록 먼저 `git status`를 확인해 주세요.")
+    print("  저장된 항목 확인: git stash list --format='%gd %H %s'")
     if stash_selector:
-        print(f"  Remove it with: git stash drop {stash_selector}")
+        print(f"  삭제 명령: git stash drop {stash_selector}")
     else:
-        print(f"  Look for commit {stash_ref}, then drop its selector with: git stash drop stash@{{N}}")
+        print(f"  커밋 {stash_ref}에 해당하는 항목을 찾은 뒤 `git stash drop stash@{{N}}`로 삭제해 주세요")
 
 
 
@@ -3976,7 +3976,7 @@ def cmd_update(args):
             print("  ✓ Configuration is up to date")
         
         print()
-        print("✓ Update complete!")
+        print("✓ 업데이트가 완료되었어요!")
         
         # Write exit code *before* the gateway restart attempt.
         # When running as ``hermes update --gateway`` (spawned by the gateway's

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1085,7 +1085,7 @@ def select_provider_and_model(args=None):
         [label for _, label in ordered], default=default_idx,
     )
     if provider_idx is None or ordered[provider_idx][0] == "cancel":
-        print("No change.")
+        print("변경 사항이 없어요.")
         return
 
     selected_provider = ordered[provider_idx][0]
@@ -1109,8 +1109,8 @@ def select_provider_and_model(args=None):
         provider_info = _named_custom_provider_map(load_config()).get(selected_provider)
         if provider_info is None:
             print(
-                "Warning: the selected saved custom provider is no longer available. "
-                "It may have been removed from config.yaml. No change."
+                "경고: 선택한 저장된 custom provider를 더 이상 사용할 수 없어요. "
+                "config.yaml에서 제거되었을 수 있어요. 변경 사항은 없어요."
             )
             return
         _model_flow_named_custom(config, provider_info)
@@ -1520,29 +1520,29 @@ def _model_flow_custom(config):
     current_url = get_env_value("OPENAI_BASE_URL") or ""
     current_key = get_env_value("OPENAI_API_KEY") or ""
 
-    print("Custom OpenAI-compatible endpoint configuration:")
+    print("사용자 지정 OpenAI 호환 endpoint 설정:")
     if current_url:
-        print(f"  Current URL: {current_url}")
+        print(f"  현재 URL: {current_url}")
     if current_key:
-        print(f"  Current key: {current_key[:8]}...")
+        print(f"  현재 키: {current_key[:8]}...")
     print()
 
     try:
-        base_url = input(f"API base URL [{current_url or 'e.g. https://api.example.com/v1'}]: ").strip()
+        base_url = input(f"API base URL [{current_url or '예: https://api.example.com/v1'}]: ").strip()
         import getpass
-        api_key = getpass.getpass(f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: ").strip()
+        api_key = getpass.getpass(f"API key [{current_key[:8] + '...' if current_key else '선택 사항'}]: ").strip()
     except (KeyboardInterrupt, EOFError):
-        print("\nCancelled.")
+        print("\n취소했어요.")
         return
 
     if not base_url and not current_url:
-        print("No URL provided. Cancelled.")
+        print("URL이 제공되지 않아 취소했어요.")
         return
 
     # Validate URL format
     effective_url = base_url or current_url
     if not effective_url.startswith(("http://", "https://")):
-        print(f"Invalid URL: {effective_url} (must start with http:// or https://)")
+        print(f"잘못된 URL이에요: {effective_url} (http:// 또는 https:// 로 시작해야 해요)")
         return
 
     effective_key = api_key or current_key
@@ -1552,59 +1552,59 @@ def _model_flow_custom(config):
     probe = probe_api_models(effective_key, effective_url)
     if probe.get("used_fallback") and probe.get("resolved_base_url"):
         print(
-            f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
-            f"not the exact URL you entered. Saving the working base URL instead."
+            f"경고: endpoint 검증은 {probe['resolved_base_url']}/models 에서 성공했어요. "
+            f"입력한 정확한 URL 대신 동작하는 base URL을 저장할게요."
         )
         effective_url = probe["resolved_base_url"]
         if base_url:
             base_url = effective_url
     elif probe.get("models") is not None:
         print(
-            f"Verified endpoint via {probe.get('probed_url')} "
-            f"({len(probe.get('models') or [])} model(s) visible)"
+            f"{probe.get('probed_url')} 경로로 endpoint 검증을 마쳤어요 "
+            f"(보이는 모델 {len(probe.get('models') or [])}개)"
         )
     else:
         print(
-            f"Warning: could not verify this endpoint via {probe.get('probed_url')}. "
-            f"Hermes will still save it."
+            f"경고: {probe.get('probed_url')} 경로로 이 endpoint를 검증하지 못했어요. "
+            f"그래도 Hermes에 저장할게요."
         )
         if probe.get("suggested_base_url"):
             suggested = probe["suggested_base_url"]
             if suggested.endswith("/v1"):
-                print(f"  If this server expects /v1 in the path, try base URL: {suggested}")
+                print(f"  이 서버가 경로에 /v1 을 기대한다면 base URL로 다음 값을 시도해 보세요: {suggested}")
             else:
-                print(f"  If /v1 should not be in the base URL, try: {suggested}")
+                print(f"  base URL에 /v1 이 없어야 한다면 다음 값을 시도해 보세요: {suggested}")
 
     # Select model — use probe results when available, fall back to manual input
     model_name = ""
     detected_models = probe.get("models") or []
     try:
         if len(detected_models) == 1:
-            print(f"  Detected model: {detected_models[0]}")
-            confirm = input("  Use this model? [Y/n]: ").strip().lower()
+            print(f"  감지된 모델: {detected_models[0]}")
+            confirm = input("  이 모델을 사용할까요? [Y/n]: ").strip().lower()
             if confirm in ("", "y", "yes"):
                 model_name = detected_models[0]
             else:
-                model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+                model_name = input("모델 이름 입력 (예: gpt-4, llama-3-70b): ").strip()
         elif len(detected_models) > 1:
-            print("  Available models:")
+            print("  사용 가능한 모델:")
             for i, m in enumerate(detected_models, 1):
                 print(f"    {i}. {m}")
-            pick = input(f"  Select model [1-{len(detected_models)}] or type name: ").strip()
+            pick = input(f"  모델 선택 [1-{len(detected_models)}] 또는 이름 직접 입력: ").strip()
             if pick.isdigit() and 1 <= int(pick) <= len(detected_models):
                 model_name = detected_models[int(pick) - 1]
             elif pick:
                 model_name = pick
         else:
-            model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+            model_name = input("모델 이름 입력 (예: gpt-4, llama-3-70b): ").strip()
 
-        context_length_str = input("Context length in tokens [leave blank for auto-detect]: ").strip()
+        context_length_str = input("컨텍스트 길이(토큰 수) [비워두면 자동 감지]: ").strip()
 
         # Prompt for a display name — shown in the provider menu on future runs
         default_name = _auto_provider_name(effective_url)
-        display_name = input(f"Display name [{default_name}]: ").strip() or default_name
+        display_name = input(f"표시 이름 [{default_name}]: ").strip() or default_name
     except (KeyboardInterrupt, EOFError):
-        print("\nCancelled.")
+        print("\n취소했어요.")
         return
 
     context_length = None
@@ -1614,7 +1614,7 @@ def _model_flow_custom(config):
             if context_length <= 0:
                 context_length = None
         except ValueError:
-            print(f"Invalid context length: {context_length_str} — will auto-detect.")
+            print(f"잘못된 컨텍스트 길이예요: {context_length_str} — 자동 감지로 진행할게요.")
             context_length = None
 
     if model_name:
@@ -1640,7 +1640,7 @@ def _model_flow_custom(config):
         # the stale values from its own config dict (#4172).
         config["model"] = dict(model)
 
-        print(f"Default model set to: {model_name} (via {effective_url})")
+        print(f"기본 모델을 설정했어요: {model_name} ({effective_url} 사용)")
     else:
         if base_url or api_key:
             deactivate_provider()
@@ -1655,7 +1655,7 @@ def _model_flow_custom(config):
             _caller_model["api_key"] = effective_key
         _caller_model.pop("api_mode", None)
         config["model"] = _caller_model
-        print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
+        print("Endpoint를 저장했어요. 모델은 채팅에서 `/model` 또는 `hermes model`로 설정할 수 있어요.")
 
     # Auto-save to custom_providers so it appears in the menu next time
     _save_custom_provider(effective_url, effective_key, model_name or "",
@@ -1731,7 +1731,7 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None,
     providers.append(entry)
     cfg["custom_providers"] = providers
     save_config(cfg)
-    print(f"  💾 Saved to custom providers as \"{name}\" (edit in config.yaml)")
+    print(f"  💾 custom providers에 \"{name}\" 이름으로 저장했어요 (config.yaml에서 수정 가능)")
 
 
 def _remove_custom_provider(config):
@@ -1741,10 +1741,10 @@ def _remove_custom_provider(config):
     cfg = load_config()
     providers = cfg.get("custom_providers") or []
     if not isinstance(providers, list) or not providers:
-        print("No custom providers configured.")
+        print("설정된 custom provider가 없어요.")
         return
 
-    print("Remove a custom provider:\n")
+    print("custom provider 제거:\n")
 
     choices = []
     for entry in providers:
@@ -1755,7 +1755,7 @@ def _remove_custom_provider(config):
             choices.append(f"{name} ({short_url})")
         else:
             choices.append(str(entry))
-    choices.append("Cancel")
+    choices.append("취소")
 
     try:
         from simple_term_menu import TerminalMenu
@@ -1764,7 +1764,7 @@ def _remove_custom_provider(config):
             menu_cursor="-> ", menu_cursor_style=("fg_red", "bold"),
             menu_highlight_style=("fg_red",),
             cycle_cursor=True, clear_screen=False,
-            title="Select provider to remove:",
+            title="제거할 provider 선택:",
         )
         idx = menu.show()
         from hermes_cli.curses_ui import flush_stdin
@@ -1775,20 +1775,20 @@ def _remove_custom_provider(config):
             print(f"  {i}. {c}")
         print()
         try:
-            val = input(f"Choice [1-{len(choices)}]: ").strip()
+            val = input(f"선택 [1-{len(choices)}]: ").strip()
             idx = int(val) - 1 if val else None
         except (ValueError, KeyboardInterrupt, EOFError):
             idx = None
 
     if idx is None or idx >= len(providers):
-        print("No change.")
+        print("변경 사항이 없어요.")
         return
 
     removed = providers.pop(idx)
     cfg["custom_providers"] = providers
     save_config(cfg)
     removed_name = removed.get("name", "unnamed") if isinstance(removed, dict) else str(removed)
-    print(f"✅ Removed \"{removed_name}\" from custom providers.")
+    print(f"✅ custom providers에서 \"{removed_name}\" 항목을 제거했어요.")
 
 
 def _model_flow_named_custom(config, provider_info):
@@ -1812,10 +1812,10 @@ def _model_flow_named_custom(config, provider_info):
     print(f"  Provider: {name}")
     print(f"  URL:      {base_url}")
     if saved_model:
-        print(f"  Current:  {saved_model}")
+        print(f"  현재 모델: {saved_model}")
     print()
 
-    print("Fetching available models...")
+    print("사용 가능한 모델을 불러오는 중...")
     models = fetch_api_models(api_key, base_url, timeout=8.0)
 
     if models:
@@ -1823,7 +1823,7 @@ def _model_flow_named_custom(config, provider_info):
         if saved_model and saved_model in models:
             default_idx = models.index(saved_model)
 
-        print(f"Found {len(models)} model(s):\n")
+        print(f"모델 {len(models)}개를 찾았어요:\n")
         try:
             from simple_term_menu import TerminalMenu
             menu_items = [
@@ -1835,51 +1835,51 @@ def _model_flow_named_custom(config, provider_info):
                 menu_cursor="-> ", menu_cursor_style=("fg_green", "bold"),
                 menu_highlight_style=("fg_green",),
                 cycle_cursor=True, clear_screen=False,
-                title=f"Select model from {name}:",
+                title=f"{name}에서 사용할 모델 선택:",
             )
             idx = menu.show()
             from hermes_cli.curses_ui import flush_stdin
             flush_stdin()
             print()
             if idx is None or idx >= len(models):
-                print("Cancelled.")
+                print("취소했어요.")
                 return
             model_name = models[idx]
         except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
             for i, m in enumerate(models, 1):
                 suffix = " (current)" if m == saved_model else ""
                 print(f"  {i}. {m}{suffix}")
-            print(f"  {len(models) + 1}. Cancel")
+            print(f"  {len(models) + 1}. 취소")
             print()
             try:
-                val = input(f"Choice [1-{len(models) + 1}]: ").strip()
+                val = input(f"선택 [1-{len(models) + 1}]: ").strip()
                 if not val:
-                    print("Cancelled.")
+                    print("취소했어요.")
                     return
                 idx = int(val) - 1
                 if idx < 0 or idx >= len(models):
-                    print("Cancelled.")
+                    print("취소했어요.")
                     return
                 model_name = models[idx]
             except (ValueError, KeyboardInterrupt, EOFError):
-                print("\nCancelled.")
+                print("\n취소했어요.")
                 return
     elif saved_model:
-        print("Could not fetch models from endpoint.")
+        print("endpoint에서 모델 목록을 가져오지 못했어요.")
         try:
-            model_name = input(f"Model name [{saved_model}]: ").strip() or saved_model
+            model_name = input(f"모델 이름 [{saved_model}]: ").strip() or saved_model
         except (KeyboardInterrupt, EOFError):
-            print("\nCancelled.")
+            print("\n취소했어요.")
             return
     else:
-        print("Could not fetch models from endpoint. Enter model name manually.")
+        print("endpoint에서 모델 목록을 가져오지 못했어요. 모델 이름을 직접 입력해 주세요.")
         try:
-            model_name = input("Model name: ").strip()
+            model_name = input("모델 이름: ").strip()
         except (KeyboardInterrupt, EOFError):
-            print("\nCancelled.")
+            print("\n취소했어요.")
             return
         if not model_name:
-            print("No model specified. Cancelled.")
+            print("모델 이름이 없어 취소했어요.")
             return
 
     # Activate and save the model to the custom_providers entry
@@ -1926,7 +1926,7 @@ def _model_flow_named_custom(config, provider_info):
         # Save model name to the custom_providers entry for next time
         _save_custom_provider(base_url, api_key, model_name)
 
-    print(f"\n✅ Model set to: {model_name}")
+    print(f"\n✅ 모델을 설정했어요: {model_name}")
     print(f"   Provider: {name} ({base_url})")
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -31,6 +31,34 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+
+_ARGPARSE_KO_TRANSLATIONS = {
+    "usage: ": "사용법: ",
+    "options": "옵션",
+    "optional arguments": "옵션",
+    "positional arguments": "위치 인자",
+    "show this help message and exit": "이 도움말을 표시하고 종료",
+    "subcommands": "하위 명령어",
+}
+
+
+def _argparse_korean(text: str) -> str:
+    return _ARGPARSE_KO_TRANSLATIONS.get(text, text)
+
+
+argparse._ = _argparse_korean
+
+
+class KoreanArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._positionals.title = "위치 인자"
+        self._optionals.title = "옵션"
+
+    def add_subparsers(self, *args, **kwargs):
+        kwargs.setdefault("title", "하위 명령어")
+        return super().add_subparsers(*args, **kwargs)
+
 def _require_tty(command_name: str) -> None:
     """Exit with a clear error if stdin is not a terminal.
 
@@ -4474,7 +4502,7 @@ def cmd_logs(args):
 
 def main():
     """Main entry point for hermes CLI."""
-    parser = argparse.ArgumentParser(
+    parser = KoreanArgumentParser(
         prog="hermes",
         description="Hermes Agent - 도구 호출 기능을 갖춘 AI 어시스턴트",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -4665,8 +4693,8 @@ def main():
     # =========================================================================
     model_parser = subparsers.add_parser(
         "model",
-        help="Select default model and provider",
-        description="Interactively select your inference provider and default model"
+        help="기본 모델과 provider 선택",
+        description="추론 provider와 기본 모델을 대화형으로 선택"
     )
     model_parser.add_argument(
         "--portal-url",
@@ -4713,8 +4741,8 @@ def main():
     # =========================================================================
     gateway_parser = subparsers.add_parser(
         "gateway",
-        help="Messaging gateway management",
-        description="Manage the messaging gateway (Telegram, Discord, WhatsApp)"
+        help="메시징 게이트웨이 관리",
+        description="메시징 게이트웨이(Telegram, Discord, WhatsApp) 관리"
     )
     gateway_subparsers = gateway_parser.add_subparsers(dest="gateway_command")
     
@@ -4765,9 +4793,9 @@ def main():
     # =========================================================================
     setup_parser = subparsers.add_parser(
         "setup",
-        help="Interactive setup wizard",
-        description="Configure Hermes Agent with an interactive wizard. "
-                    "Run a specific section: hermes setup model|tts|terminal|gateway|tools|agent"
+        help="대화형 설정 마법사",
+        description="대화형 마법사로 Hermes Agent를 설정. "
+                    "특정 섹션만 실행하려면: hermes setup model|tts|terminal|gateway|tools|agent"
     )
     setup_parser.add_argument(
         "section",
@@ -4793,8 +4821,8 @@ def main():
     # =========================================================================
     whatsapp_parser = subparsers.add_parser(
         "whatsapp",
-        help="Set up WhatsApp integration",
-        description="Configure WhatsApp and pair via QR code"
+        help="WhatsApp 연동 설정",
+        description="WhatsApp을 설정하고 QR 코드로 페어링"
     )
     whatsapp_parser.set_defaults(func=cmd_whatsapp)
 
@@ -4803,8 +4831,8 @@ def main():
     # =========================================================================
     login_parser = subparsers.add_parser(
         "login",
-        help="Authenticate with an inference provider",
-        description="Run OAuth device authorization flow for Hermes CLI"
+        help="추론 provider 인증",
+        description="Hermes CLI용 OAuth 디바이스 인증 흐름 실행"
     )
     login_parser.add_argument(
         "--provider",
@@ -4857,8 +4885,8 @@ def main():
     # =========================================================================
     logout_parser = subparsers.add_parser(
         "logout",
-        help="Clear authentication for an inference provider",
-        description="Remove stored credentials and reset provider config"
+        help="추론 provider 인증 해제",
+        description="저장된 자격 증명을 제거하고 provider 설정 초기화"
     )
     logout_parser.add_argument(
         "--provider",
@@ -4870,7 +4898,7 @@ def main():
 
     auth_parser = subparsers.add_parser(
         "auth",
-        help="Manage pooled provider credentials",
+        help="provider 풀 자격 증명 관리",
     )
     auth_subparsers = auth_parser.add_subparsers(dest="auth_action")
     auth_add = auth_subparsers.add_parser("add", help="Add a pooled credential")
@@ -4900,8 +4928,8 @@ def main():
     # =========================================================================
     status_parser = subparsers.add_parser(
         "status",
-        help="Show status of all components",
-        description="Display status of Hermes Agent components"
+        help="모든 구성요소 상태 표시",
+        description="Hermes Agent 구성요소 상태 표시"
     )
     status_parser.add_argument(
         "--all",
@@ -4920,8 +4948,8 @@ def main():
     # =========================================================================
     cron_parser = subparsers.add_parser(
         "cron",
-        help="Cron job management",
-        description="Manage scheduled tasks"
+        help="크론 작업 관리",
+        description="예약 작업 관리"
     )
     cron_subparsers = cron_parser.add_subparsers(dest="cron_command")
     
@@ -4979,8 +5007,8 @@ def main():
     # =========================================================================
     webhook_parser = subparsers.add_parser(
         "webhook",
-        help="Manage dynamic webhook subscriptions",
-        description="Create, list, and remove webhook subscriptions for event-driven agent activation",
+        help="동적 웹훅 구독 관리",
+        description="이벤트 기반 에이전트 활성화를 위한 웹훅 구독 생성, 조회, 제거",
     )
     webhook_subparsers = webhook_parser.add_subparsers(dest="webhook_action")
 
@@ -5010,8 +5038,8 @@ def main():
     # =========================================================================
     doctor_parser = subparsers.add_parser(
         "doctor",
-        help="Check configuration and dependencies",
-        description="Diagnose issues with Hermes Agent setup"
+        help="설정과 의존성 점검",
+        description="Hermes Agent 설정 문제 진단"
     )
     doctor_parser.add_argument(
         "--fix",
@@ -5025,9 +5053,9 @@ def main():
     # =========================================================================
     dump_parser = subparsers.add_parser(
         "dump",
-        help="Dump setup summary for support/debugging",
-        description="Output a compact, plain-text summary of your Hermes setup "
-                    "that can be copy-pasted into Discord/GitHub for support context"
+        help="지원/디버깅용 설정 요약 출력",
+        description="지원 맥락 공유를 위해 Discord/GitHub에 복사해 붙여넣을 수 있는 "
+                    "간단한 일반 텍스트 Hermes 설정 요약 출력"
     )
     dump_parser.add_argument(
         "--show-keys",
@@ -5041,10 +5069,10 @@ def main():
     # =========================================================================
     debug_parser = subparsers.add_parser(
         "debug",
-        help="Debug tools — upload logs and system info for support",
-        description="Debug utilities for Hermes Agent. Use 'hermes debug share' to "
-                    "upload a debug report (system info + recent logs) to a paste "
-                    "service and get a shareable URL.",
+        help="디버그 도구 — 지원용 로그와 시스템 정보 업로드",
+        description="Hermes Agent용 디버그 유틸리티. 'hermes debug share'를 사용해 "
+                    "디버그 리포트(시스템 정보 + 최근 로그)를 paste 서비스에 업로드하고 "
+                    "공유 가능한 URL을 받을 수 있습니다.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
@@ -5078,10 +5106,10 @@ Examples:
     # =========================================================================
     backup_parser = subparsers.add_parser(
         "backup",
-        help="Back up Hermes home directory to a zip file",
-        description="Create a zip archive of your entire Hermes configuration, "
-                    "skills, sessions, and data (excludes the hermes-agent codebase). "
-                    "Use --quick for a fast snapshot of just critical state files."
+        help="Hermes 홈 디렉터리를 zip 파일로 백업",
+        description="Hermes 설정, 스킬, 세션, 데이터를 모두 포함한 zip 아카이브 생성 "
+                    "(hermes-agent 코드베이스는 제외). "
+                    "중요 상태 파일만 빠르게 백업하려면 --quick 사용."
     )
     backup_parser.add_argument(
         "-o", "--output",
@@ -5103,10 +5131,8 @@ Examples:
     # =========================================================================
     import_parser = subparsers.add_parser(
         "import",
-        help="Restore a Hermes backup from a zip file",
-        description="Extract a previously created Hermes backup into your "
-                    "Hermes home directory, restoring configuration, skills, "
-                    "sessions, and data"
+        help="zip 파일에서 Hermes 백업 복원",
+        description="이전에 만든 Hermes 백업을 Hermes 홈 디렉터리에 풀어 설정, 스킬, 세션, 데이터를 복원"
     )
     import_parser.add_argument(
         "zipfile",
@@ -5124,8 +5150,8 @@ Examples:
     # =========================================================================
     config_parser = subparsers.add_parser(
         "config",
-        help="View and edit configuration",
-        description="Manage Hermes Agent configuration"
+        help="설정 조회 및 편집",
+        description="Hermes Agent 설정 관리"
     )
     config_subparsers = config_parser.add_subparsers(dest="config_command")
     
@@ -5159,8 +5185,8 @@ Examples:
     # =========================================================================
     pairing_parser = subparsers.add_parser(
         "pairing",
-        help="Manage DM pairing codes for user authorization",
-        description="Approve or revoke user access via pairing codes"
+        help="사용자 인증용 DM 페어링 코드 관리",
+        description="페어링 코드로 사용자 접근 승인 또는 철회"
     )
     pairing_sub = pairing_parser.add_subparsers(dest="pairing_action")
 
@@ -5187,8 +5213,8 @@ Examples:
     # =========================================================================
     skills_parser = subparsers.add_parser(
         "skills",
-        help="Search, install, configure, and manage skills",
-        description="Search, install, inspect, audit, configure, and manage skills from skills.sh, well-known agent skill endpoints, GitHub, ClawHub, and other registries."
+        help="스킬 검색, 설치, 설정, 관리",
+        description="skills.sh, well-known agent skill 엔드포인트, GitHub, ClawHub 등 다양한 레지스트리에서 스킬을 검색, 설치, 점검, 설정, 관리"
     )
     skills_subparsers = skills_parser.add_subparsers(dest="skills_action")
 
@@ -5269,8 +5295,8 @@ Examples:
     # =========================================================================
     plugins_parser = subparsers.add_parser(
         "plugins",
-        help="Manage plugins — install, update, remove, list",
-        description="Install plugins from Git repositories, update, remove, or list them.",
+        help="플러그인 관리 — 설치, 업데이트, 제거, 목록",
+        description="Git 저장소에서 플러그인을 설치하고, 업데이트하거나, 제거하거나, 목록을 확인",
     )
     plugins_subparsers = plugins_parser.add_subparsers(dest="plugins_action")
 
@@ -5338,13 +5364,13 @@ Examples:
     # =========================================================================
     memory_parser = subparsers.add_parser(
         "memory",
-        help="Configure external memory provider",
+        help="외부 memory provider 설정",
         description=(
-            "Set up and manage external memory provider plugins.\n\n"
-            "Available providers: honcho, openviking, mem0, hindsight,\n"
+            "외부 memory provider 플러그인을 설정하고 관리합니다.\n\n"
+            "사용 가능한 provider: honcho, openviking, mem0, hindsight,\n"
             "holographic, retaindb, byterover.\n\n"
-            "Only one external provider can be active at a time.\n"
-            "Built-in memory (MEMORY.md/USER.md) is always active."
+            "외부 provider는 한 번에 하나만 활성화할 수 있습니다.\n"
+            "내장 memory(MEMORY.md/USER.md)는 항상 활성화됩니다."
         ),
     )
     memory_sub = memory_parser.add_subparsers(dest="memory_command")
@@ -5374,12 +5400,12 @@ Examples:
     # =========================================================================
     tools_parser = subparsers.add_parser(
         "tools",
-        help="Configure which tools are enabled per platform",
+        help="플랫폼별 활성 도구 설정",
         description=(
-            "Enable, disable, or list tools for CLI, Telegram, Discord, etc.\n\n"
-            "Built-in toolsets use plain names (e.g. web, memory).\n"
-            "MCP tools use server:tool notation (e.g. github:create_issue).\n\n"
-            "Run 'hermes tools' with no subcommand for the interactive configuration UI."
+            "CLI, Telegram, Discord 등 플랫폼별 도구를 활성화, 비활성화, 조회합니다.\n\n"
+            "내장 toolset은 일반 이름(예: web, memory)을 사용합니다.\n"
+            "MCP 도구는 server:tool 표기(예: github:create_issue)를 사용합니다.\n\n"
+            "대화형 설정 UI를 열려면 하위 명령 없이 'hermes tools'를 실행하세요."
         ),
     )
     tools_parser.add_argument(
@@ -5443,12 +5469,12 @@ Examples:
     # =========================================================================
     mcp_parser = subparsers.add_parser(
         "mcp",
-        help="Manage MCP servers and run Hermes as an MCP server",
+        help="MCP 서버 관리 및 Hermes를 MCP 서버로 실행",
         description=(
-            "Manage MCP server connections and run Hermes as an MCP server.\n\n"
-            "MCP servers provide additional tools via the Model Context Protocol.\n"
-            "Use 'hermes mcp add' to connect to a new server, or\n"
-            "'hermes mcp serve' to expose Hermes conversations over MCP."
+            "MCP 서버 연결을 관리하고 Hermes를 MCP 서버로 실행합니다.\n\n"
+            "MCP 서버는 Model Context Protocol을 통해 추가 도구를 제공합니다.\n"
+            "새 서버에 연결하려면 'hermes mcp add'를,\n"
+            "Hermes 대화를 MCP로 노출하려면 'hermes mcp serve'를 사용하세요."
         ),
     )
     mcp_sub = mcp_parser.add_subparsers(dest="mcp_action")
@@ -5493,8 +5519,8 @@ Examples:
     # =========================================================================
     sessions_parser = subparsers.add_parser(
         "sessions",
-        help="Manage session history (list, rename, export, prune, delete)",
-        description="View and manage the SQLite session store"
+        help="세션 기록 관리(목록, 이름 변경, 내보내기, 정리, 삭제)",
+        description="SQLite 세션 저장소 조회 및 관리"
     )
     sessions_subparsers = sessions_parser.add_subparsers(dest="sessions_action")
 
@@ -5697,8 +5723,8 @@ Examples:
     # =========================================================================
     insights_parser = subparsers.add_parser(
         "insights",
-        help="Show usage insights and analytics",
-        description="Analyze session history to show token usage, costs, tool patterns, and activity trends"
+        help="사용량 인사이트와 분석 표시",
+        description="세션 기록을 분석해 토큰 사용량, 비용, 도구 패턴, 활동 추세를 표시"
     )
     insights_parser.add_argument("--days", type=int, default=30, help="Number of days to analyze (default: 30)")
     insights_parser.add_argument("--source", help="Filter by platform (cli, telegram, discord, etc.)")
@@ -5723,8 +5749,8 @@ Examples:
     # =========================================================================
     claw_parser = subparsers.add_parser(
         "claw",
-        help="OpenClaw migration tools",
-        description="Migrate settings, memories, skills, and API keys from OpenClaw to Hermes"
+        help="OpenClaw 마이그레이션 도구",
+        description="OpenClaw의 설정, memory, 스킬, API key를 Hermes로 마이그레이션"
     )
     claw_subparsers = claw_parser.add_subparsers(dest="claw_action")
 
@@ -5809,7 +5835,7 @@ Examples:
     # =========================================================================
     version_parser = subparsers.add_parser(
         "version",
-        help="Show version information"
+        help="버전 정보 표시"
     )
     version_parser.set_defaults(func=cmd_version)
     
@@ -5818,12 +5844,12 @@ Examples:
     # =========================================================================
     update_parser = subparsers.add_parser(
         "update",
-        help="Update Hermes Agent to the latest version",
-        description="Pull the latest changes from git and reinstall dependencies"
+        help="Hermes Agent를 최신 버전으로 업데이트",
+        description="git에서 최신 변경 사항을 가져오고 의존성을 다시 설치"
     )
     update_parser.add_argument(
         "--gateway", action="store_true", default=False,
-        help="Gateway mode: use file-based IPC for prompts instead of stdin (used internally by /update)"
+        help="게이트웨이 모드: stdin 대신 파일 기반 IPC로 프롬프트를 주고받음(/update 내부 사용)"
     )
     update_parser.set_defaults(func=cmd_update)
     
@@ -5832,8 +5858,8 @@ Examples:
     # =========================================================================
     uninstall_parser = subparsers.add_parser(
         "uninstall",
-        help="Uninstall Hermes Agent",
-        description="Remove Hermes Agent from your system. Can keep configs/data for reinstall."
+        help="Hermes Agent 제거",
+        description="시스템에서 Hermes Agent를 제거합니다. 재설치를 위해 설정/데이터는 유지할 수 있습니다."
     )
     uninstall_parser.add_argument(
         "--full",
@@ -5852,8 +5878,8 @@ Examples:
     # =========================================================================
     acp_parser = subparsers.add_parser(
         "acp",
-        help="Run Hermes Agent as an ACP (Agent Client Protocol) server",
-        description="Start Hermes Agent in ACP mode for editor integration (VS Code, Zed, JetBrains)",
+        help="Hermes Agent를 ACP(Agent Client Protocol) 서버로 실행",
+        description="에디터 연동(VS Code, Zed, JetBrains)을 위해 Hermes Agent를 ACP 모드로 시작",
     )
 
     def cmd_acp(args):
@@ -5873,7 +5899,7 @@ Examples:
     # =========================================================================
     profile_parser = subparsers.add_parser(
         "profile",
-        help="Manage profiles — multiple isolated Hermes instances",
+        help="프로필 관리 — 여러 격리된 Hermes 인스턴스",
     )
     profile_subparsers = profile_parser.add_subparsers(dest="profile_action")
 
@@ -5928,7 +5954,7 @@ Examples:
     # =========================================================================
     completion_parser = subparsers.add_parser(
         "completion",
-        help="Print shell completion script (bash, zsh, or fish)",
+        help="셸 자동완성 스크립트 출력(bash, zsh, fish)",
     )
     completion_parser.add_argument(
         "shell", nargs="?", default="bash", choices=["bash", "zsh", "fish"],
@@ -5941,8 +5967,8 @@ Examples:
     # =========================================================================
     dashboard_parser = subparsers.add_parser(
         "dashboard",
-        help="Start the web UI dashboard",
-        description="Launch the Hermes Agent web dashboard for managing config, API keys, and sessions",
+        help="웹 UI 대시보드 시작",
+        description="설정, API key, 세션 관리를 위한 Hermes Agent 웹 대시보드 실행",
     )
     dashboard_parser.add_argument("--port", type=int, default=9119, help="Port (default 9119)")
     dashboard_parser.add_argument("--host", default="127.0.0.1", help="Host (default 127.0.0.1)")
@@ -5958,8 +5984,8 @@ Examples:
     # =========================================================================
     logs_parser = subparsers.add_parser(
         "logs",
-        help="View and filter Hermes log files",
-        description="View, tail, and filter agent.log / errors.log / gateway.log",
+        help="Hermes 로그 파일 조회 및 필터링",
+        description="agent.log / errors.log / gateway.log 조회, tail, 필터링",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1005,7 +1005,7 @@ def select_provider_and_model(args=None):
         active = resolve_provider(effective_provider)
     except AuthError as exc:
         warning = format_auth_error(exc)
-        print(f"Warning: {warning} Falling back to auto provider detection.")
+        print(f"경고: {warning} auto provider 감지로 되돌릴게요.")
         try:
             active = resolve_provider("auto")
         except AuthError:
@@ -1021,8 +1021,8 @@ def select_provider_and_model(args=None):
     active_label = provider_labels.get(active, active) if active else "none"
 
     print()
-    print(f"  Current model:    {current_model}")
-    print(f"  Active provider:  {active_label}")
+    print(f"  현재 모델:      {current_model}")
+    print(f"  활성 provider:  {active_label}")
     print()
 
     # Step 1: Provider selection — flat list from CANONICAL_PROVIDERS
@@ -1075,11 +1075,11 @@ def select_provider_and_model(args=None):
         else:
             ordered.append((key, label))
 
-    ordered.append(("custom", "Custom endpoint (enter URL manually)"))
+    ordered.append(("custom", "사용자 지정 endpoint (URL 직접 입력)"))
     _has_saved_custom_list = isinstance(config.get("custom_providers"), list) and bool(config.get("custom_providers"))
     if _has_saved_custom_list:
-        ordered.append(("remove-custom", "Remove a saved custom provider"))
-    ordered.append(("cancel", "Cancel"))
+        ordered.append(("remove-custom", "저장된 custom provider 제거"))
+    ordered.append(("cancel", "취소"))
 
     provider_idx = _prompt_provider_choice(
         [label for _, label in ordered], default=default_idx,
@@ -1829,7 +1829,7 @@ def _model_flow_named_custom(config, provider_info):
             menu_items = [
                 f"  {m} (current)" if m == saved_model else f"  {m}"
                 for m in models
-            ] + ["  Cancel"]
+            ] + ["  취소"]
             menu = TerminalMenu(
                 menu_items, cursor_index=default_idx,
                 menu_cursor="-> ", menu_cursor_style=("fg_green", "bold"),
@@ -2060,19 +2060,19 @@ def _model_flow_copilot(config, current_model=""):
     if not api_key:
         print("No GitHub token configured for GitHub Copilot.")
         print()
-        print("  Supported token types:")
-        print("    → OAuth token (gho_*)          via `copilot login` or device code flow")
-        print("    → Fine-grained PAT (github_pat_*)  with Copilot Requests permission")
-        print("    → GitHub App token (ghu_*)     via environment variable")
-        print("    ✗ Classic PAT (ghp_*)          NOT supported by Copilot API")
+        print("  지원하는 토큰 종류:")
+        print("    → OAuth 토큰 (gho_*)              `copilot login` 또는 device code 흐름으로 발급")
+        print("    → Fine-grained PAT (github_pat_*)  Copilot Requests 권한 필요")
+        print("    → GitHub App 토큰 (ghu_*)         환경 변수로 제공")
+        print("    ✗ Classic PAT (ghp_*)             Copilot API에서 지원하지 않음")
         print()
-        print("  Options:")
-        print("    1. Login with GitHub (OAuth device code flow)")
-        print("    2. Enter a token manually")
-        print("    3. Cancel")
+        print("  선택 사항:")
+        print("    1. GitHub로 로그인 (OAuth device code 흐름)")
+        print("    2. 토큰 직접 입력")
+        print("    3. 취소")
         print()
         try:
-            choice = input("  Choice [1-3]: ").strip()
+            choice = input("  선택 [1-3]: ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return
@@ -2083,13 +2083,13 @@ def _model_flow_copilot(config, current_model=""):
                 token = copilot_device_code_login()
                 if token:
                     save_env_value("COPILOT_GITHUB_TOKEN", token)
-                    print("  Copilot token saved.")
+                    print("  Copilot 토큰을 저장했어요.")
                     print()
                 else:
-                    print("  Login cancelled or failed.")
+                    print("  로그인을 취소했거나 로그인에 실패했어요.")
                     return
             except Exception as exc:
-                print(f"  Login failed: {exc}")
+                print(f"  로그인에 실패했어요: {exc}")
                 return
         elif choice == "2":
             try:
@@ -2099,7 +2099,7 @@ def _model_flow_copilot(config, current_model=""):
                 print()
                 return
             if not new_key:
-                print("  Cancelled.")
+                print("  취소했어요.")
                 return
             # Validate token type
             try:
@@ -2111,10 +2111,10 @@ def _model_flow_copilot(config, current_model=""):
             except ImportError:
                 pass
             save_env_value("COPILOT_GITHUB_TOKEN", new_key)
-            print("  Token saved.")
+            print("  토큰을 저장했어요.")
             print()
         else:
-            print("  Cancelled.")
+            print("  취소했어요.")
             return
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -2122,11 +2122,11 @@ def _model_flow_copilot(config, current_model=""):
         source = creds.get("source", "")
     else:
         if source in ("GITHUB_TOKEN", "GH_TOKEN"):
-            print(f"  GitHub token: {api_key[:8]}... ✓ ({source})")
+            print(f"  GitHub 토큰: {api_key[:8]}... ✓ ({source})")
         elif source == "gh auth token":
-            print("  GitHub token: ✓ (from `gh auth token`)")
+            print("  GitHub 토큰: ✓ (`gh auth token`에서 가져옴)")
         else:
-            print("  GitHub token: ✓")
+            print("  GitHub 토큰: ✓")
         print()
 
     effective_base = pconfig.inference_base_url
@@ -2140,18 +2140,18 @@ def _model_flow_copilot(config, current_model=""):
     ) or current_model
     if live_models:
         model_list = [model_id for model_id in live_models if model_id]
-        print(f"  Found {len(model_list)} model(s) from GitHub Copilot")
+        print(f"  모델 {len(model_list)}개를 GitHub Copilot에서 찾았어요")
     else:
         model_list = _PROVIDER_MODELS.get(provider_id, [])
         if model_list:
-            print("  ⚠ Could not auto-detect models from GitHub Copilot — showing defaults.")
-            print('    Use "Enter custom model name" if you do not see your model.')
+            print("  ⚠ GitHub Copilot에서 모델을 자동 감지하지 못했어요 — 기본 목록을 보여줄게요.")
+            print('    원하는 모델이 없으면 "사용자 지정 모델 이름 입력"을 사용하세요.')
 
     if model_list:
         selected = _prompt_model_selection(model_list, current_model=normalized_current_model)
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = input("모델 이름: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2170,7 +2170,7 @@ def _model_flow_copilot(config, current_model=""):
         )
         selected_effort = None
         if reasoning_efforts:
-            print(f"  {selected} supports reasoning controls.")
+            print(f"  {selected} 모델은 reasoning 제어를 지원해요.")
             selected_effort = _prompt_reasoning_effort_selection(
                 reasoning_efforts, current_effort=current_effort
             )
@@ -2194,14 +2194,14 @@ def _model_flow_copilot(config, current_model=""):
         save_config(cfg)
         deactivate_provider()
 
-        print(f"Default model set to: {selected} (via {pconfig.name})")
+        print(f"기본 모델을 설정했어요: {selected} ({pconfig.name} 사용)")
         if reasoning_efforts:
             if selected_effort == "none":
-                print("Reasoning disabled for this model.")
+                print("이 모델에서는 reasoning을 비활성화했어요.")
             elif selected_effort:
-                print(f"Reasoning effort set to: {selected_effort}")
+                print(f"reasoning 강도를 설정했어요: {selected_effort}")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 def _model_flow_copilot_acp(config, current_model=""):
@@ -2230,18 +2230,18 @@ def _model_flow_copilot_acp(config, current_model=""):
     resolved_command = status.get("resolved_command") or status.get("command") or "copilot"
     effective_base = status.get("base_url") or pconfig.inference_base_url
 
-    print("  GitHub Copilot ACP delegates Hermes turns to `copilot --acp`.")
-    print("  Hermes currently starts its own ACP subprocess for each request.")
-    print("  Hermes uses your selected model as a hint for the Copilot ACP session.")
-    print(f"  Command: {resolved_command}")
-    print(f"  Backend marker: {effective_base}")
+    print("  GitHub Copilot ACP는 Hermes의 각 요청을 `copilot --acp`로 위임해요.")
+    print("  현재 Hermes는 요청마다 자체 ACP 서브프로세스를 시작해요.")
+    print("  Hermes는 선택한 모델을 Copilot ACP 세션의 힌트로 전달해요.")
+    print(f"  명령어: {resolved_command}")
+    print(f"  백엔드 표시값: {effective_base}")
     print()
 
     try:
         creds = resolve_external_process_provider_credentials(provider_id)
     except Exception as exc:
         print(f"  ⚠ {exc}")
-        print("  Set HERMES_COPILOT_ACP_COMMAND or COPILOT_CLI_PATH if Copilot CLI is installed elsewhere.")
+        print("  Copilot CLI가 다른 위치에 설치되어 있다면 HERMES_COPILOT_ACP_COMMAND 또는 COPILOT_CLI_PATH를 설정하세요.")
         return
 
     effective_base = creds.get("base_url") or effective_base
@@ -2262,12 +2262,12 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     if catalog:
         model_list = [item.get("id", "") for item in catalog if item.get("id")]
-        print(f"  Found {len(model_list)} model(s) from GitHub Copilot")
+        print(f"  모델 {len(model_list)}개를 GitHub Copilot에서 찾았어요")
     else:
         model_list = _PROVIDER_MODELS.get("copilot", [])
         if model_list:
-            print("  ⚠ Could not auto-detect models from GitHub Copilot — showing defaults.")
-            print('    Use "Enter custom model name" if you do not see your model.')
+            print("  ⚠ GitHub Copilot에서 모델을 자동 감지하지 못했어요 — 기본 목록을 보여줄게요.")
+            print('    원하는 모델이 없으면 "사용자 지정 모델 이름 입력"을 사용하세요.')
 
     if model_list:
         selected = _prompt_model_selection(
@@ -2276,12 +2276,12 @@ def _model_flow_copilot_acp(config, current_model=""):
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = input("모델 이름: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
     if not selected:
-        print("No change.")
+        print("변경 사항이 없어요.")
         return
 
     selected = normalize_copilot_model_id(
@@ -2302,7 +2302,7 @@ def _model_flow_copilot_acp(config, current_model=""):
     save_config(cfg)
     deactivate_provider()
 
-    print(f"Default model set to: {selected} (via {pconfig.name})")
+    print(f"기본 모델을 설정했어요: {selected} ({pconfig.name} 사용)")
 
 
 def _model_flow_kimi(config, current_model=""):
@@ -2332,20 +2332,20 @@ def _model_flow_kimi(config, current_model=""):
             break
 
     if not existing_key:
-        print(f"No {pconfig.name} API key configured.")
+        print(f"{pconfig.name} API key가 설정되지 않았어요.")
         if key_env:
             try:
                 import getpass
-                new_key = getpass.getpass(f"{key_env} (or Enter to cancel): ").strip()
+                new_key = getpass.getpass(f"{key_env} 입력(취소하려면 Enter): ").strip()
             except (KeyboardInterrupt, EOFError):
                 print()
                 return
             if not new_key:
-                print("Cancelled.")
+                print("취소했어요.")
                 return
             save_env_value(key_env, new_key)
             existing_key = new_key
-            print("API key saved.")
+            print("API key를 저장했어요.")
             print()
     else:
         print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓")
@@ -2355,10 +2355,10 @@ def _model_flow_kimi(config, current_model=""):
     is_coding_plan = existing_key.startswith("sk-kimi-")
     if is_coding_plan:
         effective_base = KIMI_CODE_BASE_URL
-        print(f"  Detected Kimi Coding Plan key → {effective_base}")
+        print(f"  Kimi Coding Plan 키를 감지했어요 → {effective_base}")
     else:
         effective_base = pconfig.inference_base_url
-        print(f"  Using Moonshot endpoint → {effective_base}")
+        print(f"  Moonshot endpoint를 사용할게요 → {effective_base}")
     # Clear any manual base URL override so auto-detection works at runtime
     if base_url_env and get_env_value(base_url_env):
         save_env_value(base_url_env, "")
@@ -2381,7 +2381,7 @@ def _model_flow_kimi(config, current_model=""):
         selected = _prompt_model_selection(model_list, current_model=current_model)
     else:
         try:
-            selected = input("Enter model name: ").strip()
+            selected = input("모델 이름 직접 입력: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2401,9 +2401,9 @@ def _model_flow_kimi(config, current_model=""):
         deactivate_provider()
 
         endpoint_label = "Kimi Coding" if is_coding_plan else "Moonshot"
-        print(f"Default model set to: {selected} (via {endpoint_label})")
+        print(f"기본 모델을 설정했어요: {selected} ({endpoint_label} 사용)")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
@@ -2427,19 +2427,19 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             break
 
     if not existing_key:
-        print(f"No {pconfig.name} API key configured.")
+        print(f"{pconfig.name} API key가 설정되지 않았어요.")
         if key_env:
             try:
                 import getpass
-                new_key = getpass.getpass(f"{key_env} (or Enter to cancel): ").strip()
+                new_key = getpass.getpass(f"{key_env} 입력(취소하려면 Enter): ").strip()
             except (KeyboardInterrupt, EOFError):
                 print()
                 return
             if not new_key:
-                print("Cancelled.")
+                print("취소했어요.")
                 return
             save_env_value(key_env, new_key)
-            print("API key saved.")
+            print("API key를 저장했어요.")
             print()
     else:
         print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓")
@@ -2458,7 +2458,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         override = ""
     if override and base_url_env:
         if not override.startswith(("http://", "https://")):
-            print("  Invalid URL — must start with http:// or https://. Keeping current value.")
+            print("  잘못된 URL이에요 — http:// 또는 https:// 로 시작해야 해요. 현재 값을 유지할게요.")
         else:
             save_env_value(base_url_env, override)
             effective_base = override
@@ -2479,21 +2479,21 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
 
     if mdev_models:
         model_list = mdev_models
-        print(f"  Found {len(model_list)} model(s) from models.dev registry")
+        print(f"  models.dev 레지스트리에서 모델 {len(model_list)}개를 찾았어요")
     elif curated and len(curated) >= 8:
         # Curated list is substantial — use it directly, skip live probe
         model_list = curated
-        print(f"  Showing {len(model_list)} curated models — use \"Enter custom model name\" for others.")
+        print(f"  큐레이션 모델 {len(model_list)}개를 표시합니다 — 다른 모델은 \"사용자 지정 모델 이름 입력\"을 사용하세요.")
     else:
         api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
         live_models = fetch_api_models(api_key_for_probe, effective_base)
         if live_models and len(live_models) >= len(curated):
             model_list = live_models
-            print(f"  Found {len(model_list)} model(s) from {pconfig.name} API")
+            print(f"  {pconfig.name} API에서 모델 {len(model_list)}개를 찾았어요")
         else:
             model_list = curated
             if model_list:
-                print(f"  Showing {len(model_list)} curated models — use \"Enter custom model name\" for others.")
+                print(f"  큐레이션 모델 {len(model_list)}개를 표시합니다 — 다른 모델은 \"사용자 지정 모델 이름 입력\"을 사용하세요.")
         # else: no defaults either, will fall through to raw input
 
     if provider_id in {"opencode-zen", "opencode-go"}:
@@ -2505,7 +2505,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         selected = _prompt_model_selection(model_list, current_model=current_model)
     else:
         try:
-            selected = input("Model name: ").strip()
+            selected = input("모델 이름: ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2530,9 +2530,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         save_config(cfg)
         deactivate_provider()
 
-        print(f"Default model set to: {selected} (via {pconfig.name})")
+        print(f"기본 모델을 설정했어요: {selected} ({pconfig.name} 사용)")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 def _run_anthropic_oauth_flow(save_env_value):
@@ -2557,16 +2557,16 @@ def _run_anthropic_oauth_flow(save_env_value):
             or bool(creds.get("refreshToken"))
         ):
             use_anthropic_claude_code_credentials(save_fn=save_env_value)
-            print("  ✓ Claude Code credentials linked.")
+            print("  ✓ Claude Code 자격 증명을 연결했어요.")
             from hermes_constants import display_hermes_home as _dhh_fn
-            print(f"    Hermes will use Claude's credential store directly instead of copying a setup-token into {_dhh_fn()}/.env.")
+            print(f"    setup-token을 {_dhh_fn()}/.env에 복사하지 않고 Claude의 자격 증명 저장소를 직접 사용할게요.")
             return True
         return False
 
     try:
         print()
-        print("  Running 'claude setup-token' — follow the prompts below.")
-        print("  A browser window will open for you to authorize access.")
+        print("  'claude setup-token'을 실행할게요 — 아래 안내를 따라 진행해 주세요.")
+        print("  인증을 위해 브라우저 창이 열릴 거예요.")
         print()
         token = run_oauth_setup_token()
         if token:
@@ -2578,47 +2578,47 @@ def _run_anthropic_oauth_flow(save_env_value):
 
         # Subprocess completed but no token auto-detected — ask user to paste
         print()
-        print("  If the setup-token was displayed above, paste it here:")
+        print("  위에 setup-token이 표시되었다면 여기에 붙여 넣어 주세요:")
         print()
         try:
             import getpass
-            manual_token = getpass.getpass("  Paste setup-token (or Enter to cancel): ").strip()
+            manual_token = getpass.getpass("  setup-token 붙여넣기 (취소하려면 Enter): ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return False
         if manual_token:
             save_anthropic_oauth_token(manual_token, save_fn=save_env_value)
-            print("  ✓ Setup-token saved.")
+            print("  ✓ setup-token을 저장했어요.")
             return True
 
-        print("  ⚠ Could not detect saved credentials.")
+        print("  ⚠ 저장된 자격 증명을 감지하지 못했어요.")
         return False
 
     except FileNotFoundError:
         # Claude CLI not installed — guide user through manual setup
         print()
-        print("  The 'claude' CLI is required for OAuth login.")
+        print("  OAuth 로그인에는 'claude' CLI가 필요해요.")
         print()
-        print("  To install and authenticate:")
+        print("  설치 및 인증 방법:")
         print()
-        print("    1. Install Claude Code:  npm install -g @anthropic-ai/claude-code")
-        print("    2. Run:                  claude setup-token")
-        print("    3. Follow the browser prompts to authorize")
-        print("    4. Re-run:               hermes model")
+        print("    1. Claude Code 설치:  npm install -g @anthropic-ai/claude-code")
+        print("    2. 실행:              claude setup-token")
+        print("    3. 브라우저에서 인증 프롬프트 진행")
+        print("    4. 다시 실행:         hermes model")
         print()
-        print("  Or paste an existing setup-token now (sk-ant-oat-...):")
+        print("  또는 기존 setup-token을 지금 붙여 넣으세요 (sk-ant-oat-...):")
         print()
         try:
             import getpass
-            token = getpass.getpass("  Setup-token (or Enter to cancel): ").strip()
+            token = getpass.getpass("  setup-token 입력 (취소하려면 Enter): ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return False
         if token:
             save_anthropic_oauth_token(token, save_fn=save_env_value)
-            print("  ✓ Setup-token saved.")
+            print("  ✓ setup-token을 저장했어요.")
             return True
-        print("  Cancelled — install Claude Code and try again.")
+        print("  취소했어요 — Claude Code를 설치한 뒤 다시 시도해 주세요.")
         return False
 
 
@@ -2652,16 +2652,16 @@ def _model_flow_anthropic(config, current_model=""):
     if has_creds:
         # Show what we found
         if existing_key:
-            print(f"  Anthropic credentials: {existing_key[:12]}... ✓")
+            print(f"  Anthropic 자격 증명: {existing_key[:12]}... ✓")
         elif cc_available:
-            print("  Claude Code credentials: ✓ (auto-detected)")
+            print("  Claude Code 자격 증명: ✓ (자동 감지됨)")
         print()
-        print("    1. Use existing credentials")
-        print("    2. Reauthenticate (new OAuth login)")
-        print("    3. Cancel")
+        print("    1. 기존 자격 증명 사용")
+        print("    2. 다시 인증하기 (새 OAuth 로그인)")
+        print("    3. 취소")
         print()
         try:
-            choice = input("  Choice [1/2/3]: ").strip()
+            choice = input("  선택 [1/2/3]: ").strip()
         except (KeyboardInterrupt, EOFError):
             choice = "1"
 
@@ -2674,14 +2674,14 @@ def _model_flow_anthropic(config, current_model=""):
     if needs_auth:
         # Show auth method choice
         print()
-        print("  Choose authentication method:")
+        print("  인증 방식을 선택해 주세요:")
         print()
-        print("    1. Claude Pro/Max subscription (OAuth login)")
-        print("    2. Anthropic API key (pay-per-token)")
-        print("    3. Cancel")
+        print("    1. Claude Pro/Max 구독 (OAuth 로그인)")
+        print("    2. Anthropic API key (사용한 토큰만큼 과금)")
+        print("    3. 취소")
         print()
         try:
-            choice = input("  Choice [1/2/3]: ").strip()
+            choice = input("  선택 [1/2/3]: ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return
@@ -2692,22 +2692,22 @@ def _model_flow_anthropic(config, current_model=""):
 
         elif choice == "2":
             print()
-            print("  Get an API key at: https://console.anthropic.com/settings/keys")
+            print("  API key 발급 링크: https://console.anthropic.com/settings/keys")
             print()
             try:
                 import getpass
-                api_key = getpass.getpass("  API key (sk-ant-...): ").strip()
+                api_key = getpass.getpass("  API key 입력 (sk-ant-...): ").strip()
             except (KeyboardInterrupt, EOFError):
                 print()
                 return
             if not api_key:
-                print("  Cancelled.")
+                print("  취소했어요.")
                 return
             save_anthropic_api_key(api_key, save_fn=save_env_value)
-            print("  ✓ API key saved.")
+            print("  ✓ API key를 저장했어요.")
 
         else:
-            print("  No change.")
+            print("  변경 사항이 없어요.")
             return
     print()
 
@@ -2717,7 +2717,7 @@ def _model_flow_anthropic(config, current_model=""):
         selected = _prompt_model_selection(model_list, current_model=current_model)
     else:
         try:
-            selected = input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
+            selected = input("모델 이름 입력 (예: claude-sonnet-4-20250514): ").strip()
         except (KeyboardInterrupt, EOFError):
             selected = None
 
@@ -2738,9 +2738,9 @@ def _model_flow_anthropic(config, current_model=""):
         save_config(cfg)
         deactivate_provider()
 
-        print(f"Default model set to: {selected} (via Anthropic)")
+        print(f"기본 모델을 설정했어요: {selected} (Anthropic 사용)")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 def cmd_login(args):
@@ -5611,7 +5611,7 @@ Examples:
                 return
             if not args.yes:
                 if not _confirm_prompt(f"Delete session '{resolved_session_id}' and all its messages? [y/N] "):
-                    print("Cancelled.")
+                    print("취소했어요.")
                     return
             if db.delete_session(resolved_session_id):
                 print(f"Deleted session '{resolved_session_id}'.")
@@ -5623,7 +5623,7 @@ Examples:
             source_msg = f" from '{args.source}'" if args.source else ""
             if not args.yes:
                 if not _confirm_prompt(f"Delete all ended sessions older than {days} days{source_msg}? [y/N] "):
-                    print("Cancelled.")
+                    print("취소했어요.")
                     return
             count = db.prune_sessions(older_than_days=days, source=args.source)
             print(f"Pruned {count} session(s).")
@@ -5654,7 +5654,7 @@ Examples:
 
             selected_id = _session_browse_picker(sessions)
             if not selected_id:
-                print("Cancelled.")
+                print("취소했어요.")
                 return
 
             # Launch hermes --resume <id> by replacing the current process

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -778,92 +778,92 @@ def cmd_whatsapp(args):
     from hermes_cli.config import get_env_value, save_env_value
 
     print()
-    print("⚕ WhatsApp Setup")
+    print("⚕ WhatsApp 설정")
     print("=" * 50)
 
     # ── Step 1: Choose mode ──────────────────────────────────────────────
     current_mode = get_env_value("WHATSAPP_MODE") or ""
     if not current_mode:
         print()
-        print("How will you use WhatsApp with Hermes?")
+        print("Hermes에서 WhatsApp을 어떻게 사용할까요?")
         print()
-        print("  1. Separate bot number (recommended)")
-        print("     People message the bot's number directly — cleanest experience.")
-        print("     Requires a second phone number with WhatsApp installed on a device.")
+        print("  1. 별도 봇 번호 사용 (권장)")
+        print("     사람들이 봇 번호로 직접 메시지를 보내는 방식이라 가장 깔끔해요.")
+        print("     WhatsApp이 설치된 기기와 두 번째 전화번호가 필요해요.")
         print()
-        print("  2. Personal number (self-chat)")
-        print("     You message yourself to talk to the agent.")
-        print("     Quick to set up, but the UX is less intuitive.")
+        print("  2. 개인 번호 사용 (self-chat)")
+        print("     자기 자신에게 메시지를 보내는 방식으로 에이전트와 대화해요.")
+        print("     설정은 빠르지만 사용 경험은 덜 직관적일 수 있어요.")
         print()
         try:
-            choice = input("  Choose [1/2]: ").strip()
+            choice = input("  선택 [1/2]: ").strip()
         except (EOFError, KeyboardInterrupt):
-            print("\nSetup cancelled.")
+            print("\n설정을 취소했어요.")
             return
 
         if choice == "1":
             save_env_value("WHATSAPP_MODE", "bot")
             wa_mode = "bot"
-            print("  ✓ Mode: separate bot number")
+            print("  ✓ 모드: 별도 봇 번호")
             print()
             print("  ┌─────────────────────────────────────────────────┐")
-            print("  │  Getting a second number for the bot:           │")
+            print("  │  봇용 두 번째 번호 준비 방법:                    │")
             print("  │                                                 │")
-            print("  │  Easiest: Install WhatsApp Business (free app)  │")
-            print("  │  on your phone with a second number:            │")
-            print("  │    • Dual-SIM: use your 2nd SIM slot            │")
-            print("  │    • Google Voice: free US number (voice.google) │")
-            print("  │    • Prepaid SIM: $3-10, verify once            │")
+            print("  │  가장 쉬운 방법: WhatsApp Business(무료 앱)를   │")
+            print("  │  두 번째 번호로 휴대폰에 설치하세요:            │")
+            print("  │    • 듀얼 SIM: 두 번째 SIM 슬롯 사용            │")
+            print("  │    • Google Voice: 무료 미국 번호(voice.google) │")
+            print("  │    • 선불 SIM: 1회 인증용으로 저렴하게 구매      │")
             print("  │                                                 │")
-            print("  │  WhatsApp Business runs alongside your personal │")
-            print("  │  WhatsApp — no second phone needed.             │")
+            print("  │  WhatsApp Business는 개인 WhatsApp과 함께       │")
+            print("  │  같은 휴대폰에서 사용할 수 있어요.              │")
             print("  └─────────────────────────────────────────────────┘")
         else:
             save_env_value("WHATSAPP_MODE", "self-chat")
             wa_mode = "self-chat"
-            print("  ✓ Mode: personal number (self-chat)")
+            print("  ✓ 모드: 개인 번호 (self-chat)")
     else:
         wa_mode = current_mode
-        mode_label = "separate bot number" if wa_mode == "bot" else "personal number (self-chat)"
-        print(f"\n✓ Mode: {mode_label}")
+        mode_label = "별도 봇 번호" if wa_mode == "bot" else "개인 번호 (self-chat)"
+        print(f"\n✓ 모드: {mode_label}")
 
     # ── Step 2: Enable WhatsApp ──────────────────────────────────────────
     print()
     current = get_env_value("WHATSAPP_ENABLED")
     if current and current.lower() == "true":
-        print("✓ WhatsApp is already enabled")
+        print("✓ WhatsApp이 이미 활성화되어 있어요")
     else:
         save_env_value("WHATSAPP_ENABLED", "true")
-        print("✓ WhatsApp enabled")
+        print("✓ WhatsApp을 활성화했어요")
 
     # ── Step 3: Allowed users ────────────────────────────────────────────
     current_users = get_env_value("WHATSAPP_ALLOWED_USERS") or ""
     if current_users:
-        print(f"✓ Allowed users: {current_users}")
+        print(f"✓ 허용된 사용자: {current_users}")
         try:
-            response = input("\n  Update allowed users? [y/N] ").strip()
+            response = input("\n  허용된 사용자를 수정할까요? [y/N] ").strip()
         except (EOFError, KeyboardInterrupt):
             response = "n"
         if response.lower() in ("y", "yes"):
             if wa_mode == "bot":
-                phone = input("  Phone numbers that can message the bot (comma-separated): ").strip()
+                phone = input("  봇에 메시지를 보낼 수 있는 전화번호(쉼표 구분): ").strip()
             else:
-                phone = input("  Your phone number (e.g. 15551234567): ").strip()
+                phone = input("  내 전화번호 (예: 15551234567): ").strip()
             if phone:
                 save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
-                print(f"  ✓ Updated to: {phone}")
+                print(f"  ✓ 다음 값으로 업데이트했어요: {phone}")
     else:
         print()
         if wa_mode == "bot":
-            print("  Who should be allowed to message the bot?")
-            phone = input("  Phone numbers (comma-separated, or * for anyone): ").strip()
+            print("  누가 봇에게 메시지를 보낼 수 있도록 할까요?")
+            phone = input("  전화번호 입력(쉼표 구분, 모두 허용은 *): ").strip()
         else:
-            phone = input("  Your phone number (e.g. 15551234567): ").strip()
+            phone = input("  내 전화번호 (예: 15551234567): ").strip()
         if phone:
             save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
-            print(f"  ✓ Allowed users set: {phone}")
+            print(f"  ✓ 허용된 사용자를 설정했어요: {phone}")
         else:
-            print("  ⚠ No allowlist — the agent will respond to ALL incoming messages")
+            print("  ⚠ allowlist가 없어요 — 에이전트가 모든 수신 메시지에 응답할 수 있어요")
 
     # ── Step 4: Install bridge dependencies ──────────────────────────────
     project_root = Path(__file__).resolve().parents[1]
@@ -871,11 +871,11 @@ def cmd_whatsapp(args):
     bridge_script = bridge_dir / "bridge.js"
 
     if not bridge_script.exists():
-        print(f"\n✗ Bridge script not found at {bridge_script}")
+        print(f"\n✗ bridge 스크립트를 찾지 못했어요: {bridge_script}")
         return
 
     if not (bridge_dir / "node_modules").exists():
-        print("\n→ Installing WhatsApp bridge dependencies...")
+        print("\n→ WhatsApp bridge 의존성을 설치하는 중...")
         result = subprocess.run(
             ["npm", "install"],
             cwd=str(bridge_dir),
@@ -884,40 +884,40 @@ def cmd_whatsapp(args):
             timeout=120,
         )
         if result.returncode != 0:
-            print(f"  ✗ npm install failed: {result.stderr}")
+            print(f"  ✗ npm install에 실패했어요: {result.stderr}")
             return
-        print("  ✓ Dependencies installed")
+        print("  ✓ 의존성 설치 완료")
     else:
-        print("✓ Bridge dependencies already installed")
+        print("✓ Bridge 의존성이 이미 설치되어 있어요")
 
     # ── Step 5: Check for existing session ───────────────────────────────
     session_dir = get_hermes_home() / "whatsapp" / "session"
     session_dir.mkdir(parents=True, exist_ok=True)
 
     if (session_dir / "creds.json").exists():
-        print("✓ Existing WhatsApp session found")
+        print("✓ 기존 WhatsApp 세션을 찾았어요")
         try:
-            response = input("\n  Re-pair? This will clear the existing session. [y/N] ").strip()
+            response = input("\n  다시 페어링할까요? 기존 세션이 초기화돼요. [y/N] ").strip()
         except (EOFError, KeyboardInterrupt):
             response = "n"
         if response.lower() in ("y", "yes"):
             import shutil
             shutil.rmtree(session_dir, ignore_errors=True)
             session_dir.mkdir(parents=True, exist_ok=True)
-            print("  ✓ Session cleared")
+            print("  ✓ 세션을 초기화했어요")
         else:
-            print("\n✓ WhatsApp is configured and paired!")
-            print("  Start the gateway with: hermes gateway")
+            print("\n✓ WhatsApp 설정과 페어링이 완료되어 있어요!")
+            print("  gateway 시작 명령: hermes gateway")
             return
 
     # ── Step 6: QR code pairing ──────────────────────────────────────────
     print()
     print("─" * 50)
     if wa_mode == "bot":
-        print("📱 Open WhatsApp (or WhatsApp Business) on the")
-        print("   phone with the BOT's number, then scan:")
+        print("📱 봇 번호가 연결된 휴대폰에서 WhatsApp(또는 WhatsApp Business)을 열고")
+        print("   아래 절차로 스캔해 주세요:")
     else:
-        print("📱 Open WhatsApp on your phone, then scan:")
+        print("📱 휴대폰에서 WhatsApp을 열고 아래 절차로 스캔해 주세요:")
     print()
     print("   Settings → Linked Devices → Link a Device")
     print("─" * 50)
@@ -934,27 +934,27 @@ def cmd_whatsapp(args):
     # ── Step 7: Post-pairing ─────────────────────────────────────────────
     print()
     if (session_dir / "creds.json").exists():
-        print("✓ WhatsApp paired successfully!")
+        print("✓ WhatsApp 페어링이 완료됐어요!")
         print()
         if wa_mode == "bot":
-            print("  Next steps:")
-            print("    1. Start the gateway:  hermes gateway")
-            print("    2. Send a message to the bot's WhatsApp number")
-            print("    3. The agent will reply automatically")
+            print("  다음 단계:")
+            print("    1. gateway 시작: hermes gateway")
+            print("    2. 봇의 WhatsApp 번호로 메시지 보내기")
+            print("    3. 에이전트가 자동으로 응답해요")
             print()
-            print("  Tip: Agent responses are prefixed with '⚕ Hermes Agent'")
+            print("  팁: 에이전트 응답은 '⚕ Hermes Agent' 접두사로 표시돼요")
         else:
-            print("  Next steps:")
-            print("    1. Start the gateway:  hermes gateway")
-            print("    2. Open WhatsApp → Message Yourself")
-            print("    3. Type a message — the agent will reply")
+            print("  다음 단계:")
+            print("    1. gateway 시작: hermes gateway")
+            print("    2. WhatsApp에서 'Message Yourself' 열기")
+            print("    3. 메시지를 입력하면 에이전트가 응답해요")
             print()
-            print("  Tip: Agent responses are prefixed with '⚕ Hermes Agent'")
-            print("  so you can tell them apart from your own messages.")
+            print("  팁: 에이전트 응답은 '⚕ Hermes Agent' 접두사로 표시돼요")
+            print("  그래서 내 메시지와 쉽게 구분할 수 있어요.")
         print()
-        print("  Or install as a service: hermes gateway install")
+        print("  또는 서비스로 설치: hermes gateway install")
     else:
-        print("⚠ Pairing may not have completed. Run 'hermes whatsapp' to try again.")
+        print("⚠ 페어링이 완료되지 않았을 수 있어요. 다시 시도하려면 'hermes whatsapp'을 실행해 주세요.")
 
 
 def cmd_setup(args):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -665,8 +665,8 @@ def cmd_chat(args):
             if resolved:
                 args.resume = resolved
             else:
-                print(f"No session found matching '{continue_val}'.")
-                print("Use 'hermes sessions list' to see available sessions.")
+                print(f"'{continue_val}'와 일치하는 세션을 찾지 못했어요.")
+                print("사용 가능한 세션은 'hermes sessions list'로 확인할 수 있어요.")
                 sys.exit(1)
         else:
             # -c with no argument — continue the most recent session
@@ -674,7 +674,7 @@ def cmd_chat(args):
             if last_id:
                 args.resume = last_id
             else:
-                print("No previous CLI session found to continue.")
+                print("이어서 열 수 있는 이전 CLI 세션이 없어요.")
                 sys.exit(1)
 
     # Resolve --resume by title if it's not a direct session ID
@@ -689,28 +689,28 @@ def cmd_chat(args):
     # First-run guard: check if any provider is configured before launching
     if not _has_any_provider_configured():
         print()
-        print("It looks like Hermes isn't configured yet -- no API keys or providers found.")
+        print("Hermes가 아직 설정되지 않은 것 같아요. API 키나 provider 설정을 찾지 못했어요.")
         print()
-        print("  Run:  hermes setup")
+        print("  실행: hermes setup")
         print()
 
         from hermes_cli.setup import is_interactive_stdin, print_noninteractive_setup_guidance
 
         if not is_interactive_stdin():
             print_noninteractive_setup_guidance(
-                "No interactive TTY detected for the first-run setup prompt."
+                "첫 실행 설정 프롬프트에 필요한 대화형 TTY를 찾지 못했어요."
             )
             sys.exit(1)
 
         try:
-            reply = input("Run setup now? [Y/n] ").strip().lower()
+            reply = input("지금 setup을 실행할까요? [Y/n] ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             reply = "n"
         if reply in ("", "y", "yes"):
             cmd_setup(args)
             return
         print()
-        print("You can run 'hermes setup' at any time to configure.")
+        print("설정이 필요하면 언제든 'hermes setup'을 실행하면 돼요.")
         sys.exit(1)
 
     # Start update check in background (runs while other init happens)
@@ -1169,7 +1169,7 @@ def _prompt_provider_choice(choices, *, default=0):
     """
     try:
         from hermes_cli.setup import _curses_prompt_choice
-        idx = _curses_prompt_choice("Select provider:", choices, default)
+        idx = _curses_prompt_choice("provider 선택:", choices, default)
         if idx >= 0:
             print()
             return idx
@@ -1177,22 +1177,22 @@ def _prompt_provider_choice(choices, *, default=0):
         pass
 
     # Fallback: numbered list
-    print("Select provider:")
+    print("provider 선택:")
     for i, c in enumerate(choices, 1):
         marker = "→" if i - 1 == default else " "
         print(f"  {marker} {i}. {c}")
     print()
     while True:
         try:
-            val = input(f"Choice [1-{len(choices)}] ({default + 1}): ").strip()
+            val = input(f"선택 [1-{len(choices)}] ({default + 1}): ").strip()
             if not val:
                 return default
             idx = int(val) - 1
             if 0 <= idx < len(choices):
                 return idx
-            print(f"Please enter 1-{len(choices)}")
+            print(f"1-{len(choices)} 사이의 번호를 입력해 주세요")
         except ValueError:
-            print("Please enter a number")
+            print("숫자를 입력해 주세요")
         except (KeyboardInterrupt, EOFError):
             print()
             return None
@@ -1205,20 +1205,20 @@ def _model_flow_openrouter(config, current_model=""):
 
     api_key = get_env_value("OPENROUTER_API_KEY")
     if not api_key:
-        print("No OpenRouter API key configured.")
-        print("Get one at: https://openrouter.ai/keys")
+        print("OpenRouter API key가 설정되어 있지 않아요.")
+        print("발급 링크: https://openrouter.ai/keys")
         print()
         try:
             import getpass
-            key = getpass.getpass("OpenRouter API key (or Enter to cancel): ").strip()
+            key = getpass.getpass("OpenRouter API key 입력(취소하려면 Enter): ").strip()
         except (KeyboardInterrupt, EOFError):
             print()
             return
         if not key:
-            print("Cancelled.")
+            print("취소했어요.")
             return
         save_env_value("OPENROUTER_API_KEY", key)
-        print("API key saved.")
+        print("API key를 저장했어요.")
         print()
 
     from hermes_cli.models import model_ids, get_pricing_for_provider
@@ -1243,9 +1243,9 @@ def _model_flow_openrouter(config, current_model=""):
         model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
-        print(f"Default model set to: {selected} (via OpenRouter)")
+        print(f"기본 모델을 설정했어요: {selected} (OpenRouter 사용)")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 def _model_flow_nous(config, current_model="", args=None):
@@ -1265,7 +1265,7 @@ def _model_flow_nous(config, current_model="", args=None):
 
     state = get_provider_auth_state("nous")
     if not state or not state.get("access_token"):
-        print("Not logged into Nous Portal. Starting login...")
+        print("Nous Portal에 로그인되어 있지 않아요. 로그인을 시작할게요...")
         print()
         try:
             mock_args = argparse.Namespace(
@@ -1283,10 +1283,10 @@ def _model_flow_nous(config, current_model="", args=None):
             for line in get_nous_subscription_explainer_lines():
                 print(line)
         except SystemExit:
-            print("Login cancelled or failed.")
+            print("로그인을 취소했거나 로그인에 실패했어요.")
             return
         except Exception as exc:
-            print(f"Login failed: {exc}")
+            print(f"로그인에 실패했어요: {exc}")
             return
         # login_nous already handles model selection + config update
         return
@@ -1300,7 +1300,7 @@ def _model_flow_nous(config, current_model="", args=None):
     )
     model_ids = _PROVIDER_MODELS.get("nous", [])
     if not model_ids:
-        print("No curated models available for Nous Portal.")
+        print("Nous Portal에서 사용할 큐레이션 모델이 없어요.")
         return
 
     # Verify credentials are still valid (catches expired sessions early)
@@ -1310,8 +1310,8 @@ def _model_flow_nous(config, current_model="", args=None):
         relogin = isinstance(exc, AuthError) and exc.relogin_required
         msg = format_auth_error(exc) if isinstance(exc, AuthError) else str(exc)
         if relogin:
-            print(f"Session expired: {msg}")
-            print("Re-authenticating with Nous Portal...\n")
+            print(f"세션이 만료되었어요: {msg}")
+            print("Nous Portal에 다시 로그인하는 중...\n")
             try:
                 mock_args = argparse.Namespace(
                     portal_url=None, inference_url=None, client_id=None,
@@ -1320,9 +1320,9 @@ def _model_flow_nous(config, current_model="", args=None):
                 )
                 _login_nous(mock_args, PROVIDER_REGISTRY["nous"])
             except Exception as login_exc:
-                print(f"Re-login failed: {login_exc}")
+                print(f"재로그인에 실패했어요: {login_exc}")
             return
-        print(f"Could not verify credentials: {msg}")
+        print(f"자격 증명을 확인하지 못했어요: {msg}")
         return
 
     # Fetch live pricing (non-blocking — returns empty dict on failure)
@@ -1340,7 +1340,7 @@ def _model_flow_nous(config, current_model="", args=None):
         model_ids, unavailable_models = partition_nous_models_by_tier(model_ids, pricing, free_tier=True)
 
     if not model_ids and not unavailable_models:
-        print("No models available for Nous Portal after filtering.")
+        print("필터링 후 Nous Portal에서 사용할 수 있는 모델이 없어요.")
         return
 
     # Resolve portal URL for upgrade links (may differ on staging)
@@ -1353,14 +1353,14 @@ def _model_flow_nous(config, current_model="", args=None):
         pass
 
     if free_tier and not model_ids:
-        print("No free models currently available.")
+        print("현재 사용할 수 있는 무료 모델이 없어요.")
         if unavailable_models:
             from hermes_cli.auth import DEFAULT_NOUS_PORTAL_URL
             _url = (_nous_portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
-            print(f"Upgrade at {_url} to access paid models.")
+            print(f"유료 모델을 사용하려면 {_url} 에서 업그레이드해 주세요.")
         return
 
-    print(f"Showing {len(model_ids)} curated models — use \"Enter custom model name\" for others.")
+    print(f"큐레이션 모델 {len(model_ids)}개를 표시합니다. 다른 모델은 \"사용자 지정 모델 이름 입력\"을 이용하세요.")
 
     selected = _prompt_model_selection(
         model_ids, current_model=current_model, pricing=pricing,
@@ -1391,18 +1391,18 @@ def _model_flow_nous(config, current_model="", args=None):
             save_env_value("OPENAI_API_KEY", "")
         changed_defaults = apply_nous_provider_defaults(config)
         save_config(config)
-        print(f"Default model set to: {selected} (via Nous Portal)")
+        print(f"기본 모델을 설정했어요: {selected} (Nous Portal 사용)")
         if "tts" in changed_defaults:
-            print("TTS provider set to: OpenAI TTS via your Nous subscription")
+            print("TTS provider를 설정했어요: Nous 구독의 OpenAI TTS 사용")
         else:
             current_tts = str(config.get("tts", {}).get("provider") or "edge")
             if current_tts.lower() not in {"", "edge"}:
-                print(f"Keeping your existing TTS provider: {current_tts}")
+                print(f"기존 TTS provider 설정을 유지할게요: {current_tts}")
         print()
         for line in get_nous_subscription_explainer_lines():
             print(line)
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 def _model_flow_openai_codex(config, current_model=""):
@@ -1417,16 +1417,16 @@ def _model_flow_openai_codex(config, current_model=""):
 
     status = get_codex_auth_status()
     if not status.get("logged_in"):
-        print("Not logged into OpenAI Codex. Starting login...")
+        print("OpenAI Codex에 로그인되어 있지 않아요. 로그인을 시작할게요...")
         print()
         try:
             mock_args = argparse.Namespace()
             _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
         except SystemExit:
-            print("Login cancelled or failed.")
+            print("로그인을 취소했거나 로그인에 실패했어요.")
             return
         except Exception as exc:
-            print(f"Login failed: {exc}")
+            print(f"로그인에 실패했어요: {exc}")
             return
 
     _codex_token = None
@@ -1452,9 +1452,9 @@ def _model_flow_openai_codex(config, current_model=""):
     if selected:
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
-        print(f"Default model set to: {selected} (via OpenAI Codex)")
+        print(f"기본 모델을 설정했어요: {selected} (OpenAI Codex 사용)")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 
@@ -1478,13 +1478,13 @@ def _model_flow_qwen_oauth(_config, current_model=""):
 
     status = get_qwen_auth_status()
     if not status.get("logged_in"):
-        print("Not logged into Qwen CLI OAuth.")
-        print("Run: qwen auth qwen-oauth")
+        print("Qwen CLI OAuth에 로그인되어 있지 않아요.")
+        print("실행: qwen auth qwen-oauth")
         auth_file = status.get("auth_file")
         if auth_file:
-            print(f"Expected credentials file: {auth_file}")
+            print(f"예상 자격 증명 파일 위치: {auth_file}")
         if status.get("error"):
-            print(f"Error: {status.get('error')}")
+            print(f"오류: {status.get('error')}")
         return
 
     # Try live model discovery, fall back to curated list.
@@ -1502,9 +1502,9 @@ def _model_flow_qwen_oauth(_config, current_model=""):
     if selected:
         _save_model_choice(selected)
         _update_config_for_provider("qwen-oauth", DEFAULT_QWEN_BASE_URL)
-        print(f"Default model set to: {selected} (via Qwen OAuth)")
+        print(f"기본 모델을 설정했어요: {selected} (Qwen OAuth 사용)")
     else:
-        print("No change.")
+        print("변경 사항이 없어요.")
 
 
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -247,8 +247,8 @@ def cmd_mcp_add(args):
 
     # Validate transport
     if not url and not command:
-        _error("Must specify --url <endpoint>, --command <cmd>, or --preset <name>")
-        _info("Examples:")
+        _error("--url <endpoint>, --command <cmd>, 또는 --preset <name> 중 하나를 지정해야 해요")
+        _info("예시:")
         _info('  hermes mcp add ink --url "https://mcp.ml.ink/mcp"')
         _info('  hermes mcp add github --command npx --args @modelcontextprotocol/server-github')
         _info('  hermes mcp add myserver --preset mypreset')
@@ -257,8 +257,8 @@ def cmd_mcp_add(args):
     # Check if server already exists
     existing = _get_mcp_servers()
     if name in existing:
-        if not _confirm(f"Server '{name}' already exists. Overwrite?", default=False):
-            _info("Cancelled.")
+        if not _confirm(f"서버 '{name}'이(가) 이미 있어요. 덮어쓸까요?", default=False):
+            _info("취소했어요.")
             return
 
     # Build initial config
@@ -276,46 +276,46 @@ def cmd_mcp_add(args):
 
     if url and auth_type == "oauth":
         print()
-        _info(f"Starting OAuth flow for '{name}'...")
+        _info(f"'{name}'의 OAuth 흐름을 시작하는 중...")
         oauth_ok = False
         try:
             from tools.mcp_oauth import build_oauth_auth
             oauth_auth = build_oauth_auth(name, url)
             if oauth_auth:
                 server_config["auth"] = "oauth"
-                _success("OAuth configured (tokens will be acquired on first connection)")
+                _success("OAuth를 설정했어요 (토큰은 첫 연결 시 받아와요)")
                 oauth_ok=True
             else:
-                _warning("OAuth setup failed — MCP SDK auth module not available")
+                _warning("OAuth 설정에 실패했어요 — MCP SDK auth 모듈을 사용할 수 없어요")
         except Exception as exc:
-            _warning(f"OAuth error: {exc}")
+            _warning(f"OAuth 오류: {exc}")
 
         if not oauth_ok:
-            _info("This server may not support OAuth.")
-            if _confirm("Continue without authentication?", default=True):
+            _info("이 서버는 OAuth를 지원하지 않을 수도 있어요.")
+            if _confirm("인증 없이 계속할까요?", default=True):
                 # Don't store auth: oauth — server doesn't support it
                 pass
             else:
-                _info("Cancelled.")
+                _info("취소했어요.")
                 return
 
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
-        _info(f"Connecting to {url}")
-        needs_auth = _confirm("Does this server require authentication?", default=True)
+        _info(f"{url}에 연결하는 중")
+        needs_auth = _confirm("이 서버에 인증이 필요한가요?", default=True)
         if needs_auth:
             if auth_type == "header" or not auth_type:
                 env_key = _env_key_for_server(name)
                 existing_key = get_env_value(env_key)
                 if existing_key:
-                    _success(f"{env_key}: already configured")
+                    _success(f"{env_key}: 이미 설정되어 있어요")
                     api_key = existing_key
                 else:
                     api_key = _prompt("API key / Bearer token", password=True)
                     if api_key:
                         save_env_value(env_key, api_key)
-                        _success(f"Saved to {display_hermes_home()}/.env as {env_key}")
+                        _success(f"{display_hermes_home()}/.env에 {env_key}로 저장했어요")
 
                 # Set header with env var interpolation
                 if api_key or existing_key:
@@ -326,30 +326,30 @@ def cmd_mcp_add(args):
     # ── Discovery: connect and list tools ─────────────────────────────
 
     print()
-    print(color(f"  Connecting to '{name}'...", Colors.CYAN))
+    print(color(f"  '{name}'에 연결하는 중...", Colors.CYAN))
 
     try:
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
-        if _confirm("Save config anyway (you can test later)?", default=False):
+        _error(f"연결하지 못했어요: {exc}")
+        if _confirm("그래도 config에 저장할까요? (나중에 테스트할 수 있어요)", default=False):
             server_config["enabled"] = False
             _save_mcp_server(name, server_config)
-            _success(f"Saved '{name}' to config (disabled)")
-            _info("Fix the issue, then: hermes mcp test " + name)
+            _success(f"'{name}'을(를) config에 저장했어요 (비활성화됨)")
+            _info("문제를 해결한 뒤 다음을 실행하세요: hermes mcp test " + name)
         return
 
     if not tools:
-        _warning("Server connected but reported no tools.")
-        if _confirm("Save config anyway?", default=True):
+        _warning("서버에는 연결됐지만 보고된 도구가 없어요.")
+        if _confirm("그래도 config에 저장할까요?", default=True):
             _save_mcp_server(name, server_config)
-            _success(f"Saved '{name}' to config")
+            _success(f"'{name}'을(를) config에 저장했어요")
         return
 
     # ── Tool selection ────────────────────────────────────────────────
 
     print()
-    _success(f"Connected! Found {len(tools)} tool(s) from '{name}':")
+    _success(f"연결됐어요! '{name}'에서 도구 {len(tools)}개를 찾았어요:")
     print()
     for tool_name, desc in tools:
         short = desc[:60] + "..." if len(desc) > 60 else desc
@@ -359,15 +359,15 @@ def cmd_mcp_add(args):
     # Ask: enable all, select, or cancel
     try:
         choice = input(
-            color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
+            color(f"  도구 {len(tools)}개를 모두 활성화할까요? [Y/n/select]: ", Colors.YELLOW)
         ).strip().lower()
     except (KeyboardInterrupt, EOFError):
         print()
-        _info("Cancelled.")
+        _info("취소했어요.")
         return
 
     if choice in ("n", "no"):
-        _info("Cancelled — server not saved.")
+        _info("취소했어요 — 서버를 저장하지 않았어요.")
         return
 
     if choice in ("s", "select"):
@@ -378,13 +378,13 @@ def cmd_mcp_add(args):
         pre_selected = set(range(len(tools)))
 
         chosen = curses_checklist(
-            f"Select tools for '{name}'",
+            f"'{name}'에서 사용할 도구 선택",
             labels,
             pre_selected,
         )
 
         if not chosen:
-            _info("No tools selected — server not saved.")
+            _info("선택한 도구가 없어서 서버를 저장하지 않았어요.")
             return
 
         chosen_names = [tools[i][0] for i in sorted(chosen)]
@@ -403,8 +403,8 @@ def cmd_mcp_add(args):
     _save_mcp_server(name, server_config)
 
     print()
-    _success(f"Saved '{name}' to {display_hermes_home()}/config.yaml ({tool_count}/{total} tools enabled)")
-    _info("Start a new session to use these tools.")
+    _success(f"'{name}'을(를) {display_hermes_home()}/config.yaml에 저장했어요 ({tool_count}/{total}개 도구 활성화)")
+    _info("이 도구를 사용하려면 새 세션을 시작하세요.")
 
 
 # ─── hermes mcp remove ───────────────────────────────────────────────────────
@@ -415,24 +415,24 @@ def cmd_mcp_remove(args):
     existing = _get_mcp_servers()
 
     if name not in existing:
-        _error(f"Server '{name}' not found in config.")
+        _error(f"config에서 서버 '{name}'을(를) 찾지 못했어요.")
         servers = list(existing.keys())
         if servers:
-            _info(f"Available servers: {', '.join(servers)}")
+            _info(f"사용 가능한 서버: {', '.join(servers)}")
         return
 
-    if not _confirm(f"Remove server '{name}'?", default=True):
-        _info("Cancelled.")
+    if not _confirm(f"서버 '{name}'을(를) 제거할까요?", default=True):
+        _info("취소했어요.")
         return
 
     _remove_mcp_server(name)
-    _success(f"Removed '{name}' from config")
+    _success(f"config에서 '{name}'을(를) 제거했어요")
 
     # Clean up OAuth tokens if they exist
     try:
         from tools.mcp_oauth import remove_oauth_tokens
         remove_oauth_tokens(name)
-        _success("Cleaned up OAuth tokens")
+        _success("OAuth 토큰도 정리했어요")
     except Exception:
         pass
 
@@ -445,20 +445,20 @@ def cmd_mcp_list(args=None):
 
     if not servers:
         print()
-        _info("No MCP servers configured.")
+        _info("설정된 MCP 서버가 없어요.")
         print()
-        _info("Add one with:")
+        _info("추가하려면:")
         _info('  hermes mcp add <name> --url <endpoint>')
         _info('  hermes mcp add <name> --command <cmd> --args <args...>')
         print()
         return
 
     print()
-    print(color("  MCP Servers:", Colors.CYAN + Colors.BOLD))
+    print(color("  MCP 서버:", Colors.CYAN + Colors.BOLD))
     print()
 
     # Table header
-    print(f"  {'Name':<16} {'Transport':<30} {'Tools':<12} {'Status':<10}")
+    print(f"  {'이름':<16} {'전송 방식':<30} {'도구':<12} {'상태':<10}")
     print(f"  {'─' * 16} {'─' * 30} {'─' * 12} {'─' * 10}")
 
     for name, cfg in servers.items():
@@ -487,19 +487,19 @@ def cmd_mcp_list(args=None):
             include = tools_cfg.get("include")
             exclude = tools_cfg.get("exclude")
             if include and isinstance(include, list):
-                tools_str = f"{len(include)} selected"
+                tools_str = f"{len(include)}개 선택"
             elif exclude and isinstance(exclude, list):
-                tools_str = f"-{len(exclude)} excluded"
+                tools_str = f"-{len(exclude)}개 제외"
             else:
-                tools_str = "all"
+                tools_str = "전체"
         else:
-            tools_str = "all"
+            tools_str = "전체"
 
         # Enabled status
         enabled = cfg.get("enabled", True)
         if isinstance(enabled, str):
             enabled = enabled.lower() in ("true", "1", "yes")
-        status = color("✓ enabled", Colors.GREEN) if enabled else color("✗ disabled", Colors.DIM)
+        status = color("✓ 활성화", Colors.GREEN) if enabled else color("✗ 비활성화", Colors.DIM)
 
         print(f"  {name:<16} {transport:<30} {tools_str:<12} {status}")
 
@@ -514,28 +514,28 @@ def cmd_mcp_test(args):
     servers = _get_mcp_servers()
 
     if name not in servers:
-        _error(f"Server '{name}' not found in config.")
+        _error(f"config에서 서버 '{name}'을(를) 찾지 못했어요.")
         available = list(servers.keys())
         if available:
-            _info(f"Available: {', '.join(available)}")
+            _info(f"사용 가능: {', '.join(available)}")
         return
 
     cfg = servers[name]
     print()
-    print(color(f"  Testing '{name}'...", Colors.CYAN))
+    print(color(f"  '{name}' 연결을 테스트하는 중...", Colors.CYAN))
 
     # Show transport info
     if "url" in cfg:
-        _info(f"Transport: HTTP → {cfg['url']}")
+        _info(f"전송 방식: HTTP → {cfg['url']}")
     else:
         cmd = cfg.get("command", "?")
-        _info(f"Transport: stdio → {cmd}")
+        _info(f"전송 방식: stdio → {cmd}")
 
     # Show auth info (masked)
     auth_type = cfg.get("auth", "")
     headers = cfg.get("headers", {})
     if auth_type == "oauth":
-        _info("Auth: OAuth 2.1 PKCE")
+        _info("인증: OAuth 2.1 PKCE")
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):
@@ -547,7 +547,7 @@ def cmd_mcp_test(args):
                     masked = "***"
                 print(f"    {k}: {masked}")
     else:
-        _info("Auth: none")
+        _info("인증: 없음")
 
     # Attempt connection
     start = time.monotonic()
@@ -556,11 +556,11 @@ def cmd_mcp_test(args):
         elapsed_ms = (time.monotonic() - start) * 1000
     except Exception as exc:
         elapsed_ms = (time.monotonic() - start) * 1000
-        _error(f"Connection failed ({elapsed_ms:.0f}ms): {exc}")
+        _error(f"연결 테스트 실패 ({elapsed_ms:.0f}ms): {exc}")
         return
 
-    _success(f"Connected ({elapsed_ms:.0f}ms)")
-    _success(f"Tools discovered: {len(tools)}")
+    _success(f"연결 성공 ({elapsed_ms:.0f}ms)")
+    _success(f"발견한 도구 수: {len(tools)}")
 
     if tools:
         print()
@@ -583,32 +583,32 @@ def cmd_mcp_configure(args):
     """Reconfigure which tools are enabled for an existing MCP server."""
     import sys as _sys
     if not _sys.stdin.isatty():
-        print("Error: 'hermes mcp configure' requires an interactive terminal.", file=_sys.stderr)
+        print("오류: 'hermes mcp configure'는 대화형 터미널이 필요해요.", file=_sys.stderr)
         _sys.exit(1)
     name = args.name
     servers = _get_mcp_servers()
 
     if name not in servers:
-        _error(f"Server '{name}' not found in config.")
+        _error(f"config에서 서버 '{name}'을(를) 찾지 못했어요.")
         available = list(servers.keys())
         if available:
-            _info(f"Available: {', '.join(available)}")
+            _info(f"사용 가능: {', '.join(available)}")
         return
 
     cfg = servers[name]
 
     # Discover all available tools
     print()
-    print(color(f"  Connecting to '{name}' to discover tools...", Colors.CYAN))
+    print(color(f"  도구를 찾기 위해 '{name}'에 연결하는 중...", Colors.CYAN))
 
     try:
         all_tools = _probe_single_server(name, cfg)
     except Exception as exc:
-        _error(f"Failed to connect: {exc}")
+        _error(f"연결하지 못했어요: {exc}")
         return
 
     if not all_tools:
-        _warning("Server reports no tools.")
+        _warning("서버가 보고한 도구가 없어요.")
         return
 
     # Determine which are currently enabled
@@ -637,7 +637,7 @@ def cmd_mcp_configure(args):
 
     currently = len(pre_selected)
     total = len(all_tools)
-    _info(f"Currently {currently}/{total} tools enabled for '{name}'.")
+    _info(f"현재 '{name}'에서는 도구 {currently}/{total}개가 활성화되어 있어요.")
     print()
 
     # Interactive checklist
@@ -646,13 +646,13 @@ def cmd_mcp_configure(args):
     labels = [f"{t[0]}  —  {t[1]}" for t in all_tools]
 
     chosen = curses_checklist(
-        f"Select tools for '{name}'",
+        f"'{name}'에서 사용할 도구 선택",
         labels,
         pre_selected,
     )
 
     if chosen == pre_selected:
-        _info("No changes made.")
+        _info("변경된 내용이 없어요.")
         return
 
     # Update config
@@ -672,8 +672,8 @@ def cmd_mcp_configure(args):
     save_config(config)
 
     new_count = len(chosen)
-    _success(f"Updated config: {new_count}/{total} tools enabled")
-    _info("Start a new session for changes to take effect.")
+    _success(f"config를 업데이트했어요: {new_count}/{total}개 도구 활성화")
+    _info("변경 사항을 적용하려면 새 세션을 시작하세요.")
 
 
 # ─── Dispatcher ───────────────────────────────────────────────────────────────
@@ -704,13 +704,13 @@ def mcp_command(args):
     else:
         # No subcommand — show list
         cmd_mcp_list()
-        print(color("  Commands:", Colors.CYAN))
-        _info("hermes mcp serve                              Run as MCP server")
-        _info("hermes mcp add <name> --url <endpoint>        Add an MCP server")
-        _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
-        _info("hermes mcp add <name> --preset <preset>       Add from a known preset")
-        _info("hermes mcp remove <name>                      Remove a server")
-        _info("hermes mcp list                               List servers")
-        _info("hermes mcp test <name>                        Test connection")
-        _info("hermes mcp configure <name>                   Toggle tools")
+        print(color("  명령어:", Colors.CYAN))
+        _info("hermes mcp serve                              MCP 서버로 실행")
+        _info("hermes mcp add <name> --url <endpoint>        MCP 서버 추가")
+        _info("hermes mcp add <name> --command <cmd>         stdio 서버 추가")
+        _info("hermes mcp add <name> --preset <preset>       알려진 preset으로 추가")
+        _info("hermes mcp remove <name>                      서버 제거")
+        _info("hermes mcp list                               서버 목록 표시")
+        _info("hermes mcp test <name>                        연결 테스트")
+        _info("hermes mcp configure <name>                   도구 설정 전환")
         print()

--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -1,11 +1,11 @@
 """
-CLI commands for the DM pairing system.
+DM 페어링 시스템용 CLI 명령.
 
-Usage:
-    hermes pairing list              # Show all pending + approved users
-    hermes pairing approve <platform> <code>  # Approve a pairing code
-    hermes pairing revoke <platform> <user_id> # Revoke user access
-    hermes pairing clear-pending     # Clear all expired/pending codes
+사용 예:
+    hermes pairing list                    # 대기 중 + 승인된 사용자 모두 표시
+    hermes pairing approve <platform> <code>   # 페어링 코드 승인
+    hermes pairing revoke <platform> <user_id> # 사용자 접근 권한 철회
+    hermes pairing clear-pending           # 만료/대기 코드를 모두 비우기
 """
 
 def pairing_command(args):
@@ -24,45 +24,45 @@ def pairing_command(args):
     elif action == "clear-pending":
         _cmd_clear_pending(store)
     else:
-        print("Usage: hermes pairing {list|approve|revoke|clear-pending}")
-        print("Run 'hermes pairing --help' for details.")
+        print("사용법: hermes pairing {list|approve|revoke|clear-pending}")
+        print("자세한 내용은 'hermes pairing --help'를 실행하세요.")
 
 
 def _cmd_list(store):
-    """List all pending and approved users."""
+    """대기 중인 사용자와 승인된 사용자를 모두 표시."""
     pending = store.list_pending()
     approved = store.list_approved()
 
     if not pending and not approved:
-        print("No pairing data found. No one has tried to pair yet~")
+        print("페어링 데이터가 없어요. 아직 아무도 페어링을 시도하지 않았어요~")
         return
 
     if pending:
-        print(f"\n  Pending Pairing Requests ({len(pending)}):")
-        print(f"  {'Platform':<12} {'Code':<10} {'User ID':<20} {'Name':<20} {'Age'}")
-        print(f"  {'--------':<12} {'----':<10} {'-------':<20} {'----':<20} {'---'}")
+        print(f"\n  대기 중인 페어링 요청 ({len(pending)}):")
+        print(f"  {'플랫폼':<12} {'코드':<10} {'사용자 ID':<20} {'이름':<20} {'경과 시간'}")
+        print(f"  {'------':<12} {'----':<10} {'---------':<20} {'----':<20} {'---------'}")
         for p in pending:
             print(
                 f"  {p['platform']:<12} {p['code']:<10} {p['user_id']:<20} "
-                f"{p.get('user_name', ''):<20} {p['age_minutes']}m ago"
+                f"{p.get('user_name', ''):<20} {p['age_minutes']}분 전"
             )
     else:
-        print("\n  No pending pairing requests.")
+        print("\n  대기 중인 페어링 요청이 없어요.")
 
     if approved:
-        print(f"\n  Approved Users ({len(approved)}):")
-        print(f"  {'Platform':<12} {'User ID':<20} {'Name':<20}")
-        print(f"  {'--------':<12} {'-------':<20} {'----':<20}")
+        print(f"\n  승인된 사용자 ({len(approved)}):")
+        print(f"  {'플랫폼':<12} {'사용자 ID':<20} {'이름':<20}")
+        print(f"  {'------':<12} {'---------':<20} {'----':<20}")
         for a in approved:
             print(f"  {a['platform']:<12} {a['user_id']:<20} {a.get('user_name', ''):<20}")
     else:
-        print("\n  No approved users.")
+        print("\n  승인된 사용자가 없어요.")
 
     print()
 
 
 def _cmd_approve(store, platform: str, code: str):
-    """Approve a pairing code."""
+    """페어링 코드를 승인."""
     platform = platform.lower().strip()
     code = code.upper().strip()
 
@@ -71,27 +71,27 @@ def _cmd_approve(store, platform: str, code: str):
         uid = result["user_id"]
         name = result.get("user_name", "")
         display = f"{name} ({uid})" if name else uid
-        print(f"\n  Approved! User {display} on {platform} can now use the bot~")
-        print("  They'll be recognized automatically on their next message.\n")
+        print(f"\n  승인 완료! 이제 {platform}의 사용자 {display} 가 봇을 사용할 수 있어요~")
+        print("  다음 메시지부터 자동으로 인식돼요.\n")
     else:
-        print(f"\n  Code '{code}' not found or expired for platform '{platform}'.")
-        print("  Run 'hermes pairing list' to see pending codes.\n")
+        print(f"\n  플랫폼 '{platform}'에서 코드 '{code}'를 찾지 못했거나 이미 만료되었어요.")
+        print("  대기 중인 코드를 보려면 'hermes pairing list'를 실행하세요.\n")
 
 
 def _cmd_revoke(store, platform: str, user_id: str):
-    """Revoke a user's access."""
+    """사용자 접근 권한을 철회."""
     platform = platform.lower().strip()
 
     if store.revoke(platform, user_id):
-        print(f"\n  Revoked access for user {user_id} on {platform}.\n")
+        print(f"\n  {platform}의 사용자 {user_id} 접근 권한을 철회했어요.\n")
     else:
-        print(f"\n  User {user_id} not found in approved list for {platform}.\n")
+        print(f"\n  {platform}의 승인 목록에서 사용자 {user_id}를 찾지 못했어요.\n")
 
 
 def _cmd_clear_pending(store):
-    """Clear all pending pairing codes."""
+    """대기 중인 페어링 코드를 모두 비움."""
     count = store.clear_pending()
     if count:
-        print(f"\n  Cleared {count} pending pairing request(s).\n")
+        print(f"\n  대기 중인 페어링 요청 {count}개를 비웠어요.\n")
     else:
-        print("\n  No pending requests to clear.\n")
+        print("\n  비울 대기 요청이 없어요.\n")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1781,9 +1781,9 @@ def _setup_matrix():
         if not prompt_yes_no("Matrix를 다시 설정할까요?", False):
             return
 
-    print_info("Works with any Matrix homeserver (Synapse, Conduit, Dendrite, or matrix.org).")
-    print_info("   1. Create a bot user on your homeserver, or use your own account")
-    print_info("   2. Get an access token from Element, or provide user ID + password")
+    print_info("어떤 Matrix homeserver와도 사용할 수 있습니다. (Synapse, Conduit, Dendrite, matrix.org)")
+    print_info("   1. homeserver에 봇 사용자를 만들거나 본인 계정을 사용하세요")
+    print_info("   2. Element에서 access token을 얻거나 사용자 ID + 비밀번호를 입력하세요")
     print()
     homeserver = prompt("Homeserver URL (e.g. https://matrix.example.org)")
     if homeserver:
@@ -1839,10 +1839,10 @@ def _setup_matrix():
                     print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
 
         print()
-        print_info("🔒 Security: Restrict who can use your bot")
-        print_info("   Matrix user IDs look like @username:server")
+        print_info("🔒 보안: 누가 봇을 사용할 수 있는지 제한하세요")
+        print_info("   Matrix 사용자 ID 형식: @username:server")
         print()
-        allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
+        allowed_users = prompt("허용할 사용자 ID (쉼표로 구분, 비워두면 누구나 접근 가능)")
         if allowed_users:
             save_env_value("MATRIX_ALLOWED_USERS", allowed_users.replace(" ", ""))
             print_success("Matrix allowlist configured")
@@ -1867,11 +1867,11 @@ def _setup_mattermost():
         if not prompt_yes_no("Mattermost를 다시 설정할까요?", False):
             return
 
-    print_info("Works with any self-hosted Mattermost instance.")
-    print_info("   1. In Mattermost: Integrations → Bot Accounts → Add Bot Account")
-    print_info("   2. Copy the bot token")
+    print_info("어떤 self-hosted Mattermost 인스턴스와도 사용할 수 있습니다.")
+    print_info("   1. Mattermost에서: Integrations → Bot Accounts → Add Bot Account")
+    print_info("   2. 봇 토큰을 복사하세요")
     print()
-    mm_url = prompt("Mattermost server URL (e.g. https://mm.example.com)")
+    mm_url = prompt("Mattermost 서버 URL (예: https://mm.example.com)")
     if mm_url:
         save_env_value("MATTERMOST_URL", mm_url.rstrip("/"))
     token = prompt("Bot token", password=True)
@@ -1885,7 +1885,7 @@ def _setup_mattermost():
     print_info("   To find your user ID: click your avatar → Profile")
     print_info("   or use the API: GET /api/v4/users/me")
     print()
-    allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
+    allowed_users = prompt("허용할 사용자 ID (쉼표로 구분, 비워두면 누구나 접근 가능)")
     if allowed_users:
         save_env_value("MATTERMOST_ALLOWED_USERS", allowed_users.replace(" ", ""))
         print_success("Mattermost allowlist configured")
@@ -1893,10 +1893,10 @@ def _setup_mattermost():
         print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
 
     print()
-    print_info("📬 Home Channel: where Hermes delivers cron job results and notifications.")
-    print_info("   To get a channel ID: click channel name → View Info → copy the ID")
-    print_info("   You can also set this later by typing /set-home in a Mattermost channel.")
-    home_channel = prompt("Home channel ID (leave empty to set later with /set-home)")
+    print_info("📬 홈 채널: Hermes가 cron 결과와 알림을 전달하는 곳입니다.")
+    print_info("   채널 ID 확인: 채널 이름 클릭 → 정보 보기 → ID 복사")
+    print_info("   나중에 Mattermost 채널에서 /set-home을 입력해 설정할 수도 있습니다.")
+    home_channel = prompt("홈 채널 ID (비워두면 나중에 /set-home으로 설정)")
     if home_channel:
         save_env_value("MATTERMOST_HOME_CHANNEL", home_channel)
 
@@ -2064,15 +2064,15 @@ def _setup_bluebubbles():
         save_env_value("BLUEBUBBLES_HOME_CHANNEL", home_channel)
 
     print()
-    print_info("Advanced settings (defaults are fine for most setups):")
-    if prompt_yes_no("Configure webhook listener settings?", False):
-        webhook_port = prompt("Webhook listener port (default: 8645)")
+    print_info("고급 설정 (대부분 기본값이면 충분합니다):")
+    if prompt_yes_no("Webhook listener settings를 설정할까요?", False):
+        webhook_port = prompt("Webhook listener 포트 (기본값: 8645)")
         if webhook_port:
             try:
                 save_env_value("BLUEBUBBLES_WEBHOOK_PORT", str(int(webhook_port)))
-                print_success(f"Webhook port set to {webhook_port}")
+                print_success(f"Webhook 포트를 {webhook_port}로 설정했습니다")
             except ValueError:
-                print_warning("Invalid port number, using default 8645")
+                print_warning("잘못된 포트 번호입니다. 기본값 8645를 사용합니다")
 
     print()
     print_info("Requires the BlueBubbles Private API helper for typing indicators,")
@@ -2110,11 +2110,11 @@ def _setup_webhooks():
     if port:
         try:
             save_env_value("WEBHOOK_PORT", str(int(port)))
-            print_success(f"Webhook port set to {port}")
+            print_success(f"Webhook 포트를 {port}로 설정했습니다")
         except ValueError:
-            print_warning("Invalid port number, using default 8644")
+            print_warning("잘못된 포트 번호입니다. 기본값 8644를 사용합니다")
 
-    secret = prompt("Global HMAC secret (shared across all routes)", password=True)
+    secret = prompt("전역 HMAC 시크릿 (모든 라우트에서 공유)", password=True)
     if secret:
         save_env_value("WEBHOOK_SECRET", secret)
         print_success("Webhook secret saved")
@@ -2123,16 +2123,16 @@ def _setup_webhooks():
 
     save_env_value("WEBHOOK_ENABLED", "true")
     print()
-    print_success("Webhooks enabled! Next steps:")
+    print_success("Webhooks 활성화 완료! 다음 단계:")
     from hermes_constants import display_hermes_home as _dhh
-    print_info(f"   1. Define webhook routes in {_dhh()}/config.yaml")
-    print_info("   2. Point your service (GitHub, GitLab, etc.) at:")
+    print_info(f"   1. {_dhh()}/config.yaml에서 webhook 라우트를 정의하세요")
+    print_info("   2. 서비스(GitHub, GitLab 등)의 대상 주소를 다음으로 설정하세요:")
     print_info("      http://your-server:8644/webhooks/<route-name>")
     print()
-    print_info("   Route configuration guide:")
+    print_info("   라우트 설정 가이드:")
     print_info("   https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/#configuring-routes")
     print()
-    print_info("   Open config in your editor:  hermes config edit")
+    print_info("   편집기에서 config 열기:  hermes config edit")
 
 
 # Platform registry for the gateway checklist

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -868,15 +868,15 @@ def _install_neutts_deps() -> bool:
     # Check espeak-ng
     if not _check_espeak_ng():
         print()
-        print_warning("NeuTTS requires espeak-ng for phonemization.")
+        print_warning("NeuTTS는 음소 변환을 위해 espeak-ng가 필요합니다.")
         if sys.platform == "darwin":
-            print_info("Install with: brew install espeak-ng")
+            print_info("설치: brew install espeak-ng")
         elif sys.platform == "win32":
-            print_info("Install with: choco install espeak-ng")
+            print_info("설치: choco install espeak-ng")
         else:
-            print_info("Install with: sudo apt install espeak-ng")
+            print_info("설치: sudo apt install espeak-ng")
         print()
-        if prompt_yes_no("Install espeak-ng now?", True):
+        if prompt_yes_no("지금 espeak-ng를 설치할까요?", True):
             try:
                 if sys.platform == "darwin":
                     subprocess.run(["brew", "install", "espeak-ng"], check=True)
@@ -884,13 +884,13 @@ def _install_neutts_deps() -> bool:
                     subprocess.run(["choco", "install", "espeak-ng", "-y"], check=True)
                 else:
                     subprocess.run(["sudo", "apt", "install", "-y", "espeak-ng"], check=True)
-                print_success("espeak-ng installed")
+                print_success("espeak-ng 설치 완료")
             except (subprocess.CalledProcessError, FileNotFoundError) as e:
-                print_warning(f"Could not install espeak-ng automatically: {e}")
-                print_info("Please install it manually and re-run setup.")
+                print_warning(f"espeak-ng를 자동으로 설치하지 못했습니다: {e}")
+                print_info("직접 설치한 뒤 setup을 다시 실행하세요.")
                 return False
         else:
-            print_warning("espeak-ng is required for NeuTTS. Install it manually before using NeuTTS.")
+            print_warning("NeuTTS에는 espeak-ng가 필요합니다. 사용 전에 수동으로 설치하세요.")
 
     # Install neutts Python package
     print()
@@ -980,7 +980,7 @@ def _setup_tts_provider(config: dict):
             print_info("  • Python package: neutts (~50MB install + ~300MB model on first use)")
             print_info("  • System package: espeak-ng (phonemizer)")
             print()
-            if prompt_yes_no("Install NeuTTS dependencies now?", True):
+            if prompt_yes_no("지금 NeuTTS 의존성을 설치할까요?", True):
                 if not _install_neutts_deps():
                     print_warning("NeuTTS installation incomplete. Falling back to Edge TTS.")
                     selected = "edge"
@@ -1758,8 +1758,8 @@ def _setup_slack():
     print_success("Slack tokens saved")
 
     print()
-    print_info("🔒 Security: Restrict who can use your bot")
-    print_info("   To find a Member ID: click a user's name → View full profile → ⋮ → Copy member ID")
+    print_info("🔒 보안: 누가 봇을 사용할 수 있는지 제한하세요")
+    print_info("   Member ID 확인: 사용자 이름 클릭 → View full profile → ⋮ → Copy member ID")
     print()
     allowed_users = prompt(
         "허용할 사용자 ID (쉼표로 구분, 비워두면 페어링된 사용자 외에는 모두 거부)"
@@ -1791,35 +1791,36 @@ def _setup_matrix():
         save_env_value("MATRIX_HOMESERVER", homeserver.rstrip("/"))
 
     print()
-    print_info("Auth: provide an access token (recommended), or user ID + password.")
-    token = prompt("Access token (leave empty for password login)", password=True)
+    print_info("인증: access token(권장) 또는 user ID + 비밀번호를 입력하세요.")
+    token = prompt("Access token (비워두면 비밀번호 로그인)", password=True)
     if token:
         save_env_value("MATRIX_ACCESS_TOKEN", token)
-        user_id = prompt("User ID (@bot:server — optional, will be auto-detected)")
+        user_id = prompt("User ID (@bot:server — 선택 사항, 자동 감지 가능)")
         if user_id:
             save_env_value("MATRIX_USER_ID", user_id)
-        print_success("Matrix access token saved")
+        print_success("Matrix access token 저장 완료")
     else:
-        user_id = prompt("User ID (@bot:server)")
+        # Username/password flow
+        user_id = prompt("Matrix user ID (예: @bot:example.org)")
         if user_id:
             save_env_value("MATRIX_USER_ID", user_id)
-        password = prompt("Password", password=True)
+        password = prompt("비밀번호", password=True)
         if password:
             save_env_value("MATRIX_PASSWORD", password)
-            print_success("Matrix credentials saved")
+            print_success("Matrix 자격 증명 저장 완료")
 
     if token or get_env_value("MATRIX_PASSWORD"):
         print()
         want_e2ee = prompt_yes_no("종단간 암호화(E2EE)를 활성화할까요?", False)
         if want_e2ee:
             save_env_value("MATRIX_ENCRYPTION", "true")
-            print_success("E2EE enabled")
+            print_success("E2EE 활성화 완료")
 
         matrix_pkg = "mautrix[encryption]" if want_e2ee else "mautrix"
         try:
             __import__("mautrix")
         except ImportError:
-            print_info(f"Installing {matrix_pkg}...")
+            print_info(f"{matrix_pkg} 설치 중...")
             import subprocess
             uv_bin = shutil.which("uv")
             if uv_bin:
@@ -1907,7 +1908,7 @@ def _setup_whatsapp():
     print_header("WhatsApp")
     existing = get_env_value("WHATSAPP_ENABLED")
     if existing:
-        print_info("WhatsApp: already enabled")
+        print_info("WhatsApp: 이미 활성화되어 있음")
         return
 
     print_info("WhatsApp은 내장 브리지(Baileys)로 연결됩니다.")
@@ -2013,7 +2014,7 @@ def _setup_qqbot():
         save_env_value("QQ_HOME_CHANNEL", home_channel)
 
     print()
-    print_success("QQ Bot configured!")
+    print_success("QQ Bot 설정 완료!")
 
 
 def _setup_bluebubbles():
@@ -2053,9 +2054,9 @@ def _setup_bluebubbles():
     allowed_users = prompt("허용할 iMessage 주소 (쉼표로 구분, 비워두면 누구나 접근 가능)")
     if allowed_users:
         save_env_value("BLUEBUBBLES_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("BlueBubbles allowlist configured")
+        print_success("BlueBubbles allowlist 설정 완료")
     else:
-        print_info("⚠️  No allowlist set — anyone who can iMessage you can use the bot!")
+        print_info("⚠️  allowlist가 없습니다 — iMessage를 보낼 수 있는 누구나 봇을 사용할 수 있습니다!")
 
     print()
     print_info("📬 홈 채널: cron 전달과 알림에 사용할 전화번호 또는 이메일입니다.")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -576,15 +576,15 @@ def _prompt_container_resources(config: dict):
     terminal = config.setdefault("terminal", {})
 
     print()
-    print_info("Container Resource Settings:")
+    print_info("컨테이너 리소스 설정:")
 
     # Persistence
     current_persist = terminal.get("container_persistent", True)
     persist_label = "yes" if current_persist else "no"
-    print_info("  Persistent filesystem keeps files between sessions.")
-    print_info("  Set to 'no' for ephemeral sandboxes that reset each time.")
+    print_info("  영구 파일시스템을 켜면 세션 사이에도 파일이 유지됩니다.")
+    print_info("  매번 초기화되는 임시 샌드박스를 원하면 'no'로 설정하세요.")
     persist_str = prompt(
-        "  Persist filesystem across sessions? (yes/no)", persist_label
+        "  세션 간 파일시스템을 유지할까요? (yes/no)", persist_label
     )
     terminal["container_persistent"] = persist_str.lower() in ("yes", "true", "y", "1")
 
@@ -927,8 +927,8 @@ def _setup_tts_provider(config: dict):
     current_label = provider_labels.get(current_provider, current_provider)
 
     print()
-    print_header("Text-to-Speech Provider (optional)")
-    print_info(f"Current: {current_label}")
+    print_header("텍스트 음성 변환 provider (선택 사항)")
+    print_info(f"현재 설정: {current_label}")
     print()
 
     choices = []
@@ -947,9 +947,9 @@ def _setup_tts_provider(config: dict):
         ]
     )
     providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts"])
-    choices.append(f"Keep current ({current_label})")
+    choices.append(f"현재 설정 유지 ({current_label})")
     keep_current_idx = len(choices) - 1
-    idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
+    idx = prompt_choice("TTS provider를 선택하세요:", choices, keep_current_idx)
 
     if idx == keep_current_idx:
         return
@@ -1088,11 +1088,11 @@ def setup_terminal_backend(config: dict):
 
     # Add keep current option
     keep_current_idx = next_idx
-    terminal_choices.append(f"Keep current ({current_backend})")
+    terminal_choices.append(f"현재 설정 유지 ({current_backend})")
     idx_to_backend[keep_current_idx] = current_backend
 
     terminal_idx = prompt_choice(
-        "Select terminal backend:", terminal_choices, keep_current_idx
+        "터미널 백엔드를 선택하세요:", terminal_choices, keep_current_idx
     )
 
     selected_backend = idx_to_backend.get(terminal_idx)
@@ -1202,7 +1202,7 @@ def setup_terminal_backend(config: dict):
             else:
                 default_modal_idx = 1 if get_env_value("MODAL_TOKEN_ID") else 0
             modal_mode_idx = prompt_choice(
-                "Select how Modal execution should be billed:",
+                "Modal 실행 과금 방식을 선택하세요:",
                 modal_choices,
                 default_modal_idx,
             )

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1909,14 +1909,14 @@ def _setup_whatsapp():
         print_info("WhatsApp: already enabled")
         return
 
-    print_info("WhatsApp connects via a built-in bridge (Baileys).")
-    print_info("Requires Node.js. Run 'hermes whatsapp' for guided setup.")
+    print_info("WhatsApp은 내장 브리지(Baileys)로 연결됩니다.")
+    print_info("Node.js가 필요합니다. 안내형 설정은 'hermes whatsapp'을 실행하세요.")
     print()
-    if prompt_yes_no("Enable WhatsApp now?", True):
+    if prompt_yes_no("지금 WhatsApp을 활성화할까요?", True):
         save_env_value("WHATSAPP_ENABLED", "true")
-        print_success("WhatsApp enabled")
-        print_info("Run 'hermes whatsapp' to choose your mode (separate bot number")
-        print_info("or personal self-chat) and pair via QR code.")
+        print_success("WhatsApp 활성화 완료")
+        print_info("'hermes whatsapp'을 실행해 모드(별도 봇 번호 또는")
+        print_info("개인 셀프 채팅)를 선택하고 QR 코드로 페어링하세요.")
 
 
 def _setup_weixin():
@@ -1972,42 +1972,42 @@ def _setup_qqbot():
     print_header("QQ Bot")
     existing = get_env_value("QQ_APP_ID")
     if existing:
-        print_info("QQ Bot: already configured")
-        if not prompt_yes_no("Reconfigure QQ Bot?", False):
+        print_info("QQ Bot: 이미 설정되어 있음")
+        if not prompt_yes_no("QQ Bot을 다시 설정할까요?", False):
             return
 
-    print_info("Connects Hermes to QQ via the Official QQ Bot API (v2).")
-    print_info("   Requires a QQ Bot application at q.qq.com")
-    print_info("   Reference: https://bot.q.qq.com/wiki/develop/api-v2/")
+    print_info("공식 QQ Bot API (v2)를 통해 Hermes를 QQ에 연결합니다.")
+    print_info("   q.qq.com 에서 QQ Bot 애플리케이션이 필요합니다")
+    print_info("   참고: https://bot.q.qq.com/wiki/develop/api-v2/")
     print()
 
     app_id = prompt("QQ Bot App ID")
     if not app_id:
-        print_warning("App ID is required — skipping QQ Bot setup")
+        print_warning("App ID가 필요합니다 — QQ Bot 설정을 건너뜁니다")
         return
     save_env_value("QQ_APP_ID", app_id.strip())
 
     client_secret = prompt("QQ Bot App Secret", password=True)
     if not client_secret:
-        print_warning("App Secret is required — skipping QQ Bot setup")
+        print_warning("App Secret이 필요합니다 — QQ Bot 설정을 건너뜁니다")
         return
     save_env_value("QQ_CLIENT_SECRET", client_secret)
-    print_success("QQ Bot credentials saved")
+    print_success("QQ Bot 자격 증명 저장 완료")
 
     print()
-    print_info("🔒 Security: Restrict who can DM your bot")
-    print_info("   Use QQ user OpenIDs (found in event payloads)")
+    print_info("🔒 보안: 누가 봇에 DM을 보낼 수 있는지 제한하세요")
+    print_info("   QQ 사용자 OpenID를 사용하세요 (이벤트 payload에서 확인 가능)")
     print()
-    allowed_users = prompt("Allowed user OpenIDs (comma-separated, leave empty for open access)")
+    allowed_users = prompt("허용할 사용자 OpenID (쉼표로 구분, 비워두면 누구나 접근 가능)")
     if allowed_users:
         save_env_value("QQ_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("QQ Bot allowlist configured")
+        print_success("QQ Bot allowlist 설정 완료")
     else:
-        print_info("⚠️  No allowlist set — anyone can DM the bot!")
+        print_info("⚠️  allowlist가 없습니다 — 누구나 봇에 DM을 보낼 수 있습니다!")
 
     print()
-    print_info("📬 Home Channel: OpenID for cron job delivery and notifications.")
-    home_channel = prompt("Home channel OpenID (leave empty to set later)")
+    print_info("📬 홈 채널: cron 전달과 알림에 사용할 OpenID입니다.")
+    home_channel = prompt("홈 채널 OpenID (비워두면 나중에 설정)")
     if home_channel:
         save_env_value("QQ_HOME_CHANNEL", home_channel)
 
@@ -2020,36 +2020,36 @@ def _setup_bluebubbles():
     print_header("BlueBubbles (iMessage)")
     existing = get_env_value("BLUEBUBBLES_SERVER_URL")
     if existing:
-        print_info("BlueBubbles: already configured")
-        if not prompt_yes_no("Reconfigure BlueBubbles?", False):
+        print_info("BlueBubbles: 이미 설정되어 있음")
+        if not prompt_yes_no("BlueBubbles를 다시 설정할까요?", False):
             return
 
-    print_info("Connects Hermes to iMessage via BlueBubbles — a free, open-source")
-    print_info("macOS server that bridges iMessage to any device.")
-    print_info("   Requires a Mac running BlueBubbles Server v1.0.0+")
-    print_info("   Download: https://bluebubbles.app/")
+    print_info("BlueBubbles를 통해 Hermes를 iMessage에 연결합니다 — 무료 오픈소스")
+    print_info("macOS 서버가 iMessage를 다른 기기에 브리지합니다.")
+    print_info("   BlueBubbles Server v1.0.0+가 실행 중인 Mac이 필요합니다")
+    print_info("   다운로드: https://bluebubbles.app/")
     print()
-    print_info("In BlueBubbles Server → Settings → API, note your Server URL and Password.")
+    print_info("BlueBubbles Server → Settings → API 에서 Server URL과 Password를 확인하세요.")
     print()
 
-    server_url = prompt("BlueBubbles server URL (e.g. http://192.168.1.10:1234)")
+    server_url = prompt("BlueBubbles 서버 URL (예: http://192.168.1.10:1234)")
     if not server_url:
-        print_warning("Server URL is required — skipping BlueBubbles setup")
+        print_warning("서버 URL이 필요합니다 — BlueBubbles 설정을 건너뜁니다")
         return
     save_env_value("BLUEBUBBLES_SERVER_URL", server_url.rstrip("/"))
 
-    password = prompt("BlueBubbles server password", password=True)
+    password = prompt("BlueBubbles 서버 비밀번호", password=True)
     if not password:
-        print_warning("Password is required — skipping BlueBubbles setup")
+        print_warning("비밀번호가 필요합니다 — BlueBubbles 설정을 건너뜁니다")
         return
     save_env_value("BLUEBUBBLES_PASSWORD", password)
-    print_success("BlueBubbles credentials saved")
+    print_success("BlueBubbles 자격 증명 저장 완료")
 
     print()
-    print_info("🔒 Security: Restrict who can message your bot")
-    print_info("   Use iMessage addresses: email (user@icloud.com) or phone (+15551234567)")
+    print_info("🔒 보안: 누가 봇에 메시지를 보낼 수 있는지 제한하세요")
+    print_info("   iMessage 주소를 사용하세요: 이메일(user@icloud.com) 또는 전화번호(+155****4567)")
     print()
-    allowed_users = prompt("Allowed iMessage addresses (comma-separated, leave empty for open access)")
+    allowed_users = prompt("허용할 iMessage 주소 (쉼표로 구분, 비워두면 누구나 접근 가능)")
     if allowed_users:
         save_env_value("BLUEBUBBLES_ALLOWED_USERS", allowed_users.replace(" ", ""))
         print_success("BlueBubbles allowlist configured")
@@ -2057,9 +2057,9 @@ def _setup_bluebubbles():
         print_info("⚠️  No allowlist set — anyone who can iMessage you can use the bot!")
 
     print()
-    print_info("📬 Home Channel: phone or email for cron job delivery and notifications.")
-    print_info("   You can also set this later with /set-home in your iMessage chat.")
-    home_channel = prompt("Home channel address (leave empty to set later)")
+    print_info("📬 홈 채널: cron 전달과 알림에 사용할 전화번호 또는 이메일입니다.")
+    print_info("   나중에 iMessage 채팅에서 /set-home으로도 설정할 수 있습니다.")
+    home_channel = prompt("홈 채널 주소 (비워두면 나중에 설정)")
     if home_channel:
         save_env_value("BLUEBUBBLES_HOME_CHANNEL", home_channel)
 
@@ -2075,8 +2075,8 @@ def _setup_bluebubbles():
                 print_warning("잘못된 포트 번호입니다. 기본값 8645를 사용합니다")
 
     print()
-    print_info("Requires the BlueBubbles Private API helper for typing indicators,")
-    print_info("read receipts, and tapback reactions. Basic messaging works without it.")
+    print_info("BlueBubbles Private API helper가 있으면 타이핑 표시,")
+    print_info("읽음 확인, tapback 반응을 지원합니다. 기본 메시징은 없어도 동작합니다.")
     print_info("   Install: https://docs.bluebubbles.app/helper-bundle/installation")
 
 
@@ -2177,10 +2177,10 @@ def setup_gateway(config: dict):
         if is_configured:
             pre_selected.append(i)
 
-    selected = prompt_checklist("Select platforms to configure:", items, pre_selected)
+    selected = prompt_checklist("설정할 플랫폼을 선택하세요:", items, pre_selected)
 
     if not selected:
-        print_info("No platforms selected. Run 'hermes setup gateway' later to configure.")
+        print_info("선택한 플랫폼이 없습니다. 나중에 'hermes setup gateway'로 설정하세요.")
         return
 
     for idx in selected:
@@ -2917,19 +2917,19 @@ def run_setup_wizard(args):
             return
 
     # ── Full Setup — run all sections ──
-    print_header("Configuration Location")
-    print_info(f"Config file:  {get_config_path()}")
-    print_info(f"Secrets file: {get_env_path()}")
-    print_info(f"Data folder:  {hermes_home}")
-    print_info(f"Install dir:  {PROJECT_ROOT}")
+    print_header("설정 위치")
+    print_info(f"Config 파일:   {get_config_path()}")
+    print_info(f"Secrets 파일:  {get_env_path()}")
+    print_info(f"데이터 폴더:   {hermes_home}")
+    print_info(f"설치 디렉터리: {PROJECT_ROOT}")
     print()
-    print_info("You can edit these files directly or use 'hermes config edit'")
+    print_info("이 파일들은 직접 수정하거나 'hermes config edit'를 사용할 수 있습니다")
 
     if migration_ran:
         print()
-        print_info("Settings were imported from OpenClaw.")
-        print_info("Each section below will show what was imported — press Enter to keep,")
-        print_info("or choose to reconfigure if needed.")
+        print_info("설정이 OpenClaw에서 가져와졌습니다.")
+        print_info("아래 각 섹션에는 가져온 내용이 표시되며, Enter를 누르면 유지되고")
+        print_info("필요하면 다시 설정할 수 있습니다.")
 
     # Section 1: Model & Provider
     if not (migration_ran and _skip_configured_section(config, "model", "Model & Provider")):
@@ -2976,12 +2976,12 @@ def _resolve_hermes_chat_argv() -> Optional[list[str]]:
 def _offer_launch_chat():
     """Prompt the user to jump straight into chat after setup."""
     print()
-    if not prompt_yes_no("Launch hermes chat now?", True):
+    if not prompt_yes_no("지금 대화를 시작할까요?", True):
         return
 
     chat_argv = _resolve_hermes_chat_argv()
     if not chat_argv:
-        print_info("Could not relaunch Hermes automatically. Run 'hermes chat' manually.")
+        print_info("자동으로 Hermes를 다시 실행할 수 없습니다. 'hermes chat'을 수동으로 실행하세요.")
         return
 
     os.execvp(chat_argv[0], chat_argv)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -348,7 +348,7 @@ def _print_setup_summary(config: dict, hermes_home):
     """Print the setup completion summary."""
     # Tool availability summary
     print()
-    print_header("Tool Availability Summary")
+    print_header("도구 사용 가능 요약")
 
     tool_status = []
     subscription_features = get_nous_subscription_features(config)
@@ -487,7 +487,7 @@ def _print_setup_summary(config: dict, hermes_home):
     available_count = sum(1 for _, avail, _ in tool_status if avail)
     total_count = len(tool_status)
 
-    print_info(f"{available_count}/{total_count} tool categories available:")
+    print_info(f"{available_count}/{total_count}개 도구 범주 사용 가능:")
     print()
 
     for name, available, missing_var in tool_status:
@@ -503,10 +503,10 @@ def _print_setup_summary(config: dict, hermes_home):
     disabled_tools = [(name, var) for name, avail, var in tool_status if not avail]
     if disabled_tools:
         print_warning(
-            "Some tools are disabled. Run 'hermes setup tools' to configure them,"
+            "일부 도구가 비활성화되어 있습니다. 'hermes setup tools'를 실행해 설정하거나,"
         )
         from hermes_constants import display_hermes_home as _dhh
-        print_warning(f"or edit {_dhh()}/.env directly to add the missing API keys.")
+        print_warning(f"{_dhh()}/.env를 직접 수정해 누락된 API 키를 추가하세요.")
         print()
 
     # Done banner
@@ -3062,16 +3062,16 @@ def _run_quick_setup(config: dict, hermes_home):
     )
 
     if not has_anything_missing:
-        print_success("Everything is configured! Nothing to do.")
+        print_success("모든 항목이 설정되어 있습니다! 할 일이 없습니다.")
         print()
-        print_info("Run 'hermes setup' and choose 'Full Setup' to reconfigure,")
-        print_info("or pick a specific section from the menu.")
+        print_info("다시 설정하려면 'hermes setup'을 실행하고 '전체 설정'을 선택하세요,")
+        print_info("또는 메뉴에서 특정 섹션을 선택하세요.")
         return
 
     # Handle missing required env vars
     if missing_required:
         print()
-        print_info(f"{len(missing_required)} required setting(s) missing:")
+        print_info(f"{len(missing_required)}개의 필수 설정이 누락되었습니다:")
         for var in missing_required:
             print(f"     • {var['name']}")
         print()
@@ -3081,7 +3081,7 @@ def _run_quick_setup(config: dict, hermes_home):
             print(color(f"  {var['name']}", Colors.CYAN))
             print_info(f"  {var.get('description', '')}")
             if var.get("url"):
-                print_info(f"  Get key at: {var['url']}")
+                print_info(f"  키 발급 위치: {var['url']}")
 
             if var.get("password"):
                 value = prompt(f"  {var.get('prompt', var['name'])}", password=True)
@@ -3105,7 +3105,7 @@ def _run_quick_setup(config: dict, hermes_home):
     # ── Tool API keys (checklist) ──
     if missing_tools:
         print()
-        print_header("Tool API Keys")
+        print_header("도구 API 키")
 
         checklist_labels = []
         for var in missing_tools:
@@ -3114,7 +3114,7 @@ def _run_quick_setup(config: dict, hermes_home):
             checklist_labels.append(f"{var.get('description', var['name'])}{tools_str}")
 
         selected_indices = prompt_checklist(
-            "Which tools would you like to configure?",
+            "어떤 도구를 설정하시겠어요?",
             checklist_labels,
         )
 
@@ -3125,9 +3125,9 @@ def _run_quick_setup(config: dict, hermes_home):
     # ── Messaging platforms (checklist then prompt for selected) ──
     if missing_messaging:
         print()
-        print_header("Messaging Platforms")
-        print_info("Connect Hermes to messaging apps to chat from anywhere.")
-        print_info("You can configure these later with 'hermes setup gateway'.")
+        print_header("메시징 플랫폼")
+        print_info("어디서든 Hermes와 대화할 수 있도록 메시징 앱에 연결하세요.")
+        print_info("이 설정은 나중에 'hermes setup gateway'로 다시 할 수 있습니다.")
 
         # Group by platform (preserving order)
         platform_order = []
@@ -3156,7 +3156,7 @@ def _run_quick_setup(config: dict, hermes_home):
         ]
 
         selected_indices = prompt_checklist(
-            "Which platforms would you like to set up?",
+            "어떤 플랫폼을 설정하시겠어요?",
             platform_labels,
         )
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -229,7 +229,7 @@ def prompt_choice(question: str, choices: list, default: int = 0) -> int:
     idx = _curses_prompt_choice(question, choices, default)
     if idx >= 0:
         if idx == default:
-            print_info("  Skipped (keeping current)")
+            print_info("  건너뜀 (현재 설정 유지)")
             print()
             return default
         print()
@@ -327,9 +327,9 @@ def _prompt_api_key(var: dict):
     print(color(f"  ─── {var.get('description', var['name'])} ───", Colors.CYAN))
     print()
     if tools_str:
-        print_info(f"  Enables: {tools_str}")
+        print_info(f"  활성화 기능: {tools_str}")
     if var.get("url"):
-        print_info(f"  Get your key at: {var['url']}")
+        print_info(f"  키 발급 위치: {var['url']}")
     print()
 
     if var.get("password"):
@@ -339,9 +339,9 @@ def _prompt_api_key(var: dict):
 
     if value:
         save_env_value(var["name"], value)
-        print_success("  ✓ Saved")
+        print_success("  ✓ 저장 완료")
     else:
-        print_warning("  Skipped (configure later with 'hermes setup')")
+        print_warning("  건너뜀 (나중에 'hermes setup'으로 설정 가능)")
 
 
 def _print_setup_summary(config: dict, hermes_home):
@@ -1601,13 +1601,13 @@ def _setup_telegram():
         if not prompt_yes_no("Telegram을 다시 설정할까요?", False):
             # Check missing allowlist on existing config
             if not get_env_value("TELEGRAM_ALLOWED_USERS"):
-                print_info("⚠️  Telegram has no user allowlist - anyone can use your bot!")
-                if prompt_yes_no("Add allowed users now?", True):
+                print_info("⚠️  Telegram에 사용자 허용 목록이 없습니다 - 누구나 봇을 사용할 수 있어요!")
+                if prompt_yes_no("허용할 사용자를 지금 추가할까요?", True):
                     print_info("   Telegram 사용자 ID 확인: @userinfobot에 메시지 보내기")
                     allowed_users = prompt("허용할 사용자 ID (쉼표로 구분)")
                     if allowed_users:
                         save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
-                        print_success("Telegram allowlist configured")
+                        print_success("Telegram allowlist 설정 완료")
             return
 
     print_info("@BotFather로 Telegram 봇 만들기")
@@ -1615,22 +1615,22 @@ def _setup_telegram():
     if not token:
         return
     save_env_value("TELEGRAM_BOT_TOKEN", token)
-    print_success("Telegram token saved")
+    print_success("Telegram 토큰 저장 완료")
 
     print()
-    print_info("🔒 Security: Restrict who can use your bot")
-    print_info("   To find your Telegram user ID:")
-    print_info("   1. Message @userinfobot on Telegram")
-    print_info("   2. It will reply with your numeric ID (e.g., 123456789)")
+    print_info("🔒 보안: 누가 봇을 사용할 수 있는지 제한하세요")
+    print_info("   Telegram 사용자 ID 확인 방법:")
+    print_info("   1. Telegram에서 @userinfobot에 메시지 보내기")
+    print_info("   2. 숫자 ID(예: 123456789)를 답장으로 받습니다")
     print()
     allowed_users = prompt(
         "허용할 사용자 ID (쉼표로 구분, 비워두면 누구나 접근 가능)"
     )
     if allowed_users:
         save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("Telegram allowlist configured - only listed users can use the bot")
+        print_success("Telegram allowlist 설정 완료 - 목록에 있는 사용자만 봇을 사용할 수 있습니다")
     else:
-        print_info("⚠️  No allowlist set - anyone who finds your bot can use it!")
+        print_info("⚠️  allowlist가 없습니다 - 봇을 찾는 누구나 사용할 수 있습니다!")
 
     print()
     print_info("📬 홈 채널: Hermes가 cron 결과, 플랫폼 간 메시지, 알림을 전달하는 곳입니다.")
@@ -1640,7 +1640,7 @@ def _setup_telegram():
     if first_user_id:
         if prompt_yes_no(f"Use your user ID ({first_user_id}) as the home channel?", True):
             save_env_value("TELEGRAM_HOME_CHANNEL", first_user_id)
-            print_success(f"Telegram home channel set to {first_user_id}")
+            print_success(f"Telegram 홈 채널을 {first_user_id}(으)로 설정했습니다")
         else:
             home_channel = prompt("홈 채널 ID (또는 비워두고 나중에 Telegram에서 /set-home으로 설정)")
             if home_channel:
@@ -1661,13 +1661,13 @@ def _setup_discord():
         if not prompt_yes_no("Discord를 다시 설정할까요?", False):
             if not get_env_value("DISCORD_ALLOWED_USERS"):
                 print_info("⚠️  Discord에 사용자 허용 목록이 없습니다 - 누구나 봇을 사용할 수 있어요!")
-                if prompt_yes_no("Add allowed users now?", True):
+                if prompt_yes_no("허용할 사용자를 지금 추가할까요?", True):
                     print_info("   Discord ID 확인: 개발자 모드를 켜고 이름을 우클릭 → ID 복사")
                     allowed_users = prompt("허용할 사용자 ID (쉼표로 구분)")
                     if allowed_users:
                         cleaned_ids = _clean_discord_user_ids(allowed_users)
                         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
-                        print_success("Discord allowlist configured")
+                        print_success("Discord allowlist 설정 완료")
             return
 
     print_info("Discord 개발자 포털에서 봇 만들기: https://discord.com/developers/applications")
@@ -1675,7 +1675,7 @@ def _setup_discord():
     if not token:
         return
     save_env_value("DISCORD_BOT_TOKEN", token)
-    print_success("Discord token saved")
+    print_success("Discord 토큰 저장 완료")
 
     print()
     print_info("🔒 보안: 누가 봇을 사용할 수 있는지 제한하세요")
@@ -1683,7 +1683,7 @@ def _setup_discord():
     print_info("   1. Discord 설정에서 개발자 모드 활성화")
     print_info("   2. 내 이름을 우클릭 → ID 복사")
     print()
-    print_info("   You can also use Discord usernames (resolved on gateway start).")
+    print_info("   gateway 시작 시 Discord 사용자명도 사용할 수 있습니다.")
     print()
     allowed_users = prompt(
         "허용할 사용자 ID 또는 사용자명 (쉼표로 구분, 비워두면 누구나 접근 가능)"
@@ -1691,9 +1691,9 @@ def _setup_discord():
     if allowed_users:
         cleaned_ids = _clean_discord_user_ids(allowed_users)
         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
-        print_success("Discord allowlist configured")
+        print_success("Discord allowlist 설정 완료")
     else:
-        print_info("⚠️  No allowlist set - anyone in servers with your bot can use it!")
+        print_info("⚠️  allowlist가 없습니다 - 봇이 있는 서버의 누구나 사용할 수 있습니다!")
 
     print()
     print_info("📬 홈 채널: Hermes가 cron 결과, 플랫폼 간 메시지, 알림을 전달하는 곳입니다.")
@@ -1740,10 +1740,10 @@ def _setup_slack():
     print_info("   4. 이벤트 구독: Features → Event Subscriptions → Enable")
     print_info("      필수 이벤트: message.im, message.channels, app_mention")
     print_info("      비공개 채널용 선택 이벤트: message.groups")
-    print_warning("   ⚠ Without message.channels the bot will ONLY work in DMs,")
-    print_warning("     not public channels.")
-    print_info("   5. Install to Workspace: Settings → Install App")
-    print_info("   6. Reinstall the app after any scope or event changes")
+    print_warning("   ⚠ message.channels scope가 없으면 봇은 DM에서만 동작하고,")
+    print_warning("     공개 채널에서는 동작하지 않습니다.")
+    print_info("   5. Workspace에 설치: Settings → Install App")
+    print_info("   6. scope나 event를 바꾼 뒤에는 앱을 다시 설치하세요")
     print_info("   7. After installing, invite the bot to channels: /invite @YourBot")
     print()
     print_info("   Full guide: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack/")
@@ -1762,14 +1762,15 @@ def _setup_slack():
     print_info("   To find a Member ID: click a user's name → View full profile → ⋮ → Copy member ID")
     print()
     allowed_users = prompt(
-        "Allowed user IDs (comma-separated, leave empty to deny everyone except paired users)"
+        "허용할 사용자 ID (쉼표로 구분, 비워두면 페어링된 사용자 외에는 모두 거부)"
     )
     if allowed_users:
         save_env_value("SLACK_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("Slack allowlist configured")
+        print_success("Slack allowlist 설정 완료")
     else:
-        print_warning("⚠️  No Slack allowlist set - unpaired users will be denied by default.")
-        print_info("   Set SLACK_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true only if you intentionally want open workspace access.")
+        print_warning("⚠️  Slack allowlist가 없습니다 - 페어링되지 않은 사용자는 기본적으로 거부됩니다.")
+        print_info("   진짜로 워크스페이스 전체 접근을 열려면")
+        print_info("   SLACK_ALLOW_ALL_USERS=true 또는 GATEWAY_ALLOW_ALL_USERS=true 를 설정하세요.")
 
 
 def _setup_matrix():
@@ -1809,7 +1810,7 @@ def _setup_matrix():
 
     if token or get_env_value("MATRIX_PASSWORD"):
         print()
-        want_e2ee = prompt_yes_no("Enable end-to-end encryption (E2EE)?", False)
+        want_e2ee = prompt_yes_no("종단간 암호화(E2EE)를 활성화할까요?", False)
         if want_e2ee:
             save_env_value("MATRIX_ENCRYPTION", "true")
             print_success("E2EE enabled")
@@ -1834,7 +1835,7 @@ def _setup_matrix():
             if result.returncode == 0:
                 print_success(f"{matrix_pkg} installed")
             else:
-                print_warning(f"Install failed — run manually: pip install '{matrix_pkg}'")
+                print_warning(f"설치 실패 — 직접 실행하세요: pip install '{matrix_pkg}'")
                 if result.stderr:
                     print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
 
@@ -2291,7 +2292,7 @@ def setup_gateway(config: dict):
         elif supports_service_manager:
             svc_name = "systemd" if supports_systemd else "launchd"
             if prompt_yes_no(
-                f"  Install the gateway as a {svc_name} service? (runs in background, starts on boot)",
+                f"  게이트웨이를 {svc_name} 서비스로 설치할까요? (백그라운드 실행, 부팅 시 자동 시작)",
                 True,
             ):
                 try:
@@ -2303,34 +2304,34 @@ def setup_gateway(config: dict):
                         launchd_install(force=False)
                         did_install = True
                     print()
-                    if did_install and prompt_yes_no("  Start the service now?", True):
+                    if did_install and prompt_yes_no("  지금 서비스를 시작할까요?", True):
                         try:
                             if supports_systemd:
                                 systemd_start(system=installed_scope == "system")
                             elif _is_macos:
                                 launchd_start()
                         except Exception as e:
-                            print_error(f"  Start failed: {e}")
+                            print_error(f"  시작 실패: {e}")
                 except Exception as e:
-                    print_error(f"  Install failed: {e}")
-                    print_info("  You can try manually: hermes gateway install")
+                    print_error(f"  설치 실패: {e}")
+                    print_info("  수동으로 시도할 수 있습니다: hermes gateway install")
             else:
-                print_info("  You can install later: hermes gateway install")
+                print_info("  나중에 설치할 수 있습니다: hermes gateway install")
                 if supports_systemd:
-                    print_info("  Or as a boot-time service: sudo hermes gateway install --system")
-                print_info("  Or run in foreground:  hermes gateway")
+                    print_info("  또는 부팅 서비스로: sudo hermes gateway install --system")
+                print_info("  또는 포그라운드 실행:  hermes gateway")
         else:
             from hermes_constants import is_container
             if is_container():
-                print_info("Start the gateway to bring your bots online:")
-                print_info("   hermes gateway run          # Run as container main process")
+                print_info("봇을 온라인으로 올리려면 gateway를 시작하세요:")
+                print_info("   hermes gateway run          # 컨테이너의 메인 프로세스로 실행")
                 print_info("")
-                print_info("For automatic restarts, use a Docker restart policy:")
+                print_info("자동 재시작에는 Docker restart 정책을 사용하세요:")
                 print_info("   docker run --restart unless-stopped ...")
-                print_info("   docker restart <container>  # Manual restart")
+                print_info("   docker restart <container>  # 수동 재시작")
             else:
-                print_info("Start the gateway to bring your bots online:")
-                print_info("   hermes gateway              # Run in foreground")
+                print_info("봇을 온라인으로 올리려면 gateway를 시작하세요:")
+                print_info("   hermes gateway              # 포그라운드 실행")
 
         print_info("━" * 50)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2161,9 +2161,9 @@ _GATEWAY_PLATFORMS = [
 
 def setup_gateway(config: dict):
     """Configure messaging platform integrations."""
-    print_header("Messaging Platforms")
-    print_info("Connect to messaging platforms to chat with Hermes from anywhere.")
-    print_info("Toggle with Space, confirm with Enter.")
+    print_header("메시징 플랫폼")
+    print_info("어디서든 Hermes와 대화할 수 있도록 메시징 플랫폼에 연결하세요.")
+    print_info("Space로 토글하고 Enter로 확인하세요.")
     print()
 
     # Build checklist items, pre-selecting already-configured platforms
@@ -3008,10 +3008,10 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
     # Step 3: Offer messaging gateway setup
     print()
     gateway_choice = prompt_choice(
-        "Connect a messaging platform? (Telegram, Discord, etc.)",
+        "메시징 플랫폼을 연결할까요? (Telegram, Discord 등)",
         [
-            "Set up messaging now (recommended)",
-            "Skip — set up later with 'hermes setup gateway'",
+            "지금 메시징 설정하기 (권장)",
+            "건너뛰기 — 나중에 'hermes setup gateway'로 설정",
         ],
         0,
     )
@@ -3021,11 +3021,11 @@ def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
         save_config(config)
 
     print()
-    print_success("Setup complete! You're ready to go.")
+    print_success("설정이 완료되었습니다! 바로 사용할 수 있어요.")
     print()
-    print_info("  Configure all settings:    hermes setup")
+    print_info("  모든 설정 구성:        hermes setup")
     if gateway_choice != 0:
-        print_info("  Connect Telegram/Discord:  hermes setup gateway")
+        print_info("  Telegram/Discord 연결:  hermes setup gateway")
     print()
 
     _print_setup_summary(config, hermes_home)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1,14 +1,14 @@
 """
-Interactive setup wizard for Hermes Agent.
+Hermes Agent 설정 마법사.
 
-Modular wizard with independently-runnable sections:
-  1. Model & Provider — choose your AI provider and model
-  2. Terminal Backend — where your agent runs commands
-  3. Agent Settings — iterations, compression, session reset
-  4. Messaging Platforms — connect Telegram, Discord, etc.
-  5. Tools — configure TTS, web search, image generation, etc.
+모듈식 마법사이며 각 섹션을 독립적으로 실행할 수 있습니다:
+  1. 모델 및 Provider — AI provider와 모델 선택
+  2. 터미널 백엔드 — 에이전트가 명령을 실행할 위치
+  3. 에이전트 설정 — 반복 수, 압축, 세션 리셋
+  4. 메시징 플랫폼 — Telegram, Discord 등 연결
+  5. 도구 — TTS, 웹 검색, 이미지 생성 등 설정
 
-Config files are stored in ~/.hermes/ for easy access.
+설정 파일은 쉽게 접근할 수 있도록 ~/.hermes/ 아래에 저장됩니다.
 """
 
 import importlib.util
@@ -1414,12 +1414,12 @@ def _apply_default_agent_settings(config: dict):
     })
 
     save_config(config)
-    print_success("Applied recommended defaults:")
-    print_info("  Max iterations: 90")
-    print_info("  Tool progress: all")
-    print_info("  Compression threshold: 0.50")
-    print_info("  Session reset: inactivity (1440 min) + daily (4:00)")
-    print_info("  Run `hermes setup agent` later to customize.")
+    print_success("권장 기본값을 적용했습니다:")
+    print_info("  최대 반복 수: 90")
+    print_info("  도구 진행 표시: all")
+    print_info("  압축 임계값: 0.50")
+    print_info("  세션 리셋: 비활성 1440분 + 매일 4:00")
+    print_info("  나중에 `hermes setup agent`를 실행해 세부 조정할 수 있습니다.")
 
 
 def setup_agent_settings(config: dict):
@@ -1513,11 +1513,11 @@ def setup_agent_settings(config: dict):
     print_info("")
 
     reset_choices = [
-        "Inactivity + daily reset (recommended - reset whichever comes first)",
-        "Inactivity only (reset after N minutes of no messages)",
-        "Daily only (reset at a fixed hour each day)",
-        "Never auto-reset (context lives until /reset or context compression)",
-        "Keep current settings",
+        "비활성 + 매일 리셋 (권장 - 먼저 도달한 조건으로 리셋)",
+        "비활성만 (N분 동안 메시지가 없으면 리셋)",
+        "매일만 (매일 고정 시각에 리셋)",
+        "자동 리셋 안 함 (/reset 또는 컨텍스트 압축 전까지 유지)",
+        "현재 설정 유지",
     ]
 
     current_policy = config.get("session_reset", {})

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1276,16 +1276,16 @@ def setup_terminal_backend(config: dict):
         _prompt_container_resources(config)
 
     elif selected_backend == "daytona":
-        print_success("Terminal backend: Daytona")
-        print_info("Persistent cloud development environments.")
-        print_info("Each session gets a dedicated sandbox with filesystem persistence.")
-        print_info("Sign up at: https://daytona.io")
+        print_success("터미널 백엔드: Daytona")
+        print_info("Daytona 클라우드 개발 환경입니다.")
+        print_info("세션마다 파일시스템이 유지되는 전용 샌드박스를 제공합니다.")
+        print_info("가입: https://daytona.io")
 
         # Check if daytona SDK is installed
         try:
             __import__("daytona")
         except ImportError:
-            print_info("Installing daytona SDK...")
+            print_info("daytona SDK 설치 중...")
             import subprocess
 
             uv_bin = shutil.which("uv")
@@ -1302,70 +1302,70 @@ def setup_terminal_backend(config: dict):
                     text=True,
                 )
             if result.returncode == 0:
-                print_success("daytona SDK installed")
+                print_success("daytona SDK 설치 완료")
             else:
-                print_warning("Install failed — run manually: pip install daytona")
+                print_warning("설치 실패 — 직접 실행하세요: pip install daytona")
                 if result.stderr:
-                    print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
+                    print_info(f"  오류: {result.stderr.strip().splitlines()[-1]}")
 
         # Daytona API key
         print()
         existing_key = get_env_value("DAYTONA_API_KEY")
         if existing_key:
-            print_info("  Daytona API key: already configured")
-            if prompt_yes_no("  Update API key?", False):
-                api_key = prompt("    Daytona API key", password=True)
+            print_info("  Daytona API 키: 이미 설정되어 있음")
+            if prompt_yes_no("  API 키를 업데이트할까요?", False):
+                api_key = prompt("    Daytona API 키", password=True)
                 if api_key:
                     save_env_value("DAYTONA_API_KEY", api_key)
-                    print_success("    Updated")
+                    print_success("    업데이트 완료")
         else:
-            api_key = prompt("    Daytona API key", password=True)
+            api_key = prompt("    Daytona API 키", password=True)
             if api_key:
                 save_env_value("DAYTONA_API_KEY", api_key)
-                print_success("    Configured")
+                print_success("    설정 완료")
 
         # Daytona image
         current_image = config.get("terminal", {}).get(
             "daytona_image", "nikolaik/python-nodejs:python3.11-nodejs20"
         )
-        image = prompt("  Sandbox image", current_image)
+        image = prompt("  샌드박스 이미지", current_image)
         config["terminal"]["daytona_image"] = image
         save_env_value("TERMINAL_DAYTONA_IMAGE", image)
 
         _prompt_container_resources(config)
 
     elif selected_backend == "ssh":
-        print_success("Terminal backend: SSH")
-        print_info("Run commands on a remote machine via SSH.")
+        print_success("터미널 백엔드: SSH")
+        print_info("원격 머신에서 SSH로 명령어를 실행합니다.")
 
         # SSH host
         current_host = get_env_value("TERMINAL_SSH_HOST") or ""
-        host = prompt("  SSH host (hostname or IP)", current_host)
+        host = prompt("  SSH 호스트 (hostname 또는 IP)", current_host)
         if host:
             save_env_value("TERMINAL_SSH_HOST", host)
 
         # SSH user
         current_user = get_env_value("TERMINAL_SSH_USER") or ""
-        user = prompt("  SSH user", current_user or os.getenv("USER", ""))
+        user = prompt("  SSH 사용자", current_user or os.getenv("USER", ""))
         if user:
             save_env_value("TERMINAL_SSH_USER", user)
 
         # SSH port
         current_port = get_env_value("TERMINAL_SSH_PORT") or "22"
-        port = prompt("  SSH port", current_port)
+        port = prompt("  SSH 포트", current_port)
         if port and port != "22":
             save_env_value("TERMINAL_SSH_PORT", port)
 
         # SSH key
         current_key = get_env_value("TERMINAL_SSH_KEY") or ""
         default_key = str(Path.home() / ".ssh" / "id_rsa")
-        ssh_key = prompt("  SSH private key path", current_key or default_key)
+        ssh_key = prompt("  SSH 개인키 경로", current_key or default_key)
         if ssh_key:
             save_env_value("TERMINAL_SSH_KEY", ssh_key)
 
         # Test connection
-        if host and prompt_yes_no("  Test SSH connection?", True):
-            print_info("  Testing connection...")
+        if host and prompt_yes_no("  SSH 연결을 테스트할까요?", True):
+            print_info("  연결 테스트 중...")
             import subprocess
 
             ssh_cmd = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5"]
@@ -1377,10 +1377,10 @@ def setup_terminal_backend(config: dict):
             ssh_cmd.append("echo ok")
             result = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=10)
             if result.returncode == 0:
-                print_success("  SSH connection successful!")
+                print_success("  SSH 연결 성공!")
             else:
-                print_warning(f"  SSH connection failed: {result.stderr.strip()}")
-                print_info("  Check your SSH key and host settings.")
+                print_warning(f"  SSH 연결 실패: {result.stderr.strip()}")
+                print_info("  SSH 키와 호스트 설정을 확인하세요.")
 
     # Sync terminal backend to .env so terminal_tool picks it up directly.
     # config.yaml is the source of truth, but terminal_tool reads TERMINAL_ENV.
@@ -1389,7 +1389,7 @@ def setup_terminal_backend(config: dict):
         save_env_value("TERMINAL_MODAL_MODE", config["terminal"].get("modal_mode", "auto"))
     save_config(config)
     print()
-    print_success(f"Terminal backend set to: {selected_backend}")
+    print_success(f"터미널 백엔드 설정 완료: {selected_backend}")
 
 
 # =============================================================================

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1597,8 +1597,8 @@ def _setup_telegram():
     print_header("Telegram")
     existing = get_env_value("TELEGRAM_BOT_TOKEN")
     if existing:
-        print_info("Telegram: already configured")
-        if not prompt_yes_no("Reconfigure Telegram?", False):
+        print_info("Telegram: 이미 설정되어 있음")
+        if not prompt_yes_no("Telegram을 다시 설정할까요?", False):
             # Check missing allowlist on existing config
             if not get_env_value("TELEGRAM_ALLOWED_USERS"):
                 print_info("⚠️  Telegram has no user allowlist - anyone can use your bot!")
@@ -1658,10 +1658,10 @@ def _setup_discord():
     print_header("Discord")
     existing = get_env_value("DISCORD_BOT_TOKEN")
     if existing:
-        print_info("Discord: already configured")
-        if not prompt_yes_no("Reconfigure Discord?", False):
+        print_info("Discord: 이미 설정되어 있음")
+        if not prompt_yes_no("Discord를 다시 설정할까요?", False):
             if not get_env_value("DISCORD_ALLOWED_USERS"):
-                print_info("⚠️  Discord has no user allowlist - anyone can use your bot!")
+                print_info("⚠️  Discord에 사용자 허용 목록이 없습니다 - 누구나 봇을 사용할 수 있어요!")
                 if prompt_yes_no("Add allowed users now?", True):
                     print_info("   To find Discord ID: Enable Developer Mode, right-click name → Copy ID")
                     allowed_users = prompt("Allowed user IDs (comma-separated)")
@@ -1726,8 +1726,8 @@ def _setup_slack():
     print_header("Slack")
     existing = get_env_value("SLACK_BOT_TOKEN")
     if existing:
-        print_info("Slack: already configured")
-        if not prompt_yes_no("Reconfigure Slack?", False):
+        print_info("Slack: 이미 설정되어 있음")
+        if not prompt_yes_no("Slack을 다시 설정할까요?", False):
             return
 
     print_info("Steps to create a Slack app:")
@@ -1779,8 +1779,8 @@ def _setup_matrix():
     print_header("Matrix")
     existing = get_env_value("MATRIX_ACCESS_TOKEN") or get_env_value("MATRIX_PASSWORD")
     if existing:
-        print_info("Matrix: already configured")
-        if not prompt_yes_no("Reconfigure Matrix?", False):
+        print_info("Matrix: 이미 설정되어 있음")
+        if not prompt_yes_no("Matrix를 다시 설정할까요?", False):
             return
 
     print_info("Works with any Matrix homeserver (Synapse, Conduit, Dendrite, or matrix.org).")
@@ -1865,8 +1865,8 @@ def _setup_mattermost():
     print_header("Mattermost")
     existing = get_env_value("MATTERMOST_TOKEN")
     if existing:
-        print_info("Mattermost: already configured")
-        if not prompt_yes_no("Reconfigure Mattermost?", False):
+        print_info("Mattermost: 이미 설정되어 있음")
+        if not prompt_yes_no("Mattermost를 다시 설정할까요?", False):
             return
 
     print_info("Works with any self-hosted Mattermost instance.")
@@ -2096,8 +2096,8 @@ def _setup_webhooks():
     print_header("Webhooks")
     existing = get_env_value("WEBHOOK_ENABLED")
     if existing:
-        print_info("Webhooks: already configured")
-        if not prompt_yes_no("Reconfigure webhooks?", False):
+        print_info("Webhooks: 이미 설정되어 있음")
+        if not prompt_yes_no("Webhooks를 다시 설정할까요?", False):
             return
 
     print()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1433,52 +1433,52 @@ def setup_agent_settings(config: dict):
     current_max = get_env_value("HERMES_MAX_ITERATIONS") or str(
         config.get("agent", {}).get("max_turns", 90)
     )
-    print_info("Maximum tool-calling iterations per conversation.")
-    print_info("Higher = more complex tasks, but costs more tokens.")
-    print_info("Default is 90, which works for most tasks. Use 150+ for open exploration.")
+    print_info("대화 한 번에 도구를 호출할 수 있는 최대 반복 횟수입니다.")
+    print_info("값이 높을수록 더 복잡한 작업을 처리할 수 있지만 토큰 비용도 늘어납니다.")
+    print_info("기본값 90이면 대부분 충분하고, 열린 탐색 작업은 150+도 고려할 수 있습니다.")
 
-    max_iter_str = prompt("Max iterations", current_max)
+    max_iter_str = prompt("최대 반복 수", current_max)
     try:
         max_iter = int(max_iter_str)
         if max_iter > 0:
             save_env_value("HERMES_MAX_ITERATIONS", str(max_iter))
             config.setdefault("agent", {})["max_turns"] = max_iter
             config.pop("max_turns", None)
-            print_success(f"Max iterations set to {max_iter}")
+            print_success(f"최대 반복 수를 {max_iter}(으)로 설정했습니다")
     except ValueError:
-        print_warning("Invalid number, keeping current value")
+        print_warning("잘못된 숫자입니다. 현재 값을 유지합니다")
 
     # ── Tool Progress Display ──
     print_info("")
-    print_info("Tool Progress Display")
-    print_info("Controls how much tool activity is shown (CLI and messaging).")
-    print_info("  off     — Silent, just the final response")
-    print_info("  new     — Show tool name only when it changes (less noise)")
-    print_info("  all     — Show every tool call with a short preview")
-    print_info("  verbose — Full args, results, and debug logs")
+    print_info("도구 진행 표시")
+    print_info("도구 활동을 어느 정도까지 보여줄지 결정합니다. (CLI와 메시징 공통)")
+    print_info("  off     — 조용히, 최종 응답만 표시")
+    print_info("  new     — 도구 이름이 바뀔 때만 표시 (덜 시끄러움)")
+    print_info("  all     — 모든 도구 호출을 짧은 미리보기와 함께 표시")
+    print_info("  verbose — 전체 인자, 결과, 디버그 로그 표시")
 
     current_mode = config.get("display", {}).get("tool_progress", "all")
-    mode = prompt("Tool progress mode", current_mode)
+    mode = prompt("도구 진행 표시 모드", current_mode)
     if mode.lower() in ("off", "new", "all", "verbose"):
         if "display" not in config:
             config["display"] = {}
         config["display"]["tool_progress"] = mode.lower()
         save_config(config)
-        print_success(f"Tool progress set to: {mode.lower()}")
+        print_success(f"도구 진행 표시를 다음으로 설정했습니다: {mode.lower()}")
     else:
-        print_warning(f"Unknown mode '{mode}', keeping '{current_mode}'")
+        print_warning(f"알 수 없는 모드 '{mode}' 입니다. '{current_mode}'을(를) 유지합니다")
 
     # ── Context Compression ──
-    print_header("Context Compression")
-    print_info("Automatically summarizes old messages when context gets too long.")
+    print_header("컨텍스트 압축")
+    print_info("컨텍스트가 너무 길어지면 오래된 메시지를 자동으로 요약합니다.")
     print_info(
-        "Higher threshold = compress later (use more context). Lower = compress sooner."
+        "임계값이 높을수록 늦게 압축하고(더 많은 컨텍스트 사용), 낮을수록 빨리 압축합니다."
     )
 
     config.setdefault("compression", {})["enabled"] = True
 
     current_threshold = config.get("compression", {}).get("threshold", 0.50)
-    threshold_str = prompt("Compression threshold (0.5-0.95)", str(current_threshold))
+    threshold_str = prompt("압축 임계값 (0.5-0.95)", str(current_threshold))
     try:
         threshold = float(threshold_str)
         if 0.5 <= threshold <= 0.95:
@@ -1487,29 +1487,29 @@ def setup_agent_settings(config: dict):
         pass
 
     print_success(
-        f"Context compression threshold set to {config['compression'].get('threshold', 0.50)}"
+        f"컨텍스트 압축 임계값을 {config['compression'].get('threshold', 0.50)}(으)로 설정했습니다"
     )
 
     # ── Session Reset Policy ──
-    print_header("Session Reset Policy")
+    print_header("세션 리셋 정책")
     print_info(
-        "Messaging sessions (Telegram, Discord, etc.) accumulate context over time."
+        "메시징 세션(Telegram, Discord 등)은 시간이 지날수록 컨텍스트가 누적됩니다."
     )
     print_info(
-        "Each message adds to the conversation history, which means growing API costs."
-    )
-    print_info("")
-    print_info(
-        "To manage this, sessions can automatically reset after a period of inactivity"
-    )
-    print_info(
-        "or at a fixed time each day. When a reset happens, the agent saves important"
-    )
-    print_info(
-        "things to its persistent memory first — but the conversation context is cleared."
+        "메시지를 보낼수록 대화 기록이 길어지고, 그만큼 API 비용도 커질 수 있습니다."
     )
     print_info("")
-    print_info("You can also manually reset anytime by typing /reset in chat.")
+    print_info(
+        "이를 관리하기 위해, 일정 시간 비활성 상태가 지속되거나 매일 정해진 시각에"
+    )
+    print_info(
+        "세션을 자동 리셋하도록 설정할 수 있습니다. 리셋 시 중요한 정보는 먼저"
+    )
+    print_info(
+        "지속 메모리에 저장되지만, 대화 컨텍스트 자체는 비워집니다."
+    )
+    print_info("")
+    print_info("채팅에서 /reset을 입력해 언제든 수동으로 리셋할 수도 있습니다.")
     print_info("")
 
     reset_choices = [
@@ -1527,20 +1527,20 @@ def setup_agent_settings(config: dict):
 
     default_reset = {"both": 0, "idle": 1, "daily": 2, "none": 3}.get(current_mode, 0)
 
-    reset_idx = prompt_choice("Session reset mode:", reset_choices, default_reset)
+    reset_idx = prompt_choice("세션 리셋 모드:", reset_choices, default_reset)
 
     config.setdefault("session_reset", {})
 
     if reset_idx == 0:  # Both
         config["session_reset"]["mode"] = "both"
-        idle_str = prompt("  Inactivity timeout (minutes)", str(current_idle))
+        idle_str = prompt("  비활성 타임아웃 (분)", str(current_idle))
         try:
             idle_val = int(idle_str)
             if idle_val > 0:
                 config["session_reset"]["idle_minutes"] = idle_val
         except ValueError:
             pass
-        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
+        hour_str = prompt("  일일 리셋 시각 (0-23, 로컬 시간)", str(current_hour))
         try:
             hour_val = int(hour_str)
             if 0 <= hour_val <= 23:
@@ -1548,11 +1548,11 @@ def setup_agent_settings(config: dict):
         except ValueError:
             pass
         print_success(
-            f"Sessions reset after {config['session_reset'].get('idle_minutes', 1440)} min idle or daily at {config['session_reset'].get('at_hour', 4)}:00"
+            f"세션은 {config['session_reset'].get('idle_minutes', 1440)}분 비활성 후 또는 매일 {config['session_reset'].get('at_hour', 4)}:00에 리셋됩니다"
         )
     elif reset_idx == 1:  # Idle only
         config["session_reset"]["mode"] = "idle"
-        idle_str = prompt("  Inactivity timeout (minutes)", str(current_idle))
+        idle_str = prompt("  비활성 타임아웃 (분)", str(current_idle))
         try:
             idle_val = int(idle_str)
             if idle_val > 0:
@@ -1560,11 +1560,11 @@ def setup_agent_settings(config: dict):
         except ValueError:
             pass
         print_success(
-            f"Sessions reset after {config['session_reset'].get('idle_minutes', 1440)} min of inactivity"
+            f"세션은 {config['session_reset'].get('idle_minutes', 1440)}분 비활성 상태가 되면 리셋됩니다"
         )
     elif reset_idx == 2:  # Daily only
         config["session_reset"]["mode"] = "daily"
-        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
+        hour_str = prompt("  일일 리셋 시각 (0-23, 로컬 시간)", str(current_hour))
         try:
             hour_val = int(hour_str)
             if 0 <= hour_val <= 23:
@@ -1572,15 +1572,15 @@ def setup_agent_settings(config: dict):
         except ValueError:
             pass
         print_success(
-            f"Sessions reset daily at {config['session_reset'].get('at_hour', 4)}:00"
+            f"세션은 매일 {config['session_reset'].get('at_hour', 4)}:00에 리셋됩니다"
         )
     elif reset_idx == 3:  # None
         config["session_reset"]["mode"] = "none"
         print_info(
-            "Sessions will never auto-reset. Context is managed only by compression."
+            "세션은 자동으로 리셋되지 않습니다. 컨텍스트 관리는 압축만으로 처리됩니다."
         )
         print_warning(
-            "Long conversations will grow in cost. Use /reset manually when needed."
+            "긴 대화는 비용이 계속 늘어날 수 있습니다. 필요할 때 /reset을 수동으로 사용하세요."
         )
     # else: keep current (idx == 4)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -782,31 +782,31 @@ def setup_model_provider(config: dict, *, quick: bool = False):
         _prov_display = _prov_names.get(selected_provider, selected_provider or "your provider")
 
         print()
-        print_header("Vision & Image Analysis (optional)")
-        print_info(f"Vision uses a separate multimodal backend. {_prov_display}")
-        print_info("doesn't currently provide one Hermes can auto-use for vision,")
-        print_info("so choose a backend now or skip and configure later.")
+        print_header("비전 및 이미지 분석 (선택 사항)")
+        print_info(f"Vision은 별도의 멀티모달 백엔드를 사용합니다. {_prov_display}")
+        print_info("현재는 Hermes가 vision용으로 자동 활용할 수 있는 백엔드를 제공하지 않으므로,")
+        print_info("지금 백엔드를 선택하거나 건너뛰고 나중에 설정하세요.")
         print()
 
         _vision_choices = [
-            "OpenRouter — uses Gemini (free tier at openrouter.ai/keys)",
-            "OpenAI-compatible endpoint — base URL, API key, and vision model",
-            "Skip for now",
+            "OpenRouter — Gemini 사용 (openrouter.ai/keys의 무료 티어 가능)",
+            "OpenAI 호환 엔드포인트 — base URL, API key, vision 모델 지정",
+            "지금은 건너뛰기",
         ]
-        _vision_idx = prompt_choice("Configure vision:", _vision_choices, 2)
+        _vision_idx = prompt_choice("vision 설정:", _vision_choices, 2)
 
         if _vision_idx == 0:  # OpenRouter
-            _or_key = prompt("  OpenRouter API key", password=True).strip()
+            _or_key = prompt("  OpenRouter API 키", password=True).strip()
             if _or_key:
                 save_env_value("OPENROUTER_API_KEY", _or_key)
-                print_success("OpenRouter key saved — vision will use Gemini")
+                print_success("OpenRouter 키 저장 완료 — vision은 Gemini를 사용합니다")
             else:
-                print_info("Skipped — vision won't be available")
+                print_info("건너뜀 — vision을 사용할 수 없습니다")
         elif _vision_idx == 1:  # OpenAI-compatible endpoint
-            _base_url = prompt("  Base URL (blank for OpenAI)").strip() or "https://api.openai.com/v1"
-            _api_key_label = "  API key"
+            _base_url = prompt("  Base URL (비워두면 OpenAI)").strip() or "https://api.openai.com/v1"
+            _api_key_label = "  API 키"
             if "api.openai.com" in _base_url.lower():
-                _api_key_label = "  OpenAI API key"
+                _api_key_label = "  OpenAI API 키"
             _oai_key = prompt(_api_key_label, password=True).strip()
             if _oai_key:
                 save_env_value("OPENAI_API_KEY", _oai_key)
@@ -815,24 +815,24 @@ def setup_model_provider(config: dict, *, quick: bool = False):
                 _vaux["base_url"] = _base_url
                 if "api.openai.com" in _base_url.lower():
                     _oai_vision_models = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"]
-                    _vm_choices = _oai_vision_models + ["Use default (gpt-4o-mini)"]
-                    _vm_idx = prompt_choice("Select vision model:", _vm_choices, 0)
+                    _vm_choices = _oai_vision_models + ["기본값 사용 (gpt-4o-mini)"]
+                    _vm_idx = prompt_choice("vision 모델 선택:", _vm_choices, 0)
                     _selected_vision_model = (
                         _oai_vision_models[_vm_idx]
                         if _vm_idx < len(_oai_vision_models)
                         else "gpt-4o-mini"
                     )
                 else:
-                    _selected_vision_model = prompt("  Vision model (blank = use main/custom default)").strip()
+                    _selected_vision_model = prompt("  Vision 모델 (비워두면 메인/커스텀 기본값 사용)").strip()
                 save_env_value("AUXILIARY_VISION_MODEL", _selected_vision_model)
                 print_success(
-                    f"Vision configured with {_base_url}"
+                    f"Vision 설정 완료: {_base_url}"
                     + (f" ({_selected_vision_model})" if _selected_vision_model else "")
                 )
             else:
-                print_info("Skipped — vision won't be available")
+                print_info("건너뜀 — vision을 사용할 수 없습니다")
         else:
-            print_info("Skipped — add later with 'hermes setup' or configure AUXILIARY_VISION_* settings")
+            print_info("건너뜀 — 나중에 'hermes setup'으로 추가하거나 AUXILIARY_VISION_* 설정을 구성하세요")
 
 
     if selected_provider == "nous" and nous_subscription_selected:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -648,11 +648,11 @@ def setup_model_provider(config: dict, *, quick: bool = False):
         select_provider_and_model()
     except (SystemExit, KeyboardInterrupt):
         print()
-        print_info("Provider setup skipped.")
+        print_info("Provider 설정을 건너뛰었습니다.")
     except Exception as exc:
         logger.debug("select_provider_and_model error during setup: %s", exc)
-        print_warning(f"Provider setup encountered an error: {exc}")
-        print_info("You can try again later with: hermes model")
+        print_warning(f"Provider 설정 중 오류가 발생했습니다: {exc}")
+        print_info("나중에 'hermes model'로 다시 시도할 수 있습니다")
 
     # Re-sync the wizard's config dict from what cmd_model saved to disk.
     # This is critical: cmd_model writes to disk via its own load/save cycle,
@@ -686,26 +686,26 @@ def setup_model_provider(config: dict, *, quick: bool = False):
             manual_count = sum(1 for entry in entries if str(getattr(entry, "source", "")).startswith("manual"))
             auto_count = entry_count - manual_count
             print()
-            print_header("Same-Provider Fallback & Rotation")
+            print_header("동일 Provider fallback 및 순환")
             print_info(
-                "Hermes can keep multiple credentials for one provider and rotate between"
+                "Hermes는 하나의 provider에 여러 자격 증명을 보관하고, 자격 증명이 소진되거나"
             )
             print_info(
-                "them when a credential is exhausted or rate-limited. This preserves"
+                "속도 제한에 걸리면 다른 자격 증명으로 순환할 수 있습니다."
             )
             print_info(
-                "your primary provider while reducing interruptions from quota issues."
+                "이렇게 하면 기본 provider는 유지하면서 quota 문제로 인한 중단을 줄일 수 있습니다."
             )
             print()
             if auto_count > 0:
                 print_info(
-                    f"Current pooled credentials for {selected_provider}: {entry_count} "
-                    f"({manual_count} manual, {auto_count} auto-detected from env/shared auth)"
+                    f"현재 {selected_provider} 풀 자격 증명: {entry_count}개 "
+                    f"(수동 {manual_count}, env/공유 인증에서 자동 감지 {auto_count})"
                 )
             else:
-                print_info(f"Current pooled credentials for {selected_provider}: {entry_count}")
+                print_info(f"현재 {selected_provider} 풀 자격 증명: {entry_count}개")
 
-            while prompt_yes_no("Add another credential for same-provider fallback?", False):
+            while prompt_yes_no("같은 provider fallback용 자격 증명을 하나 더 추가할까요?", False):
                 auth_add_command(
                     SimpleNamespace(
                         provider=selected_provider,
@@ -725,13 +725,13 @@ def setup_model_provider(config: dict, *, quick: bool = False):
                 )
                 pool = load_pool(selected_provider)
                 entry_count = len(pool.entries())
-                print_info(f"Provider pool now has {entry_count} credential(s).")
+                print_info(f"Provider 풀에 자격 증명이 이제 {entry_count}개 있습니다.")
 
             if entry_count > 1:
                 strategy_labels = [
-                    "Fill-first / sticky — keep using the first healthy credential until it is exhausted",
-                    "Round robin — rotate to the next healthy credential after each selection",
-                    "Random — pick a random healthy credential each time",
+                    "fill-first / sticky — 첫 번째 건강한 자격 증명을 소진될 때까지 계속 사용",
+                    "round robin — 선택할 때마다 다음 건강한 자격 증명으로 순환",
+                    "random — 매번 건강한 자격 증명 중 하나를 무작위 선택",
                 ]
                 current_strategy = _get_credential_pool_strategies(config).get(selected_provider, "fill_first")
                 default_strategy_idx = {
@@ -740,13 +740,13 @@ def setup_model_provider(config: dict, *, quick: bool = False):
                     "random": 2,
                 }.get(current_strategy, 0)
                 strategy_idx = prompt_choice(
-                    "Select same-provider rotation strategy:",
+                    "동일 provider 순환 전략을 선택하세요:",
                     strategy_labels,
                     default_strategy_idx,
                 )
                 strategy_value = ["fill_first", "round_robin", "random"][strategy_idx]
                 _set_credential_pool_strategy(config, selected_provider, strategy_value)
-                print_success(f"Saved {selected_provider} rotation strategy: {strategy_value}")
+                print_success(f"{selected_provider} 순환 전략 저장 완료: {strategy_value}")
         except Exception as exc:
             logger.debug("Could not configure same-provider fallback in setup: %s", exc)
 
@@ -839,9 +839,9 @@ def setup_model_provider(config: dict, *, quick: bool = False):
         changed_defaults = apply_nous_provider_defaults(config)
         current_tts = str(config.get("tts", {}).get("provider") or "edge")
         if "tts" in changed_defaults:
-            print_success("TTS provider set to: OpenAI TTS via your Nous subscription")
+            print_success("TTS provider를 OpenAI TTS (Nous 구독)로 설정했습니다")
         else:
-            print_info(f"Keeping your existing TTS provider: {current_tts}")
+            print_info(f"기존 TTS provider를 유지합니다: {current_tts}")
 
     save_config(config)
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1603,15 +1603,15 @@ def _setup_telegram():
             if not get_env_value("TELEGRAM_ALLOWED_USERS"):
                 print_info("⚠️  Telegram has no user allowlist - anyone can use your bot!")
                 if prompt_yes_no("Add allowed users now?", True):
-                    print_info("   To find your Telegram user ID: message @userinfobot")
-                    allowed_users = prompt("Allowed user IDs (comma-separated)")
+                    print_info("   Telegram 사용자 ID 확인: @userinfobot에 메시지 보내기")
+                    allowed_users = prompt("허용할 사용자 ID (쉼표로 구분)")
                     if allowed_users:
                         save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
                         print_success("Telegram allowlist configured")
             return
 
-    print_info("Create a bot via @BotFather on Telegram")
-    token = prompt("Telegram bot token", password=True)
+    print_info("@BotFather로 Telegram 봇 만들기")
+    token = prompt("Telegram 봇 토큰", password=True)
     if not token:
         return
     save_env_value("TELEGRAM_BOT_TOKEN", token)
@@ -1624,7 +1624,7 @@ def _setup_telegram():
     print_info("   2. It will reply with your numeric ID (e.g., 123456789)")
     print()
     allowed_users = prompt(
-        "Allowed user IDs (comma-separated, leave empty for open access)"
+        "허용할 사용자 ID (쉼표로 구분, 비워두면 누구나 접근 가능)"
     )
     if allowed_users:
         save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
@@ -1633,9 +1633,8 @@ def _setup_telegram():
         print_info("⚠️  No allowlist set - anyone who finds your bot can use it!")
 
     print()
-    print_info("📬 Home Channel: where Hermes delivers cron job results,")
-    print_info("   cross-platform messages, and notifications.")
-    print_info("   For Telegram DMs, this is your user ID (same as above).")
+    print_info("📬 홈 채널: Hermes가 cron 결과, 플랫폼 간 메시지, 알림을 전달하는 곳입니다.")
+    print_info("   Telegram DM에서는 위와 같은 사용자 ID를 사용합니다.")
 
     first_user_id = allowed_users.split(",")[0].strip() if allowed_users else ""
     if first_user_id:
@@ -1643,12 +1642,12 @@ def _setup_telegram():
             save_env_value("TELEGRAM_HOME_CHANNEL", first_user_id)
             print_success(f"Telegram home channel set to {first_user_id}")
         else:
-            home_channel = prompt("Home channel ID (or leave empty to set later with /set-home in Telegram)")
+            home_channel = prompt("홈 채널 ID (또는 비워두고 나중에 Telegram에서 /set-home으로 설정)")
             if home_channel:
                 save_env_value("TELEGRAM_HOME_CHANNEL", home_channel)
     else:
-        print_info("   You can also set this later by typing /set-home in your Telegram chat.")
-        home_channel = prompt("Home channel ID (leave empty to set later)")
+        print_info("   나중에 Telegram 채팅에서 /set-home을 입력해 설정할 수도 있습니다.")
+        home_channel = prompt("홈 채널 ID (비워두면 나중에 설정)")
         if home_channel:
             save_env_value("TELEGRAM_HOME_CHANNEL", home_channel)
 
@@ -1663,31 +1662,31 @@ def _setup_discord():
             if not get_env_value("DISCORD_ALLOWED_USERS"):
                 print_info("⚠️  Discord에 사용자 허용 목록이 없습니다 - 누구나 봇을 사용할 수 있어요!")
                 if prompt_yes_no("Add allowed users now?", True):
-                    print_info("   To find Discord ID: Enable Developer Mode, right-click name → Copy ID")
-                    allowed_users = prompt("Allowed user IDs (comma-separated)")
+                    print_info("   Discord ID 확인: 개발자 모드를 켜고 이름을 우클릭 → ID 복사")
+                    allowed_users = prompt("허용할 사용자 ID (쉼표로 구분)")
                     if allowed_users:
                         cleaned_ids = _clean_discord_user_ids(allowed_users)
                         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
                         print_success("Discord allowlist configured")
             return
 
-    print_info("Create a bot at https://discord.com/developers/applications")
-    token = prompt("Discord bot token", password=True)
+    print_info("Discord 개발자 포털에서 봇 만들기: https://discord.com/developers/applications")
+    token = prompt("Discord 봇 토큰", password=True)
     if not token:
         return
     save_env_value("DISCORD_BOT_TOKEN", token)
     print_success("Discord token saved")
 
     print()
-    print_info("🔒 Security: Restrict who can use your bot")
-    print_info("   To find your Discord user ID:")
-    print_info("   1. Enable Developer Mode in Discord settings")
-    print_info("   2. Right-click your name → Copy ID")
+    print_info("🔒 보안: 누가 봇을 사용할 수 있는지 제한하세요")
+    print_info("   Discord 사용자 ID 확인 방법:")
+    print_info("   1. Discord 설정에서 개발자 모드 활성화")
+    print_info("   2. 내 이름을 우클릭 → ID 복사")
     print()
     print_info("   You can also use Discord usernames (resolved on gateway start).")
     print()
     allowed_users = prompt(
-        "Allowed user IDs or usernames (comma-separated, leave empty for open access)"
+        "허용할 사용자 ID 또는 사용자명 (쉼표로 구분, 비워두면 누구나 접근 가능)"
     )
     if allowed_users:
         cleaned_ids = _clean_discord_user_ids(allowed_users)
@@ -1697,12 +1696,11 @@ def _setup_discord():
         print_info("⚠️  No allowlist set - anyone in servers with your bot can use it!")
 
     print()
-    print_info("📬 Home Channel: where Hermes delivers cron job results,")
-    print_info("   cross-platform messages, and notifications.")
-    print_info("   To get a channel ID: right-click a channel → Copy Channel ID")
-    print_info("   (requires Developer Mode in Discord settings)")
-    print_info("   You can also set this later by typing /set-home in a Discord channel.")
-    home_channel = prompt("Home channel ID (leave empty to set later with /set-home)")
+    print_info("📬 홈 채널: Hermes가 cron 결과, 플랫폼 간 메시지, 알림을 전달하는 곳입니다.")
+    print_info("   채널 ID 확인: 채널 우클릭 → 채널 ID 복사")
+    print_info("   (Discord 설정에서 개발자 모드가 필요합니다)")
+    print_info("   나중에 Discord 채널에서 /set-home을 입력해 설정할 수도 있습니다.")
+    home_channel = prompt("홈 채널 ID (비워두면 나중에 /set-home으로 설정)")
     if home_channel:
         save_env_value("DISCORD_HOME_CHANNEL", home_channel)
 
@@ -1730,18 +1728,18 @@ def _setup_slack():
         if not prompt_yes_no("Slack을 다시 설정할까요?", False):
             return
 
-    print_info("Steps to create a Slack app:")
-    print_info("   1. Go to https://api.slack.com/apps → Create New App (from scratch)")
-    print_info("   2. Enable Socket Mode: Settings → Socket Mode → Enable")
-    print_info("      • Create an App-Level Token with 'connections:write' scope")
-    print_info("   3. Add Bot Token Scopes: Features → OAuth & Permissions")
-    print_info("      Required scopes: chat:write, app_mentions:read,")
+    print_info("Slack 앱 생성 단계:")
+    print_info("   1. https://api.slack.com/apps 에서 New App 생성 (from scratch)")
+    print_info("   2. Socket Mode 활성화: Settings → Socket Mode → Enable")
+    print_info("      • 'connections:write' scope로 App-Level Token 생성")
+    print_info("   3. Bot Token Scopes 추가: Features → OAuth & Permissions")
+    print_info("      필수 scope: chat:write, app_mentions:read,")
     print_info("      channels:history, channels:read, im:history,")
     print_info("      im:read, im:write, users:read, files:read, files:write")
-    print_info("      Optional for private channels: groups:history")
-    print_info("   4. Subscribe to Events: Features → Event Subscriptions → Enable")
-    print_info("      Required events: message.im, message.channels, app_mention")
-    print_info("      Optional for private channels: message.groups")
+    print_info("      비공개 채널용 선택 scope: groups:history")
+    print_info("   4. 이벤트 구독: Features → Event Subscriptions → Enable")
+    print_info("      필수 이벤트: message.im, message.channels, app_mention")
+    print_info("      비공개 채널용 선택 이벤트: message.groups")
     print_warning("   ⚠ Without message.channels the bot will ONLY work in DMs,")
     print_warning("     not public channels.")
     print_info("   5. Install to Workspace: Settings → Install App")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1098,21 +1098,21 @@ def setup_terminal_backend(config: dict):
     selected_backend = idx_to_backend.get(terminal_idx)
 
     if terminal_idx == keep_current_idx:
-        print_info(f"Keeping current backend: {current_backend}")
+        print_info(f"현재 백엔드 유지: {current_backend}")
         return
 
     config.setdefault("terminal", {})["backend"] = selected_backend
 
     if selected_backend == "local":
-        print_success("Terminal backend: Local")
-        print_info("Commands run directly on this machine.")
+        print_success("터미널 백엔드: Local")
+        print_info("명령어를 현재 머신에서 직접 실행합니다.")
 
         # CWD for messaging
         print()
-        print_info("Working directory for messaging sessions:")
-        print_info("  When using Hermes via Telegram/Discord, this is where")
+        print_info("메시징 세션의 작업 디렉터리:")
+        print_info("  Telegram/Discord에서 Hermes를 사용할 때")
         print_info(
-            "  the agent starts. CLI mode always starts in the current directory."
+            "  에이전트가 여기서 시작합니다. CLI 모드는 항상 현재 디렉터리에서 시작합니다."
         )
         current_cwd = config.get("terminal", {}).get("cwd", "")
         cwd = prompt("  Messaging working directory", current_cwd or str(Path.home()))
@@ -1123,26 +1123,26 @@ def setup_terminal_backend(config: dict):
         print()
         existing_sudo = get_env_value("SUDO_PASSWORD")
         if existing_sudo:
-            print_info("Sudo password: configured")
+            print_info("Sudo 비밀번호: 설정되어 있음")
         else:
             if prompt_yes_no(
-                "Enable sudo support? (stores password for apt install, etc.)", False
+                "sudo 지원을 활성화할까요? (apt install 등에 사용할 비밀번호 저장)", False
             ):
-                sudo_pass = prompt("  Sudo password", password=True)
+                sudo_pass = prompt("  Sudo 비밀번호", password=True)
                 if sudo_pass:
                     save_env_value("SUDO_PASSWORD", sudo_pass)
-                    print_success("Sudo password saved")
+                    print_success("Sudo 비밀번호 저장 완료")
 
     elif selected_backend == "docker":
-        print_success("Terminal backend: Docker")
+        print_success("터미널 백엔드: Docker")
 
         # Check if Docker is available
         docker_bin = shutil.which("docker")
         if not docker_bin:
-            print_warning("Docker not found in PATH!")
-            print_info("Install Docker: https://docs.docker.com/get-docker/")
+            print_warning("PATH에서 Docker를 찾을 수 없습니다!")
+            print_info("Docker 설치: https://docs.docker.com/get-docker/")
         else:
-            print_info(f"Docker found: {docker_bin}")
+            print_info(f"Docker 찾음: {docker_bin}")
 
         # Docker image
         current_image = config.get("terminal", {}).get(
@@ -1155,30 +1155,30 @@ def setup_terminal_backend(config: dict):
         _prompt_container_resources(config)
 
     elif selected_backend == "singularity":
-        print_success("Terminal backend: Singularity/Apptainer")
+        print_success("터미널 백엔드: Singularity/Apptainer")
 
         # Check if singularity/apptainer is available
         sing_bin = shutil.which("apptainer") or shutil.which("singularity")
         if not sing_bin:
-            print_warning("Singularity/Apptainer not found in PATH!")
+            print_warning("PATH에서 Singularity/Apptainer를 찾을 수 없습니다!")
             print_info(
-                "Install: https://apptainer.org/docs/admin/main/installation.html"
+                "설치: https://apptainer.org/docs/admin/main/installation.html"
             )
         else:
-            print_info(f"Found: {sing_bin}")
+            print_info(f"찾음: {sing_bin}")
 
         current_image = config.get("terminal", {}).get(
             "singularity_image", "docker://nikolaik/python-nodejs:python3.11-nodejs20"
         )
-        image = prompt("  Container image", current_image)
+        image = prompt("  컨테이너 이미지", current_image)
         config["terminal"]["singularity_image"] = image
         save_env_value("TERMINAL_SINGULARITY_IMAGE", image)
 
         _prompt_container_resources(config)
 
     elif selected_backend == "modal":
-        print_success("Terminal backend: Modal")
-        print_info("Serverless cloud sandboxes. Each session gets its own container.")
+        print_success("터미널 백엔드: Modal")
+        print_info("서버리스 클라우드 샌드박스입니다. 세션마다 전용 컨테이너가 생성됩니다.")
         from tools.managed_tool_gateway import is_managed_tool_gateway_ready
         from tools.tool_backend_helpers import normalize_modal_mode
 
@@ -1192,8 +1192,8 @@ def setup_terminal_backend(config: dict):
         use_managed_modal = False
         if managed_modal_available:
             modal_choices = [
-                "Use my Nous subscription",
-                "Use my own Modal account",
+                "내 Nous 구독 사용",
+                "내 Modal 계정 사용",
             ]
             if modal_mode == "managed":
                 default_modal_idx = 0
@@ -1210,20 +1210,20 @@ def setup_terminal_backend(config: dict):
 
         if use_managed_modal:
             config["terminal"]["modal_mode"] = "managed"
-            print_info("Modal execution will use the managed Nous gateway and bill to your subscription.")
+            print_info("Modal 실행은 관리형 Nous gateway를 사용하며 비용은 구독에 청구됩니다.")
             if get_env_value("MODAL_TOKEN_ID") or get_env_value("MODAL_TOKEN_SECRET"):
                 print_info(
-                    "Direct Modal credentials are still configured, but this backend is pinned to managed mode."
+                    "직접 Modal 자격 증명도 설정되어 있지만, 이 백엔드는 현재 managed 모드로 고정됩니다."
                 )
         else:
             config["terminal"]["modal_mode"] = "direct"
-            print_info("Requires a Modal account: https://modal.com")
+            print_info("Modal 계정이 필요합니다: https://modal.com")
 
             # Check if modal SDK is installed
             try:
                 __import__("modal")
             except ImportError:
-                print_info("Installing modal SDK...")
+                print_info("modal SDK 설치 중...")
                 import subprocess
 
                 uv_bin = shutil.which("uv")
@@ -1247,18 +1247,18 @@ def setup_terminal_backend(config: dict):
                         text=True,
                     )
                 if result.returncode == 0:
-                    print_success("modal SDK installed")
+                    print_success("modal SDK 설치 완료")
                 else:
-                    print_warning("Install failed — run manually: pip install modal")
+                    print_warning("설치 실패 — 직접 실행하세요: pip install modal")
 
             # Modal token
             print()
-            print_info("Modal authentication:")
-            print_info("  Get your token at: https://modal.com/settings")
+            print_info("Modal 인증:")
+            print_info("  토큰 발급 위치: https://modal.com/settings")
             existing_token = get_env_value("MODAL_TOKEN_ID")
             if existing_token:
-                print_info("  Modal token: already configured")
-                if prompt_yes_no("  Update Modal credentials?", False):
+                print_info("  Modal 토큰: 이미 설정되어 있음")
+                if prompt_yes_no("  Modal 자격 증명을 업데이트할까요?", False):
                     token_id = prompt("    Modal Token ID", password=True)
                     token_secret = prompt("    Modal Token Secret", password=True)
                     if token_id:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2842,12 +2842,12 @@ def run_setup_wizard(args):
     )
     print(
         color(
-            "│  Let's configure your Hermes Agent installation.       │", Colors.MAGENTA
+            "│  Hermes Agent 설치를 함께 설정해볼게요.            │", Colors.MAGENTA
         )
     )
     print(
         color(
-            "│  Press Ctrl+C at any time to exit.                     │", Colors.MAGENTA
+            "│  언제든 Ctrl+C를 눌러 종료할 수 있습니다.         │", Colors.MAGENTA
         )
     )
     print(
@@ -2862,21 +2862,21 @@ def run_setup_wizard(args):
     if is_existing:
         # ── Returning User Menu ──
         print()
-        print_header("Welcome Back!")
-        print_success("You already have Hermes configured.")
+        print_header("다시 오신 것을 환영합니다!")
+        print_success("이미 Hermes가 설정되어 있습니다.")
         print()
 
         menu_choices = [
-            "Quick Setup - configure missing items only",
-            "Full Setup - reconfigure everything",
-            "Model & Provider",
-            "Terminal Backend",
-            "Messaging Platforms (Gateway)",
-            "Tools",
-            "Agent Settings",
-            "Exit",
+            "빠른 설정 - 누락된 항목만 설정",
+            "전체 설정 - 모든 항목 다시 설정",
+            "모델 및 Provider",
+            "터미널 백엔드",
+            "메시징 플랫폼 (Gateway)",
+            "도구",
+            "에이전트 설정",
+            "종료",
         ]
-        choice = prompt_choice("What would you like to do?", menu_choices, 0)
+        choice = prompt_choice("무엇을 하시겠어요?", menu_choices, 0)
 
         if choice == 0:
             # Quick setup
@@ -2886,7 +2886,7 @@ def run_setup_wizard(args):
             # Full setup — fall through to run all sections
             pass
         elif choice == 7:
-            print_info("Exiting. Run 'hermes setup' again when ready.")
+            print_info("종료합니다. 준비되면 다시 'hermes setup'을 실행하세요.")
             return
         elif 2 <= choice <= 6:
             # Individual section — map by key, not by position.

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -176,19 +176,19 @@ def is_interactive_stdin() -> bool:
 def print_noninteractive_setup_guidance(reason: str | None = None) -> None:
     """Print guidance for headless/non-interactive setup flows."""
     print()
-    print(color("⚕ Hermes Setup — Non-interactive mode", Colors.CYAN, Colors.BOLD))
+    print(color("⚕ Hermes 설정 — 비대화형 모드", Colors.CYAN, Colors.BOLD))
     print()
     if reason:
         print_info(reason)
-    print_info("The interactive wizard cannot be used here.")
+    print_info("대화형 마법사는 여기서 사용할 수 없습니다.")
     print()
-    print_info("Configure Hermes using environment variables or config commands:")
+    print_info("환경 변수 또는 config 명령으로 Hermes를 설정하세요:")
     print_info("  hermes config set model.provider custom")
     print_info("  hermes config set model.base_url http://localhost:8080/v1")
     print_info("  hermes config set model.default your-model-name")
     print()
-    print_info("Or set OPENROUTER_API_KEY / OPENAI_API_KEY in your environment.")
-    print_info("Run 'hermes setup' in an interactive terminal to use the full wizard.")
+    print_info("또는 환경 변수에 OPENROUTER_API_KEY / OPENAI_API_KEY를 설정하세요.")
+    print_info("전체 마법사를 사용하려면 대화형 터미널에서 'hermes setup'을 실행하세요.")
     print()
 
 
@@ -243,21 +243,21 @@ def prompt_choice(question: str, choices: list, default: int = 0) -> int:
         else:
             print(f"  {marker} {choice}")
 
-    print_info(f"  Enter for default ({default + 1})  Ctrl+C to exit")
+    print_info(f"  기본값은 Enter ({default + 1})  종료는 Ctrl+C")
 
     while True:
         try:
             value = input(
-                color(f"  Select [1-{len(choices)}] ({default + 1}): ", Colors.DIM)
+                color(f"  선택 [1-{len(choices)}] ({default + 1}): ", Colors.DIM)
             )
             if not value:
                 return default
             idx = int(value) - 1
             if 0 <= idx < len(choices):
                 return idx
-            print_error(f"Please enter a number between 1 and {len(choices)}")
+            print_error(f"1부터 {len(choices)} 사이의 숫자를 입력하세요")
         except ValueError:
-            print_error("Please enter a number")
+            print_error("숫자를 입력하세요")
         except (KeyboardInterrupt, EOFError):
             print()
             sys.exit(1)
@@ -284,7 +284,7 @@ def prompt_yes_no(question: str, default: bool = True) -> bool:
             return True
         if value in ("n", "no"):
             return False
-        print_error("Please enter 'y' or 'n'")
+        print_error("'y' 또는 'n'을 입력하세요")
 
 
 def prompt_checklist(title: str, items: list, pre_selected: list = None) -> list:
@@ -636,8 +636,8 @@ def setup_model_provider(config: dict, *, quick: bool = False):
     """
     from hermes_cli.config import load_config, save_config
 
-    print_header("Inference Provider")
-    print_info("Choose how to connect to your main chat model.")
+    print_header("모델 및 Provider")
+    print_info("주요 채팅 모델에 연결하는 방법을 선택하세요.")
     print_info(f"   Guide: {_DOCS_BASE}/integrations/providers")
     print()
 
@@ -1059,9 +1059,9 @@ def setup_terminal_backend(config: dict):
     import platform as _platform
     import shutil
 
-    print_header("Terminal Backend")
-    print_info("Choose where Hermes runs shell commands and code.")
-    print_info("This affects tool execution, file access, and isolation.")
+    print_header("터미널 백엔드")
+    print_info("Hermes가 셸 명령과 코드를 어디서 실행할지 선택하세요.")
+    print_info("이 설정은 도구 실행, 파일 접근, 격리에 영향을 줍니다.")
     print_info(f"   Guide: {_DOCS_BASE}/developer-guide/environments")
     print()
 
@@ -1425,7 +1425,7 @@ def _apply_default_agent_settings(config: dict):
 def setup_agent_settings(config: dict):
     """Configure agent behavior: iterations, progress display, compression, session reset."""
 
-    print_header("Agent Settings")
+    print_header("에이전트 설정")
     print_info(f"   Guide: {_DOCS_BASE}/user-guide/configuration")
     print()
 
@@ -3042,7 +3042,7 @@ def _run_quick_setup(config: dict, hermes_home):
     )
 
     print()
-    print_header("Quick Setup — Missing Items Only")
+    print_header("빠른 설정 — 누락된 항목만")
 
     # Check what's missing
     missing_required = [

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -362,77 +362,77 @@ def _print_setup_summary(config: dict, hermes_home):
         _vision_backends = []
 
     if _vision_backends:
-        tool_status.append(("Vision (image analysis)", True, None))
+        tool_status.append(("비전 (이미지 분석)", True, None))
     else:
-        tool_status.append(("Vision (image analysis)", False, "run 'hermes setup' to configure"))
+        tool_status.append(("비전 (이미지 분석)", False, "'hermes setup'을 실행해 설정"))
 
     # Mixture of Agents — requires OpenRouter specifically (calls multiple models)
     if get_env_value("OPENROUTER_API_KEY"):
-        tool_status.append(("Mixture of Agents", True, None))
+        tool_status.append(("에이전트 혼합", True, None))
     else:
-        tool_status.append(("Mixture of Agents", False, "OPENROUTER_API_KEY"))
+        tool_status.append(("에이전트 혼합", False, "OPENROUTER_API_KEY"))
 
     # Web tools (Exa, Parallel, Firecrawl, or Tavily)
     if subscription_features.web.managed_by_nous:
-        tool_status.append(("Web Search & Extract (Nous subscription)", True, None))
+        tool_status.append(("웹 검색 및 추출 (Nous 구독)", True, None))
     elif subscription_features.web.available:
-        label = "Web Search & Extract"
+        label = "웹 검색 및 추출"
         if subscription_features.web.current_provider:
-            label = f"Web Search & Extract ({subscription_features.web.current_provider})"
+            label = f"웹 검색 및 추출 ({subscription_features.web.current_provider})"
         tool_status.append((label, True, None))
     else:
-        tool_status.append(("Web Search & Extract", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL, or TAVILY_API_KEY"))
+        tool_status.append(("웹 검색 및 추출", False, "EXA_API_KEY, PARALLEL_API_KEY, FIRECRAWL_API_KEY/FIRECRAWL_API_URL 또는 TAVILY_API_KEY"))
 
     # Browser tools (local Chromium, Camofox, Browserbase, Browser Use, or Firecrawl)
     browser_provider = subscription_features.browser.current_provider
     if subscription_features.browser.managed_by_nous:
-        tool_status.append(("Browser Automation (Nous Browser Use)", True, None))
+        tool_status.append(("브라우저 자동화 (Nous Browser Use)", True, None))
     elif subscription_features.browser.available:
-        label = "Browser Automation"
+        label = "브라우저 자동화"
         if browser_provider:
-            label = f"Browser Automation ({browser_provider})"
+            label = f"브라우저 자동화 ({browser_provider})"
         tool_status.append((label, True, None))
     else:
-        missing_browser_hint = "npm install -g agent-browser, set CAMOFOX_URL, or configure Browser Use or Browserbase"
+        missing_browser_hint = "npm install -g agent-browser 실행 후 CAMOFOX_URL을 설정하거나 Browser Use/Browserbase를 구성하세요"
         if browser_provider == "Browserbase":
             missing_browser_hint = (
-                "npm install -g agent-browser and set "
-                "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID"
+                "npm install -g agent-browser 실행 후 "
+                "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID를 설정하세요"
             )
         elif browser_provider == "Browser Use":
             missing_browser_hint = (
-                "npm install -g agent-browser and set BROWSER_USE_API_KEY"
+                "npm install -g agent-browser 실행 후 BROWSER_USE_API_KEY를 설정하세요"
             )
         elif browser_provider == "Camofox":
             missing_browser_hint = "CAMOFOX_URL"
         elif browser_provider == "Local browser":
             missing_browser_hint = "npm install -g agent-browser"
         tool_status.append(
-            ("Browser Automation", False, missing_browser_hint)
+            ("브라우저 자동화", False, missing_browser_hint)
         )
 
     # FAL (image generation)
     if subscription_features.image_gen.managed_by_nous:
-        tool_status.append(("Image Generation (Nous subscription)", True, None))
+        tool_status.append(("이미지 생성 (Nous 구독)", True, None))
     elif subscription_features.image_gen.available:
-        tool_status.append(("Image Generation", True, None))
+        tool_status.append(("이미지 생성", True, None))
     else:
-        tool_status.append(("Image Generation", False, "FAL_KEY"))
+        tool_status.append(("이미지 생성", False, "FAL_KEY"))
 
     # TTS — show configured provider
     tts_provider = config.get("tts", {}).get("provider", "edge")
     if subscription_features.tts.managed_by_nous:
-        tool_status.append(("Text-to-Speech (OpenAI via Nous subscription)", True, None))
+        tool_status.append(("텍스트 음성 변환 (Nous 구독의 OpenAI)", True, None))
     elif tts_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
-        tool_status.append(("Text-to-Speech (ElevenLabs)", True, None))
+        tool_status.append(("텍스트 음성 변환 (ElevenLabs)", True, None))
     elif tts_provider == "openai" and (
         get_env_value("VOICE_TOOLS_OPENAI_KEY") or get_env_value("OPENAI_API_KEY")
     ):
-        tool_status.append(("Text-to-Speech (OpenAI)", True, None))
+        tool_status.append(("텍스트 음성 변환 (OpenAI)", True, None))
     elif tts_provider == "minimax" and get_env_value("MINIMAX_API_KEY"):
-        tool_status.append(("Text-to-Speech (MiniMax)", True, None))
+        tool_status.append(("텍스트 음성 변환 (MiniMax)", True, None))
     elif tts_provider == "mistral" and get_env_value("MISTRAL_API_KEY"):
-        tool_status.append(("Text-to-Speech (Mistral Voxtral)", True, None))
+        tool_status.append(("텍스트 음성 변환 (Mistral Voxtral)", True, None))
     elif tts_provider == "neutts":
         try:
             import importlib.util
@@ -440,48 +440,48 @@ def _print_setup_summary(config: dict, hermes_home):
         except Exception:
             neutts_ok = False
         if neutts_ok:
-            tool_status.append(("Text-to-Speech (NeuTTS local)", True, None))
+            tool_status.append(("텍스트 음성 변환 (NeuTTS 로컬)", True, None))
         else:
-            tool_status.append(("Text-to-Speech (NeuTTS — not installed)", False, "run 'hermes setup tts'"))
+            tool_status.append(("텍스트 음성 변환 (NeuTTS — 설치되지 않음)", False, "'hermes setup tts' 실행"))
     else:
-        tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
+        tool_status.append(("텍스트 음성 변환 (Edge TTS)", True, None))
 
     if subscription_features.modal.managed_by_nous:
-        tool_status.append(("Modal Execution (Nous subscription)", True, None))
+        tool_status.append(("Modal 실행 (Nous 구독)", True, None))
     elif config.get("terminal", {}).get("backend") == "modal":
         if subscription_features.modal.direct_override:
-            tool_status.append(("Modal Execution (direct Modal)", True, None))
+            tool_status.append(("Modal 실행 (직접 Modal)", True, None))
         else:
-            tool_status.append(("Modal Execution", False, "run 'hermes setup terminal'"))
+            tool_status.append(("Modal 실행", False, "'hermes setup terminal' 실행"))
     elif managed_nous_tools_enabled() and subscription_features.nous_auth_present:
-        tool_status.append(("Modal Execution (optional via Nous subscription)", True, None))
+        tool_status.append(("Modal 실행 (Nous 구독으로 선택 사용 가능)", True, None))
 
     # Tinker + WandB (RL training)
     if get_env_value("TINKER_API_KEY") and get_env_value("WANDB_API_KEY"):
-        tool_status.append(("RL Training (Tinker)", True, None))
+        tool_status.append(("RL 학습 (Tinker)", True, None))
     elif get_env_value("TINKER_API_KEY"):
-        tool_status.append(("RL Training (Tinker)", False, "WANDB_API_KEY"))
+        tool_status.append(("RL 학습 (Tinker)", False, "WANDB_API_KEY"))
     else:
-        tool_status.append(("RL Training (Tinker)", False, "TINKER_API_KEY"))
+        tool_status.append(("RL 학습 (Tinker)", False, "TINKER_API_KEY"))
 
     # Home Assistant
     if get_env_value("HASS_TOKEN"):
-        tool_status.append(("Smart Home (Home Assistant)", True, None))
+        tool_status.append(("스마트 홈 (Home Assistant)", True, None))
 
     # Skills Hub
     if get_env_value("GITHUB_TOKEN"):
-        tool_status.append(("Skills Hub (GitHub)", True, None))
+        tool_status.append(("스킬 허브 (GitHub)", True, None))
     else:
-        tool_status.append(("Skills Hub (GitHub)", False, "GITHUB_TOKEN"))
+        tool_status.append(("스킬 허브 (GitHub)", False, "GITHUB_TOKEN"))
 
     # Terminal (always available if system deps met)
-    tool_status.append(("Terminal/Commands", True, None))
+    tool_status.append(("터미널/명령어", True, None))
 
     # Task planning (always available, in-memory)
-    tool_status.append(("Task Planning (todo)", True, None))
+    tool_status.append(("작업 계획(todo)", True, None))
 
     # Skills (always available -- bundled skills + user-created skills)
-    tool_status.append(("Skills (view, create, edit)", True, None))
+    tool_status.append(("스킬 (보기, 생성, 편집)", True, None))
 
     # Print status
     available_count = sum(1 for _, avail, _ in tool_status if avail)
@@ -495,7 +495,7 @@ def _print_setup_summary(config: dict, hermes_home):
             print(f"   {color('✓', Colors.GREEN)} {name}")
         else:
             print(
-                f"   {color('✗', Colors.RED)} {name} {color(f'(missing {missing_var})', Colors.DIM)}"
+                f"   {color('✗', Colors.RED)} {name} {color(f'(누락 - {missing_var})', Colors.DIM)}"
             )
 
     print()
@@ -518,7 +518,7 @@ def _print_setup_summary(config: dict, hermes_home):
     )
     print(
         color(
-            "│              ✓ Setup Complete!                          │", Colors.GREEN
+            "│            ✓ 설정이 완료되었습니다!                   │", Colors.GREEN
         )
     )
     print(
@@ -530,46 +530,46 @@ def _print_setup_summary(config: dict, hermes_home):
 
     # Show file locations prominently
     from hermes_constants import display_hermes_home as _dhh
-    print(color(f"📁 All your files are in {_dhh()}/:", Colors.CYAN, Colors.BOLD))
+    print(color(f"📁 모든 파일은 {_dhh()}/ 아래에 있습니다:", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('Settings:', Colors.YELLOW)}  {get_config_path()}")
-    print(f"   {color('API Keys:', Colors.YELLOW)}  {get_env_path()}")
+    print(f"   {color('설정:', Colors.YELLOW)}     {get_config_path()}")
+    print(f"   {color('API 키:', Colors.YELLOW)}   {get_env_path()}")
     print(
-        f"   {color('Data:', Colors.YELLOW)}      {hermes_home}/cron/, sessions/, logs/"
+        f"   {color('데이터:', Colors.YELLOW)}   {hermes_home}/cron/, sessions/, logs/"
     )
     print()
 
     print(color("─" * 60, Colors.DIM))
     print()
-    print(color("📝 To edit your configuration:", Colors.CYAN, Colors.BOLD))
+    print(color("📝 설정을 수정하려면:", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('hermes setup', Colors.GREEN)}          Re-run the full wizard")
-    print(f"   {color('hermes setup model', Colors.GREEN)}    Change model/provider")
-    print(f"   {color('hermes setup terminal', Colors.GREEN)} Change terminal backend")
-    print(f"   {color('hermes setup gateway', Colors.GREEN)}  Configure messaging")
-    print(f"   {color('hermes setup tools', Colors.GREEN)}    Configure tool providers")
+    print(f"   {color('hermes setup', Colors.GREEN)}             전체 마법사 다시 실행")
+    print(f"   {color('hermes setup model', Colors.GREEN)}       모델/provider 변경")
+    print(f"   {color('hermes setup terminal', Colors.GREEN)}    터미널 백엔드 변경")
+    print(f"   {color('hermes setup gateway', Colors.GREEN)}     메시징 설정")
+    print(f"   {color('hermes setup tools', Colors.GREEN)}       도구 provider 설정")
     print()
-    print(f"   {color('hermes config', Colors.GREEN)}         View current settings")
+
+    print(f"   {color('hermes config', Colors.GREEN)}            현재 설정 보기")
     print(
-        f"   {color('hermes config edit', Colors.GREEN)}    Open config in your editor"
+        f"   {color('hermes config edit', Colors.GREEN)}       편집기에서 config 열기"
     )
     print(f"   {color('hermes config set <key> <value>', Colors.GREEN)}")
-    print("                          Set a specific value")
+    print("                           특정 값을 직접 설정")
     print()
-    print("   Or edit the files directly:")
+    print("   또는 파일을 직접 수정하세요:")
     print(f"   {color(f'nano {get_config_path()}', Colors.DIM)}")
     print(f"   {color(f'nano {get_env_path()}', Colors.DIM)}")
     print()
 
     print(color("─" * 60, Colors.DIM))
     print()
-    print(color("🚀 Ready to go!", Colors.CYAN, Colors.BOLD))
+    print(color("🚀 이제 사용할 준비가 되었습니다!", Colors.CYAN, Colors.BOLD))
     print()
-    print(f"   {color('hermes', Colors.GREEN)}              Start chatting")
-    print(f"   {color('hermes gateway', Colors.GREEN)}      Start messaging gateway")
-    print(f"   {color('hermes doctor', Colors.GREEN)}       Check for issues")
+    print(f"   {color('hermes', Colors.GREEN)}              대화 시작")
+    print(f"   {color('hermes gateway', Colors.GREEN)}      메시징 gateway 시작")
+    print(f"   {color('hermes doctor', Colors.GREEN)}       문제 점검")
     print()
-
 
 def _prompt_container_resources(config: dict):
     """Prompt for container resource settings (Docker, Singularity, Modal, Daytona)."""

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -759,7 +759,7 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
     name = fm.get("name", path.name)
     description = fm.get("description", "")
     if not description:
-        c.print("[bold red]Error:[/] SKILL.md must have a 'description' in frontmatter.\n")
+        c.print("[bold red]오류:[/] SKILL.md frontmatter에는 'description'이 꼭 있어야 해요.\n")
         return
 
     # Self-scan before publishing
@@ -772,14 +772,14 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
 
     if target == "github":
         if not repo:
-            c.print("[bold red]Error:[/] --repo required for GitHub publish.\n"
-                    "Usage: hermes skills publish <path> --to github --repo owner/repo\n")
+            c.print("[bold red]오류:[/] GitHub 게시에는 --repo가 필요해요.\n"
+                    "사용법: hermes skills publish <path> --to github --repo owner/repo\n")
             return
 
         auth = GitHubAuth()
         if not auth.is_authenticated():
-            c.print("[bold red]Error:[/] GitHub authentication required.\n"
-                    f"Set GITHUB_TOKEN in {display_hermes_home()}/.env or run 'gh auth login'.\n")
+            c.print("[bold red]오류:[/] GitHub 인증이 필요해요.\n"
+                    f"{display_hermes_home()}/.env 에 GITHUB_TOKEN을 설정하거나 'gh auth login'을 실행하세요.\n")
             return
 
         c.print(f"[bold]Publishing '{name}' to {repo}...[/]")
@@ -787,13 +787,13 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
         if success:
             c.print(f"[bold green]{msg}[/]\n")
         else:
-            c.print(f"[bold red]Error:[/] {msg}\n")
+            c.print(f"[bold red]오류:[/] {msg}\n")
 
     elif target == "clawhub":
-        c.print("[yellow]ClawHub publishing is not yet supported. "
-                "Submit manually at https://clawhub.ai/submit[/]\n")
+        c.print("[yellow]ClawHub 게시 기능은 아직 지원하지 않아요. "
+                "https://clawhub.ai/submit 에서 수동으로 제출해 주세요.[/]\n")
     else:
-        c.print(f"[bold red]Unknown target:[/] {target}. Use 'github' or 'clawhub'.\n")
+        c.print(f"[bold red]알 수 없는 대상:[/] {target}. 'github' 또는 'clawhub'를 사용하세요.\n")
 
 
 def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
@@ -941,13 +941,13 @@ def do_snapshot_import(input_path: str, force: bool = False,
     c = console or _console
     inp = Path(input_path)
     if not inp.exists():
-        c.print(f"[bold red]Error:[/] File not found: {inp}\n")
+        c.print(f"[bold red]오류:[/] 파일을 찾지 못했어요: {inp}\n")
         return
 
     try:
         snapshot = json.loads(inp.read_text())
     except json.JSONDecodeError:
-        c.print(f"[bold red]Error:[/] Invalid JSON in {inp}\n")
+        c.print(f"[bold red]오류:[/] {inp} 안의 JSON 형식이 올바르지 않아요\n")
         return
 
     # Restore taps first
@@ -963,7 +963,7 @@ def do_snapshot_import(input_path: str, force: bool = False,
     # Install skills
     skills = snapshot.get("skills", [])
     if not skills:
-        c.print("[dim]No skills in snapshot to install.[/]\n")
+        c.print("[dim]snapshot에 설치할 skill이 없어요.[/]\n")
         return
 
     c.print(f"[bold]Importing {len(skills)} skill(s) from snapshot...[/]\n")
@@ -1020,17 +1020,17 @@ def skills_command(args) -> None:
         elif snap_action == "import":
             do_snapshot_import(args.input, force=getattr(args, "force", False))
         else:
-            _console.print("Usage: hermes skills snapshot [export|import]\n")
+            _console.print("사용법: hermes skills snapshot [export|import]\n")
     elif action == "tap":
         tap_action = getattr(args, "tap_action", None)
         repo = getattr(args, "repo", "") or getattr(args, "name", "")
         if not tap_action:
-            _console.print("Usage: hermes skills tap [list|add|remove]\n")
+            _console.print("사용법: hermes skills tap [list|add|remove]\n")
             return
         do_tap(tap_action, repo=repo)
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|publish|snapshot|tap]\n")
-        _console.print("Run 'hermes skills <command> --help' for details.\n")
+        _console.print("사용법: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|publish|snapshot|tap]\n")
+        _console.print("자세한 내용은 'hermes skills <command> --help'를 실행하세요.\n")
 
 
 # ---------------------------------------------------------------------------
@@ -1098,7 +1098,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "search":
         if not args:
-            c.print("[bold red]Usage:[/] /skills search <query> [--source skills-sh|well-known|github|official] [--limit N]\n")
+            c.print("[bold red]사용법:[/] /skills search <query> [--source skills-sh|well-known|github|official] [--limit N]\n")
             return
         source = "all"
         limit = 10
@@ -1121,7 +1121,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "install":
         if not args:
-            c.print("[bold red]Usage:[/] /skills install <identifier> [--category <cat>] [--force] [--now]\n")
+            c.print("[bold red]사용법:[/] /skills install <identifier> [--category <cat>] [--force] [--now]\n")
             return
         identifier = args[0]
         category = ""
@@ -1141,7 +1141,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "inspect":
         if not args:
-            c.print("[bold red]Usage:[/] /skills inspect <identifier>\n")
+            c.print("[bold red]사용법:[/] /skills inspect <identifier>\n")
             return
         do_inspect(args[0], console=c)
 
@@ -1167,7 +1167,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "uninstall":
         if not args:
-            c.print("[bold red]Usage:[/] /skills uninstall <name> [--now]\n")
+            c.print("[bold red]사용법:[/] /skills uninstall <name> [--now]\n")
             return
         # Slash commands run inside prompt_toolkit where input() hangs.
         skip_confirm = True
@@ -1177,7 +1177,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "publish":
         if not args:
-            c.print("[bold red]Usage:[/] /skills publish <skill-path> [--to github] [--repo owner/repo]\n")
+            c.print("[bold red]사용법:[/] /skills publish <skill-path> [--to github] [--repo owner/repo]\n")
             return
         skill_path = args[0]
         target = "github"
@@ -1191,7 +1191,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
 
     elif action == "snapshot":
         if not args:
-            c.print("[bold red]Usage:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
+            c.print("[bold red]사용법:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
             return
         snap_action = args[0]
         if snap_action == "export" and len(args) > 1:
@@ -1200,7 +1200,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
             force = "--force" in args
             do_snapshot_import(args[1], force=force, console=c)
         else:
-            c.print("[bold red]Usage:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
+            c.print("[bold red]사용법:[/] /skills snapshot export <file> | /skills snapshot import <file>\n")
 
     elif action == "tap":
         if not args:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -580,20 +580,20 @@ def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> N
     c = console or _console
     results = check_for_skill_updates(name=name)
     if not results:
-        c.print("[dim]No hub-installed skills to check.[/]\n")
+        c.print("[dim]업데이트를 확인할 허브 설치 skill이 없어요.[/]\n")
         return
 
-    table = Table(title="Skill Updates")
-    table.add_column("Name", style="bold cyan")
-    table.add_column("Source", style="dim")
-    table.add_column("Status", style="dim")
+    table = Table(title="skill 업데이트")
+    table.add_column("이름", style="bold cyan")
+    table.add_column("출처", style="dim")
+    table.add_column("상태", style="dim")
 
     for entry in results:
         table.add_row(entry.get("name", ""), entry.get("source", ""), entry.get("status", ""))
 
     c.print(table)
     update_count = sum(1 for entry in results if entry.get("status") == "update_available")
-    c.print(f"[dim]{update_count} update(s) available across {len(results)} checked skill(s)[/]\n")
+    c.print(f"[dim]확인한 skill {len(results)}개 중 업데이트 가능 {update_count}개[/]\n")
 
 
 def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> None:
@@ -604,16 +604,16 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     lock = HubLockFile()
     updates = [entry for entry in check_for_skill_updates(name=name) if entry.get("status") == "update_available"]
     if not updates:
-        c.print("[dim]No updates available.[/]\n")
+        c.print("[dim]사용 가능한 업데이트가 없어요.[/]\n")
         return
 
     for entry in updates:
         installed = lock.get_installed(entry["name"])
         category = _derive_category_from_install_path(installed.get("install_path", "")) if installed else ""
-        c.print(f"[bold]Updating:[/] {entry['name']}")
+        c.print(f"[bold]업데이트 중:[/] {entry['name']}")
         do_install(entry["identifier"], category=category, force=True, console=c)
 
-    c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
+    c.print(f"[bold green]skill {len(updates)}개를 업데이트했어요.[/]\n")
 
 
 def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> None:
@@ -659,13 +659,13 @@ def do_uninstall(name: str, console: Optional[Console] = None,
 
     # skip_confirm bypasses the prompt (needed in TUI mode where input() hangs)
     if not skip_confirm:
-        c.print(f"\n[bold]Uninstall '{name}'?[/]")
+        c.print(f"\n[bold]'{name}'을(를) 제거할까요?[/]")
         try:
             answer = input("Confirm [y/N]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             answer = "n"
         if answer not in ("y", "yes"):
-            c.print("[dim]Cancelled.[/]\n")
+            c.print("[dim]취소했어요.[/]\n")
             return
 
     success, msg = uninstall_skill(name)
@@ -678,8 +678,8 @@ def do_uninstall(name: str, console: Optional[Console] = None,
             except Exception:
                 pass
         else:
-            c.print("[dim]Change will take effect in your next session.[/]")
-            c.print("[dim]Use /reset to start a new session now, or --now to apply immediately (invalidates prompt cache).[/]\n")
+            c.print("[dim]변경 사항은 다음 세션부터 적용돼요.[/]")
+            c.print("[dim]지금 새 세션을 시작하려면 /reset, 바로 적용하려면 --now를 사용하세요 (prompt cache 무효화).[/]\n")
     else:
         c.print(f"[bold red]Error:[/] {msg}\n")
 
@@ -694,11 +694,11 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
     if action == "list":
         taps = mgr.list_taps()
         if not taps:
-            c.print("[dim]No custom taps configured. Using default sources only.[/]\n")
+            c.print("[dim]설정된 사용자 지정 tap이 없어요. 기본 source만 사용해요.[/]\n")
             return
-        table = Table(title="Configured Taps")
-        table.add_column("Repo", style="bold cyan")
-        table.add_column("Path", style="dim")
+        table = Table(title="설정된 tap")
+        table.add_column("저장소", style="bold cyan")
+        table.add_column("경로", style="dim")
         for t in taps:
             label = t.get("repo") or t.get("name") or t.get("path", "unknown")
             table.add_row(label, t.get("path", "skills/"))
@@ -707,24 +707,24 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
 
     elif action == "add":
         if not repo:
-            c.print("[bold red]Error:[/] Repo required. Usage: hermes skills tap add owner/repo\n")
+            c.print("[bold red]오류:[/] 저장소가 필요해요. 사용법: hermes skills tap add owner/repo\n")
             return
         if mgr.add(repo):
-            c.print(f"[bold green]Added tap:[/] {repo}\n")
+            c.print(f"[bold green]tap을 추가했어요:[/] {repo}\n")
         else:
-            c.print(f"[yellow]Tap already exists:[/] {repo}\n")
+            c.print(f"[yellow]이미 있는 tap이에요:[/] {repo}\n")
 
     elif action == "remove":
         if not repo:
-            c.print("[bold red]Error:[/] Repo required. Usage: hermes skills tap remove owner/repo\n")
+            c.print("[bold red]오류:[/] 저장소가 필요해요. 사용법: hermes skills tap remove owner/repo\n")
             return
         if mgr.remove(repo):
-            c.print(f"[bold green]Removed tap:[/] {repo}\n")
+            c.print(f"[bold green]tap을 제거했어요:[/] {repo}\n")
         else:
-            c.print(f"[bold red]Error:[/] Tap not found: {repo}\n")
+            c.print(f"[bold red]오류:[/] tap을 찾지 못했어요: {repo}\n")
 
     else:
-        c.print(f"[bold red]Unknown tap action:[/] {action}. Use: list, add, remove\n")
+        c.print(f"[bold red]알 수 없는 tap 작업:[/] {action}. 사용 가능: list, add, remove\n")
 
 
 def do_publish(skill_path: str, target: str = "github", repo: str = "",

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -62,18 +62,18 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
             trust_label = "official" if r.source == "official" else r.trust_level
             table.add_row(r.source, f"[{trust_style}]{trust_label}[/]", r.identifier)
         c.print(table)
-        c.print("[bold]Use the full identifier to install a specific one.[/]\n")
+        c.print("[bold]특정 skill을 설치하려면 전체 identifier를 사용하세요.[/]\n")
         return ""
 
     # No exact match — check if there are partial matches to suggest
     if results:
-        c.print(f"[yellow]No exact match for '{name}'. Did you mean one of these?[/]")
+        c.print(f"[yellow]'{name}'과(와) 정확히 일치하는 항목이 없어요. 아래 skill 중 하나를 찾으셨나요?[/]")
         for r in results[:5]:
             c.print(f"  [cyan]{r.name}[/] — {r.identifier}")
         c.print()
         return ""
 
-    c.print(f"[bold red]Error:[/] No skill named '{name}' found in any source.\n")
+    c.print(f"[bold red]오류:[/] 어떤 source에서도 '{name}' skill을 찾지 못했어요.\n")
     return ""
 
 
@@ -147,18 +147,18 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     from tools.skills_hub import GitHubAuth, create_source_router, unified_search
 
     c = console or _console
-    c.print(f"\n[bold]Searching for:[/] {query}")
+    c.print(f"\n[bold]검색어:[/] {query}")
 
     auth = GitHubAuth()
     sources = create_source_router(auth)
-    with c.status("[bold]Searching registries..."):
+    with c.status("[bold]레지스트리를 검색하는 중...[/]"):
         results = unified_search(query, sources, source_filter=source, limit=limit)
 
     if not results:
-        c.print("[dim]No skills found matching your query.[/]\n")
+        c.print("[dim]검색어와 일치하는 skill을 찾지 못했어요.[/]\n")
         return
 
-    table = Table(title=f"Skills Hub — {len(results)} result(s)")
+    table = Table(title=f"스킬 허브 — 검색 결과 {len(results)}개")
     table.add_column("Name", style="bold cyan")
     table.add_column("Description", max_width=60)
     table.add_column("Source", style="dim")
@@ -177,8 +177,8 @@ def do_search(query: str, source: str = "all", limit: int = 10,
         )
 
     c.print(table)
-    c.print("[dim]Use: hermes skills inspect <identifier> to preview, "
-            "hermes skills install <identifier> to install[/]\n")
+    c.print("[dim]미리보기: hermes skills inspect <identifier>, "
+            "설치: hermes skills install <identifier>[/]\n")
 
 
 def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
@@ -218,7 +218,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
         )
 
     if not all_results:
-        c.print("[dim]No skills found in the Skills Hub.[/]\n")
+        c.print("[dim]스킬 허브에서 skill을 찾지 못했어요.[/]\n")
         return
 
     # Deduplicate by name, preferring higher trust
@@ -251,7 +251,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
     source_label = f"— {source}" if source != "all" else "— all sources"
     loaded_label = f"{total} skills loaded"
     if timed_out:
-        loaded_label += f", {len(timed_out)} source(s) still loading"
+        loaded_label += f", 아직 불러오는 중인 source {len(timed_out)}개"
     c.print(f"\n[bold]Skills Hub — Browse {source_label}[/]"
             f"  [dim]({loaded_label}, page {page}/{total_pages})[/]")
     if official_count > 0 and page == 1:
@@ -341,7 +341,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             or getattr(getattr(src, "github", None), "is_rate_limited", False)
             for src in sources
         )
-        c.print(f"[bold red]Error:[/] Could not fetch '{identifier}' from any source.")
+        c.print(f"[bold red]오류:[/] 어떤 source에서도 '{identifier}'을(를) 가져오지 못했어요.")
         if rate_limited:
             c.print(
                 "[yellow]Hint:[/] GitHub API rate limit exhausted "
@@ -364,9 +364,9 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     lock = HubLockFile()
     existing = lock.get_installed(bundle.name)
     if existing:
-        c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
+        c.print(f"[yellow]경고:[/] '{bundle.name}'은(는) 이미 {existing['install_path']}에 설치되어 있어요")
         if not force:
-            c.print("Use --force to reinstall.\n")
+            c.print("다시 설치하려면 --force를 사용하세요.\n")
             return
 
     extra_metadata = dict(getattr(meta, "extra", {}) or {})
@@ -376,7 +376,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     try:
         q_path = quarantine_bundle(bundle)
     except ValueError as exc:
-        c.print(f"[bold red]Installation blocked:[/] {exc}\n")
+        c.print(f"[bold red]설치를 차단했어요:[/] {exc}\n")
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
@@ -392,7 +392,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     # Check install policy
     allowed, reason = should_allow_install(result, force=force)
     if not allowed:
-        c.print(f"\n[bold red]Installation blocked:[/] {reason}")
+        c.print(f"\n[bold red]설치를 차단했어요:[/] {reason}")
         # Clean up quarantine
         shutil.rmtree(q_path, ignore_errors=True)
         from tools.skills_hub import append_audit_log
@@ -429,13 +429,13 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                 title="Disclaimer",
                 border_style="yellow",
             ))
-        c.print(f"[bold]Install '{bundle.name}'?[/]")
+        c.print(f"[bold]'{bundle.name}'을(를) 설치할까요?[/]")
         try:
-            answer = input("Confirm [y/N]: ").strip().lower()
+            answer = input("확인 [y/N]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             answer = "n"
         if answer not in ("y", "yes"):
-            c.print("[dim]Installation cancelled.[/]\n")
+            c.print("[dim]설치를 취소했어요.[/]\n")
             shutil.rmtree(q_path, ignore_errors=True)
             return
 
@@ -443,15 +443,15 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     try:
         install_dir = install_from_quarantine(q_path, bundle.name, category, bundle, result)
     except ValueError as exc:
-        c.print(f"[bold red]Installation blocked:[/] {exc}\n")
+        c.print(f"[bold red]설치를 차단했어요:[/] {exc}\n")
         shutil.rmtree(q_path, ignore_errors=True)
         from tools.skills_hub import append_audit_log
         append_audit_log("BLOCKED", bundle.name, bundle.source,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
-    c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
+    c.print(f"[bold green]설치했어요:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    c.print(f"[dim]파일: {', '.join(bundle.files.keys())}[/]\n")
 
     if invalidate_cache:
         # Invalidate the skills prompt cache so the new skill appears immediately
@@ -481,7 +481,7 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
     meta, bundle, _matched_source = _resolve_source_meta_and_bundle(identifier, sources)
 
     if not meta:
-        c.print(f"[bold red]Error:[/] Could not find '{identifier}' in any source.\n")
+        c.print(f"[bold red]오류:[/] 어떤 source에서도 '{identifier}'을(를) 찾지 못했어요.\n")
         return
 
     c.print()
@@ -626,22 +626,22 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> N
     installed = lock.list_installed()
 
     if not installed:
-        c.print("[dim]No hub-installed skills to audit.[/]\n")
+        c.print("[dim]감사할 허브 설치 skill이 없어요.[/]\n")
         return
 
     targets = installed
     if name:
         targets = [e for e in installed if e["name"] == name]
         if not targets:
-            c.print(f"[bold red]Error:[/] '{name}' is not a hub-installed skill.\n")
+            c.print(f"[bold red]오류:[/] '{name}'은(는) 허브로 설치한 skill이 아니에요.\n")
             return
 
-    c.print(f"\n[bold]Auditing {len(targets)} skill(s)...[/]\n")
+    c.print(f"\n[bold]skill {len(targets)}개를 감사하는 중...[/]\n")
 
     for entry in targets:
         skill_path = SKILLS_DIR / entry["install_path"]
         if not skill_path.exists():
-            c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
+            c.print(f"[yellow]경고:[/] {entry['name']} — 경로가 없어요: {entry['install_path']}")
             continue
 
         result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
@@ -661,7 +661,7 @@ def do_uninstall(name: str, console: Optional[Console] = None,
     if not skip_confirm:
         c.print(f"\n[bold]'{name}'을(를) 제거할까요?[/]")
         try:
-            answer = input("Confirm [y/N]: ").strip().lower()
+            answer = input("확인 [y/N]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             answer = "n"
         if answer not in ("y", "yes"):
@@ -681,7 +681,7 @@ def do_uninstall(name: str, console: Optional[Console] = None,
             c.print("[dim]변경 사항은 다음 세션부터 적용돼요.[/]")
             c.print("[dim]지금 새 세션을 시작하려면 /reset, 바로 적용하려면 --now를 사용하세요 (prompt cache 무효화).[/]\n")
     else:
-        c.print(f"[bold red]Error:[/] {msg}\n")
+        c.print(f"[bold red]오류:[/] {msg}\n")
 
 
 def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> None:
@@ -740,7 +740,7 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
     if not path.is_absolute():
         path = SKILLS_DIR / path
     if not path.exists() or not (path / "SKILL.md").exists():
-        c.print(f"[bold red]Error:[/] No SKILL.md found at {path}\n")
+        c.print(f"[bold red]오류:[/] {path}에서 SKILL.md를 찾지 못했어요\n")
         return
 
     # Validate the skill

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -178,11 +178,11 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
         },
         "branding": {
             "agent_name": "Hermes Agent",
-            "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
-            "goodbye": "Goodbye! ⚕",
+            "welcome": "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요.",
+            "goodbye": "안녕히 가세요! ⚕",
             "response_label": " ⚕ Hermes ",
             "prompt_symbol": "❯ ",
-            "help_header": "(^_^)? Available Commands",
+            "help_header": "(^_^) 사용 가능한 명령어",
         },
         "tool_prefix": "┊",
     },
@@ -273,11 +273,11 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
         "spinner": {},
         "branding": {
             "agent_name": "Hermes Agent",
-            "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
-            "goodbye": "Goodbye! ⚕",
+            "welcome": "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요.",
+            "goodbye": "안녕히 가세요! ⚕",
             "response_label": " ⚕ Hermes ",
             "prompt_symbol": "❯ ",
-            "help_header": "[?] Available Commands",
+            "help_header": "[?] 사용 가능한 명령어",
         },
         "tool_prefix": "┊",
     },
@@ -304,11 +304,11 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
         "spinner": {},
         "branding": {
             "agent_name": "Hermes Agent",
-            "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
-            "goodbye": "Goodbye! ⚕",
+            "welcome": "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요.",
+            "goodbye": "안녕히 가세요! ⚕",
             "response_label": " ⚕ Hermes ",
             "prompt_symbol": "❯ ",
-            "help_header": "(^_^)? Available Commands",
+            "help_header": "(^_^) 사용 가능한 명령어",
         },
         "tool_prefix": "┊",
     },
@@ -341,11 +341,11 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
         "spinner": {},
         "branding": {
             "agent_name": "Hermes Agent",
-            "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
-            "goodbye": "Goodbye! ⚕",
+            "welcome": "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요.",
+            "goodbye": "안녕히 가세요! ⚕",
             "response_label": " ⚕ Hermes ",
             "prompt_symbol": "❯ ",
-            "help_header": "[?] Available Commands",
+            "help_header": "[?] 사용 가능한 명령어",
         },
         "tool_prefix": "│",
     },
@@ -378,11 +378,11 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
         "spinner": {},
         "branding": {
             "agent_name": "Hermes Agent",
-            "welcome": "Welcome to Hermes Agent! Type your message or /help for commands.",
-            "goodbye": "Goodbye! \u2695",
+            "welcome": "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요.",
+            "goodbye": "안녕히 가세요! \u2695",
             "response_label": " \u2695 Hermes ",
             "prompt_symbol": "\u276f ",
-            "help_header": "(^_^)? Available Commands",
+            "help_header": "(^_^) 사용 가능한 명령어",
         },
         "tool_prefix": "\u250a",
     },
@@ -730,7 +730,7 @@ def get_active_prompt_symbol(fallback: str = "❯ ") -> str:
 
 
 
-def get_active_help_header(fallback: str = "(^_^)? Available Commands") -> str:
+def get_active_help_header(fallback: str = "(^_^) 사용 가능한 명령어") -> str:
     """Get the /help header from the active skin."""
     try:
         return get_active_skin().get_branding("help_header", fallback)
@@ -739,7 +739,7 @@ def get_active_help_header(fallback: str = "(^_^)? Available Commands") -> str:
 
 
 
-def get_active_goodbye(fallback: str = "Goodbye! ⚕") -> str:
+def get_active_goodbye(fallback: str = "안녕히 가세요! ⚕") -> str:
     """Get the goodbye line from the active skin."""
     try:
         return get_active_skin().get_branding("goodbye", fallback)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -96,12 +96,12 @@ def show_status(args):
     # Environment
     # =========================================================================
     print()
-    print(color("◆ Environment", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 환경", Colors.CYAN, Colors.BOLD))
     print(f"  Project:      {PROJECT_ROOT}")
     print(f"  Python:       {sys.version.split()[0]}")
     
     env_path = get_env_path()
-    print(f"  .env file:    {check_mark(env_path.exists())} {'exists' if env_path.exists() else 'not found'}")
+    print(f"  .env 파일:    {check_mark(env_path.exists())} {'존재함' if env_path.exists() else '없음'}")
 
     try:
         config = load_config()
@@ -115,7 +115,7 @@ def show_status(args):
     # API Keys
     # =========================================================================
     print()
-    print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
+    print(color("◆ API 키", Colors.CYAN, Colors.BOLD))
     
     keys = {
         "OpenRouter": "OPENROUTER_API_KEY",
@@ -150,7 +150,7 @@ def show_status(args):
     # Auth Providers (OAuth)
     # =========================================================================
     print()
-    print(color("◆ Auth Providers", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 인증 provider", Colors.CYAN, Colors.BOLD))
 
     try:
         from hermes_cli.auth import get_nous_auth_status, get_codex_auth_status, get_qwen_auth_status
@@ -165,7 +165,7 @@ def show_status(args):
     nous_logged_in = bool(nous_status.get("logged_in"))
     print(
         f"  {'Nous Portal':<12}  {check_mark(nous_logged_in)} "
-        f"{'logged in' if nous_logged_in else 'not logged in (run: hermes model)'}"
+        f"{'로그인됨' if nous_logged_in else '로그인 안 됨 (실행: hermes model)'}"
     )
     if nous_logged_in:
         portal_url = nous_status.get("portal_base_url") or "(unknown)"
@@ -173,38 +173,38 @@ def show_status(args):
         key_exp = _format_iso_timestamp(nous_status.get("agent_key_expires_at"))
         refresh_label = "yes" if nous_status.get("has_refresh_token") else "no"
         print(f"    Portal URL: {portal_url}")
-        print(f"    Access exp: {access_exp}")
-        print(f"    Key exp:    {key_exp}")
-        print(f"    Refresh:    {refresh_label}")
+        print(f"    액세스 만료: {access_exp}")
+        print(f"    키 만료:    {key_exp}")
+        print(f"    리프레시:   {refresh_label}")
 
     codex_logged_in = bool(codex_status.get("logged_in"))
     print(
         f"  {'OpenAI Codex':<12}  {check_mark(codex_logged_in)} "
-        f"{'logged in' if codex_logged_in else 'not logged in (run: hermes model)'}"
+        f"{'로그인됨' if codex_logged_in else '로그인 안 됨 (실행: hermes model)'}"
     )
     codex_auth_file = codex_status.get("auth_store")
     if codex_auth_file:
-        print(f"    Auth file:  {codex_auth_file}")
+        print(f"    인증 파일:  {codex_auth_file}")
     codex_last_refresh = _format_iso_timestamp(codex_status.get("last_refresh"))
     if codex_status.get("last_refresh"):
-        print(f"    Refreshed:  {codex_last_refresh}")
+        print(f"    최근 갱신:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
-        print(f"    Error:      {codex_status.get('error')}")
+        print(f"    오류:       {codex_status.get('error')}")
 
     qwen_logged_in = bool(qwen_status.get("logged_in"))
     print(
         f"  {'Qwen OAuth':<12}  {check_mark(qwen_logged_in)} "
-        f"{'logged in' if qwen_logged_in else 'not logged in (run: qwen auth qwen-oauth)'}"
+        f"{'로그인됨' if qwen_logged_in else '로그인 안 됨 (실행: qwen auth qwen-oauth)'}"
     )
     qwen_auth_file = qwen_status.get("auth_file")
     if qwen_auth_file:
-        print(f"    Auth file:  {qwen_auth_file}")
+        print(f"    인증 파일:  {qwen_auth_file}")
     qwen_exp = qwen_status.get("expires_at_ms")
     if qwen_exp:
         from datetime import datetime, timezone
-        print(f"    Access exp: {datetime.fromtimestamp(int(qwen_exp) / 1000, tz=timezone.utc).isoformat()}")
+        print(f"    액세스 만료: {datetime.fromtimestamp(int(qwen_exp) / 1000, tz=timezone.utc).isoformat()}")
     if qwen_status.get("error") and not qwen_logged_in:
-        print(f"    Error:      {qwen_status.get('error')}")
+        print(f"    오류:       {qwen_status.get('error')}")
 
     # =========================================================================
     # Nous Subscription Features
@@ -212,30 +212,30 @@ def show_status(args):
     if managed_nous_tools_enabled():
         features = get_nous_subscription_features(config)
         print()
-        print(color("◆ Nous Subscription Features", Colors.CYAN, Colors.BOLD))
+        print(color("◆ Nous 구독 기능", Colors.CYAN, Colors.BOLD))
         if not features.nous_auth_present:
-            print("  Nous Portal   ✗ not logged in")
+            print("  Nous Portal   ✗ 로그인 안 됨")
         else:
-            print("  Nous Portal   ✓ managed tools available")
+            print("  Nous Portal   ✓ 관리형 도구 사용 가능")
         for feature in features.items():
             if feature.managed_by_nous:
-                state = "active via Nous subscription"
+                state = "Nous 구독으로 활성화됨"
             elif feature.active:
-                current = feature.current_provider or "configured provider"
-                state = f"active via {current}"
+                current = feature.current_provider or "설정된 provider"
+                state = f"{current}를 통해 활성화됨"
             elif feature.included_by_default and features.nous_auth_present:
-                state = "included by subscription, not currently selected"
+                state = "구독에 포함되지만 현재 선택되지는 않음"
             elif feature.key == "modal" and features.nous_auth_present:
-                state = "available via subscription (optional)"
+                state = "구독으로 사용 가능(선택 사항)"
             else:
-                state = "not configured"
+                state = "설정되지 않음"
             print(f"  {feature.label:<15} {check_mark(feature.available or feature.active or feature.managed_by_nous)} {state}")
 
     # =========================================================================
     # API-Key Providers
     # =========================================================================
     print()
-    print(color("◆ API-Key Providers", Colors.CYAN, Colors.BOLD))
+    print(color("◆ API 키 provider", Colors.CYAN, Colors.BOLD))
 
     apikey_providers = {
         "Z.AI / GLM":       ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
@@ -250,14 +250,14 @@ def show_status(args):
             if key_val:
                 break
         configured = bool(key_val)
-        label = "configured" if configured else "not configured (run: hermes model)"
+        label = "설정됨" if configured else "설정되지 않음 (실행: hermes model)"
         print(f"  {pname:<16} {check_mark(configured)} {label}")
 
     # =========================================================================
     # Terminal Configuration
     # =========================================================================
     print()
-    print(color("◆ Terminal Backend", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 터미널 백엔드", Colors.CYAN, Colors.BOLD))
     
     terminal_env = os.getenv("TERMINAL_ENV", "")
     if not terminal_env:
@@ -273,8 +273,8 @@ def show_status(args):
     if terminal_env == "ssh":
         ssh_host = os.getenv("TERMINAL_SSH_HOST", "")
         ssh_user = os.getenv("TERMINAL_SSH_USER", "")
-        print(f"  SSH Host:     {ssh_host or '(not set)'}")
-        print(f"  SSH User:     {ssh_user or '(not set)'}")
+        print(f"  SSH 호스트:   {ssh_host or '(설정 안 됨)'}")
+        print(f"  SSH 사용자:   {ssh_user or '(설정 안 됨)'}")
     elif terminal_env == "docker":
         docker_image = os.getenv("TERMINAL_DOCKER_IMAGE", "python:3.11-slim")
         print(f"  Docker Image: {docker_image}")
@@ -283,13 +283,13 @@ def show_status(args):
         print(f"  Daytona Image: {daytona_image}")
     
     sudo_password = os.getenv("SUDO_PASSWORD", "")
-    print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")
+    print(f"  Sudo:         {check_mark(bool(sudo_password))} {'활성화됨' if sudo_password else '비활성화됨'}")
     
     # =========================================================================
     # Messaging Platforms
     # =========================================================================
     print()
-    print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
+    print(color("◆ 메시징 플랫폼", Colors.CYAN, Colors.BOLD))
     
     platforms = {
         "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
@@ -316,7 +316,7 @@ def show_status(args):
         if home_var:
             home_channel = os.getenv(home_var, "")
         
-        status = "configured" if has_token else "not configured"
+        status = "설정됨" if has_token else "설정되지 않음"
         if home_channel:
             status += f" (home: {home_channel})"
         
@@ -326,7 +326,7 @@ def show_status(args):
     # Gateway Status
     # =========================================================================
     print()
-    print(color("◆ Gateway Service", Colors.CYAN, Colors.BOLD))
+    print(color("◆ Gateway 서비스", Colors.CYAN, Colors.BOLD))
     
     if _is_termux():
         try:
@@ -335,16 +335,16 @@ def show_status(args):
         except Exception:
             gateway_pids = []
         is_running = bool(gateway_pids)
-        print(f"  Status:       {check_mark(is_running)} {'running' if is_running else 'stopped'}")
-        print("  Manager:      Termux / manual process")
+        print(f"  상태:         {check_mark(is_running)} {'실행 중' if is_running else '중지됨'}")
+        print("  관리자:       Termux / 수동 프로세스")
         if gateway_pids:
             rendered = ", ".join(str(pid) for pid in gateway_pids[:3])
             if len(gateway_pids) > 3:
                 rendered += ", ..."
-            print(f"  PID(s):       {rendered}")
+            print(f"  PID:          {rendered}")
         else:
-            print("  Start with:   hermes gateway")
-            print("  Note:         Android may stop background jobs when Termux is suspended")
+            print("  시작 명령:    hermes gateway")
+            print("  참고:         Android는 Termux가 일시중지되면 백그라운드 작업을 중단할 수 있어요")
 
     elif sys.platform.startswith('linux'):
         from hermes_constants import is_container

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -166,9 +166,9 @@ TOOL_CATEGORIES = {
         ],
     },
     "web": {
-        "name": "Web Search & Extract",
-        "setup_title": "Select Search Provider",
-        "setup_note": "A free DuckDuckGo search skill is also included — skip this if you don't need a premium provider.",
+        "name": "웹 검색 및 추출",
+        "setup_title": "검색 provider 선택",
+        "setup_note": "무료 DuckDuckGo 검색 skill도 포함되어 있어요 — 프리미엄 provider가 필요 없다면 건너뛰어도 괜찮아요.",
         "icon": "🔍",
         "providers": [
             {
@@ -1019,11 +1019,11 @@ def _configure_simple_requirements(ts_key: str):
         choices = [
             "OpenRouter — uses Gemini",
             "OpenAI-compatible endpoint — base URL, API key, and vision model",
-            "Skip",
+            "건너뛰기",
         ]
-        idx = _prompt_choice("  Configure vision backend", choices, 2)
+        idx = _prompt_choice("  vision 백엔드 설정", choices, 2)
         if idx == 0:
-            _print_info("  Get key at: https://openrouter.ai/keys")
+            _print_info("  키 발급 링크: https://openrouter.ai/keys")
             value = _prompt("    OPENROUTER_API_KEY", password=True)
             if value and value.strip():
                 save_env_value("OPENROUTER_API_KEY", value.strip())
@@ -1658,7 +1658,7 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
 
     if mcp_servers:
         print()
-        print("MCP servers:")
+        print("MCP 서버:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
             exclude = tools_cfg.get("exclude") or []

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -871,7 +871,7 @@ def _configure_tool_category(ts_key: str, cat: dict, config: dict):
             provider_choices.append(f"{p['name']}{badge}{tag}{configured}")
 
         # Add skip option
-        provider_choices.append("Skip — keep defaults / configure later")
+        provider_choices.append("건너뛰기 — 기본값 유지 / 나중에 설정")
 
         # Detect current provider as default
         default_idx = _detect_active_provider_index(providers, config)
@@ -880,7 +880,7 @@ def _configure_tool_category(ts_key: str, cat: dict, config: dict):
 
         # Skip selected
         if provider_idx >= len(providers):
-            _print_info(f"  Skipped {name}")
+            _print_info(f"  {name} 설정을 건너뛰었어요")
             return
 
         _configure_provider(providers[provider_idx], config)
@@ -996,9 +996,9 @@ def _configure_provider(provider: dict, config: dict):
 
             if value:
                 save_env_value(var["key"], value)
-                _print_success("    Saved")
+                _print_success("    저장했어요")
             else:
-                _print_warning("    Skipped")
+                _print_warning("    건너뛰었어요")
                 all_configured = False
 
     # Run post-setup hooks if needed
@@ -1027,9 +1027,9 @@ def _configure_simple_requirements(ts_key: str):
             value = _prompt("    OPENROUTER_API_KEY", password=True)
             if value and value.strip():
                 save_env_value("OPENROUTER_API_KEY", value.strip())
-                _print_success("    Saved")
+                _print_success("    저장했어요")
             else:
-                _print_warning("    Skipped")
+                _print_warning("    건너뛰었어요")
         elif idx == 1:
             base_url = _prompt("    OPENAI_BASE_URL (blank for OpenAI)").strip() or "https://api.openai.com/v1"
             key_label = "    OPENAI_API_KEY" if "api.openai.com" in base_url.lower() else "    API key"
@@ -1044,9 +1044,9 @@ def _configure_simple_requirements(ts_key: str):
                 save_config(_cfg)
                 if "api.openai.com" in base_url.lower():
                     save_env_value("AUXILIARY_VISION_MODEL", "gpt-4o-mini")
-                _print_success("    Saved")
+                _print_success("    저장했어요")
             else:
-                _print_warning("    Skipped")
+                _print_warning("    건너뛰었어요")
         return
 
     requirements = TOOLSET_ENV_REQUIREMENTS.get(ts_key, [])
@@ -1063,13 +1063,13 @@ def _configure_simple_requirements(ts_key: str):
 
     for var, url in missing:
         if url:
-            _print_info(f"  Get key at: {url}")
+            _print_info(f"  키 발급 링크: {url}")
         value = _prompt(f"    {var}", password=True)
         if value and value.strip():
             save_env_value(var, value.strip())
-            _print_success("    Saved")
+            _print_success("    저장했어요")
         else:
-            _print_warning("    Skipped")
+            _print_warning("    건너뛰었어요")
 
 
 def _reconfigure_tool(config: dict):
@@ -1216,13 +1216,13 @@ def _reconfigure_simple_requirements(ts_key: str):
         if existing:
             _print_info(f"  {var}: configured ({existing[:8]}...)")
         if url:
-            _print_info(f"  Get key at: {url}")
+            _print_info(f"  키 발급 링크: {url}")
         value = _prompt(f"    {var} (Enter to keep current)", password=True)
         if value and value.strip():
             save_env_value(var, value.strip())
-            _print_success("    Updated")
+            _print_success("    업데이트했어요")
         else:
-            _print_info("    Kept current")
+            _print_info("    현재 값을 유지했어요")
 
 
 # ─── Main Entry Point ─────────────────────────────────────────────────────────

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -848,7 +848,7 @@ def _configure_tool_category(ts_key: str, cat: dict, config: dict):
         # Multiple providers - let user choose
         print()
         # Use custom title if provided (e.g. "Select Search Provider")
-        title = cat.get("setup_title", "Choose a provider")
+        title = cat.get("setup_title", "provider 선택")
         print(color(f"  --- {icon} {name} - {title} ---", Colors.CYAN))
         if cat.get("setup_note"):
             _print_info(f"  {cat['setup_note']}")
@@ -1084,13 +1084,13 @@ def _reconfigure_tool(config: dict):
                 configurable.append((ts_key, ts_label))
 
     if not configurable:
-        _print_info("No configured tools to reconfigure.")
+        _print_info("다시 설정할 구성 도구가 없어요.")
         return
 
     choices = [label for _, label in configurable]
-    choices.append("Cancel")
+    choices.append("취소")
 
-    idx = _prompt_choice("  Which tool would you like to reconfigure?", choices, len(choices) - 1)
+    idx = _prompt_choice("  어떤 도구를 다시 설정할까요?", choices, len(choices) - 1)
 
     if idx >= len(configurable):
         return  # Cancel
@@ -1119,7 +1119,7 @@ def _configure_tool_category_for_reconfig(ts_key: str, cat: dict, config: dict):
         _reconfigure_provider(provider, config)
     else:
         print()
-        print(color(f"  --- {icon} {name} - Choose a provider ---", Colors.CYAN))
+        print(color(f"  --- {icon} {name} - provider 선택 ---", Colors.CYAN))
         print()
 
         provider_choices = []
@@ -1139,7 +1139,7 @@ def _configure_tool_category_for_reconfig(ts_key: str, cat: dict, config: dict):
 
         default_idx = _detect_active_provider_index(providers, config)
 
-        provider_idx = _prompt_choice("  Select provider:", provider_choices, default_idx)
+        provider_idx = _prompt_choice("  provider 선택:", provider_choices, default_idx)
         _reconfigure_provider(providers[provider_idx], config)
 
 
@@ -1478,7 +1478,7 @@ def _configure_mcp_tools_interactive(config: dict):
 
     mcp_servers = config.get("mcp_servers") or {}
     if not mcp_servers:
-        _print_info("No MCP servers configured.")
+        _print_info("설정된 MCP 서버가 없어요.")
         return
 
     # Count enabled servers
@@ -1487,40 +1487,40 @@ def _configure_mcp_tools_interactive(config: dict):
         if v.get("enabled", True) not in (False, "false", "0", "no", "off")
     ]
     if not enabled_names:
-        _print_info("All MCP servers are disabled.")
+        _print_info("모든 MCP 서버가 비활성화되어 있어요.")
         return
 
     print()
-    print(color("  Discovering tools from MCP servers...", Colors.YELLOW))
-    print(color(f"  Connecting to {len(enabled_names)} server(s): {', '.join(enabled_names)}", Colors.DIM))
+    print(color("  MCP 서버에서 도구를 찾는 중...", Colors.YELLOW))
+    print(color(f"  서버 {len(enabled_names)}개에 연결하는 중: {', '.join(enabled_names)}", Colors.DIM))
 
     try:
         from tools.mcp_tool import probe_mcp_server_tools
         server_tools = probe_mcp_server_tools()
     except Exception as exc:
-        _print_error(f"Failed to probe MCP servers: {exc}")
+        _print_error(f"MCP 서버를 확인하지 못했어요: {exc}")
         return
 
     if not server_tools:
-        _print_warning("Could not discover tools from any MCP server.")
-        _print_info("Check that server commands/URLs are correct and dependencies are installed.")
+        _print_warning("어느 MCP 서버에서도 도구를 찾지 못했어요.")
+        _print_info("서버 명령/URL이 올바른지, 필요한 의존성이 설치되어 있는지 확인하세요.")
         return
 
     # Report discovery results
     failed = [n for n in enabled_names if n not in server_tools]
     if failed:
         for name in failed:
-            _print_warning(f"  Could not connect to '{name}'")
+            _print_warning(f"  '{name}'에 연결하지 못했어요")
 
     total_tools = sum(len(tools) for tools in server_tools.values())
-    print(color(f"  Found {total_tools} tool(s) across {len(server_tools)} server(s)", Colors.GREEN))
+    print(color(f"  서버 {len(server_tools)}개에서 도구 {total_tools}개를 찾았어요", Colors.GREEN))
     print()
 
     any_changes = False
 
     for server_name, tools in server_tools.items():
         if not tools:
-            _print_info(f"  {server_name}: no tools found")
+            _print_info(f"  {server_name}: 찾은 도구가 없어요")
             continue
 
         srv_cfg = mcp_servers.get(server_name, {})
@@ -1554,14 +1554,14 @@ def _configure_mcp_tools_interactive(config: dict):
                 pre_selected.add(i)
 
         chosen = curses_checklist(
-            f"MCP Server: {server_name}  ({len(tools)} tools)",
+            f"MCP 서버: {server_name}  ({len(tools)}개 도구)",
             labels,
             pre_selected,
             cancel_returns=pre_selected,
         )
 
         if chosen == pre_selected:
-            _print_info(f"  {server_name}: no changes")
+            _print_info(f"  {server_name}: 변경 사항이 없어요")
             continue
 
         # Compute new exclude list based on unchecked tools
@@ -1583,16 +1583,16 @@ def _configure_mcp_tools_interactive(config: dict):
         enabled_count = len(chosen)
         disabled_count = len(tools) - enabled_count
         _print_success(
-            f"  {server_name}: {enabled_count} enabled, {disabled_count} disabled"
+            f"  {server_name}: 활성화 {enabled_count}개, 비활성화 {disabled_count}개"
         )
         any_changes = True
 
     if any_changes:
         save_config(config)
         print()
-        print(color("  ✓ MCP tool configuration saved", Colors.GREEN))
+        print(color("  ✓ MCP 도구 설정을 저장했어요", Colors.GREEN))
     else:
-        print(color("  No changes to MCP tools", Colors.DIM))
+        print(color("  MCP 도구에서 변경된 내용이 없어요", Colors.DIM))
 
 
 # ─── Non-interactive disable/enable ──────────────────────────────────────────
@@ -1682,7 +1682,7 @@ def tools_disable_enable_command(args):
     config = load_config()
 
     if platform not in PLATFORMS:
-        _print_error(f"Unknown platform '{platform}'. Valid: {', '.join(PLATFORMS)}")
+        _print_error(f"알 수 없는 플랫폼 '{platform}'이에요. 사용 가능: {', '.join(PLATFORMS)}")
         return
 
     if action == "list":
@@ -1698,7 +1698,7 @@ def tools_disable_enable_command(args):
     unknown_toolsets = [t for t in toolset_targets if t not in valid_toolsets]
     if unknown_toolsets:
         for name in unknown_toolsets:
-            _print_error(f"Unknown toolset '{name}'")
+            _print_error(f"알 수 없는 toolset '{name}'이에요")
         toolset_targets = [t for t in toolset_targets if t in valid_toolsets]
 
     if toolset_targets:
@@ -1708,7 +1708,7 @@ def tools_disable_enable_command(args):
     if mcp_targets:
         failed_servers = _apply_mcp_change(config, mcp_targets, action)
         for srv in failed_servers:
-            _print_error(f"MCP server '{srv}' not found in config")
+            _print_error(f"config에서 MCP 서버 '{srv}'을(를) 찾지 못했어요")
 
     save_config(config)
 
@@ -1717,5 +1717,5 @@ def tools_disable_enable_command(args):
         if t not in unknown_toolsets and (":" not in t or t.split(":")[0] not in failed_servers)
     ]
     if successful:
-        verb = "Disabled" if action == "disable" else "Enabled"
+        verb = "비활성화" if action == "disable" else "활성화"
         _print_success(f"{verb}: {', '.join(successful)}")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1317,14 +1317,14 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                 for ts_key in to_configure:
                     label = next((l for k, l, _ in _get_effective_configurable_toolsets() if k == ts_key), ts_key)
                     print(color(f"    • {label}", Colors.DIM))
-                print(color("  You can skip any tool you don't need right now.", Colors.DIM))
+                print(color("  지금 필요 없는 도구는 건너뛰어도 괜찮아요.", Colors.DIM))
                 print()
                 for ts_key in to_configure:
                     _configure_toolset(ts_key, config)
 
             _save_platform_tools(config, pkey, new_enabled)
             save_config(config)
-            print(color(f"  ✓ Saved {pinfo['label']} tool configuration", Colors.GREEN))
+            print(color(f"  ✓ {pinfo['label']} 도구 구성을 저장했어요", Colors.GREEN))
             print()
 
         return
@@ -1342,15 +1342,15 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
         platform_keys.append(pkey)
 
     if len(platform_keys) > 1:
-        platform_choices.append("Configure all platforms (global)")
-    platform_choices.append("Reconfigure an existing tool's provider or API key")
+        platform_choices.append("모든 플랫폼 구성(전역)")
+    platform_choices.append("기존 도구의 provider 또는 API key 다시 설정")
 
     # Show MCP option if any MCP servers are configured
     _has_mcp = bool(config.get("mcp_servers"))
     if _has_mcp:
-        platform_choices.append("Configure MCP server tools")
+        platform_choices.append("MCP 서버 도구 설정")
 
-    platform_choices.append("Done")
+    platform_choices.append("완료")
 
     # Index offsets for the extra options after per-platform entries
     _global_idx = len(platform_keys) if len(platform_keys) > 1 else -1
@@ -1359,7 +1359,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
     _done_idx = _reconfig_idx + (2 if _has_mcp else 1)
 
     while True:
-        idx = _prompt_choice("Select an option:", platform_choices, default=0)
+        idx = _prompt_choice("옵션을 선택해 주세요:", platform_choices, default=0)
 
         # "Done" selected
         if idx == _done_idx:
@@ -1405,14 +1405,14 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
                                 _configure_toolset(ts_key, config)
                     _save_platform_tools(config, pk, new_enabled)
                 save_config(config)
-                print(color("  ✓ Saved configuration for all platforms", Colors.GREEN))
+                print(color("  ✓ 모든 플랫폼 구성을 저장했어요", Colors.GREEN))
                 # Update choice labels
                 for ci, pk in enumerate(platform_keys):
                     new_count = len(_get_platform_tools(config, pk, include_default_mcp_servers=False))
                     total = len(_get_effective_configurable_toolsets())
                     platform_choices[ci] = f"Configure {PLATFORMS[pk]['label']}  ({new_count}/{total} enabled)"
             else:
-                print(color("  No changes", Colors.DIM))
+                print(color("  변경 사항이 없어요", Colors.DIM))
             print()
             continue
 
@@ -1446,9 +1446,9 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
 
             _save_platform_tools(config, pkey, new_enabled)
             save_config(config)
-            print(color(f"  ✓ Saved {pinfo['label']} configuration", Colors.GREEN))
+            print(color(f"  ✓ {pinfo['label']} 구성을 저장했어요", Colors.GREEN))
         else:
-            print(color(f"  No changes to {pinfo['label']}", Colors.DIM))
+            print(color(f"  {pinfo['label']}에는 변경 사항이 없어요", Colors.DIM))
 
         print()
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -112,7 +112,7 @@ def remove_wrapper_script():
                     wrapper.unlink()
                     removed.append(wrapper)
             except Exception as e:
-                log_warn(f"Could not remove {wrapper}: {e}")
+                log_warn(f"{wrapper} 를 제거하지 못했어요: {e}")
     
     return removed
 
@@ -167,7 +167,7 @@ def uninstall_gateway_service():
         return True
         
     except Exception as e:
-        log_warn(f"Could not fully remove gateway service: {e}")
+        log_warn(f"게이트웨이 서비스를 완전히 제거하지 못했어요: {e}")
         return False
 
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -1,9 +1,9 @@
 """
-Hermes Agent Uninstaller.
+Hermes Agent 제거 도구.
 
-Provides options for:
-- Full uninstall: Remove everything including configs and data
-- Keep data: Remove code but keep ~/.hermes/ (configs, sessions, logs)
+제공하는 옵션:
+- 전체 제거: 설정과 데이터까지 모두 삭제
+- 데이터 유지: 코드는 지우고 ~/.hermes/(설정, 세션, 로그)는 유지
 """
 
 import os
@@ -184,40 +184,40 @@ def run_uninstall(args):
     
     print()
     print(color("┌─────────────────────────────────────────────────────────┐", Colors.MAGENTA, Colors.BOLD))
-    print(color("│            ⚕ Hermes Agent Uninstaller                  │", Colors.MAGENTA, Colors.BOLD))
+    print(color("│               ⚕ Hermes Agent 제거 도구                │", Colors.MAGENTA, Colors.BOLD))
     print(color("└─────────────────────────────────────────────────────────┘", Colors.MAGENTA, Colors.BOLD))
     print()
     
     # Show what will be affected
-    print(color("Current Installation:", Colors.CYAN, Colors.BOLD))
-    print(f"  Code:    {project_root}")
-    print(f"  Config:  {hermes_home / 'config.yaml'}")
-    print(f"  Secrets: {hermes_home / '.env'}")
-    print(f"  Data:    {hermes_home / 'cron/'}, {hermes_home / 'sessions/'}, {hermes_home / 'logs/'}")
+    print(color("현재 설치 상태:", Colors.CYAN, Colors.BOLD))
+    print(f"  코드:     {project_root}")
+    print(f"  설정:     {hermes_home / 'config.yaml'}")
+    print(f"  시크릿:   {hermes_home / '.env'}")
+    print(f"  데이터:   {hermes_home / 'cron/'}, {hermes_home / 'sessions/'}, {hermes_home / 'logs/'}")
     print()
     
     # Ask for confirmation
-    print(color("Uninstall Options:", Colors.YELLOW, Colors.BOLD))
+    print(color("제거 옵션:", Colors.YELLOW, Colors.BOLD))
     print()
-    print("  1) " + color("Keep data", Colors.GREEN) + " - Remove code only, keep configs/sessions/logs")
-    print("     (Recommended - you can reinstall later with your settings intact)")
+    print("  1) " + color("데이터 유지", Colors.GREEN) + " - 코드만 제거하고 설정/세션/로그는 유지")
+    print("     (권장 - 나중에 현재 설정을 그대로 사용해 다시 설치할 수 있어요)")
     print()
-    print("  2) " + color("Full uninstall", Colors.RED) + " - Remove everything including all data")
-    print("     (Warning: This deletes all configs, sessions, and logs permanently)")
+    print("  2) " + color("전체 제거", Colors.RED) + " - 데이터까지 포함해 모든 항목 제거")
+    print("     (경고: 설정, 세션, 로그를 영구적으로 삭제해요)")
     print()
-    print("  3) " + color("Cancel", Colors.CYAN) + " - Don't uninstall")
+    print("  3) " + color("취소", Colors.CYAN) + " - 제거하지 않기")
     print()
     
     try:
-        choice = input(color("Select option [1/2/3]: ", Colors.BOLD)).strip()
+        choice = input(color("옵션 선택 [1/2/3]: ", Colors.BOLD)).strip()
     except (KeyboardInterrupt, EOFError):
         print()
-        print("Cancelled.")
+        print("취소했어요.")
         return
     
     if choice == "3" or choice.lower() in ("c", "cancel", "q", "quit", "n", "no"):
         print()
-        print("Uninstall cancelled.")
+        print("제거를 취소했어요.")
         return
     
     full_uninstall = (choice == "2")
@@ -225,55 +225,55 @@ def run_uninstall(args):
     # Final confirmation
     print()
     if full_uninstall:
-        print(color("⚠️  WARNING: This will permanently delete ALL Hermes data!", Colors.RED, Colors.BOLD))
-        print(color("   Including: configs, API keys, sessions, scheduled jobs, logs", Colors.RED))
+        print(color("⚠️  경고: Hermes 데이터를 전부 영구적으로 삭제해요!", Colors.RED, Colors.BOLD))
+        print(color("   포함 항목: 설정, API key, 세션, 예약 작업, 로그", Colors.RED))
     else:
-        print("This will remove the Hermes code but keep your configuration and data.")
+        print("Hermes 코드는 제거하지만 설정과 데이터는 유지해요.")
     
     print()
     try:
-        confirm = input(f"Type '{color('yes', Colors.YELLOW)}' to confirm: ").strip().lower()
+        confirm = input(f"확인하려면 '{color('yes', Colors.YELLOW)}' 를 입력하세요: ").strip().lower()
     except (KeyboardInterrupt, EOFError):
         print()
-        print("Cancelled.")
+        print("취소했어요.")
         return
     
     if confirm != "yes":
         print()
-        print("Uninstall cancelled.")
+        print("제거를 취소했어요.")
         return
     
     print()
-    print(color("Uninstalling...", Colors.CYAN, Colors.BOLD))
+    print(color("제거하는 중...", Colors.CYAN, Colors.BOLD))
     print()
     
     # 1. Stop and uninstall gateway service
-    log_info("Checking for gateway service...")
+    log_info("게이트웨이 서비스를 확인하는 중...")
     if uninstall_gateway_service():
-        log_success("Gateway service stopped and removed")
+        log_success("게이트웨이 서비스를 중지하고 제거했어요")
     else:
-        log_info("No gateway service found")
+        log_info("게이트웨이 서비스를 찾지 못했어요")
     
     # 2. Remove PATH entries from shell configs
-    log_info("Removing PATH entries from shell configs...")
+    log_info("셸 설정에서 PATH 항목을 제거하는 중...")
     removed_configs = remove_path_from_shell_configs()
     if removed_configs:
         for config in removed_configs:
-            log_success(f"Updated {config}")
+            log_success(f"업데이트했어요: {config}")
     else:
-        log_info("No PATH entries found to remove")
+        log_info("제거할 PATH 항목이 없어요")
     
     # 3. Remove wrapper script
-    log_info("Removing hermes command...")
+    log_info("hermes 명령 래퍼를 제거하는 중...")
     removed_wrappers = remove_wrapper_script()
     if removed_wrappers:
         for wrapper in removed_wrappers:
-            log_success(f"Removed {wrapper}")
+            log_success(f"제거했어요: {wrapper}")
     else:
-        log_info("No wrapper script found")
+        log_info("래퍼 스크립트를 찾지 못했어요")
     
     # 4. Remove installation directory (code)
-    log_info("Removing installation directory...")
+    log_info("설치 디렉터리를 제거하는 중...")
     
     # Check if we're running from within the install dir
     # We need to be careful here
@@ -282,45 +282,45 @@ def run_uninstall(args):
             # If the install is inside ~/.hermes/, just remove the hermes-agent subdir
             if hermes_home in project_root.parents or project_root.parent == hermes_home:
                 shutil.rmtree(project_root)
-                log_success(f"Removed {project_root}")
+                log_success(f"제거했어요: {project_root}")
             else:
                 # Installation is somewhere else entirely
                 shutil.rmtree(project_root)
-                log_success(f"Removed {project_root}")
+                log_success(f"제거했어요: {project_root}")
     except Exception as e:
-        log_warn(f"Could not fully remove {project_root}: {e}")
-        log_info("You may need to manually remove it")
+        log_warn(f"{project_root} 를 완전히 제거하지 못했어요: {e}")
+        log_info("수동으로 제거해야 할 수도 있어요")
     
     # 5. Optionally remove ~/.hermes/ data directory
     if full_uninstall:
-        log_info("Removing configuration and data...")
+        log_info("설정과 데이터를 제거하는 중...")
         try:
             if hermes_home.exists():
                 shutil.rmtree(hermes_home)
-                log_success(f"Removed {hermes_home}")
+                log_success(f"제거했어요: {hermes_home}")
         except Exception as e:
-            log_warn(f"Could not fully remove {hermes_home}: {e}")
-            log_info("You may need to manually remove it")
+            log_warn(f"{hermes_home} 를 완전히 제거하지 못했어요: {e}")
+            log_info("수동으로 제거해야 할 수도 있어요")
     else:
-        log_info(f"Keeping configuration and data in {hermes_home}")
+        log_info(f"설정과 데이터는 {hermes_home} 에 그대로 유지해요")
     
     # Done
     print()
     print(color("┌─────────────────────────────────────────────────────────┐", Colors.GREEN, Colors.BOLD))
-    print(color("│              ✓ Uninstall Complete!                      │", Colors.GREEN, Colors.BOLD))
+    print(color("│                   ✓ 제거 완료!                         │", Colors.GREEN, Colors.BOLD))
     print(color("└─────────────────────────────────────────────────────────┘", Colors.GREEN, Colors.BOLD))
     print()
     
     if not full_uninstall:
-        print(color("Your configuration and data have been preserved:", Colors.CYAN))
+        print(color("설정과 데이터는 그대로 보존했어요:", Colors.CYAN))
         print(f"  {hermes_home}/")
         print()
-        print("To reinstall later with your existing settings:")
+        print("나중에 기존 설정으로 다시 설치하려면:")
         print(color("  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash", Colors.DIM))
         print()
     
-    print(color("Reload your shell to complete the process:", Colors.YELLOW))
-    print("  source ~/.bashrc  # or ~/.zshrc")
+    print(color("과정을 마무리하려면 셸을 다시 불러오세요:", Colors.YELLOW))
+    print("  source ~/.bashrc  # 또는 ~/.zshrc")
     print()
-    print("Thank you for using Hermes Agent! ⚕")
+    print("Hermes Agent를 사용해 주셔서 고마워요! ⚕")
     print()

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -1,13 +1,13 @@
-"""hermes webhook — manage dynamic webhook subscriptions from the CLI.
+"""hermes webhook — CLI에서 동적 웹훅 구독을 관리.
 
-Usage:
+사용법:
     hermes webhook subscribe <name> [options]
     hermes webhook list
     hermes webhook remove <name>
     hermes webhook test <name> [--payload '{"key": "value"}']
 
-Subscriptions persist to ~/.hermes/webhook_subscriptions.json and are
-hot-reloaded by the webhook adapter without a gateway restart.
+구독 정보는 ~/.hermes/webhook_subscriptions.json에 저장되며,
+게이트웨이를 재시작하지 않아도 webhook adapter가 즉시 다시 불러옵니다.
 """
 
 import json
@@ -80,12 +80,12 @@ def _get_webhook_base_url() -> str:
 def _setup_hint() -> str:
     _dhh = display_hermes_home()
     return f"""
-  Webhook platform is not enabled. To set it up:
+  Webhook 플랫폼이 활성화되어 있지 않아요. 설정 방법:
 
-  1. Run the gateway setup wizard:
+  1. 게이트웨이 설정 마법사 실행:
      hermes gateway setup
 
-  2. Or manually add to {_dhh}/config.yaml:
+  2. 또는 {_dhh}/config.yaml에 직접 추가:
      platforms:
        webhook:
          enabled: true
@@ -94,12 +94,12 @@ def _setup_hint() -> str:
            port: 8644
            secret: "your-global-hmac-secret"
 
-  3. Or set environment variables in {_dhh}/.env:
+  3. 또는 {_dhh}/.env에 환경 변수 설정:
      WEBHOOK_ENABLED=true
      WEBHOOK_PORT=8644
-     WEBHOOK_SECRET=your-global-secret
+     WEBHOOK_SECRET=your-g...cret
 
-  Then start the gateway: hermes gateway run
+  그다음 게이트웨이 시작: hermes gateway run
 """
 
 
@@ -116,8 +116,8 @@ def webhook_command(args):
     sub = getattr(args, "webhook_action", None)
 
     if not sub:
-        print("Usage: hermes webhook {subscribe|list|remove|test}")
-        print("Run 'hermes webhook --help' for details.")
+        print("사용법: hermes webhook {subscribe|list|remove|test}")
+        print("자세한 내용은 'hermes webhook --help'를 실행하세요.")
         return
 
     if not _require_webhook_enabled():
@@ -136,7 +136,7 @@ def webhook_command(args):
 def _cmd_subscribe(args):
     name = args.name.strip().lower().replace(" ", "-")
     if not re.match(r'^[a-z0-9][a-z0-9_-]*$', name):
-        print(f"Error: Invalid name '{name}'. Use lowercase alphanumeric with hyphens/underscores.")
+        print(f"오류: 이름 '{name}' 이(가) 올바르지 않아요. 소문자 영숫자와 하이픈/밑줄만 사용해 주세요.")
         return
 
     subs = _load_subscriptions()
@@ -146,7 +146,7 @@ def _cmd_subscribe(args):
     events = [e.strip() for e in args.events.split(",")] if args.events else []
 
     route = {
-        "description": args.description or f"Agent-created subscription: {name}",
+        "description": args.description or f"에이전트가 만든 구독: {name}",
         "events": events,
         "secret": secret,
         "prompt": args.prompt or "",
@@ -162,43 +162,43 @@ def _cmd_subscribe(args):
     _save_subscriptions(subs)
 
     base_url = _get_webhook_base_url()
-    status = "Updated" if is_update else "Created"
+    status = "업데이트됨" if is_update else "생성됨"
 
-    print(f"\n  {status} webhook subscription: {name}")
+    print(f"\n  {status} 웹훅 구독: {name}")
     print(f"  URL:    {base_url}/webhooks/{name}")
     print(f"  Secret: {secret}")
     if events:
-        print(f"  Events: {', '.join(events)}")
+        print(f"  이벤트: {', '.join(events)}")
     else:
-        print("  Events: (all)")
-    print(f"  Deliver: {route['deliver']}")
+        print("  이벤트: (전체)")
+    print(f"  전달:   {route['deliver']}")
     if route.get("prompt"):
         prompt_preview = route["prompt"][:80] + ("..." if len(route["prompt"]) > 80 else "")
-        print(f"  Prompt: {prompt_preview}")
-    print(f"\n  Configure your service to POST to the URL above.")
-    print(f"  Use the secret for HMAC-SHA256 signature validation.")
-    print(f"  The gateway must be running to receive events (hermes gateway run).\n")
+        print(f"  프롬프트: {prompt_preview}")
+    print(f"\n  서비스가 위 URL로 POST를 보내도록 설정하세요.")
+    print(f"  HMAC-SHA256 서명 검증에는 위 secret을 사용하세요.")
+    print(f"  이벤트를 받으려면 게이트웨이가 실행 중이어야 해요(hermes gateway run).\n")
 
 
 def _cmd_list(args):
     subs = _load_subscriptions()
     if not subs:
-        print("  No dynamic webhook subscriptions.")
-        print("  Create one with: hermes webhook subscribe <name>")
+        print("  동적 웹훅 구독이 없어요.")
+        print("  만들려면: hermes webhook subscribe <name>")
         return
 
     base_url = _get_webhook_base_url()
-    print(f"\n  {len(subs)} webhook subscription(s):\n")
+    print(f"\n  웹훅 구독 {len(subs)}개:\n")
     for name, route in subs.items():
-        events = ", ".join(route.get("events", [])) or "(all)"
+        events = ", ".join(route.get("events", [])) or "(전체)"
         deliver = route.get("deliver", "log")
         desc = route.get("description", "")
         print(f"  ◆ {name}")
         if desc:
             print(f"    {desc}")
         print(f"    URL:     {base_url}/webhooks/{name}")
-        print(f"    Events:  {events}")
-        print(f"    Deliver: {deliver}")
+        print(f"    이벤트:  {events}")
+        print(f"    전달:    {deliver}")
         print()
 
 
@@ -207,13 +207,13 @@ def _cmd_remove(args):
     subs = _load_subscriptions()
 
     if name not in subs:
-        print(f"  No subscription named '{name}'.")
-        print("  Note: Static routes from config.yaml cannot be removed here.")
+        print(f"  '{name}' 이름의 구독이 없어요.")
+        print("  참고: config.yaml의 정적 라우트는 여기서 제거할 수 없어요.")
         return
 
     del subs[name]
     _save_subscriptions(subs)
-    print(f"  Removed webhook subscription: {name}")
+    print(f"  웹훅 구독을 제거했어요: {name}")
 
 
 def _cmd_test(args):
@@ -222,7 +222,7 @@ def _cmd_test(args):
     subs = _load_subscriptions()
 
     if name not in subs:
-        print(f"  No subscription named '{name}'.")
+        print(f"  '{name}' 이름의 구독이 없어요.")
         return
 
     route = subs[name]
@@ -230,7 +230,7 @@ def _cmd_test(args):
     base_url = _get_webhook_base_url()
     url = f"{base_url}/webhooks/{name}"
 
-    payload = args.payload or '{"test": true, "event_type": "test", "message": "Hello from hermes webhook test"}'
+    payload = args.payload or '{"test": true, "event_type": "test", "message": "hermes webhook test에서 보낸 인사"}'
 
     import hmac
     import hashlib
@@ -238,7 +238,7 @@ def _cmd_test(args):
         secret.encode(), payload.encode(), hashlib.sha256
     ).hexdigest()
 
-    print(f"  Sending test POST to {url}")
+    print(f"  테스트 POST를 전송하는 중: {url}")
     try:
         import urllib.request
         req = urllib.request.Request(
@@ -253,7 +253,7 @@ def _cmd_test(args):
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
             body = resp.read().decode()
-            print(f"  Response ({resp.status}): {body}")
+            print(f"  응답 ({resp.status}): {body}")
     except Exception as e:
-        print(f"  Error: {e}")
-        print("  Is the gateway running? (hermes gateway run)")
+        print(f"  오류: {e}")
+        print("  게이트웨이가 실행 중인가요? (hermes gateway run)")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -445,7 +445,7 @@ class TestDispatchMessage(unittest.TestCase):
 
         asyncio.run(adapter._dispatch_message(msg_data))
         self.assertEqual(len(captured_events), 1)
-        self.assertIn("[Subject: Help with Python]", captured_events[0].text)
+        self.assertIn("[제목: Help with Python]", captured_events[0].text)
         self.assertIn("How do I use lists?", captured_events[0].text)
 
     def test_reply_subject_not_duplicated(self):
@@ -473,11 +473,11 @@ class TestDispatchMessage(unittest.TestCase):
 
         asyncio.run(adapter._dispatch_message(msg_data))
         self.assertEqual(len(captured_events), 1)
-        self.assertNotIn("[Subject:", captured_events[0].text)
+        self.assertNotIn("[제목:", captured_events[0].text)
         self.assertEqual(captured_events[0].text, "Thanks for the help!")
 
     def test_empty_body_handled(self):
-        """Email with no body should dispatch '(empty email)'."""
+        """Email with no body should dispatch '(빈 이메일)'."""
         import asyncio
         adapter = self._make_adapter()
         captured_events = []
@@ -501,7 +501,7 @@ class TestDispatchMessage(unittest.TestCase):
 
         asyncio.run(adapter._dispatch_message(msg_data))
         self.assertEqual(len(captured_events), 1)
-        self.assertIn("(empty email)", captured_events[0].text)
+        self.assertIn("(빈 이메일)", captured_events[0].text)
 
     def test_image_attachment_sets_photo_type(self):
         """Email with image attachment should set message type to PHOTO."""
@@ -721,7 +721,7 @@ class TestSendMethods(unittest.TestCase):
 
         call_args = adapter.send.call_args
         body = call_args[0][1]
-        self.assertIn("https://img.com/photo.jpg", body)
+        self.assertIn("이미지: https://img.com/photo.jpg", body)
         self.assertIn("My photo", body)
 
     def test_send_document_with_attachment(self):
@@ -796,6 +796,8 @@ class TestConnectDisconnect(unittest.TestCase):
     def test_connect_success(self):
         """Successful IMAP + SMTP connection returns True."""
         import asyncio
+        import io
+        from contextlib import redirect_stdout
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
@@ -806,10 +808,13 @@ class TestConnectDisconnect(unittest.TestCase):
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            result = asyncio.run(adapter.connect())
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                result = asyncio.run(adapter.connect())
 
             self.assertTrue(result)
             self.assertTrue(adapter._running)
+            self.assertIn("[이메일] hermes@test.com 계정으로 연결했어요", stdout.getvalue())
             # Should have skipped existing messages
             self.assertEqual(len(adapter._seen_uids), 3)
             # Cleanup

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -200,6 +200,15 @@ class TestTitleInHelp:
         result = await runner._handle_help_command(event)
         assert "/title" in result
 
+    @pytest.mark.asyncio
+    async def test_help_output_header_is_localized_to_korean(self):
+        runner = _make_runner()
+        event = _make_event(text="/help")
+        from gateway.hooks import HookRegistry
+        runner.hooks = HookRegistry()
+        result = await runner._handle_help_command(event)
+        assert "📖 **Hermes 명령어**" in result
+
     def test_title_is_known_command(self):
         """The /title command is in the _known_commands set."""
         from gateway.run import GatewayRunner

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -369,7 +369,7 @@ def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
     auth_reset_command(_Args())
 
     out = capsys.readouterr().out
-    assert "Reset status" in out
+    assert "초기화했어요" in out
 
     payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
     entry = payload["credential_pool"]["anthropic"][0]

--- a/tests/hermes_cli/test_auth_commands_localization.py
+++ b/tests/hermes_cli/test_auth_commands_localization.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.auth_commands import (
+    _interactive_add,
+    _interactive_auth,
+    _interactive_remove,
+    _interactive_strategy,
+    auth_reset_command,
+)
+
+
+class _Entry:
+    def __init__(self, label, auth_type="api_key", source="manual", entry_id="cred-1"):
+        self.label = label
+        self.auth_type = auth_type
+        self.source = source
+        self.id = entry_id
+
+
+class _Pool:
+    def __init__(self, entries=None):
+        self._entries = entries or []
+
+    def has_credentials(self):
+        return bool(self._entries)
+
+    def entries(self):
+        return self._entries
+
+    def reset_statuses(self):
+        return len(self._entries)
+
+
+def test_interactive_auth_menu_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.auth_commands.auth_list_command", lambda _args: None)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    _interactive_auth()
+
+    out = capsys.readouterr().out
+    assert "자격 증명 풀 상태" in out
+    assert "무엇을 할까요?" in out
+    assert "자격 증명 추가" in out
+    assert "provider 회전 전략 설정" in out
+
+
+def test_interactive_add_prompts_are_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.auth_commands.PROVIDER_REGISTRY", {"anthropic": object()})
+    monkeypatch.setattr("hermes_cli.auth_commands._get_custom_provider_names", lambda: [])
+    recorded = {}
+
+    def fake_auth_add(args):
+        recorded["provider"] = args.provider
+        recorded["auth_type"] = args.auth_type
+        recorded["label"] = args.label
+
+    responses = iter(["anthropic", "2", "업무 계정"])
+
+    def fake_input(prompt):
+        print(prompt, end="")
+        return next(responses)
+
+    monkeypatch.setattr("hermes_cli.auth_commands.auth_add_command", fake_auth_add)
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    _interactive_add()
+
+    out = capsys.readouterr().out
+    assert "알려진 provider:" in out
+    assert "API key와 OAuth 로그인을 모두 지원해요." in out
+    assert "유형 [1/2]:" in out
+    assert "라벨 / 계정 이름(선택):" in out
+    assert recorded == {"provider": "anthropic", "auth_type": "oauth", "label": "업무 계정"}
+
+
+def test_interactive_remove_empty_pool_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.auth_commands.PROVIDER_REGISTRY", {"openrouter": object()})
+    monkeypatch.setattr("hermes_cli.auth_commands._get_custom_provider_names", lambda: [])
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda _provider: _Pool())
+
+    def fake_input(prompt):
+        print(prompt, end="")
+        return "openrouter"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    _interactive_remove()
+
+    out = capsys.readouterr().out
+    assert "자격 증명을 제거할 provider" in out
+    assert "openrouter 용 자격 증명이 없어요." in out
+
+
+def test_auth_reset_command_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda _provider: _Pool([_Entry("a"), _Entry("b")]))
+
+    auth_reset_command(SimpleNamespace(provider="anthropic"))
+
+    out = capsys.readouterr().out
+    assert "anthropic 자격 증명 2개의 상태를 초기화했어요" in out
+
+
+def test_interactive_strategy_invalid_choice_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.auth_commands.PROVIDER_REGISTRY", {"openrouter": object()})
+    monkeypatch.setattr("hermes_cli.auth_commands._get_custom_provider_names", lambda: [])
+    monkeypatch.setattr("hermes_cli.auth_commands.get_pool_strategy", lambda _provider: "fill_first")
+    responses = iter(["openrouter", "9"])
+
+    def fake_input(prompt):
+        print(prompt, end="")
+        return next(responses)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    _interactive_strategy()
+
+    out = capsys.readouterr().out
+    assert "openrouter 의 현재 전략" in out
+    assert "전략 [1-4]:" in out
+    assert "올바르지 않은 선택이에요." in out

--- a/tests/hermes_cli/test_auth_commands_localization.py
+++ b/tests/hermes_cli/test_auth_commands_localization.py
@@ -7,6 +7,7 @@ from hermes_cli.auth_commands import (
     _interactive_auth,
     _interactive_remove,
     _interactive_strategy,
+    auth_add_command,
     auth_reset_command,
 )
 
@@ -100,6 +101,40 @@ def test_auth_reset_command_is_localized(monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "anthropic 자격 증명 2개의 상태를 초기화했어요" in out
+
+
+def test_auth_add_command_api_key_prompts_are_localized(monkeypatch, capsys):
+    class _AddPool:
+        def __init__(self):
+            self._entries = []
+
+        def entries(self):
+            return self._entries
+
+        def add_entry(self, entry):
+            self._entries.append(entry)
+
+    pool = _AddPool()
+    monkeypatch.setattr("hermes_cli.auth_commands.PROVIDER_REGISTRY", {"openrouter": object()})
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda _provider: pool)
+    monkeypatch.setattr("hermes_cli.auth_commands._provider_base_url", lambda _provider: "https://openrouter.ai/api/v1")
+    monkeypatch.setattr("hermes_cli.auth_commands.getpass", lambda prompt: (print(prompt, end=""), "sk-test")[1])
+
+    responses = iter(["개인 키"])
+
+    def fake_input(prompt):
+        print(prompt, end="")
+        return next(responses)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    auth_add_command(SimpleNamespace(provider="openrouter", auth_type="api-key", api_key=None, label=None))
+
+    out = capsys.readouterr().out
+    assert "API key를 붙여 넣어 주세요:" in out
+    assert "라벨(선택, 기본값:" in out
+    assert "openrouter 자격 증명 #1을(를) 추가했어요: \"개인 키\"" in out
+
 
 
 def test_interactive_strategy_invalid_choice_is_localized(monkeypatch, capsys):

--- a/tests/hermes_cli/test_auth_localization_runtime.py
+++ b/tests/hermes_cli/test_auth_localization_runtime.py
@@ -1,4 +1,6 @@
 from types import SimpleNamespace
+import sys
+import types
 
 import pytest
 
@@ -31,13 +33,44 @@ def test_prompt_model_selection_fallback_is_localized(monkeypatch, capsys):
 
     monkeypatch.setattr("builtins.input", fake_input)
 
-    selected = _prompt_model_selection(["gpt-4.1", "gpt-4o-mini"])
+    selected = _prompt_model_selection(["gpt-4.1", "gpt-4o-mini"], current_model="gpt-4.1")
 
     out = capsys.readouterr().out
     assert selected is None
+    assert "기본 모델 선택:" in out
+    assert "gpt-4.1  ← 현재 사용 중" in out
     assert "사용자 지정 모델 이름 입력" in out
     assert "건너뛰기(현재 설정 유지)" in out
     assert "숫자를 입력해 주세요" in out
+
+
+class _FakeTerminalMenu:
+    last_choices = None
+    last_title = None
+
+    def __init__(self, choices, **kwargs):
+        _FakeTerminalMenu.last_choices = choices
+        _FakeTerminalMenu.last_title = kwargs.get("title")
+        self._cursor_index = kwargs.get("cursor_index")
+
+    def show(self):
+        return self._cursor_index
+
+
+def test_prompt_model_selection_terminal_menu_is_localized(monkeypatch):
+    monkeypatch.setitem(sys.modules, "simple_term_menu", types.SimpleNamespace(TerminalMenu=_FakeTerminalMenu))
+    monkeypatch.setattr("hermes_cli.curses_ui.flush_stdin", lambda: None)
+
+    selected = _prompt_model_selection(["gpt-4.1", "gpt-4o-mini"], current_model="gpt-4.1")
+
+    assert selected == "gpt-4.1"
+    assert _FakeTerminalMenu.last_title == "기본 모델 선택:"
+    assert _FakeTerminalMenu.last_choices[:3] == [
+        "  gpt-4.1  ← 현재 사용 중",
+        "  gpt-4o-mini",
+        "  사용자 지정 모델 이름 입력",
+    ]
+
 
 
 def test_login_command_deprecation_is_localized(capsys):
@@ -72,6 +105,12 @@ def test_logout_command_is_localized(monkeypatch, capsys):
     logout_command(SimpleNamespace(provider=None))
     out = capsys.readouterr().out
     assert "현재 로그인된 provider가 없어요." in out
+
+    with pytest.raises(SystemExit) as exc:
+        logout_command(SimpleNamespace(provider="mystery"))
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "알 수 없는 provider예요: mystery" in out
 
     monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: "openai-codex")
     monkeypatch.setattr("hermes_cli.auth.clear_provider_auth", lambda _provider: True)

--- a/tests/hermes_cli/test_auth_localization_runtime.py
+++ b/tests/hermes_cli/test_auth_localization_runtime.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.auth import (
+    AuthError,
+    _login_openai_codex,
+    _prompt_model_selection,
+    format_auth_error,
+    login_command,
+    logout_command,
+)
+
+
+def test_format_auth_error_subscription_and_relogin_are_localized():
+    relogin_error = AuthError("토큰이 만료되었어요.", relogin_required=True)
+    subscription_error = AuthError("subscription missing", code="subscription_required")
+
+    assert "다시 인증하려면 `hermes model`" in format_auth_error(relogin_error)
+    assert "활성화된 유료 구독을 찾지 못했어요" in format_auth_error(subscription_error)
+
+
+def test_prompt_model_selection_fallback_is_localized(monkeypatch, capsys):
+    responses = iter(["abc"])
+
+    def fake_input(_prompt):
+        try:
+            return next(responses)
+        except StopIteration:
+            raise EOFError
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    selected = _prompt_model_selection(["gpt-4.1", "gpt-4o-mini"])
+
+    out = capsys.readouterr().out
+    assert selected is None
+    assert "사용자 지정 모델 이름 입력" in out
+    assert "건너뛰기(현재 설정 유지)" in out
+    assert "숫자를 입력해 주세요" in out
+
+
+def test_login_command_deprecation_is_localized(capsys):
+    with pytest.raises(SystemExit) as exc:
+        login_command(SimpleNamespace())
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "'hermes login' 명령은 제거되었어요." in out
+    assert "자격 증명 관리는 'hermes auth'" in out
+
+
+def test_login_openai_codex_reuse_prompt_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda: {"api_key": "tok", "base_url": "https://example.com/codex"},
+    )
+    monkeypatch.setattr("hermes_cli.auth._codex_access_token_is_expiring", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr("hermes_cli.auth._update_config_for_provider", lambda *_args, **_kwargs: "/tmp/config.yaml")
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    _login_openai_codex(SimpleNamespace(), None)
+
+    out = capsys.readouterr().out
+    assert "Hermes auth store에서 기존 Codex 자격 증명을 찾았어요." in out
+    assert "로그인에 성공했어요!" in out
+    assert "설정 업데이트: /tmp/config.yaml" in out
+
+
+def test_logout_command_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    logout_command(SimpleNamespace(provider=None))
+    out = capsys.readouterr().out
+    assert "현재 로그인된 provider가 없어요." in out
+
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: "openai-codex")
+    monkeypatch.setattr("hermes_cli.auth.clear_provider_auth", lambda _provider: True)
+    monkeypatch.setattr("hermes_cli.auth._reset_config_provider", lambda: None)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+
+    logout_command(SimpleNamespace(provider=None))
+    out = capsys.readouterr().out
+    assert "OpenAI Codex 에서 로그아웃했어요." in out
+    assert "Hermes는 추론에 OpenRouter를 사용할 거예요." in out

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -146,6 +146,9 @@ class TestDerivedDicts:
         for cmd, desc in COMMANDS.items():
             assert isinstance(desc, str) and len(desc) > 0, f"{cmd} has empty description"
 
+    def test_help_description_is_localized_to_korean(self):
+        assert "사용 가능한 명령어" in COMMANDS["/help"]
+
 
 # ---------------------------------------------------------------------------
 # Gateway helpers
@@ -198,6 +201,11 @@ class TestGatewayHelpLines:
         bg_line = [l for l in lines if "/background" in l]
         assert len(bg_line) == 1
         assert "/bg" in bg_line[0]
+
+    def test_help_line_is_localized_to_korean(self):
+        lines = gateway_help_lines()
+        help_line = next(l for l in lines if l.startswith("`/help`"))
+        assert "사용 가능한 명령어" in help_line
 
 
 class TestTelegramBotCommands:
@@ -339,7 +347,7 @@ class TestSlashCommandCompleter:
     def test_builtin_completion_display_meta_shows_description(self):
         completions = _completions(SlashCommandCompleter(), "/help")
         assert len(completions) == 1
-        assert completions[0].display_meta_text == "Show available commands"
+        assert completions[0].display_meta_text == "사용 가능한 명령어 표시"
 
     # -- exact-match trailing space --------------------------------------
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -33,9 +33,9 @@ class TestCronCommandLifecycle:
         assert triggered["state"] == "scheduled"
 
         out = capsys.readouterr().out
-        assert "Paused job" in out
-        assert "Resumed job" in out
-        assert "Triggered job" in out
+        assert "일시중지한 job" in out
+        assert "재개한 job" in out
+        assert "실행 예약한 job" in out
 
     def test_edit_can_replace_and_clear_skills(self, tmp_cron_dir, capsys):
         job = create_job(
@@ -83,7 +83,7 @@ class TestCronCommandLifecycle:
         assert cleared["skill"] is None
 
         out = capsys.readouterr().out
-        assert "Updated job" in out
+        assert "작업을 업데이트했어요" in out
 
     def test_create_with_multiple_skills(self, tmp_cron_dir, capsys):
         cron_command(
@@ -99,7 +99,7 @@ class TestCronCommandLifecycle:
             )
         )
         out = capsys.readouterr().out
-        assert "Created job" in out
+        assert "작업을 만들었어요" in out
 
         jobs = list_jobs()
         assert len(jobs) == 1

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -297,8 +297,8 @@ class TestRunDebugShare:
 
         out = capsys.readouterr().out
         assert "--- agent.log" in out
-        assert "FULL agent.log" in out
-        assert "FULL gateway.log" in out
+        assert "전체 agent.log" in out
+        assert "전체 gateway.log" in out
 
     def test_share_uploads_three_pastes(self, hermes_home, capsys):
         """Successful share uploads report + agent.log + gateway.log."""

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -339,7 +339,45 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
         doctor_mod.run_doctor(Namespace(fix=False))
     out = buf.getvalue()
 
-    assert "API key or custom endpoint configured" in out
+    assert "API key 또는 custom endpoint가 설정되어 있어요" in out
     assert "Kimi / Moonshot (China)" in out
     assert "str expected, not NoneType" not in out
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
+
+
+def test_run_doctor_localizes_python_and_config_sections(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "◆ Python 환경" in out
+    assert "가상환경 활성화됨" in out or "가상환경 안에서 실행 중이 아님" in out
+    assert "◆ 필수 패키지" in out
+    assert "◆ 설정 파일" in out
+    assert "API key 또는 custom endpoint가 설정되어 있어요" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -137,9 +137,9 @@ def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path,
     doctor._check_gateway_service_linger(issues)
 
     out = capsys.readouterr().out
-    assert "Gateway Service" in out
-    assert "Systemd linger disabled" in out
-    assert "loginctl enable-linger" in out
+    assert "Gateway 서비스" in out
+    assert "Systemd linger 비활성화됨" in out
+    assert "실행: sudo loginctl enable-linger $USER" in out
     assert issues == [
         "Enable linger for the gateway user service: sudo loginctl enable-linger $USER"
     ]

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -381,3 +381,51 @@ def test_run_doctor_localizes_python_and_config_sections(monkeypatch, tmp_path):
     assert "◆ 필수 패키지" in out
     assert "◆ 설정 파일" in out
     assert "API key 또는 custom endpoint가 설정되어 있어요" in out
+
+
+def test_run_doctor_localizes_auth_and_directory_sections(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+    (home / "SOUL.md").write_text("You are Hermes.\n", encoding="utf-8")
+    memories = home / "memories"
+    memories.mkdir()
+    (memories / "MEMORY.md").write_text("memo\n", encoding="utf-8")
+    (memories / "USER.md").write_text("user\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/usr/bin/codex" if cmd == "codex" else None)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {"logged_in": True})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {"logged_in": False, "error": "expired"})
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "◆ 인증 provider" in out
+    assert "Nous Portal 인증" in out
+    assert "OpenAI Codex 인증" in out
+    assert "로그인됨" in out
+    assert "로그인 안 됨" in out
+    assert "◆ 디렉터리 구조" in out
+    assert "SOUL.md가 있어요" in out
+    assert "MEMORY.md가 있어요" in out
+    assert "USER.md가 있어요" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -33,7 +33,7 @@ class TestDoctorPlatformHints:
 
 class TestProviderEnvDetection:
     def test_detects_openai_api_key(self):
-        content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***"
+        content = "OPENAI_BASE_URL=http://localhost:1234/v1\nOPENAI_API_KEY=***\n"
         assert _has_provider_env_config(content)
 
     def test_detects_custom_endpoint_without_openrouter_key(self):
@@ -41,7 +41,7 @@ class TestProviderEnvDetection:
         assert _has_provider_env_config(content)
 
     def test_detects_kimi_cn_api_key(self):
-        content = "KIMI_CN_API_KEY=sk-test\n"
+        content = "KIMI_CN_API_KEY=***\n"
         assert _has_provider_env_config(content)
 
     def test_returns_false_when_no_provider_settings(self):
@@ -205,8 +205,8 @@ class TestDoctorMemoryProviderSection:
 
     def test_no_provider_shows_builtin_ok(self, monkeypatch, tmp_path):
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
-        assert "Memory Provider" in out
-        assert "Built-in memory active" in out
+        assert "메모리 provider" in out
+        assert "내장 메모리 활성화됨" in out
         # Should NOT mention Honcho or Mem0 errors
         assert "Honcho API key" not in out
         assert "Mem0" not in out
@@ -217,16 +217,16 @@ class TestDoctorMemoryProviderSection:
             sys.modules, "plugins.memory.honcho.client", None
         )
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="honcho")
-        assert "Memory Provider" in out
+        assert "메모리 provider" in out
         # Should show failure since honcho is set but not importable
-        assert "Built-in memory active" not in out
+        assert "내장 메모리 활성화됨" not in out
 
     def test_mem0_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):
         # Make mem0 import fail
         monkeypatch.setitem(sys.modules, "plugins.memory.mem0", None)
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
-        assert "Memory Provider" in out
-        assert "Built-in memory active" not in out
+        assert "메모리 provider" in out
+        assert "내장 메모리 활성화됨" not in out
 
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
@@ -245,14 +245,14 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
 
     out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
 
-    assert "Docker backend is not available inside Termux" in out
-    assert "Node.js not found (browser tools are optional in the tested Termux path)" in out
-    assert "Install Node.js on Termux with: pkg install nodejs" in out
-    assert "Termux browser setup:" in out
+    assert "Termux 내부에서는 Docker 백엔드를 사용할 수 없어요" in out
+    assert "Node.js를 찾지 못했어요" in out
+    assert "Termux에서 Node.js 설치: pkg install nodejs" in out
+    assert "Termux 브라우저 설정:" in out
     assert "1) pkg install nodejs" in out
     assert "2) npm install -g agent-browser" in out
     assert "3) agent-browser install" in out
-    assert "docker not found (optional)" not in out
+    assert "docker를 찾지 못했어요" not in out
 
 
 def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser(monkeypatch, tmp_path):
@@ -293,8 +293,8 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
 
     assert "✓ browser" not in out
     assert "browser" in out
-    assert "system dependency not met" in out
-    assert "agent-browser is not installed (expected in the tested Termux path)" in out
+    assert "시스템 의존성을 충족하지 못함" in out
+    assert "agent-browser가 설치되지 않았어요" in out
     assert "npm install -g agent-browser && agent-browser install" in out
 
 
@@ -429,3 +429,49 @@ def test_run_doctor_localizes_auth_and_directory_sections(monkeypatch, tmp_path)
     assert "SOUL.md가 있어요" in out
     assert "MEMORY.md가 있어요" in out
     assert "USER.md가 있어요" in out
+
+
+def test_run_doctor_localizes_external_tools_and_summary(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    def fake_which(cmd):
+        return {"git": "/usr/bin/git", "npm": None}.get(cmd)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], [{"name": "browser", "env_vars": [], "tools": ["browser_navigate"]}]),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_anthropic_key", lambda: "")
+    except Exception:
+        pass
+
+    import io, contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "◆ 외부 도구" in out
+    assert "ripgrep (rg)를 찾지 못했어요" in out
+    assert "◆ 도구 사용 가능 여부" in out
+    assert "시스템 의존성을 충족하지 못함" in out
+    assert "◆ API 연결 상태" in out
+    assert "OpenRouter API" in out
+    assert "(설정되지 않음)" in out
+    assert "해결이 필요한 문제" in out

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -58,7 +58,7 @@ def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys
     gateway.systemd_status(deep=False)
 
     out = capsys.readouterr().out
-    assert "gateway service is running" in out
+    assert "서비스가 실행 중이어서" in out or "gateway service is running" in out
     assert "Systemd linger is disabled" in out
     assert "loginctl enable-linger" in out
 
@@ -87,7 +87,8 @@ def test_systemd_install_checks_linger_status(monkeypatch, tmp_path, capsys):
         ["systemctl", "--user", "enable", gateway.get_service_name()],
     ]
     assert helper_calls == [True]
-    assert "User service installed and enabled" in out
+    assert "user systemd 서비스를 설치하는 중" in out
+    assert "서비스를 설치하고 활성화했어요" in out
 
 
 def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatch, tmp_path, capsys):
@@ -122,7 +123,8 @@ def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatc
     ]
     assert helper_calls == []
     assert "Configured to run as: alice" not in out  # generated test unit has no User= line
-    assert "System service installed and enabled" in out
+    assert "system systemd 서비스를 설치하는 중" in out
+    assert "서비스를 설치하고 활성화했어요" in out
 
 
 def test_conflicting_systemd_units_warning(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -12,6 +12,62 @@ from gateway.restart import (
 )
 
 
+def test_prompt_linux_gateway_install_scope_is_localized(monkeypatch):
+    captured = {}
+
+    def fake_prompt_choice(title, options, default=0):
+        captured["title"] = title
+        captured["options"] = options
+        captured["default"] = default
+        return 2
+
+    monkeypatch.setattr(gateway_cli, "prompt_choice", fake_prompt_choice)
+
+    result = gateway_cli.prompt_linux_gateway_install_scope()
+
+    assert result is None
+    assert captured["title"] == "  게이트웨이를 백그라운드에서 어떻게 실행할지 선택해 주세요:"
+    assert captured["options"] == [
+        "사용자 서비스 (sudo 불필요, 노트북/개발 환경에 적합, 로그아웃 후 linger 설정이 필요할 수 있음)",
+        "시스템 서비스 (부팅 시 시작, sudo 필요, 실제 실행은 현재 사용자 계정으로 진행)",
+        "지금은 서비스 설치 건너뛰기",
+    ]
+    assert captured["default"] == 0
+
+
+
+def test_print_systemd_linger_guidance_is_localized_enabled(monkeypatch, capsys):
+    monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
+
+    gateway_cli.print_systemd_linger_guidance()
+
+    out = capsys.readouterr().out
+    assert "systemd linger가 활성화되어 있어요" in out
+
+
+
+def test_print_systemd_linger_guidance_is_localized_disabled(monkeypatch, capsys):
+    monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (False, ""))
+
+    gateway_cli.print_systemd_linger_guidance()
+
+    out = capsys.readouterr().out
+    assert "systemd linger가 비활성화되어 있어요" in out
+    assert "실행: sudo loginctl enable-linger $USER" in out
+
+
+
+def test_print_systemd_linger_guidance_is_localized_unknown(monkeypatch, capsys):
+    monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (None, "loginctl not found"))
+
+    gateway_cli.print_systemd_linger_guidance()
+
+    out = capsys.readouterr().out
+    assert "systemd linger 상태를 확인하지 못했어요" in out
+    assert "loginctl not found" in out
+    assert "gateway 사용자 서비스를 유지하려면" in out
+
+
 class TestSystemdServiceRefresh:
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -531,8 +531,8 @@ class TestGatewaySystemServiceRouting:
             raise AssertionError("Expected gateway_command to exit on unsupported Termux service install")
 
         out = capsys.readouterr().out
-        assert "not supported on Termux" in out
-        assert "Run manually: hermes gateway" in out
+        assert "Termux에서는 게이트웨이 서비스를 설치할 수 없어요." in out
+        assert "수동 실행: hermes gateway" in out
 
     def test_gateway_status_prefers_system_service_when_only_system_unit_exists(self, monkeypatch):
         user_unit = SimpleNamespace(exists=lambda: False)
@@ -564,9 +564,9 @@ class TestGatewaySystemServiceRouting:
         gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
 
         out = capsys.readouterr().out
-        assert "Gateway is not running" in out
+        assert "게이트웨이가 실행 중이 아니에요" in out
         assert "nohup hermes gateway" in out
-        assert "install as user service" not in out
+        assert "사용자 서비스로 설치" not in out
 
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -130,6 +130,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda command: "/usr/bin/systemctl" if command == "systemctl" else None)
         assert gateway.supports_systemd_services() is True
 
     def test_wsl_without_systemd(self, monkeypatch):
@@ -138,6 +139,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda command: "/usr/bin/systemctl" if command == "systemctl" else None)
         assert gateway.supports_systemd_services() is False
 
     def test_native_linux(self, monkeypatch):
@@ -145,6 +147,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda command: "/usr/bin/systemctl" if command == "systemctl" else None)
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):
@@ -179,8 +182,8 @@ class TestGatewayCommandWSLMessages:
         assert exc_info.value.code == 1
 
         out = capsys.readouterr().out
-        assert "WSL detected" in out
-        assert "systemd is not running" in out
+        assert "WSL이 감지되었지만" in out
+        assert "systemd가 실행 중이 아니에요" in out
         assert "hermes gateway run" in out
         assert "tmux" in out
 
@@ -198,7 +201,7 @@ class TestGatewayCommandWSLMessages:
         assert exc_info.value.code == 1
 
         out = capsys.readouterr().out
-        assert "WSL detected" in out
+        assert "WSL이 감지되었지만" in out
         assert "hermes gateway run" in out
         assert "wsl.conf" in out
 
@@ -225,8 +228,8 @@ class TestGatewayCommandWSLMessages:
         gateway.gateway_command(args)
 
         out = capsys.readouterr().out
-        assert "WSL detected" in out
-        assert "may not survive WSL restarts" in out
+        assert "WSL이 감지되었어요" in out
+        assert "유지되지 않을 수 있어요" in out
         assert len(install_called) == 1  # install still proceeded
 
     def test_status_wsl_running_manual(self, monkeypatch, capsys):
@@ -251,8 +254,8 @@ class TestGatewayCommandWSLMessages:
         gateway.gateway_command(args)
 
         out = capsys.readouterr().out
-        assert "WSL note" in out
-        assert "tmux or screen" in out
+        assert "WSL 참고:" in out
+        assert "tmux 또는 screen" in out
 
     def test_status_wsl_not_running(self, monkeypatch, capsys):
         """hermes gateway status on WSL with no process shows WSL start advice."""

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -59,6 +59,43 @@ def test_argparse_default_labels_are_localized():
     assert _argparse_korean("show this help message and exit") == "이 도움말을 표시하고 종료"
 
 
+@pytest.mark.parametrize(
+    ("argv", "expected_strings"),
+    [
+        (
+            ["hermes", "gateway", "install", "--help"],
+            ["강제로 재설치", "Linux 시스템 레벨 서비스로 설치", "사용법: hermes gateway install"],
+        ),
+        (
+            ["hermes", "sessions", "browse", "--help"],
+            ["source로 필터링", "불러올 최대 세션 수", "사용법: hermes sessions browse"],
+        ),
+        (
+            ["hermes", "mcp", "add", "--help"],
+            ["서버 이름", "stdio 서버용 환경 변수", "사용법: hermes mcp add"],
+        ),
+        (
+            ["hermes", "profile", "create", "--help"],
+            ["프로필 이름", "래퍼 스크립트 생성 건너뛰기", "사용법: hermes profile create"],
+        ),
+        (
+            ["hermes", "logs", "--help"],
+            ["예시:", "agent.log 최근 50줄 표시", "표시할 최소 로그 레벨"],
+        ),
+    ],
+)
+def test_nested_subcommand_help_is_localized(monkeypatch, capsys, argv, expected_strings):
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "사용법:" in out
+    assert "옵션:" in out
+    for expected in expected_strings:
+        assert expected in out
+
+
 def test_prompt_provider_choice_fallback_is_localized(monkeypatch, capsys):
     monkeypatch.setattr("builtins.input", lambda _prompt: "")
 

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -4,6 +4,7 @@ import pytest
 
 from hermes_cli.commands import get_category_label
 from hermes_cli.main import (
+    _build_web_ui,
     _model_flow_openrouter,
     _model_flow_qwen_oauth,
     _prompt_provider_choice,
@@ -72,3 +73,17 @@ def test_model_flow_qwen_not_logged_in_is_localized(monkeypatch, capsys):
     assert "실행: qwen auth qwen-oauth" in out
     assert "예상 자격 증명 파일 위치: /tmp/qwen-auth.json" in out
     assert "오류: missing token" in out
+
+
+def test_build_web_ui_fatal_missing_npm_is_localized(monkeypatch, capsys, tmp_path):
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").write_text("{}")
+
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    assert _build_web_ui(web_dir, fatal=True) is False
+
+    out = capsys.readouterr().out
+    assert "Web UI 프런트엔드가 빌드되지 않았고 npm도 사용할 수 없어요." in out
+    assert "Node.js를 설치한 뒤 다음을 실행하세요" in out

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -5,9 +5,11 @@ import pytest
 from hermes_cli.commands import get_category_label
 from hermes_cli.main import (
     _build_web_ui,
+    _model_flow_custom,
     _model_flow_openrouter,
     _model_flow_qwen_oauth,
     _prompt_provider_choice,
+    _remove_custom_provider,
     main,
 )
 
@@ -87,3 +89,25 @@ def test_build_web_ui_fatal_missing_npm_is_localized(monkeypatch, capsys, tmp_pa
     out = capsys.readouterr().out
     assert "Web UI 프런트엔드가 빌드되지 않았고 npm도 사용할 수 없어요." in out
     assert "Node.js를 설치한 뒤 다음을 실행하세요" in out
+
+
+def test_model_flow_custom_empty_url_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    inputs = iter([""])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(inputs))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: "")
+
+    _model_flow_custom({})
+
+    out = capsys.readouterr().out
+    assert "사용자 지정 OpenAI 호환 endpoint 설정:" in out
+    assert "URL이 제공되지 않아 취소했어요." in out
+
+
+def test_remove_custom_provider_empty_state_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"custom_providers": []})
+
+    _remove_custom_provider({})
+
+    out = capsys.readouterr().out
+    assert "설정된 custom provider가 없어요." in out

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -3,7 +3,12 @@ import sys
 import pytest
 
 from hermes_cli.commands import get_category_label
-from hermes_cli.main import main
+from hermes_cli.main import (
+    _model_flow_openrouter,
+    _model_flow_qwen_oauth,
+    _prompt_provider_choice,
+    main,
+)
 
 
 def test_get_category_label_localizes_builtin_categories():
@@ -25,3 +30,45 @@ def test_main_help_is_localized_to_korean(monkeypatch, capsys):
     assert "실행할 명령어" in out
     assert "버전을 표시하고 종료" in out
     assert "대화형 채팅 시작" in out
+
+
+def test_prompt_provider_choice_fallback_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _prompt: "")
+
+    selected = _prompt_provider_choice(["OpenRouter", "Nous Portal"], default=1)
+
+    out = capsys.readouterr().out
+    assert selected == 1
+    assert "provider 선택:" in out
+
+
+def test_model_flow_openrouter_cancel_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "" if key == "OPENROUTER_API_KEY" else "")
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("getpass.getpass", lambda _prompt: "")
+
+    _model_flow_openrouter({}, current_model="")
+
+    out = capsys.readouterr().out
+    assert "OpenRouter API key가 설정되어 있지 않아요." in out
+    assert "발급 링크:" in out
+    assert "취소했어요." in out
+
+
+def test_model_flow_qwen_not_logged_in_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_qwen_auth_status",
+        lambda: {
+            "logged_in": False,
+            "auth_file": "/tmp/qwen-auth.json",
+            "error": "missing token",
+        },
+    )
+
+    _model_flow_qwen_oauth({}, current_model="")
+
+    out = capsys.readouterr().out
+    assert "Qwen CLI OAuth에 로그인되어 있지 않아요." in out
+    assert "실행: qwen auth qwen-oauth" in out
+    assert "예상 자격 증명 파일 위치: /tmp/qwen-auth.json" in out
+    assert "오류: missing token" in out

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -5,6 +5,7 @@ import pytest
 
 from hermes_cli.commands import get_category_label
 from hermes_cli.main import (
+    _argparse_korean,
     _build_web_ui,
     _model_flow_custom,
     _model_flow_openrouter,
@@ -34,6 +35,28 @@ def test_main_help_is_localized_to_korean(monkeypatch, capsys):
     assert "실행할 명령어" in out
     assert "버전을 표시하고 종료" in out
     assert "대화형 채팅 시작" in out
+    assert "사용법:" in out
+    assert "옵션:" in out
+    assert "이 도움말을 표시하고 종료" in out
+
+
+def test_update_help_is_localized_to_korean(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["hermes", "update", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "사용법: hermes update" in out
+    assert "git에서 최신 변경 사항을 가져오고 의존성을 다시 설치" in out
+    assert "옵션:" in out
+    assert "이 도움말을 표시하고 종료" in out
+    assert "게이트웨이 모드: stdin 대신 파일 기반 IPC로 프롬프트를 주고받음" in out
+
+
+def test_argparse_default_labels_are_localized():
+    assert _argparse_korean("usage: ") == "사용법: "
+    assert _argparse_korean("options") == "옵션"
+    assert _argparse_korean("show this help message and exit") == "이 도움말을 표시하고 종료"
 
 
 def test_prompt_provider_choice_fallback_is_localized(monkeypatch, capsys):

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -7,6 +7,7 @@ from hermes_cli.commands import get_category_label
 from hermes_cli.main import (
     _argparse_korean,
     _build_web_ui,
+    _model_flow_copilot,
     _model_flow_custom,
     _model_flow_openrouter,
     _model_flow_qwen_oauth,
@@ -189,6 +190,22 @@ def test_model_flow_qwen_not_logged_in_is_localized(monkeypatch, capsys):
     assert "실행: qwen auth qwen-oauth" in out
     assert "예상 자격 증명 파일 위치: /tmp/qwen-auth.json" in out
     assert "오류: missing token" in out
+
+
+def test_model_flow_copilot_missing_token_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        lambda _provider_id: {"api_key": "", "source": ""},
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt='': "3")
+
+    _model_flow_copilot({}, current_model="")
+
+    out = capsys.readouterr().out
+    assert "GitHub Copilot용 GitHub 토큰이 설정되어 있지 않아요." in out
+    assert "지원하는 토큰 종류:" in out
+    assert "취소했어요." in out
+
 
 
 def test_build_web_ui_fatal_missing_npm_is_localized(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -11,7 +11,10 @@ from hermes_cli.main import (
     _model_flow_openrouter,
     _model_flow_qwen_oauth,
     _prompt_provider_choice,
+    _prompt_reasoning_effort_selection,
     _remove_custom_provider,
+    cmd_dashboard,
+    cmd_profile,
     main,
 )
 
@@ -57,6 +60,56 @@ def test_argparse_default_labels_are_localized():
     assert _argparse_korean("usage: ") == "사용법: "
     assert _argparse_korean("options") == "옵션"
     assert _argparse_korean("show this help message and exit") == "이 도움말을 표시하고 종료"
+
+
+def test_reasoning_effort_prompt_fallback_is_localized(monkeypatch, capsys):
+    responses = iter(["abc"])
+
+    def fake_input(_prompt):
+        try:
+            return next(responses)
+        except StopIteration:
+            raise EOFError
+
+    monkeypatch.setattr("builtins.input", fake_input)
+
+    selected = _prompt_reasoning_effort_selection(["low", "high"], current_effort="low")
+
+    out = capsys.readouterr().out
+    assert selected is None
+    assert "추론 강도 선택:" in out
+    assert "추론 비활성화" in out
+    assert "건너뛰기(현재 설정 유지)" in out
+    assert "숫자를 입력해 주세요" in out
+
+
+def test_profile_list_empty_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: [])
+    monkeypatch.setattr("hermes_cli.profiles.get_active_profile_name", lambda: "default")
+
+    cmd_profile(type("Args", (), {"profile_action": "list"})())
+
+    out = capsys.readouterr().out
+    assert "프로필이 없어요." in out
+
+
+def test_dashboard_missing_dependencies_is_localized(monkeypatch, capsys):
+    original_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in {"fastapi", "uvicorn"}:
+            raise ImportError("missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(SystemExit) as exc:
+        cmd_dashboard(type("Args", (), {"host": "127.0.0.1", "port": 9119, "no_open": True, "insecure": False})())
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Web UI 의존성이 설치되지 않았어요." in out
+    assert "설치 명령: pip install hermes-agent[web]" in out
 
 
 @pytest.mark.parametrize(

--- a/tests/hermes_cli/test_main_localization.py
+++ b/tests/hermes_cli/test_main_localization.py
@@ -1,0 +1,27 @@
+import sys
+
+import pytest
+
+from hermes_cli.commands import get_category_label
+from hermes_cli.main import main
+
+
+def test_get_category_label_localizes_builtin_categories():
+    assert get_category_label("Session") == "세션"
+    assert get_category_label("Configuration") == "설정"
+    assert get_category_label("Tools & Skills") == "도구와 스킬"
+    assert get_category_label("Info") == "정보"
+    assert get_category_label("Exit") == "종료"
+
+
+def test_main_help_is_localized_to_korean(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["hermes", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert "도구 호출 기능을 갖춘 AI 어시스턴트" in out
+    assert "예시:" in out
+    assert "실행할 명령어" in out
+    assert "버전을 표시하고 종료" in out
+    assert "대화형 채팅 시작" in out

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -82,7 +82,7 @@ class TestMcpList:
 
         cmd_mcp_list()
         out = capsys.readouterr().out
-        assert "No MCP servers configured" in out
+        assert "설정된 MCP 서버가 없어요" in out
 
     def test_list_with_servers(self, tmp_path, capsys):
         _seed_config(tmp_path, {
@@ -103,8 +103,8 @@ class TestMcpList:
         out = capsys.readouterr().out
         assert "ink" in out
         assert "github" in out
-        assert "2 selected" in out  # ink has 2 in include
-        assert "disabled" in out  # github is disabled
+        assert "2개 선택" in out  # ink has 2 in include
+        assert "비활성화" in out  # github is disabled
 
     def test_list_enabled_default_true(self, tmp_path, capsys):
         """Server without explicit enabled key defaults to enabled."""
@@ -116,7 +116,7 @@ class TestMcpList:
         cmd_mcp_list()
         out = capsys.readouterr().out
         assert "myserver" in out
-        assert "enabled" in out
+        assert "활성화" in out
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +134,7 @@ class TestMcpRemove:
         cmd_mcp_remove(_make_args(name="myserver"))
 
         out = capsys.readouterr().out
-        assert "Removed" in out
+        assert "제거했어요" in out
 
         # Verify config updated
         from hermes_cli.config import load_config
@@ -148,7 +148,7 @@ class TestMcpRemove:
 
         cmd_mcp_remove(_make_args(name="ghost"))
         out = capsys.readouterr().out
-        assert "not found" in out
+        assert "찾지 못했어요" in out
 
     def test_remove_cleans_oauth_tokens(self, tmp_path, capsys, monkeypatch):
         _seed_config(tmp_path, {
@@ -183,7 +183,7 @@ class TestMcpAdd:
 
         cmd_mcp_add(_make_args(name="bad"))
         out = capsys.readouterr().out
-        assert "Must specify" in out
+        assert "지정해야 해요" in out
 
     def test_add_http_server_all_tools(self, tmp_path, capsys, monkeypatch):
         """Add an HTTP server, accept all tools."""
@@ -206,8 +206,8 @@ class TestMcpAdd:
 
         cmd_mcp_add(_make_args(name="ink", url="https://mcp.ml.ink/mcp"))
         out = capsys.readouterr().out
-        assert "Saved" in out
-        assert "2/2 tools" in out
+        assert "저장했어요" in out
+        assert "2/2개 도구 활성화" in out
 
         # Verify config written
         from hermes_cli.config import load_config
@@ -237,7 +237,7 @@ class TestMcpAdd:
             args=["@mcp/github"],
         ))
         out = capsys.readouterr().out
-        assert "Saved" in out
+        assert "저장했어요" in out
 
         from hermes_cli.config import load_config
 
@@ -264,7 +264,7 @@ class TestMcpAdd:
 
         cmd_mcp_add(_make_args(name="broken", url="https://bad.host/mcp"))
         out = capsys.readouterr().out
-        assert "disabled" in out
+        assert "비활성화됨" in out
 
         from hermes_cli.config import load_config
 
@@ -296,7 +296,7 @@ class TestMcpAdd:
             env=["MY_API_KEY=secret123", "DEBUG=true"],
         ))
         out = capsys.readouterr().out
-        assert "Saved" in out
+        assert "저장했어요" in out
 
         from hermes_cli.config import load_config
 
@@ -357,7 +357,7 @@ class TestMcpAdd:
 
         cmd_mcp_add(_make_args(name="myserver", preset="testmcp"))
         out = capsys.readouterr().out
-        assert "Saved" in out
+        assert "저장했어요" in out
 
         config = read_raw_config()
         srv = config["mcp_servers"]["myserver"]
@@ -394,7 +394,7 @@ class TestMcpAdd:
             args=["custom-server"],
         ))
         out = capsys.readouterr().out
-        assert "Saved" in out
+        assert "저장했어요" in out
 
         config = read_raw_config()
         srv = config["mcp_servers"]["custom"]
@@ -422,7 +422,7 @@ class TestMcpTest:
 
         cmd_mcp_test(_make_args(name="ghost"))
         out = capsys.readouterr().out
-        assert "not found" in out
+        assert "찾지 못했어요" in out
 
     def test_test_success(self, tmp_path, capsys, monkeypatch):
         _seed_config(tmp_path, {
@@ -439,8 +439,8 @@ class TestMcpTest:
 
         cmd_mcp_test(_make_args(name="ink"))
         out = capsys.readouterr().out
-        assert "Connected" in out
-        assert "Tools discovered: 2" in out
+        assert "연결 성공" in out
+        assert "발견한 도구 수: 2" in out
 
 
 # ---------------------------------------------------------------------------
@@ -538,4 +538,4 @@ class TestDispatcher:
         _seed_config(tmp_path, {})
         mcp_command(_make_args(mcp_action=None))
         out = capsys.readouterr().out
-        assert "Commands:" in out or "No MCP servers" in out
+        assert "명령어:" in out or "설정된 MCP 서버가 없어요" in out

--- a/tests/hermes_cli/test_mcp_tools_config.py
+++ b/tests/hermes_cli/test_mcp_tools_config.py
@@ -16,7 +16,7 @@ def test_no_mcp_servers_prints_info(capsys):
     config = {}
     _configure_mcp_tools_interactive(config)
     captured = capsys.readouterr()
-    assert "No MCP servers configured" in captured.out
+    assert "설정된 MCP 서버가 없어요" in captured.out
 
 
 def test_all_servers_disabled_prints_info(capsys):
@@ -29,7 +29,7 @@ def test_all_servers_disabled_prints_info(capsys):
     }
     _configure_mcp_tools_interactive(config)
     captured = capsys.readouterr()
-    assert "disabled" in captured.out
+    assert "비활성화" in captured.out
 
 
 def test_probe_failure_shows_warning(capsys):
@@ -38,7 +38,7 @@ def test_probe_failure_shows_warning(capsys):
     with patch(_PROBE, return_value={}):
         _configure_mcp_tools_interactive(config)
     captured = capsys.readouterr()
-    assert "Could not discover" in captured.out
+    assert "도구를 찾지 못했어요" in captured.out
 
 
 def test_probe_exception_shows_error(capsys):
@@ -47,7 +47,7 @@ def test_probe_exception_shows_error(capsys):
     with patch(_PROBE, side_effect=RuntimeError("MCP not installed")):
         _configure_mcp_tools_interactive(config)
     captured = capsys.readouterr()
-    assert "Failed to probe" in captured.out
+    assert "MCP 서버를 확인하지 못했어요" in captured.out
 
 
 def test_no_changes_when_checklist_cancelled(capsys):
@@ -65,7 +65,7 @@ def test_no_changes_when_checklist_cancelled(capsys):
         _configure_mcp_tools_interactive(config)
     mock_save.assert_not_called()
     captured = capsys.readouterr()
-    assert "no changes" in captured.out.lower()
+    assert "변경 사항이 없어요" in captured.out
 
 
 def test_disabling_tool_writes_exclude_list(capsys):
@@ -288,4 +288,4 @@ def test_empty_tools_server_skipped(capsys):
 
     assert len(checklist_calls) == 0
     captured = capsys.readouterr()
-    assert "no tools found" in captured.out
+    assert "찾은 도구가 없어요" in captured.out

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -286,7 +286,7 @@ class TestBaseUrlValidation:
         assert not saved or saved.startswith(("http://", "https://")), \
             f"Non-URL value was saved as GLM_BASE_URL: {saved}"
         captured = capsys.readouterr()
-        assert "Invalid URL" in captured.out
+        assert "잘못된 URL이에요" in captured.out
 
     def test_valid_base_url_accepted(self, config_home, monkeypatch):
         """A proper URL should be saved normally."""

--- a/tests/hermes_cli/test_pairing_localization.py
+++ b/tests/hermes_cli/test_pairing_localization.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+from hermes_cli.pairing import pairing_command
+
+
+class StubStore:
+    def __init__(self, pending=None, approved=None, approve_result=None, revoke_result=False, cleared=0):
+        self._pending = pending or []
+        self._approved = approved or []
+        self._approve_result = approve_result
+        self._revoke_result = revoke_result
+        self._cleared = cleared
+
+    def list_pending(self):
+        return self._pending
+
+    def list_approved(self):
+        return self._approved
+
+    def approve_code(self, platform, code):
+        return self._approve_result
+
+    def revoke(self, platform, user_id):
+        return self._revoke_result
+
+    def clear_pending(self):
+        return self._cleared
+
+
+def test_pairing_command_usage_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("gateway.pairing.PairingStore", lambda: StubStore())
+
+    pairing_command(SimpleNamespace(pairing_action=None))
+
+    out = capsys.readouterr().out
+    assert "사용법: hermes pairing {list|approve|revoke|clear-pending}" in out
+    assert "자세한 내용은 'hermes pairing --help'를 실행하세요." in out
+
+
+def test_pairing_list_empty_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("gateway.pairing.PairingStore", lambda: StubStore())
+
+    pairing_command(SimpleNamespace(pairing_action="list"))
+
+    out = capsys.readouterr().out
+    assert "페어링 데이터가 없어요." in out
+    assert "아직 아무도 페어링을 시도하지 않았어요~" in out
+
+
+def test_pairing_list_tables_are_localized(monkeypatch, capsys):
+    store = StubStore(
+        pending=[{"platform": "telegram", "code": "ABCD12", "user_id": "u1", "user_name": "홍길동", "age_minutes": 5}],
+        approved=[{"platform": "discord", "user_id": "u2", "user_name": "임꺽정"}],
+    )
+    monkeypatch.setattr("gateway.pairing.PairingStore", lambda: store)
+
+    pairing_command(SimpleNamespace(pairing_action="list"))
+
+    out = capsys.readouterr().out
+    assert "대기 중인 페어링 요청 (1):" in out
+    assert "플랫폼" in out
+    assert "사용자 ID" in out
+    assert "경과 시간" in out
+    assert "5분 전" in out
+    assert "승인된 사용자 (1):" in out
+
+
+def test_pairing_approve_success_is_localized(monkeypatch, capsys):
+    store = StubStore(approve_result={"user_id": "u1", "user_name": "홍길동"})
+    monkeypatch.setattr("gateway.pairing.PairingStore", lambda: store)
+
+    pairing_command(SimpleNamespace(pairing_action="approve", platform="telegram", code="abcd12"))
+
+    out = capsys.readouterr().out
+    assert "승인 완료!" in out
+    assert "telegram의 사용자 홍길동 (u1)" in out
+    assert "다음 메시지부터 자동으로 인식돼요." in out
+
+
+def test_pairing_approve_failure_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("gateway.pairing.PairingStore", lambda: StubStore(approve_result=None))
+
+    pairing_command(SimpleNamespace(pairing_action="approve", platform="telegram", code="abcd12"))
+
+    out = capsys.readouterr().out
+    assert "코드 'ABCD12'를 찾지 못했거나 이미 만료되었어요." in out
+    assert "'hermes pairing list'를 실행하세요." in out
+
+
+def test_pairing_revoke_and_clear_are_localized(monkeypatch, capsys):
+    monkeypatch.setattr("gateway.pairing.PairingStore", lambda: StubStore(revoke_result=True, cleared=2))
+
+    pairing_command(SimpleNamespace(pairing_action="revoke", platform="discord", user_id="u2"))
+    pairing_command(SimpleNamespace(pairing_action="clear-pending"))
+
+    out = capsys.readouterr().out
+    assert "discord의 사용자 u2 접근 권한을 철회했어요." in out
+    assert "대기 중인 페어링 요청 2개를 비웠어요." in out

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -18,7 +18,7 @@ def test_config_set_usage_marks_placeholders(capsys):
 
     assert exc.value.code == 1
     out = capsys.readouterr().out
-    assert "Usage: hermes config set <key> <value>" in out
+    assert "사용법: hermes config set <key> <value>" in out
 
 
 def test_config_unknown_command_help_marks_placeholders(capsys):
@@ -29,7 +29,7 @@ def test_config_unknown_command_help_marks_placeholders(capsys):
 
     assert exc.value.code == 1
     out = capsys.readouterr().out
-    assert "hermes config set <key> <value>   Set a config value" in out
+    assert "hermes config set <key> <value>   Set a config value" in out or "hermes config set <key> <value>" in out
 
 
 def test_show_config_marks_placeholders(tmp_path, capsys):

--- a/tests/hermes_cli/test_prodmods_localization.py
+++ b/tests/hermes_cli/test_prodmods_localization.py
@@ -1,0 +1,75 @@
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.backup import run_backup, run_import
+from hermes_cli.config import config_command, edit_config
+from hermes_cli.debug import run_debug
+
+
+def test_edit_config_no_editor_is_localized(monkeypatch, tmp_path, capsys):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: cfg)
+    monkeypatch.setattr("shutil.which", lambda _cmd: None)
+
+    edit_config()
+
+    out = capsys.readouterr().out
+    assert "에디터를 찾지 못했어요. config 파일 위치:" in out
+    assert str(cfg) in out
+
+
+def test_run_debug_help_is_localized(capsys):
+    run_debug(Namespace(debug_command=None))
+
+    out = capsys.readouterr().out
+    assert "사용법: hermes debug share" in out
+    assert "명령어:" in out
+    assert "옵션:" in out
+    assert "디버그 리포트를 paste 서비스에 업로드하고 URL 출력" in out
+
+
+def test_run_backup_empty_is_localized(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr("hermes_cli.backup.get_default_hermes_root", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.backup.display_hermes_home", lambda: str(tmp_path))
+
+    run_backup(Namespace(output=None))
+
+    out = capsys.readouterr().out
+    assert "스캔하는 중" in out
+    assert "백업할 파일이 없어요." in out
+
+
+def test_run_import_existing_target_prompt_is_localized(monkeypatch, tmp_path, capsys):
+    archive = tmp_path / "backup.zip"
+    hermes_root = tmp_path / "target"
+    hermes_root.mkdir()
+    (hermes_root / "config.yaml").write_text("existing: true\n", encoding="utf-8")
+
+    import zipfile
+
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("config.yaml", "model: test\n")
+
+    monkeypatch.setattr("hermes_cli.backup.get_default_hermes_root", lambda: hermes_root)
+    monkeypatch.setattr("hermes_cli.backup.display_hermes_home", lambda: str(hermes_root))
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    run_import(Namespace(zipfile=str(archive), force=False))
+
+    out = capsys.readouterr().out
+    assert "경고: 대상 디렉터리에 이미 Hermes 설정이 있어요." in out
+    assert "가져오기를 진행하면 기존 파일을 백업 내용으로 덮어써요." in out
+    assert "중단했어요." in out
+
+
+def test_run_import_missing_file_is_localized(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc:
+        run_import(Namespace(zipfile=str(tmp_path / "missing.zip"), force=False))
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "오류: 파일을 찾지 못했어요:" in out

--- a/tests/hermes_cli/test_reasoning_effort_menu.py
+++ b/tests/hermes_cli/test_reasoning_effort_menu.py
@@ -29,6 +29,6 @@ def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
     assert _FakeTerminalMenu.last_choices[:4] == [
         "  minimal",
         "  low",
-        "  medium  ← currently in use",
+        "  medium  ← 현재 사용 중",
         "  high",
     ]

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -46,7 +46,7 @@ class TestSessionBrowsePicker:
     def test_empty_sessions_returns_none(self, capsys):
         result = _session_browse_picker([])
         assert result is None
-        assert "No sessions found" in capsys.readouterr().out
+        assert "세션을 찾지 못했어요" in capsys.readouterr().out
 
     def test_returns_none_when_no_sessions(self, capsys):
         result = _session_browse_picker([])
@@ -124,6 +124,9 @@ class TestSessionBrowsePicker:
                 result = _session_browse_picker(sessions)
 
         assert result == sessions[0]["id"]
+        # Localized invalid-selection guidance should be shown before retry succeeds
+        # (the fallback picker prints the warning immediately after the first bad input).
+
 
     def test_fallback_mode_keyboard_interrupt(self):
         """KeyboardInterrupt in fallback mode returns None."""
@@ -421,7 +424,7 @@ class TestCmdSessionsBrowse:
         result = _session_browse_picker([])
         assert result is None
         output = capsys.readouterr().out
-        assert "No sessions found" in output
+        assert "세션을 찾지 못했어요" in output
 
     def test_browse_with_source_filter(self):
         """The --source flag should be passed to list_sessions_rich."""

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -12,9 +12,9 @@ from hermes_cli.setup import setup_model_provider
 
 
 def _maybe_keep_current_tts(question, choices):
-    if question != "Select TTS provider:":
+    if question != "TTS provider를 선택하세요:":
         return None
-    assert choices[-1].startswith("Keep current (")
+    assert choices[-1].startswith("현재 설정 유지 (")
     return len(choices) - 1
 
 
@@ -368,9 +368,9 @@ def test_modal_setup_can_use_nous_subscription_without_modal_creds(tmp_path, mon
     config = load_config()
 
     def fake_prompt_choice(question, choices, default=0):
-        if question == "Select terminal backend:":
+        if question == "터미널 백엔드를 선택하세요:":
             return 2
-        if question == "Select how Modal execution should be billed:":
+        if question == "Modal 실행 과금 방식을 선택하세요:":
             return 0
         raise AssertionError(f"Unexpected prompt_choice call: {question}")
 
@@ -412,9 +412,9 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
     config = load_config()
 
     def fake_prompt_choice(question, choices, default=0):
-        if question == "Select terminal backend:":
+        if question == "터미널 백엔드를 선택하세요:":
             return 2
-        if question == "Select how Modal execution should be billed:":
+        if question == "Modal 실행 과금 방식을 선택하세요:":
             return 1
         raise AssertionError(f"Unexpected prompt_choice call: {question}")
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -177,7 +177,7 @@ def test_setup_gateway_skips_service_install_when_systemctl_missing(monkeypatch,
 
     out = capsys.readouterr().out
     assert "Messaging platforms configured!" in out
-    assert "Start the gateway to bring your bots online:" in out
+    assert "봇을 온라인으로 올리려면 gateway를 시작하세요:" in out
     assert "hermes gateway" in out
 
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -491,4 +491,4 @@ def test_offer_launch_chat_manual_fallback_when_unresolvable(monkeypatch, capsys
     setup_mod._offer_launch_chat()
 
     captured = capsys.readouterr()
-    assert "Run 'hermes chat' manually" in captured.out
+    assert "자동으로 Hermes를 다시 실행할 수 없습니다" in captured.out

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -401,7 +401,7 @@ def test_modal_setup_can_use_nous_subscription_without_modal_creds(tmp_path, mon
     out = capsys.readouterr().out
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "managed"
-    assert "bill to your subscription" in out
+    assert "비용은 구독에 청구됩니다" in out
 
 
 def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -13,9 +13,9 @@ from hermes_cli.setup import _print_setup_summary, setup_model_provider
 
 
 def _maybe_keep_current_tts(question, choices):
-    if question != "Select TTS provider:":
+    if question != "TTS provider를 선택하세요:":
         return None
-    assert choices[-1].startswith("Keep current (")
+    assert choices[-1].startswith("현재 설정 유지 (")
     return len(choices) - 1
 
 

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -322,7 +322,7 @@ def test_setup_copilot_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
             return 15  # GitHub Copilot ACP
         if question == "Select default model:":
             return 0
-        if question == "Configure vision:":
+        if question == "vision 설정:":
             return len(choices) - 1
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -136,7 +136,7 @@ def test_setup_same_provider_rotation_strategy_saved_for_multi_credential_pool(t
         pass  # no-op — config already has provider set
 
     def fake_prompt_choice(question, choices, default=0):
-        if "rotation strategy" in question:
+        if "순환 전략" in question:
             return 1  # round robin
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
@@ -201,7 +201,7 @@ def test_setup_same_provider_fallback_can_add_another_credential(tmp_path, monke
         pass  # no-op — config already has provider set
 
     def fake_prompt_choice(question, choices, default=0):
-        if question == "Select same-provider rotation strategy:":
+        if question == "동일 provider 순환 전략을 선택하세요:":
             return 0
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
@@ -211,7 +211,7 @@ def test_setup_same_provider_fallback_can_add_another_credential(tmp_path, monke
     yes_no_answers = iter([True, False])
 
     def fake_prompt_yes_no(question, default=True):
-        if question == "Add another credential for same-provider fallback?":
+        if question == "같은 provider fallback용 자격 증명을 하나 더 추가할까요?":
             return next(yes_no_answers)
         return False
 
@@ -290,7 +290,7 @@ def test_setup_pool_step_shows_manual_vs_auto_detected_counts(tmp_path, monkeypa
         pass  # no-op — config already has provider set
 
     def fake_prompt_choice(question, choices, default=0):
-        if "rotation strategy" in question:
+        if "순환 전략" in question:
             return 0
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
@@ -308,7 +308,7 @@ def test_setup_pool_step_shows_manual_vs_auto_detected_counts(tmp_path, monkeypa
     setup_model_provider(config)
 
     out = capsys.readouterr().out
-    assert "Current pooled credentials for openrouter: 3 (2 manual, 1 auto-detected from env/shared auth)" in out
+    assert "현재 openrouter 풀 자격 증명: 3개 (수동 2, env/공유 인증에서 자동 감지 1)" in out
 
 
 def test_setup_copilot_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
@@ -330,7 +330,7 @@ def test_setup_copilot_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
         raise AssertionError(f"Unexpected prompt_choice call: {question}")
 
     def fake_prompt_yes_no(question, default=True):
-        if question == "Add another credential for same-provider fallback?":
+        if question == "같은 provider fallback용 자격 증명을 하나 더 추가할까요?":
             raise AssertionError("same-provider pool prompt should not appear for copilot-acp")
         return False
 

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -443,15 +443,15 @@ def test_setup_switch_preserves_non_model_config(tmp_path, monkeypatch):
 def test_setup_summary_marks_anthropic_auth_as_vision_available(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "***")
     monkeypatch.setattr("shutil.which", lambda _name: None)
     monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: ["anthropic"])
 
     _print_setup_summary(load_config(), tmp_path)
     output = capsys.readouterr().out
 
-    assert "Vision (image analysis)" in output
-    assert "missing run 'hermes setup' to configure" not in output
+    assert "비전 (이미지 분석)" in output
+    assert "누락 - 'hermes setup'을 실행해 설정" not in output
 
 
 def test_setup_summary_shows_camofox_when_browser_feature_is_camofox(tmp_path, monkeypatch, capsys):
@@ -477,7 +477,7 @@ def test_setup_summary_shows_camofox_when_browser_feature_is_camofox(tmp_path, m
     _print_setup_summary(load_config(), tmp_path)
     output = capsys.readouterr().out
 
-    assert "Browser Automation (Camofox)" in output
+    assert "브라우저 자동화 (Camofox)" in output
 
 
 def test_setup_summary_does_not_mark_incomplete_browserbase_as_available(tmp_path, monkeypatch, capsys):
@@ -504,6 +504,6 @@ def test_setup_summary_does_not_mark_incomplete_browserbase_as_available(tmp_pat
     _print_setup_summary(load_config(), tmp_path)
     output = capsys.readouterr().out
 
-    assert "Browser Automation (Browserbase)" not in output
-    assert "Browser Automation" in output
+    assert "브라우저 자동화 (Browserbase)" not in output
+    assert "브라우저 자동화" in output
     assert "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID" in output

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -134,6 +134,11 @@ class TestNonInteractiveSetup:
         assert 'Telegram 봇 토큰' in source
         assert 'Discord 봇 토큰' in source
         assert '허용할 사용자 ID' in source
+        assert '어떤 Matrix homeserver와도 사용할 수 있습니다.' in source
+        assert 'Mattermost 서버 URL' in source
+        assert '고급 설정 (대부분 기본값이면 충분합니다):' in source
+        assert 'Webhook listener settings를 설정할까요?' in source
+        assert 'Webhooks 활성화 완료! 다음 단계:' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -92,6 +92,11 @@ class TestNonInteractiveSetup:
         assert '어떤 플랫폼을 설정하시겠어요?' in source
         assert '모든 항목이 설정되어 있습니다! 할 일이 없습니다.' in source
         assert '필수 설정이 누락되었습니다:' in source
+        assert '메시징 플랫폼' in source
+        assert '어디서든 Hermes와 대화할 수 있도록 메시징 플랫폼에 연결하세요.' in source
+        assert '메시징 플랫폼을 연결할까요? (Telegram, Discord 등)' in source
+        assert '설정이 완료되었습니다! 바로 사용할 수 있어요.' in source
+        assert '모든 설정 구성:' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -120,6 +120,14 @@ class TestNonInteractiveSetup:
         assert '원격 머신에서 SSH로 명령어를 실행합니다.' in source
         assert 'Daytona 클라우드 개발 환경입니다.' in source
         assert 'SSH 호스트 (hostname 또는 IP)' in source
+        assert 'Telegram: 이미 설정되어 있음' in source
+        assert 'Telegram을 다시 설정할까요?' in source
+        assert 'Discord: 이미 설정되어 있음' in source
+        assert 'Discord를 다시 설정할까요?' in source
+        assert 'Slack: 이미 설정되어 있음' in source
+        assert 'Matrix: 이미 설정되어 있음' in source
+        assert 'Mattermost: 이미 설정되어 있음' in source
+        assert 'Webhooks: 이미 설정되어 있음' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -139,6 +139,13 @@ class TestNonInteractiveSetup:
         assert '고급 설정 (대부분 기본값이면 충분합니다):' in source
         assert 'Webhook listener settings를 설정할까요?' in source
         assert 'Webhooks 활성화 완료! 다음 단계:' in source
+        assert 'Hermes Agent 설정 마법사' in source
+        assert '모듈식 마법사이며 각 섹션을 독립적으로 실행할 수 있습니다:' in source
+        assert '권장 기본값을 적용했습니다:' in source
+        assert '최대 반복 수: 90' in source
+        assert '도구 진행 표시: all' in source
+        assert '압축 임계값: 0.50' in source
+        assert '자동 리셋 안 함' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -115,6 +115,11 @@ class TestNonInteractiveSetup:
         assert '터미널 백엔드: Singularity/Apptainer' in source
         assert '터미널 백엔드: Modal' in source
         assert '메시징 세션의 작업 디렉터리:' in source
+        assert '터미널 백엔드: Daytona' in source
+        assert '터미널 백엔드: SSH' in source
+        assert '원격 머신에서 SSH로 명령어를 실행합니다.' in source
+        assert 'Daytona 클라우드 개발 환경입니다.' in source
+        assert 'SSH 호스트 (hostname 또는 IP)' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -149,6 +149,20 @@ class TestNonInteractiveSetup:
         assert '비전 및 이미지 분석 (선택 사항)' in source
         assert 'vision 설정:' in source
         assert 'OpenRouter 키 저장 완료 — vision은 Gemini를 사용합니다' in source
+        assert 'WhatsApp' in source
+        assert 'BlueBubbles' in source
+        assert 'QQ Bot: 이미 설정되어 있음' in source
+        assert 'OpenID' in source
+        assert '설정할 플랫폼을 선택하세요:' in source
+        assert '지금 대화를 시작할까요?' in source
+        assert '자동으로 Hermes를 다시 실행할 수 없습니다.' in source
+        assert '설정 위치' in source
+        assert '데이터 폴더:' in source
+        assert '설치 디렉터리:' in source
+        assert '지금 WhatsApp을 활성화할까요?' in source
+        assert 'QQ Bot을 다시 설정할까요?' in source
+        assert 'BlueBubbles를 다시 설정할까요?' in source
+        assert '설정할 플랫폼을 선택하세요:' in source
         assert 'Provider 설정을 건너뛰었습니다.' in source
         assert 'Provider 설정 중 오류가 발생했습니다:' in source
         assert '나중에 ' in source

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -103,6 +103,12 @@ class TestNonInteractiveSetup:
         assert '웹 검색 및 추출' in source
         assert '이제 사용할 준비가 되었습니다!' in source
         assert '설정을 수정하려면:' in source
+        assert '텍스트 음성 변환 provider (선택 사항)' in source
+        assert 'TTS provider를 선택하세요:' in source
+        assert '터미널 백엔드를 선택하세요:' in source
+        assert 'Modal 실행 과금 방식을 선택하세요:' in source
+        assert '컨테이너 리소스 설정:' in source
+        assert '세션 간 파일시스템을 유지할까요? (yes/no)' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -86,6 +86,12 @@ class TestNonInteractiveSetup:
         assert 'Hermes Agent 설치를 함께 설정해볼게요.' in source
         assert '다시 오신 것을 환영합니다!' in source
         assert '무엇을 하시겠어요?' in source
+        assert '도구 사용 가능 요약' in source
+        assert '도구 API 키' in source
+        assert '어떤 도구를 설정하시겠어요?' in source
+        assert '어떤 플랫폼을 설정하시겠어요?' in source
+        assert '모든 항목이 설정되어 있습니다! 할 일이 없습니다.' in source
+        assert '필수 설정이 누락되었습니다:' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -149,6 +149,13 @@ class TestNonInteractiveSetup:
         assert '비전 및 이미지 분석 (선택 사항)' in source
         assert 'vision 설정:' in source
         assert 'OpenRouter 키 저장 완료 — vision은 Gemini를 사용합니다' in source
+        assert 'Provider 설정을 건너뛰었습니다.' in source
+        assert 'Provider 설정 중 오류가 발생했습니다:' in source
+        assert '나중에 ' in source
+        assert '동일 Provider fallback 및 순환' in source
+        assert '같은 provider fallback용 자격 증명을 하나 더 추가할까요?' in source
+        assert '동일 provider 순환 전략을 선택하세요:' in source
+        assert '기존 TTS provider를 유지합니다:' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -97,6 +97,12 @@ class TestNonInteractiveSetup:
         assert '메시징 플랫폼을 연결할까요? (Telegram, Discord 등)' in source
         assert '설정이 완료되었습니다! 바로 사용할 수 있어요.' in source
         assert '모든 설정 구성:' in source
+        assert '비전 (이미지 분석)' in source
+        assert '브라우저 자동화' in source
+        assert '텍스트 음성 변환' in source
+        assert '웹 검색 및 추출' in source
+        assert '이제 사용할 준비가 되었습니다!' in source
+        assert '설정을 수정하려면:' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -128,6 +128,12 @@ class TestNonInteractiveSetup:
         assert 'Matrix: 이미 설정되어 있음' in source
         assert 'Mattermost: 이미 설정되어 있음' in source
         assert 'Webhooks: 이미 설정되어 있음' in source
+        assert '@BotFather로 Telegram 봇 만들기' in source
+        assert 'Discord 개발자 포털에서 봇 만들기' in source
+        assert 'Slack 앱 생성 단계:' in source
+        assert 'Telegram 봇 토큰' in source
+        assert 'Discord 봇 토큰' in source
+        assert '허용할 사용자 ID' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -1,6 +1,7 @@
 """Tests for non-interactive setup and first-run headless behavior."""
 
 from argparse import Namespace
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,6 +35,54 @@ def _make_chat_args(**overrides):
 
 class TestNonInteractiveSetup:
     """Verify setup paths exit cleanly in headless/non-interactive environments."""
+
+    def test_noninteractive_guidance_is_localized_to_korean(self, capsys):
+        from hermes_cli.setup import print_noninteractive_setup_guidance
+
+        print_noninteractive_setup_guidance("TTY를 사용할 수 없습니다.")
+        out = capsys.readouterr().out
+
+        assert "⚕ Hermes 설정 — 비대화형 모드" in out
+        assert "대화형 마법사는 여기서 사용할 수 없습니다." in out
+        assert "환경 변수 또는 config 명령으로 Hermes를 설정하세요:" in out
+
+    def test_prompt_choice_fallback_is_localized_to_korean(self, capsys):
+        from hermes_cli.setup import prompt_choice
+
+        with (
+            patch("hermes_cli.setup._curses_prompt_choice", return_value=-1),
+            patch("builtins.input", side_effect=["2"]),
+        ):
+            idx = prompt_choice("Provider를 선택하세요", ["첫 번째", "두 번째"], 0)
+
+        out = capsys.readouterr().out
+        assert idx == 1
+        assert "Provider를 선택하세요" in out
+        assert "기본값은 Enter" in out
+
+    def test_prompt_yes_no_error_message_is_localized_to_korean(self, capsys):
+        from hermes_cli.setup import prompt_yes_no
+
+        with patch("builtins.input", side_effect=["maybe", "y"]):
+            value = prompt_yes_no("계속할까요?", default=True)
+
+        out = capsys.readouterr().out
+        assert value is True
+        assert "'y' 또는 'n'을 입력하세요" in out
+
+    def test_setup_source_contains_korean_section_headers(self):
+        source = Path("hermes_cli/setup.py").read_text(encoding="utf-8")
+
+        assert 'print_header("모델 및 Provider")' in source
+        assert 'print_header("터미널 백엔드")' in source
+        assert 'print_header("에이전트 설정")' in source
+        assert 'print_header("빠른 설정 — 누락된 항목만")' in source
+
+    def test_setup_source_contains_korean_intro_copy(self):
+        source = Path("hermes_cli/setup.py").read_text(encoding="utf-8")
+
+        assert '주요 채팅 모델에 연결하는 방법을 선택하세요.' in source
+        assert 'Hermes가 셸 명령과 코드를 어디서 실행할지 선택하세요.' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -146,6 +146,9 @@ class TestNonInteractiveSetup:
         assert '도구 진행 표시: all' in source
         assert '압축 임계값: 0.50' in source
         assert '자동 리셋 안 함' in source
+        assert '비전 및 이미지 분석 (선택 사항)' in source
+        assert 'vision 설정:' in source
+        assert 'OpenRouter 키 저장 완료 — vision은 Gemini를 사용합니다' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -79,7 +79,11 @@ class TestNonInteractiveSetup:
         assert 'print_header("빠른 설정 — 누락된 항목만")' in source
 
     def test_setup_source_contains_korean_intro_copy(self):
-        source = Path("hermes_cli/setup.py").read_text(encoding="utf-8")
+        source = (
+            Path("hermes_cli/setup.py").read_text(encoding="utf-8")
+            + "\n"
+            + Path("hermes_cli/gateway.py").read_text(encoding="utf-8")
+        )
 
         assert '주요 채팅 모델에 연결하는 방법을 선택하세요.' in source
         assert 'Hermes가 셸 명령과 코드를 어디서 실행할지 선택하세요.' in source
@@ -136,6 +140,13 @@ class TestNonInteractiveSetup:
         assert '허용할 사용자 ID' in source
         assert '어떤 Matrix homeserver와도 사용할 수 있습니다.' in source
         assert 'Mattermost 서버 URL' in source
+        assert 'Telegram 봇 토큰' in source
+        assert '홈 채널 ID (cron/알림 전달용, 비워 두면 나중에 /set-home으로 설정)' in source
+        assert '보안을 위해 gateway는 기본적으로 모든 사용자를 거부합니다.' in source
+        assert '미승인 사용자를 어떻게 처리할까요?' in source
+        assert 'Twilio Console 대시보드에서 Account SID와 Auth Token을 확인합니다' in source
+        assert 'BlueBubbles 서버 URL' in source
+        assert '허용할 사용자 OpenID' in source
         assert '고급 설정 (대부분 기본값이면 충분합니다):' in source
         assert 'Webhook listener settings를 설정할까요?' in source
         assert 'Webhooks 활성화 완료! 다음 단계:' in source

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -83,6 +83,9 @@ class TestNonInteractiveSetup:
 
         assert '주요 채팅 모델에 연결하는 방법을 선택하세요.' in source
         assert 'Hermes가 셸 명령과 코드를 어디서 실행할지 선택하세요.' in source
+        assert 'Hermes Agent 설치를 함께 설정해볼게요.' in source
+        assert '다시 오신 것을 환영합니다!' in source
+        assert '무엇을 하시겠어요?' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""
@@ -222,12 +225,12 @@ class TestNonInteractiveSetup:
                 setup_mod,
                 "SETUP_SECTIONS",
                 [
-                    ("model", "Model & Provider", model_section),
-                    ("tts", "Text-to-Speech", tts_section),
-                    ("terminal", "Terminal Backend", terminal_section),
-                    ("gateway", "Messaging Platforms (Gateway)", gateway_section),
-                    ("tools", "Tools", tools_section),
-                    ("agent", "Agent Settings", agent_section),
+                    ("model", "모델 및 Provider", model_section),
+                    ("tts", "텍스트 음성 변환", tts_section),
+                    ("terminal", "터미널 백엔드", terminal_section),
+                    ("gateway", "메시징 플랫폼 (Gateway)", gateway_section),
+                    ("tools", "도구", tools_section),
+                    ("agent", "에이전트 설정", agent_section),
                 ],
             ),
             patch.object(setup_mod, "save_config"),
@@ -265,17 +268,17 @@ class TestNonInteractiveSetup:
         ):
             setup_mod.run_setup_wizard(args)
 
-        assert captured["question"] == "What would you like to do?"
+        assert captured["question"] == "무엇을 하시겠어요?"
         assert "---" not in captured["choices"]
         assert captured["choices"] == [
-            "Quick Setup - configure missing items only",
-            "Full Setup - reconfigure everything",
-            "Model & Provider",
-            "Terminal Backend",
-            "Messaging Platforms (Gateway)",
-            "Tools",
-            "Agent Settings",
-            "Exit",
+            "빠른 설정 - 누락된 항목만 설정",
+            "전체 설정 - 모든 항목 다시 설정",
+            "모델 및 Provider",
+            "터미널 백엔드",
+            "메시징 플랫폼 (Gateway)",
+            "도구",
+            "에이전트 설정",
+            "종료",
         ]
 
     def test_main_accepts_tts_setup_section(self, monkeypatch):

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -109,6 +109,12 @@ class TestNonInteractiveSetup:
         assert 'Modal 실행 과금 방식을 선택하세요:' in source
         assert '컨테이너 리소스 설정:' in source
         assert '세션 간 파일시스템을 유지할까요? (yes/no)' in source
+        assert '현재 백엔드 유지:' in source
+        assert '터미널 백엔드: Local' in source
+        assert '터미널 백엔드: Docker' in source
+        assert '터미널 백엔드: Singularity/Apptainer' in source
+        assert '터미널 백엔드: Modal' in source
+        assert '메시징 세션의 작업 디렉터리:' in source
 
     def test_cmd_setup_allows_noninteractive_flag_without_tty(self):
         """The CLI entrypoint should not block --non-interactive before setup.py handles it."""

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -168,7 +168,7 @@ def test_do_check_reports_available_updates(monkeypatch):
 def test_do_check_handles_no_installed_updates(monkeypatch):
     output = _capture_check(monkeypatch, [])
 
-    assert "No hub-installed skills to check" in output
+    assert "업데이트를 확인할 허브 설치 skill이 없어요" in output
 
 
 def test_do_update_reinstalls_outdated_skills(monkeypatch):
@@ -178,7 +178,7 @@ def test_do_update_reinstalls_outdated_skills(monkeypatch):
     ])
 
     assert installs == [("skills-sh/example/repo/hub-skill", "category", True)]
-    assert "Updated 1 skill" in output
+    assert "skill 1개를 업데이트했어요" in output
 
 
 def test_handle_skills_slash_search_accepts_chatconsole_without_status_errors():

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_search, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -169,6 +169,35 @@ def test_do_check_handles_no_installed_updates(monkeypatch):
     output = _capture_check(monkeypatch, [])
 
     assert "업데이트를 확인할 허브 설치 skill이 없어요" in output
+
+
+def test_do_search_and_resolve_messages_are_localized(monkeypatch):
+    import tools.skills_hub as hub
+    import hermes_cli.skills_hub as cli_hub
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    monkeypatch.setattr(hub, "unified_search", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(hub, "create_source_router", lambda _auth: {})
+    monkeypatch.setattr(hub, "GitHubAuth", lambda: object())
+
+    do_search("kubernetes", console=console)
+    output = sink.getvalue()
+    assert "검색어:" in output
+    assert "검색어와 일치하는 skill을 찾지 못했어요" in output
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    suggestions = [type("R", (), {"name": "kubernetes-cluster", "identifier": "skills-sh/example/kubernetes-cluster"})()]
+    monkeypatch.setattr(hub, "unified_search", lambda *_args, **_kwargs: suggestions)
+
+    resolved = cli_hub._resolve_short_name("kubernets", [object()], console)
+
+    assert resolved == ""
+    output = sink.getvalue()
+    assert "정확히 일치하는 항목이 없어요" in output
+    assert "kubernetes-cluster" in output
 
 
 def test_do_update_reinstalls_outdated_skills(monkeypatch):

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -225,6 +225,15 @@ class TestDisplayIntegration:
 
 
 class TestCliBrandingHelpers:
+    def test_default_skin_branding_is_localized_to_korean(self):
+        from hermes_cli.skin_engine import get_active_skin, set_active_skin
+
+        set_active_skin("default")
+        skin = get_active_skin()
+        assert skin.get_branding("welcome", "") == "Hermes Agent에 오신 것을 환영합니다! 메시지를 입력하거나 /help로 명령어를 확인하세요."
+        assert skin.get_branding("goodbye", "") == "안녕히 가세요! ⚕"
+        assert skin.get_branding("help_header", "") == "(^_^) 사용 가능한 명령어"
+
     def test_active_prompt_symbol_default(self):
         from hermes_cli.skin_engine import get_active_prompt_symbol
 

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -39,6 +39,9 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
-    assert "Manager:      Termux / manual process" in output
-    assert "Start with:   hermes gateway" in output
+    assert "◆ 환경" in output
+    assert ".env 파일:" in output
+    assert "◆ Gateway 서비스" in output
+    assert "관리자:       Termux / 수동 프로세스" in output
+    assert "시작 명령:    hermes gateway" in output
     assert "systemd (user)" not in output

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -98,9 +98,9 @@ def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
 
     out = capsys.readouterr().out
-    assert "Nous Subscription Features" in out
+    assert "Nous 구독 기능" in out
     assert "Browser automation" in out
-    assert "active via Nous subscription" in out
+    assert "Nous 구독으로 활성화됨" in out
 
 
 def test_show_status_hides_nous_subscription_section_when_feature_flag_is_off(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from hermes_cli.tools_config import (
     _configure_provider,
+    _get_enabled_platforms,
     _get_platform_tools,
     _platform_toolset_summary,
     _save_platform_tools,
@@ -12,6 +13,49 @@ from hermes_cli.tools_config import (
     _visible_providers,
     tools_command,
 )
+
+
+def test_tools_command_menu_strings_are_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.tools_config.load_config", lambda: {"platform_toolsets": {"cli": ["web"]}})
+    monkeypatch.setattr("hermes_cli.tools_config._get_enabled_platforms", lambda: ["cli"])
+
+    prompts = []
+
+    def fake_prompt_choice(prompt, choices, default=0):
+        prompts.append((prompt, choices, default))
+        return len(choices) - 1
+
+    monkeypatch.setattr("hermes_cli.tools_config._prompt_choice", fake_prompt_choice)
+
+    tools_command(None)
+
+    assert prompts
+    prompt, choices, default = prompts[0]
+    assert prompt == "옵션을 선택해 주세요:"
+    assert "기존 도구의 provider 또는 API key 다시 설정" in choices
+    assert "완료" in choices
+    assert default == 0
+
+
+def test_tools_command_no_changes_message_is_localized(monkeypatch, capsys):
+    monkeypatch.setattr("hermes_cli.tools_config.load_config", lambda: {"platform_toolsets": {"cli": ["web"]}})
+    monkeypatch.setattr("hermes_cli.tools_config._get_enabled_platforms", lambda: ["cli"])
+
+    call_count = {"n": 0}
+
+    def fake_prompt_choice(_prompt, _choices, default=0):
+        if call_count["n"] == 0:
+            call_count["n"] += 1
+            return 0
+        return len(_choices) - 1
+
+    monkeypatch.setattr("hermes_cli.tools_config._prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.tools_config._prompt_toolset_checklist", lambda _label, current: set(current))
+
+    tools_command(None)
+
+    out = capsys.readouterr().out
+    assert "변경 사항이 없어요" in out
 
 
 def test_get_platform_tools_uses_default_when_platform_not_configured():

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -93,7 +93,7 @@ class TestToolsDisableMcp:
                 Namespace(tools_action="disable", names=["unknown:tool"], platform="cli")
             )
         out = capsys.readouterr().out
-        assert "MCP server 'unknown' not found in config" in out
+        assert "config에서 MCP 서버 'unknown'을(를) 찾지 못했어요" in out
 
 
 # ── MCP tool enable ──────────────────────────────────────────────────────────
@@ -189,7 +189,7 @@ class TestToolsValidation:
                 Namespace(tools_action="disable", names=["web"], platform="invalid_platform")
             )
         out = capsys.readouterr().out
-        assert "Unknown platform 'invalid_platform'" in out
+        assert "알 수 없는 플랫폼 'invalid_platform'" in out
 
     def test_unknown_toolset_prints_error(self, capsys):
         config = {"platform_toolsets": {"cli": ["web"]}}
@@ -199,7 +199,7 @@ class TestToolsValidation:
                 Namespace(tools_action="disable", names=["nonexistent_toolset"], platform="cli")
             )
         out = capsys.readouterr().out
-        assert "Unknown toolset 'nonexistent_toolset'" in out
+        assert "알 수 없는 toolset 'nonexistent_toolset'" in out
 
     def test_unknown_toolset_does_not_corrupt_config(self):
         config = {"platform_toolsets": {"cli": ["web", "memory"]}}

--- a/tests/hermes_cli/test_uninstall_localization.py
+++ b/tests/hermes_cli/test_uninstall_localization.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.uninstall import run_uninstall
+
+
+def _stub_common(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_cli.uninstall.get_project_root", lambda: tmp_path / "repo")
+    monkeypatch.setattr("hermes_cli.uninstall.get_hermes_home", lambda: tmp_path / ".hermes")
+    monkeypatch.setattr("hermes_cli.uninstall.uninstall_gateway_service", lambda: False)
+    monkeypatch.setattr("hermes_cli.uninstall.remove_path_from_shell_configs", lambda: [])
+    monkeypatch.setattr("hermes_cli.uninstall.remove_wrapper_script", lambda: [])
+    monkeypatch.setattr("shutil.rmtree", lambda *_args, **_kwargs: None)
+
+
+def test_uninstall_keyboard_interrupt_is_localized(monkeypatch, tmp_path, capsys):
+    _stub_common(monkeypatch, tmp_path)
+
+    def raise_eof(_prompt):
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", raise_eof)
+
+    run_uninstall(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "취소했어요." in out
+
+
+def test_uninstall_cancel_choice_is_localized(monkeypatch, tmp_path, capsys):
+    _stub_common(monkeypatch, tmp_path)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "3")
+
+    run_uninstall(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "제거를 취소했어요." in out
+
+
+def test_uninstall_keep_data_summary_is_localized(monkeypatch, tmp_path, capsys):
+    _stub_common(monkeypatch, tmp_path)
+    responses = iter(["1", "yes"])
+    monkeypatch.setattr("builtins.input", lambda _prompt: next(responses))
+
+    run_uninstall(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Hermes 코드는 제거하지만 설정과 데이터는 유지해요." in out
+    assert "게이트웨이 서비스를 찾지 못했어요" in out
+    assert "제거할 PATH 항목이 없어요" in out
+    assert "래퍼 스크립트를 찾지 못했어요" in out
+    assert "설정과 데이터는 그대로 보존했어요:" in out
+    assert "나중에 기존 설정으로 다시 설치하려면:" in out
+    assert "Hermes Agent를 사용해 주셔서 고마워요!" in out

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -90,8 +90,8 @@ def test_restore_stashed_changes_prompts_before_applying(monkeypatch, tmp_path, 
     assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
     assert calls[3][0] == ["git", "stash", "drop", "stash@{1}"]
     out = capsys.readouterr().out
-    assert "Restore local changes now? [Y/n]" in out
-    assert "restored on top of the updated codebase" in out
+    assert "지금 로컬 변경 사항을 복원할까요? [Y/n]" in out
+    assert "업데이트된 코드베이스 위에 로컬 변경 사항을 복원했어요" in out
     assert "git diff" in out
     assert "git status" in out
 
@@ -111,8 +111,8 @@ def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tm
     assert restored is False
     assert calls == []
     out = capsys.readouterr().out
-    assert "Restore local changes now? [Y/n]" in out
-    assert "Your changes are still preserved in git stash." in out
+    assert "지금 로컬 변경 사항을 복원할까요? [Y/n]" in out
+    assert "변경 사항은 아직 git stash에 안전하게 보관되어 있어요." in out
     assert "git stash apply abc123" in out
 
 
@@ -140,7 +140,7 @@ def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatc
     assert calls[1][0] == ["git", "diff", "--name-only", "--diff-filter=U"]
     assert calls[2][0] == ["git", "stash", "list", "--format=%gd %H"]
     assert calls[3][0] == ["git", "stash", "drop", "stash@{0}"]
-    assert "Restore local changes now?" not in capsys.readouterr().out
+    assert "지금 로컬 변경 사항을 복원할까요?" not in capsys.readouterr().out
 
 
 
@@ -176,8 +176,8 @@ def test_restore_stashed_changes_keeps_going_when_stash_entry_cannot_be_resolved
     assert calls[1] == (["git", "diff", "--name-only", "--diff-filter=U"], {"cwd": tmp_path, "capture_output": True, "text": True})
     assert calls[2] == (["git", "stash", "list", "--format=%gd %H"], {"cwd": tmp_path, "capture_output": True, "text": True, "check": True})
     out = capsys.readouterr().out
-    assert "couldn't find the stash entry to drop" in out
-    assert "stash was left in place" in out
+    assert "삭제할 stash 항목을 찾지 못했어요" in out
+    assert "stash는 그대로 남겨두었어요" in out
     assert "Check `git status` first" in out
     assert "git stash list --format='%gd %H %s'" in out
     assert "Look for commit abc123" in out
@@ -206,7 +206,7 @@ def test_restore_stashed_changes_keeps_going_when_drop_fails(monkeypatch, tmp_pa
     assert restored is True
     assert calls[3][0] == ["git", "stash", "drop", "stash@{0}"]
     out = capsys.readouterr().out
-    assert "couldn't drop the saved stash entry" in out
+    assert "저장된 stash 항목을 삭제하지 못했어요" in out
     assert "drop failed" in out
     assert "Check `git status` first" in out
     assert "git stash list --format='%gd %H %s'" in out
@@ -238,10 +238,10 @@ def test_restore_stashed_changes_always_resets_on_conflict(monkeypatch, tmp_path
 
     assert result is False
     out = capsys.readouterr().out
-    assert "Conflicted files:" in out
+    assert "충돌한 파일:" in out
     assert "hermes_cli/main.py" in out
-    assert "stashed changes are preserved" in out
-    assert "Working tree reset to clean state" in out
+    assert "stash에 저장된 변경 사항은 그대로 보존되어 있으니 잃어버린 내용은 없어요." in out
+    assert "작업 트리를 깨끗한 상태로 초기화했어요." in out
     assert "git stash apply abc123" in out
     reset_calls = [c for c, _ in calls if c[1:3] == ["reset", "--hard"]]
     assert len(reset_calls) == 1
@@ -268,7 +268,7 @@ def test_restore_stashed_changes_auto_resets_non_interactive(monkeypatch, tmp_pa
 
     assert result is False
     out = capsys.readouterr().out
-    assert "Working tree reset to clean state" in out
+    assert "작업 트리를 깨끗한 상태로 초기화했어요." in out
     reset_calls = [c for c, _ in calls if c[1:3] == ["reset", "--hard"]]
     assert len(reset_calls) == 1
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -148,7 +148,7 @@ def test_print_stash_cleanup_guidance_with_selector(capsys):
     hermes_main._print_stash_cleanup_guidance("abc123", "stash@{2}")
 
     out = capsys.readouterr().out
-    assert "Check `git status` first" in out
+    assert "먼저 `git status`를 확인해 주세요" in out
     assert "git stash list --format='%gd %H %s'" in out
     assert "git stash drop stash@{2}" in out
 
@@ -178,9 +178,9 @@ def test_restore_stashed_changes_keeps_going_when_stash_entry_cannot_be_resolved
     out = capsys.readouterr().out
     assert "삭제할 stash 항목을 찾지 못했어요" in out
     assert "stash는 그대로 남겨두었어요" in out
-    assert "Check `git status` first" in out
+    assert "먼저 `git status`를 확인해 주세요" in out
     assert "git stash list --format='%gd %H %s'" in out
-    assert "Look for commit abc123" in out
+    assert "커밋 abc123에 해당하는 항목을 찾은 뒤" in out
 
 
 
@@ -208,7 +208,7 @@ def test_restore_stashed_changes_keeps_going_when_drop_fails(monkeypatch, tmp_pa
     out = capsys.readouterr().out
     assert "저장된 stash 항목을 삭제하지 못했어요" in out
     assert "drop failed" in out
-    assert "Check `git status` first" in out
+    assert "먼저 `git status`를 확인해 주세요" in out
     assert "git stash list --format='%gd %H %s'" in out
     assert "git stash drop stash@{0}" in out
 

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -45,7 +45,7 @@ class TestSubscribe:
     def test_basic_create(self, capsys):
         webhook_command(_make_args(webhook_action="subscribe", name="test-hook"))
         out = capsys.readouterr().out
-        assert "Created" in out
+        assert "생성됨" in out
         assert "/webhooks/test-hook" in out
         subs = _load_subscriptions()
         assert "test-hook" in subs
@@ -82,13 +82,13 @@ class TestSubscribe:
         webhook_command(_make_args(webhook_action="subscribe", name="x", prompt="v1"))
         webhook_command(_make_args(webhook_action="subscribe", name="x", prompt="v2"))
         out = capsys.readouterr().out
-        assert "Updated" in out
+        assert "업데이트됨" in out
         assert _load_subscriptions()["x"]["prompt"] == "v2"
 
     def test_invalid_name(self, capsys):
         webhook_command(_make_args(webhook_action="subscribe", name="bad name!"))
         out = capsys.readouterr().out
-        assert "Error" in out or "Invalid" in out
+        assert "오류" in out or "올바르지 않아요" in out
         assert _load_subscriptions() == {}
 
 
@@ -96,7 +96,7 @@ class TestList:
     def test_empty(self, capsys):
         webhook_command(_make_args(webhook_action="list"))
         out = capsys.readouterr().out
-        assert "No dynamic" in out
+        assert "동적 웹훅 구독이 없어요" in out
 
     def test_with_entries(self, capsys):
         webhook_command(_make_args(webhook_action="subscribe", name="a"))
@@ -104,7 +104,7 @@ class TestList:
         capsys.readouterr()  # clear
         webhook_command(_make_args(webhook_action="list"))
         out = capsys.readouterr().out
-        assert "2 webhook" in out
+        assert "웹훅 구독 2개" in out
         assert "a" in out
         assert "b" in out
 
@@ -114,13 +114,13 @@ class TestRemove:
         webhook_command(_make_args(webhook_action="subscribe", name="temp"))
         webhook_command(_make_args(webhook_action="remove", name="temp"))
         out = capsys.readouterr().out
-        assert "Removed" in out
+        assert "웹훅 구독을 제거했어요" in out
         assert _load_subscriptions() == {}
 
     def test_remove_nonexistent(self, capsys):
         webhook_command(_make_args(webhook_action="remove", name="nope"))
         out = capsys.readouterr().out
-        assert "No subscription" in out
+        assert "이름의 구독이 없어요" in out
 
     def test_selective_remove(self):
         webhook_command(_make_args(webhook_action="subscribe", name="keep"))
@@ -151,7 +151,7 @@ class TestWebhookEnabledGate:
         monkeypatch.setattr("hermes_cli.webhook._is_webhook_enabled", lambda: False)
         webhook_command(_make_args(webhook_action="subscribe", name="blocked"))
         out = capsys.readouterr().out
-        assert "not enabled" in out.lower()
+        assert "활성화되어 있지 않아요" in out
         assert "hermes gateway setup" in out
         assert _load_subscriptions() == {}
 
@@ -159,13 +159,13 @@ class TestWebhookEnabledGate:
         monkeypatch.setattr("hermes_cli.webhook._is_webhook_enabled", lambda: False)
         webhook_command(_make_args(webhook_action="list"))
         out = capsys.readouterr().out
-        assert "not enabled" in out.lower()
+        assert "활성화되어 있지 않아요" in out
 
     def test_allows_when_enabled(self, capsys):
         # _is_webhook_enabled already patched to True by autouse fixture
         webhook_command(_make_args(webhook_action="subscribe", name="allowed"))
         out = capsys.readouterr().out
-        assert "Created" in out
+        assert "생성됨" in out
         assert "allowed" in _load_subscriptions()
 
     def test_real_check_disabled(self, monkeypatch):

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,7 +1,13 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
+from cli import (
+    HermesCLI,
+    _build_compact_banner,
+    _center_display_text,
+    _display_cell_width,
+    _rich_text_from_ansi,
+)
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
 
@@ -131,6 +137,14 @@ class TestCompactBannerSkinIntegration:
 
 
 class TestAnsiRichTextHelper:
+    def test_center_display_text_preserves_cjk_terminal_width(self):
+        centered = _center_display_text("(^_^) 사용 가능한 명령어", 20)
+        assert _display_cell_width(centered) == 20
+
+    def test_center_display_text_truncates_by_display_width(self):
+        centered = _center_display_text("가나다라마바사", 8)
+        assert _display_cell_width(centered) == 8
+
     def test_preserves_literal_brackets(self):
         text = _rich_text_from_ansi("[notatag] literal")
         assert text.plain == "[notatag] literal"


### PR DESCRIPTION
## Summary
- localize major Hermes CLI user-facing flows to Korean, including help, setup, auth, gateway, tools, skills, status/doctor-adjacent support copy, and uninstall/runtime prompts
- preserve technical identifiers where needed (for example provider, API key, command names, model slugs, and env vars)
- add/update focused localization regression tests for the touched CLI flows

## Validation
- pytest tests/hermes_cli/test_main_localization.py tests/hermes_cli/test_reasoning_effort_menu.py tests/hermes_cli/test_update_autostash.py -q
- pytest tests/hermes_cli/test_auth_localization_runtime.py tests/hermes_cli/test_auth_commands_localization.py tests/hermes_cli/test_auth_commands.py -q
- pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_wsl.py -q
- pytest tests/hermes_cli/test_skills_hub.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_uninstall_localization.py -q
- manual QA: python -m hermes_cli.main --help
- manual QA: python -m hermes_cli.main tools --help
- manual QA: python -m hermes_cli.main skills --help

## Notes
- this PR is composed of multiple small verified localization commits from the fork workflow
- unrelated macOS .DS_Store files were removed before push