### PR TITLE
fix(gateway): skip malformed persisted platform config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -173,17 +173,38 @@ class PlatformConfig:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"platform config must be a mapping, got {type(data).__name__}"
+            )
+
         home_channel = None
         if "home_channel" in data:
-            home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+            if isinstance(data["home_channel"], dict):
+                home_channel = HomeChannel.from_dict(data["home_channel"])
+            else:
+                logger.warning(
+                    "Ignoring invalid home_channel in platform config "
+                    "(expected mapping, got %s)",
+                    type(data["home_channel"]).__name__,
+                )
+
+        extra = data.get("extra", {})
+        if not isinstance(extra, dict):
+            logger.warning(
+                "Ignoring invalid platform extra config "
+                "(expected mapping, got %s)",
+                type(extra).__name__,
+            )
+            extra = {}
+
         return cls(
             enabled=data.get("enabled", False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -181,7 +181,12 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             if isinstance(data["home_channel"], dict):
-                home_channel = HomeChannel.from_dict(data["home_channel"])
+                try:
+                    home_channel = HomeChannel.from_dict(data["home_channel"])
+                except (KeyError, TypeError, ValueError):
+                    logger.warning(
+                        "Ignoring malformed home_channel in platform config"
+                    )
             else:
                 logger.warning(
                     "Ignoring invalid home_channel in platform config "

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -52,6 +52,21 @@ class TestPlatformConfigRoundtrip:
         assert restored.enabled is False
         assert restored.token is None
 
+    def test_invalid_nested_values_are_ignored(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "token": "tok_123",
+                "home_channel": "not-a-mapping",
+                "extra": "not-a-mapping",
+            }
+        )
+
+        assert restored.enabled is True
+        assert restored.token == "tok_123"
+        assert restored.home_channel is None
+        assert restored.extra == {}
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):
@@ -136,6 +151,19 @@ class TestGatewayConfigRoundtrip:
 
         assert restored.unauthorized_dm_behavior == "ignore"
         assert restored.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
+
+    def test_from_dict_skips_invalid_platform_blocks_and_keeps_valid_ones(self):
+        restored = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "telegram": "not-a-mapping",
+                    "discord": {"enabled": True, "token": "discord-token"},
+                }
+            }
+        )
+
+        assert Platform.TELEGRAM not in restored.platforms
+        assert restored.platforms[Platform.DISCORD].token == "discord-token"
 
 
 class TestLoadGatewayConfig:
@@ -283,6 +311,22 @@ class TestLoadGatewayConfig:
 
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
+
+    def test_load_gateway_config_skips_invalid_legacy_platform_blocks(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        gateway_json_path = hermes_home / "gateway.json"
+        gateway_json_path.write_text(
+            '{"platforms":{"telegram":"broken","discord":{"enabled":true,"token":"discord-token"}}}',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert Platform.TELEGRAM not in config.platforms
+        assert config.platforms[Platform.DISCORD].token == "discord-token"
 
     def test_bridges_telegram_disable_link_previews_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -67,6 +67,19 @@ class TestPlatformConfigRoundtrip:
         assert restored.home_channel is None
         assert restored.extra == {}
 
+    def test_malformed_home_channel_mapping_is_ignored(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "token": "tok_123",
+                "home_channel": {"platform": "not-a-platform"},
+            }
+        )
+
+        assert restored.enabled is True
+        assert restored.token == "tok_123"
+        assert restored.home_channel is None
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway config deserialization bug where malformed persisted platform state could abort `load_gateway_config()`.

Root cause:
- `GatewayConfig.from_dict()` only skipped unknown platform names.
- It still trusted each `platforms.<name>` payload to be a mapping.
- If legacy `gateway.json` or merged gateway config state contained something like `platforms.telegram: "broken"`, deserialization raised `AttributeError`/`TypeError` and the gateway config load failed instead of skipping the bad block.

This PR keeps the existing precedence model intact (`config.yaml` over legacy `gateway.json`, env vars over both) and makes the smallest safe change:
- reject non-mapping platform blocks at the platform-config boundary
- ignore malformed nested `home_channel` values
- coerce malformed `extra` payloads to `{}`
- preserve valid sibling platform configs during the same load

## Related Issue

N/A — self-contained bug fix discovered during gateway/config audit.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/config.py`
- Validate `PlatformConfig.from_dict()` input before reading mapping fields
- Ignore invalid nested `home_channel` payloads instead of crashing platform config deserialization
- Ignore invalid `extra` payloads instead of preserving unusable non-mapping state
- Keep `GatewayConfig.from_dict()` behavior of skipping invalid platform entries, now including malformed platform payloads
- `tests/gateway/test_config.py`
- Add regression coverage for malformed nested platform values
- Add regression coverage that malformed platform blocks are skipped while valid sibling platforms still load
- Add an end-to-end loader regression test covering malformed legacy `gateway.json` platform state

## How to Test

1. Reproduce the old failure mode with malformed persisted state:
   ```bash
   source venv/bin/activate
   python - <<'PY'
   import os, json, tempfile
   from pathlib import Path
   from gateway.config import load_gateway_config, Platform

   with tempfile.TemporaryDirectory() as td:
       home = Path(td) / '.hermes'
       home.mkdir()
       (home / 'gateway.json').write_text(
           json.dumps({'platforms': {'telegram': 'broken', 'discord': {'enabled': True, 'token': 'discord-token'}}}),
           encoding='utf-8',
       )
       os.environ['HERMES_HOME'] = str(home)
       cfg = load_gateway_config()
       print('telegram_present', Platform.TELEGRAM in cfg.platforms)
       print('discord_token', cfg.platforms[Platform.DISCORD].token)
   PY
   ```
2. Run the focused config slice:
   ```bash
   source venv/bin/activate
   python -m pytest tests/gateway/test_config.py -q
   ```
3. Run one adjacent gateway loader slice:
   ```bash
   source venv/bin/activate
   python -m pytest tests/gateway/test_stt_config.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run locally:

- `source venv/bin/activate && python -m pytest tests/gateway/test_config.py -q`
  - `24 passed in 2.05s`
- `source venv/bin/activate && python -m pytest tests/gateway/test_stt_config.py -q`
  - `5 passed in 2.21s`
- `git diff --check`
  - passed
- `source venv/bin/activate && python -m py_compile gateway/config.py tests/gateway/test_config.py`
  - passed
- `source venv/bin/activate && python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`
  - failed with broad pre-existing failures outside the touched surface (`73 failed, 11848 passed, 37 skipped`)
  - representative untouched failure groups during this run:
    - `tests/gateway/test_discord_slash_commands.py`
    - `tests/gateway/test_dm_topics.py`
    - `tests/cli/test_cli_new_session.py`
    - `tests/gateway/test_telegram_*`
    - `tests/hermes_cli/test_gateway_service.py`
    - `tests/skills/test_google_workspace_api.py`

No standalone lint command is defined in the repo docs or CI workflow, so I used the repo-documented pytest command plus `py_compile` and `git diff --check` as the cheap local safety checks.
