### PR TITLE
fix(cron): guard telegram import against ImportError (#2964)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -327,9 +327,15 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
     from gateway.platforms.base import BasePlatformAdapter, utf16_len
-    from gateway.platforms.telegram import TelegramAdapter
     from gateway.platforms.discord import DiscordAdapter
     from gateway.platforms.slack import SlackAdapter
+
+    # Telegram adapter import is optional (requires python-telegram-bot)
+    try:
+        from gateway.platforms.telegram import TelegramAdapter
+        _telegram_available = True
+    except ImportError:
+        _telegram_available = False
 
     # Feishu adapter import is optional (requires lark-oapi)
     try:
@@ -349,7 +355,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     # Platform message length limits (from adapter class attributes)
     _MAX_LENGTHS = {
-        Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH,
+        Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
         Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
         Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
     }


### PR DESCRIPTION
Re-implementation of #2964 by @jneeee (original PR was 1645 commits behind, too stale to cherry-pick).

**Problem:** In `tools/send_message_tool.py`, the `_send_to_platform()` function had a bare import:
```python
from gateway.platforms.telegram import TelegramAdapter
```
This crashes the cron scheduler if `python-telegram-bot` is not installed.

**Fix:** Wrap the `TelegramAdapter` import in a `try/except ImportError` guard, mirroring the existing Feishu adapter pattern already in the same function. When the import fails, `_telegram_available` is set to `False` and `MAX_MESSAGE_LENGTH` falls back to a hardcoded `4096`.

Note: the lower-level `_send_telegram()` function already had its own ImportError guard for the `telegram` package. This fixes the remaining unguarded import of `TelegramAdapter` in the platform-routing function.

Original author: @jneeee (attributed via git commit author)