### PR TITLE
feat: unblock execute_code for subagents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -570,8 +570,14 @@ class TestDelegateObservability(unittest.TestCase):
 
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):
-        for tool in ["delegate_task", "clarify", "memory", "send_message", "execute_code"]:
+        for tool in ["delegate_task", "clarify", "memory", "send_message"]:
             self.assertIn(tool, DELEGATE_BLOCKED_TOOLS)
+
+    def test_execute_code_not_blocked(self):
+        # execute_code is intentionally allowed for subagents — lets them
+        # batch parallel curl calls / data filtering in a single tool call
+        # instead of 30+ individual tool turns.
+        self.assertNotIn("execute_code", DELEGATE_BLOCKED_TOOLS)
 
     def test_constants(self):
         from tools.delegate_tool import (

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -44,7 +44,6 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
         "clarify",  # no user interaction
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects
-        "execute_code",  # children should reason step-by-step, not write scripts
     ]
 )
 
@@ -2317,10 +2316,10 @@ DELEGATE_TASK_SCHEMA = {
         "- Subagents have NO memory of your conversation. Pass all relevant "
         "info (file paths, error messages, constraints) via the 'context' field.\n"
         "- Leaf subagents (role='leaf', the default) CANNOT call: "
-        "delegate_task, clarify, memory, send_message, execute_code.\n"
+        "delegate_task, clarify, memory, send_message.\n"
         "- Orchestrator subagents (role='orchestrator') retain "
         "delegate_task so they can spawn their own workers, but still "
-        "cannot use clarify, memory, send_message, or execute_code. "
+        "cannot use clarify, memory, or send_message. "
         "Orchestrators are bounded by delegation.max_spawn_depth "
         "(default 2) and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"


### PR DESCRIPTION
## Summary

Rebased onto current `main` and scoped down to the only net-new change after @alt-glitch's [feedback](https://github.com/NousResearch/hermes-agent/pull/10635#issuecomment-4320720008).

### What this PR now does
**Unblock `execute_code` for subagents.** Removes `execute_code` from `DELEGATE_BLOCKED_TOOLS` so subagents can write Python scripts with parallel curl calls, data processing, and filtering — replacing 30+ individual tool calls with a single script execution.

### What was dropped (already covered on main)
- ~~Wall-clock timeout~~ → covered by `delegation.child_timeout_seconds` (default 600s)
- ~~Stall detection~~ → covered by `_HEARTBEAT_STALE_CYCLES_IDLE` heartbeat logic in `_run_single_child`
- ~~`max_duration` kwarg~~ → redundant with the existing config knob; can be added later as a per-call override if there is demand

### Diff
+9 / −4 across 2 files (was +314/−10).

Tests pass:
- `test_blocked_tools_constant` updated to drop `execute_code`
- new `test_execute_code_not_blocked` guards the new contract