### PR TITLE
fix(feishu): terminate process on unrecoverable websocket drops

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1012,8 +1012,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     _apply_runtime_ws_overrides()
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.error("[Feishu] WebSocket client crashed: %s", exc, exc_info=True)
     finally:
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
@@ -1032,6 +1032,11 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             pass
         adapter._ws_thread_loop = None
+
+        if getattr(adapter, "_running", False):
+            import os
+            logger.error("[Feishu] WebSocket loop terminated unexpectedly (zombie state). Forcing process crash to trigger Restarter fallback.")
+            os._exit(1)
 
 
 def check_feishu_requirements() -> bool:


### PR DESCRIPTION
Fixes #10616

### Description
When using the Feishu integration, if the underlying connection suffers a `keepalive ping timeout`, the SDK's message loop exits, but the main Hermes agent process doesn't terminate or successfully reconnect. This leaves the Gateway in a zombie state where it appears "running" to system daemon managers (like systemd) but accepts no messages.

This PR adds a Crash-Only architecture mechanism: if the Feishu websocket loop terminates unexpectedly while the gateway adapter is still running, it forces the process to crash (`os._exit(1)`). This allows system level managers (`Restart=always`) to successfully identify the failure and restart the agent.