### PR TITLE
Hardening: autonomy guardrails and readiness controls

### DIFF
--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -1,0 +1,36 @@
+name: Readiness
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: readiness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Run canonical readiness gate
+        run: |
+          source .venv/bin/activate
+          python scripts/run_readiness.py

--- a/GATES.md
+++ b/GATES.md
@@ -1,0 +1,24 @@
+# Canonical Readiness Gate
+
+The only canonical readiness gate for the autonomy foundation layer is:
+
+```bash
+python scripts/run_readiness.py
+```
+
+This script is backed by:
+
+- `/Users/jonathannugroho/Developer/PersonalProjects/Hermes-agent/hermes-agent/autonomy_policy.yaml`
+- `/Users/jonathannugroho/Developer/PersonalProjects/Hermes-agent/hermes-agent/.github/workflows/readiness.yml`
+
+There are no non-blocking shortcuts in this gate. Any failing command is blocking.
+
+## Required GitHub Protection
+
+This local gate is not sufficient by itself. The GitHub repo must also enforce:
+
+- protect `main`
+- require pull requests before merge
+- require the `Readiness` workflow as a required status check
+- block direct pushes to `main`
+- block force-pushes to `main`

--- a/autonomy_policy.yaml
+++ b/autonomy_policy.yaml
@@ -1,0 +1,58 @@
+version: 1
+
+branch_protection:
+  protected_branches:
+    - main
+    - master
+
+approval:
+  forbidden_command_fragments:
+    - --dangerously-skip-permissions
+    - --yolo
+    - /yolo
+  require_explicit_approval_patterns:
+    - pattern: '\bgit\s+push\b'
+      description: push commits to a remote
+    - pattern: '\bgit\s+tag\b'
+      description: create or move a git tag
+    - pattern: '\bgh\s+pr\s+(create|merge|ready)\b'
+      description: change pull request state
+    - pattern: '\b(hermes|claude)\b.*\b(publish|release|deploy)\b'
+      description: publish or deploy changes
+    - pattern: '\bnpm\s+publish\b'
+      description: publish an npm package
+    - pattern: '\bpython(?:3)?\s+.*release\.py\b'
+      description: run a release script
+
+terminal_writes:
+  patterns:
+    - pattern: '\bgit\s+(add|commit|merge|rebase|cherry-pick|apply|am|revert|rm|mv)\b'
+      description: git mutation
+    - pattern: '\b(touch|mkdir|rmdir|rm|mv|cp|install)\b'
+      description: filesystem mutation
+    - pattern: '\bsed\s+(-[^\s]*i|--in-place)\b'
+      description: in-place file edit
+    - pattern: '\btee\b'
+      description: file write via tee
+    - pattern: '(?<!\d)>{1,2}(?!\d)'
+      description: shell redirection write
+
+bootstrap:
+  required_commands:
+    - git
+    - python3
+    - uv
+  require_hermes_config_without_explicit_credentials: true
+  require_provider_resolution: true
+  require_provider_auth: true
+
+proof_of_done:
+  output_dir: proof_of_done
+  max_command_preview_chars: 240
+
+readiness:
+  script: scripts/run_readiness.py
+  smoke_script: scripts/smoke_autonomy.py
+  pytest_targets:
+    - tests/tools/test_autonomy_guard.py
+    - tests/run_agent/test_autonomy_runtime.py

--- a/autonomy_policy.yaml
+++ b/autonomy_policy.yaml
@@ -60,6 +60,12 @@ execute_code:
       description: spawn subprocesses from execute_code
     - pattern: '\bos\.system\s*\('
       description: spawn shell commands from execute_code
+    - pattern: '\b(eval|exec)\s*\('
+      description: execute dynamic Python code inside execute_code
+    - pattern: '__import__\s*\(\s*["''](?:os|subprocess)["'']\s*\)\s*\.\s*(system|run|Popen|call|check_call|check_output)\s*\('
+      description: invoke shell or subprocess calls through dynamic imports
+    - pattern: 'getattr\s*\(\s*(?:os|subprocess|__import__\s*\([^)]*\))\s*,\s*["''](?:system|run|Popen|call|check_call|check_output)["'']\s*\)\s*\('
+      description: invoke shell or subprocess calls through getattr
 
 bootstrap:
   required_commands:
@@ -74,9 +80,21 @@ proof_of_done:
   output_dir: proof_of_done
   max_command_preview_chars: 240
 
+delegate:
+  approval_required_for_mcp_toolsets: true
+  approval_required_if_acp_command: true
+
+mcp:
+  approval_required_tool_name_patterns:
+    - pattern: '(^|_)(add|create|update|delete|remove|destroy|merge|reply|label|enable|publish|deploy|release|push|tag|commit|write|patch|edit|set)(_|$)'
+      description: mutate remote state through an MCP tool
+
 readiness:
   script: scripts/run_readiness.py
   smoke_script: scripts/smoke_autonomy.py
   pytest_targets:
     - tests/tools/test_autonomy_guard.py
     - tests/run_agent/test_autonomy_runtime.py
+    - tests/tools/test_delegate.py::TestDelegateTask::test_explicit_mcp_toolset_requires_approval
+    - tests/tools/test_delegate.py::TestDelegateTask::test_acp_command_requires_approval
+    - tests/tools/test_mcp_tool.py::TestToolHandler::test_mutating_mcp_tool_requires_approval

--- a/autonomy_policy.yaml
+++ b/autonomy_policy.yaml
@@ -97,4 +97,5 @@ readiness:
     - tests/run_agent/test_autonomy_runtime.py
     - tests/tools/test_delegate.py::TestDelegateTask::test_explicit_mcp_toolset_requires_approval
     - tests/tools/test_delegate.py::TestDelegateTask::test_acp_command_requires_approval
+    - tests/tools/test_delegate.py::TestDelegateTask::test_per_task_acp_command_requires_approval
     - tests/tools/test_mcp_tool.py::TestToolHandler::test_mutating_mcp_tool_requires_approval

--- a/autonomy_policy.yaml
+++ b/autonomy_policy.yaml
@@ -37,6 +37,30 @@ terminal_writes:
     - pattern: '(?<!\d)>{1,2}(?!\d)'
       description: shell redirection write
 
+execute_code:
+  forbidden_code_fragments:
+    - --dangerously-skip-permissions
+    - --yolo
+    - /yolo
+  protected_branch_block_patterns:
+    - pattern: '\bopen\s*\([^,\n]+,\s*["''][^"'']*[wax+][^"'']*["'']'
+      description: raw Python file write
+    - pattern: '\.\s*write_text\s*\('
+      description: write text directly from execute_code
+    - pattern: '\.\s*write_bytes\s*\('
+      description: write bytes directly from execute_code
+    - pattern: '\.\s*(unlink|rename|replace)\s*\('
+      description: mutate or delete files directly from execute_code
+    - pattern: '\bos\.(remove|unlink|rename|replace)\s*\('
+      description: mutate or delete files directly from execute_code
+    - pattern: '\bshutil\.rmtree\s*\('
+      description: delete directory trees directly from execute_code
+  approval_required_patterns:
+    - pattern: '\bsubprocess\.(run|Popen|call|check_call|check_output)\s*\('
+      description: spawn subprocesses from execute_code
+    - pattern: '\bos\.system\s*\('
+      description: spawn shell commands from execute_code
+
 bootstrap:
   required_commands:
     - git

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6579,13 +6579,56 @@ class GatewayRunner:
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"
         session_key = self._session_key_for_source(event.source)
+        branch_name = None
+        dirty = None
+        status_sample = []
+        dev_checkout = any(
+            (project_root / marker).exists()
+            for marker in (".hermes-dev-checkout", ".hermes-no-self-update")
+        )
+        try:
+            branch_result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=project_root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            branch_name = branch_result.stdout.strip() or None
+            status_result = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=project_root,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
+            dirty = bool(status_lines)
+            status_sample = status_lines[:5]
+        except Exception as e:
+            logger.debug("Could not inspect repo state for /update request: %s", e)
+
         pending = {
             "platform": event.source.platform.value,
             "chat_id": event.source.chat_id,
             "user_id": event.source.user_id,
             "session_key": session_key,
             "timestamp": datetime.now().isoformat(),
+            "update_source": "gateway_message",
+            "project_root": str(project_root),
+            "checkout_branch": branch_name,
+            "checkout_dirty": dirty,
+            "status_sample": status_sample,
+            "dev_checkout": dev_checkout,
         }
+        logger.info(
+            "Gateway /update requested: platform=%s chat_id=%s branch=%s dirty=%s dev_checkout=%s",
+            event.source.platform.value,
+            event.source.chat_id,
+            branch_name,
+            dirty,
+            dev_checkout,
+        )
         _tmp_pending = pending_path.with_suffix(".tmp")
         _tmp_pending.write_text(json.dumps(pending))
         _tmp_pending.replace(pending_path)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -44,6 +44,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -165,12 +166,16 @@ except Exception:
 
 import logging
 import time as _time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from hermes_cli import __version__, __release_date__
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
+
+_UPDATE_PROTECTION_MARKERS = (".hermes-dev-checkout", ".hermes-no-self-update")
+_UPDATE_DEV_ENV_VARS = ("HERMES_DEV_CHECKOUT", "HERMES_NO_SELF_UPDATE")
+_UPDATE_GUARD_LOG_NAME = "update_guard.jsonl"
 
 
 def _relative_time(ts) -> str:
@@ -189,6 +194,32 @@ def _relative_time(ts) -> str:
     if delta < 604800:
         return f"{int(delta / 86400)}d ago"
     return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+
+
+def _is_truthy_env_var(name: str) -> bool:
+    value = os.getenv(name, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _append_update_guard_event(event: str, **fields) -> None:
+    """Write a small JSONL trace for update attempts and guard decisions."""
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        "project_root": str(PROJECT_ROOT),
+        **fields,
+    }
+
+    try:
+        log_dir = get_hermes_home() / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / _UPDATE_GUARD_LOG_NAME
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, sort_keys=True) + "\n")
+    except Exception as e:
+        logger.debug("Failed to append update guard event: %s", e)
+
+    logger.info("Hermes update event: %s", payload)
 
 
 def _has_any_provider_configured() -> bool:
@@ -3534,6 +3565,97 @@ def _invalidate_update_cache():
             pass
 
 
+def _collect_update_guard_state(git_cmd: list[str], cwd: Path) -> dict:
+    marker_hits = [name for name in _UPDATE_PROTECTION_MARKERS if (cwd / name).exists()]
+    env_hits = [name for name in _UPDATE_DEV_ENV_VARS if _is_truthy_env_var(name)]
+
+    state = {
+        "branch": None,
+        "dirty": False,
+        "status_sample": [],
+        "dev_checkout": bool(marker_hits or env_hits),
+        "protection_sources": marker_hits + env_hits,
+        "inspection_error": None,
+    }
+
+    try:
+        branch_result = subprocess.run(
+            git_cmd + ["rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        state["branch"] = branch_result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        state["inspection_error"] = stderr or str(exc)
+        return state
+
+    try:
+        status_result = subprocess.run(
+            git_cmd + ["status", "--porcelain"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        status_lines = [line for line in status_result.stdout.splitlines() if line.strip()]
+        state["dirty"] = bool(status_lines)
+        state["status_sample"] = status_lines[:5]
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        state["inspection_error"] = stderr or str(exc)
+
+    return state
+
+
+def _update_guard_reasons(state: dict) -> list[str]:
+    reasons: list[str] = []
+    if state.get("inspection_error"):
+        reasons.append(
+            "could not inspect repository state safely "
+            f"({state['inspection_error']})"
+        )
+        return reasons
+
+    branch = state.get("branch")
+    if branch != "main":
+        if branch == "HEAD":
+            reasons.append(
+                "current checkout is detached HEAD; self-update only runs from the "
+                "`main` runtime checkout"
+            )
+        elif branch:
+            reasons.append(
+                f"current branch is `{branch}`; self-update only runs from `main`"
+            )
+        else:
+            reasons.append("current branch could not be determined")
+
+    if state.get("dirty"):
+        sample = ", ".join(state.get("status_sample") or [])
+        detail = f" ({sample})" if sample else ""
+        reasons.append(f"working tree has local changes{detail}")
+
+    if state.get("dev_checkout"):
+        sources = ", ".join(state.get("protection_sources") or [])
+        reasons.append(
+            "checkout is protected from self-update"
+            + (f" via {sources}" if sources else "")
+        )
+
+    return reasons
+
+
+def _print_update_guard_block(reasons: list[str]) -> None:
+    print("✗ Refusing to update this checkout.")
+    for reason in reasons:
+        print(f"  - {reason}")
+    print("  Use a clean runtime checkout on `main` for `hermes update`.")
+    print("  For development clones, create `.hermes-dev-checkout` at the repo root.")
+
+
 def _load_installable_optional_extras() -> list[str]:
     """Return the optional extras referenced by the ``all`` group.
 
@@ -3621,8 +3743,6 @@ def cmd_update(args):
         return
 
     gateway_mode = getattr(args, "gateway", False)
-    # In gateway mode, use file-based IPC for prompts instead of stdin
-    gw_input_fn = (lambda prompt, default="": _gateway_prompt(prompt, default)) if gateway_mode else None
     
     print("⚕ Updating Hermes Agent...")
     print()
@@ -3653,7 +3773,37 @@ def cmd_update(args):
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
-    # Detect if we're updating from a fork (before any branch logic)
+    if use_zip_update:
+        # ZIP-based update for Windows when git is broken
+        _update_via_zip(args)
+        return
+
+    update_guard_state = _collect_update_guard_state(git_cmd, PROJECT_ROOT)
+    _append_update_guard_event(
+        "attempt",
+        gateway_mode=gateway_mode,
+        branch=update_guard_state.get("branch"),
+        dirty=update_guard_state.get("dirty"),
+        dev_checkout=update_guard_state.get("dev_checkout"),
+        protection_sources=update_guard_state.get("protection_sources"),
+        status_sample=update_guard_state.get("status_sample"),
+        inspection_error=update_guard_state.get("inspection_error"),
+    )
+    guard_reasons = _update_guard_reasons(update_guard_state)
+    if guard_reasons:
+        _append_update_guard_event(
+            "blocked",
+            gateway_mode=gateway_mode,
+            branch=update_guard_state.get("branch"),
+            dirty=update_guard_state.get("dirty"),
+            dev_checkout=update_guard_state.get("dev_checkout"),
+            protection_sources=update_guard_state.get("protection_sources"),
+            reasons=guard_reasons,
+        )
+        _print_update_guard_block(guard_reasons)
+        sys.exit(1)
+
+    # Detect if we're updating from a fork after guard checks succeed.
     origin_url = _get_origin_url(git_cmd, PROJECT_ROOT)
     is_fork = _is_fork(origin_url)
 
@@ -3662,14 +3812,8 @@ def cmd_update(args):
         print(f"  {origin_url}")
         print()
 
-    if use_zip_update:
-        # ZIP-based update for Windows when git is broken
-        _update_via_zip(args)
-        return
-
     # Fetch and pull
     try:
-
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
             git_cmd + ["fetch", "origin"],
@@ -3679,6 +3823,12 @@ def cmd_update(args):
         )
         if fetch_result.returncode != 0:
             stderr = fetch_result.stderr.strip()
+            _append_update_guard_event(
+                "fetch_failed",
+                gateway_mode=gateway_mode,
+                branch=update_guard_state.get("branch"),
+                stderr=stderr,
+            )
             if "Could not resolve host" in stderr or "unable to access" in stderr:
                 print("✗ Network error — cannot reach the remote repository.")
                 print(f"  {stderr.splitlines()[0]}" if stderr else "")
@@ -3699,29 +3849,7 @@ def cmd_update(args):
             check=True,
         )
         current_branch = result.stdout.strip()
-
-        # Always update against main
         branch = "main"
-
-        # If user is on a non-main branch or detached HEAD, switch to main
-        if current_branch != "main":
-            label = "detached HEAD" if current_branch == "HEAD" else f"branch '{current_branch}'"
-            print(f"  ⚠ Currently on {label} — switching to main for update...")
-            # Stash before checkout so uncommitted work isn't lost
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
-            subprocess.run(
-                git_cmd + ["checkout", "main"],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-        else:
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
-
-        prompt_for_restore = auto_stash_ref is not None and (
-            gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty())
-        )
 
         # Check if there are updates
         result = subprocess.run(
@@ -3735,67 +3863,60 @@ def cmd_update(args):
 
         if commit_count == 0:
             _invalidate_update_cache()
-            # Restore stash and switch back to original branch if we moved
-            if auto_stash_ref is not None:
-                _restore_stashed_changes(
-                    git_cmd, PROJECT_ROOT, auto_stash_ref,
-                    prompt_user=prompt_for_restore,
-                    input_fn=gw_input_fn,
-                )
-            if current_branch not in ("main", "HEAD"):
-                subprocess.run(
-                    git_cmd + ["checkout", current_branch],
-                    cwd=PROJECT_ROOT, capture_output=True, text=True, check=False,
-                )
+            _append_update_guard_event(
+                "already_up_to_date",
+                gateway_mode=gateway_mode,
+                branch=current_branch,
+            )
             print("✓ Already up to date!")
             return
 
         print(f"→ Found {commit_count} new commit(s)")
 
         print("→ Pulling updates...")
-        update_succeeded = False
-        try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
+        pull_result = subprocess.run(
+            git_cmd + ["pull", "--ff-only", "origin", branch],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if pull_result.returncode != 0:
+            # ff-only failed — local and remote have diverged. A clean runtime
+            # checkout may still safely hard reset to match origin/main.
+            print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
+            _append_update_guard_event(
+                "reset_to_origin",
+                gateway_mode=gateway_mode,
+                branch=current_branch,
+                reason="fast_forward_failed",
+            )
+            reset_result = subprocess.run(
+                git_cmd + ["reset", "--hard", f"origin/{branch}"],
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True,
             )
-            if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
+            if reset_result.returncode != 0:
+                _append_update_guard_event(
+                    "reset_failed",
+                    gateway_mode=gateway_mode,
+                    branch=current_branch,
+                    stderr=reset_result.stderr.strip(),
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print("  Try manually: git fetch origin && git reset --hard origin/main")
-                    sys.exit(1)
-            update_succeeded = True
-        finally:
-            if auto_stash_ref is not None:
-                # Don't attempt stash restore if the code update itself failed —
-                # working tree is in an unknown state.
-                if not update_succeeded:
-                    print(f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})")
-                    print(f"  Restore manually with: git stash apply")
-                else:
-                    _restore_stashed_changes(
-                        git_cmd,
-                        PROJECT_ROOT,
-                        auto_stash_ref,
-                        prompt_user=prompt_for_restore,
-                        input_fn=gw_input_fn,
-                    )
+                print(f"✗ Failed to reset to origin/{branch}.")
+                if reset_result.stderr.strip():
+                    print(f"  {reset_result.stderr.strip()}")
+                print("  Try manually: git fetch origin && git reset --hard origin/main")
+                sys.exit(1)
         
         _invalidate_update_cache()
+        _append_update_guard_event(
+            "updated",
+            gateway_mode=gateway_mode,
+            branch=current_branch,
+            commit_count=commit_count,
+            used_reset=pull_result.returncode != 0,
+        )
 
         # Clear stale .pyc bytecode cache — prevents ImportError on gateway
         # restart when updated source references names that didn't exist in

--- a/run_agent.py
+++ b/run_agent.py
@@ -66,6 +66,12 @@ from model_tools import (
     handle_function_call,
     check_toolset_requirements,
 )
+from tools.autonomy_guard import (
+    create_proof_state,
+    record_tool_event,
+    run_bootstrap_preflight,
+    write_proof_artifact,
+)
 from tools.terminal_tool import cleanup_vm, get_active_env, is_persistent_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
 from tools.interrupt import set_interrupt as _set_interrupt
@@ -6143,12 +6149,6 @@ class AIAgent:
                 elif self.reasoning_config.get("effort"):
                     reasoning_effort = self.reasoning_config["effort"]
 
-            # Clamp effort levels not supported by the Responses API model.
-            # GPT-5.4 supports none/low/medium/high/xhigh but not "minimal".
-            # "minimal" is valid on OpenRouter and GPT-5 but fails on 5.2/5.4.
-            _effort_clamp = {"minimal": "low"}
-            reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
-
             kwargs = {
                 "model": self.model,
                 "instructions": instructions,
@@ -6896,18 +6896,6 @@ class AIAgent:
         tools. Used by the concurrent execution path; the sequential path retains
         its own inline invocation for backward-compatible display handling.
         """
-        # Check plugin hooks for a block directive before executing anything.
-        block_message: Optional[str] = None
-        try:
-            from hermes_cli.plugins import get_pre_tool_call_block_message
-            block_message = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
-            )
-        except Exception:
-            pass
-        if block_message is not None:
-            return json.dumps({"error": block_message}, ensure_ascii=False)
-
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             return _todo_tool(
@@ -6972,8 +6960,43 @@ class AIAgent:
                 tool_call_id=tool_call_id,
                 session_id=self.session_id or "",
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                skip_pre_tool_call_hook=True,
             )
+
+    def _record_proof_tool_event(self, function_name: str, function_args: dict, function_result: str) -> None:
+        """Best-effort proof-of-done tracking for this turn."""
+        proof_state = getattr(self, "_proof_state", None)
+        if not isinstance(proof_state, dict):
+            return
+        try:
+            record_tool_event(proof_state, function_name, function_args, function_result)
+        except Exception as exc:
+            logger.debug("proof-of-done tool event failed: %s", exc)
+
+    def _finalize_proof_of_done(
+        self,
+        *,
+        effective_task_id: str,
+        completed: bool,
+        interrupted: bool,
+        final_response: Optional[str],
+        api_calls: int,
+    ) -> Optional[str]:
+        """Persist the proof-of-done artifact for this turn."""
+        proof_state = getattr(self, "_proof_state", None)
+        if not isinstance(proof_state, dict):
+            return None
+        try:
+            return write_proof_artifact(
+                proof_state,
+                completed=completed,
+                interrupted=interrupted,
+                final_response=final_response,
+                api_calls=api_calls,
+                repo_hint=os.getcwd(),
+            )
+        except Exception as exc:
+            logger.warning("proof-of-done artifact write failed: %s", exc)
+            return None
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute multiple tool calls concurrently using a thread pool.
@@ -7136,6 +7159,7 @@ class AIAgent:
                     logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
                     logging.debug(f"Tool result ({len(function_result)} chars): {function_result}")
 
+            self._record_proof_tool_event(name, args, function_result)
             # Print cute message per tool
             if self._should_emit_quiet_tool_messages():
                 cute_msg = _get_cute_tool_message_impl(name, args, tool_duration, result=function_result)
@@ -7203,6 +7227,12 @@ class AIAgent:
 
             function_name = tool_call.function.name
 
+            # Reset nudge counters when the relevant tool is actually used
+            if function_name == "memory":
+                self._turns_since_memory = 0
+            elif function_name == "skill_manage":
+                self._iters_since_skill = 0
+
             try:
                 function_args = json.loads(tool_call.function.arguments)
             except json.JSONDecodeError as e:
@@ -7210,27 +7240,6 @@ class AIAgent:
                 function_args = {}
             if not isinstance(function_args, dict):
                 function_args = {}
-
-            # Check plugin hooks for a block directive before executing.
-            _block_msg: Optional[str] = None
-            try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                _block_msg = get_pre_tool_call_block_message(
-                    function_name, function_args, task_id=effective_task_id or "",
-                )
-            except Exception:
-                pass
-
-            if _block_msg is not None:
-                # Tool blocked by plugin policy — skip counter resets.
-                # Execution is handled below in the tool dispatch chain.
-                pass
-            else:
-                # Reset nudge counters when the relevant tool is actually used
-                if function_name == "memory":
-                    self._turns_since_memory = 0
-                elif function_name == "skill_manage":
-                    self._iters_since_skill = 0
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
@@ -7241,35 +7250,33 @@ class AIAgent:
                     args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
                     print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
-            if _block_msg is None:
-                self._current_tool = function_name
-                self._touch_activity(f"executing tool: {function_name}")
+            self._current_tool = function_name
+            self._touch_activity(f"executing tool: {function_name}")
 
             # Set activity callback for long-running tool execution (terminal
             # commands, etc.) so the gateway's inactivity monitor doesn't kill
             # the agent while a command is running.
-            if _block_msg is None:
-                try:
-                    from tools.environments.base import set_activity_callback
-                    set_activity_callback(self._touch_activity)
-                except Exception:
-                    pass
+            try:
+                from tools.environments.base import set_activity_callback
+                set_activity_callback(self._touch_activity)
+            except Exception:
+                pass
 
-            if _block_msg is None and self.tool_progress_callback:
+            if self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(function_name, function_args)
                     self.tool_progress_callback("tool.started", function_name, preview, function_args)
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
-            if _block_msg is None and self.tool_start_callback:
+            if self.tool_start_callback:
                 try:
                     self.tool_start_callback(tool_call.id, function_name, function_args)
                 except Exception as cb_err:
                     logging.debug(f"Tool start callback error: {cb_err}")
 
             # Checkpoint: snapshot working dir before file-mutating tools
-            if _block_msg is None and function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
+            if function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
@@ -7281,7 +7288,7 @@ class AIAgent:
                     pass  # never block tool execution
 
             # Checkpoint before destructive terminal commands
-            if _block_msg is None and function_name == "terminal" and self._checkpoint_mgr.enabled:
+            if function_name == "terminal" and self._checkpoint_mgr.enabled:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
@@ -7294,11 +7301,7 @@ class AIAgent:
 
             tool_start_time = time.time()
 
-            if _block_msg is not None:
-                # Tool blocked by plugin policy — return error without executing.
-                function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
-                tool_duration = 0.0
-            elif function_name == "todo":
+            if function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
                 function_result = _todo_tool(
                     todos=function_args.get("todos"),
@@ -7441,7 +7444,6 @@ class AIAgent:
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                        skip_pre_tool_call_hook=True,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -7461,7 +7463,6 @@ class AIAgent:
                         tool_call_id=tool_call.id,
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
-                        skip_pre_tool_call_hook=True,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
@@ -7502,6 +7503,7 @@ class AIAgent:
                 except Exception as cb_err:
                     logging.debug(f"Tool complete callback error: {cb_err}")
 
+            self._record_proof_tool_event(function_name, function_args, function_result)
             function_result = maybe_persist_tool_result(
                 content=function_result,
                 tool_name=function_name,
@@ -7798,6 +7800,14 @@ class AIAgent:
         self._persist_user_message_override = persist_user_message
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
+        _proof_user_message = persist_user_message if persist_user_message is not None else user_message
+        self._proof_state = create_proof_state(
+            session_id=self.session_id or "",
+            task_id=effective_task_id,
+            user_message=_proof_user_message or "",
+            model=self.model,
+            provider=self.provider,
+        )
         
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
@@ -7864,6 +7874,53 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+
+        preflight = run_bootstrap_preflight(
+            explicit_api_key=self.api_key,
+            explicit_base_url=self.base_url,
+            requested_provider=self.provider,
+        )
+        if isinstance(self._proof_state, dict):
+            self._proof_state["preflight"] = preflight
+        if not preflight.get("ok"):
+            final_response = preflight.get("message", "Autonomy bootstrap preflight failed.")
+            artifact_path = self._finalize_proof_of_done(
+                effective_task_id=effective_task_id,
+                completed=False,
+                interrupted=False,
+                final_response=final_response,
+                api_calls=0,
+            )
+            self._stream_callback = None
+            early_result = {
+                "final_response": final_response,
+                "last_reasoning": None,
+                "messages": [],
+                "api_calls": 0,
+                "completed": False,
+                "partial": False,
+                "interrupted": False,
+                "response_previewed": False,
+                "model": self.model,
+                "provider": self.provider,
+                "base_url": self.base_url,
+                "input_tokens": self.session_input_tokens,
+                "output_tokens": self.session_output_tokens,
+                "cache_read_tokens": self.session_cache_read_tokens,
+                "cache_write_tokens": self.session_cache_write_tokens,
+                "reasoning_tokens": self.session_reasoning_tokens,
+                "prompt_tokens": self.session_prompt_tokens,
+                "completion_tokens": self.session_completion_tokens,
+                "total_tokens": self.session_total_tokens,
+                "last_prompt_tokens": getattr(self.context_compressor, "last_prompt_tokens", 0) or 0,
+                "estimated_cost_usd": self.session_estimated_cost_usd,
+                "cost_status": self.session_cost_status,
+                "cost_source": self.session_cost_source,
+                "proof_of_done_artifact": artifact_path,
+                "preflight": preflight,
+            }
+            self._proof_state = None
+            return early_result
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on
@@ -10466,6 +10523,14 @@ class AIAgent:
         # Determine if conversation completed successfully
         completed = final_response is not None and api_call_count < self.max_iterations
 
+        proof_artifact = self._finalize_proof_of_done(
+            effective_task_id=effective_task_id,
+            completed=completed,
+            interrupted=interrupted,
+            final_response=final_response,
+            api_calls=api_call_count,
+        )
+
         # Save trajectory if enabled
         self._save_trajectory(messages, user_message, completed)
 
@@ -10570,6 +10635,8 @@ class AIAgent:
             "estimated_cost_usd": self.session_estimated_cost_usd,
             "cost_status": self.session_cost_status,
             "cost_source": self.session_cost_source,
+            "proof_of_done_artifact": proof_artifact,
+            "preflight": getattr(self, "_proof_state", {}).get("preflight"),
         }
         self._response_was_previewed = False
         
@@ -10636,6 +10703,7 @@ class AIAgent:
         except Exception as exc:
             logger.warning("on_session_end hook failed: %s", exc)
 
+        self._proof_state = None
         return result
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6980,6 +6980,7 @@ class AIAgent:
         interrupted: bool,
         final_response: Optional[str],
         api_calls: int,
+        stop_reason: Optional[str] = None,
     ) -> Optional[str]:
         """Persist the proof-of-done artifact for this turn."""
         proof_state = getattr(self, "_proof_state", None)
@@ -6992,6 +6993,7 @@ class AIAgent:
                 interrupted=interrupted,
                 final_response=final_response,
                 api_calls=api_calls,
+                stop_reason=stop_reason,
                 repo_hint=os.getcwd(),
             )
         except Exception as exc:
@@ -7890,6 +7892,7 @@ class AIAgent:
                 interrupted=False,
                 final_response=final_response,
                 api_calls=0,
+                stop_reason="bootstrap_preflight_failed",
             )
             self._stream_callback = None
             early_result = {
@@ -10529,6 +10532,7 @@ class AIAgent:
             interrupted=interrupted,
             final_response=final_response,
             api_calls=api_call_count,
+            stop_reason=_turn_exit_reason,
         )
 
         # Save trajectory if enabled

--- a/scripts/run_readiness.py
+++ b/scripts/run_readiness.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Canonical readiness gate for autonomy foundations."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from tools.autonomy_guard import load_autonomy_policy
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(cmd: list[str]) -> int:
+    print("$", " ".join(cmd))
+    completed = subprocess.run(cmd, cwd=REPO_ROOT)
+    return completed.returncode
+
+
+def main() -> int:
+    policy = load_autonomy_policy()
+    readiness = policy.get("readiness", {})
+    pytest_targets = [str(target) for target in readiness.get("pytest_targets", [])]
+    smoke_script = readiness.get("smoke_script", "scripts/smoke_autonomy.py")
+
+    if pytest_targets:
+        rc = _run([sys.executable, "-m", "pytest", *pytest_targets, "-q"])
+        if rc != 0:
+            return rc
+
+    return _run([sys.executable, smoke_script])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_autonomy.py
+++ b/scripts/smoke_autonomy.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Deterministic smoke checks for the autonomy foundation layer."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from tools.autonomy_guard import (
+    command_mutates_filesystem,
+    enforce_write_policy,
+    evaluate_terminal_command,
+    load_autonomy_policy,
+    run_bootstrap_preflight,
+)
+
+
+def _init_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True, text=True)
+    (repo / "tracked.txt").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-c", "user.name=Smoke", "-c", "user.email=smoke@example.com", "commit", "-m", "init"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return repo
+
+
+def main() -> int:
+    policy = load_autonomy_policy()
+    assert policy["version"] == 1
+    assert policy["readiness"]["script"] == "scripts/run_readiness.py"
+    assert command_mutates_filesystem("git add tracked.txt") is True
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo = _init_repo(Path(tmpdir))
+        blocked = enforce_write_policy("write_file", str(repo / "tracked.txt"))
+        assert blocked["allowed"] is False
+
+        approval = evaluate_terminal_command("git push origin HEAD", workdir=str(repo))
+        assert approval["status"] == "approval_required"
+
+    preflight = run_bootstrap_preflight(
+        explicit_api_key="smoke-key",
+        explicit_base_url="https://example.com/v1",
+        requested_provider="openrouter",
+    )
+    assert preflight["ok"] is True
+
+    print("autonomy smoke: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"autonomy smoke: FAIL - {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/smoke_autonomy.py
+++ b/scripts/smoke_autonomy.py
@@ -6,11 +6,15 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
+from unittest.mock import patch
 from pathlib import Path
 
 from tools.autonomy_guard import (
     command_mutates_filesystem,
     enforce_write_policy,
+    evaluate_delegate_request,
+    evaluate_execute_code,
+    evaluate_mcp_tool_call,
     evaluate_terminal_command,
     load_autonomy_policy,
     run_bootstrap_preflight,
@@ -46,6 +50,23 @@ def main() -> int:
 
         approval = evaluate_terminal_command("git push origin HEAD", workdir=str(repo))
         assert approval["status"] == "approval_required"
+        code_approval = evaluate_execute_code("eval(\"print(1)\")", workdir=str(repo))
+        assert code_approval["status"] == "approval_required"
+
+    with patch.dict(
+        "toolsets.TOOLSETS",
+        {"github": {"description": "MCP server 'github' tools", "tools": ["mcp_github_create_pull_request"]}},
+        clear=False,
+    ):
+        delegate_approval = evaluate_delegate_request(
+            toolsets=["github"],
+            tasks=None,
+            acp_command=None,
+        )
+        assert delegate_approval["status"] == "approval_required"
+
+    mcp_approval = evaluate_mcp_tool_call("github", "create_pull_request")
+    assert mcp_approval["status"] == "approval_required"
 
     preflight = run_bootstrap_preflight(
         explicit_api_key="smoke-key",

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -200,9 +200,18 @@ class TestHandleUpdateCommand:
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
 
+        def fake_run(cmd, **kwargs):
+            joined = " ".join(cmd)
+            if "rev-parse --abbrev-ref HEAD" in joined:
+                return MagicMock(stdout="main\n")
+            if "status --porcelain" in joined:
+                return MagicMock(stdout="")
+            raise AssertionError(f"unexpected command: {cmd}")
+
         with patch("gateway.run._hermes_home", hermes_home), \
              patch("gateway.run.__file__", fake_file), \
              patch("shutil.which", side_effect=lambda x: "/usr/bin/hermes" if x == "hermes" else "/usr/bin/setsid"), \
+             patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen"):
             result = await runner._handle_update_command(event)
 
@@ -212,6 +221,10 @@ class TestHandleUpdateCommand:
         assert data["platform"] == "telegram"
         assert data["chat_id"] == "99999"
         assert "timestamp" in data
+        assert data["update_source"] == "gateway_message"
+        assert data["checkout_branch"] == "main"
+        assert data["checkout_dirty"] is False
+        assert data["dev_checkout"] is False
         assert not (hermes_home / ".update_exit_code").exists()
 
     @pytest.mark.asyncio

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,4 +1,4 @@
-"""Tests for cmd_update — branch fallback when remote branch doesn't exist."""
+"""Focused tests for cmd_update checkout protection."""
 
 import subprocess
 from types import SimpleNamespace
@@ -6,32 +6,29 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.main import cmd_update
 
 
-def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
-    """Build a side_effect function for subprocess.run that simulates git commands."""
+def _make_run_side_effect(*, branch="main", dirty=False, commit_count="0"):
+    recorded = []
 
     def side_effect(cmd, **kwargs):
+        recorded.append(cmd)
         joined = " ".join(str(c) for c in cmd)
 
-        # git rev-parse --abbrev-ref HEAD  (get current branch)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return subprocess.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
 
-        # git rev-parse --verify origin/{branch}  (check remote branch exists)
-        if "rev-parse" in joined and "--verify" in joined:
-            rc = 0 if verify_ok else 128
-            return subprocess.CompletedProcess(cmd, rc, stdout="", stderr="")
+        if "status --porcelain" in joined:
+            stdout = " M hermes_cli/main.py\n" if dirty else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
-        # git rev-list HEAD..origin/{branch} --count
         if "rev-list" in joined:
             return subprocess.CompletedProcess(cmd, 0, stdout=f"{commit_count}\n", stderr="")
 
-        # Fallback: return a successful CompletedProcess with empty stdout
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-    return side_effect
+    return side_effect, recorded
 
 
 @pytest.fixture
@@ -39,90 +36,51 @@ def mock_args():
     return SimpleNamespace()
 
 
-class TestCmdUpdateBranchFallback:
-    """cmd_update falls back to main when current branch has no remote counterpart."""
+@patch("shutil.which", return_value=None)
+@patch("subprocess.run")
+def test_update_blocks_non_main_checkout(mock_run, _mock_which, mock_args, capsys):
+    """cmd_update should refuse feature branches instead of silently switching."""
+    mock_run.side_effect, recorded = _make_run_side_effect(branch="feature/safe-branch")
 
-    @patch("shutil.which", return_value=None)
-    @patch("subprocess.run")
-    def test_update_falls_back_to_main_when_branch_not_on_remote(
-        self, mock_run, _mock_which, mock_args, capsys
-    ):
-        mock_run.side_effect = _make_run_side_effect(
-            branch="fix/stoicneko", verify_ok=False, commit_count="3"
-        )
-
+    with pytest.raises(SystemExit, match="1"):
         cmd_update(mock_args)
 
-        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+    commands = [" ".join(str(a) for a in cmd) for cmd in recorded]
+    assert all("fetch origin" not in command for command in commands)
 
-        # rev-list should use origin/main, not origin/fix/stoicneko
-        rev_list_cmds = [c for c in commands if "rev-list" in c]
-        assert len(rev_list_cmds) == 1
-        assert "origin/main" in rev_list_cmds[0]
-        assert "origin/fix/stoicneko" not in rev_list_cmds[0]
+    out = capsys.readouterr().out
+    assert "Refusing to update this checkout" in out
+    assert "feature/safe-branch" in out
 
-        # pull should use main, not fix/stoicneko
-        pull_cmds = [c for c in commands if "pull" in c]
-        assert len(pull_cmds) == 1
-        assert "main" in pull_cmds[0]
 
-    @patch("shutil.which", return_value=None)
-    @patch("subprocess.run")
-    def test_update_uses_current_branch_when_on_remote(
-        self, mock_run, _mock_which, mock_args, capsys
-    ):
-        mock_run.side_effect = _make_run_side_effect(
-            branch="main", verify_ok=True, commit_count="2"
-        )
+@patch("shutil.which", return_value=None)
+@patch("subprocess.run")
+def test_update_blocks_dirty_checkout(mock_run, _mock_which, mock_args, capsys):
+    """Dirty worktrees should fail before any network or reset action."""
+    mock_run.side_effect, recorded = _make_run_side_effect(dirty=True)
 
+    with pytest.raises(SystemExit, match="1"):
         cmd_update(mock_args)
 
-        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+    commands = [" ".join(str(a) for a in cmd) for cmd in recorded]
+    assert all("fetch origin" not in command for command in commands)
 
-        rev_list_cmds = [c for c in commands if "rev-list" in c]
-        assert len(rev_list_cmds) == 1
-        assert "origin/main" in rev_list_cmds[0]
+    out = capsys.readouterr().out
+    assert "working tree has local changes" in out
 
-        pull_cmds = [c for c in commands if "pull" in c]
-        assert len(pull_cmds) == 1
-        assert "main" in pull_cmds[0]
 
-    @patch("shutil.which", return_value=None)
-    @patch("subprocess.run")
-    def test_update_already_up_to_date(
-        self, mock_run, _mock_which, mock_args, capsys
-    ):
-        mock_run.side_effect = _make_run_side_effect(
-            branch="main", verify_ok=True, commit_count="0"
-        )
+@patch("shutil.which", return_value=None)
+@patch("subprocess.run")
+def test_update_blocks_dev_checkout_env(mock_run, _mock_which, mock_args, capsys, monkeypatch):
+    """An explicit dev-checkout env flag should hard-block self-update."""
+    monkeypatch.setenv("HERMES_DEV_CHECKOUT", "1")
+    mock_run.side_effect, recorded = _make_run_side_effect()
 
+    with pytest.raises(SystemExit, match="1"):
         cmd_update(mock_args)
 
-        captured = capsys.readouterr()
-        assert "Already up to date!" in captured.out
+    commands = [" ".join(str(a) for a in cmd) for cmd in recorded]
+    assert all("fetch origin" not in command for command in commands)
 
-        # Should NOT have called pull
-        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
-        pull_cmds = [c for c in commands if "pull" in c]
-        assert len(pull_cmds) == 0
-
-    def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
-        """When stdin/stdout aren't TTYs, config migration prompt is skipped."""
-        with patch("shutil.which", return_value=None), patch(
-            "subprocess.run"
-        ) as mock_run, patch("builtins.input") as mock_input, patch(
-            "hermes_cli.config.get_missing_env_vars", return_value=["MISSING_KEY"]
-        ), patch("hermes_cli.config.get_missing_config_fields", return_value=[]), patch(
-            "hermes_cli.config.check_config_version", return_value=(1, 2)
-        ), patch("hermes_cli.main.sys") as mock_sys:
-            mock_sys.stdin.isatty.return_value = False
-            mock_sys.stdout.isatty.return_value = False
-            mock_run.side_effect = _make_run_side_effect(
-                branch="main", verify_ok=True, commit_count="1"
-            )
-
-            cmd_update(mock_args)
-
-            mock_input.assert_not_called()
-            captured = capsys.readouterr()
-            assert "Non-interactive session" in captured.out
+    out = capsys.readouterr().out
+    assert "protected from self-update" in out

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -321,9 +321,11 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "origin", "main"]:
+        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
@@ -366,9 +368,11 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
         if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "origin", "main"]:
+        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         return SimpleNamespace(returncode=0)
 
@@ -388,6 +392,7 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    dirty=False,
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
@@ -405,6 +410,9 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
+        if "status" in joined and "--porcelain" in joined:
+            stdout = " M hermes_cli/main.py\n" if dirty else ""
+            return SimpleNamespace(stdout=stdout, stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
@@ -459,76 +467,94 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Non-main branch → auto-checkout main
+# Unsafe checkout state → block update
 # ---------------------------------------------------------------------------
 
-def test_cmd_update_switches_to_main_from_feature_branch(monkeypatch, tmp_path, capsys):
-    """When on a feature branch, update checks out main before pulling."""
+def test_cmd_update_blocks_feature_branch(monkeypatch, tmp_path, capsys):
+    """Feature branches are dev checkouts; update must refuse instead of switching."""
     _setup_update_mocks(monkeypatch, tmp_path)
-    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(current_branch="fix/something")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
 
-    checkout_calls = [c for c in recorded if "checkout" in c and "main" in c]
-    assert len(checkout_calls) == 1
+    checkout_calls = [c for c in recorded if "checkout" in c]
+    fetch_calls = [c for c in recorded if c[:3] == ["git", "fetch", "origin"]]
+    assert checkout_calls == []
+    assert fetch_calls == []
 
     out = capsys.readouterr().out
+    assert "Refusing to update this checkout" in out
     assert "fix/something" in out
-    assert "switching to main" in out
 
 
-def test_cmd_update_switches_to_main_from_detached_head(monkeypatch, tmp_path, capsys):
-    """When in detached HEAD state, update checks out main before pulling."""
+def test_cmd_update_blocks_detached_head(monkeypatch, tmp_path, capsys):
+    """Detached HEAD is not a safe runtime checkout for self-update."""
     _setup_update_mocks(monkeypatch, tmp_path)
-    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(current_branch="HEAD")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
 
-    checkout_calls = [c for c in recorded if "checkout" in c and "main" in c]
-    assert len(checkout_calls) == 1
+    checkout_calls = [c for c in recorded if "checkout" in c]
+    assert checkout_calls == []
 
     out = capsys.readouterr().out
     assert "detached HEAD" in out
+    assert "Refusing to update this checkout" in out
 
 
-def test_cmd_update_restores_stash_and_branch_when_already_up_to_date(monkeypatch, tmp_path, capsys):
-    """When on a feature branch with no updates, stash is restored and branch switched back."""
+def test_cmd_update_blocks_dirty_worktree(monkeypatch, tmp_path, capsys):
+    """Local changes must be resolved explicitly before update runs."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    side_effect, recorded = _make_update_side_effect(dirty=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "working tree has local changes" in out
+    fetch_calls = [c for c in recorded if c[:3] == ["git", "fetch", "origin"]]
+    assert fetch_calls == []
+
+
+def test_cmd_update_blocks_dev_checkout_marker(monkeypatch, tmp_path, capsys):
+    """A dev-checkout marker should hard-block self-update even on main."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    (tmp_path / ".hermes-dev-checkout").write_text("")
+
+    side_effect, recorded = _make_update_side_effect()
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "protected from self-update" in out
+    fetch_calls = [c for c in recorded if c[:3] == ["git", "fetch", "origin"]]
+    assert fetch_calls == []
+
+
+def test_cmd_update_already_up_to_date_on_main(monkeypatch, tmp_path, capsys):
+    """Clean main checkouts should still report already-up-to-date cleanly."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
-    # Enable stash so it returns a ref
-    monkeypatch.setattr(
-        hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
-    )
-    restore_calls = []
-    monkeypatch.setattr(
-        hermes_main, "_restore_stashed_changes",
-        lambda *a, **kw: restore_calls.append(1) or True,
-    )
-
-    side_effect, recorded = _make_update_side_effect(
-        current_branch="fix/something", commit_count="0",
-    )
+    side_effect, recorded = _make_update_side_effect(current_branch="main", commit_count="0")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     hermes_main.cmd_update(SimpleNamespace())
 
-    # Stash should have been restored
-    assert len(restore_calls) == 1
-
-    # Should have checked out back to the original branch
-    checkout_back = [c for c in recorded if "checkout" in c and "fix/something" in c]
-    assert len(checkout_back) == 1
-
-    out = capsys.readouterr().out
-    assert "Already up to date" in out
+    pull_calls = [c for c in recorded if "pull" in c]
+    checkout_calls = [c for c in recorded if "checkout" in c]
+    assert pull_calls == []
+    assert checkout_calls == []
+    assert "Already up to date" in capsys.readouterr().out
 
 
 def test_cmd_update_no_checkout_when_already_on_main(monkeypatch, tmp_path):
@@ -584,22 +610,12 @@ def test_cmd_update_auth_error_shows_friendly_message(monkeypatch, tmp_path, cap
 
 
 # ---------------------------------------------------------------------------
-# reset --hard failure — don't attempt stash restore
+# reset --hard failure — stop with a clear error
 # ---------------------------------------------------------------------------
 
-def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, capsys):
-    """When reset --hard fails, stash restore is skipped with a helpful message."""
+def test_cmd_update_exits_when_reset_fails(monkeypatch, tmp_path, capsys):
+    """When reset --hard fails, update stops with a clear manual recovery hint."""
     _setup_update_mocks(monkeypatch, tmp_path)
-    # Re-enable stash so it actually returns a ref
-    monkeypatch.setattr(
-        hermes_main, "_stash_local_changes_if_needed",
-        lambda *a, **kw: "abc123deadbeef",
-    )
-    restore_calls = []
-    monkeypatch.setattr(
-        hermes_main, "_restore_stashed_changes",
-        lambda *a, **kw: restore_calls.append(1) or True,
-    )
 
     side_effect, _ = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
@@ -607,8 +623,5 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
     with pytest.raises(SystemExit, match="1"):
         hermes_main.cmd_update(SimpleNamespace())
 
-    # Stash restore should NOT have been called
-    assert len(restore_calls) == 0
-
     out = capsys.readouterr().out
-    assert "preserved in stash" in out
+    assert "Failed to reset to origin/main" in out

--- a/tests/run_agent/test_autonomy_runtime.py
+++ b/tests/run_agent/test_autonomy_runtime.py
@@ -1,0 +1,123 @@
+"""Runtime autonomy tests for bootstrap preflight and proof-of-done artifacts."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from run_agent import AIAgent
+from tests.run_agent.test_run_agent import _make_tool_defs, _mock_response, _mock_tool_call
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("write_file", "terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = patch("run_agent.OpenAI").start()
+        yield a
+        patch.stopall()
+
+
+def _setup_agent(agent: AIAgent) -> None:
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+
+
+def test_run_conversation_returns_preflight_failure_artifact(agent, tmp_path, monkeypatch):
+    _setup_agent(agent)
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with patch("run_agent.run_bootstrap_preflight", return_value={
+        "ok": False,
+        "diagnostics": ["Missing Hermes config"],
+        "message": "Autonomy bootstrap preflight failed:\n- Missing Hermes config",
+    }):
+        result = agent.run_conversation("build something")
+
+    assert result["completed"] is False
+    assert "preflight failed" in result["final_response"].lower()
+    artifact_path = Path(result["proof_of_done_artifact"])
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["preflight"]["ok"] is False
+
+
+def test_run_conversation_emits_proof_of_done_artifact(agent, tmp_path, monkeypatch):
+    _setup_agent(agent)
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    tc = _mock_tool_call(
+        name="write_file",
+        arguments=json.dumps({"path": "/tmp/example.txt", "content": "hello"}),
+        call_id="c1",
+    )
+    resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+    resp2 = _mock_response(content="Done", finish_reason="stop")
+    agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+    with (
+        patch("run_agent.run_bootstrap_preflight", return_value={"ok": True, "diagnostics": [], "message": "ok"}),
+        patch("run_agent.handle_function_call", return_value=json.dumps({"status": "ok"})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("write the file")
+
+    artifact_path = Path(result["proof_of_done_artifact"])
+    assert artifact_path.exists()
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert payload["completed"] is True
+    assert "/tmp/example.txt" in payload["files_touched"]
+    assert payload["preflight"]["ok"] is True
+    assert payload["status"] == "passed"
+    assert payload["stop_reason"]
+
+
+def test_proof_of_done_artifact_records_commands_and_gate_outcomes(agent, tmp_path, monkeypatch):
+    _setup_agent(agent)
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    tc = _mock_tool_call(
+        name="terminal",
+        arguments=json.dumps({"command": "python scripts/run_readiness.py", "workdir": str(tmp_path)}),
+        call_id="c2",
+    )
+    resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+    resp2 = _mock_response(content="Done", finish_reason="stop")
+    agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+    with (
+        patch("run_agent.run_bootstrap_preflight", return_value={"ok": True, "diagnostics": [], "message": "ok"}),
+        patch("run_agent.handle_function_call", return_value=json.dumps({"status": "ok", "exit_code": 0})),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("verify the repo")
+
+    payload = json.loads(Path(result["proof_of_done_artifact"]).read_text(encoding="utf-8"))
+    assert payload["status"] == "passed"
+    assert "python scripts/run_readiness.py" in payload["commands_run"]
+    assert payload["gates_run"][0]["name"] == "run_readiness"
+    assert payload["gates_run"][0]["outcome"] == "passed"
+    assert payload["next_required_human_action"] is None

--- a/tests/run_agent/test_autonomy_runtime.py
+++ b/tests/run_agent/test_autonomy_runtime.py
@@ -89,6 +89,7 @@ def test_run_conversation_emits_proof_of_done_artifact(agent, tmp_path, monkeypa
     assert payload["preflight"]["ok"] is True
     assert payload["status"] == "passed"
     assert payload["stop_reason"]
+    assert payload["stop_reason_code"]
 
 
 def test_proof_of_done_artifact_records_commands_and_gate_outcomes(agent, tmp_path, monkeypatch):
@@ -121,3 +122,4 @@ def test_proof_of_done_artifact_records_commands_and_gate_outcomes(agent, tmp_pa
     assert payload["gates_run"][0]["name"] == "run_readiness"
     assert payload["gates_run"][0]["outcome"] == "passed"
     assert payload["next_required_human_action"] is None
+    assert payload["stop_reason_code"] == "text_response"

--- a/tests/tools/test_autonomy_guard.py
+++ b/tests/tools/test_autonomy_guard.py
@@ -1,0 +1,186 @@
+"""Autonomy guard tests for protected branches, approvals, and tool wiring."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools import autonomy_guard
+from tools.autonomy_guard import enforce_write_policy, evaluate_terminal_command, run_bootstrap_preflight
+
+
+def _init_repo(tmp_path: Path, branch: str = "main") -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", branch], cwd=repo, check=True, capture_output=True, text=True)
+    (repo / "tracked.txt").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return repo
+
+
+@pytest.fixture(autouse=True)
+def _clear_policy_cache():
+    autonomy_guard.load_autonomy_policy.cache_clear()
+    yield
+    autonomy_guard.load_autonomy_policy.cache_clear()
+
+
+def test_enforce_write_policy_blocks_protected_branch(tmp_path):
+    repo = _init_repo(tmp_path, branch="main")
+    decision = enforce_write_policy("write_file", str(repo / "tracked.txt"))
+    assert decision["allowed"] is False
+    assert decision["status"] == "blocked"
+    assert decision["branch"] == "main"
+
+
+def test_enforce_write_policy_allows_feature_branch(tmp_path):
+    repo = _init_repo(tmp_path, branch="codex/test-branch")
+    decision = enforce_write_policy("write_file", str(repo / "tracked.txt"))
+    assert decision["allowed"] is True
+    assert decision["branch"] == "codex/test-branch"
+
+
+def test_terminal_policy_requires_approval_for_push(tmp_path):
+    repo = _init_repo(tmp_path, branch="codex/push-test")
+    decision = evaluate_terminal_command("git push origin HEAD", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+    assert "push commits" in decision["description"]
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("git tag v1.2.3", "git tag"),
+        ("gh pr merge 123 --squash", "pull request"),
+        ("npm publish", "publish"),
+    ],
+)
+def test_terminal_policy_requires_approval_for_release_commands(tmp_path, command, expected):
+    repo = _init_repo(tmp_path, branch="codex/release-test")
+    decision = evaluate_terminal_command(command, workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+    assert expected in decision["message"].lower() or expected in decision["description"].lower()
+
+
+def test_terminal_policy_blocks_forbidden_bypass(tmp_path):
+    repo = _init_repo(tmp_path, branch="codex/safe")
+    decision = evaluate_terminal_command("claude --dangerously-skip-permissions", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "blocked"
+
+
+def test_terminal_policy_blocks_mutating_command_on_main(tmp_path):
+    repo = _init_repo(tmp_path, branch="main")
+    decision = evaluate_terminal_command("git add tracked.txt", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "blocked"
+    assert "protected branch" in decision["message"]
+
+
+@patch("tools.file_tools._get_file_ops")
+def test_write_file_tool_returns_blocked_when_policy_denies(mock_get):
+    from tools.file_tools import write_file_tool
+
+    with patch(
+        "tools.file_tools.enforce_write_policy",
+        return_value={"allowed": False, "status": "blocked", "branch": "main", "repo_root": "/tmp/repo", "message": "blocked"},
+    ):
+        result = json.loads(write_file_tool("/tmp/out.txt", "data"))
+
+    assert result["status"] == "blocked"
+    assert result["error"] == "blocked"
+    mock_get.assert_not_called()
+
+
+def test_terminal_tool_returns_approval_required_before_exec():
+    from tools.terminal_tool import terminal_tool
+
+    with patch("tools.terminal_tool._get_env_config", return_value={
+        "env_type": "local",
+        "timeout": 180,
+        "cwd": "/tmp",
+        "host_cwd": None,
+        "modal_mode": "auto",
+        "docker_image": "",
+        "singularity_image": "",
+        "modal_image": "",
+        "daytona_image": "",
+    }), patch("tools.terminal_tool._start_cleanup_thread"), patch(
+        "tools.terminal_tool.evaluate_terminal_command",
+        return_value={
+            "allowed": False,
+            "status": "approval_required",
+            "description": "push commits to a remote",
+            "message": "approval required",
+        },
+    ):
+        result = json.loads(terminal_tool("git push origin HEAD"))
+
+    assert result["status"] == "approval_required"
+    assert "approval required" in result["error"]
+
+
+def test_bootstrap_preflight_accepts_explicit_credentials(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = run_bootstrap_preflight(
+        explicit_api_key="test-key",
+        explicit_base_url="https://example.com/v1",
+        requested_provider="openrouter",
+    )
+
+    assert result["ok"] is True
+
+
+def test_terminal_policy_fails_closed_when_policy_is_malformed(tmp_path, monkeypatch):
+    malformed = tmp_path / "autonomy_policy.yaml"
+    malformed.write_text("approval: [\n", encoding="utf-8")
+    monkeypatch.setattr(autonomy_guard, "POLICY_PATH", malformed)
+    autonomy_guard.load_autonomy_policy.cache_clear()
+
+    decision = evaluate_terminal_command("git push origin HEAD", workdir=str(tmp_path))
+    assert decision["allowed"] is False
+    assert decision["status"] == "blocked"
+    assert "malformed" in decision["message"].lower()
+
+
+def test_bootstrap_preflight_fails_closed_when_policy_is_missing(tmp_path, monkeypatch):
+    missing = tmp_path / "missing-policy.yaml"
+    monkeypatch.setattr(autonomy_guard, "POLICY_PATH", missing)
+    autonomy_guard.load_autonomy_policy.cache_clear()
+
+    result = run_bootstrap_preflight(
+        explicit_api_key="test-key",
+        explicit_base_url="https://example.com/v1",
+        requested_provider="openrouter",
+    )
+
+    assert result["ok"] is False
+    assert "missing" in result["message"].lower()
+
+
+def test_write_file_tool_blocks_when_policy_is_malformed(tmp_path, monkeypatch):
+    from tools.file_tools import write_file_tool
+
+    malformed = tmp_path / "autonomy_policy.yaml"
+    malformed.write_text("branch_protection: [\n", encoding="utf-8")
+    monkeypatch.setattr(autonomy_guard, "POLICY_PATH", malformed)
+    autonomy_guard.load_autonomy_policy.cache_clear()
+    monkeypatch.setattr("tools.file_tools._check_sensitive_path", lambda _path: None)
+
+    result = json.loads(write_file_tool(str(tmp_path / "out.txt"), "data"))
+    assert result["status"] == "blocked"
+    assert "malformed" in result["error"].lower()

--- a/tests/tools/test_autonomy_guard.py
+++ b/tests/tools/test_autonomy_guard.py
@@ -8,7 +8,12 @@ from unittest.mock import patch
 import pytest
 
 from tools import autonomy_guard
-from tools.autonomy_guard import enforce_write_policy, evaluate_terminal_command, run_bootstrap_preflight
+from tools.autonomy_guard import (
+    enforce_write_policy,
+    evaluate_execute_code,
+    evaluate_terminal_command,
+    run_bootstrap_preflight,
+)
 
 
 def _init_repo(tmp_path: Path, branch: str = "main") -> Path:
@@ -86,6 +91,22 @@ def test_terminal_policy_blocks_mutating_command_on_main(tmp_path):
     assert decision["allowed"] is False
     assert decision["status"] == "blocked"
     assert "protected branch" in decision["message"]
+
+
+def test_execute_code_policy_blocks_raw_write_on_main(tmp_path):
+    repo = _init_repo(tmp_path, branch="main")
+    decision = evaluate_execute_code("from pathlib import Path\nPath('tracked.txt').write_text('x')", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "blocked"
+    assert "feature branch" in decision["message"].lower()
+
+
+def test_execute_code_policy_requires_approval_for_subprocess(tmp_path):
+    repo = _init_repo(tmp_path, branch="codex/safe")
+    decision = evaluate_execute_code("import subprocess\nsubprocess.run(['git', 'push'])", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+    assert "subprocesses" in decision["description"]
 
 
 @patch("tools.file_tools._get_file_ops")
@@ -170,6 +191,17 @@ def test_bootstrap_preflight_fails_closed_when_policy_is_missing(tmp_path, monke
 
     assert result["ok"] is False
     assert "missing" in result["message"].lower()
+
+
+def test_execute_code_policy_fails_closed_when_policy_is_missing(tmp_path, monkeypatch):
+    missing = tmp_path / "missing-policy.yaml"
+    monkeypatch.setattr(autonomy_guard, "POLICY_PATH", missing)
+    autonomy_guard.load_autonomy_policy.cache_clear()
+
+    decision = evaluate_execute_code("print('hi')", workdir=str(tmp_path))
+    assert decision["allowed"] is False
+    assert decision["status"] == "blocked"
+    assert "missing" in decision["message"].lower()
 
 
 def test_write_file_tool_blocks_when_policy_is_malformed(tmp_path, monkeypatch):

--- a/tests/tools/test_autonomy_guard.py
+++ b/tests/tools/test_autonomy_guard.py
@@ -10,8 +10,11 @@ import pytest
 from tools import autonomy_guard
 from tools.autonomy_guard import (
     enforce_write_policy,
+    evaluate_delegate_request,
     evaluate_execute_code,
+    evaluate_mcp_tool_call,
     evaluate_terminal_command,
+    normalize_stop_reason,
     run_bootstrap_preflight,
 )
 
@@ -107,6 +110,45 @@ def test_execute_code_policy_requires_approval_for_subprocess(tmp_path):
     assert decision["allowed"] is False
     assert decision["status"] == "approval_required"
     assert "subprocesses" in decision["description"]
+
+
+def test_execute_code_policy_requires_approval_for_eval(tmp_path):
+    repo = _init_repo(tmp_path, branch="codex/safe")
+    decision = evaluate_execute_code("eval(\"open('tracked.txt', 'w').write('x')\")", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+    assert "dynamic python" in decision["description"].lower()
+
+
+def test_execute_code_policy_requires_approval_for_indirect_os_system(tmp_path):
+    repo = _init_repo(tmp_path, branch="codex/safe")
+    decision = evaluate_execute_code("__import__('os').system('git push origin HEAD')", workdir=str(repo))
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+    assert "dynamic imports" in decision["description"].lower()
+
+
+def test_delegate_policy_requires_approval_for_explicit_mcp_toolset(monkeypatch):
+    monkeypatch.setitem(
+        __import__("toolsets").TOOLSETS,
+        "github",
+        {"description": "MCP server 'github' tools", "tools": ["mcp_github_create_pull_request"]},
+    )
+    decision = evaluate_delegate_request(toolsets=["github"], tasks=None, acp_command=None)
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+
+
+def test_mcp_policy_requires_approval_for_mutating_tool():
+    decision = evaluate_mcp_tool_call("github", "create_pull_request")
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+
+
+def test_normalize_stop_reason_collapses_dynamic_variants():
+    assert normalize_stop_reason("text_response(finish_reason=stop)") == "text_response"
+    assert normalize_stop_reason("max_iterations_reached(3/3)") == "max_iterations_reached"
+    assert normalize_stop_reason(None) == "unknown"
 
 
 @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_autonomy_guard.py
+++ b/tests/tools/test_autonomy_guard.py
@@ -139,6 +139,23 @@ def test_delegate_policy_requires_approval_for_explicit_mcp_toolset(monkeypatch)
     assert decision["status"] == "approval_required"
 
 
+def test_delegate_policy_requires_approval_for_nested_mcp_toolset(monkeypatch):
+    toolsets_mod = __import__("toolsets")
+    monkeypatch.setitem(
+        toolsets_mod.TOOLSETS,
+        "github",
+        {"description": "MCP server 'github' tools", "tools": ["mcp_github_create_pull_request"]},
+    )
+    monkeypatch.setitem(
+        toolsets_mod.TOOLSETS,
+        "release-bot",
+        {"description": "alias", "tools": [], "includes": ["github"]},
+    )
+    decision = evaluate_delegate_request(toolsets=["release-bot"], tasks=None, acp_command=None)
+    assert decision["allowed"] is False
+    assert decision["status"] == "approval_required"
+
+
 def test_mcp_policy_requires_approval_for_mutating_tool():
     decision = evaluate_mcp_tool_call("github", "create_pull_request")
     assert decision["allowed"] is False
@@ -148,6 +165,8 @@ def test_mcp_policy_requires_approval_for_mutating_tool():
 def test_normalize_stop_reason_collapses_dynamic_variants():
     assert normalize_stop_reason("text_response(finish_reason=stop)") == "text_response"
     assert normalize_stop_reason("max_iterations_reached(3/3)") == "max_iterations_reached"
+    assert normalize_stop_reason("bootstrap_preflight_failed") == "bootstrap_preflight_failed"
+    assert normalize_stop_reason("interrupted_by_user") == "interrupted_by_user"
     assert normalize_stop_reason(None) == "unknown"
 
 

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -17,6 +17,7 @@ import pytest
 
 import json
 import os
+import subprocess
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -34,6 +35,7 @@ import sys
 import time
 import threading
 import unittest
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from tools.code_execution_tool import (
@@ -242,6 +244,36 @@ print(result)
         """Empty code string returns an error."""
         result = json.loads(execute_code("", task_id="test"))
         self.assertIn("error", result)
+
+    def test_execute_code_blocks_raw_write_on_main_branch(self):
+        # unittest helpers don't provide tmp_path; use a real temp repo.
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True, text=True)
+            (repo / "tracked.txt").write_text("hello\n", encoding="utf-8")
+            subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True, capture_output=True, text=True)
+            subprocess.run(
+                ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            previous = os.getcwd()
+            try:
+                os.chdir(repo)
+                result = json.loads(execute_code("from pathlib import Path\nPath('tracked.txt').write_text('mutated')", task_id="test"))
+            finally:
+                os.chdir(previous)
+        self.assertEqual(result["status"], "blocked")
+        self.assertIn("protected branch", result["error"])
+
+    def test_execute_code_requires_approval_for_subprocess_bypass(self):
+        result = json.loads(execute_code("import subprocess\nsubprocess.run(['git', 'push'])", task_id="test"))
+        self.assertEqual(result["status"], "approval_required")
+        self.assertIn("subprocess", result["description"].lower())
 
     def test_output_captured(self):
         """Multiple print statements are captured in order."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -222,6 +222,17 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("ACP command override", result["error"])
         mock_run.assert_not_called()
 
+    @patch("tools.delegate_tool._run_single_child")
+    def test_per_task_acp_command_requires_approval(self, mock_run):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(
+            tasks=[{"goal": "Run Claude child", "acp_command": "claude"}],
+            parent_agent=parent,
+        ))
+        self.assertEqual(result["status"], "approval_required")
+        self.assertIn("ACP command override", result["error"])
+        mock_run.assert_not_called()
+
     def test_depth_increments(self):
         """Verify child gets parent's depth + 1."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -205,6 +205,23 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["status"], "error")
         self.assertIn("Something broke", result["results"][0]["error"])
 
+    @patch.dict("toolsets.TOOLSETS", {"github": {"description": "MCP server 'github' tools", "tools": ["mcp_github_create_pull_request"]}}, clear=False)
+    @patch("tools.delegate_tool._run_single_child")
+    def test_explicit_mcp_toolset_requires_approval(self, mock_run):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="Open a PR", toolsets=["github"], parent_agent=parent))
+        self.assertEqual(result["status"], "approval_required")
+        self.assertIn("MCP-backed toolset", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_acp_command_requires_approval(self, mock_run):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="Run Claude child", acp_command="claude", parent_agent=parent))
+        self.assertEqual(result["status"], "approval_required")
+        self.assertIn("ACP command override", result["error"])
+        mock_run.assert_not_called()
+
     def test_depth_increments(self):
         """Verify child gets parent's depth + 1."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -240,6 +240,23 @@ class TestToolHandler:
         assert "error" in result
         assert "not connected" in result["error"]
 
+    def test_mutating_mcp_tool_requires_approval(self):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=_make_call_result("should not run", is_error=False))
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "create_pull_request", 120)
+            result = json.loads(handler({}))
+            assert result["status"] == "approval_required"
+            assert "autonomy policy" in result["error"].lower()
+            mock_session.call_tool.assert_not_called()
+        finally:
+            _servers.pop("test_srv", None)
+
     def test_exception_during_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers
 
@@ -1179,7 +1196,11 @@ class TestConfigurableTimeouts:
         try:
             handler = _make_tool_handler("test_srv", "my_tool", 180)
             with patch("tools.mcp_tool._run_on_mcp_loop") as mock_run:
-                mock_run.return_value = json.dumps({"result": "ok"})
+                def _fake_run(coro, timeout=30):
+                    coro.close()
+                    return json.dumps({"result": "ok"})
+
+                mock_run.side_effect = _fake_run
                 handler({})
                 # Verify timeout=180 was passed
                 call_kwargs = mock_run.call_args

--- a/tools/autonomy_guard.py
+++ b/tools/autonomy_guard.py
@@ -1,0 +1,459 @@
+"""Core autonomy policy loading and enforcement helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+
+POLICY_PATH = Path(__file__).resolve().parent.parent / "autonomy_policy.yaml"
+
+
+class AutonomyPolicyError(RuntimeError):
+    """Raised when the autonomy policy is unavailable or malformed."""
+
+
+@lru_cache(maxsize=1)
+def load_autonomy_policy() -> Dict[str, Any]:
+    """Load the repo-local autonomy policy."""
+    try:
+        with POLICY_PATH.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except FileNotFoundError as exc:
+        raise AutonomyPolicyError(f"Autonomy policy is missing at {POLICY_PATH}.") from exc
+    except yaml.YAMLError as exc:
+        raise AutonomyPolicyError(f"Autonomy policy at {POLICY_PATH} is malformed: {exc}") from exc
+    if not isinstance(data, dict):
+        raise AutonomyPolicyError(f"Autonomy policy at {POLICY_PATH} must be a mapping.")
+    return data
+
+
+def _iter_pattern_entries(entries: Iterable[Dict[str, Any]]) -> Iterable[tuple[re.Pattern[str], str]]:
+    for entry in entries:
+        pattern = entry.get("pattern", "")
+        description = entry.get("description", pattern or "policy rule")
+        if not isinstance(pattern, str) or not pattern.strip():
+            continue
+        yield re.compile(pattern, re.IGNORECASE), str(description)
+
+
+def _git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def get_git_context(start_path: str) -> Dict[str, Optional[str]]:
+    """Return git repo metadata for the given path, if any."""
+    path = Path(start_path).expanduser()
+    base = path if path.is_dir() else path.parent
+    base = base.resolve()
+    repo_root_proc = _git(["rev-parse", "--show-toplevel"], str(base))
+    if repo_root_proc.returncode != 0:
+        return {"repo_root": None, "branch": None}
+
+    repo_root = repo_root_proc.stdout.strip()
+    branch_proc = _git(["branch", "--show-current"], repo_root)
+    branch = branch_proc.stdout.strip() if branch_proc.returncode == 0 else ""
+    return {"repo_root": repo_root or None, "branch": branch or None}
+
+
+def _protected_branches() -> set[str]:
+    policy = load_autonomy_policy()
+    branches = policy.get("branch_protection", {}).get("protected_branches", [])
+    return {str(branch).strip() for branch in branches if str(branch).strip()}
+
+
+def enforce_write_policy(action: str, target_path: str) -> Dict[str, Any]:
+    """Block mutating writes on protected branches."""
+    try:
+        protected_branches = _protected_branches()
+    except AutonomyPolicyError as exc:
+        return {
+            "allowed": False,
+            "status": "blocked",
+            "branch": None,
+            "repo_root": None,
+            "description": "autonomy policy unavailable",
+            "message": f"BLOCKED: {exc}",
+        }
+    git_ctx = get_git_context(target_path)
+    branch = git_ctx.get("branch")
+    repo_root = git_ctx.get("repo_root")
+    if repo_root and branch in protected_branches:
+        return {
+            "allowed": False,
+            "status": "blocked",
+            "branch": branch,
+            "repo_root": repo_root,
+            "message": (
+                f"BLOCKED: {action} is not allowed on protected branch '{branch}'. "
+                "Create or switch to a feature branch before writing."
+            ),
+        }
+    return {
+        "allowed": True,
+        "status": "ok",
+        "branch": branch,
+        "repo_root": repo_root,
+    }
+
+
+def command_mutates_filesystem(command: str) -> bool:
+    """Return True when the command is likely to change files or git state."""
+    policy = load_autonomy_policy()
+    entries = policy.get("terminal_writes", {}).get("patterns", [])
+    for regex, _description in _iter_pattern_entries(entries):
+        if regex.search(command):
+            return True
+    return False
+
+
+def evaluate_terminal_command(command: str, *, workdir: Optional[str], force: bool = False) -> Dict[str, Any]:
+    """Apply autonomy policy to terminal execution."""
+    try:
+        policy = load_autonomy_policy()
+    except AutonomyPolicyError as exc:
+        return {
+            "allowed": False,
+            "status": "blocked",
+            "description": "autonomy policy unavailable",
+            "message": f"BLOCKED: {exc}",
+        }
+    approval_cfg = policy.get("approval", {})
+
+    for fragment in approval_cfg.get("forbidden_command_fragments", []):
+        text = str(fragment).strip()
+        if text and text in command:
+            return {
+                "allowed": False,
+                "status": "blocked",
+                "description": f"forbidden autonomy bypass: {text}",
+                "message": (
+                    f"BLOCKED: autonomy policy forbids `{text}` in terminal commands."
+                ),
+            }
+
+    cwd = workdir or os.getenv("TERMINAL_CWD", os.getcwd())
+    if command_mutates_filesystem(command):
+        write_decision = enforce_write_policy("terminal command", cwd)
+        if not write_decision["allowed"]:
+            write_decision["description"] = "write on protected branch"
+            return write_decision
+
+    for regex, description in _iter_pattern_entries(
+        approval_cfg.get("require_explicit_approval_patterns", [])
+    ):
+        if regex.search(command):
+            if force:
+                return {
+                    "allowed": True,
+                    "status": "ok",
+                    "description": description,
+                    "approved_via_force": True,
+                }
+            return {
+                "allowed": False,
+                "status": "approval_required",
+                "description": description,
+                "message": (
+                    f"Human approval required by autonomy policy: {description}.\n\n"
+                    f"Command:\n```\n{command}\n```"
+                ),
+            }
+
+    return {"allowed": True, "status": "ok"}
+
+
+def _has_explicit_runtime_credentials(explicit_api_key: Optional[str], explicit_base_url: Optional[str]) -> bool:
+    return bool((explicit_api_key or "").strip() or (explicit_base_url or "").strip())
+
+
+def run_bootstrap_preflight(
+    *,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+    requested_provider: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Validate machine prerequisites before an autonomous turn runs."""
+    try:
+        policy = load_autonomy_policy()
+    except AutonomyPolicyError as exc:
+        return {
+            "ok": False,
+            "provider": None,
+            "diagnostics": [str(exc)],
+            "message": f"Autonomy bootstrap preflight failed:\n- {exc}",
+        }
+    bootstrap = policy.get("bootstrap", {})
+    diagnostics: list[str] = []
+
+    missing_commands = [
+        cmd for cmd in bootstrap.get("required_commands", [])
+        if not shutil.which(str(cmd))
+    ]
+    if missing_commands:
+        diagnostics.append(
+            "Missing required commands: " + ", ".join(sorted(missing_commands))
+        )
+
+    hermes_home = get_hermes_home()
+    config_path = hermes_home / "config.yaml"
+    explicit_creds = _has_explicit_runtime_credentials(explicit_api_key, explicit_base_url)
+
+    if (
+        bootstrap.get("require_hermes_config_without_explicit_credentials", True)
+        and not explicit_creds
+        and not config_path.exists()
+    ):
+        diagnostics.append(
+            f"Missing Hermes config at {config_path}. Run `hermes model` or `hermes setup` first."
+        )
+
+    provider = None
+    if bootstrap.get("require_provider_resolution", True):
+        try:
+            from hermes_cli.auth import AuthError, get_auth_status, resolve_provider
+
+            provider = resolve_provider(
+                requested=requested_provider,
+                explicit_api_key=explicit_api_key,
+                explicit_base_url=explicit_base_url,
+            )
+
+            if bootstrap.get("require_provider_auth", True) and not explicit_creds:
+                if provider == "openrouter":
+                    has_openrouter_key = bool(os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY"))
+                    if not has_openrouter_key:
+                        diagnostics.append(
+                            "Resolved provider 'openrouter' but no OPENROUTER_API_KEY or OPENAI_API_KEY is available."
+                        )
+                else:
+                    status = get_auth_status(provider)
+                    if not status.get("logged_in"):
+                        msg = status.get("error") or f"Provider '{provider}' is not authenticated."
+                        diagnostics.append(str(msg))
+        except AuthError as exc:
+            diagnostics.append(str(exc))
+        except Exception as exc:  # pragma: no cover - defensive path
+            diagnostics.append(f"Autonomy bootstrap preflight failed: {exc}")
+
+    if diagnostics:
+        return {
+            "ok": False,
+            "provider": provider,
+            "diagnostics": diagnostics,
+            "message": "Autonomy bootstrap preflight failed:\n- " + "\n- ".join(diagnostics),
+        }
+
+    return {
+        "ok": True,
+        "provider": provider,
+        "diagnostics": [],
+        "message": "Autonomy bootstrap preflight passed.",
+    }
+
+
+def create_proof_state(*, session_id: str, task_id: str, user_message: str, model: str, provider: str) -> Dict[str, Any]:
+    """Return a fresh in-memory proof-of-done state object."""
+    return {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "session_id": session_id,
+        "task_id": task_id,
+        "user_message": user_message,
+        "model": model,
+        "provider": provider,
+        "tool_events": [],
+        "files_touched": [],
+        "approval_events": [],
+        "commands_run": [],
+        "gates_run": [],
+        "preflight": None,
+    }
+
+
+def extract_patch_paths(patch: str) -> list[str]:
+    return re.findall(r"^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$", patch or "", re.MULTILINE)
+
+
+def record_tool_event(proof_state: Dict[str, Any], tool_name: str, args: Dict[str, Any], result: str) -> None:
+    """Record tool activity for the final proof artifact."""
+    preview_limit = int(load_autonomy_policy().get("proof_of_done", {}).get("max_command_preview_chars", 240))
+    event: Dict[str, Any] = {"tool": tool_name}
+
+    if tool_name == "terminal":
+        command = str(args.get("command", ""))
+        event["command"] = command[:preview_limit]
+        proof_state["commands_run"].append(command[:preview_limit])
+    if tool_name == "write_file":
+        path = str(args.get("path", ""))
+        if path:
+            proof_state["files_touched"].append(path)
+            event["path"] = path
+    if tool_name == "patch":
+        paths: list[str] = []
+        if args.get("path"):
+            paths.append(str(args["path"]))
+        if args.get("mode") == "patch":
+            paths.extend(extract_patch_paths(str(args.get("patch", ""))))
+        if paths:
+            proof_state["files_touched"].extend(paths)
+            event["paths"] = paths
+
+    parsed: Optional[Dict[str, Any]] = None
+    try:
+        parsed = json.loads(result)
+    except Exception:
+        parsed = None
+
+    if isinstance(parsed, dict):
+        status = parsed.get("status")
+        error = parsed.get("error")
+        exit_code = parsed.get("exit_code")
+        if status:
+            event["status"] = status
+        if error:
+            event["error"] = error
+        if isinstance(exit_code, int):
+            event["exit_code"] = exit_code
+        if tool_name == "terminal" and "command" in event:
+            gate_name = _classify_gate_command(event["command"])
+            if gate_name:
+                proof_state["gates_run"].append(
+                    {
+                        "name": gate_name,
+                        "command": event["command"],
+                        "outcome": _gate_outcome(parsed),
+                    }
+                )
+        if status == "approval_required" or parsed.get("approved") is False:
+            proof_state["approval_events"].append(
+                {
+                    "tool": tool_name,
+                    "status": status or "blocked",
+                    "description": parsed.get("description", ""),
+                    "error": error,
+                }
+            )
+    proof_state["tool_events"].append(event)
+
+
+def _classify_gate_command(command: str) -> Optional[str]:
+    lowered = command.lower()
+    if "scripts/run_readiness.py" in lowered:
+        return "run_readiness"
+    if "scripts/smoke_autonomy.py" in lowered:
+        return "smoke_autonomy"
+    if "pytest" in lowered:
+        return "pytest"
+    return None
+
+
+def _gate_outcome(result: Dict[str, Any]) -> str:
+    status = str(result.get("status") or "")
+    if status == "approval_required":
+        return "approval-required"
+    if status == "blocked":
+        return "blocked"
+    exit_code = result.get("exit_code")
+    if isinstance(exit_code, int):
+        return "passed" if exit_code == 0 else "failed"
+    if result.get("error"):
+        return "failed"
+    return "passed"
+
+
+def _derive_artifact_status(proof_state: Dict[str, Any], *, completed: bool, interrupted: bool) -> str:
+    if interrupted:
+        return "failed"
+    preflight = proof_state.get("preflight") or {}
+    if isinstance(preflight, dict) and preflight.get("ok") is False:
+        return "failed"
+
+    tool_events = proof_state.get("tool_events", [])
+    statuses = [str(event.get("status", "")) for event in tool_events if isinstance(event, dict)]
+    if "approval_required" in statuses:
+        return "approval-required"
+    if "blocked" in statuses:
+        return "blocked"
+
+    for event in tool_events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("error"):
+            return "failed"
+        if isinstance(event.get("exit_code"), int) and event["exit_code"] != 0:
+            return "failed"
+    return "passed" if completed else "failed"
+
+
+def _next_required_human_action(status: str) -> Optional[str]:
+    if status == "approval-required":
+        return "Review the requested action and explicitly approve or reject it."
+    if status == "blocked":
+        return "Move the work onto a feature branch or change the requested action so it satisfies policy."
+    if status == "failed":
+        return "Inspect the diagnostics, fix the failure, then re-run the task."
+    return None
+
+
+def write_proof_artifact(
+    proof_state: Dict[str, Any],
+    *,
+    completed: bool,
+    interrupted: bool,
+    final_response: Optional[str],
+    api_calls: int,
+    stop_reason: Optional[str] = None,
+    repo_hint: Optional[str] = None,
+) -> str:
+    """Persist a proof-of-done artifact and return its path."""
+    proof_cfg: Dict[str, Any] = {}
+    try:
+        policy = load_autonomy_policy()
+        proof_cfg = policy.get("proof_of_done", {})
+    except AutonomyPolicyError:
+        proof_cfg = {}
+    out_dir = get_hermes_home() / str(proof_cfg.get("output_dir", "proof_of_done"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    git_ctx = get_git_context(repo_hint or os.getcwd())
+    status = _derive_artifact_status(proof_state, completed=completed, interrupted=interrupted)
+    artifact = {
+        **proof_state,
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "completed": completed,
+        "interrupted": interrupted,
+        "api_calls": api_calls,
+        "stop_reason": stop_reason,
+        "final_response_present": bool(final_response),
+        "final_response_length": len(final_response or ""),
+        "files_touched": sorted(set(proof_state.get("files_touched", []))),
+        "commands_run": proof_state.get("commands_run", []),
+        "gates_run": proof_state.get("gates_run", []),
+        "next_step_requires_human_approval": bool(proof_state.get("approval_events")),
+        "next_required_human_action": _next_required_human_action(status),
+        "git": git_ctx,
+    }
+
+    session_stub = proof_state.get("session_id") or proof_state.get("task_id") or "session"
+    safe_stub = re.sub(r"[^A-Za-z0-9._-]+", "-", str(session_stub)).strip("-") or "session"
+    artifact_path = out_dir / f"{safe_stub}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return str(artifact_path)

--- a/tools/autonomy_guard.py
+++ b/tools/autonomy_guard.py
@@ -254,19 +254,26 @@ def evaluate_execute_code(code: str, *, workdir: Optional[str]) -> Dict[str, Any
     return {"allowed": True, "status": "ok"}
 
 
-def _toolset_contains_mcp(toolset_name: str) -> bool:
+def _toolset_contains_mcp(toolset_name: str, *, _visited: Optional[set[str]] = None) -> bool:
     try:
         from toolsets import TOOLSETS
     except Exception:
         return toolset_name.startswith("mcp-")
 
+    visited = _visited or set()
+    if toolset_name in visited:
+        return False
+    visited.add(toolset_name)
+
     definition = TOOLSETS.get(toolset_name) or {}
     description = str(definition.get("description") or "")
     tools = [str(tool) for tool in definition.get("tools", [])]
+    includes = [str(name) for name in definition.get("includes", [])]
     return (
         toolset_name.startswith("mcp-")
         or description.startswith("MCP server '")
         or any(tool.startswith("mcp_") for tool in tools)
+        or any(_toolset_contains_mcp(name, _visited=visited) for name in includes)
     )
 
 
@@ -588,12 +595,26 @@ _STOP_REASON_CODE_PREFIXES = {
     "max_iterations_reached(": "max_iterations_reached",
 }
 
+_STOP_REASON_CODE_EXACT = {
+    "unknown",
+    "interrupted_by_user",
+    "budget_exhausted",
+    "interrupted_during_api_call",
+    "all_retries_exhausted_no_response",
+    "partial_stream_recovery",
+    "fallback_prior_turn_content",
+    "empty_response_exhausted",
+    "bootstrap_preflight_failed",
+}
+
 
 def normalize_stop_reason(stop_reason: Optional[str]) -> str:
     """Return a stable stop-reason code alongside the raw reason text."""
     raw = str(stop_reason or "").strip()
     if not raw:
         return "unknown"
+    if raw in _STOP_REASON_CODE_EXACT:
+        return raw
     for prefix, code in _STOP_REASON_CODE_PREFIXES.items():
         if raw.startswith(prefix):
             return code

--- a/tools/autonomy_guard.py
+++ b/tools/autonomy_guard.py
@@ -48,6 +48,13 @@ def _iter_pattern_entries(entries: Iterable[Dict[str, Any]]) -> Iterable[tuple[r
         yield re.compile(pattern, re.IGNORECASE), str(description)
 
 
+def _first_matching_description(text: str, entries: Iterable[Dict[str, Any]]) -> Optional[str]:
+    for regex, description in _iter_pattern_entries(entries):
+        if regex.search(text):
+            return description
+    return None
+
+
 def _git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -176,6 +183,69 @@ def evaluate_terminal_command(command: str, *, workdir: Optional[str], force: bo
                     f"Command:\n```\n{command}\n```"
                 ),
             }
+
+    return {"allowed": True, "status": "ok"}
+
+
+def evaluate_execute_code(code: str, *, workdir: Optional[str]) -> Dict[str, Any]:
+    """Apply autonomy policy to execute_code payloads."""
+    try:
+        policy = load_autonomy_policy()
+    except AutonomyPolicyError as exc:
+        return {
+            "allowed": False,
+            "status": "blocked",
+            "description": "autonomy policy unavailable",
+            "message": f"BLOCKED: {exc}",
+        }
+
+    exec_cfg = policy.get("execute_code", {})
+    approval_cfg = policy.get("approval", {})
+
+    for fragment in [
+        *approval_cfg.get("forbidden_command_fragments", []),
+        *exec_cfg.get("forbidden_code_fragments", []),
+    ]:
+        text = str(fragment).strip()
+        if text and text in code:
+            return {
+                "allowed": False,
+                "status": "blocked",
+                "description": f"forbidden autonomy bypass: {text}",
+                "message": (
+                    f"BLOCKED: autonomy policy forbids `{text}` inside execute_code payloads."
+                ),
+            }
+
+    cwd = workdir or os.getcwd()
+    block_description = _first_matching_description(
+        code,
+        exec_cfg.get("protected_branch_block_patterns", []),
+    )
+    if block_description:
+        write_decision = enforce_write_policy("execute_code", cwd)
+        if not write_decision["allowed"]:
+            write_decision["description"] = block_description
+            write_decision["message"] = (
+                f"BLOCKED: execute_code attempted {block_description} on protected branch "
+                f"'{write_decision.get('branch')}'. Use a feature branch and Hermes write tools instead."
+            )
+            return write_decision
+
+    approval_description = _first_matching_description(
+        code,
+        exec_cfg.get("approval_required_patterns", []),
+    )
+    if approval_description:
+        return {
+            "allowed": False,
+            "status": "approval_required",
+            "description": approval_description,
+            "message": (
+                f"Human approval required by autonomy policy: {approval_description}.\n\n"
+                "Use the terminal tool directly when a subprocess is actually needed."
+            ),
+        }
 
     return {"allowed": True, "status": "ok"}
 

--- a/tools/autonomy_guard.py
+++ b/tools/autonomy_guard.py
@@ -55,6 +55,15 @@ def _first_matching_description(text: str, entries: Iterable[Dict[str, Any]]) ->
     return None
 
 
+def _policy_unavailable(exc: AutonomyPolicyError) -> Dict[str, Any]:
+    return {
+        "allowed": False,
+        "status": "blocked",
+        "description": "autonomy policy unavailable",
+        "message": f"BLOCKED: {exc}",
+    }
+
+
 def _git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -192,12 +201,7 @@ def evaluate_execute_code(code: str, *, workdir: Optional[str]) -> Dict[str, Any
     try:
         policy = load_autonomy_policy()
     except AutonomyPolicyError as exc:
-        return {
-            "allowed": False,
-            "status": "blocked",
-            "description": "autonomy policy unavailable",
-            "message": f"BLOCKED: {exc}",
-        }
+        return _policy_unavailable(exc)
 
     exec_cfg = policy.get("execute_code", {})
     approval_cfg = policy.get("approval", {})
@@ -247,6 +251,102 @@ def evaluate_execute_code(code: str, *, workdir: Optional[str]) -> Dict[str, Any
             ),
         }
 
+    return {"allowed": True, "status": "ok"}
+
+
+def _toolset_contains_mcp(toolset_name: str) -> bool:
+    try:
+        from toolsets import TOOLSETS
+    except Exception:
+        return toolset_name.startswith("mcp-")
+
+    definition = TOOLSETS.get(toolset_name) or {}
+    description = str(definition.get("description") or "")
+    tools = [str(tool) for tool in definition.get("tools", [])]
+    return (
+        toolset_name.startswith("mcp-")
+        or description.startswith("MCP server '")
+        or any(tool.startswith("mcp_") for tool in tools)
+    )
+
+
+def evaluate_delegate_request(
+    *,
+    toolsets: Optional[Iterable[str]],
+    tasks: Optional[Iterable[Dict[str, Any]]],
+    acp_command: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Apply autonomy policy to delegate_task requests."""
+    try:
+        policy = load_autonomy_policy()
+    except AutonomyPolicyError as exc:
+        return _policy_unavailable(exc)
+
+    delegate_cfg = policy.get("delegate", {})
+    if delegate_cfg.get("approval_required_if_acp_command", True):
+        explicit_acp = []
+        if str(acp_command or "").strip():
+            explicit_acp.append(str(acp_command).strip())
+        for task in tasks or []:
+            value = str((task or {}).get("acp_command") or "").strip()
+            if value:
+                explicit_acp.append(value)
+        if explicit_acp:
+            return {
+                "allowed": False,
+                "status": "approval_required",
+                "description": "spawn child agents through an ACP command override",
+                "message": (
+                    "Human approval required by autonomy policy: spawn child agents "
+                    "through an ACP command override."
+                ),
+            }
+
+    if delegate_cfg.get("approval_required_for_mcp_toolsets", True):
+        explicit_toolsets = [str(name) for name in toolsets or [] if str(name).strip()]
+        for task in tasks or []:
+            explicit_toolsets.extend(
+                str(name)
+                for name in ((task or {}).get("toolsets") or [])
+                if str(name).strip()
+            )
+        for toolset_name in explicit_toolsets:
+            if _toolset_contains_mcp(toolset_name):
+                return {
+                    "allowed": False,
+                    "status": "approval_required",
+                    "description": f"delegate work with MCP-backed toolset '{toolset_name}'",
+                    "message": (
+                        "Human approval required by autonomy policy: "
+                        f"delegate work with MCP-backed toolset '{toolset_name}'."
+                    ),
+                }
+
+    return {"allowed": True, "status": "ok"}
+
+
+def evaluate_mcp_tool_call(server_name: str, tool_name: str, *, workdir: Optional[str] = None) -> Dict[str, Any]:
+    """Apply autonomy policy to mutating MCP tool invocations."""
+    try:
+        policy = load_autonomy_policy()
+    except AutonomyPolicyError as exc:
+        return _policy_unavailable(exc)
+
+    mcp_cfg = policy.get("mcp", {})
+    description = _first_matching_description(
+        tool_name,
+        mcp_cfg.get("approval_required_tool_name_patterns", []),
+    )
+    if description:
+        return {
+            "allowed": False,
+            "status": "approval_required",
+            "description": description,
+            "message": (
+                f"Human approval required by autonomy policy: {description} "
+                f"({server_name}.{tool_name})."
+            ),
+        }
     return {"allowed": True, "status": "ok"}
 
 
@@ -482,6 +582,24 @@ def _next_required_human_action(status: str) -> Optional[str]:
     return None
 
 
+_STOP_REASON_CODE_PREFIXES = {
+    "text_response(": "text_response",
+    "error_near_max_iterations(": "error_near_max_iterations",
+    "max_iterations_reached(": "max_iterations_reached",
+}
+
+
+def normalize_stop_reason(stop_reason: Optional[str]) -> str:
+    """Return a stable stop-reason code alongside the raw reason text."""
+    raw = str(stop_reason or "").strip()
+    if not raw:
+        return "unknown"
+    for prefix, code in _STOP_REASON_CODE_PREFIXES.items():
+        if raw.startswith(prefix):
+            return code
+    return raw
+
+
 def write_proof_artifact(
     proof_state: Dict[str, Any],
     *,
@@ -512,6 +630,7 @@ def write_proof_artifact(
         "interrupted": interrupted,
         "api_calls": api_calls,
         "stop_reason": stop_reason,
+        "stop_reason_code": normalize_stop_reason(stop_reason),
         "final_response_present": bool(final_response),
         "final_response_length": len(final_response or ""),
         "files_touched": sorted(set(proof_state.get("files_touched", []))),

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -46,6 +46,8 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
+from tools.autonomy_guard import evaluate_execute_code
+
 # Availability gate: UDS requires a POSIX OS
 logger = logging.getLogger(__name__)
 
@@ -915,6 +917,18 @@ def execute_code(
 
     if not code or not code.strip():
         return tool_error("No code provided.")
+
+    policy_decision = evaluate_execute_code(code, workdir=os.getcwd())
+    if not policy_decision.get("allowed"):
+        return json.dumps(
+            {
+                "status": policy_decision.get("status", "blocked"),
+                "error": policy_decision.get("message", "execute_code blocked by autonomy policy."),
+                "description": policy_decision.get("description"),
+                "approved": False,
+            },
+            ensure_ascii=False,
+        )
 
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -26,6 +26,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
+from tools.autonomy_guard import evaluate_delegate_request
 
 
 # Tools that children must never have access to
@@ -691,6 +692,22 @@ def delegate_task(
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    delegate_policy = evaluate_delegate_request(
+        toolsets=None if tasks else toolsets,
+        tasks=task_list,
+        acp_command=acp_command,
+    )
+    if not delegate_policy.get("allowed"):
+        return json.dumps(
+            {
+                "status": delegate_policy.get("status", "blocked"),
+                "error": delegate_policy.get("message", "delegate_task blocked by autonomy policy."),
+                "description": delegate_policy.get("description"),
+                "approved": False,
+            },
+            ensure_ascii=False,
+        )
 
     overall_start = time.monotonic()
     results = []

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -7,6 +7,7 @@ import logging
 import os
 import threading
 from pathlib import Path
+from tools.autonomy_guard import enforce_write_policy
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import ShellFileOperations
 from agent.redact import redact_sensitive_text
@@ -543,6 +544,14 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     sensitive_err = _check_sensitive_path(path)
     if sensitive_err:
         return tool_error(sensitive_err)
+    branch_decision = enforce_write_policy("write_file", path)
+    if not branch_decision["allowed"]:
+        return tool_error(
+            branch_decision["message"],
+            status=branch_decision["status"],
+            branch=branch_decision.get("branch"),
+            repo_root=branch_decision.get("repo_root"),
+        )
     try:
         stale_warning = _check_file_staleness(path, task_id)
         file_ops = _get_file_ops(task_id)
@@ -578,6 +587,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p)
         if sensitive_err:
             return tool_error(sensitive_err)
+        branch_decision = enforce_write_policy("patch", _p)
+        if not branch_decision["allowed"]:
+            return tool_error(
+                branch_decision["message"],
+                status=branch_decision["status"],
+                branch=branch_decision.get("branch"),
+                repo_root=branch_decision.get("repo_root"),
+                path=_p,
+            )
     try:
         # Check staleness for all files this patch will touch.
         stale_warnings = []

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -84,6 +84,8 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+from tools.autonomy_guard import evaluate_mcp_tool_call
+
 # ---------------------------------------------------------------------------
 # Graceful import -- MCP SDK is an optional dependency
 # ---------------------------------------------------------------------------
@@ -1286,6 +1288,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """
 
     def _handler(args: dict, **kwargs) -> str:
+        policy = evaluate_mcp_tool_call(server_name, tool_name, workdir=os.getcwd())
+        if not policy.get("allowed"):
+            return json.dumps({
+                "status": policy.get("status", "blocked"),
+                "error": policy.get("message", "MCP tool blocked by autonomy policy."),
+                "description": policy.get("description"),
+                "approved": False,
+            })
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:
@@ -1328,11 +1338,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 return json.dumps({"result": structured})
             return json.dumps({"result": text_result})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(coro, timeout=tool_timeout)
         except InterruptedError:
+            coro.close()
             return _interrupted_call_result()
         except Exception as exc:
+            coro.close()
             logger.error(
                 "MCP tool %s/%s call failed: %s",
                 server_name, tool_name, exc,
@@ -1373,11 +1386,14 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
                 resources.append(entry)
             return json.dumps({"resources": resources})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(coro, timeout=tool_timeout)
         except InterruptedError:
+            coro.close()
             return _interrupted_call_result()
         except Exception as exc:
+            coro.close()
             logger.error(
                 "MCP %s/list_resources failed: %s", server_name, exc,
             )
@@ -1419,11 +1435,14 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
                     parts.append(f"[binary data, {len(block.blob)} bytes]")
             return json.dumps({"result": "\n".join(parts) if parts else ""})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(coro, timeout=tool_timeout)
         except InterruptedError:
+            coro.close()
             return _interrupted_call_result()
         except Exception as exc:
+            coro.close()
             logger.error(
                 "MCP %s/read_resource failed: %s", server_name, exc,
             )
@@ -1468,11 +1487,14 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
                 prompts.append(entry)
             return json.dumps({"prompts": prompts})
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(coro, timeout=tool_timeout)
         except InterruptedError:
+            coro.close()
             return _interrupted_call_result()
         except Exception as exc:
+            coro.close()
             logger.error(
                 "MCP %s/list_prompts failed: %s", server_name, exc,
             )
@@ -1525,11 +1547,14 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
                 resp["description"] = result.description
             return json.dumps(resp)
 
+        coro = _call()
         try:
-            return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            return _run_on_mcp_loop(coro, timeout=tool_timeout)
         except InterruptedError:
+            coro.close()
             return _interrupted_call_result()
         except Exception as exc:
+            coro.close()
             logger.error(
                 "MCP %s/get_prompt failed: %s", server_name, exc,
             )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -44,6 +44,8 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
+from tools.autonomy_guard import evaluate_terminal_command
+
 logger = logging.getLogger(__name__)
 
 
@@ -1285,6 +1287,25 @@ def terminal_tool(
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
+        policy_decision = evaluate_terminal_command(command, workdir=workdir or cwd, force=force)
+        if not policy_decision["allowed"]:
+            if policy_decision.get("status") == "approval_required":
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": policy_decision.get("message", "Waiting for user approval"),
+                    "status": "approval_required",
+                    "command": command,
+                    "description": policy_decision.get("description", "command flagged by autonomy policy"),
+                    "pattern_key": "autonomy-policy",
+                }, ensure_ascii=False)
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": policy_decision.get("message", "Command blocked by autonomy policy"),
+                "status": policy_decision.get("status", "blocked"),
+                "description": policy_decision.get("description", ""),
+            }, ensure_ascii=False)
         if not force:
             approval = _check_all_guards(command, env_type)
             if not approval["approved"]:

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -16,6 +16,18 @@ hermes update
 
 This pulls the latest code, updates dependencies, and prompts you to configure any new options that were added since your last update.
 
+:::warning Use separate runtime and development checkouts
+`hermes update` is intended for the clean runtime checkout that actually runs your live Hermes gateway or CLI install.
+
+If you actively develop inside a separate clone or worktree, mark that checkout as development-only:
+
+```bash
+touch .hermes-dev-checkout
+```
+
+Hermes now refuses self-update when the checkout is not on `main`, has local changes, or is marked with `.hermes-dev-checkout` / `.hermes-no-self-update`.
+:::
+
 :::tip
 `hermes update` automatically detects new configuration options and prompts you to add them. If you skipped that prompt, you can manually run `hermes config check` to see missing options, then `hermes config migrate` to interactively add them.
 :::


### PR DESCRIPTION
## Summary
- add protected-branch, self-update, execute_code, delegate, and MCP autonomy guardrails
- emit stable proof-of-done stop reason codes and tighten readiness smoke coverage
- preserve dev/runtime checkout separation and recovery checkpoints

## Verification
- python3 -m pytest tests/tools/test_autonomy_guard.py tests/tools/test_delegate.py tests/tools/test_mcp_tool.py tests/run_agent/test_autonomy_runtime.py -q
- python3 scripts/run_readiness.py
- Hermes read-only verification from clean verification checkout

## Notes
- branch protection and required status checks on main should be enabled before merge
- draft PR intentionally opened before any pilot build