### PR TITLE
fix: include telegram dependency in Termux bundle (#9311)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ termux = [
   # Tested Android / Termux path: keeps the core CLI feature-rich while
   # avoiding extras that currently depend on non-Android wheels (notably
   # faster-whisper -> ctranslate2 via the voice extra).
+  "python-telegram-bot[webhooks]>=22.6,<23",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[pty]",

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -16,6 +16,7 @@ The tested Termux bundle installs:
 - the Hermes CLI
 - cron support
 - PTY/background terminal support
+- Telegram gateway support (manual / best-effort background runs)
 - MCP support
 - Honcho memory support
 - ACP support
@@ -34,6 +35,7 @@ A few features still need desktop/server-style dependencies that are not publish
 - the `voice` extra is blocked by `faster-whisper -> ctranslate2`, and `ctranslate2` does not publish Android wheels
 - automatic browser / Playwright bootstrap is skipped in the Termux installer
 - Docker-based terminal isolation is not available inside Termux
+- Android may still suspend Termux background jobs, so gateway persistence is best-effort rather than a normal managed service
 
 That does not stop Hermes from working well as a phone-native CLI agent — it just means the recommended mobile install is intentionally narrower than the desktop/server install.
 


### PR DESCRIPTION
Salvaged from #9311 by @helix4u.

Adds the `telegram` optional dependency to the Termux install bundle so that `pip install hermes-agent[termux]` pulls in the Telegram adapter dependencies. Previously Termux users who wanted Telegram had to install the dependency separately.

**Original PR:** #9311

> **Merge style:** please use **Rebase and merge**.