### PR TITLE
fix(gateway): fix macOS gateway PID detection in find_gateway_pids

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -88,16 +88,27 @@ def _get_service_pids() -> set:
                 capture_output=True, text=True, timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                # Modern macOS (12+) returns a property-list dict:
+                #   "PID" = 12345;
+                # Older versions returned a tabular format:
+                #   PID\tStatus\tLabel
+                import re
+                pid_match = re.search(r'"PID"\s*=\s*(\d+)', result.stdout)
+                if pid_match:
+                    pid = int(pid_match.group(1))
+                    if pid > 0:
+                        pids.add(pid)
+                else:
+                    # Fallback: tabular format (legacy macOS)
+                    for line in result.stdout.strip().splitlines():
+                        parts = line.split()
+                        if len(parts) >= 3 and parts[2] == label:
+                            try:
+                                pid = int(parts[0])
+                                if pid > 0:
+                                    pids.add(pid)
+                            except ValueError:
+                                pass
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -222,7 +233,7 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "-A", "eww", "-o", "pid=,command="],
+                ["ps", "-Aeww", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,


### PR DESCRIPTION
## Summary

`find_gateway_pids()` fails to detect running gateway processes on macOS, causing `hermes cron status` to report "Gateway is not running" even when the gateway is alive and healthy (`/health` returns OK).

Two root causes:

### 1. `launchctl list <label>` output format mismatch

Modern macOS (12+) returns a property-list dictionary:

```
"PID" = 12345;
"Label" = "ai.hermes.gateway";
```

The parser expects legacy tabular format (`PID\tStatus\tLabel`) and never extracts the PID.

**Fix:** Regex extraction (`"PID"\s*=\s*(\d+)`) for the modern dict format, with fallback to the legacy tabular parser.

### 2. `ps` flag argument splitting (#9069, #9100)

```python
# Before — "eww" treated as process name filter on BSD ps
["ps", "-A", "eww", "-o", "pid=,command="]  # Returns ~5 results

# After — flags combined correctly
["ps", "-Aeww", "-o", "pid=,command="]      # Returns ~400+ results
```

When `eww` is a separate argument, BSD `ps` interprets it as a process name filter instead of flags, returning only processes matching "eww" as a keyword.

## Test plan

Tested on macOS 15.4 (Sequoia) with launchd-managed gateway:

- [x] `hermes cron status` correctly shows "Gateway is running — PID: \<pid>"
- [x] `hermes cron run <id>` fires and completes successfully
- [x] `hermes cron tick` executes due jobs
- [x] Gateway health endpoint responds OK
- [x] No regression on `hermes update` (restart detection still works)

## Related issues

- #9069 — FreeBSD `ps eww` gateway detection fails
- #9100 — PR switching `ps eww` to `ps ww` (this PR provides an alternative fix)
- #4820 — launchctl modernization (closed without merging the PID parsing fix)