### PR TITLE
Keep Feishu in-flight status accurate and reduce provider list noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ mini-swe-agent/
 .direnv/
 result
 website/static/api/skills-index.json
+.omx/

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -8,7 +8,7 @@ Supports:
 - Gateway allowlist integration via FEISHU_ALLOWED_USERS
 - Persistent dedup state across restarts
 - Per-chat serial message processing (matches openclaw createChatQueue)
-- Persistent ACK emoji reaction on inbound messages
+- Transient ACK emoji reaction on inbound messages while processing is active
 - Reaction events routed as synthetic text events (matches openclaw)
 - Interactive card button-click events routed as synthetic COMMAND events
 - Webhook anomaly tracking (matches openclaw createWebhookAnomalyTracker)
@@ -98,6 +98,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
     cache_document_from_bytes,
@@ -1074,6 +1075,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
         self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
         self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
+        self._pending_ack_reaction_ids: Dict[str, str] = {}  # inbound message_id → ack reaction_id
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
@@ -2064,23 +2066,25 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _handle_message_with_guards(self, event: MessageEvent) -> None:
         """Dispatch a single event through the agent pipeline with per-chat serialization
-        and a persistent ACK emoji reaction before processing starts.
+        and an ACK emoji reaction before processing starts.
 
         - Per-chat lock: ensures messages in the same chat are processed one at a time
           (matches openclaw's createChatQueue serial queue behaviour).
-        - ACK indicator: adds a CHECK reaction to the triggering message before handing
-          off to the agent and leaves it in place as a receipt marker.
+        - ACK indicator: adds an OK reaction to the triggering message before handing
+          off to the agent, then removes it when processing finishes.
         """
         chat_id = getattr(event.source, "chat_id", "") or "" if event.source else ""
         chat_lock = self._get_chat_lock(chat_id)
         async with chat_lock:
             message_id = event.message_id
             if message_id:
-                await self._add_ack_reaction(message_id)
+                reaction_id = await self._add_ack_reaction(message_id)
+                if reaction_id:
+                    self._pending_ack_reaction_ids[message_id] = reaction_id
             await self.handle_message(event)
 
     async def _add_ack_reaction(self, message_id: str) -> Optional[str]:
-        """Add a persistent ACK emoji reaction to signal the message was received."""
+        """Add an ACK emoji reaction to signal the message was received."""
         if not self._client or not message_id:
             return None
         try:
@@ -2112,6 +2116,40 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to add ack reaction to %s", message_id, exc_info=True)
         return None
+
+    async def _remove_ack_reaction(self, message_id: str) -> bool:
+        """Remove the in-flight ACK emoji reaction after processing finishes."""
+        reaction_id = self._pending_ack_reaction_ids.pop(message_id, None)
+        if not self._client or not message_id or not reaction_id:
+            return False
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageReactionRequest
+
+            request = (
+                DeleteMessageReactionRequest.builder()
+                .message_id(message_id)
+                .reaction_id(reaction_id)
+                .build()
+            )
+            response = await asyncio.to_thread(self._client.im.v1.message_reaction.delete, request)
+            if response and getattr(response, "success", lambda: False)():
+                return True
+            logger.warning(
+                "[Feishu] Failed to remove ack reaction from %s: code=%s msg=%s",
+                message_id,
+                getattr(response, "code", None),
+                getattr(response, "msg", None),
+            )
+        except Exception:
+            logger.warning("[Feishu] Failed to remove ack reaction from %s", message_id, exc_info=True)
+        return False
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        """Clear the ACK reaction when processing ends, regardless of outcome."""
+        del outcome  # Feishu only needs to know that processing finished.
+        message_id = getattr(event, "message_id", None)
+        if message_id:
+            await self._remove_ack_reaction(message_id)
 
     # =========================================================================
     # Webhook server and security

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1053,9 +1053,20 @@ def list_authenticated_providers(
     if custom_providers and isinstance(custom_providers, list):
         from collections import OrderedDict
 
+        user_provider_keys = set()
+        if isinstance(user_providers, dict):
+            user_provider_keys = {str(k).strip().lower() for k in user_providers.keys()}
+
         groups: "OrderedDict[str, dict]" = OrderedDict()
         for entry in custom_providers:
             if not isinstance(entry, dict):
+                continue
+
+            compat_provider_key = str(entry.get("provider_key", "") or "").strip().lower()
+            if compat_provider_key and compat_provider_key in user_provider_keys:
+                # This entry is a compatibility projection of the new providers:
+                # schema. The real provider row is already shown in section 3,
+                # so skip the synthetic legacy custom:* duplicate.
                 continue
 
             display_name = (entry.get("name") or "").strip()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -729,6 +729,51 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
+    def test_remove_ack_reaction_uses_stored_reaction_id(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._pending_ack_reaction_ids["om_msg"] = "r_ack"
+        captured = {}
+
+        class _ReactionAPI:
+            def delete(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message_reaction=_ReactionAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            removed = asyncio.run(adapter._remove_ack_reaction("om_msg"))
+
+        self.assertTrue(removed)
+        self.assertEqual(captured["request"].message_id, "om_msg")
+        self.assertEqual(captured["request"].reaction_id, "r_ack")
+        self.assertNotIn("om_msg", adapter._pending_ack_reaction_ids)
+
+    @patch.dict(os.environ, {}, clear=True)
+    @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
+    def test_on_processing_complete_removes_ack_reaction_on_cancelled(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import ProcessingOutcome
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        event = SimpleNamespace(message_id="om_msg")
+
+        with patch.object(adapter, "_remove_ack_reaction", new=AsyncMock(return_value=True)) as remove_ack:
+            asyncio.run(adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED))
+
+        remove_ack.assert_awaited_once_with("om_msg")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_ack_reaction_events_are_ignored_to_avoid_feedback_loops(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- make Feishu ACK reactions transient so they show in-flight work instead of leaving a permanent receipt marker
- remove the ACK reaction on processing completion for all outcomes and cover the reaction cleanup path with tests
- skip synthetic legacy `custom:*` provider rows in the model switcher when the same provider already exists in the new user provider schema
- ignore local `.omx/` artifacts

## Testing
- `source venv/bin/activate && python -m pytest tests/gateway/test_feishu.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_custom_provider_model_switch.py -q`

## Behavior changes
- Feishu now adds an ACK reaction when a message starts processing and removes it once processing finishes, including cancelled runs.
- The model switch provider list no longer shows duplicate compatibility rows for providers that are already represented by the new user-provider config.