### PR TITLE
fix: validate Telegram bot token format during gateway setup (#9964)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1611,9 +1611,19 @@ def _setup_telegram():
             return
 
     print_info("Create a bot via @BotFather on Telegram")
-    token = prompt("Telegram bot token", password=True)
-    if not token:
-        return
+    import re
+
+    while True:
+        token = prompt("Telegram bot token", password=True)
+        if not token:
+            return
+        if not re.match(r"^\d+:[A-Za-z0-9_-]{30,}$", token):
+            print_error(
+                "Invalid token format. Expected: <numeric_id>:<alphanumeric_hash> "
+                "(e.g., 123456789:ABCdefGHI-jklMNOpqrSTUvwxYZ)"
+            )
+            continue
+        break
     save_env_value("TELEGRAM_BOT_TOKEN", token)
     print_success("Telegram token saved")
 


### PR DESCRIPTION
Salvaged from original PR #9964 by @Magicray1217. Addresses issue #9843.

## Problem
The setup wizard accepts any string as a Telegram bot token without validation, leading to confusing errors later when the token is actually used to connect to the Telegram API.

## Fix
Adds regex validation (`^\d+:[A-Za-z0-9_-]{35,}$`) for Telegram bot tokens in the interactive setup wizard. Invalid tokens trigger a re-prompt loop with a helpful error message, catching malformed tokens early before they cause downstream failures.

---
Cherry-picked from community contribution by @Magicray1217.