### PR TITLE
feat(xai): add xAI provider with video generation, image editing, X s…

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -58,6 +58,9 @@ _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
+    "x-ai": "xai",
+    "x.ai": "xai",
+    "grok": "xai",
     "glm": "zai",
     "z-ai": "zai",
     "z.ai": "zai",
@@ -94,6 +97,7 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
+    "xai": "grok-4.20-reasoning",
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
     "kimi-coding-cn": "kimi-k2-turbo-preview",

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -219,6 +219,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.openai.com": "openai",
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
+    "api.x.ai": "xai",
     "api.z.ai": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.moonshot.cn": "kimi-coding-cn",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -144,6 +144,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
         base_url_env_var="GEMINI_BASE_URL",
     ),
+    "xai": ProviderConfig(
+        id="xai",
+        name="xAI",
+        auth_type="api_key",
+        inference_base_url="https://api.x.ai/v1",
+        api_key_env_vars=("XAI_API_KEY",),
+        base_url_env_var="XAI_BASE_URL",
+    ),
     "zai": ProviderConfig(
         id="zai",
         name="Z.AI / GLM",
@@ -213,14 +221,6 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.deepseek.com/v1",
         api_key_env_vars=("DEEPSEEK_API_KEY",),
         base_url_env_var="DEEPSEEK_BASE_URL",
-    ),
-    "xai": ProviderConfig(
-        id="xai",
-        name="xAI",
-        auth_type="api_key",
-        inference_base_url="https://api.x.ai/v1",
-        api_key_env_vars=("XAI_API_KEY",),
-        base_url_env_var="XAI_BASE_URL",
     ),
     "ai-gateway": ProviderConfig(
         id="ai-gateway",
@@ -911,6 +911,7 @@ def resolve_provider(
     _PROVIDER_ALIASES = {
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
+        "x-ai": "xai", "x.ai": "xai", "grok": "xai",
         "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
         "kimi-cn": "kimi-coding-cn", "moonshot-cn": "kimi-coding-cn",
         "arcee-ai": "arcee", "arceeai": "arcee",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -399,6 +399,21 @@ DEFAULT_CONFIG = {
         },
     },
 
+    "image_generation": {
+        "provider": "auto",  # "auto" | "fal" | "xai"
+    },
+
+    "video_generation": {
+        "provider": "xai",  # xAI is currently the only native video backend
+    },
+
+    "x_search": {
+        "provider": "xai",
+        "model": "grok-4.20-reasoning",
+        "timeout_seconds": 180,
+        "retries": 2,
+    },
+
     # Filesystem checkpoints — automatic snapshots before destructive file ops.
     # When enabled, the agent takes a snapshot of the working directory once per
     # conversation turn (on first write_file/patch call).  Use /rollback to restore.
@@ -517,7 +532,7 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -530,6 +545,12 @@ DEFAULT_CONFIG = {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
             # Voices: alloy, echo, fable, onyx, nova, shimmer
+        },
+        "xai": {
+            "voice_id": "eve",
+            "language": "en",
+            "sample_rate": 24000,
+            "bit_rate": 128000,
         },
         "mistral": {
             "model": "voxtral-mini-tts-2603",
@@ -703,7 +724,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -719,6 +740,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    18: ["XAI_API_KEY", "XAI_BASE_URL"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -766,6 +788,22 @@ OPTIONAL_ENV_VARS = {
     "GEMINI_BASE_URL": {
         "description": "Google AI Studio base URL override",
         "prompt": "Gemini base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "XAI_API_KEY": {
+        "description": "xAI API key",
+        "prompt": "xAI API key",
+        "url": "https://console.x.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "XAI_BASE_URL": {
+        "description": "xAI base URL override",
+        "prompt": "xAI base URL (leave empty for default)",
         "url": None,
         "password": False,
         "category": "provider",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4612,7 +4612,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "xai", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1086,5 +1086,3 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
-

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,6 +133,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemma-4-31b-it",
         "gemma-4-26b-it",
     ],
+    "xai": [
+        "grok-4.20-reasoning",
+        "grok-4-1-fast-reasoning",
+    ],
     "zai": [
         "glm-5.1",
         "glm-5",
@@ -141,19 +145,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.7",
         "glm-4.5",
         "glm-4.5-flash",
-    ],
-    "xai": [
-        "grok-4.20-0309-reasoning",
-        "grok-4.20-0309-non-reasoning",
-        "grok-4.20-multi-agent-0309",
-        "grok-4-1-fast-reasoning",
-        "grok-4-1-fast-non-reasoning",
-        "grok-4-fast-reasoning",
-        "grok-4-fast-non-reasoning",
-        "grok-4-0709",
-        "grok-code-fast-1",
-        "grok-3",
-        "grok-3-mini",
     ],
     "kimi-coding": [
         "kimi-for-coding",
@@ -556,6 +547,9 @@ _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
+    "x-ai": "xai",
+    "x.ai": "xai",
+    "grok": "xai",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
     "kimi-cn": "kimi-coding-cn",
@@ -587,9 +581,6 @@ _PROVIDER_ALIASES = {
     "huggingface-hub": "huggingface",
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
-    "grok": "xai",
-    "x-ai": "xai",
-    "x.ai": "xai",
 }
 
 
@@ -881,7 +872,6 @@ def list_available_providers() -> list[dict[str, str]]:
     """
     # Derive display order from canonical list + custom
     provider_order = [p.slug for p in CANONICAL_PROVIDERS] + ["custom"]
-
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
     for alias, canonical in _PROVIDER_ALIASES.items():

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -143,6 +143,7 @@ def _tts_label(current_provider: str) -> str:
         "openai": "OpenAI TTS",
         "elevenlabs": "ElevenLabs",
         "edge": "Edge TTS",
+        "xai": "xAI TTS",
         "mistral": "Mistral Voxtral TTS",
         "neutts": "NeuTTS",
     }

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -78,6 +78,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="anthropic_messages",
         extra_env_vars=("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
     ),
+    "xai": HermesOverlay(
+        transport="codex_responses",
+        base_url_override="https://api.x.ai/v1",
+        base_url_env_var="XAI_BASE_URL",
+    ),
     "zai": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
@@ -127,11 +132,6 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="HF_BASE_URL",
     ),
-    "xai": HermesOverlay(
-        transport="openai_chat",
-        base_url_override="https://api.x.ai/v1",
-        base_url_env_var="XAI_BASE_URL",
-    ),
     "xiaomi": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="XIAOMI_BASE_URL",
@@ -177,10 +177,6 @@ ALIASES: Dict[str, str] = {
     "z.ai": "zai",
     "zhipu": "zai",
 
-    # xai
-    "x-ai": "xai",
-    "x.ai": "xai",
-
     # kimi-for-coding (models.dev ID)
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",
@@ -194,6 +190,11 @@ ALIASES: Dict[str, str] = {
     # anthropic
     "claude": "anthropic",
     "claude-code": "anthropic",
+
+    # xai
+    "x-ai": "xai",
+    "x.ai": "xai",
+    "grok": "xai",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -41,6 +41,8 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     tool calls with reasoning (chat/completions returns 400).
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
+    if "api.x.ai" in normalized:
+        return "codex_responses"
     if "api.openai.com" in normalized and "openrouter" not in normalized:
         return "codex_responses"
     return None
@@ -163,6 +165,8 @@ def _resolve_runtime_from_pool_entry(
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "openrouter":
         base_url = base_url or OPENROUTER_BASE_URL
+    elif provider == "xai":
+        api_mode = "codex_responses"
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
@@ -627,6 +631,8 @@ def _resolve_explicit_runtime(
         api_mode = "chat_completions"
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+        elif provider == "xai":
+            api_mode = "codex_responses"
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if configured_mode:
@@ -852,6 +858,8 @@ def resolve_runtime_provider(
         api_mode = "chat_completions"
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+        elif provider == "xai":
+            api_mode = "codex_responses"
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -25,7 +25,7 @@ from hermes_cli.nous_subscription import (
     get_nous_subscription_features,
 )
 from tools.tool_backend_helpers import managed_nous_tools_enabled
-from hermes_constants import get_optional_skills_dir
+from hermes_constants import display_hermes_home, get_optional_skills_dir
 
 logger = logging.getLogger(__name__)
 
@@ -920,6 +920,7 @@ def _setup_tts_provider(config: dict):
         "edge": "Edge TTS",
         "elevenlabs": "ElevenLabs",
         "openai": "OpenAI TTS",
+        "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
         "neutts": "NeuTTS",
@@ -941,12 +942,13 @@ def _setup_tts_provider(config: dict):
             "Edge TTS (free, cloud-based, no setup needed)",
             "ElevenLabs (premium quality, needs API key)",
             "OpenAI TTS (good quality, needs API key)",
+            "xAI TTS (Grok voices, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "neutts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1010,6 +1012,22 @@ def _setup_tts_provider(config: dict):
                 print_success("OpenAI TTS API key saved")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "xai":
+        existing = get_env_value("XAI_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("xAI API key for TTS", password=True)
+            if api_key:
+                save_env_value("XAI_API_KEY", api_key)
+                print_success("xAI TTS API key saved")
+            else:
+                print_warning(
+                    "No xAI API key provided for TTS. Configure XAI_API_KEY via "
+                    f"hermes setup model or {display_hermes_home()}/.env to use xAI TTS. "
+                    "Falling back to Edge TTS."
+                )
                 selected = "edge"
 
     elif selected == "minimax":

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -48,12 +48,14 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
 # These map to keys in toolsets.py TOOLSETS dict.
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
+    ("x_search",        "🐦 X Search",                 "x_search"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("video_gen",       "🎬 Video Generation",          "video_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),
@@ -116,6 +118,20 @@ PLATFORMS = {
 # Toolsets not in this map either need no config or use the simple fallback.
 
 TOOL_CATEGORIES = {
+    "x_search": {
+        "name": "X Search",
+        "icon": "🐦",
+        "providers": [
+            {
+                "name": "xAI X Search",
+                "tag": "Search X posts and threads via xAI",
+                "env_vars": [
+                    {"key": "XAI_API_KEY", "prompt": "xAI API key", "url": "https://console.x.ai/"},
+                ],
+                "x_search_provider": "xai",
+            },
+        ],
+    },
     "tts": {
         "name": "Text-to-Speech",
         "icon": "🔊",
@@ -145,6 +161,14 @@ TOOL_CATEGORIES = {
                     {"key": "VOICE_TOOLS_OPENAI_KEY", "prompt": "OpenAI API key", "url": "https://platform.openai.com/api-keys"},
                 ],
                 "tts_provider": "openai",
+            },
+            {
+                "name": "xAI TTS",
+                "tag": "Grok voices - requires xAI API key",
+                "env_vars": [
+                    {"key": "XAI_API_KEY", "prompt": "xAI API key", "url": "https://console.x.ai/"},
+                ],
+                "tts_provider": "xai",
             },
             {
                 "name": "ElevenLabs",
@@ -241,6 +265,7 @@ TOOL_CATEGORIES = {
                 "requires_nous_auth": True,
                 "managed_nous_feature": "image_gen",
                 "override_env_vars": ["FAL_KEY"],
+                "image_provider": "fal",
             },
             {
                 "name": "FAL.ai",
@@ -249,6 +274,29 @@ TOOL_CATEGORIES = {
                 "env_vars": [
                     {"key": "FAL_KEY", "prompt": "FAL API key", "url": "https://fal.ai/dashboard/keys"},
                 ],
+                "image_provider": "fal",
+            },
+            {
+                "name": "xAI Images",
+                "tag": "Grok Imagine image generation and editing",
+                "env_vars": [
+                    {"key": "XAI_API_KEY", "prompt": "xAI API key", "url": "https://console.x.ai/"},
+                ],
+                "image_provider": "xai",
+            },
+        ],
+    },
+    "video_gen": {
+        "name": "Video Generation",
+        "icon": "🎬",
+        "providers": [
+            {
+                "name": "xAI Videos",
+                "tag": "Grok Imagine video generation, edits, and extensions",
+                "env_vars": [
+                    {"key": "XAI_API_KEY", "prompt": "xAI API key", "url": "https://console.x.ai/"},
+                ],
+                "video_provider": "xai",
             },
         ],
     },
@@ -807,6 +855,13 @@ def _toolset_needs_configuration_prompt(ts_key: str, config: dict) -> bool:
     if ts_key == "tts":
         tts_cfg = config.get("tts", {})
         return not isinstance(tts_cfg, dict) or "provider" not in tts_cfg
+    if ts_key == "x_search":
+        x_search_cfg = config.get("x_search", {})
+        return (
+            not isinstance(x_search_cfg, dict)
+            or x_search_cfg.get("provider") != "xai"
+            or not get_env_value("XAI_API_KEY")
+        )
     if ts_key == "web":
         web_cfg = config.get("web", {})
         return not isinstance(web_cfg, dict) or "backend" not in web_cfg
@@ -814,7 +869,22 @@ def _toolset_needs_configuration_prompt(ts_key: str, config: dict) -> bool:
         browser_cfg = config.get("browser", {})
         return not isinstance(browser_cfg, dict) or "cloud_provider" not in browser_cfg
     if ts_key == "image_gen":
-        return not get_env_value("FAL_KEY")
+        image_cfg = config.get("image_generation", {})
+        if not isinstance(image_cfg, dict) or "provider" not in image_cfg:
+            return True
+        provider = str(image_cfg.get("provider") or "").strip().lower()
+        if provider == "xai":
+            return not get_env_value("XAI_API_KEY")
+        if provider == "fal":
+            return not get_env_value("FAL_KEY")
+        return True
+    if ts_key == "video_gen":
+        video_cfg = config.get("video_generation", {})
+        return (
+            not isinstance(video_cfg, dict)
+            or video_cfg.get("provider") != "xai"
+            or not get_env_value("XAI_API_KEY")
+        )
 
     return not _toolset_has_keys(ts_key, config)
 
@@ -896,7 +966,10 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
         if feature is None:
             return False
         if managed_feature == "image_gen":
-            return feature.managed_by_nous
+            return (
+                feature.managed_by_nous
+                and config.get("image_generation", {}).get("provider") == provider.get("image_provider")
+            )
         if provider.get("tts_provider"):
             return (
                 feature.managed_by_nous
@@ -912,6 +985,12 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
 
     if provider.get("tts_provider"):
         return config.get("tts", {}).get("provider") == provider["tts_provider"]
+    if provider.get("x_search_provider"):
+        return config.get("x_search", {}).get("provider") == provider["x_search_provider"]
+    if provider.get("image_provider"):
+        return config.get("image_generation", {}).get("provider") == provider["image_provider"]
+    if provider.get("video_provider"):
+        return config.get("video_generation", {}).get("provider") == provider["video_provider"]
     if "browser_provider" in provider:
         current = config.get("browser", {}).get("cloud_provider")
         return provider["browser_provider"] == current
@@ -947,6 +1026,12 @@ def _configure_provider(provider: dict, config: dict):
     # Set TTS provider in config if applicable
     if provider.get("tts_provider"):
         config.setdefault("tts", {})["provider"] = provider["tts_provider"]
+    if provider.get("x_search_provider"):
+        config.setdefault("x_search", {})["provider"] = provider["x_search_provider"]
+    if provider.get("image_provider"):
+        config.setdefault("image_generation", {})["provider"] = provider["image_provider"]
+    if provider.get("video_provider"):
+        config.setdefault("video_generation", {})["provider"] = provider["video_provider"]
 
     # Set browser cloud provider in config if applicable
     if "browser_provider" in provider:
@@ -1158,6 +1243,15 @@ def _reconfigure_provider(provider: dict, config: dict):
     if provider.get("tts_provider"):
         config.setdefault("tts", {})["provider"] = provider["tts_provider"]
         _print_success(f"  TTS provider set to: {provider['tts_provider']}")
+    if provider.get("x_search_provider"):
+        config.setdefault("x_search", {})["provider"] = provider["x_search_provider"]
+        _print_success(f"  X Search provider set to: {provider['x_search_provider']}")
+    if provider.get("image_provider"):
+        config.setdefault("image_generation", {})["provider"] = provider["image_provider"]
+        _print_success(f"  Image provider set to: {provider['image_provider']}")
+    if provider.get("video_provider"):
+        config.setdefault("video_generation", {})["provider"] = provider["video_provider"]
+        _print_success(f"  Video provider set to: {provider['video_provider']}")
 
     if "browser_provider" in provider:
         bp = provider["browser_provider"]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -224,12 +224,14 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "approvals": "security",
     "human_delay": "display",
     "smart_model_routing": "agent",
+    "image_generation": "media",
+    "video_generation": "media",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
 _CATEGORY_ORDER = [
     "general", "agent", "terminal", "display", "delegation",
-    "memory", "compression", "security", "browser", "voice",
+    "memory", "compression", "security", "browser", "media", "voice",
     "tts", "stt", "logging", "discord", "auxiliary",
 ]
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -689,9 +689,14 @@ class AIAgent:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
             self.api_mode = "codex_responses"
+        elif self.provider == "xai":
+            self.api_mode = "codex_responses"
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower:
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
+        elif (provider_name is None) and "api.x.ai" in self._base_url_lower:
+            self.api_mode = "codex_responses"
+            self.provider = "xai"
         elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self._base_url_lower):
             self.api_mode = "anthropic_messages"
             self.provider = "anthropic"
@@ -3906,6 +3911,7 @@ class AIAgent:
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
             "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
+            "extra_headers",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3940,6 +3946,20 @@ class AIAgent:
             val = api_kwargs.get(passthrough_key)
             if val is not None:
                 normalized[passthrough_key] = val
+
+        extra_headers = api_kwargs.get("extra_headers")
+        if extra_headers is not None:
+            if not isinstance(extra_headers, dict):
+                raise ValueError("Codex Responses request 'extra_headers' must be an object.")
+            normalized_headers: Dict[str, str] = {}
+            for key, value in extra_headers.items():
+                if not isinstance(key, str) or not key.strip():
+                    raise ValueError("Codex Responses request 'extra_headers' keys must be non-empty strings.")
+                if value is None:
+                    continue
+                normalized_headers[key.strip()] = str(value)
+            if normalized_headers:
+                normalized["extra_headers"] = normalized_headers
 
         if allow_stream:
             stream = api_kwargs.get("stream")
@@ -6284,7 +6304,11 @@ class AIAgent:
             if not is_github_responses:
                 kwargs["prompt_cache_key"] = self.session_id
 
-            if reasoning_enabled:
+            is_xai_responses = self.provider == "xai" or "api.x.ai" in (self.base_url or "").lower()
+
+            if reasoning_enabled and is_xai_responses:
+                kwargs["include"] = ["reasoning.encrypted_content"]
+            elif reasoning_enabled:
                 if is_github_responses:
                     # Copilot's Responses route advertises reasoning-effort support,
                     # but not OpenAI-specific prompt cache or encrypted reasoning
@@ -6295,7 +6319,7 @@ class AIAgent:
                 else:
                     kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
                     kwargs["include"] = ["reasoning.encrypted_content"]
-            elif not is_github_responses:
+            elif not is_github_responses and not is_xai_responses:
                 kwargs["include"] = []
 
             if self.request_overrides:
@@ -6303,6 +6327,9 @@ class AIAgent:
 
             if self.max_tokens is not None and not is_codex_backend:
                 kwargs["max_output_tokens"] = self.max_tokens
+
+            if is_xai_responses and getattr(self, "session_id", None):
+                kwargs["extra_headers"] = {"x-grok-conv-id": self.session_id}
 
             return kwargs
 
@@ -6473,12 +6500,6 @@ class AIAgent:
 
         if extra_body:
             api_kwargs["extra_body"] = extra_body
-
-        # xAI prompt caching: send x-grok-conv-id header to route requests
-        # to the same server, maximizing automatic cache hits.
-        # https://docs.x.ai/developers/advanced-api-usage/prompt-caching
-        if "x.ai" in self._base_url_lower and hasattr(self, "session_id") and self.session_id:
-            api_kwargs["extra_headers"] = {"x-grok-conv-id": self.session_id}
 
         # Priority Processing / generic request overrides (e.g. service_tier).
         # Applied last so overrides win over any defaults set above.
@@ -8432,6 +8453,7 @@ class AIAgent:
             for am in api_messages:
                 if isinstance(am.get("content"), str):
                     am["content"] = am["content"].strip()
+
             for am in api_messages:
                 tcs = am.get("tool_calls")
                 if not tcs:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -91,6 +91,7 @@ AUTHOR_MAP = {
     "socrates1024@gmail.com": "socrates1024",
     "satelerd@gmail.com": "satelerd",
     "numman.ali@gmail.com": "nummanali",
+    "jankiewiczmilosz@gmail.com": "Jaaneek",
     "0xNyk@users.noreply.github.com": "0xNyk",
     "0xnykcd@googlemail.com": "0xNyk",
     "buraysandro9@gmail.com": "buray",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -159,12 +159,11 @@ class TestDefaultContextLengths:
     def test_grok_substring_matching(self):
         # Longest-first substring matching must resolve the real xAI model
         # IDs to the correct fallback entries without 128k probe-down.
-        from agent.model_metadata import get_model_context_length
-        from unittest.mock import patch as mock_patch
-
         # Fake the provider/API/cache layers so the lookup falls through
         # to DEFAULT_CONTEXT_LENGTHS.
-        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}),              mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}),              mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+        with patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None):
             cases = [
                 ("grok-4.20-0309-reasoning", 2000000),
                 ("grok-4.20-0309-non-reasoning", 2000000),
@@ -189,6 +188,18 @@ class TestDefaultContextLengths:
                 assert actual == expected_ctx, (
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
+
+    def test_xai_base_url_uses_grok_fallbacks_not_128k_probe_down(self):
+        with patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            actual = get_model_context_length(
+                "grok-4.20-reasoning",
+                base_url="https://api.x.ai/v1",
+                provider="xai",
+            )
+
+        assert actual == 2000000
 
     def test_all_values_positive(self):
         for key, value in DEFAULT_CONTEXT_LENGTHS.items():

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -22,13 +22,14 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "web_search" in tools
         assert "web_extract" in tools
+        assert "x_search" in tools
 
     def test_toolset_includes_core_tools(self):
         tools = resolve_toolset("hermes-api-server")
         expected = [
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
-            "vision_analyze", "image_generate",
+            "vision_analyze", "image_generate", "video_generate",
             "execute_code", "delegate_task",
             "todo", "memory", "session_search", "cronjob",
         ]

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1,4 +1,4 @@
-"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway)."""
+"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, xAI, AI Gateway)."""
 
 import os
 import sys
@@ -26,6 +26,8 @@ from hermes_cli.auth import (
     _resolve_kimi_base_url,
 )
 from hermes_cli.copilot_auth import _try_gh_cli_token
+from hermes_cli.models import _PROVIDER_ALIASES, _PROVIDER_LABELS, _PROVIDER_MODELS
+from hermes_cli.runtime_provider import resolve_runtime_provider
 
 
 # =============================================================================
@@ -39,8 +41,8 @@ class TestProviderRegistry:
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
-        ("zai", "Z.AI / GLM", "api_key"),
         ("xai", "xAI", "api_key"),
+        ("zai", "Z.AI / GLM", "api_key"),
         ("kimi-coding", "Kimi / Moonshot", "api_key"),
         ("minimax", "MiniMax", "api_key"),
         ("minimax-cn", "MiniMax (China)", "api_key"),
@@ -103,6 +105,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["xai"].inference_base_url == "https://api.x.ai/v1"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
@@ -126,6 +129,7 @@ class TestProviderRegistry:
 PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "XAI_API_KEY", "XAI_BASE_URL",
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
@@ -150,6 +154,9 @@ class TestResolveProvider:
     def test_explicit_zai(self):
         assert resolve_provider("zai") == "zai"
 
+    def test_explicit_xai(self):
+        assert resolve_provider("xai") == "xai"
+
     def test_explicit_kimi_coding(self):
         assert resolve_provider("kimi-coding") == "kimi-coding"
 
@@ -170,6 +177,15 @@ class TestResolveProvider:
 
     def test_alias_zhipu(self):
         assert resolve_provider("zhipu") == "zai"
+
+    def test_alias_x_ai(self):
+        assert resolve_provider("x-ai") == "xai"
+
+    def test_alias_x_dot_ai(self):
+        assert resolve_provider("x.ai") == "xai"
+
+    def test_alias_grok(self):
+        assert resolve_provider("grok") == "xai"
 
     def test_alias_kimi(self):
         assert resolve_provider("kimi") == "kimi-coding"
@@ -265,6 +281,10 @@ class TestResolveProvider:
         monkeypatch.setenv("HF_TOKEN", "hf_test_token")
         assert resolve_provider("auto") == "huggingface"
 
+    def test_auto_detects_xai_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "xai_test_token")
+        assert resolve_provider("auto") == "xai"
+
     def test_openrouter_takes_priority_over_glm(self, monkeypatch):
         """OpenRouter API key should win over GLM in auto-detection."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
@@ -302,6 +322,14 @@ class TestApiKeyProviderStatus:
         status = get_api_key_provider_status("zai")
         assert status["configured"] is True
         assert status["key_source"] == "ZAI_API_KEY"
+
+    def test_xai_status_with_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "xai-key")
+        monkeypatch.setenv("XAI_BASE_URL", "https://proxy.x.ai/v1")
+        status = get_api_key_provider_status("xai")
+        assert status["configured"] is True
+        assert status["key_source"] == "XAI_API_KEY"
+        assert status["base_url"] == "https://proxy.x.ai/v1"
 
     def test_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-key")
@@ -426,6 +454,13 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["api_key"] == "kimi-secret-key"
         assert creds["base_url"] == "https://api.moonshot.ai/v1"
 
+    def test_resolve_xai_with_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "xai-secret-key")
+        creds = resolve_api_key_provider_credentials("xai")
+        assert creds["provider"] == "xai"
+        assert creds["api_key"] == "xai-secret-key"
+        assert creds["base_url"] == "https://api.x.ai/v1"
+
     def test_resolve_minimax_with_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-secret-key")
         creds = resolve_api_key_provider_credentials("minimax")
@@ -507,6 +542,14 @@ class TestRuntimeProviderResolution:
         assert result["api_mode"] == "chat_completions"
         assert result["api_key"] == "glm-key"
         assert "z.ai" in result["base_url"] or "api.z.ai" in result["base_url"]
+
+    def test_runtime_xai(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "xai-key")
+        result = resolve_runtime_provider(requested="xai")
+        assert result["provider"] == "xai"
+        assert result["api_mode"] == "codex_responses"
+        assert result["api_key"] == "xai-key"
+        assert result["base_url"] == "https://api.x.ai/v1"
 
     def test_runtime_kimi(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-key")
@@ -986,3 +1029,20 @@ class TestHuggingFaceModels:
         from hermes_cli.models import _PROVIDER_LABELS
         assert "huggingface" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["huggingface"] == "Hugging Face"
+
+
+class TestXaiModels:
+    def test_models_py_has_xai(self):
+        assert "xai" in _PROVIDER_MODELS
+        assert _PROVIDER_MODELS["xai"] == [
+            "grok-4.20-reasoning",
+            "grok-4-1-fast-reasoning",
+        ]
+
+    def test_provider_aliases_in_models_py(self):
+        assert _PROVIDER_ALIASES.get("x-ai") == "xai"
+        assert _PROVIDER_ALIASES.get("x.ai") == "xai"
+        assert _PROVIDER_ALIASES.get("grok") == "xai"
+
+    def test_provider_label(self):
+        assert _PROVIDER_LABELS["xai"] == "xAI"

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -459,7 +459,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -606,6 +606,6 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 17
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -125,6 +125,7 @@ def test_resolve_runtime_provider_codex(monkeypatch):
         lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
     )
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
     monkeypatch.setattr(
         rp,
         "resolve_codex_runtime_credentials",
@@ -236,6 +237,20 @@ def test_resolve_runtime_provider_ai_gateway(monkeypatch):
     assert resolved["base_url"] == "https://ai-gateway.vercel.sh/v1"
     assert resolved["api_key"] == "test-ai-gw-key"
     assert resolved["requested_provider"] == "ai-gateway"
+
+
+def test_resolve_runtime_provider_xai(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "xai")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("XAI_API_KEY", "test-xai-key")
+
+    resolved = rp.resolve_runtime_provider(requested="xai")
+
+    assert resolved["provider"] == "xai"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://api.x.ai/v1"
+    assert resolved["api_key"] == "test-xai-key"
+    assert resolved["requested_provider"] == "xai"
 
 
 def test_resolve_runtime_provider_ai_gateway_explicit_override_skips_pool(monkeypatch):
@@ -803,6 +818,10 @@ def test_model_config_api_mode(monkeypatch):
 
     assert resolved["api_mode"] == "codex_responses"
     assert resolved["base_url"] == "http://127.0.0.1:9208/v1"
+
+
+def test_detect_api_mode_for_xai_url():
+    assert rp._detect_api_mode_for_url("https://api.x.ai/v1") == "codex_responses"
 
 
 def test_model_config_api_mode_ignored_when_provider_differs(monkeypatch):

--- a/tests/hermes_cli/test_setup_tts_xai.py
+++ b/tests/hermes_cli/test_setup_tts_xai.py
@@ -1,0 +1,57 @@
+from hermes_cli.config import load_config
+from hermes_cli.setup import _setup_tts_provider
+
+
+def test_setup_tts_provider_lists_xai_option(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+    captured = {}
+
+    def _fake_prompt_choice(question, choices, default=0):
+        if question == "Select TTS provider:":
+            captured["choices"] = choices
+            return len(choices) - 1
+        return default
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", _fake_prompt_choice)
+
+    _setup_tts_provider(config)
+
+    assert any("xAI TTS" in choice for choice in captured["choices"])
+
+
+def test_setup_tts_provider_saves_xai_selection(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = load_config()
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda question, choices, default=0: choices.index("xAI TTS (Grok voices, needs API key)"),
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *a, **kw: "xai-test-key")
+
+    _setup_tts_provider(config)
+
+    saved = load_config()
+    assert saved["tts"]["provider"] == "xai"
+
+
+def test_setup_tts_provider_warns_with_remediation_when_xai_key_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    config = load_config()
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda question, choices, default=0: choices.index("xAI TTS (Grok voices, needs API key)"),
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *a, **kw: "")
+    monkeypatch.setattr("hermes_cli.setup.print_warning", lambda message: captured.setdefault("warning", message))
+
+    _setup_tts_provider(config)
+
+    saved = load_config()
+    assert saved["tts"]["provider"] == "edge"
+    assert "hermes setup model" in captured["warning"]
+    assert "XAI_API_KEY" in captured["warning"]

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from hermes_cli.config import load_config
 from hermes_cli.tools_config import (
     _configure_provider,
     _get_platform_tools,
@@ -30,6 +31,51 @@ def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 
     assert "messaging" in enabled
+
+
+def test_default_config_includes_image_and_video_generation_sections(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = load_config()
+
+    assert config["image_generation"]["provider"] == "auto"
+    assert config["video_generation"]["provider"] == "xai"
+    assert config["x_search"]["provider"] == "xai"
+
+
+def test_tts_tool_category_includes_xai_provider():
+    providers = TOOL_CATEGORIES["tts"]["providers"]
+    xai = next((provider for provider in providers if provider.get("tts_provider") == "xai"), None)
+
+    assert xai is not None
+    assert xai["name"] == "xAI TTS"
+    assert xai["env_vars"][0]["key"] == "XAI_API_KEY"
+
+
+def test_x_search_tool_category_includes_xai_provider():
+    providers = TOOL_CATEGORIES["x_search"]["providers"]
+
+    assert len(providers) == 1
+    assert providers[0]["name"] == "xAI X Search"
+    assert providers[0]["env_vars"][0]["key"] == "XAI_API_KEY"
+    assert providers[0]["x_search_provider"] == "xai"
+
+
+def test_image_gen_tool_category_includes_xai_provider():
+    providers = TOOL_CATEGORIES["image_gen"]["providers"]
+    xai = next((provider for provider in providers if provider.get("image_provider") == "xai"), None)
+
+    assert xai is not None
+    assert xai["name"] == "xAI Images"
+    assert xai["env_vars"][0]["key"] == "XAI_API_KEY"
+
+
+def test_video_gen_tool_category_includes_xai_provider():
+    providers = TOOL_CATEGORIES["video_gen"]["providers"]
+
+    assert len(providers) == 1
+    assert providers[0]["name"] == "xAI Videos"
+    assert providers[0]["env_vars"][0]["key"] == "XAI_API_KEY"
 
 
 def test_get_platform_tools_preserves_explicit_empty_selection():
@@ -335,6 +381,91 @@ def test_local_browser_provider_is_saved_explicitly(monkeypatch):
     _configure_provider(local_provider, config)
 
     assert config["browser"]["cloud_provider"] == "local"
+
+
+def test_image_provider_is_saved_explicitly():
+    config = {}
+    xai_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["image_gen"]["providers"]
+        if provider.get("image_provider") == "xai"
+    )
+
+    with patch("hermes_cli.tools_config.get_env_value", return_value=None), \
+         patch("hermes_cli.tools_config._prompt", return_value="xai-test-key"), \
+         patch("hermes_cli.tools_config.save_env_value"):
+        _configure_provider(xai_provider, config)
+
+    assert config["image_generation"]["provider"] == "xai"
+
+
+def test_video_provider_is_saved_explicitly():
+    config = {}
+    xai_provider = TOOL_CATEGORIES["video_gen"]["providers"][0]
+
+    with patch("hermes_cli.tools_config.get_env_value", return_value=None), \
+         patch("hermes_cli.tools_config._prompt", return_value="xai-test-key"), \
+         patch("hermes_cli.tools_config.save_env_value"):
+        _configure_provider(xai_provider, config)
+
+    assert config["video_generation"]["provider"] == "xai"
+
+
+def test_x_search_provider_is_saved_explicitly():
+    config = {}
+    xai_provider = TOOL_CATEGORIES["x_search"]["providers"][0]
+
+    with patch("hermes_cli.tools_config.get_env_value", return_value=None), \
+         patch("hermes_cli.tools_config._prompt", return_value="xai-test-key"), \
+         patch("hermes_cli.tools_config.save_env_value"):
+        _configure_provider(xai_provider, config)
+
+    assert config["x_search"]["provider"] == "xai"
+
+
+def test_x_search_provider_is_marked_active():
+    from hermes_cli.tools_config import _is_provider_active
+
+    config = {"x_search": {"provider": "xai"}}
+    xai_provider = TOOL_CATEGORIES["x_search"]["providers"][0]
+
+    assert _is_provider_active(xai_provider, config) is True
+
+
+def test_x_search_provider_is_reconfigured_explicitly():
+    from hermes_cli.tools_config import _reconfigure_provider
+
+    config = {}
+    xai_provider = TOOL_CATEGORIES["x_search"]["providers"][0]
+
+    with patch("hermes_cli.tools_config.get_env_value", return_value=None), \
+         patch("hermes_cli.tools_config._prompt", return_value="xai-test-key"), \
+         patch("hermes_cli.tools_config.save_env_value"):
+        _reconfigure_provider(xai_provider, config)
+
+    assert config["x_search"]["provider"] == "xai"
+
+
+def test_managed_image_provider_not_active_when_image_backend_is_xai(monkeypatch):
+    from types import SimpleNamespace
+    from hermes_cli.tools_config import _is_provider_active
+
+    config = {"image_generation": {"provider": "xai"}}
+    managed_provider = next(
+        provider
+        for provider in TOOL_CATEGORIES["image_gen"]["providers"]
+        if provider.get("managed_nous_feature") == "image_gen"
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.get_nous_subscription_features",
+        lambda _cfg: SimpleNamespace(
+            features={"image_gen": SimpleNamespace(managed_by_nous=True)},
+            nous_auth_present=True,
+        ),
+    )
+
+    assert _is_provider_active(managed_provider, config) is False
 
 
 def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):

--- a/tests/hermes_cli/test_xai_provider_model_flow.py
+++ b/tests/hermes_cli/test_xai_provider_model_flow.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+
+def test_xai_setup_flow_uses_standard_model_selection(monkeypatch):
+    from hermes_cli.main import _model_flow_api_key_provider
+
+    captured = {}
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    def _capture_models(models, current_model=""):
+        captured["models"] = models
+        return None
+
+    with (
+        patch("hermes_cli.main.input", return_value=""),
+        patch("agent.models_dev.list_agentic_models", return_value=["grok-2-1212", "grok-4-fast"]),
+        patch("hermes_cli.models.fetch_api_models", return_value=["grok-2-1212"]),
+        patch("hermes_cli.auth._prompt_model_selection", side_effect=_capture_models),
+        ):
+            _model_flow_api_key_provider({}, "xai")
+
+    assert captured["models"] == ["grok-2-1212", "grok-4-fast"]
+
+
+def test_xai_provider_uses_codex_responses_transport():
+    from hermes_cli.providers import determine_api_mode, get_provider
+
+    provider = get_provider("xai")
+
+    assert provider is not None
+    assert provider.transport == "codex_responses"
+    assert determine_api_mode("xai") == "codex_responses"
+
+
+def test_xai_auxiliary_model_uses_grok_420():
+    from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+
+    assert _API_KEY_PROVIDER_AUX_MODELS["xai"] == "grok-4.20-reasoning"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -70,6 +70,27 @@ def _build_copilot_agent(monkeypatch, *, model="gpt-5.4"):
     return agent
 
 
+def _build_xai_agent(monkeypatch, *, model="grok-4.20-reasoning"):
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model=model,
+        provider="xai",
+        api_mode="codex_responses",
+        base_url="https://api.x.ai/v1",
+        api_key="xai-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._save_session_log = lambda messages: None
+    return agent
+
+
 def _codex_message_response(text: str):
     return SimpleNamespace(
         output=[
@@ -387,6 +408,28 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
     assert "reasoning" not in kwargs
     assert "include" not in kwargs
     assert "prompt_cache_key" not in kwargs
+
+
+def test_build_api_kwargs_xai_omits_default_reasoning_parameter(monkeypatch):
+    agent = _build_xai_agent(monkeypatch)
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    assert kwargs["model"] == "grok-4.20-reasoning"
+    assert kwargs["store"] is False
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+    assert isinstance(kwargs["prompt_cache_key"], str)
+    assert "reasoning" not in kwargs
+    assert kwargs["include"] == ["reasoning.encrypted_content"]
+
+
+def test_build_api_kwargs_xai_adds_grok_conversation_header(monkeypatch):
+    agent = _build_xai_agent(monkeypatch)
+    agent.session_id = "sess_xai_123"
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    assert kwargs["extra_headers"] == {"x-grok-conv-id": "sess_xai_123"}
 
 
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
@@ -757,6 +800,15 @@ def test_preflight_codex_api_kwargs_allows_service_tier(monkeypatch):
 
     result = agent._preflight_codex_api_kwargs(kwargs)
     assert result["service_tier"] == "priority"
+
+
+def test_preflight_codex_api_kwargs_allows_extra_headers(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["extra_headers"] = {"x-grok-conv-id": "sess_xai_123"}
+
+    result = agent._preflight_codex_api_kwargs(kwargs)
+    assert result["extra_headers"] == {"x-grok-conv-id": "sess_xai_123"}
 
 
 def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
@@ -1188,6 +1240,28 @@ def test_chat_messages_to_responses_input_reasoning_only_has_following_item(monk
     assert ri_idx < len(items) - 1, "Reasoning item must not be the last item (missing_following_item)"
     following = items[ri_idx + 1]
     assert following.get("role") == "assistant"
+
+
+def test_chat_messages_to_responses_input_xai_replays_encrypted_reasoning(monkeypatch):
+    agent = _build_xai_agent(monkeypatch)
+    messages = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "visible answer",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_xai_1", "encrypted_content": "enc_xai", "summary": []},
+            ],
+        },
+        {"role": "user", "content": "follow up"},
+    ]
+
+    items = agent._chat_messages_to_responses_input(messages)
+    reasoning_items = [item for item in items if item.get("type") == "reasoning"]
+
+    assert len(reasoning_items) == 1
+    assert reasoning_items[0]["encrypted_content"] == "enc_xai"
+    assert {"role": "assistant", "content": "visible answer"} in items
 
 
 def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch):

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 17
+        assert DEFAULT_CONFIG["_config_version"] >= 17

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -1,0 +1,207 @@
+import json
+import requests
+
+
+class _FakeResponse:
+    def __init__(self, payload, *, status_code=200, text=None):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.HTTPError(f"{self.status_code} Client Error")
+            err.response = self
+            raise err
+
+    def json(self):
+        return self._payload
+
+
+def test_x_search_posts_responses_request(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+    from hermes_cli import __version__
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "output_text": "People on X are discussing xAI's latest launch.",
+                "citations": [{"url": "https://x.com/example/status/1", "title": "Example post"}],
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(
+        x_search_tool(
+            query="What are people saying about xAI on X?",
+            allowed_x_handles=["xai", "@grok"],
+            from_date="2026-04-01",
+            to_date="2026-04-10",
+            enable_image_understanding=True,
+        )
+    )
+
+    tool_def = captured["json"]["tools"][0]
+    assert captured["url"] == "https://api.x.ai/v1/responses"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["model"] == "grok-4.20-reasoning"
+    assert captured["json"]["store"] is False
+    assert tool_def["type"] == "x_search"
+    assert tool_def["allowed_x_handles"] == ["xai", "grok"]
+    assert tool_def["from_date"] == "2026-04-01"
+    assert tool_def["to_date"] == "2026-04-10"
+    assert tool_def["enable_image_understanding"] is True
+    assert result["success"] is True
+    assert result["answer"] == "People on X are discussing xAI's latest launch."
+
+
+def test_x_search_rejects_conflicting_handle_filters(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(
+        x_search_tool(
+            query="latest xAI discussion",
+            allowed_x_handles=["xai"],
+            excluded_x_handles=["grok"],
+        )
+    )
+
+    assert result["error"] == "allowed_x_handles and excluded_x_handles cannot be used together"
+
+
+def test_x_search_extracts_inline_url_citations(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(
+            {
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "xAI posted an update on X.",
+                                "annotations": [
+                                    {
+                                        "type": "url_citation",
+                                        "url": "https://x.com/xai/status/123",
+                                        "title": "xAI update",
+                                        "start_index": 0,
+                                        "end_index": 3,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="latest post from xai"))
+
+    assert result["success"] is True
+    assert result["answer"] == "xAI posted an update on X."
+    assert result["inline_citations"] == [
+        {
+            "url": "https://x.com/xai/status/123",
+            "title": "xAI update",
+            "start_index": 0,
+            "end_index": 3,
+        }
+    ]
+
+
+def test_x_search_returns_structured_http_error(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    class _FailingResponse:
+        status_code = 403
+        text = '{"code":"forbidden","error":"x_search is not enabled for this model"}'
+
+        def json(self):
+            return {
+                "code": "forbidden",
+                "error": "x_search is not enabled for this model",
+            }
+
+        def raise_for_status(self):
+            err = requests.HTTPError("403 Client Error: Forbidden")
+            err.response = self
+            raise err
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", lambda *a, **k: _FailingResponse())
+
+    result = json.loads(x_search_tool(query="latest xai discussion"))
+
+    assert result["success"] is False
+    assert result["provider"] == "xai"
+    assert result["tool"] == "x_search"
+    assert result["error_type"] == "HTTPError"
+    assert result["error"] == "forbidden: x_search is not enabled for this model"
+
+
+def test_x_search_retries_read_timeout_then_succeeds(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise requests.ReadTimeout("timed out")
+        return _FakeResponse(
+            {
+                "output_text": "Recovered after retry.",
+                "citations": [],
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.x_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(x_search_tool(query="grok xai"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after retry."
+
+
+def test_x_search_retries_5xx_then_succeeds(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    calls = {"count": 0}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return _FakeResponse(
+                {"code": "Internal error", "error": "Service temporarily unavailable."},
+                status_code=500,
+            )
+        return _FakeResponse({"output_text": "Recovered after 5xx retry."})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+    monkeypatch.setattr("tools.x_search_tool.time.sleep", lambda *_: None)
+
+    result = json.loads(x_search_tool(query="grok xai"))
+
+    assert calls["count"] == 2
+    assert result["success"] is True
+    assert result["answer"] == "Recovered after 5xx retry."

--- a/tests/tools/test_xai_media_tools.py
+++ b/tests/tools/test_xai_media_tools.py
@@ -1,0 +1,611 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+
+def test_video_generate_schema_guides_prompt_without_requiring_it():
+    from tools.video_generation_tool import VIDEO_GENERATE_SCHEMA
+
+    parameters = VIDEO_GENERATE_SCHEMA["parameters"]
+    properties = parameters["properties"]
+
+    assert "prompt" not in parameters.get("required", [])
+    assert "Usually pass this" in properties["prompt"]["description"]
+    assert "Optional only for image-to-video" in properties["prompt"]["description"]
+    assert "output" not in properties
+    assert "output_upload_url" not in properties
+
+
+class _FakeResponse:
+    def __init__(self, *, json_payload=None, content=b""):
+        self._json_payload = json_payload or {}
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._json_payload
+
+
+def _fake_httpx_client(*, post_fn, get_fn=None):
+    """Build a mock httpx.AsyncClient that delegates to sync test helpers."""
+    client = AsyncMock()
+
+    async def _post(url, *, headers=None, json=None, timeout=None):
+        return post_fn(url, headers=headers, json=json, timeout=timeout)
+
+    async def _get(url, *, headers=None, timeout=None):
+        return get_fn(url, headers=headers, timeout=timeout)
+
+    client.post = _post
+    if get_fn is not None:
+        client.get = _get
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+def test_image_generate_tool_supports_xai_provider(monkeypatch):
+    from tools.image_generation_tool import image_generate_tool
+    from hermes_cli import __version__
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        assert url == "https://api.x.ai/v1/images/generations"
+        assert headers["User-Agent"] == f"Hermes-Agent/{__version__}"
+        assert json["model"] == "grok-imagine-image"
+        assert json["aspect_ratio"] == "16:9"
+        return _FakeResponse(
+            json_payload={
+                "data": [
+                    {
+                        "url": "https://cdn.example.com/generated.png",
+                        "width": 1280,
+                        "height": 720,
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("tools.image_generation_tool.requests.post", _fake_post)
+    monkeypatch.setattr("tools.image_generation_tool._has_fal_backend", lambda: False)
+
+    result = json.loads(
+        image_generate_tool(
+            prompt="a cinematic skyline at sunset",
+            provider="xai",
+            aspect_ratio="landscape",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["provider"] == "xai"
+    assert result["image"] == "https://cdn.example.com/generated.png"
+
+
+def test_image_generate_tool_supports_xai_reference_images_for_generate(monkeypatch):
+    from tools.image_generation_tool import image_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(
+            json_payload={
+                "data": [
+                    {
+                        "url": "https://cdn.example.com/reference-guided.png",
+                        "width": 1280,
+                        "height": 720,
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("tools.image_generation_tool.requests.post", _fake_post)
+    monkeypatch.setattr("tools.image_generation_tool._has_fal_backend", lambda: True)
+
+    result = json.loads(
+        image_generate_tool(
+            prompt="A campaign portrait in xAI style.",
+            provider="auto",
+            aspect_ratio="16:9",
+            reference_image_urls=[
+                "https://cdn.example.com/reference-a.png",
+                "https://cdn.example.com/reference-b.png",
+            ],
+        )
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/images/generations"
+    assert captured["json"]["reference_images"] == [
+        {"type": "image_url", "url": "https://cdn.example.com/reference-a.png"},
+        {"type": "image_url", "url": "https://cdn.example.com/reference-b.png"},
+    ]
+    assert result["success"] is True
+    assert result["provider"] == "xai"
+    assert result["image"] == "https://cdn.example.com/reference-guided.png"
+
+
+def test_image_generate_tool_supports_xai_edit_with_multiple_source_images(monkeypatch):
+    from tools.image_generation_tool import image_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(
+            json_payload={
+                "data": [
+                    {
+                        "url": "https://cdn.example.com/edited.png",
+                        "width": 1536,
+                        "height": 1024,
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("tools.image_generation_tool.requests.post", _fake_post)
+    monkeypatch.setattr("tools.image_generation_tool._has_fal_backend", lambda: True)
+
+    result = json.loads(
+        image_generate_tool(
+            prompt="Put the two people together in one cinematic rooftop portrait.",
+            operation="edit",
+            provider="auto",
+            aspect_ratio="3:2",
+            resolution="2k",
+            source_image_urls=[
+                "https://cdn.example.com/person-a.png",
+                "https://cdn.example.com/person-b.png",
+            ],
+        )
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/images/edits"
+    assert captured["json"]["images"][0]["url"] == "https://cdn.example.com/person-a.png"
+    assert captured["json"]["images"][1]["url"] == "https://cdn.example.com/person-b.png"
+    assert captured["json"]["aspect_ratio"] == "3:2"
+    assert captured["json"]["resolution"] == "2k"
+    assert result["success"] is True
+    assert result["provider"] == "xai"
+    assert result["operation"] == "edit"
+    assert result["image"] == "https://cdn.example.com/edited.png"
+
+
+def test_image_generate_tool_uses_configured_xai_provider_by_default(monkeypatch):
+    from tools.image_generation_tool import image_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(
+            json_payload={
+                "data": [
+                    {
+                        "url": "https://cdn.example.com/configured-xai.png",
+                        "width": 1024,
+                        "height": 1024,
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("tools.image_generation_tool.requests.post", _fake_post)
+    monkeypatch.setattr("tools.image_generation_tool._has_fal_backend", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"image_generation": {"provider": "xai"}},
+    )
+
+    result = json.loads(
+        image_generate_tool(
+            prompt="an xAI-first image backend test",
+            aspect_ratio="square",
+        )
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/images/generations"
+    assert result["success"] is True
+    assert result["provider"] == "xai"
+
+
+def test_image_generate_tool_prefers_xai_only_features_over_saved_fal_default(monkeypatch):
+    from tools.image_generation_tool import image_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _FakeResponse(
+            json_payload={
+                "data": [
+                    {
+                        "url": "https://cdn.example.com/edited-with-xai.png",
+                        "width": 1024,
+                        "height": 1024,
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("tools.image_generation_tool.requests.post", _fake_post)
+    monkeypatch.setattr("tools.image_generation_tool._has_fal_backend", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"image_generation": {"provider": "fal"}},
+    )
+
+    result = json.loads(
+        image_generate_tool(
+            prompt="edit this image",
+            provider="auto",
+            operation="edit",
+            source_image_url="https://cdn.example.com/source.png",
+        )
+    )
+
+    assert captured["url"] == "https://api.x.ai/v1/images/edits"
+    assert result["success"] is True
+    assert result["provider"] == "xai"
+
+
+def test_image_generate_tool_errors_clearly_when_xai_only_features_need_xai(monkeypatch):
+    from tools.image_generation_tool import image_generate_tool
+
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr("tools.image_generation_tool._has_fal_backend", lambda: True)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    result = json.loads(
+        image_generate_tool(
+            prompt="edit this image",
+            provider="auto",
+            operation="edit",
+            source_image_url="https://cdn.example.com/source.png",
+        )
+    )
+
+    assert result["success"] is False
+    assert "requires xAI image support" in result["error"]
+
+
+def test_video_generate_tool_polls_until_done(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+    from hermes_cli import __version__
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["submit_json"] = json
+        return _FakeResponse(json_payload={"request_id": "vid-123"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        captured.setdefault("poll_urls", []).append(url)
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "video": {"url": "https://cdn.example.com/generated.mp4"},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                prompt="slow drone shot over a neon city",
+                duration=8,
+                aspect_ratio="16:9",
+                resolution="720p",
+                poll_interval_seconds=0,
+                timeout_seconds=30,
+            )
+        )
+    )
+
+    assert captured["submit_url"] == "https://api.x.ai/v1/videos/generations"
+    assert captured["submit_json"]["prompt"] == "slow drone shot over a neon city"
+    assert captured["poll_urls"] == ["https://api.x.ai/v1/videos/vid-123"]
+    assert result["success"] is True
+    assert result["provider"] == "xai"
+    assert result["video"] == "https://cdn.example.com/generated.mp4"
+
+
+def test_video_generate_tool_sends_hermes_user_agent(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+    from hermes_cli import __version__
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_headers"] = headers
+        return _FakeResponse(json_payload={"request_id": "vid-ua"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        captured["poll_headers"] = headers
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "video": {"url": "https://cdn.example.com/generated.mp4"},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    asyncio.run(
+        video_generate_tool(
+            prompt="slow drone shot over a neon city",
+            duration=8,
+            aspect_ratio="16:9",
+            resolution="720p",
+            poll_interval_seconds=0,
+            timeout_seconds=30,
+        )
+    )
+
+    assert captured["submit_headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["poll_headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+
+
+def test_video_generate_tool_supports_native_extend(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["submit_json"] = json
+        return _FakeResponse(json_payload={"request_id": "vid-456"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "video": {"url": "https://cdn.example.com/extended.mp4"},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                prompt="Continue the shot as the camera drifts behind the subject.",
+                operation="extend",
+                duration=6,
+                video_url="https://cdn.example.com/source.mp4",
+                poll_interval_seconds=0,
+                timeout_seconds=30,
+            )
+        )
+    )
+
+    assert captured["submit_url"] == "https://api.x.ai/v1/videos/extensions"
+    assert captured["submit_json"]["video"]["url"] == "https://cdn.example.com/source.mp4"
+    assert captured["submit_json"]["duration"] == 6
+    assert result["success"] is True
+    assert result["operation"] == "extend"
+    assert result["video"] == "https://cdn.example.com/extended.mp4"
+
+
+def test_video_generate_tool_recovers_promptless_extend_from_source_video_url(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+
+    captured = {}
+    source_url = "https://cdn.example.com/source.mp4"
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["submit_json"] = json
+        return _FakeResponse(json_payload={"request_id": "vid-extend-auto"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "video": {"url": "https://cdn.example.com/extended-auto.mp4"},
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                duration=8,
+                video_url=source_url,
+                poll_interval_seconds=0,
+                timeout_seconds=30,
+            )
+        )
+    )
+
+    assert captured["submit_url"] == "https://api.x.ai/v1/videos/extensions"
+    assert captured["submit_json"]["video"]["url"] == source_url
+    assert captured["submit_json"]["prompt"] == "Continue the existing video naturally."
+    assert result["success"] is True
+    assert result["operation"] == "extend"
+    assert any("default continuation prompt" in note for note in result["notes"])
+
+
+def test_video_generate_tool_edit_without_prompt_still_errors(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                operation="edit",
+                video_url="https://cdn.example.com/source.mp4",
+            )
+        )
+    )
+
+    assert result["error"] == "prompt is required for xAI video edit"
+
+
+def test_video_generate_tool_uses_video_object_for_edit(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["submit_json"] = json
+        return _FakeResponse(json_payload={"request_id": "vid-edit"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "model": "grok-imagine-video",
+                "video": {
+                    "url": "https://cdn.example.com/edited.mp4",
+                    "duration": 8,
+                    "respect_moderation": True,
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                prompt="Give the subject a silver necklace.",
+                operation="edit",
+                video_url="https://cdn.example.com/source.mp4",
+                user="jaaneek",
+                poll_interval_seconds=0,
+                timeout_seconds=30,
+            )
+        )
+    )
+
+    assert captured["submit_url"] == "https://api.x.ai/v1/videos/edits"
+    assert captured["submit_json"]["video"]["url"] == "https://cdn.example.com/source.mp4"
+    assert captured["submit_json"]["user"] == "jaaneek"
+    assert "output" not in captured["submit_json"]
+    assert result["success"] is True
+    assert result["operation"] == "edit"
+    assert result["video"] == "https://cdn.example.com/edited.mp4"
+    assert result["respect_moderation"] is True
+
+
+def test_video_generate_tool_ignores_duration_for_edit(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_json"] = json
+        return _FakeResponse(json_payload={"request_id": "vid-edit-duration"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "video": {
+                    "url": "https://cdn.example.com/edited.mp4",
+                    "duration": 8,
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                prompt="Give the subject a silver necklace.",
+                operation="edit",
+                duration=20,
+                video_url="https://cdn.example.com/source.mp4",
+                poll_interval_seconds=0,
+                timeout_seconds=30,
+            )
+        )
+    )
+
+    assert result["success"] is True
+    assert "duration" not in captured["submit_json"]
+    assert result["duration"] == 8
+
+
+def test_video_generate_tool_supports_promptless_image_to_video(monkeypatch):
+    from tools.video_generation_tool import video_generate_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["submit_url"] = url
+        captured["submit_json"] = json
+        return _FakeResponse(json_payload={"request_id": "vid-i2v"})
+
+    def _fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(
+            json_payload={
+                "status": "done",
+                "video": {
+                    "url": "https://cdn.example.com/i2v.mp4",
+                    "duration": 8,
+                    "respect_moderation": True,
+                },
+            }
+        )
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    mock_client = _fake_httpx_client(post_fn=_fake_post, get_fn=_fake_get)
+    monkeypatch.setattr("tools.video_generation_tool.httpx.AsyncClient", lambda: mock_client)
+
+    result = json.loads(
+        asyncio.run(
+            video_generate_tool(
+                prompt="",
+                operation="generate",
+                image_url="https://cdn.example.com/still.png",
+                seconds=8,
+                aspect_ratio="4:3",
+                resolution="480p",
+                size="848x480",
+                poll_interval_seconds=0,
+                timeout_seconds=30,
+            )
+        )
+    )
+
+    assert captured["submit_url"] == "https://api.x.ai/v1/videos/generations"
+    assert "prompt" not in captured["submit_json"]
+    assert captured["submit_json"]["image"]["url"] == "https://cdn.example.com/still.png"
+    assert captured["submit_json"]["duration"] == 8
+    assert captured["submit_json"]["aspect_ratio"] == "4:3"
+    assert captured["submit_json"]["resolution"] == "480p"
+    assert captured["submit_json"]["size"] == "848x480"
+    assert result["success"] is True
+    assert result["video"] == "https://cdn.example.com/i2v.mp4"

--- a/tests/tools/test_xai_tts_tool.py
+++ b/tests/tools/test_xai_tts_tool.py
@@ -1,0 +1,71 @@
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, *, content=b""):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+def test_generate_xai_tts_writes_audio_file(monkeypatch, tmp_path):
+    from hermes_cli import __version__
+    from tools.tts_tool import _generate_xai_tts
+
+    captured = {}
+    output_path = tmp_path / "speech.mp3"
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _FakeResponse(content=b"fake-mp3-bytes")
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = _generate_xai_tts("hello world", str(output_path), {"xai": {"voice_id": "eve"}})
+
+    assert result == str(output_path)
+    assert output_path.read_bytes() == b"fake-mp3-bytes"
+    assert captured["url"] == "https://api.x.ai/v1/tts"
+    assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
+    assert captured["json"]["text"] == "hello world"
+    assert captured["json"]["voice_id"] == "eve"
+    assert captured["json"]["language"] == "en"
+    assert "output_format" not in captured["json"]
+
+
+def test_generate_xai_tts_includes_output_format_for_non_default_overrides(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_xai_tts
+
+    captured = {}
+    output_path = tmp_path / "speech.wav"
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse(content=b"fake-wav-bytes")
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = _generate_xai_tts(
+        "hello world",
+        str(output_path),
+        {"xai": {"voice_id": "eve", "language": "en", "sample_rate": 44100}},
+    )
+
+    assert result == str(output_path)
+    assert captured["json"]["output_format"]["codec"] == "wav"
+    assert captured["json"]["output_format"]["sample_rate"] == 44100
+
+
+def test_generate_xai_tts_missing_key_raises_value_error(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_xai_tts
+
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="XAI_API_KEY"):
+        _generate_xai_tts("hello world", str(tmp_path / "speech.mp3"), {"xai": {"voice_id": "eve"}})

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -2,8 +2,9 @@
 """
 Image Generation Tools Module
 
-This module provides image generation tools using FAL.ai's FLUX 2 Pro model with 
-automatic upscaling via FAL.ai's Clarity Upscaler for enhanced image quality.
+This module provides image generation tools using either:
+- FAL.ai FLUX 2 Pro with automatic Clarity upscaling
+- xAI grok-imagine-image
 
 Available tools:
 - image_generate_tool: Generate images from text prompts with automatic upscaling
@@ -34,17 +35,22 @@ import os
 import datetime
 import threading
 import uuid
+import requests
 from typing import Dict, Any, Optional, Union
 from urllib.parse import urlencode
-import fal_client
 from tools.debug_helpers import DebugSession
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled
+from tools.xai_http import hermes_xai_user_agent
 
 logger = logging.getLogger(__name__)
 
 # Configuration for image generation
+DEFAULT_PROVIDER = "auto"
+DEFAULT_OPERATION = "generate"
 DEFAULT_MODEL = "fal-ai/flux-2-pro"
+DEFAULT_XAI_MODEL = "grok-imagine-image"
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_ASPECT_RATIO = "landscape"
 DEFAULT_NUM_INFERENCE_STEPS = 50
 DEFAULT_GUIDANCE_SCALE = 4.5
@@ -79,11 +85,42 @@ VALID_IMAGE_SIZES = [
 ]
 VALID_OUTPUT_FORMATS = ["jpeg", "png"]
 VALID_ACCELERATION_MODES = ["none", "regular", "high"]
+XAI_ASPECT_RATIO_MAP = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+VALID_XAI_ASPECT_RATIOS = {
+    "auto",
+    "1:1",
+    "16:9",
+    "9:16",
+    "4:3",
+    "3:4",
+    "3:2",
+    "2:3",
+    "2:1",
+    "1:2",
+    "19.5:9",
+    "9:19.5",
+    "20:9",
+    "9:20",
+}
+VALID_XAI_RESOLUTIONS = {"1k", "2k"}
+VALID_XAI_RESPONSE_FORMATS = {"url", "b64_json"}
+VALID_XAI_OPERATIONS = {"generate", "edit"}
 
 _debug = DebugSession("image_tools", env_var="IMAGE_TOOLS_DEBUG")
 _managed_fal_client = None
 _managed_fal_client_config = None
 _managed_fal_client_lock = threading.Lock()
+
+
+def _import_fal_client():
+    """Lazy import fal_client so xAI-only users can still use image generation."""
+    import fal_client
+
+    return fal_client
 
 
 def _resolve_managed_fal_gateway():
@@ -104,6 +141,7 @@ class _ManagedFalSyncClient:
     """Small per-instance wrapper around fal_client.SyncClient for managed queue hosts."""
 
     def __init__(self, *, key: str, queue_run_origin: str):
+        fal_client = _import_fal_client()
         sync_client_class = getattr(fal_client, "SyncClient", None)
         if sync_client_class is None:
             raise RuntimeError("fal_client.SyncClient is required for managed FAL gateway mode")
@@ -204,6 +242,7 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
     request_headers = {"x-idempotency-key": str(uuid.uuid4())}
     managed_gateway = _resolve_managed_fal_gateway()
     if managed_gateway is None:
+        fal_client = _import_fal_client()
         return fal_client.submit(model, arguments=arguments, headers=request_headers)
 
     managed_client = _get_managed_fal_client(managed_gateway)
@@ -212,6 +251,246 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
         arguments=arguments,
         headers=request_headers,
     )
+
+
+def _has_fal_backend() -> bool:
+    """Return True when FAL image generation can run with direct or managed auth."""
+    if not (os.getenv("FAL_KEY") or _resolve_managed_fal_gateway()):
+        return False
+    try:
+        _import_fal_client()
+        return True
+    except ImportError:
+        return False
+
+
+def _has_xai_image_backend() -> bool:
+    return bool(os.getenv("XAI_API_KEY", "").strip())
+
+
+def _normalize_provider(provider: Optional[str]) -> str:
+    normalized = (provider or DEFAULT_PROVIDER).lower().strip()
+    aliases = {
+        "grok": "xai",
+        "x-ai": "xai",
+        "x.ai": "xai",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in {"auto", "fal", "xai"}:
+        raise ValueError("provider must be one of: auto, fal, xai")
+    return normalized
+
+
+def _resolve_image_provider(
+    provider: Optional[str],
+    *,
+    prefer_xai: bool = False,
+) -> str:
+    requested = _normalize_provider(provider)
+    if requested == "auto" and not prefer_xai:
+        try:
+            from hermes_cli.config import load_config
+
+            configured_provider = _normalize_provider(
+                (load_config().get("image_generation", {}) or {}).get("provider")
+            )
+            if configured_provider != "auto":
+                requested = configured_provider
+        except Exception:
+            pass
+    if requested != "auto":
+        return requested
+    if prefer_xai and _has_xai_image_backend():
+        return "xai"
+    if prefer_xai:
+        raise ValueError(
+            "This image request requires xAI image support. Configure XAI_API_KEY or call image_generate with provider='fal' only for basic generation."
+        )
+    if _has_fal_backend():
+        return "fal"
+    if _has_xai_image_backend():
+        return "xai"
+    return "fal"
+
+
+def _data_uri_from_b64(encoded: str, output_format: str) -> str:
+    mime = "image/png" if output_format == "png" else "image/jpeg"
+    return f"data:{mime};base64,{encoded}"
+
+
+def _normalize_xai_aspect_ratio(aspect_ratio: Optional[str]) -> str:
+    normalized = (aspect_ratio or DEFAULT_ASPECT_RATIO).strip().lower()
+    return XAI_ASPECT_RATIO_MAP.get(normalized, normalized)
+
+
+def _normalize_xai_operation(
+    operation: Optional[str],
+    source_image_url: Optional[str],
+    source_image_urls: Optional[list[str]],
+) -> str:
+    normalized = (operation or "").strip().lower()
+    if not normalized:
+        return "edit" if ((source_image_url or "").strip() or (source_image_urls or [])) else DEFAULT_OPERATION
+    aliases = {
+        "generate_image": "generate",
+        "edit_image": "edit",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in VALID_XAI_OPERATIONS:
+        raise ValueError(f"operation must be one of {sorted(VALID_XAI_OPERATIONS)}")
+    return normalized
+
+
+def _normalize_xai_source_images(
+    source_image_url: Optional[str],
+    source_image_urls: Optional[list[str]],
+) -> list[dict[str, str]]:
+    merged: list[str] = []
+    if source_image_url and source_image_url.strip():
+        merged.append(source_image_url.strip())
+    for value in source_image_urls or []:
+        normalized = (value or "").strip()
+        if normalized:
+            merged.append(normalized)
+
+    deduped: list[str] = []
+    seen = set()
+    for value in merged:
+        if value not in seen:
+            seen.add(value)
+            deduped.append(value)
+    return [{"type": "image_url", "url": value} for value in deduped]
+
+
+def _normalize_xai_reference_images(
+    reference_image_urls: Optional[list[str]],
+) -> list[dict[str, str]]:
+    deduped: list[str] = []
+    seen = set()
+    for value in reference_image_urls or []:
+        normalized = (value or "").strip()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            deduped.append(normalized)
+    return [{"type": "image_url", "url": value} for value in deduped]
+
+
+def _generate_image_with_xai(
+    prompt: str,
+    operation: str,
+    aspect_ratio: Optional[str],
+    num_images: int,
+    output_format: str,
+    resolution: Optional[str] = None,
+    response_format: str = "url",
+    source_image_url: Optional[str] = None,
+    source_image_urls: Optional[list[str]] = None,
+    reference_image_urls: Optional[list[str]] = None,
+) -> list[Dict[str, Any]]:
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("XAI_API_KEY environment variable not set")
+
+    base_url = (os.getenv("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+    normalized_operation = _normalize_xai_operation(
+        operation,
+        source_image_url,
+        source_image_urls,
+    )
+    normalized_aspect_ratio = _normalize_xai_aspect_ratio(aspect_ratio)
+    normalized_response_format = (response_format or "url").strip().lower()
+    if normalized_response_format not in VALID_XAI_RESPONSE_FORMATS:
+        raise ValueError(
+            f"response_format must be one of {sorted(VALID_XAI_RESPONSE_FORMATS)}"
+        )
+
+    normalized_resolution = None
+    if resolution:
+        normalized_resolution = (resolution or "").strip().lower()
+        if normalized_resolution not in VALID_XAI_RESOLUTIONS:
+            raise ValueError(
+                f"resolution must be one of {sorted(VALID_XAI_RESOLUTIONS)}"
+            )
+
+    payload: Dict[str, Any] = {
+        "model": DEFAULT_XAI_MODEL,
+        "prompt": prompt.strip(),
+        "n": num_images,
+    }
+    source_images = _normalize_xai_source_images(
+        source_image_url,
+        source_image_urls,
+    )
+    reference_images = _normalize_xai_reference_images(reference_image_urls)
+
+    if normalized_operation == "generate":
+        if source_images:
+            raise ValueError("source images are only supported for xAI image edit")
+        if len(reference_images) > 5:
+            raise ValueError("xAI image generation supports at most 5 reference images")
+        if normalized_aspect_ratio not in VALID_XAI_ASPECT_RATIOS:
+            raise ValueError(
+                f"aspect_ratio must be one of {sorted(VALID_XAI_ASPECT_RATIOS)} or landscape/square/portrait"
+            )
+        payload["aspect_ratio"] = normalized_aspect_ratio
+        if reference_images:
+            payload["reference_images"] = reference_images
+        endpoint = "images/generations"
+    else:
+        if not source_images:
+            raise ValueError("source_image_url or source_image_urls is required for xAI image edit")
+        if len(source_images) + len(reference_images) > 5:
+            raise ValueError("xAI image edit supports at most 5 combined source and reference images")
+        if len(source_images) == 1:
+            payload["image"] = source_images[0]
+        else:
+            if normalized_aspect_ratio not in VALID_XAI_ASPECT_RATIOS:
+                raise ValueError(
+                    f"aspect_ratio must be one of {sorted(VALID_XAI_ASPECT_RATIOS)} or landscape/square/portrait"
+                )
+            payload["images"] = source_images
+            payload["aspect_ratio"] = normalized_aspect_ratio
+        if reference_images:
+            payload["reference_images"] = reference_images
+        endpoint = "images/edits"
+
+    if normalized_resolution:
+        payload["resolution"] = normalized_resolution
+    if normalized_response_format == "b64_json":
+        payload["response_format"] = "b64_json"
+
+    response = requests.post(
+        f"{base_url}/{endpoint}",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": hermes_xai_user_agent(),
+            "x-idempotency-key": str(uuid.uuid4()),
+        },
+        json=payload,
+        timeout=120,
+    )
+    response.raise_for_status()
+
+    result = response.json()
+    images = []
+    for item in result.get("data", []):
+        image_url = item.get("url")
+        if not image_url and item.get("b64_json"):
+            image_url = _data_uri_from_b64(item["b64_json"], output_format)
+        if not image_url:
+            continue
+        images.append(
+            {
+                "url": image_url,
+                "width": item.get("width", 0),
+                "height": item.get("height", 0),
+                "upscaled": False,
+                "provider": "xai",
+                "operation": normalized_operation,
+            }
+        )
+    return images
 
 
 def _validate_parameters(
@@ -351,11 +630,18 @@ def _upscale_image(image_url: str, original_prompt: str) -> Dict[str, Any]:
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    operation: str = DEFAULT_OPERATION,
     num_inference_steps: int = DEFAULT_NUM_INFERENCE_STEPS,
     guidance_scale: float = DEFAULT_GUIDANCE_SCALE,
     num_images: int = DEFAULT_NUM_IMAGES,
     output_format: str = DEFAULT_OUTPUT_FORMAT,
-    seed: Optional[int] = None
+    seed: Optional[int] = None,
+    provider: str = DEFAULT_PROVIDER,
+    resolution: Optional[str] = None,
+    response_format: str = "url",
+    source_image_url: Optional[str] = None,
+    source_image_urls: Optional[list[str]] = None,
+    reference_image_urls: Optional[list[str]] = None,
 ) -> str:
     """
     Generate images from text prompts using FAL.ai's FLUX 2 Pro model with automatic upscaling.
@@ -397,7 +683,11 @@ def image_generate_tool(
             "guidance_scale": guidance_scale,
             "num_images": num_images,
             "output_format": output_format,
-            "seed": seed
+            "seed": seed,
+            "provider": provider,
+            "operation": operation,
+            "resolution": resolution,
+            "response_format": response_format,
         },
         "error": None,
         "success": False,
@@ -408,98 +698,133 @@ def image_generate_tool(
     start_time = datetime.datetime.now()
     
     try:
-        logger.info("Generating %s image(s) with FLUX 2 Pro: %s", num_images, prompt[:80])
+        normalized_operation = _normalize_xai_operation(
+            operation,
+            source_image_url,
+            source_image_urls,
+        )
+        prefer_xai = (
+            normalized_operation == "edit"
+            or bool((source_image_url or "").strip())
+            or bool(source_image_urls)
+            or bool(reference_image_urls)
+            or bool(resolution)
+            or (response_format or "").strip().lower() == "b64_json"
+            or _normalize_xai_aspect_ratio(aspect_ratio) not in {"16:9", "1:1", "9:16"}
+        )
+        resolved_provider = _resolve_image_provider(provider, prefer_xai=prefer_xai)
+        debug_call_data["parameters"]["resolved_provider"] = resolved_provider
+
+        logger.info(
+            "Generating %s image(s) with %s image backend: %s",
+            num_images,
+            resolved_provider,
+            prompt[:80],
+        )
         
         # Validate prompt
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
         
-        # Check API key availability
-        if not (os.getenv("FAL_KEY") or _resolve_managed_fal_gateway()):
-            message = "FAL_KEY environment variable not set"
-            if managed_nous_tools_enabled():
-                message += " and managed FAL gateway is unavailable"
-            raise ValueError(message)
-        
         # Validate other parameters
         validated_params = _validate_parameters(
             image_size, num_inference_steps, guidance_scale, num_images, output_format, "none"
         )
-        
-        # Prepare arguments for FAL.ai FLUX 2 Pro API
-        arguments = {
-            "prompt": prompt.strip(),
-            "image_size": validated_params["image_size"],
-            "num_inference_steps": validated_params["num_inference_steps"],
-            "guidance_scale": validated_params["guidance_scale"],
-            "num_images": validated_params["num_images"],
-            "output_format": validated_params["output_format"],
-            "enable_safety_checker": ENABLE_SAFETY_CHECKER,
-            "safety_tolerance": SAFETY_TOLERANCE,
-            "sync_mode": True  # Use sync mode for immediate results
-        }
-        
-        # Add seed if provided
-        if seed is not None and isinstance(seed, int):
-            arguments["seed"] = seed
-        
-        logger.info("Submitting generation request to FAL.ai FLUX 2 Pro...")
-        logger.info("  Model: %s", DEFAULT_MODEL)
-        logger.info("  Aspect Ratio: %s -> %s", aspect_ratio_lower, image_size)
-        logger.info("  Steps: %s", validated_params['num_inference_steps'])
-        logger.info("  Guidance: %s", validated_params['guidance_scale'])
-        
-        # Submit request to FAL.ai using sync API (avoids cached event loop issues)
-        handler = _submit_fal_request(
-            DEFAULT_MODEL,
-            arguments=arguments,
-        )
-        
-        # Get the result (sync — blocks until done)
-        result = handler.get()
-        
-        generation_time = (datetime.datetime.now() - start_time).total_seconds()
-        
-        # Process the response
-        if not result or "images" not in result:
-            raise ValueError("Invalid response from FAL.ai API - no images returned")
-        
-        images = result.get("images", [])
-        if not images:
-            raise ValueError("No images were generated")
-        
-        # Format image data and upscale images
-        formatted_images = []
-        for img in images:
-            if isinstance(img, dict) and "url" in img:
-                original_image = {
-                    "url": img["url"],
-                    "width": img.get("width", 0),
-                    "height": img.get("height", 0)
-                }
-                
-                # Attempt to upscale the image
-                upscaled_image = _upscale_image(img["url"], prompt.strip())
-                
-                if upscaled_image:
-                    # Use upscaled image if successful
-                    formatted_images.append(upscaled_image)
-                else:
-                    # Fall back to original image if upscaling fails
-                    logger.warning("Using original image as fallback")
-                    original_image["upscaled"] = False
-                    formatted_images.append(original_image)
-        
+
+        if resolved_provider == "fal":
+            if source_image_url or source_image_urls or reference_image_urls or normalized_operation == "edit":
+                raise ValueError("FAL image backend only supports generation. Use provider='xai' for image edit/reference workflows.")
+            if not (os.getenv("FAL_KEY") or _resolve_managed_fal_gateway()):
+                message = "FAL_KEY environment variable not set"
+                if managed_nous_tools_enabled():
+                    message += " and managed FAL gateway is unavailable"
+                raise ValueError(message)
+
+            arguments = {
+                "prompt": prompt.strip(),
+                "image_size": validated_params["image_size"],
+                "num_inference_steps": validated_params["num_inference_steps"],
+                "guidance_scale": validated_params["guidance_scale"],
+                "num_images": validated_params["num_images"],
+                "output_format": validated_params["output_format"],
+                "enable_safety_checker": ENABLE_SAFETY_CHECKER,
+                "safety_tolerance": SAFETY_TOLERANCE,
+                "sync_mode": True,
+            }
+
+            if seed is not None and isinstance(seed, int):
+                arguments["seed"] = seed
+
+            logger.info("Submitting generation request to FAL.ai FLUX 2 Pro...")
+            logger.info("  Model: %s", DEFAULT_MODEL)
+            logger.info("  Aspect Ratio: %s -> %s", aspect_ratio_lower, image_size)
+            logger.info("  Steps: %s", validated_params["num_inference_steps"])
+            logger.info("  Guidance: %s", validated_params["guidance_scale"])
+
+            handler = _submit_fal_request(
+                DEFAULT_MODEL,
+                arguments=arguments,
+            )
+            result = handler.get()
+
+            if not result or "images" not in result:
+                raise ValueError("Invalid response from FAL.ai API - no images returned")
+
+            images = result.get("images", [])
+            if not images:
+                raise ValueError("No images were generated")
+
+            formatted_images = []
+            for img in images:
+                if isinstance(img, dict) and "url" in img:
+                    original_image = {
+                        "url": img["url"],
+                        "width": img.get("width", 0),
+                        "height": img.get("height", 0),
+                        "provider": "fal",
+                    }
+
+                    upscaled_image = _upscale_image(img["url"], prompt.strip())
+
+                    if upscaled_image:
+                        upscaled_image["provider"] = "fal"
+                        formatted_images.append(upscaled_image)
+                    else:
+                        logger.warning("Using original image as fallback")
+                        original_image["upscaled"] = False
+                        formatted_images.append(original_image)
+        else:
+            logger.info("Submitting generation request to xAI image API...")
+            logger.info("  Model: %s", DEFAULT_XAI_MODEL)
+            logger.info("  Operation: %s", normalized_operation)
+            formatted_images = _generate_image_with_xai(
+                prompt=prompt,
+                operation=normalized_operation,
+                aspect_ratio=aspect_ratio,
+                num_images=validated_params["num_images"],
+                output_format=validated_params["output_format"],
+                resolution=resolution,
+                response_format=response_format,
+                source_image_url=source_image_url,
+                source_image_urls=source_image_urls,
+                reference_image_urls=reference_image_urls,
+            )
+
         if not formatted_images:
-            raise ValueError("No valid image URLs returned from API")
-        
+            raise ValueError(f"No valid image URLs returned from {resolved_provider} API")
+
+        generation_time = (datetime.datetime.now() - start_time).total_seconds()
+
         upscaled_count = sum(1 for img in formatted_images if img.get("upscaled", False))
         logger.info("Generated %s image(s) in %.1fs (%s upscaled)", len(formatted_images), generation_time, upscaled_count)
         
         # Prepare successful response - minimal format
         response_data = {
             "success": True,
-            "image": formatted_images[0]["url"] if formatted_images else None
+            "image": formatted_images[0]["url"] if formatted_images else None,
+            "provider": resolved_provider,
+            "operation": formatted_images[0].get("operation", normalized_operation),
+            "images": formatted_images,
         }
         
         debug_call_data["success"] = True
@@ -551,15 +876,11 @@ def check_image_generation_requirements() -> bool:
         bool: True if requirements are met, False otherwise
     """
     try:
-        # Check API key
-        if not check_fal_api_key():
-            return False
-        
-        # Check if fal_client is available
-        import fal_client  # noqa: F401 — SDK presence check
-        return True
-        
-    except ImportError:
+        if _has_fal_backend() or _has_xai_image_backend():
+            return True
+        return False
+
+    except Exception:
         return False
 
 
@@ -646,7 +967,7 @@ from tools.registry import registry, tool_error
 
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
-    "description": "Generate high-quality images from text prompts using FLUX 2 Pro model with automatic 2x upscaling. Creates detailed, artistic images that are automatically upscaled for hi-rez results. Returns a single upscaled image URL. Display it using markdown: ![description](URL)",
+    "description": "Generate or edit images. FAL supports text-to-image generation; xAI grok-imagine-image supports generation, single-image edits, multi-image edits, source/reference images, extra aspect ratios, 1k/2k resolution, and optional base64 output. Returns a primary image URL plus an images list.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -654,11 +975,55 @@ IMAGE_GENERATE_SCHEMA = {
                 "type": "string",
                 "description": "The text prompt describing the desired image. Be detailed and descriptive."
             },
+            "operation": {
+                "type": "string",
+                "enum": sorted(VALID_XAI_OPERATIONS),
+                "description": "Use 'generate' for a new image or 'edit' to transform one or more source images. If source_image_url/source_image_urls are provided, xAI edit mode is used automatically.",
+                "default": DEFAULT_OPERATION
+            },
+            "provider": {
+                "type": "string",
+                "enum": ["auto", "fal", "xai"],
+                "description": "Image backend to use. 'auto' prefers xAI when you request xAI-only features such as edit, source images, extra aspect ratios, 1k/2k resolution, or b64_json output; otherwise it prefers FAL when available.",
+                "default": "auto"
+            },
             "aspect_ratio": {
                 "type": "string",
-                "enum": ["landscape", "square", "portrait"],
-                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "enum": ["landscape", "square", "portrait", "auto", "1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "2:1", "1:2", "19.5:9", "9:19.5", "20:9", "9:20"],
+                "description": "Aspect ratio. FAL supports landscape/square/portrait. xAI also supports direct ratios like 3:2, 4:3, 2:1, 20:9, and auto.",
                 "default": "landscape"
+            },
+            "num_images": {
+                "type": "integer",
+                "description": "Number of images to generate. Best used with xAI generate mode.",
+                "default": DEFAULT_NUM_IMAGES,
+                "minimum": 1,
+                "maximum": 4
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["1k", "2k"],
+                "description": "xAI-only image resolution."
+            },
+            "response_format": {
+                "type": "string",
+                "enum": sorted(VALID_XAI_RESPONSE_FORMATS),
+                "description": "xAI-only response format. Use b64_json to force inline base64 output.",
+                "default": "url"
+            },
+            "source_image_url": {
+                "type": "string",
+                "description": "Optional source image URL or data URI for xAI image editing."
+            },
+            "source_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of source image URLs or data URIs for xAI multi-image editing. Up to 5."
+            },
+            "reference_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional xAI reference images. For generate mode they guide style/content; for edit mode they are combined with source images. Up to 5 combined images total."
             }
         },
         "required": ["prompt"]
@@ -672,10 +1037,17 @@ def _handle_image_generate(args, **kw):
         return tool_error("prompt is required for image generation")
     return image_generate_tool(
         prompt=prompt,
+        operation=args.get("operation", DEFAULT_OPERATION),
+        provider=args.get("provider", "auto"),
         aspect_ratio=args.get("aspect_ratio", "landscape"),
+        resolution=args.get("resolution"),
+        response_format=args.get("response_format", "url"),
+        source_image_url=args.get("source_image_url"),
+        source_image_urls=args.get("source_image_urls"),
+        reference_image_urls=args.get("reference_image_urls"),
         num_inference_steps=50,
         guidance_scale=4.5,
-        num_images=1,
+        num_images=args.get("num_images", 1),
         output_format="png",
         seed=None,
     )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -6,6 +6,7 @@ Supports six TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
+- xAI TTS: Grok text-to-speech, needs XAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
@@ -45,6 +46,7 @@ from hermes_constants import display_hermes_home
 logger = logging.getLogger(__name__)
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_openai_audio_api_key
+from tools.xai_http import hermes_xai_user_agent
 
 # ---------------------------------------------------------------------------
 # Lazy imports -- providers are imported only when actually used to avoid
@@ -88,6 +90,11 @@ DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_XAI_VOICE_ID = "eve"
+DEFAULT_XAI_LANGUAGE = "en"
+DEFAULT_XAI_SAMPLE_RATE = 24000
+DEFAULT_XAI_BIT_RATE = 128000
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_MINIMAX_MODEL = "speech-2.8-hd"
 DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
@@ -297,6 +304,71 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         close = getattr(client, "close", None)
         if callable(close):
             close()
+
+
+# ===========================================================================
+# Provider: xAI TTS
+# ===========================================================================
+def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """
+    Generate audio using xAI TTS.
+
+    xAI exposes a dedicated /v1/tts endpoint instead of the OpenAI audio.speech
+    API shape, so this is implemented as a separate backend.
+    """
+    import requests
+
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("XAI_API_KEY not set. Get one at https://console.x.ai/")
+
+    xai_config = tts_config.get("xai", {})
+    voice_id = str(xai_config.get("voice_id", DEFAULT_XAI_VOICE_ID)).strip() or DEFAULT_XAI_VOICE_ID
+    language = str(xai_config.get("language", DEFAULT_XAI_LANGUAGE)).strip() or DEFAULT_XAI_LANGUAGE
+    sample_rate = int(xai_config.get("sample_rate", DEFAULT_XAI_SAMPLE_RATE))
+    bit_rate = int(xai_config.get("bit_rate", DEFAULT_XAI_BIT_RATE))
+    base_url = str(
+        xai_config.get("base_url")
+        or os.getenv("XAI_BASE_URL")
+        or DEFAULT_XAI_BASE_URL
+    ).strip().rstrip("/")
+
+    # Match the documented minimal POST /v1/tts shape by default. Only send
+    # output_format when Hermes actually needs a non-default format/override.
+    codec = "wav" if output_path.endswith(".wav") else "mp3"
+    payload: Dict[str, Any] = {
+        "text": text,
+        "voice_id": voice_id,
+        "language": language,
+    }
+    if (
+        codec != "mp3"
+        or sample_rate != DEFAULT_XAI_SAMPLE_RATE
+        or (codec == "mp3" and bit_rate != DEFAULT_XAI_BIT_RATE)
+    ):
+        output_format: Dict[str, Any] = {"codec": codec}
+        if sample_rate:
+            output_format["sample_rate"] = sample_rate
+        if codec == "mp3" and bit_rate:
+            output_format["bit_rate"] = bit_rate
+        payload["output_format"] = output_format
+
+    response = requests.post(
+        f"{base_url}/tts",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": hermes_xai_user_agent(),
+        },
+        json=payload,
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+
+    return output_path
 
 
 # ===========================================================================
@@ -573,6 +645,10 @@ def text_to_speech_tool(
     file_str = str(file_path)
 
     try:
+        generated_file_str = file_str
+        if provider == "xai" and file_str.endswith(".ogg"):
+            generated_file_str = str(Path(file_str).with_suffix(".mp3"))
+
         # Generate audio with the configured provider
         if provider == "elevenlabs":
             try:
@@ -595,6 +671,10 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
             logger.info("Generating speech with OpenAI TTS...")
             _generate_openai_tts(text, file_str, tts_config)
+
+        elif provider == "xai":
+            logger.info("Generating speech with xAI TTS...")
+            _generate_xai_tts(text, generated_file_str, tts_config)
 
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")
@@ -652,7 +732,7 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
 
         # Check the file was actually created
-        if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
+        if not os.path.exists(generated_file_str) or os.path.getsize(generated_file_str) == 0:
             return json.dumps({
                 "success": False,
                 "error": f"TTS generation produced no output (provider: {provider})"
@@ -661,13 +741,19 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
-            opus_path = _convert_to_opus(file_str)
+        if provider in ("edge", "neutts", "minimax", "xai") and not generated_file_str.endswith(".ogg"):
+            opus_path = _convert_to_opus(generated_file_str)
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
+            else:
+                file_str = generated_file_str
         elif provider in ("elevenlabs", "openai", "mistral"):
+            # These providers can output Opus natively if the path ends in .ogg
+            file_str = generated_file_str
             voice_compatible = file_str.endswith(".ogg")
+        else:
+            file_str = generated_file_str
 
         file_size = os.path.getsize(file_str)
         logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{file_size:,}", provider)
@@ -732,6 +818,8 @@ def check_tts_requirements() -> bool:
             return True
     except ImportError:
         pass
+    if os.getenv("XAI_API_KEY"):
+        return True
     if os.getenv("MINIMAX_API_KEY"):
         return True
     try:

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+Video generation tool using xAI's async video API.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import uuid
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_XAI_VIDEO_MODEL = "grok-imagine-video"
+DEFAULT_OPERATION = "generate"
+DEFAULT_DURATION = 8
+DEFAULT_ASPECT_RATIO = "16:9"
+DEFAULT_RESOLUTION = "720p"
+DEFAULT_TIMEOUT_SECONDS = 240
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+VALID_ASPECT_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"}
+VALID_RESOLUTIONS = {"480p", "720p"}
+VALID_SIZES = {"848x480", "1696x960", "1280x720", "1920x1080"}
+VALID_OPERATIONS = {"generate", "edit", "extend"}
+
+
+def _get_xai_base_url() -> str:
+    return (os.getenv("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+
+
+def check_video_generation_requirements() -> bool:
+    return bool(os.getenv("XAI_API_KEY", "").strip())
+
+
+def _xai_headers() -> Dict[str, str]:
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError("XAI_API_KEY not set. Get one at https://console.x.ai/")
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+
+
+def _normalize_reference_images(
+    image_url: Optional[str],
+    reference_image_urls: Optional[List[str]],
+) -> tuple[Optional[Dict[str, str]], Optional[List[Dict[str, str]]]]:
+    primary_image = None
+    if image_url and image_url.strip():
+        primary_image = {"url": image_url.strip()}
+
+    refs = []
+    for url in reference_image_urls or []:
+        normalized = (url or "").strip()
+        if normalized:
+            refs.append({"url": normalized})
+    return primary_image, refs or None
+
+
+def _normalize_operation(
+    operation: Optional[str],
+    video_url: Optional[str],
+    prompt: Optional[str],
+) -> str:
+    normalized = (operation or "").strip().lower()
+    if not normalized:
+        if (video_url or "").strip():
+            prompt_lower = (prompt or "").strip().lower()
+            if not prompt_lower:
+                return "extend"
+            extend_cues = (
+                "extend",
+                "continue",
+                "continuation",
+                "longer",
+                "further",
+                "keep going",
+                "carry on",
+                "more of",
+            )
+            return "extend" if any(cue in prompt_lower for cue in extend_cues) else "edit"
+        return DEFAULT_OPERATION
+    aliases = {
+        "generate_video": "generate",
+        "edit_video": "edit",
+        "extend_video": "extend",
+    }
+    normalized = aliases.get(normalized, normalized)
+    if normalized not in VALID_OPERATIONS:
+        raise ValueError(f"operation must be one of {sorted(VALID_OPERATIONS)}")
+    return normalized
+
+
+def _normalize_duration(
+    *,
+    operation: str,
+    duration: Optional[int],
+    seconds: Optional[int],
+    reference_images_present: bool,
+) -> int:
+    if operation == "edit":
+        # xAI video edits inherit duration from the source video. Ignore any
+        # caller-provided duration/seconds instead of rejecting the request.
+        return DEFAULT_DURATION
+
+    value = seconds if seconds is not None else duration
+    if value is None:
+        value = 6 if operation == "extend" else DEFAULT_DURATION
+
+    if value < 1:
+        raise ValueError("duration must be at least 1 second")
+
+    if operation == "extend":
+        if value > 10:
+            raise ValueError("xAI video extension supports a maximum duration of 10 seconds")
+    else:
+        if value > 15:
+            raise ValueError("xAI video generation supports a maximum duration of 15 seconds")
+        if reference_images_present and value > 10:
+            raise ValueError(
+                "xAI video generation supports a maximum duration of 10 seconds when using reference_image_urls"
+            )
+    return value
+
+
+async def _submit_video_request(
+    client: httpx.AsyncClient,
+    operation: str,
+    payload: Dict[str, Any],
+) -> str:
+    endpoint_map = {
+        "generate": "videos/generations",
+        "edit": "videos/edits",
+        "extend": "videos/extensions",
+    }
+    submit_response = await client.post(
+        f"{_get_xai_base_url()}/{endpoint_map[operation]}",
+        headers={**_xai_headers(), "x-idempotency-key": str(uuid.uuid4())},
+        json=payload,
+        timeout=60,
+    )
+    submit_response.raise_for_status()
+    submit_payload = submit_response.json()
+    request_id = submit_payload.get("request_id")
+    if not request_id:
+        raise RuntimeError("xAI video response did not include request_id")
+    return request_id
+
+
+async def video_generate_tool(
+    prompt: Optional[str] = None,
+    operation: Optional[str] = None,
+    duration: Optional[int] = DEFAULT_DURATION,
+    seconds: Optional[int] = None,
+    aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    resolution: str = DEFAULT_RESOLUTION,
+    size: Optional[str] = None,
+    video_url: Optional[str] = None,
+    image_url: Optional[str] = None,
+    reference_image_urls: Optional[List[str]] = None,
+    user: Optional[str] = None,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    poll_interval_seconds: int = DEFAULT_POLL_INTERVAL_SECONDS,
+    prompt_source: Optional[str] = None,
+) -> str:
+    normalized_prompt = (prompt or "").strip()
+    normalized_video_url = (video_url or "").strip() or None
+    notes: List[str] = []
+
+    try:
+        normalized_operation = _normalize_operation(operation, normalized_video_url, normalized_prompt)
+    except ValueError as e:
+        return tool_error(str(e))
+
+    normalized_aspect_ratio = (aspect_ratio or DEFAULT_ASPECT_RATIO).strip()
+    normalized_resolution = (resolution or DEFAULT_RESOLUTION).strip().lower()
+    normalized_size = (size or "").strip()
+    normalized_user = (user or "").strip() or None
+
+    if normalized_operation == "extend" and not normalized_prompt:
+        normalized_prompt = "Continue the existing video naturally."
+        notes.append("used a default continuation prompt because extend was requested without a prompt")
+    elif prompt_source == "user_task_fallback" and normalized_prompt:
+        notes.append("used the current user message as prompt because the model omitted prompt")
+    if normalized_operation == "edit" and not normalized_prompt:
+        return tool_error(f"prompt is required for xAI video {normalized_operation}")
+    if normalized_operation == "generate" and not normalized_prompt and not (image_url or "").strip():
+        return tool_error("prompt is required for text-to-video generation unless image_url is provided")
+
+    if timeout_seconds < 10:
+        return tool_error("timeout_seconds must be at least 10")
+    if poll_interval_seconds < 1:
+        return tool_error("poll_interval_seconds must be at least 1")
+
+    primary_image, refs = _normalize_reference_images(image_url, reference_image_urls)
+    if refs and len(refs) > 7:
+        return tool_error("reference_image_urls supports at most 7 images with xAI")
+
+    try:
+        normalized_duration = _normalize_duration(
+            operation=normalized_operation,
+            duration=duration,
+            seconds=seconds,
+            reference_images_present=bool(refs),
+        )
+    except ValueError as e:
+        return tool_error(str(e))
+
+    payload: Dict[str, Any] = {
+        "model": DEFAULT_XAI_VIDEO_MODEL,
+    }
+    if normalized_prompt:
+        payload["prompt"] = normalized_prompt
+    if normalized_user:
+        payload["user"] = normalized_user
+
+    if normalized_operation == "generate":
+        if normalized_aspect_ratio not in VALID_ASPECT_RATIOS:
+            return tool_error(
+                f"aspect_ratio must be one of {sorted(VALID_ASPECT_RATIOS)}"
+            )
+        if normalized_resolution not in VALID_RESOLUTIONS:
+            return tool_error(
+                f"resolution must be one of {sorted(VALID_RESOLUTIONS)}"
+            )
+        if normalized_size and normalized_size not in VALID_SIZES:
+            return tool_error(
+                f"size must be one of {sorted(VALID_SIZES)}"
+            )
+        if primary_image and refs:
+            return tool_error(
+                "image_url and reference_image_urls cannot be combined for xAI video generation"
+            )
+        payload.update(
+            {
+                "duration": normalized_duration,
+                "aspect_ratio": normalized_aspect_ratio,
+                "resolution": normalized_resolution,
+            }
+        )
+        if normalized_size:
+            payload["size"] = normalized_size
+        if primary_image:
+            payload["image"] = primary_image
+        if refs:
+            payload["reference_images"] = refs
+
+    elif normalized_operation == "edit":
+        if not normalized_video_url:
+            return tool_error("video_url is required for xAI video edit")
+        if primary_image or refs:
+            return tool_error("image_url and reference_image_urls are not supported for xAI video edit")
+        payload["video"] = {"url": normalized_video_url}
+        notes.append("duration, aspect_ratio, and resolution are inherited from the source video for xAI video edit")
+
+    else:
+        if not normalized_video_url:
+            return tool_error("video_url is required for xAI video extension")
+        if primary_image or refs:
+            return tool_error("image_url and reference_image_urls are not supported for xAI video extension")
+        payload["duration"] = normalized_duration
+        payload["video"] = {"url": normalized_video_url}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            request_id = await _submit_video_request(client, normalized_operation, payload)
+
+            elapsed = 0.0
+            last_status = "queued"
+            while elapsed < timeout_seconds:
+                status_response = await client.get(
+                    f"{_get_xai_base_url()}/videos/{request_id}",
+                    headers=_xai_headers(),
+                    timeout=30,
+                )
+                status_response.raise_for_status()
+                status_payload = status_response.json()
+                last_status = (status_payload.get("status") or "").lower()
+
+                if last_status == "done":
+                    video = status_payload.get("video") or {}
+                    video_url = video.get("url")
+                    if not video_url:
+                        raise RuntimeError("xAI video generation completed without a video URL")
+                    return json.dumps(
+                        {
+                            "success": True,
+                            "provider": "xai",
+                            "operation": normalized_operation,
+                            "request_id": request_id,
+                            "status": "done",
+                            "video": video_url,
+                            "duration": video.get("duration", normalized_duration),
+                            "aspect_ratio": normalized_aspect_ratio if normalized_operation == "generate" else None,
+                            "resolution": normalized_resolution if normalized_operation == "generate" else None,
+                            "size": normalized_size if normalized_operation == "generate" else None,
+                            "respect_moderation": video.get("respect_moderation"),
+                            "model": status_payload.get("model"),
+                            "usage": status_payload.get("usage"),
+                            "notes": notes,
+                        },
+                        ensure_ascii=False,
+                    )
+
+                if last_status in {"failed", "error", "expired", "cancelled"}:
+                    error_message = (
+                        status_payload.get("error", {}).get("message")
+                        or status_payload.get("message")
+                        or f"Video generation ended with status '{last_status}'"
+                    )
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "provider": "xai",
+                            "operation": normalized_operation,
+                            "request_id": request_id,
+                            "status": last_status,
+                            "error": error_message,
+                        },
+                        ensure_ascii=False,
+                    )
+
+                await asyncio.sleep(poll_interval_seconds)
+                elapsed += poll_interval_seconds
+
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "operation": normalized_operation,
+                "request_id": request_id,
+                "status": last_status,
+                "error": f"Timed out waiting for video generation after {timeout_seconds} seconds",
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("Video generation failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "operation": normalized_operation,
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+VIDEO_GENERATE_SCHEMA = {
+    "name": "video_generate",
+    "description": "Generate, edit, or extend short videos with xAI grok-imagine-video. Supports text-to-video, image-to-video, reference-image-guided generation, native video edits, and native video extensions.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Describe the video to generate, edit, or extend. Usually pass this whenever the user provides motion, scene, style, edit, or continuation instructions. Optional only for image-to-video calls where the image alone is the complete instruction.",
+            },
+            "operation": {
+                "type": "string",
+                "enum": sorted(VALID_OPERATIONS),
+                "description": "Video mode. Use 'generate' for new videos, 'edit' to modify an existing video, and 'extend' to continue an existing video.",
+                "default": DEFAULT_OPERATION,
+            },
+            "duration": {
+                "type": "integer",
+                "description": "Requested duration in seconds. Generate supports 1-15 seconds. Extend supports 1-10 seconds. For xAI video edit, the source video duration is retained.",
+                "default": DEFAULT_DURATION,
+            },
+            "seconds": {
+                "type": "integer",
+                "description": "Alias for duration for OpenAI-compatible callers.",
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": sorted(VALID_ASPECT_RATIOS),
+                "description": "Output aspect ratio for generate mode.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+            "resolution": {
+                "type": "string",
+                "enum": sorted(VALID_RESOLUTIONS),
+                "description": "Output resolution for generate mode.",
+                "default": DEFAULT_RESOLUTION,
+            },
+            "size": {
+                "type": "string",
+                "enum": sorted(VALID_SIZES),
+                "description": "Optional explicit output size for generate mode.",
+            },
+            "video_url": {
+                "type": "string",
+                "description": "Required for edit and extend modes. Source video URL to modify or continue.",
+            },
+            "image_url": {
+                "type": "string",
+                "description": "Optional source image URL for image-to-video generation.",
+            },
+            "reference_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional reference image URLs for generate mode. Use these to carry people, objects, or clothing into a new video without fixing the first frame.",
+            },
+            "user": {
+                "type": "string",
+                "description": "Optional end-user identifier forwarded to xAI.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+async def _handle_video_generate(args, **kw):
+    prompt = args.get("prompt", "")
+    prompt_source = None
+    if not (prompt or "").strip():
+        user_task = kw.get("user_task")
+        if user_task and isinstance(user_task, str) and user_task.strip():
+            prompt = user_task.strip()
+            prompt_source = "user_task_fallback"
+            logger.info("video_generate: prompt was empty, falling back to user_task=%r", prompt[:100])
+    return await video_generate_tool(
+        prompt=prompt,
+        operation=args.get("operation"),
+        duration=args.get("duration", DEFAULT_DURATION),
+        seconds=args.get("seconds"),
+        aspect_ratio=args.get("aspect_ratio", DEFAULT_ASPECT_RATIO),
+        resolution=args.get("resolution", DEFAULT_RESOLUTION),
+        size=args.get("size"),
+        video_url=args.get("video_url"),
+        image_url=args.get("image_url"),
+        reference_image_urls=args.get("reference_image_urls"),
+        user=args.get("user"),
+        prompt_source=prompt_source,
+    )
+
+
+registry.register(
+    name="video_generate",
+    toolset="video_gen",
+    schema=VIDEO_GENERATE_SCHEMA,
+    handler=_handle_video_generate,
+    check_fn=check_video_generation_requirements,
+    requires_env=["XAI_API_KEY"],
+    is_async=True,
+    emoji="🎬",
+)

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""
+X Search tool backed by xAI's built-in x_search Responses API tool.
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from tools.registry import registry, tool_error
+from tools.xai_http import hermes_xai_user_agent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
+DEFAULT_X_SEARCH_MODEL = "grok-4.20-reasoning"
+DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
+DEFAULT_X_SEARCH_RETRIES = 2
+MAX_HANDLES = 10
+
+
+def _get_xai_base_url() -> str:
+    return (os.getenv("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
+
+
+def _load_x_search_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("x_search", {})
+    except Exception:
+        return {}
+
+
+def _get_x_search_model() -> str:
+    cfg = _load_x_search_config()
+    return (cfg.get("model") or DEFAULT_X_SEARCH_MODEL).strip()
+
+
+def _get_x_search_timeout_seconds() -> int:
+    cfg = _load_x_search_config()
+    raw_value = cfg.get("timeout_seconds", DEFAULT_X_SEARCH_TIMEOUT_SECONDS)
+    try:
+        return max(30, int(raw_value))
+    except Exception:
+        return DEFAULT_X_SEARCH_TIMEOUT_SECONDS
+
+
+def _get_x_search_retries() -> int:
+    cfg = _load_x_search_config()
+    raw_value = cfg.get("retries", DEFAULT_X_SEARCH_RETRIES)
+    try:
+        return max(0, int(raw_value))
+    except Exception:
+        return DEFAULT_X_SEARCH_RETRIES
+
+
+def check_x_search_requirements() -> bool:
+    return bool(os.getenv("XAI_API_KEY", "").strip())
+
+
+def _normalize_handles(handles: Optional[List[str]], field_name: str) -> List[str]:
+    cleaned = []
+    for handle in handles or []:
+        normalized = str(handle or "").strip().lstrip("@")
+        if normalized:
+            cleaned.append(normalized)
+    if len(cleaned) > MAX_HANDLES:
+        raise ValueError(f"{field_name} supports at most {MAX_HANDLES} handles")
+    return cleaned
+
+
+def _extract_response_text(payload: Dict[str, Any]) -> str:
+    output_text = str(payload.get("output_text") or "").strip()
+    if output_text:
+        return output_text
+
+    parts: List[str] = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            ctype = content.get("type")
+            if ctype in ("output_text", "text"):
+                text = str(content.get("text") or "").strip()
+                if text:
+                    parts.append(text)
+    return "\n\n".join(parts).strip()
+
+
+def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    citations = []
+    for item in payload.get("output", []) or []:
+        if item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            for annotation in content.get("annotations", []) or []:
+                if annotation.get("type") != "url_citation":
+                    continue
+                citations.append(
+                    {
+                        "url": annotation.get("url", ""),
+                        "title": annotation.get("title", ""),
+                        "start_index": annotation.get("start_index"),
+                        "end_index": annotation.get("end_index"),
+                    }
+                )
+    return citations
+
+
+def _http_error_message(exc: requests.HTTPError) -> str:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return str(exc)
+
+    try:
+        payload = response.json()
+    except Exception:
+        payload = None
+
+    if isinstance(payload, dict):
+        code = str(payload.get("code") or "").strip()
+        error = str(payload.get("error") or "").strip()
+        message = error or str(payload)
+        if code and code not in message:
+            message = f"{code}: {message}"
+        return message or str(exc)
+
+    text = str(getattr(response, "text", "") or "").strip()
+    if text:
+        return text[:500]
+    return str(exc)
+
+
+def x_search_tool(
+    query: str,
+    allowed_x_handles: Optional[List[str]] = None,
+    excluded_x_handles: Optional[List[str]] = None,
+    from_date: str = "",
+    to_date: str = "",
+    enable_image_understanding: bool = False,
+    enable_video_understanding: bool = False,
+) -> str:
+    if not query or not query.strip():
+        return tool_error("query is required for x_search")
+
+    api_key = os.getenv("XAI_API_KEY", "").strip()
+    if not api_key:
+        return tool_error("XAI_API_KEY is not set")
+
+    try:
+        allowed = _normalize_handles(allowed_x_handles, "allowed_x_handles")
+        excluded = _normalize_handles(excluded_x_handles, "excluded_x_handles")
+        if allowed and excluded:
+            return tool_error("allowed_x_handles and excluded_x_handles cannot be used together")
+
+        tool_def: Dict[str, Any] = {"type": "x_search"}
+        if allowed:
+            tool_def["allowed_x_handles"] = allowed
+        if excluded:
+            tool_def["excluded_x_handles"] = excluded
+        if from_date.strip():
+            tool_def["from_date"] = from_date.strip()
+        if to_date.strip():
+            tool_def["to_date"] = to_date.strip()
+        if enable_image_understanding:
+            tool_def["enable_image_understanding"] = True
+        if enable_video_understanding:
+            tool_def["enable_video_understanding"] = True
+
+        payload = {
+            "model": _get_x_search_model(),
+            "input": [
+                {
+                    "role": "user",
+                    "content": query.strip(),
+                }
+            ],
+            "tools": [tool_def],
+            "store": False,
+        }
+
+        timeout_seconds = _get_x_search_timeout_seconds()
+        max_retries = _get_x_search_retries()
+        response = None
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.post(
+                    f"{_get_xai_base_url()}/responses",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                        "User-Agent": hermes_xai_user_agent(),
+                    },
+                    json=payload,
+                    timeout=timeout_seconds,
+                )
+                response.raise_for_status()
+                break
+            except requests.HTTPError as e:
+                status_code = getattr(getattr(e, "response", None), "status_code", None)
+                if status_code is None or status_code < 500 or attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "x_search upstream failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    _http_error_message(e),
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+            except (requests.ReadTimeout, requests.ConnectionError) as e:
+                if attempt >= max_retries:
+                    raise
+                logger.warning(
+                    "x_search transient failure on attempt %s/%s: %s",
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                time.sleep(min(5.0, 1.5 * (attempt + 1)))
+
+        if response is None:
+            raise RuntimeError("x_search request did not return a response")
+
+        data = response.json()
+
+        answer = _extract_response_text(data)
+        citations = list(data.get("citations") or [])
+        inline_citations = _extract_inline_citations(data)
+
+        return json.dumps(
+            {
+                "success": True,
+                "provider": "xai",
+                "tool": "x_search",
+                "model": payload["model"],
+                "query": query.strip(),
+                "answer": answer,
+                "citations": citations,
+                "inline_citations": inline_citations,
+            },
+            ensure_ascii=False,
+        )
+    except requests.HTTPError as e:
+        logger.error("x_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "x_search",
+                "error": _http_error_message(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except requests.ReadTimeout as e:
+        logger.error("x_search timed out: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "x_search",
+                "error": f"xAI x_search timed out after {_get_x_search_timeout_seconds()} seconds",
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        logger.error("x_search failed: %s", e, exc_info=True)
+        return json.dumps(
+            {
+                "success": False,
+                "provider": "xai",
+                "tool": "x_search",
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+X_SEARCH_SCHEMA = {
+    "name": "x_search",
+    "description": "Search X (Twitter) posts, profiles, and threads using xAI's built-in X Search tool. Use this for current discussion, reactions, or claims on X rather than general web pages.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to look up on X.",
+            },
+            "allowed_x_handles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of X handles to include exclusively (max 10).",
+            },
+            "excluded_x_handles": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of X handles to exclude (max 10).",
+            },
+            "from_date": {
+                "type": "string",
+                "description": "Optional start date in YYYY-MM-DD format.",
+            },
+            "to_date": {
+                "type": "string",
+                "description": "Optional end date in YYYY-MM-DD format.",
+            },
+            "enable_image_understanding": {
+                "type": "boolean",
+                "description": "Whether xAI should analyze images attached to matching X posts.",
+                "default": False,
+            },
+            "enable_video_understanding": {
+                "type": "boolean",
+                "description": "Whether xAI should analyze videos attached to matching X posts.",
+                "default": False,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def _handle_x_search(args, **kw):
+    return x_search_tool(
+        query=args.get("query", ""),
+        allowed_x_handles=args.get("allowed_x_handles"),
+        excluded_x_handles=args.get("excluded_x_handles"),
+        from_date=args.get("from_date", ""),
+        to_date=args.get("to_date", ""),
+        enable_image_understanding=bool(args.get("enable_image_understanding", False)),
+        enable_video_understanding=bool(args.get("enable_video_understanding", False)),
+    )
+
+
+registry.register(
+    name="x_search",
+    toolset="x_search",
+    schema=X_SEARCH_SCHEMA,
+    handler=_handle_x_search,
+    check_fn=check_x_search_requirements,
+    requires_env=["XAI_API_KEY"],
+    emoji="🐦",
+    max_result_size_chars=100_000,
+)

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -1,0 +1,12 @@
+"""Shared helpers for direct xAI HTTP integrations."""
+
+from __future__ import annotations
+
+
+def hermes_xai_user_agent() -> str:
+    """Return a stable Hermes-specific User-Agent for xAI HTTP calls."""
+    try:
+        from hermes_cli import __version__
+    except Exception:
+        __version__ = "unknown"
+    return f"Hermes-Agent/{__version__}"

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,13 +30,13 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "x_search",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "image_generate", "video_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -78,6 +78,12 @@ TOOLSETS = {
         "tools": ["web_search"],
         "includes": []
     },
+
+    "x_search": {
+        "description": "Search X (Twitter) posts and threads using xAI",
+        "tools": ["x_search"],
+        "includes": []
+    },
     
     "vision": {
         "description": "Image analysis and vision tools",
@@ -88,6 +94,12 @@ TOOLSETS = {
     "image_gen": {
         "description": "Creative generation tools (images)",
         "tools": ["image_generate"],
+        "includes": []
+    },
+
+    "video_gen": {
+        "description": "Creative generation tools (video)",
+        "tools": ["video_generate"],
         "includes": []
     },
     
@@ -151,7 +163,7 @@ TOOLSETS = {
     },
     
     "tts": {
-        "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, or OpenAI",
+        "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",
         "tools": ["text_to_speech"],
         "includes": []
     },
@@ -213,7 +225,7 @@ TOOLSETS = {
     "safe": {
         "description": "Safe toolkit without terminal access",
         "tools": [],
-        "includes": ["web", "vision", "image_gen"]
+        "includes": ["web", "x_search", "vision", "image_gen", "video_gen"]
     },
     
     # ==========================================================================
@@ -246,13 +258,13 @@ TOOLSETS = {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
             # Web
-            "web_search", "web_extract",
+            "web_search", "web_extract", "x_search",
             # Terminal + process management
             "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation
-            "vision_analyze", "image_generate",
+            "vision_analyze", "image_generate", "video_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation


### PR DESCRIPTION
## What does this PR do?

Switches xAI from completions to responses API
New tools based on xAI: image generation/editing, video generation, X (Twitter) search, and text-to-speech.

xAI now uses the `codex_responses` transport (Responses API) instead of `openai_chat`, with proper `x-grok-conv-id` session headers for prompt caching, reasoning support, and provider aliases (`grok`, `x-ai`, `x.ai`).

Config/CLI: provider registry, model catalog, setup wizard flows, `hermes tools` configurator entries, config.yaml sections, and env var migration all wired up.

## Related Issue

N/A — new feature contribution.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add xAI as an inference provider using `codex_responses` transport with session-scoped `x-grok-conv-id` headers for prompt caching
- Add xAI reasoning support (encrypted content include, no effort param — xAI reasons automatically)
- Add `extra_headers` passthrough support for the Codex Responses request builder
- Add video generation tool with async polling (generate, edit, extend modes), duration/aspect ratio/resolution validation, and reference image support
- Add X search tool backed by xAI Responses API with retry logic, citation extraction, and configurable model/timeout/retries via config.yaml
- Add xAI image generation and editing backend with single/multi-image edits, reference images, extra aspect ratios, 1k/2k resolution, and b64 output
- Add auto provider resolution that prefers xAI when xAI-only features are requested (edit, reference images, extra ratios)
- Add xAI TTS provider with dedicated `/v1/tts` endpoint, `.ogg` to `.mp3` intermediate conversion, and Opus output for Telegram voice bubbles
- Add shared `xai_http.py` module for common xAI HTTP helpers (User-Agent string)
- Add xAI provider registry entry, model catalog, and aliases (`grok`, `x-ai`, `x.ai`) across auth, models, providers, auxiliary client, and model metadata
- Add `codex_responses` API mode detection for `api.x.ai` base URLs across all runtime provider resolution paths
- Add `x_search` and `video_gen` toolset definitions and wire them into core tools, safe toolset, and API server toolset
- Add `XAI_API_KEY` and `XAI_BASE_URL` to env var registry with config version migration (17→18)
- Add config.yaml sections for `image_generation`, `video_generation`, `x_search`, and `tts.xai`
- Add xAI TTS and X Search provider options to the `hermes tools` configurator and setup wizard
- Add comprehensive test coverage for all new tools, provider resolution, config flows, and Responses API kwargs

## How to Test

Requires `XAI_API_KEY` set in `~/.hermes/.env`. Get one at https://console.x.ai/

**1. xAI as inference provider**
```bash
hermes --provider xai --model grok-4.20-reasoning
```
Ask it anything — verify it responds, tool calls work, and reasoning traces appear if `show_reasoning` is enabled.

**2. Image generation (xAI backend)**
```
> generate an image of a cat sitting on a spaceship in 4:3 aspect ratio
```
Verify the tool returns a URL. Then test editing:
```
> edit that image to make the cat wear a top hat
```

**3. Video generation**
```
> generate a 5 second video of ocean waves crashing on rocks at sunset
```
Verify the tool polls until completion and returns a video URL. Then test extend:
```
> extend that video for 6 more seconds
```

**4. X Search**
```
> search X for what people are saying about the latest SpaceX launch
```
Verify the response includes an answer with citations from X posts.

**5. TTS with xAI provider**

Set `tts.provider: xai` in `~/.hermes/config.yaml`, then:
```
> say "hello world, this is a test of xAI text to speech"
```
Verify an audio file is generated. On Telegram, verify it plays as a voice bubble.

**6. Setup wizard**
```bash
hermes setup
```
Verify xAI TTS appears as a provider option. Select it, enter an API key, confirm it saves.

**7. Tools configurator**
```bash
hermes tools
```
Verify "X Search" and "Video Generation" appear in the toolset list and can be toggled on/off.

**8. Model switching**
```
/model xai/grok-4-1-fast-reasoning
```
Verify it switches cleanly and subsequent messages work.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="514" height="446" alt="image" src="https://github.com/user-attachments/assets/1c5561e3-0853-4815-9950-6aa00efdafee" />

<img width="553" height="192" alt="image" src="https://github.com/user-attachments/assets/6004ebd5-1542-4a92-8b95-1f1f296fc3fa" />

<img width="666" height="372" alt="image" src="https://github.com/user-attachments/assets/242e1799-2dd7-49b3-84b1-99e8bcd3175e" />

generated video:
<img width="382" height="677" alt="image" src="https://github.com/user-attachments/assets/7802731a-6706-48c5-9e50-1b5556c48e13" />

X search + TTS
<img width="383" height="692" alt="image" src="https://github.com/user-attachments/assets/723ce577-38be-4a9b-87d2-1ee1df305aea" />

