### PR TITLE
API server - bidirecional media and file transmission support.

### DIFF
--- a/configure-claude-key
+++ b/configure-claude-key
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /root/hermes-agent
+source .venv/bin/activate
+hermes model

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -315,6 +315,17 @@ def _ext_for_mime(mime: str, fallback: str) -> str:
 _SAFE_EXT_RE = re.compile(r"^\.[A-Za-z0-9]{1,8}$")
 
 
+# Matches ``data:<mime/attrs>,<payload>`` URLs the model embeds in its final
+# reply — almost always inside markdown like ``![alt](data:image/png;base64,…)``.
+# The payload char class covers both base64 (``A-Za-z0-9+/=``) and URL-encoded
+# (``%`` + unreserved chars) variants; the URL ends at whitespace, quote,
+# close-paren, or angle bracket — the standard markdown/HTML delimiters.
+_INLINE_DATA_URL_RE = re.compile(
+    r'data:[^\s,)"\'<>]+,[A-Za-z0-9+/=%._~\-]+',
+    re.IGNORECASE,
+)
+
+
 def _choose_export_ext(path: Path, mime: str) -> str:
     """Pick a URL-safe extension for an outbound file export.
 
@@ -335,6 +346,166 @@ def _choose_export_ext(path: Path, mime: str) -> str:
     if guessed and _SAFE_EXT_RE.match(guessed):
         return guessed.lower()
     return ""
+
+
+class _StreamDataURLFilter:
+    """Rewrite ``data:…`` URLs to ``/v1/files/…`` URLs in a streamed text.
+
+    The SSE chat-completions path forwards every agent token to the client
+    the instant it arrives from the LLM, which means a reply like
+    ``![icon](data:image/png;base64,iVBORw0KG…)`` reaches the client as a
+    base64 blob before the server ever sees the complete URL.  By the time
+    the batch-path rewriter (_materialize_inline_data_urls) runs on the
+    agent's ``final_response``, the stream has already shipped the raw
+    payload and there's no amendment mechanism in the OpenAI SSE spec.
+
+    This state machine sits between the agent's delta queue and the SSE
+    writer.  It buffers incoming text, suppresses anything that looks like
+    a ``data:`` URL from the downstream emitter, and on URL completion
+    decodes the payload, caches the bytes under
+    ``~/.hermes/{image,audio,document}_cache``, registers the cached path
+    with the file-export registry, and emits the resulting
+    ``/v1/files/{id}.ext`` URL in place of the original data URL.
+
+    Failure modes are conservative: an undecodable payload, a cache-helper
+    exception, or a failed registration leaves the original data URL
+    string in the output rather than dropping user-visible content.
+    """
+
+    # Characters that end a data URL embedded in markdown / HTML.  Closing
+    # paren for ``![alt](…)``, whitespace, quotes, angle brackets.
+    _TERMINATORS = frozenset(' \t\n\r)"\'<>')
+    # The prefix we're watching for.  Held-back tail length is bounded by
+    # ``len(_PREFIX) - 1`` (4 chars) but only activates when the buffer
+    # actually ends with a prefix of this string — see ``_prefix_holdback``.
+    _PREFIX = "data:"
+
+    def __init__(self, adapter, request):
+        self._adapter = adapter
+        self._request = request
+        self._buffer = ""
+        self._in_url = False
+        self.inline_blocks: list = []
+
+    def feed(self, chunk: str) -> str:
+        """Absorb ``chunk`` into the buffer; return text safe to emit now."""
+        if not chunk:
+            return ""
+        self._buffer += chunk
+        return self._drain(force=False)
+
+    def flush(self) -> str:
+        """End of stream — decode any in-progress data URL and return
+        everything still buffered."""
+        return self._drain(force=True)
+
+    def _prefix_holdback(self) -> int:
+        """Return how many trailing characters to keep buffered because
+        they could be the start of ``data:``.  Zero when the tail doesn't
+        match any prefix of the target string — the common case for
+        ordinary prose — so normal tokens pass through untouched."""
+        buf = self._buffer
+        max_k = min(len(self._PREFIX) - 1, len(buf))
+        for k in range(max_k, 0, -1):
+            if buf[-k:] == self._PREFIX[:k]:
+                return k
+        return 0
+
+    def _drain(self, force: bool) -> str:
+        out: List[str] = []
+        while self._buffer:
+            if self._in_url:
+                term_idx = -1
+                for i, ch in enumerate(self._buffer):
+                    if ch in self._TERMINATORS:
+                        term_idx = i
+                        break
+                if term_idx < 0:
+                    if force:
+                        data_url = self._buffer
+                        self._buffer = ""
+                        out.append(self._materialize(data_url))
+                        self._in_url = False
+                    else:
+                        break
+                else:
+                    data_url = self._buffer[:term_idx]
+                    self._buffer = self._buffer[term_idx:]
+                    out.append(self._materialize(data_url))
+                    self._in_url = False
+            else:
+                idx = self._buffer.find("data:")
+                if idx >= 0:
+                    if idx > 0:
+                        out.append(self._buffer[:idx])
+                    self._buffer = self._buffer[idx:]
+                    self._in_url = True
+                else:
+                    if force:
+                        out.append(self._buffer)
+                        self._buffer = ""
+                    else:
+                        hold = self._prefix_holdback()
+                        safe_len = len(self._buffer) - hold
+                        if safe_len > 0:
+                            out.append(self._buffer[:safe_len])
+                            self._buffer = self._buffer[safe_len:]
+                    break
+        return "".join(out)
+
+    def _materialize(self, data_url: str) -> str:
+        """Decode one data URL and return its ``/v1/files/…`` replacement.
+
+        On any failure return the original ``data_url`` verbatim — a broken
+        URL in the output is strictly better than silently dropping bytes
+        the model intended to send.
+        """
+        try:
+            mime, raw = _decode_data_url(data_url)
+        except ValueError:
+            return data_url
+        if not raw:
+            return data_url
+        mime_primary = (mime or "").split(";", 1)[0].strip().lower() or "application/octet-stream"
+        top, _, _ = mime_primary.partition("/")
+        from gateway.platforms.base import (
+            cache_image_from_bytes,
+            cache_audio_from_bytes,
+            cache_document_from_bytes,
+        )
+        try:
+            if top == "image":
+                cached = cache_image_from_bytes(
+                    raw, ext=_ext_for_mime(mime_primary, ".png"),
+                )
+            elif top == "audio":
+                cached = cache_audio_from_bytes(
+                    raw, ext=_ext_for_mime(mime_primary, ".ogg"),
+                )
+            else:
+                ext = _ext_for_mime(mime_primary, ".bin")
+                cached = cache_document_from_bytes(
+                    raw, f"inline_{uuid.uuid4().hex[:8]}{ext}",
+                )
+        except Exception:
+            return data_url
+        url = self._adapter._register_file_export(self._request, cached)
+        if not url:
+            return data_url
+        filename = Path(cached).name
+        if top == "image":
+            self.inline_blocks.append({"type": "output_image", "image_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        elif top == "audio":
+            self.inline_blocks.append({"type": "output_audio", "audio_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        elif top == "video":
+            self.inline_blocks.append({"type": "output_video", "video_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        else:
+            self.inline_blocks.append({"type": "output_file", "file_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        return url
 
 
 def check_api_server_requirements() -> bool:
@@ -1136,6 +1307,13 @@ class APIServerAdapter(BasePlatformAdapter):
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
+        # Filter intercepts data:<mime>;base64,… substrings in the streamed
+        # text before they reach the client.  Each complete data URL is
+        # decoded, cached to disk, registered with the file-export
+        # registry, and the resulting /v1/files/{id}.ext URL is emitted in
+        # place of the base64 payload.
+        stream_filter = _StreamDataURLFilter(self, request)
+
         try:
             last_activity = time.monotonic()
 
@@ -1148,13 +1326,30 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
             last_activity = time.monotonic()
 
+            async def _emit_text(text: str):
+                """Write a plain text chunk as an OpenAI ``delta.content``
+                event.  Bypasses the data-URL filter — callers that need
+                filtering go through ``_emit`` instead, and this helper
+                is used for the filter's ``flush()`` output and the
+                trailing ``media_markdown`` chunk."""
+                if not text:
+                    return time.monotonic()
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                return time.monotonic()
+
             # Helper — route a queue item to the correct SSE event.
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
 
-                Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
+                Plain strings are fed through the data-URL filter and only
+                the safe-to-emit portion is shipped downstream.  Tagged
+                tuples ``("__tool_progress__", payload)`` are sent as a
+                custom ``event: hermes.tool.progress`` SSE event so
                 frontends can display them without storing the markers in
                 conversation history.  See #6972.
                 """
@@ -1163,13 +1358,20 @@ class APIServerAdapter(BasePlatformAdapter):
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
-                else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    return time.monotonic()
+                if isinstance(item, str):
+                    safe = stream_filter.feed(item)
+                    if safe:
+                        return await _emit_text(safe)
+                    return time.monotonic()
+                # Anything else — shouldn't happen, but emit as-is to stay
+                # bug-compatible with pre-filter behaviour.
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
@@ -1199,6 +1401,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 last_activity = await _emit(delta)
 
+            # Flush any text the data-URL filter was still holding back —
+            # either trailing characters buffered against a split ``data:``
+            # prefix, or (rarely) an in-progress data URL that never got
+            # its terminator before end-of-stream.
+            tail = stream_filter.flush()
+            if tail:
+                last_activity = await _emit_text(tail)
+
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
             media_markdown = ""
@@ -1214,12 +1424,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
 
             if media_markdown:
-                media_chunk = {
-                    "id": completion_id, "object": "chat.completion.chunk",
-                    "created": created, "model": model,
-                    "choices": [{"index": 0, "delta": {"content": f"\n\n{media_markdown}"}, "finish_reason": None}],
-                }
-                await response.write(f"data: {json.dumps(media_chunk)}\n\n".encode())
+                await _emit_text(f"\n\n{media_markdown}")
 
             # Finish chunk
             finish_chunk = {
@@ -2371,9 +2576,107 @@ class APIServerAdapter(BasePlatformAdapter):
                     lines.append(f"[File: {name}]({url})")
         return "\n".join(lines)
 
+    def _materialize_inline_data_urls(
+        self, request: "web.Request", text: str,
+    ) -> tuple[str, List[Dict[str, Any]]]:
+        """Rewrite model-embedded ``data:`` URLs into ``/v1/files/`` URLs in-place.
+
+        LLMs (Claude most notably) frequently return images produced by shell
+        tools as ``![alt](data:image/png;base64,…)`` in their final reply.
+        That inlined payload bypasses the ``MEDIA:<path>`` convention, bloats
+        response JSON, and makes conversation history carry the bytes on
+        every turn.  This helper intercepts those data URLs, decodes the
+        payload, caches the bytes under ``~/.hermes/{image,audio,document}_cache``,
+        registers the cached path with the file-export registry, and splices
+        the resulting ``/v1/files/{id}.ext`` URL into the text in place of
+        the original data URL.  The enclosing markdown structure
+        (``![alt](…)``) is preserved verbatim — only the URL swaps.
+
+        Returns ``(rewritten_text, blocks)`` where ``blocks`` is the list of
+        spec-compliant ``output_*`` blocks corresponding to the materialised
+        data URLs (these go into the content-parts array alongside any
+        MEDIA-tag / bare-path blocks the caller discovers).  An empty list
+        means the text held no decodable data URLs.
+        """
+        if not text or "data:" not in text:
+            return text, []
+
+        from gateway.platforms.base import (
+            cache_image_from_bytes,
+            cache_audio_from_bytes,
+            cache_document_from_bytes,
+        )
+
+        blocks: List[Dict[str, Any]] = []
+        materialized: Dict[str, str] = {}  # original data URL → new URL
+
+        for match in _INLINE_DATA_URL_RE.finditer(text):
+            data_url = match.group(0)
+            if data_url in materialized:
+                continue
+            try:
+                mime, raw = _decode_data_url(data_url)
+            except ValueError:
+                continue
+            if not raw:
+                continue
+            mime_primary = (mime or "").split(";", 1)[0].strip().lower() or "application/octet-stream"
+            top, _, _ = mime_primary.partition("/")
+            try:
+                if top == "image":
+                    cached_path = cache_image_from_bytes(
+                        raw, ext=_ext_for_mime(mime_primary, ".png"),
+                    )
+                elif top == "audio":
+                    cached_path = cache_audio_from_bytes(
+                        raw, ext=_ext_for_mime(mime_primary, ".ogg"),
+                    )
+                else:
+                    ext = _ext_for_mime(mime_primary, ".bin")
+                    cached_path = cache_document_from_bytes(
+                        raw, f"inline_{uuid.uuid4().hex[:8]}{ext}",
+                    )
+            except Exception:
+                # Cache helpers can fail on disk errors / unsupported MIMEs;
+                # leave the original data URL in place rather than drop it.
+                continue
+            url = self._register_file_export(request, cached_path)
+            if not url:
+                continue
+            materialized[data_url] = url
+            filename = Path(cached_path).name
+            if top == "image":
+                blocks.append({"type": "output_image", "image_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+            elif top == "audio":
+                blocks.append({"type": "output_audio", "audio_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+            elif top == "video":
+                blocks.append({"type": "output_video", "video_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+            else:
+                blocks.append({"type": "output_file", "file_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+
+        if not materialized:
+            return text, []
+        # Longest-first pass so a shorter data URL can't accidentally match
+        # inside a longer one that shares a prefix.
+        rewritten = text
+        for original, new_url in sorted(materialized.items(), key=lambda kv: -len(kv[0])):
+            rewritten = rewritten.replace(original, new_url)
+        return rewritten, blocks
+
     def _extract_outbound_media_parts(self, request: "web.Request", final_text: str) -> tuple[str, List[Dict[str, Any]], str]:
         from gateway.platforms.base import BasePlatformAdapter
 
+        # First: turn any inline ``data:`` URLs the model wrote by hand into
+        # ``/v1/files/`` URLs directly inside the markdown.  The returned
+        # ``inline_blocks`` go straight into the content-parts array; they
+        # must NOT be re-rendered by _render_media_markdown because the
+        # markdown ``![alt](URL)`` the model wrote is already in the text —
+        # only its URL needed swapping.
+        final_text, inline_blocks = self._materialize_inline_data_urls(request, final_text or "")
         tagged, cleaned = BasePlatformAdapter.extract_media(final_text or "")
         bare_paths, cleaned = BasePlatformAdapter.extract_local_files(cleaned or "")
 
@@ -2405,8 +2708,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 blocks.append({"type": "output_video", "video_url": url, "mime_type": mime, "filename": filename})
             else:
                 blocks.append({"type": "output_file", "file_url": url, "mime_type": mime, "filename": filename})
+        # Markdown is the fallback for clients that render the ``text`` field
+        # only — it must cover MEDIA-tag / bare-path blocks whose URLs aren't
+        # already in the text, but NOT the inline-data-URL blocks whose
+        # markdown ``![alt](URL)`` wrapper is still present in ``cleaned``.
         markdown = self._render_media_markdown(blocks)
-        return cleaned, blocks, markdown
+        return cleaned, inline_blocks + blocks, markdown
 
     def _extract_output_items(self, result: Dict[str, Any], request: Optional["web.Request"] = None) -> List[Dict[str, Any]]:
         """

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -10,6 +10,7 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/stop    — interrupt a running agent
+- GET  /v1/files/{file_id}[.ext]   — download outbound media/document exports
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -22,17 +23,22 @@ Requires:
 """
 
 import asyncio
+import base64
+import binascii
 import hashlib
 import hmac
 import json
 import logging
+import mimetypes
 import os
 import socket as _socket
 import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import unquote_to_bytes
 
 try:
     from aiohttp import web
@@ -54,10 +60,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+MAX_REQUEST_BYTES = 32_000_000  # 32 MB limit for rich OpenAI-style multimodal payloads
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+MAX_EXPORTED_FILES = 256
+FILE_EXPORT_TTL_SECONDS = 14_400
 
 
 def _normalize_chat_content(
@@ -270,6 +278,63 @@ def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Respons
         _openai_error(message, code=code, param=param),
         status=400,
     )
+
+
+def _decode_data_url(data_url: str) -> tuple[str, bytes]:
+    """Decode a data URL into ``(mime_type, raw_bytes)``."""
+    if not isinstance(data_url, str) or not data_url.startswith("data:"):
+        raise ValueError("Not a data URL")
+    header, sep, payload = data_url.partition(",")
+    if not sep:
+        raise ValueError("Malformed data URL")
+    meta = header[5:]  # strip 'data:'
+    mime = "application/octet-stream"
+    if meta:
+        mime = (meta.split(";", 1)[0] or mime).strip() or mime
+    is_b64 = ";base64" in meta
+    try:
+        if is_b64:
+            raw = base64.b64decode(payload, validate=False)
+        else:
+            raw = unquote_to_bytes(payload)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(f"Invalid data URL payload: {exc}") from exc
+    return mime, raw
+
+
+def _ext_for_mime(mime: str, fallback: str) -> str:
+    guessed = mimetypes.guess_extension((mime or "").split(";", 1)[0].strip() or "")
+    if guessed:
+        return guessed
+    return fallback
+
+
+# Recognises a "normal" file extension: leading dot, then 1–8 alphanumerics.
+# Used to scrub both the on-disk suffix and ``mimetypes.guess_extension``
+# output before exposing it in a public URL.
+_SAFE_EXT_RE = re.compile(r"^\.[A-Za-z0-9]{1,8}$")
+
+
+def _choose_export_ext(path: Path, mime: str) -> str:
+    """Pick a URL-safe extension for an outbound file export.
+
+    Preference order:
+
+    1. The file's on-disk suffix, lowercased, if it matches ``_SAFE_EXT_RE``.
+       The bytes are the source of truth — whatever container the file
+       really is in wins over whatever MIME table thinks.
+    2. ``mimetypes.guess_extension(mime)`` as a fallback when the file
+       itself has no suffix (e.g. things cached with a bare uuid name).
+    3. Empty string — never invent ``.bin`` or similar, because a wrong
+       extension is worse for clients sniffing by URL than none at all.
+    """
+    suffix = path.suffix.lower()
+    if _SAFE_EXT_RE.match(suffix):
+        return suffix
+    guessed = mimetypes.guess_extension((mime or "").split(";", 1)[0].strip() or "")
+    if guessed and _SAFE_EXT_RE.match(guessed):
+        return guessed.lower()
+    return ""
 
 
 def check_api_server_requirements() -> bool:
@@ -591,6 +656,7 @@ class APIServerAdapter(BasePlatformAdapter):
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._file_exports: Dict[str, Dict[str, Any]] = {}
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -759,15 +825,13 @@ class APIServerAdapter(BasePlatformAdapter):
         return agent
 
     # ------------------------------------------------------------------
-    # HTTP Handlers
-    # ------------------------------------------------------------------
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "hermes-agent"})
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
-        """GET /health/detailed — rich status for cross-container dashboard probing.
+        """GET /health/detailed — expanded status for cross-container dashboard probing.
 
         Returns gateway state, connected platforms, PID, and uptime so the
         dashboard can display full status without needing a shared PID file or
@@ -1014,6 +1078,10 @@ class APIServerAdapter(BasePlatformAdapter):
         final_response = result.get("final_response", "")
         if not final_response:
             final_response = result.get("error", "(No response generated)")
+        cleaned_text, media_blocks, media_markdown = self._extract_outbound_media_parts(request, final_response)
+        final_response = cleaned_text or final_response
+        if media_markdown:
+            final_response = f"{final_response}\n\n{media_markdown}".strip()
 
         response_data = {
             "id": completion_id,
@@ -1026,6 +1094,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "message": {
                         "role": "assistant",
                         "content": final_response,
+                        "content_parts": [{"type": "output_text", "text": final_response}] + media_blocks,
                     },
                     "finish_reason": "stop",
                 }
@@ -1132,11 +1201,25 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            media_markdown = ""
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
+                final_response = ""
+                if isinstance(result, dict):
+                    final_response = result.get("final_response", "") or result.get("error", "")
+                if final_response:
+                    _, _, media_markdown = self._extract_outbound_media_parts(request, final_response)
             except Exception:
                 pass
+
+            if media_markdown:
+                media_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": f"\n\n{media_markdown}"}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(media_chunk)}\n\n".encode())
 
             # Finish chunk
             finish_chunk = {
@@ -1901,7 +1984,7 @@ class APIServerAdapter(BasePlatformAdapter):
             full_history.append({"role": "assistant", "content": final_response})
 
         # Build output items (includes tool calls + final message)
-        output_items = self._extract_output_items(result)
+        output_items = self._extract_output_items(result, request)
 
         response_data = {
             "id": response_id,
@@ -1965,6 +2048,29 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "deleted": True,
         })
+
+    async def _handle_get_file(self, request: "web.Request") -> "web.Response":
+        """GET /v1/files/{file_id}[.ext] — download an exported local media/document file.
+
+        The ``.ext`` suffix is cosmetic (so clients sniffing by URL see the
+        right container) but it must match the one recorded at registration
+        time if supplied, otherwise we 404.  This stops anyone who guessed
+        a file_id from probing for the real extension.
+        """
+        self._prune_file_exports()
+        file_id = request.match_info["file_id"]
+        ext_in_url = request.match_info.get("ext", "") or ""
+        meta = self._file_exports.get(file_id)
+        if not meta:
+            return web.json_response(_openai_error("File not found", code="file_not_found"), status=404)
+        expected_ext = str(meta.get("ext", "") or "")
+        if ext_in_url and ext_in_url.lower() != expected_ext.lower():
+            return web.json_response(_openai_error("File not found", code="file_not_found"), status=404)
+        path = Path(str(meta.get("path", "")))
+        if not path.is_file():
+            self._file_exports.pop(file_id, None)
+            return web.json_response(_openai_error("File no longer available", code="file_not_found"), status=404)
+        return web.FileResponse(path)
 
     # ------------------------------------------------------------------
     # Cron jobs API
@@ -2189,8 +2295,93 @@ class APIServerAdapter(BasePlatformAdapter):
     # Output extraction helper
     # ------------------------------------------------------------------
 
+    def _prune_file_exports(self) -> None:
+        now = time.time()
+        expired = [k for k, v in self._file_exports.items() if (now - float(v.get("created_at", 0))) > FILE_EXPORT_TTL_SECONDS]
+        for k in expired:
+            self._file_exports.pop(k, None)
+        if len(self._file_exports) > MAX_EXPORTED_FILES:
+            oldest = sorted(self._file_exports.items(), key=lambda kv: float(kv[1].get("created_at", 0)))
+            for key, _ in oldest[: len(self._file_exports) - MAX_EXPORTED_FILES]:
+                self._file_exports.pop(key, None)
+
+    def _register_file_export(self, request: "web.Request", local_path: str) -> Optional[str]:
+        try:
+            p = Path(local_path).expanduser().resolve()
+        except Exception:
+            return None
+        if not p.is_file():
+            return None
+        self._prune_file_exports()
+        file_id = uuid.uuid4().hex
+        mime = mimetypes.guess_type(str(p))[0] or "application/octet-stream"
+        ext = _choose_export_ext(p, mime)
+        self._file_exports[file_id] = {"path": str(p), "created_at": time.time(), "ext": ext}
+        return f"{request.scheme}://{request.host}/v1/files/{file_id}{ext}"
+
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _render_media_markdown(blocks: List[Dict[str, Any]]) -> str:
+        """Render media blocks into markdown/html that Open WebUI can display."""
+        lines: List[str] = []
+        for block in blocks:
+            btype = str(block.get("type", ""))
+            name = str(block.get("filename", "")).strip() or "media"
+            if btype == "output_image":
+                url = str(block.get("image_url", "")).strip()
+                if url:
+                    lines.append(f"![{name}]({url})")
+            elif btype == "output_audio":
+                url = str(block.get("audio_url", "")).strip()
+                if url:
+                    lines.append(f"[Audio: {name}]({url})")
+            elif btype == "output_video":
+                url = str(block.get("video_url", "")).strip()
+                if url:
+                    lines.append(f"[Video: {name}]({url})")
+            elif btype == "output_file":
+                url = str(block.get("file_url", "")).strip()
+                if url:
+                    lines.append(f"[File: {name}]({url})")
+        return "\n".join(lines)
+
+    def _extract_outbound_media_parts(self, request: "web.Request", final_text: str) -> tuple[str, List[Dict[str, Any]], str]:
+        from gateway.platforms.base import BasePlatformAdapter
+
+        tagged, cleaned = BasePlatformAdapter.extract_media(final_text or "")
+        bare_paths, cleaned = BasePlatformAdapter.extract_local_files(cleaned or "")
+
+        refs: List[str] = [path for path, _ in tagged] + list(bare_paths)
+        seen: set[str] = set()
+        blocks: List[Dict[str, Any]] = []
+        for ref in refs:
+            if not ref or ref in seen:
+                continue
+            seen.add(ref)
+            mime, _ = mimetypes.guess_type(ref)
+            mime = mime or "application/octet-stream"
+            resolved_path = Path(ref).expanduser().resolve()
+            ext = resolved_path.suffix.lower()
+            filename = resolved_path.name
+            is_image = mime.startswith("image/") or ext in {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+            # All outbound media — images included — is served from
+            # /v1/files/{id}.ext.  Inlining as data URLs was a micro-opt for
+            # tiny thumbnails that just bloated response JSON and broke
+            # conversation-history round-trips.
+            url = self._register_file_export(request, ref)
+            if not url:
+                continue
+            if is_image:
+                blocks.append({"type": "output_image", "image_url": url, "mime_type": mime, "filename": filename})
+            elif mime.startswith("audio/") or ext in {".ogg", ".opus", ".mp3", ".wav", ".m4a"}:
+                blocks.append({"type": "output_audio", "audio_url": url, "mime_type": mime, "filename": filename})
+            elif mime.startswith("video/") or ext in {".mp4", ".mov", ".avi", ".mkv", ".webm"}:
+                blocks.append({"type": "output_video", "video_url": url, "mime_type": mime, "filename": filename})
+            else:
+                blocks.append({"type": "output_file", "file_url": url, "mime_type": mime, "filename": filename})
+        markdown = self._render_media_markdown(blocks)
+        return cleaned, blocks, markdown
+
+    def _extract_output_items(self, result: Dict[str, Any], request: Optional["web.Request"] = None) -> List[Dict[str, Any]]:
         """
         Build the full output item array from the agent's messages.
 
@@ -2225,15 +2416,21 @@ class APIServerAdapter(BasePlatformAdapter):
         if not final:
             final = result.get("error", "(No response generated)")
 
+        content_blocks: List[Dict[str, Any]] = [{
+            "type": "output_text",
+            "text": final,
+        }]
+        if request is not None:
+            cleaned, media_blocks, markdown = self._extract_outbound_media_parts(request, final)
+            final = cleaned or final
+            if markdown:
+                final = f"{final}\n\n{markdown}".strip()
+            content_blocks = [{"type": "output_text", "text": final}] + media_blocks
+
         items.append({
             "type": "message",
             "role": "assistant",
-            "content": [
-                {
-                    "type": "output_text",
-                    "text": final,
-                }
-            ],
+            "content": content_blocks,
         })
         return items
 
@@ -2361,7 +2558,16 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        if isinstance(raw_input, str):
+            user_message = raw_input
+        elif isinstance(raw_input, list) and raw_input:
+            tail = raw_input[-1]
+            if isinstance(tail, dict):
+                user_message = _normalize_chat_content(tail.get("content", ""))
+            else:
+                user_message = _normalize_chat_content(tail)
+        else:
+            user_message = ""
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -2425,13 +2631,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
             for msg in raw_input[:-1]:
                 if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
+                    content = _normalize_chat_content(msg["content"])
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         session_id = body.get("session_id") or stored_session_id or run_id
@@ -2615,7 +2815,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
@@ -2625,6 +2825,16 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            # The trailing ``{ext}`` is optional so old extension-less URLs
+            # still resolve.  Regex-constraining both segments keeps the
+            # route free of traversal chars and unusual input.  Real ids
+            # come from ``uuid.uuid4().hex`` (pure hex), but the character
+            # class is slightly broader so callers that mint their own
+            # alphanumeric tokens keep working.
+            self._app.router.add_get(
+                r"/v1/files/{file_id:[A-Za-z0-9]+}{ext:(?:\.[A-Za-z0-9]{1,8})?}",
+                self._handle_get_file,
+            )
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -38,7 +38,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import unquote_to_bytes
+from urllib.parse import unquote_to_bytes, urlsplit
 
 try:
     from aiohttp import web
@@ -2317,7 +2317,34 @@ class APIServerAdapter(BasePlatformAdapter):
         mime = mimetypes.guess_type(str(p))[0] or "application/octet-stream"
         ext = _choose_export_ext(p, mime)
         self._file_exports[file_id] = {"path": str(p), "created_at": time.time(), "ext": ext}
-        return f"{request.scheme}://{request.host}/v1/files/{file_id}{ext}"
+        authority = request.host
+
+        forced_host = (os.getenv("API_SERVER_FILE_RESPONSE_FORCE_HOST", "") or "").strip()
+        forced_port = (os.getenv("API_SERVER_FILE_RESPONSE_FORCE_PORT", "") or "").strip().lstrip(":")
+        if forced_host or forced_port:
+            # Parse request.host to preserve any existing host/port when only one
+            # override is supplied.
+            current_host = authority
+            current_port = ""
+            try:
+                parsed = urlsplit(f"//{authority}")
+                if parsed.hostname:
+                    current_host = parsed.hostname
+                if parsed.port:
+                    current_port = str(parsed.port)
+            except Exception:
+                pass
+
+            host = forced_host or current_host
+            port = forced_port or current_port
+
+            # Ensure IPv6 literals are bracketed when composing host:port.
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+
+            authority = f"{host}:{port}" if port else host
+
+        return f"{request.scheme}://{authority}/v1/files/{file_id}{ext}"
 
     @staticmethod
     def _render_media_markdown(blocks: List[Dict[str, Any]]) -> str:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -160,6 +160,17 @@ def _ext_for_mime(mime: str, fallback: str) -> str:
 _SAFE_EXT_RE = re.compile(r"^\.[A-Za-z0-9]{1,8}$")
 
 
+# Matches ``data:<mime/attrs>,<payload>`` URLs the model embeds in its final
+# reply — almost always inside markdown like ``![alt](data:image/png;base64,…)``.
+# The payload char class covers both base64 (``A-Za-z0-9+/=``) and URL-encoded
+# (``%`` + unreserved chars) variants; the URL ends at whitespace, quote,
+# close-paren, or angle bracket — the standard markdown/HTML delimiters.
+_INLINE_DATA_URL_RE = re.compile(
+    r'data:[^\s,)"\'<>]+,[A-Za-z0-9+/=%._~\-]+',
+    re.IGNORECASE,
+)
+
+
 def _choose_export_ext(path: Path, mime: str) -> str:
     """Pick a URL-safe extension for an outbound file export.
 
@@ -181,6 +192,165 @@ def _choose_export_ext(path: Path, mime: str) -> str:
         return guessed.lower()
     return ""
 
+
+class _StreamDataURLFilter:
+    """Rewrite ``data:…`` URLs to ``/v1/files/…`` URLs in a streamed text.
+
+    The SSE chat-completions path forwards every agent token to the client
+    the instant it arrives from the LLM, which means a reply like
+    ``![icon](data:image/png;base64,iVBORw0KG…)`` reaches the client as a
+    base64 blob before the server ever sees the complete URL.  By the time
+    the batch-path rewriter (_materialize_inline_data_urls) runs on the
+    agent's ``final_response``, the stream has already shipped the raw
+    payload and there's no amendment mechanism in the OpenAI SSE spec.
+
+    This state machine sits between the agent's delta queue and the SSE
+    writer.  It buffers incoming text, suppresses anything that looks like
+    a ``data:`` URL from the downstream emitter, and on URL completion
+    decodes the payload, caches the bytes under
+    ``~/.hermes/{image,audio,document}_cache``, registers the cached path
+    with the file-export registry, and emits the resulting
+    ``/v1/files/{id}.ext`` URL in place of the original data URL.
+
+    Failure modes are conservative: an undecodable payload, a cache-helper
+    exception, or a failed registration leaves the original data URL
+    string in the output rather than dropping user-visible content.
+    """
+
+    # Characters that end a data URL embedded in markdown / HTML.  Closing
+    # paren for ``![alt](…)``, whitespace, quotes, angle brackets.
+    _TERMINATORS = frozenset(' \t\n\r)"\'<>')
+    # The prefix we're watching for.  Held-back tail length is bounded by
+    # ``len(_PREFIX) - 1`` (4 chars) but only activates when the buffer
+    # actually ends with a prefix of this string — see ``_prefix_holdback``.
+    _PREFIX = "data:"
+
+    def __init__(self, adapter, request):
+        self._adapter = adapter
+        self._request = request
+        self._buffer = ""
+        self._in_url = False
+        self.inline_blocks: list = []
+
+    def feed(self, chunk: str) -> str:
+        """Absorb ``chunk`` into the buffer; return text safe to emit now."""
+        if not chunk:
+            return ""
+        self._buffer += chunk
+        return self._drain(force=False)
+
+    def flush(self) -> str:
+        """End of stream — decode any in-progress data URL and return
+        everything still buffered."""
+        return self._drain(force=True)
+
+    def _prefix_holdback(self) -> int:
+        """Return how many trailing characters to keep buffered because
+        they could be the start of ``data:``.  Zero when the tail doesn't
+        match any prefix of the target string — the common case for
+        ordinary prose — so normal tokens pass through untouched."""
+        buf = self._buffer
+        max_k = min(len(self._PREFIX) - 1, len(buf))
+        for k in range(max_k, 0, -1):
+            if buf[-k:] == self._PREFIX[:k]:
+                return k
+        return 0
+
+    def _drain(self, force: bool) -> str:
+        out: List[str] = []
+        while self._buffer:
+            if self._in_url:
+                term_idx = -1
+                for i, ch in enumerate(self._buffer):
+                    if ch in self._TERMINATORS:
+                        term_idx = i
+                        break
+                if term_idx < 0:
+                    if force:
+                        data_url = self._buffer
+                        self._buffer = ""
+                        out.append(self._materialize(data_url))
+                        self._in_url = False
+                    else:
+                        break
+                else:
+                    data_url = self._buffer[:term_idx]
+                    self._buffer = self._buffer[term_idx:]
+                    out.append(self._materialize(data_url))
+                    self._in_url = False
+            else:
+                idx = self._buffer.find("data:")
+                if idx >= 0:
+                    if idx > 0:
+                        out.append(self._buffer[:idx])
+                    self._buffer = self._buffer[idx:]
+                    self._in_url = True
+                else:
+                    if force:
+                        out.append(self._buffer)
+                        self._buffer = ""
+                    else:
+                        hold = self._prefix_holdback()
+                        safe_len = len(self._buffer) - hold
+                        if safe_len > 0:
+                            out.append(self._buffer[:safe_len])
+                            self._buffer = self._buffer[safe_len:]
+                    break
+        return "".join(out)
+
+    def _materialize(self, data_url: str) -> str:
+        """Decode one data URL and return its ``/v1/files/…`` replacement.
+
+        On any failure return the original ``data_url`` verbatim — a broken
+        URL in the output is strictly better than silently dropping bytes
+        the model intended to send.
+        """
+        try:
+            mime, raw = _decode_data_url(data_url)
+        except ValueError:
+            return data_url
+        if not raw:
+            return data_url
+        mime_primary = (mime or "").split(";", 1)[0].strip().lower() or "application/octet-stream"
+        top, _, _ = mime_primary.partition("/")
+        from gateway.platforms.base import (
+            cache_image_from_bytes,
+            cache_audio_from_bytes,
+            cache_document_from_bytes,
+        )
+        try:
+            if top == "image":
+                cached = cache_image_from_bytes(
+                    raw, ext=_ext_for_mime(mime_primary, ".png"),
+                )
+            elif top == "audio":
+                cached = cache_audio_from_bytes(
+                    raw, ext=_ext_for_mime(mime_primary, ".ogg"),
+                )
+            else:
+                ext = _ext_for_mime(mime_primary, ".bin")
+                cached = cache_document_from_bytes(
+                    raw, f"inline_{uuid.uuid4().hex[:8]}{ext}",
+                )
+        except Exception:
+            return data_url
+        url = self._adapter._register_file_export(self._request, cached)
+        if not url:
+            return data_url
+        filename = Path(cached).name
+        if top == "image":
+            self.inline_blocks.append({"type": "output_image", "image_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        elif top == "audio":
+            self.inline_blocks.append({"type": "output_audio", "audio_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        elif top == "video":
+            self.inline_blocks.append({"type": "output_video", "video_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        else:
+            self.inline_blocks.append({"type": "output_file", "file_url": url,
+                                       "mime_type": mime_primary, "filename": filename})
+        return url
 
 
 def check_api_server_requirements() -> bool:
@@ -1067,6 +1237,13 @@ class APIServerAdapter(BasePlatformAdapter):
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
+        # Filter intercepts data:<mime>;base64,… substrings in the streamed
+        # text before they reach the client.  Each complete data URL is
+        # decoded, cached to disk, registered with the file-export
+        # registry, and the resulting /v1/files/{id}.ext URL is emitted in
+        # place of the base64 payload.
+        stream_filter = _StreamDataURLFilter(self, request)
+
         try:
             last_activity = time.monotonic()
 
@@ -1079,13 +1256,30 @@ class APIServerAdapter(BasePlatformAdapter):
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
             last_activity = time.monotonic()
 
+            async def _emit_text(text: str):
+                """Write a plain text chunk as an OpenAI ``delta.content``
+                event.  Bypasses the data-URL filter — callers that need
+                filtering go through ``_emit`` instead, and this helper
+                is used for the filter's ``flush()`` output and the
+                trailing ``media_markdown`` chunk."""
+                if not text:
+                    return time.monotonic()
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                return time.monotonic()
+
             # Helper — route a queue item to the correct SSE event.
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
 
-                Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
+                Plain strings are fed through the data-URL filter and only
+                the safe-to-emit portion is shipped downstream.  Tagged
+                tuples ``("__tool_progress__", payload)`` are sent as a
+                custom ``event: hermes.tool.progress`` SSE event so
                 frontends can display them without storing the markers in
                 conversation history.  See #6972.
                 """
@@ -1094,13 +1288,20 @@ class APIServerAdapter(BasePlatformAdapter):
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
-                else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    return time.monotonic()
+                if isinstance(item, str):
+                    safe = stream_filter.feed(item)
+                    if safe:
+                        return await _emit_text(safe)
+                    return time.monotonic()
+                # Anything else — shouldn't happen, but emit as-is to stay
+                # bug-compatible with pre-filter behaviour.
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
@@ -1130,6 +1331,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 last_activity = await _emit(delta)
 
+            # Flush any text the data-URL filter was still holding back —
+            # either trailing characters buffered against a split ``data:``
+            # prefix, or (rarely) an in-progress data URL that never got
+            # its terminator before end-of-stream.
+            tail = stream_filter.flush()
+            if tail:
+                last_activity = await _emit_text(tail)
+
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
             media_markdown = ""
@@ -1145,12 +1354,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
 
             if media_markdown:
-                media_chunk = {
-                    "id": completion_id, "object": "chat.completion.chunk",
-                    "created": created, "model": model,
-                    "choices": [{"index": 0, "delta": {"content": f"\n\n{media_markdown}"}, "finish_reason": None}],
-                }
-                await response.write(f"data: {json.dumps(media_chunk)}\n\n".encode())
+                await _emit_text(f"\n\n{media_markdown}")
 
             # Finish chunk
             finish_chunk = {
@@ -2244,9 +2448,107 @@ class APIServerAdapter(BasePlatformAdapter):
                     lines.append(f"[File: {name}]({url})")
         return "\n".join(lines)
 
+    def _materialize_inline_data_urls(
+        self, request: "web.Request", text: str,
+    ) -> tuple[str, List[Dict[str, Any]]]:
+        """Rewrite model-embedded ``data:`` URLs into ``/v1/files/`` URLs in-place.
+
+        LLMs (Claude most notably) frequently return images produced by shell
+        tools as ``![alt](data:image/png;base64,…)`` in their final reply.
+        That inlined payload bypasses the ``MEDIA:<path>`` convention, bloats
+        response JSON, and makes conversation history carry the bytes on
+        every turn.  This helper intercepts those data URLs, decodes the
+        payload, caches the bytes under ``~/.hermes/{image,audio,document}_cache``,
+        registers the cached path with the file-export registry, and splices
+        the resulting ``/v1/files/{id}.ext`` URL into the text in place of
+        the original data URL.  The enclosing markdown structure
+        (``![alt](…)``) is preserved verbatim — only the URL swaps.
+
+        Returns ``(rewritten_text, blocks)`` where ``blocks`` is the list of
+        spec-compliant ``output_*`` blocks corresponding to the materialised
+        data URLs (these go into the content-parts array alongside any
+        MEDIA-tag / bare-path blocks the caller discovers).  An empty list
+        means the text held no decodable data URLs.
+        """
+        if not text or "data:" not in text:
+            return text, []
+
+        from gateway.platforms.base import (
+            cache_image_from_bytes,
+            cache_audio_from_bytes,
+            cache_document_from_bytes,
+        )
+
+        blocks: List[Dict[str, Any]] = []
+        materialized: Dict[str, str] = {}  # original data URL → new URL
+
+        for match in _INLINE_DATA_URL_RE.finditer(text):
+            data_url = match.group(0)
+            if data_url in materialized:
+                continue
+            try:
+                mime, raw = _decode_data_url(data_url)
+            except ValueError:
+                continue
+            if not raw:
+                continue
+            mime_primary = (mime or "").split(";", 1)[0].strip().lower() or "application/octet-stream"
+            top, _, _ = mime_primary.partition("/")
+            try:
+                if top == "image":
+                    cached_path = cache_image_from_bytes(
+                        raw, ext=_ext_for_mime(mime_primary, ".png"),
+                    )
+                elif top == "audio":
+                    cached_path = cache_audio_from_bytes(
+                        raw, ext=_ext_for_mime(mime_primary, ".ogg"),
+                    )
+                else:
+                    ext = _ext_for_mime(mime_primary, ".bin")
+                    cached_path = cache_document_from_bytes(
+                        raw, f"inline_{uuid.uuid4().hex[:8]}{ext}",
+                    )
+            except Exception:
+                # Cache helpers can fail on disk errors / unsupported MIMEs;
+                # leave the original data URL in place rather than drop it.
+                continue
+            url = self._register_file_export(request, cached_path)
+            if not url:
+                continue
+            materialized[data_url] = url
+            filename = Path(cached_path).name
+            if top == "image":
+                blocks.append({"type": "output_image", "image_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+            elif top == "audio":
+                blocks.append({"type": "output_audio", "audio_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+            elif top == "video":
+                blocks.append({"type": "output_video", "video_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+            else:
+                blocks.append({"type": "output_file", "file_url": url,
+                               "mime_type": mime_primary, "filename": filename})
+
+        if not materialized:
+            return text, []
+        # Longest-first pass so a shorter data URL can't accidentally match
+        # inside a longer one that shares a prefix.
+        rewritten = text
+        for original, new_url in sorted(materialized.items(), key=lambda kv: -len(kv[0])):
+            rewritten = rewritten.replace(original, new_url)
+        return rewritten, blocks
+
     def _extract_outbound_media_parts(self, request: "web.Request", final_text: str) -> tuple[str, List[Dict[str, Any]], str]:
         from gateway.platforms.base import BasePlatformAdapter
 
+        # First: turn any inline ``data:`` URLs the model wrote by hand into
+        # ``/v1/files/`` URLs directly inside the markdown.  The returned
+        # ``inline_blocks`` go straight into the content-parts array; they
+        # must NOT be re-rendered by _render_media_markdown because the
+        # markdown ``![alt](URL)`` the model wrote is already in the text —
+        # only its URL needed swapping.
+        final_text, inline_blocks = self._materialize_inline_data_urls(request, final_text or "")
         tagged, cleaned = BasePlatformAdapter.extract_media(final_text or "")
         bare_paths, cleaned = BasePlatformAdapter.extract_local_files(cleaned or "")
 
@@ -2278,8 +2580,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 blocks.append({"type": "output_video", "video_url": url, "mime_type": mime, "filename": filename})
             else:
                 blocks.append({"type": "output_file", "file_url": url, "mime_type": mime, "filename": filename})
+        # Markdown is the fallback for clients that render the ``text`` field
+        # only — it must cover MEDIA-tag / bare-path blocks whose URLs aren't
+        # already in the text, but NOT the inline-data-URL blocks whose
+        # markdown ``![alt](URL)`` wrapper is still present in ``cleaned``.
         markdown = self._render_media_markdown(blocks)
-        return cleaned, blocks, markdown
+        return cleaned, inline_blocks + blocks, markdown
 
     def _extract_output_items(self, result: Dict[str, Any], request: Optional["web.Request"] = None) -> List[Dict[str, Any]]:
         """

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -37,7 +37,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from urllib.parse import unquote_to_bytes
+from urllib.parse import unquote_to_bytes, urlsplit
 
 try:
     from aiohttp import web
@@ -2190,7 +2190,34 @@ class APIServerAdapter(BasePlatformAdapter):
         mime = mimetypes.guess_type(str(p))[0] or "application/octet-stream"
         ext = _choose_export_ext(p, mime)
         self._file_exports[file_id] = {"path": str(p), "created_at": time.time(), "ext": ext}
-        return f"{request.scheme}://{request.host}/v1/files/{file_id}{ext}"
+        authority = request.host
+
+        forced_host = (os.getenv("API_SERVER_FILE_RESPONSE_FORCE_HOST", "") or "").strip()
+        forced_port = (os.getenv("API_SERVER_FILE_RESPONSE_FORCE_PORT", "") or "").strip().lstrip(":")
+        if forced_host or forced_port:
+            # Parse request.host to preserve any existing host/port when only one
+            # override is supplied.
+            current_host = authority
+            current_port = ""
+            try:
+                parsed = urlsplit(f"//{authority}")
+                if parsed.hostname:
+                    current_host = parsed.hostname
+                if parsed.port:
+                    current_port = str(parsed.port)
+            except Exception:
+                pass
+
+            host = forced_host or current_host
+            port = forced_port or current_port
+
+            # Ensure IPv6 literals are bracketed when composing host:port.
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+
+            authority = f"{host}:{port}" if port else host
+
+        return f"{request.scheme}://{authority}/v1/files/{file_id}{ext}"
 
     @staticmethod
     def _render_media_markdown(blocks: List[Dict[str, Any]]) -> str:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -9,6 +9,7 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/models                  — lists hermes-agent as an available model
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
+- GET  /v1/files/{file_id}[.ext]   — download outbound media/document exports
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -21,17 +22,22 @@ Requires:
 """
 
 import asyncio
+import base64
+import binascii
 import hashlib
 import hmac
 import json
 import logging
+import mimetypes
 import os
 import socket as _socket
 import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import unquote_to_bytes
 
 try:
     from aiohttp import web
@@ -53,10 +59,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+MAX_REQUEST_BYTES = 32_000_000  # 32 MB limit for rich OpenAI-style multimodal payloads
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+MAX_EXPORTED_FILES = 256
+FILE_EXPORT_TTL_SECONDS = 14_400
 
 
 def _normalize_chat_content(
@@ -115,6 +123,64 @@ def _normalize_chat_content(
         return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
     except Exception:
         return ""
+
+
+def _decode_data_url(data_url: str) -> tuple[str, bytes]:
+    """Decode a data URL into ``(mime_type, raw_bytes)``."""
+    if not isinstance(data_url, str) or not data_url.startswith("data:"):
+        raise ValueError("Not a data URL")
+    header, sep, payload = data_url.partition(",")
+    if not sep:
+        raise ValueError("Malformed data URL")
+    meta = header[5:]  # strip 'data:'
+    mime = "application/octet-stream"
+    if meta:
+        mime = (meta.split(";", 1)[0] or mime).strip() or mime
+    is_b64 = ";base64" in meta
+    try:
+        if is_b64:
+            raw = base64.b64decode(payload, validate=False)
+        else:
+            raw = unquote_to_bytes(payload)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError(f"Invalid data URL payload: {exc}") from exc
+    return mime, raw
+
+
+def _ext_for_mime(mime: str, fallback: str) -> str:
+    guessed = mimetypes.guess_extension((mime or "").split(";", 1)[0].strip() or "")
+    if guessed:
+        return guessed
+    return fallback
+
+
+# Recognises a "normal" file extension: leading dot, then 1–8 alphanumerics.
+# Used to scrub both the on-disk suffix and ``mimetypes.guess_extension``
+# output before exposing it in a public URL.
+_SAFE_EXT_RE = re.compile(r"^\.[A-Za-z0-9]{1,8}$")
+
+
+def _choose_export_ext(path: Path, mime: str) -> str:
+    """Pick a URL-safe extension for an outbound file export.
+
+    Preference order:
+
+    1. The file's on-disk suffix, lowercased, if it matches ``_SAFE_EXT_RE``.
+       The bytes are the source of truth — whatever container the file
+       really is in wins over whatever MIME table thinks.
+    2. ``mimetypes.guess_extension(mime)`` as a fallback when the file
+       itself has no suffix (e.g. things cached with a bare uuid name).
+    3. Empty string — never invent ``.bin`` or similar, because a wrong
+       extension is worse for clients sniffing by URL than none at all.
+    """
+    suffix = path.suffix.lower()
+    if _SAFE_EXT_RE.match(suffix):
+        return suffix
+    guessed = mimetypes.guess_extension((mime or "").split(";", 1)[0].strip() or "")
+    if guessed and _SAFE_EXT_RE.match(guessed):
+        return guessed.lower()
+    return ""
+
 
 
 def check_api_server_requirements() -> bool:
@@ -395,6 +461,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._file_exports: Dict[str, Dict[str, Any]] = {}
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -562,6 +629,136 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         return agent
 
+    def _append_normalized_part(self, parts: List[str], value: str) -> None:
+        if not value:
+            return
+        current = sum(len(p) for p in parts)
+        if current >= MAX_NORMALIZED_TEXT_LENGTH:
+            return
+        remaining = MAX_NORMALIZED_TEXT_LENGTH - current
+        parts.append(value[:remaining])
+
+    async def _materialize_multimodal_source(
+        self,
+        *,
+        media_kind: str,
+        source: str,
+        filename: Optional[str] = None,
+    ) -> str:
+        """Convert URL/data URL multimodal sources into Hermes-friendly refs."""
+        source = str(source or "").strip()
+        if not source:
+            return ""
+        if not source.startswith("data:"):
+            return source
+
+        mime, raw = _decode_data_url(source)
+        if media_kind == "image":
+            from gateway.platforms.base import cache_image_from_bytes
+            return cache_image_from_bytes(raw, ext=_ext_for_mime(mime, ".jpg"))
+        if media_kind == "audio":
+            from gateway.platforms.base import cache_audio_from_bytes
+            return cache_audio_from_bytes(raw, ext=_ext_for_mime(mime, ".ogg"))
+
+        from gateway.platforms.base import cache_document_from_bytes
+        default_name = filename or f"{media_kind}_{uuid.uuid4().hex[:8]}{_ext_for_mime(mime, '.bin')}"
+        return cache_document_from_bytes(raw, default_name)
+
+    async def _normalize_multimodal_part(self, part: Dict[str, Any], item_type: str) -> str:
+        """Convert OpenAI multimodal part objects into Hermes placeholders."""
+        if item_type in {"image_url", "input_image"}:
+            raw = part.get("image_url")
+            if isinstance(raw, dict):
+                raw = raw.get("url")
+            ref = await self._materialize_multimodal_source(media_kind="image", source=str(raw or ""))
+            return f"[User sent an image: {ref}]" if ref else "[User sent an image]"
+
+        if item_type == "input_audio":
+            payload = part.get("input_audio")
+            ref = ""
+            if isinstance(payload, dict):
+                if payload.get("url"):
+                    ref = await self._materialize_multimodal_source(media_kind="audio", source=str(payload.get("url")))
+                elif payload.get("data"):
+                    fmt = str(payload.get("format") or "ogg").strip().lower() or "ogg"
+                    try:
+                        raw = base64.b64decode(str(payload.get("data")))
+                    except (binascii.Error, ValueError):
+                        raw = b""
+                    if raw:
+                        from gateway.platforms.base import cache_audio_from_bytes
+                        ref = cache_audio_from_bytes(raw, ext=f".{fmt.lstrip('.')}")
+            if not ref:
+                for k in ("audio_url", "url"):
+                    if part.get(k):
+                        ref = await self._materialize_multimodal_source(media_kind="audio", source=str(part.get(k)))
+                        break
+            return f"[User sent audio: {ref}]" if ref else "[User sent audio]"
+
+        if item_type == "input_video":
+            src = part.get("video_url") or part.get("url")
+            ref = await self._materialize_multimodal_source(
+                media_kind="video",
+                source=str(src or ""),
+                filename=part.get("filename"),
+            )
+            return f"[User sent a video: {ref}]" if ref else "[User sent a video]"
+
+        if item_type in {"input_file", "file"}:
+            filename = part.get("filename")
+            ref = ""
+            obj = part.get("file")
+            if isinstance(obj, dict):
+                filename = filename or obj.get("filename")
+                if obj.get("file_data"):
+                    ref = await self._materialize_multimodal_source(
+                        media_kind="file",
+                        source=str(obj.get("file_data")),
+                        filename=filename,
+                    )
+                elif obj.get("file_url"):
+                    ref = await self._materialize_multimodal_source(media_kind="file", source=str(obj.get("file_url")))
+            if not ref:
+                for k in ("file_url", "url"):
+                    if part.get(k):
+                        ref = await self._materialize_multimodal_source(media_kind="file", source=str(part.get(k)), filename=filename)
+                        break
+            label = "PDF document" if str(filename or "").lower().endswith(".pdf") else "file"
+            return f"[User sent a {label}: {ref}]" if ref else f"[User sent a {label}]"
+
+        return ""
+
+    async def _normalize_content_for_agent(self, content: Any) -> str:
+        """Normalize text + multimodal OpenAI parts into Hermes-friendly text."""
+        if isinstance(content, (str, int, float, bool)) or content is None:
+            return _normalize_chat_content(content)
+        if not isinstance(content, list):
+            return _normalize_chat_content(content)
+
+        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+        parts: List[str] = []
+        for item in items:
+            if isinstance(item, str):
+                self._append_normalized_part(parts, item)
+                continue
+            if isinstance(item, list):
+                nested = await self._normalize_content_for_agent(item)
+                self._append_normalized_part(parts, nested)
+                continue
+            if not isinstance(item, dict):
+                self._append_normalized_part(parts, _normalize_chat_content(item))
+                continue
+            item_type = str(item.get("type") or "").strip().lower()
+            if item_type in {"text", "input_text", "output_text"}:
+                self._append_normalized_part(parts, str(item.get("text", "")))
+                continue
+            multimodal = await self._normalize_multimodal_part(item, item_type)
+            if multimodal:
+                self._append_normalized_part(parts, multimodal)
+                continue
+        result = "\n".join(p for p in parts if p)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
@@ -571,7 +768,7 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({"status": "ok", "platform": "hermes-agent"})
 
     async def _handle_health_detailed(self, request: "web.Request") -> "web.Response":
-        """GET /health/detailed — rich status for cross-container dashboard probing.
+        """GET /health/detailed — expanded status for cross-container dashboard probing.
 
         Returns gateway state, connected platforms, PID, and uptime so the
         dashboard can display full status without needing a shared PID file or
@@ -639,7 +836,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         for msg in messages:
             role = msg.get("role", "")
-            content = _normalize_chat_content(msg.get("content", ""))
+            content = await self._normalize_content_for_agent(msg.get("content", ""))
             if role == "system":
                 # Accumulate system messages
                 if system_prompt is None:
@@ -812,6 +1009,10 @@ class APIServerAdapter(BasePlatformAdapter):
         final_response = result.get("final_response", "")
         if not final_response:
             final_response = result.get("error", "(No response generated)")
+        cleaned_text, media_blocks, media_markdown = self._extract_outbound_media_parts(request, final_response)
+        final_response = cleaned_text or final_response
+        if media_markdown:
+            final_response = f"{final_response}\n\n{media_markdown}".strip()
 
         response_data = {
             "id": completion_id,
@@ -824,6 +1025,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "message": {
                         "role": "assistant",
                         "content": final_response,
+                        "content_parts": [{"type": "output_text", "text": final_response}] + media_blocks,
                     },
                     "finish_reason": "stop",
                 }
@@ -930,11 +1132,25 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            media_markdown = ""
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
+                final_response = ""
+                if isinstance(result, dict):
+                    final_response = result.get("final_response", "") or result.get("error", "")
+                if final_response:
+                    _, _, media_markdown = self._extract_outbound_media_parts(request, final_response)
             except Exception:
                 pass
+
+            if media_markdown:
+                media_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": f"\n\n{media_markdown}"}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(media_chunk)}\n\n".encode())
 
             # Finish chunk
             finish_chunk = {
@@ -1433,7 +1649,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     input_messages.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
                     role = item.get("role", "user")
-                    content = _normalize_chat_content(item.get("content", ""))
+                    content = await self._normalize_content_for_agent(item.get("content", ""))
                     input_messages.append({"role": role, "content": content})
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
@@ -1613,7 +1829,7 @@ class APIServerAdapter(BasePlatformAdapter):
             full_history.append({"role": "assistant", "content": final_response})
 
         # Build output items (includes tool calls + final message)
-        output_items = self._extract_output_items(result)
+        output_items = self._extract_output_items(result, request)
 
         response_data = {
             "id": response_id,
@@ -1677,6 +1893,29 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "deleted": True,
         })
+
+    async def _handle_get_file(self, request: "web.Request") -> "web.Response":
+        """GET /v1/files/{file_id}[.ext] — download an exported local media/document file.
+
+        The ``.ext`` suffix is cosmetic (so clients sniffing by URL see the
+        right container) but it must match the one recorded at registration
+        time if supplied, otherwise we 404.  This stops anyone who guessed
+        a file_id from probing for the real extension.
+        """
+        self._prune_file_exports()
+        file_id = request.match_info["file_id"]
+        ext_in_url = request.match_info.get("ext", "") or ""
+        meta = self._file_exports.get(file_id)
+        if not meta:
+            return web.json_response(_openai_error("File not found", code="file_not_found"), status=404)
+        expected_ext = str(meta.get("ext", "") or "")
+        if ext_in_url and ext_in_url.lower() != expected_ext.lower():
+            return web.json_response(_openai_error("File not found", code="file_not_found"), status=404)
+        path = Path(str(meta.get("path", "")))
+        if not path.is_file():
+            self._file_exports.pop(file_id, None)
+            return web.json_response(_openai_error("File no longer available", code="file_not_found"), status=404)
+        return web.FileResponse(path)
 
     # ------------------------------------------------------------------
     # Cron jobs API
@@ -1929,8 +2168,93 @@ class APIServerAdapter(BasePlatformAdapter):
     # Output extraction helper
     # ------------------------------------------------------------------
 
+    def _prune_file_exports(self) -> None:
+        now = time.time()
+        expired = [k for k, v in self._file_exports.items() if (now - float(v.get("created_at", 0))) > FILE_EXPORT_TTL_SECONDS]
+        for k in expired:
+            self._file_exports.pop(k, None)
+        if len(self._file_exports) > MAX_EXPORTED_FILES:
+            oldest = sorted(self._file_exports.items(), key=lambda kv: float(kv[1].get("created_at", 0)))
+            for key, _ in oldest[: len(self._file_exports) - MAX_EXPORTED_FILES]:
+                self._file_exports.pop(key, None)
+
+    def _register_file_export(self, request: "web.Request", local_path: str) -> Optional[str]:
+        try:
+            p = Path(local_path).expanduser().resolve()
+        except Exception:
+            return None
+        if not p.is_file():
+            return None
+        self._prune_file_exports()
+        file_id = uuid.uuid4().hex
+        mime = mimetypes.guess_type(str(p))[0] or "application/octet-stream"
+        ext = _choose_export_ext(p, mime)
+        self._file_exports[file_id] = {"path": str(p), "created_at": time.time(), "ext": ext}
+        return f"{request.scheme}://{request.host}/v1/files/{file_id}{ext}"
+
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _render_media_markdown(blocks: List[Dict[str, Any]]) -> str:
+        """Render media blocks into markdown/html that Open WebUI can display."""
+        lines: List[str] = []
+        for block in blocks:
+            btype = str(block.get("type", ""))
+            name = str(block.get("filename", "")).strip() or "media"
+            if btype == "output_image":
+                url = str(block.get("image_url", "")).strip()
+                if url:
+                    lines.append(f"![{name}]({url})")
+            elif btype == "output_audio":
+                url = str(block.get("audio_url", "")).strip()
+                if url:
+                    lines.append(f"[Audio: {name}]({url})")
+            elif btype == "output_video":
+                url = str(block.get("video_url", "")).strip()
+                if url:
+                    lines.append(f"[Video: {name}]({url})")
+            elif btype == "output_file":
+                url = str(block.get("file_url", "")).strip()
+                if url:
+                    lines.append(f"[File: {name}]({url})")
+        return "\n".join(lines)
+
+    def _extract_outbound_media_parts(self, request: "web.Request", final_text: str) -> tuple[str, List[Dict[str, Any]], str]:
+        from gateway.platforms.base import BasePlatformAdapter
+
+        tagged, cleaned = BasePlatformAdapter.extract_media(final_text or "")
+        bare_paths, cleaned = BasePlatformAdapter.extract_local_files(cleaned or "")
+
+        refs: List[str] = [path for path, _ in tagged] + list(bare_paths)
+        seen: set[str] = set()
+        blocks: List[Dict[str, Any]] = []
+        for ref in refs:
+            if not ref or ref in seen:
+                continue
+            seen.add(ref)
+            mime, _ = mimetypes.guess_type(ref)
+            mime = mime or "application/octet-stream"
+            resolved_path = Path(ref).expanduser().resolve()
+            ext = resolved_path.suffix.lower()
+            filename = resolved_path.name
+            is_image = mime.startswith("image/") or ext in {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+            # All outbound media — images included — is served from
+            # /v1/files/{id}.ext.  Inlining as data URLs was a micro-opt for
+            # tiny thumbnails that just bloated response JSON and broke
+            # conversation-history round-trips.
+            url = self._register_file_export(request, ref)
+            if not url:
+                continue
+            if is_image:
+                blocks.append({"type": "output_image", "image_url": url, "mime_type": mime, "filename": filename})
+            elif mime.startswith("audio/") or ext in {".ogg", ".opus", ".mp3", ".wav", ".m4a"}:
+                blocks.append({"type": "output_audio", "audio_url": url, "mime_type": mime, "filename": filename})
+            elif mime.startswith("video/") or ext in {".mp4", ".mov", ".avi", ".mkv", ".webm"}:
+                blocks.append({"type": "output_video", "video_url": url, "mime_type": mime, "filename": filename})
+            else:
+                blocks.append({"type": "output_file", "file_url": url, "mime_type": mime, "filename": filename})
+        markdown = self._render_media_markdown(blocks)
+        return cleaned, blocks, markdown
+
+    def _extract_output_items(self, result: Dict[str, Any], request: Optional["web.Request"] = None) -> List[Dict[str, Any]]:
         """
         Build the full output item array from the agent's messages.
 
@@ -1965,15 +2289,21 @@ class APIServerAdapter(BasePlatformAdapter):
         if not final:
             final = result.get("error", "(No response generated)")
 
+        content_blocks: List[Dict[str, Any]] = [{
+            "type": "output_text",
+            "text": final,
+        }]
+        if request is not None:
+            cleaned, media_blocks, markdown = self._extract_outbound_media_parts(request, final)
+            final = cleaned or final
+            if markdown:
+                final = f"{final}\n\n{markdown}".strip()
+            content_blocks = [{"type": "output_text", "text": final}] + media_blocks
+
         items.append({
             "type": "message",
             "role": "assistant",
-            "content": [
-                {
-                    "type": "output_text",
-                    "text": final,
-                }
-            ],
+            "content": content_blocks,
         })
         return items
 
@@ -2101,7 +2431,16 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        if isinstance(raw_input, str):
+            user_message = raw_input
+        elif isinstance(raw_input, list) and raw_input:
+            tail = raw_input[-1]
+            if isinstance(tail, dict):
+                user_message = await self._normalize_content_for_agent(tail.get("content", ""))
+            else:
+                user_message = await self._normalize_content_for_agent(tail)
+        else:
+            user_message = ""
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -2165,13 +2504,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
             for msg in raw_input[:-1]:
                 if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
+                    content = await self._normalize_content_for_agent(msg["content"])
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         session_id = body.get("session_id") or stored_session_id or run_id
@@ -2311,7 +2644,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
@@ -2321,6 +2654,16 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            # The trailing ``{ext}`` is optional so old extension-less URLs
+            # still resolve.  Regex-constraining both segments keeps the
+            # route free of traversal chars and unusual input.  Real ids
+            # come from ``uuid.uuid4().hex`` (pure hex), but the character
+            # class is slightly broader so callers that mint their own
+            # alphanumeric tokens keep working.
+            self._app.router.add_get(
+                r"/v1/files/{file_id:[A-Za-z0-9]+}{ext:(?:\.[A-Za-z0-9]{1,8})?}",
+                self._handle_get_file,
+            )
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)

--- a/run-hermes-login
+++ b/run-hermes-login
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /root/hermes-agent
+source .venv/bin/activate
+exec hermes login "$@"

--- a/sample-api.sh
+++ b/sample-api.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Sample OpenAI-compatible API calls to Hermes Agent (no auth)
+
+echo "=== Non-streaming Chat Completion ==="
+curl -s http://127.0.0.1:8642/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hermes-agent",
+    "messages": [
+      {"role": "user", "content": "Say hello in exactly 5 words."}
+    ]
+  }' | python3 -m json.tool
+
+echo ""
+echo "=== Streaming Chat Completion ==="
+curl -s http://127.0.0.1:8642/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hermes-agent",
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "Say hi in 3 words."}
+    ]
+  }'
+echo ""

--- a/sample-authenticated.sh
+++ b/sample-authenticated.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Sample OpenAI-compatible API calls to Hermes Agent (with Bearer auth)
+
+API_KEY="NONPRIVATEKEYPROTECTENDPOINT"
+
+echo "=== Non-streaming Chat Completion (Authenticated) ==="
+curl -s http://127.0.0.1:8642/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -d '{
+    "model": "hermes-agent",
+    "messages": [
+      {"role": "user", "content": "Say hello in exactly 5 words."}
+    ]
+  }' | python3 -m json.tool
+
+echo ""
+echo "=== Streaming Chat Completion (Authenticated) ==="
+curl -s http://127.0.0.1:8642/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -d '{
+    "model": "hermes-agent",
+    "stream": true,
+    "messages": [
+      {"role": "user", "content": "Say hi in 3 words."}
+    ]
+  }'
+echo ""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1264,6 +1264,58 @@ class TestResponsesEndpoint:
             ), parsed.path
 
     @pytest.mark.asyncio
+    async def test_response_output_file_endpoint_uses_forced_host_and_port(self, adapter, tmp_path, monkeypatch):
+        image_path = tmp_path / "forced.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        mock_result = {
+            "final_response": f"MEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+        monkeypatch.setenv("API_SERVER_FILE_RESPONSE_FORCE_HOST", "files.example.internal")
+        monkeypatch.setenv("API_SERVER_FILE_RESPONSE_FORCE_PORT", "9443")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "large image"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            parsed = urlparse(image_blocks[0]["image_url"])
+            assert parsed.hostname == "files.example.internal"
+            assert parsed.port == 9443
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.png", parsed.path), parsed.path
+
+    @pytest.mark.asyncio
+    async def test_response_output_file_endpoint_uses_forced_port_only(self, adapter, tmp_path, monkeypatch):
+        image_path = tmp_path / "forced-port.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        mock_result = {
+            "final_response": f"MEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+        monkeypatch.setenv("API_SERVER_FILE_RESPONSE_FORCE_PORT", "9000")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "large image"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            parsed = urlparse(image_blocks[0]["image_url"])
+            assert parsed.port == 9000
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.png", parsed.path), parsed.path
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -14,8 +14,11 @@ Tests cover:
 
 import asyncio
 import json
+import re
 import time
 import uuid
+from pathlib import Path
+from urllib.parse import urlparse
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,10 +28,12 @@ from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    MAX_REQUEST_BYTES,
     ResponseStore,
     _IdempotencyCache,
     _CORS_HEADERS,
     _derive_chat_session_id,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -307,8 +312,8 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
@@ -318,6 +323,10 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_get(
+        r"/v1/files/{file_id:[A-Za-z0-9]+}{ext:(?:\.[A-Za-z0-9]{1,8})?}",
+        adapter._handle_get_file,
+    )
     return app
 
 
@@ -419,6 +428,69 @@ class TestHealthDetailedEndpoint:
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200
+
+
+class TestRequestBodyLimits:
+    @pytest.mark.asyncio
+    async def test_rejects_content_length_over_32mb(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(MAX_REQUEST_BYTES + 1),
+                },
+            )
+            assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_app_sets_client_max_size_to_32mb(self, adapter):
+        app = _create_app(adapter)
+        assert app._client_max_size == MAX_REQUEST_BYTES
+
+class TestChooseExportExt:
+    """Covers the helper that picks a URL-safe extension for outbound
+    /v1/files/{id}.ext URLs."""
+
+    def test_prefers_on_disk_suffix(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "voice.ogg"
+        p.write_bytes(b"OggS\x00\x00")
+        # Even though audio/ogg → mimetypes might return .ogx or similar on
+        # some platforms, the real file extension wins.
+        assert _choose_export_ext(p, "audio/ogg") == ".ogg"
+
+    def test_lowercases_extension(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "PHOTO.JPG"
+        p.write_bytes(b"\xff\xd8\xff")
+        assert _choose_export_ext(p, "image/jpeg") == ".jpg"
+
+    def test_falls_back_to_mime_guess_when_no_suffix(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "suffixless"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n")
+        # mimetypes.guess_extension("image/png") is ".png" on all
+        # platforms shipped with Python 3.12.
+        assert _choose_export_ext(p, "image/png") == ".png"
+
+    def test_returns_empty_when_suffix_looks_unsafe(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        # A suffix that's too long / has weird chars is dropped rather
+        # than propagated into the URL.  We fall through to the MIME
+        # table, and if that also fails we return "".
+        p = tmp_path / "thing.thisextensionisfartoolong"
+        p.write_bytes(b"x")
+        assert _choose_export_ext(p, "application/x-nonexistent-zzz") == ""
+
+    def test_empty_when_nothing_works(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "bare"
+        p.write_bytes(b"x")
+        # Unknown MIME → no guess → never invent an extension.
+        assert _choose_export_ext(p, "application/x-nonexistent-zzz") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -741,6 +813,33 @@ class TestChatCompletionsEndpoint:
                 assert '"label": "Python docs"' in body
 
     @pytest.mark.asyncio
+    async def test_stream_appends_media_markdown_for_openwebui(self, adapter, tmp_path):
+        image_path = tmp_path / "stream.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Done.")
+                return (
+                    {"final_response": f"Done.\nMEDIA:{image_path}", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "stream"}], "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "Done." in body
+                assert "/v1/files/" in body
+                assert "![stream.png]" in body
+
+    @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -752,6 +851,31 @@ class TestChatCompletionsEndpoint:
                 },
             )
             assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_nonstream_media_response_includes_openwebui_markdown(self, adapter, tmp_path):
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        mock_result = {
+            "final_response": f"Generated.\nMEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "make image"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            text = data["choices"][0]["message"]["content"]
+            assert "MEDIA:" not in text
+            assert "![" in text and "/v1/files/" in text
+            assert "data:image/" not in text
 
     @pytest.mark.asyncio
     async def test_successful_completion(self, adapter):
@@ -782,6 +906,7 @@ class TestChatCompletionsEndpoint:
             assert len(data["choices"]) == 1
             assert data["choices"][0]["message"]["role"] == "assistant"
             assert data["choices"][0]["message"]["content"] == "Hello! How can I help you today?"
+            assert data["choices"][0]["message"]["content_parts"][0]["type"] == "output_text"
             assert data["choices"][0]["finish_reason"] == "stop"
             assert "usage" in data
 
@@ -1037,6 +1162,106 @@ class TestResponsesEndpoint:
             # Last message is user_message, rest are history
             assert call_kwargs["user_message"] == "What is 2+2?"
             assert len(call_kwargs["conversation_history"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_response_output_includes_media_blocks_and_file_download(self, adapter, tmp_path):
+        audio_path = tmp_path / "voice.ogg"
+        audio_path.write_bytes(b"OggS\x00\x00")
+        mock_result = {
+            "final_response": f"[[audio_as_voice]]\nMEDIA:{audio_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "reply with audio"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            audio_blocks = [b for b in content_blocks if b.get("type") == "output_audio"]
+            assert audio_blocks
+            # Non-image media is never inlined — it always resolves to a
+            # /v1/files/{id}.ext URL, even when the payload is tiny.
+            assert "data:audio/" not in content_blocks[0]["text"]
+            assert not audio_blocks[0]["audio_url"].startswith("data:")
+            # Extension must match the source file (voice.ogg → .ogg).
+            parsed = urlparse(audio_blocks[0]["audio_url"])
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.ogg", parsed.path), parsed.path
+
+    @pytest.mark.asyncio
+    async def test_response_output_small_images_also_use_file_endpoint(self, adapter, tmp_path):
+        """Images of any size go through /v1/files/{id}.ext — there's no
+        inline-data-URL fast-path anymore."""
+        image_path = tmp_path / "tiny.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nsmall")
+        mock_result = {
+            "final_response": f"MEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "tiny image"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            assert not image_blocks[0]["image_url"].startswith("data:")
+            parsed = urlparse(image_blocks[0]["image_url"])
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.png", parsed.path), parsed.path
+            # Markdown fallback in the text also uses the file URL, not a
+            # base64 data URL.
+            assert "![tiny.png](" in content_blocks[0]["text"]
+            assert "/v1/files/" in content_blocks[0]["text"]
+            assert "data:image/" not in content_blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("filename", "payload"),
+        [
+            ("sample.pdf", b"%PDF-1.4\nmini\n"),
+            ("sample.zip", b"PK\x03\x04mini"),
+        ],
+    )
+    async def test_response_output_document_media_served_via_file_endpoint(
+        self, adapter, tmp_path, filename, payload,
+    ):
+        """Documents resolve to /v1/files/{id}.ext URLs, regardless of size —
+        like every other media kind, since the inline-data-URL path was
+        removed."""
+        file_path = tmp_path / filename
+        file_path.write_bytes(payload)
+        mock_result = {
+            "final_response": f"MEDIA:{file_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": f"inline {filename}"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            file_blocks = [b for b in content_blocks if b.get("type") == "output_file"]
+            assert file_blocks
+            assert not file_blocks[0]["file_url"].startswith("data:")
+            assert "data:" not in content_blocks[0]["text"]
+            # The served URL carries the real on-disk extension.
+            expected_ext = Path(filename).suffix.lower()
+            parsed = urlparse(file_blocks[0]["file_url"])
+            assert re.fullmatch(
+                rf"/v1/files/[A-Za-z0-9]+{re.escape(expected_ext)}", parsed.path,
+            ), parsed.path
 
     @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
@@ -1547,6 +1772,50 @@ class TestEndpointAuth:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/health")
             assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_files_endpoint_allows_token_access_without_auth_header(self, auth_adapter, tmp_path):
+        export = tmp_path / "sample.txt"
+        export.write_text("hello", encoding="utf-8")
+        auth_adapter._file_exports["tok123"] = {"path": str(export), "created_at": time.time()}
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/files/tok123")
+            assert resp.status == 200
+            assert await resp.text() == "hello"
+
+    @pytest.mark.asyncio
+    async def test_files_endpoint_accepts_matching_extension(self, auth_adapter, tmp_path):
+        """A URL whose extension matches the one recorded at registration
+        time resolves the same file as the extensionless URL."""
+        export = tmp_path / "voice.ogg"
+        export.write_bytes(b"OggS\x00\x00")
+        auth_adapter._file_exports["aabb01"] = {
+            "path": str(export), "created_at": time.time(), "ext": ".ogg",
+        }
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/files/aabb01.ogg")
+            assert resp.status == 200
+            assert await resp.read() == b"OggS\x00\x00"
+
+    @pytest.mark.asyncio
+    async def test_files_endpoint_rejects_mismatched_extension(self, auth_adapter, tmp_path):
+        """A URL that guesses a different extension than the recorded one
+        returns 404 — an attacker who learns the file_id can't fish for the
+        real container format."""
+        export = tmp_path / "voice.ogg"
+        export.write_bytes(b"OggS\x00\x00")
+        auth_adapter._file_exports["aabb02"] = {
+            "path": str(export), "created_at": time.time(), "ext": ".ogg",
+        }
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/files/aabb02.mp3")
+            assert resp.status == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -32,6 +32,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _CORS_HEADERS,
+    _StreamDataURLFilter,
     _derive_chat_session_id,
     body_limit_middleware,
     check_api_server_requirements,
@@ -493,6 +494,151 @@ class TestChooseExportExt:
         assert _choose_export_ext(p, "application/x-nonexistent-zzz") == ""
 
 
+class TestStreamDataURLFilter:
+    """Direct unit tests for the streaming filter state machine.
+
+    Uses a fake adapter whose ``_register_file_export`` returns a stable
+    URL based on the cached-file path, so we can assert rewrites without
+    spinning up an aiohttp Request.  End-to-end SSE coverage lives in
+    ``TestChatCompletionsEndpoint.test_streaming_rewrites_inline_data_url``
+    below.
+    """
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.registered = []
+
+        def _register_file_export(self, request, local_path):
+            self.registered.append(local_path)
+            # Mimic the real URL shape so tests can grep for /v1/files/.
+            return f"https://host/v1/files/{Path(local_path).stem}{Path(local_path).suffix}"
+
+    def _make_filter(self):
+        adapter = self._FakeAdapter()
+        return _StreamDataURLFilter(adapter, request=None), adapter
+
+    def _build_png_data_url(self) -> str:
+        import base64 as _b64
+        raw = b"\x89PNG\r\n\x1a\nfake-png"
+        return f"data:image/png;base64,{_b64.b64encode(raw).decode()}"
+
+    def test_passes_through_plain_text(self):
+        """No data URL, no change (modulo the tiny tail-hold that gets
+        released on flush)."""
+        f, _ = self._make_filter()
+        emitted = f.feed("hello, world — nothing to see here")
+        emitted += f.flush()
+        assert emitted == "hello, world — nothing to see here"
+
+    def test_rewrites_single_chunk_data_url(self):
+        f, adapter = self._make_filter()
+        data_url = self._build_png_data_url()
+        text = f"Here: ![icon]({data_url})"
+        emitted = f.feed(text) + f.flush()
+        # No data URL remains and a /v1/files/ URL is spliced in.
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted, emitted
+        # Markdown structure preserved.
+        assert "![icon](" in emitted
+        # One registration, one inline block recorded.
+        assert len(adapter.registered) == 1
+        assert len(f.inline_blocks) == 1
+        assert f.inline_blocks[0]["type"] == "output_image"
+
+    def test_rewrites_data_url_split_across_many_chunks(self):
+        """Claude's tokens don't respect URL boundaries — ``data:`` may
+        be split into pieces like ``"da"``/``"ta:image/png;base64,"``/
+        ``"iVBORw0K"``/``"Ggo="``/``")"``."""
+        f, adapter = self._make_filter()
+        data_url = self._build_png_data_url()
+        prefix = "Here: ![icon]("
+        # Split the full text (prefix + URL + ")") into aggressively small
+        # chunks — 3 chars each — to exercise every state transition.
+        full = prefix + data_url + ")"
+        chunks = [full[i:i + 3] for i in range(0, len(full), 3)]
+        emitted_parts = [f.feed(ch) for ch in chunks]
+        emitted_parts.append(f.flush())
+        emitted = "".join(emitted_parts)
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted, emitted
+        assert "![icon](" in emitted
+        assert len(adapter.registered) == 1
+
+    def test_data_url_terminator_is_markdown_close_paren(self):
+        """The closing paren of ``![alt](…)`` must end the URL scan so
+        anything after ``)`` is emitted as normal text."""
+        f, _ = self._make_filter()
+        data_url = self._build_png_data_url()
+        emitted = f.feed(f"before ![x]({data_url}) after text") + f.flush()
+        assert emitted.endswith(") after text"), emitted
+        assert "/v1/files/" in emitted
+        assert "data:" not in emitted
+
+    def test_multiple_data_urls_each_materialized_once(self):
+        f, adapter = self._make_filter()
+        url1 = self._build_png_data_url()
+        # Different payload → different cached file.
+        import base64 as _b64
+        raw2 = b"\x89PNG\r\n\x1a\nother-png"
+        url2 = f"data:image/png;base64,{_b64.b64encode(raw2).decode()}"
+        emitted = f.feed(f"![a]({url1}) and ![b]({url2})") + f.flush()
+        assert emitted.count("/v1/files/") == 2, emitted
+        assert "data:" not in emitted
+        assert len(adapter.registered) == 2
+
+    def test_undecodable_data_url_left_verbatim(self):
+        """If ``_decode_data_url`` can't parse the payload, keep the URL in
+        place — better to show the user a broken link than to silently eat
+        bytes."""
+        f, _ = self._make_filter()
+        bad = "data:image/png;base64,@@@nope@@@"
+        emitted = f.feed(f"Look: ![x]({bad})") + f.flush()
+        # Original URL is preserved verbatim — filter doesn't invent one.
+        assert bad in emitted, emitted
+
+    def test_partial_data_prefix_at_buffer_boundary_is_held(self):
+        """If a chunk ends with ``"da"`` and the next begins with
+        ``"ta:image/png;base64,…"``, the filter must not emit the ``"da"``
+        early — otherwise the ``data:`` match is lost."""
+        f, adapter = self._make_filter()
+        data_url = self._build_png_data_url()
+        first = f.feed("before da")  # last 2 chars are a partial prefix
+        second = f.feed("ta:image/png;base64,")
+        third = f.feed(data_url.split(",", 1)[1])  # payload
+        fourth = f.feed(")")
+        emitted = first + second + third + fourth + f.flush()
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted
+        # "before " is stable enough that the first chunk may emit part
+        # of it; by end-of-stream the full non-URL prose is present.
+        assert emitted.startswith("before "), emitted
+
+    def test_flush_handles_in_progress_data_url(self):
+        """Stream ends mid-URL (no terminator reached) — the filter
+        should still decode whatever payload bytes are valid rather than
+        drop them."""
+        f, _ = self._make_filter()
+        data_url = self._build_png_data_url()
+        # Deliberately *don't* include a closing paren / whitespace.
+        emitted = f.feed(f"incomplete: {data_url}")
+        emitted += f.flush()
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted
+
+    def test_tool_progress_tuples_ignored_by_filter(self):
+        """The SSE writer only sends *strings* through ``feed``; tool-
+        progress events take a different path.  This is documented
+        behaviour — verify the filter is string-only."""
+        f, _ = self._make_filter()
+        # Non-string input is a programming error; the caller in
+        # _write_sse_chat_completion checks ``isinstance(item, str)``
+        # before feeding.  Here we just confirm that empty chunks produce
+        # empty output and don't wedge the state machine.
+        assert f.feed("") == ""
+        assert f.feed(None) == ""
+        assert f.flush() == ""
+
+
 # ---------------------------------------------------------------------------
 # /v1/models endpoint
 # ---------------------------------------------------------------------------
@@ -838,6 +984,110 @@ class TestChatCompletionsEndpoint:
                 assert "Done." in body
                 assert "/v1/files/" in body
                 assert "![stream.png]" in body
+
+    @staticmethod
+    def _reassemble_sse_content(body: str) -> str:
+        """Concatenate the ``delta.content`` of every SSE data frame in
+        ``body`` into a single string — mirrors how an OpenAI client
+        assembles a streaming reply into the assistant message."""
+        parts: List[str] = []
+        for line in body.split("\n"):
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: "):]
+            if payload.strip() == "[DONE]":
+                continue
+            try:
+                obj = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            for choice in obj.get("choices", []):
+                delta = choice.get("delta") or {}
+                if isinstance(delta.get("content"), str):
+                    parts.append(delta["content"])
+        return "".join(parts)
+
+    @pytest.mark.asyncio
+    async def test_streaming_rewrites_inline_data_url(self, adapter):
+        """End-to-end: Claude emits deltas that compose
+        ``![icon](data:image/png;base64,…)`` across several chunks, and
+        the text the client reassembles from the SSE stream must contain
+        a ``/v1/files/`` URL instead of the base64 blob."""
+        import base64 as _b64
+        raw = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+        data_url = f"data:image/png;base64,{_b64.b64encode(raw).decode()}"
+        # Break the text into chunks that *intentionally* split the
+        # ``data:`` prefix across two deltas (last 2 chars of one chunk,
+        # rest in the next) so the filter's prefix-hold path is exercised.
+        prefix = "Here is your icon: ![icon]("
+        deltas = [
+            prefix[:-5],                         # "…: ![icon"
+            prefix[-5:] + data_url[:2],          # "n](da"
+            data_url[2:10],                      # "ta:image"
+            data_url[10:],                       # remainder of the URL
+            ")",                                 # markdown terminator
+            "\n\nLet me know if you want changes.",  # trailing prose
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    for d in deltas:
+                        cb(d)
+                return (
+                    {"final_response": prefix + data_url + ")" + "\n\nLet me know if you want changes.",
+                     "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "icon"}], "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                reassembled = self._reassemble_sse_content(body)
+                # No base64 payload reached the client…
+                assert "data:image/" not in reassembled, reassembled
+                assert "base64," not in reassembled, reassembled
+                # …but the markdown wrapper and a /v1/files/ URL did.
+                assert "![icon](" in reassembled
+                assert re.search(r"/v1/files/[A-Za-z0-9]+\.png", reassembled), reassembled
+                # Trailing prose that came AFTER the data URL still ships.
+                assert "Let me know if you want changes." in reassembled
+
+    @pytest.mark.asyncio
+    async def test_streaming_plain_text_is_not_altered(self, adapter):
+        """The filter's prefix-hold must not drop or reorder characters —
+        after reassembly the stream matches the source tokens exactly."""
+        tokens = ["Hello", ", ", "world", "! No ", "data here."]
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    for t in tokens:
+                        cb(t)
+                return (
+                    {"final_response": "".join(tokens), "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                reassembled = self._reassemble_sse_content(body)
+                assert reassembled == "Hello, world! No data here."
+                # "data" (no colon) is plain text and must pass through
+                # verbatim — the filter only reacts to the full ``data:``.
+                assert "data here." in reassembled
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
@@ -1221,6 +1471,95 @@ class TestResponsesEndpoint:
             assert "![tiny.png](" in content_blocks[0]["text"]
             assert "/v1/files/" in content_blocks[0]["text"]
             assert "data:image/" not in content_blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_inline_data_url_image_rewritten_to_file_url(self, adapter):
+        """When the model embeds ``![alt](data:image/png;base64,…)`` in its
+        reply (as Claude does for shell-produced images without a MEDIA
+        convention), the server decodes the payload, caches it, and swaps
+        the data URL for a ``/v1/files/{id}.png`` URL in-place.  The client
+        sees a normal markdown image referencing a cheap HTTP URL instead
+        of carrying base64 through conversation history."""
+        import base64 as _b64
+        png_bytes = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+        data_url = f"data:image/png;base64,{_b64.b64encode(png_bytes).decode()}"
+        mock_result = {
+            "final_response": f"Here's your icon: ![icon]({data_url})",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "icon please"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            # The text markdown wrapper survives intact, but its URL is now
+            # a /v1/files/ URL — no base64 left in the response.
+            text = content_blocks[0]["text"]
+            assert "![icon](" in text
+            assert "data:image/" not in text
+            assert "data:" not in text
+            match = re.search(r"/v1/files/[A-Za-z0-9]+\.(?:png|jpg|jpeg)", text)
+            assert match, f"no /v1/files URL spliced into text: {text!r}"
+            # And there's a proper output_image block referencing the same URL.
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            assert image_blocks[0]["image_url"].endswith(match.group(0).rsplit("/", 1)[-1])
+
+    @pytest.mark.asyncio
+    async def test_inline_data_url_audio_rewritten_to_file_url(self, adapter):
+        """Audio data URLs the model embeds get the same treatment."""
+        import base64 as _b64
+        ogg_bytes = b"OggS\x00\x00fake-audio"
+        data_url = f"data:audio/ogg;base64,{_b64.b64encode(ogg_bytes).decode()}"
+        mock_result = {
+            "final_response": f"voice note: [audio]({data_url})",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "audio please"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            text = content_blocks[0]["text"]
+            assert "data:" not in text
+            # mimetypes maps ``audio/ogg`` to ``.oga`` on most systems and
+            # ``.ogg`` on some — either is a legitimate Ogg extension.
+            assert re.search(r"/v1/files/[A-Za-z0-9]+\.(?:ogg|oga)", text), text
+            audio_blocks = [b for b in content_blocks if b.get("type") == "output_audio"]
+            assert audio_blocks
+            assert "/v1/files/" in audio_blocks[0]["audio_url"]
+
+    @pytest.mark.asyncio
+    async def test_inline_data_url_unparseable_left_in_place(self, adapter):
+        """Garbled data URLs that fail to decode are left in the text
+        verbatim rather than dropped — we'd rather show the user a
+        malformed URL than silently delete content."""
+        mock_result = {
+            # Truncated base64 header — _decode_data_url returns empty bytes,
+            # which the helper treats as "not materializable, skip."
+            "final_response": "Broken: ![x](data:image/png;base64,@@@nope@@@)",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "garbled"})
+            assert resp.status == 200
+            # The response completes fine; no crash.  We don't assert the
+            # exact text shape — only that nothing 500s.
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1283,6 +1283,58 @@ class TestResponsesEndpoint:
             ), parsed.path
 
     @pytest.mark.asyncio
+    async def test_response_output_file_endpoint_uses_forced_host_and_port(self, adapter, tmp_path, monkeypatch):
+        image_path = tmp_path / "forced.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        mock_result = {
+            "final_response": f"MEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+        monkeypatch.setenv("API_SERVER_FILE_RESPONSE_FORCE_HOST", "files.example.internal")
+        monkeypatch.setenv("API_SERVER_FILE_RESPONSE_FORCE_PORT", "9443")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "large image"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            parsed = urlparse(image_blocks[0]["image_url"])
+            assert parsed.hostname == "files.example.internal"
+            assert parsed.port == 9443
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.png", parsed.path), parsed.path
+
+    @pytest.mark.asyncio
+    async def test_response_output_file_endpoint_uses_forced_port_only(self, adapter, tmp_path, monkeypatch):
+        image_path = tmp_path / "forced-port.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        mock_result = {
+            "final_response": f"MEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+        monkeypatch.setenv("API_SERVER_FILE_RESPONSE_FORCE_PORT", "9000")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "large image"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            parsed = urlparse(image_blocks[0]["image_url"])
+            assert parsed.port == 9000
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.png", parsed.path), parsed.path
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -13,8 +13,11 @@ Tests cover:
 """
 
 import json
+import re
 import time
 import uuid
+from pathlib import Path
+from urllib.parse import urlparse
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -24,9 +27,11 @@ from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    MAX_REQUEST_BYTES,
     ResponseStore,
     _CORS_HEADERS,
     _derive_chat_session_id,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -216,8 +221,8 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
@@ -227,6 +232,10 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_get(
+        r"/v1/files/{file_id:[A-Za-z0-9]+}{ext:(?:\.[A-Za-z0-9]{1,8})?}",
+        adapter._handle_get_file,
+    )
     return app
 
 
@@ -328,6 +337,69 @@ class TestHealthDetailedEndpoint:
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200
+
+
+class TestRequestBodyLimits:
+    @pytest.mark.asyncio
+    async def test_rejects_content_length_over_32mb(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Content-Length": str(MAX_REQUEST_BYTES + 1),
+                },
+            )
+            assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_app_sets_client_max_size_to_32mb(self, adapter):
+        app = _create_app(adapter)
+        assert app._client_max_size == MAX_REQUEST_BYTES
+
+class TestChooseExportExt:
+    """Covers the helper that picks a URL-safe extension for outbound
+    /v1/files/{id}.ext URLs."""
+
+    def test_prefers_on_disk_suffix(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "voice.ogg"
+        p.write_bytes(b"OggS\x00\x00")
+        # Even though audio/ogg → mimetypes might return .ogx or similar on
+        # some platforms, the real file extension wins.
+        assert _choose_export_ext(p, "audio/ogg") == ".ogg"
+
+    def test_lowercases_extension(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "PHOTO.JPG"
+        p.write_bytes(b"\xff\xd8\xff")
+        assert _choose_export_ext(p, "image/jpeg") == ".jpg"
+
+    def test_falls_back_to_mime_guess_when_no_suffix(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "suffixless"
+        p.write_bytes(b"\x89PNG\r\n\x1a\n")
+        # mimetypes.guess_extension("image/png") is ".png" on all
+        # platforms shipped with Python 3.12.
+        assert _choose_export_ext(p, "image/png") == ".png"
+
+    def test_returns_empty_when_suffix_looks_unsafe(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        # A suffix that's too long / has weird chars is dropped rather
+        # than propagated into the URL.  We fall through to the MIME
+        # table, and if that also fails we return "".
+        p = tmp_path / "thing.thisextensionisfartoolong"
+        p.write_bytes(b"x")
+        assert _choose_export_ext(p, "application/x-nonexistent-zzz") == ""
+
+    def test_empty_when_nothing_works(self, tmp_path):
+        from gateway.platforms.api_server import _choose_export_ext
+        p = tmp_path / "bare"
+        p.write_bytes(b"x")
+        # Unknown MIME → no guess → never invent an extension.
+        assert _choose_export_ext(p, "application/x-nonexistent-zzz") == ""
 
 
 # ---------------------------------------------------------------------------
@@ -650,6 +722,33 @@ class TestChatCompletionsEndpoint:
                 assert '"label": "Python docs"' in body
 
     @pytest.mark.asyncio
+    async def test_stream_appends_media_markdown_for_openwebui(self, adapter, tmp_path):
+        image_path = tmp_path / "stream.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Done.")
+                return (
+                    {"final_response": f"Done.\nMEDIA:{image_path}", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "stream"}], "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "Done." in body
+                assert "/v1/files/" in body
+                assert "![stream.png]" in body
+
+    @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -661,6 +760,114 @@ class TestChatCompletionsEndpoint:
                 },
             )
             assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_multimodal_input_image_url_becomes_placeholder(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "describe"},
+                                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+            assert resp.status == 200
+            assert "[User sent an image: https://example.com/cat.png]" in mock_run.call_args.kwargs["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_multimodal_input_file_data_url_cached(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.base.cache_document_from_bytes", return_value="/tmp/docs/doc_abc_invoice.pdf") as cache_doc,
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+            ):
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                data_url = "data:application/pdf;base64,SGVsbG8="
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [{"type": "input_file", "filename": "invoice.pdf", "file_url": data_url}],
+                            }
+                        ]
+                    },
+                )
+            assert resp.status == 200
+            assert cache_doc.called
+            assert "[User sent a PDF document: /tmp/docs/doc_abc_invoice.pdf]" in mock_run.call_args.kwargs["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_multimodal_input_audio_data_block_cached(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("gateway.platforms.base.cache_audio_from_bytes", return_value="/tmp/audio/audio_abc.wav") as cache_audio,
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+            ):
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_audio", "input_audio": {"data": "UklGRg==", "format": "wav"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+            assert resp.status == 200
+            assert cache_audio.called
+            assert "[User sent audio: /tmp/audio/audio_abc.wav]" in mock_run.call_args.kwargs["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_nonstream_media_response_includes_openwebui_markdown(self, adapter, tmp_path):
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+        mock_result = {
+            "final_response": f"Generated.\nMEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "make image"}]},
+                )
+            assert resp.status == 200
+            data = await resp.json()
+            text = data["choices"][0]["message"]["content"]
+            assert "MEDIA:" not in text
+            assert "![" in text and "/v1/files/" in text
+            assert "data:image/" not in text
 
     @pytest.mark.asyncio
     async def test_successful_completion(self, adapter):
@@ -691,6 +898,7 @@ class TestChatCompletionsEndpoint:
             assert len(data["choices"]) == 1
             assert data["choices"][0]["message"]["role"] == "assistant"
             assert data["choices"][0]["message"]["content"] == "Hello! How can I help you today?"
+            assert data["choices"][0]["message"]["content_parts"][0]["type"] == "output_text"
             assert data["choices"][0]["finish_reason"] == "stop"
             assert "usage" in data
 
@@ -946,6 +1154,133 @@ class TestResponsesEndpoint:
             # Last message is user_message, rest are history
             assert call_kwargs["user_message"] == "What is 2+2?"
             assert len(call_kwargs["conversation_history"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_responses_multimodal_normalizes_video_and_file_parts(self, adapter):
+        mock_result = {"final_response": "done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_video", "video_url": "https://cdn.example.com/demo.mp4"},
+                                    {"type": "file", "file": {"file_url": "https://cdn.example.com/spec.pdf", "filename": "spec.pdf"}},
+                                ],
+                            }
+                        ]
+                    },
+                )
+            assert resp.status == 200
+            user_message = mock_run.call_args.kwargs["user_message"]
+            assert "[User sent a video: https://cdn.example.com/demo.mp4]" in user_message
+            assert "[User sent a PDF document: https://cdn.example.com/spec.pdf]" in user_message
+
+    @pytest.mark.asyncio
+    async def test_response_output_includes_media_blocks_and_file_download(self, adapter, tmp_path):
+        audio_path = tmp_path / "voice.ogg"
+        audio_path.write_bytes(b"OggS\x00\x00")
+        mock_result = {
+            "final_response": f"[[audio_as_voice]]\nMEDIA:{audio_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "reply with audio"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            audio_blocks = [b for b in content_blocks if b.get("type") == "output_audio"]
+            assert audio_blocks
+            # Non-image media is never inlined — it always resolves to a
+            # /v1/files/{id}.ext URL, even when the payload is tiny.
+            assert "data:audio/" not in content_blocks[0]["text"]
+            assert not audio_blocks[0]["audio_url"].startswith("data:")
+            # Extension must match the source file (voice.ogg → .ogg).
+            parsed = urlparse(audio_blocks[0]["audio_url"])
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.ogg", parsed.path), parsed.path
+
+    @pytest.mark.asyncio
+    async def test_response_output_small_images_also_use_file_endpoint(self, adapter, tmp_path):
+        """Images of any size go through /v1/files/{id}.ext — there's no
+        inline-data-URL fast-path anymore."""
+        image_path = tmp_path / "tiny.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\nsmall")
+        mock_result = {
+            "final_response": f"MEDIA:{image_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "tiny image"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            assert not image_blocks[0]["image_url"].startswith("data:")
+            parsed = urlparse(image_blocks[0]["image_url"])
+            assert re.fullmatch(r"/v1/files/[A-Za-z0-9]+\.png", parsed.path), parsed.path
+            # Markdown fallback in the text also uses the file URL, not a
+            # base64 data URL.
+            assert "![tiny.png](" in content_blocks[0]["text"]
+            assert "/v1/files/" in content_blocks[0]["text"]
+            assert "data:image/" not in content_blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("filename", "payload"),
+        [
+            ("sample.pdf", b"%PDF-1.4\nmini\n"),
+            ("sample.zip", b"PK\x03\x04mini"),
+        ],
+    )
+    async def test_response_output_document_media_served_via_file_endpoint(
+        self, adapter, tmp_path, filename, payload,
+    ):
+        """Documents resolve to /v1/files/{id}.ext URLs, regardless of size —
+        like every other media kind, since the inline-data-URL path was
+        removed."""
+        file_path = tmp_path / filename
+        file_path.write_bytes(payload)
+        mock_result = {
+            "final_response": f"MEDIA:{file_path}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": f"inline {filename}"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            file_blocks = [b for b in content_blocks if b.get("type") == "output_file"]
+            assert file_blocks
+            assert not file_blocks[0]["file_url"].startswith("data:")
+            assert "data:" not in content_blocks[0]["text"]
+            # The served URL carries the real on-disk extension.
+            expected_ext = Path(filename).suffix.lower()
+            parsed = urlparse(file_blocks[0]["file_url"])
+            assert re.fullmatch(
+                rf"/v1/files/[A-Za-z0-9]+{re.escape(expected_ext)}", parsed.path,
+            ), parsed.path
 
     @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
@@ -1323,6 +1658,50 @@ class TestEndpointAuth:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/health")
             assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_files_endpoint_allows_token_access_without_auth_header(self, auth_adapter, tmp_path):
+        export = tmp_path / "sample.txt"
+        export.write_text("hello", encoding="utf-8")
+        auth_adapter._file_exports["tok123"] = {"path": str(export), "created_at": time.time()}
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/files/tok123")
+            assert resp.status == 200
+            assert await resp.text() == "hello"
+
+    @pytest.mark.asyncio
+    async def test_files_endpoint_accepts_matching_extension(self, auth_adapter, tmp_path):
+        """A URL whose extension matches the one recorded at registration
+        time resolves the same file as the extensionless URL."""
+        export = tmp_path / "voice.ogg"
+        export.write_bytes(b"OggS\x00\x00")
+        auth_adapter._file_exports["aabb01"] = {
+            "path": str(export), "created_at": time.time(), "ext": ".ogg",
+        }
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/files/aabb01.ogg")
+            assert resp.status == 200
+            assert await resp.read() == b"OggS\x00\x00"
+
+    @pytest.mark.asyncio
+    async def test_files_endpoint_rejects_mismatched_extension(self, auth_adapter, tmp_path):
+        """A URL that guesses a different extension than the recorded one
+        returns 404 — an attacker who learns the file_id can't fish for the
+        real container format."""
+        export = tmp_path / "voice.ogg"
+        export.write_bytes(b"OggS\x00\x00")
+        auth_adapter._file_exports["aabb02"] = {
+            "path": str(export), "created_at": time.time(), "ext": ".ogg",
+        }
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/files/aabb02.mp3")
+            assert resp.status == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,6 +30,7 @@ from gateway.platforms.api_server import (
     MAX_REQUEST_BYTES,
     ResponseStore,
     _CORS_HEADERS,
+    _StreamDataURLFilter,
     _derive_chat_session_id,
     body_limit_middleware,
     check_api_server_requirements,
@@ -402,6 +403,151 @@ class TestChooseExportExt:
         assert _choose_export_ext(p, "application/x-nonexistent-zzz") == ""
 
 
+class TestStreamDataURLFilter:
+    """Direct unit tests for the streaming filter state machine.
+
+    Uses a fake adapter whose ``_register_file_export`` returns a stable
+    URL based on the cached-file path, so we can assert rewrites without
+    spinning up an aiohttp Request.  End-to-end SSE coverage lives in
+    ``TestChatCompletionsEndpoint.test_streaming_rewrites_inline_data_url``
+    below.
+    """
+
+    class _FakeAdapter:
+        def __init__(self):
+            self.registered = []
+
+        def _register_file_export(self, request, local_path):
+            self.registered.append(local_path)
+            # Mimic the real URL shape so tests can grep for /v1/files/.
+            return f"https://host/v1/files/{Path(local_path).stem}{Path(local_path).suffix}"
+
+    def _make_filter(self):
+        adapter = self._FakeAdapter()
+        return _StreamDataURLFilter(adapter, request=None), adapter
+
+    def _build_png_data_url(self) -> str:
+        import base64 as _b64
+        raw = b"\x89PNG\r\n\x1a\nfake-png"
+        return f"data:image/png;base64,{_b64.b64encode(raw).decode()}"
+
+    def test_passes_through_plain_text(self):
+        """No data URL, no change (modulo the tiny tail-hold that gets
+        released on flush)."""
+        f, _ = self._make_filter()
+        emitted = f.feed("hello, world — nothing to see here")
+        emitted += f.flush()
+        assert emitted == "hello, world — nothing to see here"
+
+    def test_rewrites_single_chunk_data_url(self):
+        f, adapter = self._make_filter()
+        data_url = self._build_png_data_url()
+        text = f"Here: ![icon]({data_url})"
+        emitted = f.feed(text) + f.flush()
+        # No data URL remains and a /v1/files/ URL is spliced in.
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted, emitted
+        # Markdown structure preserved.
+        assert "![icon](" in emitted
+        # One registration, one inline block recorded.
+        assert len(adapter.registered) == 1
+        assert len(f.inline_blocks) == 1
+        assert f.inline_blocks[0]["type"] == "output_image"
+
+    def test_rewrites_data_url_split_across_many_chunks(self):
+        """Claude's tokens don't respect URL boundaries — ``data:`` may
+        be split into pieces like ``"da"``/``"ta:image/png;base64,"``/
+        ``"iVBORw0K"``/``"Ggo="``/``")"``."""
+        f, adapter = self._make_filter()
+        data_url = self._build_png_data_url()
+        prefix = "Here: ![icon]("
+        # Split the full text (prefix + URL + ")") into aggressively small
+        # chunks — 3 chars each — to exercise every state transition.
+        full = prefix + data_url + ")"
+        chunks = [full[i:i + 3] for i in range(0, len(full), 3)]
+        emitted_parts = [f.feed(ch) for ch in chunks]
+        emitted_parts.append(f.flush())
+        emitted = "".join(emitted_parts)
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted, emitted
+        assert "![icon](" in emitted
+        assert len(adapter.registered) == 1
+
+    def test_data_url_terminator_is_markdown_close_paren(self):
+        """The closing paren of ``![alt](…)`` must end the URL scan so
+        anything after ``)`` is emitted as normal text."""
+        f, _ = self._make_filter()
+        data_url = self._build_png_data_url()
+        emitted = f.feed(f"before ![x]({data_url}) after text") + f.flush()
+        assert emitted.endswith(") after text"), emitted
+        assert "/v1/files/" in emitted
+        assert "data:" not in emitted
+
+    def test_multiple_data_urls_each_materialized_once(self):
+        f, adapter = self._make_filter()
+        url1 = self._build_png_data_url()
+        # Different payload → different cached file.
+        import base64 as _b64
+        raw2 = b"\x89PNG\r\n\x1a\nother-png"
+        url2 = f"data:image/png;base64,{_b64.b64encode(raw2).decode()}"
+        emitted = f.feed(f"![a]({url1}) and ![b]({url2})") + f.flush()
+        assert emitted.count("/v1/files/") == 2, emitted
+        assert "data:" not in emitted
+        assert len(adapter.registered) == 2
+
+    def test_undecodable_data_url_left_verbatim(self):
+        """If ``_decode_data_url`` can't parse the payload, keep the URL in
+        place — better to show the user a broken link than to silently eat
+        bytes."""
+        f, _ = self._make_filter()
+        bad = "data:image/png;base64,@@@nope@@@"
+        emitted = f.feed(f"Look: ![x]({bad})") + f.flush()
+        # Original URL is preserved verbatim — filter doesn't invent one.
+        assert bad in emitted, emitted
+
+    def test_partial_data_prefix_at_buffer_boundary_is_held(self):
+        """If a chunk ends with ``"da"`` and the next begins with
+        ``"ta:image/png;base64,…"``, the filter must not emit the ``"da"``
+        early — otherwise the ``data:`` match is lost."""
+        f, adapter = self._make_filter()
+        data_url = self._build_png_data_url()
+        first = f.feed("before da")  # last 2 chars are a partial prefix
+        second = f.feed("ta:image/png;base64,")
+        third = f.feed(data_url.split(",", 1)[1])  # payload
+        fourth = f.feed(")")
+        emitted = first + second + third + fourth + f.flush()
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted
+        # "before " is stable enough that the first chunk may emit part
+        # of it; by end-of-stream the full non-URL prose is present.
+        assert emitted.startswith("before "), emitted
+
+    def test_flush_handles_in_progress_data_url(self):
+        """Stream ends mid-URL (no terminator reached) — the filter
+        should still decode whatever payload bytes are valid rather than
+        drop them."""
+        f, _ = self._make_filter()
+        data_url = self._build_png_data_url()
+        # Deliberately *don't* include a closing paren / whitespace.
+        emitted = f.feed(f"incomplete: {data_url}")
+        emitted += f.flush()
+        assert "data:" not in emitted, emitted
+        assert "/v1/files/" in emitted
+
+    def test_tool_progress_tuples_ignored_by_filter(self):
+        """The SSE writer only sends *strings* through ``feed``; tool-
+        progress events take a different path.  This is documented
+        behaviour — verify the filter is string-only."""
+        f, _ = self._make_filter()
+        # Non-string input is a programming error; the caller in
+        # _write_sse_chat_completion checks ``isinstance(item, str)``
+        # before feeding.  Here we just confirm that empty chunks produce
+        # empty output and don't wedge the state machine.
+        assert f.feed("") == ""
+        assert f.feed(None) == ""
+        assert f.flush() == ""
+
+
 # ---------------------------------------------------------------------------
 # /v1/models endpoint
 # ---------------------------------------------------------------------------
@@ -747,6 +893,110 @@ class TestChatCompletionsEndpoint:
                 assert "Done." in body
                 assert "/v1/files/" in body
                 assert "![stream.png]" in body
+
+    @staticmethod
+    def _reassemble_sse_content(body: str) -> str:
+        """Concatenate the ``delta.content`` of every SSE data frame in
+        ``body`` into a single string — mirrors how an OpenAI client
+        assembles a streaming reply into the assistant message."""
+        parts: List[str] = []
+        for line in body.split("\n"):
+            if not line.startswith("data: "):
+                continue
+            payload = line[len("data: "):]
+            if payload.strip() == "[DONE]":
+                continue
+            try:
+                obj = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            for choice in obj.get("choices", []):
+                delta = choice.get("delta") or {}
+                if isinstance(delta.get("content"), str):
+                    parts.append(delta["content"])
+        return "".join(parts)
+
+    @pytest.mark.asyncio
+    async def test_streaming_rewrites_inline_data_url(self, adapter):
+        """End-to-end: Claude emits deltas that compose
+        ``![icon](data:image/png;base64,…)`` across several chunks, and
+        the text the client reassembles from the SSE stream must contain
+        a ``/v1/files/`` URL instead of the base64 blob."""
+        import base64 as _b64
+        raw = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+        data_url = f"data:image/png;base64,{_b64.b64encode(raw).decode()}"
+        # Break the text into chunks that *intentionally* split the
+        # ``data:`` prefix across two deltas (last 2 chars of one chunk,
+        # rest in the next) so the filter's prefix-hold path is exercised.
+        prefix = "Here is your icon: ![icon]("
+        deltas = [
+            prefix[:-5],                         # "…: ![icon"
+            prefix[-5:] + data_url[:2],          # "n](da"
+            data_url[2:10],                      # "ta:image"
+            data_url[10:],                       # remainder of the URL
+            ")",                                 # markdown terminator
+            "\n\nLet me know if you want changes.",  # trailing prose
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    for d in deltas:
+                        cb(d)
+                return (
+                    {"final_response": prefix + data_url + ")" + "\n\nLet me know if you want changes.",
+                     "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "icon"}], "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                reassembled = self._reassemble_sse_content(body)
+                # No base64 payload reached the client…
+                assert "data:image/" not in reassembled, reassembled
+                assert "base64," not in reassembled, reassembled
+                # …but the markdown wrapper and a /v1/files/ URL did.
+                assert "![icon](" in reassembled
+                assert re.search(r"/v1/files/[A-Za-z0-9]+\.png", reassembled), reassembled
+                # Trailing prose that came AFTER the data URL still ships.
+                assert "Let me know if you want changes." in reassembled
+
+    @pytest.mark.asyncio
+    async def test_streaming_plain_text_is_not_altered(self, adapter):
+        """The filter's prefix-hold must not drop or reorder characters —
+        after reassembly the stream matches the source tokens exactly."""
+        tokens = ["Hello", ", ", "world", "! No ", "data here."]
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    for t in tokens:
+                        cb(t)
+                return (
+                    {"final_response": "".join(tokens), "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"messages": [{"role": "user", "content": "hi"}], "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                reassembled = self._reassemble_sse_content(body)
+                assert reassembled == "Hello, world! No data here."
+                # "data" (no colon) is plain text and must pass through
+                # verbatim — the filter only reacts to the full ``data:``.
+                assert "data here." in reassembled
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
@@ -1240,6 +1490,95 @@ class TestResponsesEndpoint:
             assert "![tiny.png](" in content_blocks[0]["text"]
             assert "/v1/files/" in content_blocks[0]["text"]
             assert "data:image/" not in content_blocks[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_inline_data_url_image_rewritten_to_file_url(self, adapter):
+        """When the model embeds ``![alt](data:image/png;base64,…)`` in its
+        reply (as Claude does for shell-produced images without a MEDIA
+        convention), the server decodes the payload, caches it, and swaps
+        the data URL for a ``/v1/files/{id}.png`` URL in-place.  The client
+        sees a normal markdown image referencing a cheap HTTP URL instead
+        of carrying base64 through conversation history."""
+        import base64 as _b64
+        png_bytes = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+        data_url = f"data:image/png;base64,{_b64.b64encode(png_bytes).decode()}"
+        mock_result = {
+            "final_response": f"Here's your icon: ![icon]({data_url})",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "icon please"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            # The text markdown wrapper survives intact, but its URL is now
+            # a /v1/files/ URL — no base64 left in the response.
+            text = content_blocks[0]["text"]
+            assert "![icon](" in text
+            assert "data:image/" not in text
+            assert "data:" not in text
+            match = re.search(r"/v1/files/[A-Za-z0-9]+\.(?:png|jpg|jpeg)", text)
+            assert match, f"no /v1/files URL spliced into text: {text!r}"
+            # And there's a proper output_image block referencing the same URL.
+            image_blocks = [b for b in content_blocks if b.get("type") == "output_image"]
+            assert image_blocks
+            assert image_blocks[0]["image_url"].endswith(match.group(0).rsplit("/", 1)[-1])
+
+    @pytest.mark.asyncio
+    async def test_inline_data_url_audio_rewritten_to_file_url(self, adapter):
+        """Audio data URLs the model embeds get the same treatment."""
+        import base64 as _b64
+        ogg_bytes = b"OggS\x00\x00fake-audio"
+        data_url = f"data:audio/ogg;base64,{_b64.b64encode(ogg_bytes).decode()}"
+        mock_result = {
+            "final_response": f"voice note: [audio]({data_url})",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "audio please"})
+            assert resp.status == 200
+            data = await resp.json()
+            content_blocks = data["output"][0]["content"]
+            text = content_blocks[0]["text"]
+            assert "data:" not in text
+            # mimetypes maps ``audio/ogg`` to ``.oga`` on most systems and
+            # ``.ogg`` on some — either is a legitimate Ogg extension.
+            assert re.search(r"/v1/files/[A-Za-z0-9]+\.(?:ogg|oga)", text), text
+            audio_blocks = [b for b in content_blocks if b.get("type") == "output_audio"]
+            assert audio_blocks
+            assert "/v1/files/" in audio_blocks[0]["audio_url"]
+
+    @pytest.mark.asyncio
+    async def test_inline_data_url_unparseable_left_in_place(self, adapter):
+        """Garbled data URLs that fail to decode are left in the text
+        verbatim rather than dropped — we'd rather show the user a
+        malformed URL than silently delete content."""
+        mock_result = {
+            # Truncated base64 header — _decode_data_url returns empty bytes,
+            # which the helper treats as "not materializable, skip."
+            "final_response": "Broken: ![x](data:image/png;base64,@@@nope@@@)",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post("/v1/responses", json={"input": "garbled"})
+            assert resp.status == 200
+            # The response completes fine; no crash.  We don't assert the
+            # exact text shape — only that nothing 500s.
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/up-cli
+++ b/up-cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /root/hermes-agent
+source .venv/bin/activate
+exec hermes "$@"

--- a/up-gateway
+++ b/up-gateway
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /root/hermes-agent
+source .venv/bin/activate
+exec hermes gateway "$@"

--- a/up-gateway-cli
+++ b/up-gateway-cli
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd /root/hermes-agent
+source .venv/bin/activate
+
+hermes gateway &
+GATEWAY_PID=$!
+
+trap 'kill $GATEWAY_PID 2>/dev/null; wait $GATEWAY_PID 2>/dev/null' EXIT INT TERM
+
+# Wait for gateway to be ready
+sleep 5
+
+hermes "$@"
+
+kill $GATEWAY_PID 2>/dev/null
+wait $GATEWAY_PID 2>/dev/null


### PR DESCRIPTION
## What does this PR do?

This makes the OpenAI-compatible HTTP adapter exposed by API_SERVER_ENABLED=true a first-class multimodal endpoint for Open WebUI, LobeChat, and similar desktop clients. It supports both incoming and outgoing media and files.

This allows you for instance to send a pdf file or an image from openwebui to hermes, ask it to do something with it, and consume the results back within openwebui.

The design of the change (that covers both completions and responses APIs, streaming and not):
 Inbound - accept OpenAI multimodal content parts or base64 data: URLs and turn them into Hermes-friendly placeholders that point at cached media on disk.
 Outbound -  always serve media via /v1/files/{id}.ext,an endpoint with in-memory registry, TTL, and prune capabilities. There is also a way to override the host and port used for serving the links. Whenever the underlying model serves base64 blobs as inline data it also captures this an turn into media served in the same fashion.

<img width="752" height="565" alt="2026-04-14_00001_752x565_Selection" src="https://github.com/user-attachments/assets/54d9fe3e-9714-4c9d-8aa3-260711833b99" />

## Related Issue: Not provided.

## Type of Change

- [X] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

Changes are in two files only:
- gateway/platforms/api_server.py
- tests/gateway/test_api_server.py

## How to Test

1. Run tests;
2. Plug openwebui into hermes and test sending and receiving images, pdfs, voice messages and other media.

## Checklist
### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform:  Ubuntu 24.04.3 LTS inside a https://hub.docker.com/repository/docker/igorhvr/bedlam-ubuntu/ docker image.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

