### PR TITLE
fix(wecom): remove event-message /start loop and add proper /start command

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -328,8 +328,6 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         corp_id = root.findtext("ToUserName", default=app.get("corp_id", ""))
         scoped_chat_id = self._user_app_key(corp_id, user_id)
         content = root.findtext("Content", default="").strip()
-        if not content and msg_type == "event":
-            content = "/start"
         msg_id = (
             root.findtext("MsgId")
             or f"{user_id}:{root.findtext('CreateTime', default='0')}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2977,6 +2977,9 @@ class GatewayRunner:
         if canonical == "help":
             return await self._handle_help_command(event)
 
+        if canonical == "start":
+            return await self._handle_start_command(event)
+
         if canonical == "commands":
             return await self._handle_commands_command(event)
         
@@ -4512,6 +4515,21 @@ class GatewayRunner:
         if active_agents:
             return f"⏳ Draining {active_agents} active agent(s) before restart..."
         return "♻ Restarting gateway. If you aren't notified within 60 seconds, restart from the console with `hermes gateway restart`."
+
+    async def _handle_start_command(self, event: MessageEvent) -> str:
+        """Handle /start command - friendly welcome message."""
+        return (
+            "👋 欢迎使用 Hermes！\n\n"
+            "我是鲲和数科的智能助理，可以帮你：\n"
+            "• 查询业务数据和系统状态\n"
+            "• 指导系统操作、排查问题\n"
+            "• 监控使用情况、发现异常\n\n"
+            "直接发送消息即可开始对话，也可以使用以下命令：\n"
+            "/help — 查看所有可用命令\n"
+            "/commands — 查看完整命令列表\n"
+            "/new — 开始新会话\n\n"
+            "有什么可以帮你的？"
+        )
 
     async def _handle_help_command(self, event: MessageEvent) -> str:
         """Handle /help command - list available commands."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -60,6 +60,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Session
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",)),
+    CommandDef("start", "Welcome message — get started with Hermes", "Session"),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("history", "Show conversation history", "Session",


### PR DESCRIPTION
## Summary

- **Remove** hack in  that faked  for empty event messages (caused infinite message loops)
- **Add** proper  in  with a friendly welcome message
- **Register**  command in 

## Changes

### 
- Removed:  — this line caused event messages without content to be treated as /start commands, triggering loops

### 
- Added  method returning a friendly welcome message
- Added dispatch in the command router

### 
- Added  to the registry

## Test Plan

- [ ] WeCom: Send a bare event message — should NOT trigger /start loop
- [ ] WeCom: Explicitly send /start — should receive welcome message
- [ ] CLI/gateway: /start command shows help text