### PR TITLE
fix: include models dict in /model picker for custom providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1066,6 +1066,12 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            # Also include models from the `models` dict (multi-model entries)
+            models_dict = entry.get("models")
+            if isinstance(models_dict, dict):
+                for m in models_dict.keys():
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
 
         for slug, grp in groups.items():
             if slug in seen_slugs:


### PR DESCRIPTION
## Summary

- `custom_providers` entries support a `models` dict for multi-model configuration (e.g. multiple models under a single LM Studio endpoint)
- The `/model` picker only read the single `model` field from each entry, ignoring the `models` dict entirely
- Users with multi-model entries only saw one model in the picker instead of all configured models

## Test plan

- [ ] Add a `custom_providers` entry with a `models` dict containing multiple model IDs
- [ ] Send `/model` in Telegram or Discord — all models should appear in the picker
- [ ] Verify the default `model` field still appears and deduplication works

Co-generated with Claude Code