### PR TITLE
fix(prompt): correct Telegram platform hint — markdown is supported (#8261)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -295,7 +295,9 @@ PLATFORM_HINTS = {
     ),
     "telegram": (
         "You are on a text messaging communication platform, Telegram. "
-        "Please do not use markdown as it does not render. "
+        "Standard markdown is automatically converted to Telegram format. "
+        "Supported: **bold**, *italic*, ~~strikethrough~~, ||spoiler||, "
+        "`inline code`, ```code blocks```, [links](url), and ## headers. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio (.ogg) sends as voice "


### PR DESCRIPTION
Salvaged from #8261 by @flobo3.

The Telegram platform hint in `prompt_builder.py` currently tells the LLM "do not use markdown" for Telegram, which is incorrect — the Telegram adapter has full MarkdownV2 conversion support. This PR corrects the hint to list the supported Telegram markdown formatting (bold, italic, code, links, etc.) so the LLM produces properly formatted responses.

**Original PR:** #8261

> **Merge style:** please use **Rebase and merge**.