### PR TITLE
docs: clarify canonical runtime identity file locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,14 @@ mini-swe-agent/
 .direnv/
 result
 website/static/api/skills-index.json
+
+# Local runtime/persona files belong in HERMES_HOME, not the repo root.
+/.DS_Store
+/.openclaw/
+/memory/
+/SOUL.md
+/USER.md
+/IDENTITY.md
+/TOOLS.md
+/HEARTBEAT.md
+/BOOTSTRAP.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,17 @@ Use `get_hermes_home()` from `hermes_constants` for code paths. Use `display_her
 for user-facing print/log messages. Hardcoding `~/.hermes` breaks profiles — each profile
 has its own `HERMES_HOME` directory. This was the source of 5 bugs fixed in PR #3575.
 
+### DO NOT treat repo-root persona files as live runtime state
+The active persona and memory files live under `HERMES_HOME`, not the git checkout:
+- `get_hermes_home() / "SOUL.md"`
+- `get_hermes_home() / "memories" / "MEMORY.md"`
+- `get_hermes_home() / "memories" / "USER.md"`
+
+If `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`
+appear at the repo root, treat them as templates, migration artifacts, or local mistakes —
+not canonical runtime inputs. Do not read from, write to, or rely on repo-root copies when
+changing agent behavior.
+
 ### DO NOT use `simple_term_menu` for interactive menus
 Rendering bugs in tmux/iTerm2 — ghosting on scroll. Use `curses` (stdlib) instead. See `hermes_cli/tools_config.py` for the pattern.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,12 +188,15 @@ hermes-agent/
 | `~/.hermes/config.yaml` | Settings (model, terminal, toolsets, compression, etc.) |
 | `~/.hermes/.env` | API keys and secrets |
 | `~/.hermes/auth.json` | OAuth credentials (Nous Portal) |
+| `~/.hermes/SOUL.md` | Active agent identity / persona file |
 | `~/.hermes/skills/` | All active skills (bundled + hub-installed + agent-created) |
 | `~/.hermes/memories/` | Persistent memory (MEMORY.md, USER.md) |
 | `~/.hermes/state.db` | SQLite session database |
 | `~/.hermes/sessions/` | JSON session logs |
 | `~/.hermes/cron/` | Scheduled job data |
 | `~/.hermes/whatsapp/session/` | WhatsApp bridge credentials |
+
+> Runtime identity and memory live under `HERMES_HOME`, not the git checkout. Do not create or rely on repo-root `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, or `HEARTBEAT.md` files for active behavior.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,14 +124,16 @@ hermes claw migrate --overwrite  # Overwrite existing conflicts
 ```
 
 What gets imported:
-- **SOUL.md** — persona file
-- **Memories** — MEMORY.md and USER.md entries
+- **SOUL.md** — persona file → `~/.hermes/SOUL.md`
+- **Memories** — MEMORY.md and USER.md entries → `~/.hermes/memories/`
 - **Skills** — user-created skills → `~/.hermes/skills/openclaw-imports/`
 - **Command allowlist** — approval patterns
 - **Messaging settings** — platform configs, allowed users, working directory
 - **API keys** — allowlisted secrets (Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs)
 - **TTS assets** — workspace audio files
 - **Workspace instructions** — AGENTS.md (with `--workspace-target`)
+
+Canonical local identity/memory paths live under `HERMES_HOME` (usually `~/.hermes`), not in the git checkout. If you see `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, or `HEARTBEAT.md` appear at the repo root, treat them as stray local files or templates — not the active runtime docs.
 
 See `hermes claw migrate --help` for all options, or use the `openclaw-migration` skill for an interactive agent-guided migration with dry-run previews.
 


### PR DESCRIPTION
## Summary
- document that active runtime identity files live under HERMES_HOME, not the git checkout
- ignore stray repo-root persona/runtime artifacts that confused local workspace state
- warn contributors not to treat repo-root persona files as canonical runtime inputs

## Why
A duplicate generic/template doc set appeared in the repo checkout alongside the real live Henry docs under ~/.hermes. That made the active identity/memory locations ambiguous for both operator and agent.

## Test Plan
- verified live runtime files still exist at ~/.hermes/SOUL.md and ~/.hermes/memories/{MEMORY,USER}.md
- verified repo checkout no longer surfaces shadow files in git status
- verified updated docs mention HERMES_HOME as canonical path