### PR TITLE
fix(gateway): use unconditional KeepAlive in launchd plist

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1361,11 +1361,11 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
-    
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     
@@ -1474,7 +1474,7 @@ def launchd_stop():
     target = f"{_launchd_domain()}/{label}"
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # immediately restarts it because KeepAlive is unconditional.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)


### PR DESCRIPTION
## Summary

The generated launchd plist uses `KeepAlive > SuccessfulExit = false`, which means the gateway is **not restarted** when it exits with code 0 (clean exit). This causes the gateway to silently die and never recover in several real-world scenarios:

- Discord slash command sync failure → gateway shuts down gracefully (exit 0) → launchd doesn't restart
- `--replace` logic detects stale processes → exits cleanly → launchd doesn't restart
- Any transient error handled with a graceful shutdown path

### Before

```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
</dict>
```

Gateway exits with code 0 → **stays dead**. Cron jobs stop firing. No recovery until manual restart.

### After

```xml
<key>KeepAlive</key>
<true/>

<key>ThrottleInterval</key>
<integer>5</integer>
```

Gateway always restarts regardless of exit code. `ThrottleInterval: 5` prevents overly aggressive restart loops.

### Why this is safe

`launchd_stop()` already uses `launchctl bootout` which **fully unloads** the service definition, preventing KeepAlive from respawning. So intentional stops (via `hermes gateway stop` or `hermes update`) are completely unaffected.

## Test plan

- [x] Gateway restarts automatically after exit 0 (previously stayed dead)
- [x] Gateway restarts after crash (non-zero exit) — unchanged behavior
- [x] `hermes gateway stop` / `hermes update` still cleanly stop the gateway
- [x] No restart loop — ThrottleInterval prevents rapid cycling
- [x] `hermes cron status` reports gateway as running after restart

Fixes #9659