### PR TITLE
fix: wrap truncated tool arguments in valid JSON object

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -456,7 +456,14 @@ class ContextCompressor(ContextEngine):
                 if isinstance(tc, dict):
                     args = tc.get("function", {}).get("arguments", "")
                     if len(args) > 500:
-                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
+                        # Wrap truncated content in valid JSON object (#10398)
+                        truncated_args = args[:200]
+                        safe_truncated = json.dumps({
+                            "_truncated": True,
+                            "_original_length": len(args),
+                            "_prefix": truncated_args
+                        })
+                        tc = {**tc, "function": {**tc["function"], "arguments": safe_truncated}}
                         modified = True
                 new_tcs.append(tc)
             if modified:


### PR DESCRIPTION
## Summary
Fix context compressor producing invalid JSON when truncating tool call arguments.

## Root Cause
The context compressor truncated tool_call.function.arguments by doing string slicing (args[:200] + "...[truncated]"), which produces invalid JSON. This causes AI gateways to return HTTP 400 errors, and the bad data persists in state.db, permanently breaking the session.

## Fix
Wrap truncated content in a valid JSON object with _truncated, _original_length, and _prefix fields, ensuring the arguments field remains parseable JSON.

Closes NousResearch/hermes-agent#10398