### PR TITLE
fix(gateway): preserve notify context in executor threads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24,6 +24,7 @@ import signal
 import tempfile
 import threading
 import time
+from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
@@ -5720,8 +5721,7 @@ class GatewayRunner:
                     task_id=task_id,
                 )
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            result = await self._run_in_executor_with_context(run_sync)
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -5903,8 +5903,7 @@ class GatewayRunner:
                     task_id=task_id,
                 )
 
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, run_sync)
+            result = await self._run_in_executor_with_context(run_sync)
 
             response = (result.get("final_response") or "") if result else ""
             if not response and result and result.get("error"):
@@ -7317,6 +7316,12 @@ class GatewayRunner:
         """Restore session context variables to their pre-handler values."""
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
+
+    async def _run_in_executor_with_context(self, func, *args):
+        """Run blocking work in the thread pool while preserving session contextvars."""
+        loop = asyncio.get_event_loop()
+        ctx = copy_context()
+        return await loop.run_in_executor(None, ctx.run, func, *args)
     
     async def _enrich_message_with_vision(
         self,
@@ -9059,9 +9064,8 @@ class GatewayRunner:
             _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
-            loop = asyncio.get_event_loop()
             _executor_task = asyncio.ensure_future(
-                loop.run_in_executor(None, run_sync)
+                self._run_in_executor_with_context(run_sync)
             )
 
             _inactivity_timeout = False

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -251,3 +251,48 @@ def test_session_key_no_race_condition_with_contextvars(monkeypatch):
     assert results["session-B"] == "session-B", (
         f"Session B got '{results['session-B']}' instead of 'session-B' — race condition!"
     )
+
+
+@pytest.mark.asyncio
+async def test_run_in_executor_with_context_preserves_session_env(monkeypatch):
+    """Gateway executor work should inherit session contextvars for tool routing."""
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="2144471399",
+        chat_type="dm",
+        user_id="123456",
+        user_name="alice",
+        thread_id=None,
+    )
+    context = SessionContext(
+        source=source,
+        connected_platforms=[],
+        home_channels={},
+        session_key="agent:main:telegram:dm:2144471399",
+    )
+
+    tokens = runner._set_session_env(context)
+    try:
+        result = await runner._run_in_executor_with_context(
+            lambda: {
+                "platform": get_session_env("HERMES_SESSION_PLATFORM"),
+                "chat_id": get_session_env("HERMES_SESSION_CHAT_ID"),
+                "user_id": get_session_env("HERMES_SESSION_USER_ID"),
+                "session_key": get_session_env("HERMES_SESSION_KEY"),
+            }
+        )
+    finally:
+        runner._clear_session_env(tokens)
+
+    assert result == {
+        "platform": "telegram",
+        "chat_id": "2144471399",
+        "user_id": "123456",
+        "session_key": "agent:main:telegram:dm:2144471399",
+    }


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway/session-context bug that broke `notify_on_complete` background process notifications on messaging platforms like Telegram.

The gateway stores per-chat routing metadata in `contextvars`, but it was running the agent/tool loop in a thread pool without propagating that context into the executor thread. Background terminal calls with `notify_on_complete=true` therefore lost their session routing metadata when they spawned, so the watcher had nothing usable to route the completion turn back to the originating chat.

This change wraps gateway executor work in `copy_context()` so thread-pool agent runs inherit the active session context. That lets background process watchers keep the correct platform/chat/user/session metadata and inject the completion event back into the right Telegram session.

## Related Issue

Support-reported bug. No tracked issue number.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `GatewayRunner._run_in_executor_with_context()` in `gateway/run.py`
- Switched gateway thread-pool agent execution paths to use the context-preserving helper
- Added a regression test in `tests/gateway/test_session_env.py` proving session context survives into the executor thread

## How to Test

1. In a gateway chat, run a background terminal command with `notify_on_complete=true`, for example a short `sleep 5 && echo done` repro
2. Confirm the background process completes and Hermes injects the completion turn back into the same Telegram chat/session
3. Verify the focused test slices pass:
   - `python -m pytest tests/gateway/test_session_env.py tests/gateway/test_internal_event_bypass_pairing.py tests/tools/test_notify_on_complete.py -q -n 4`
   - `python -m pytest tests/gateway/test_background_process_notifications.py tests/gateway/test_usage_command.py -q -n 4`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused validation passes:

- `tests/gateway/test_session_env.py tests/gateway/test_internal_event_bypass_pairing.py tests/tools/test_notify_on_complete.py -q -n 4` → `39 passed`
- `tests/gateway/test_background_process_notifications.py tests/gateway/test_usage_command.py -q -n 4` → `31 passed`

Full suite run:

- `python -m pytest tests/ -q -n 4` → `47 failed, 11707 passed, 34 skipped, 10 errors in 287.63s`

The full-suite failures are pre-existing and outside this change area. Representative unrelated reds include Discord reply/slash-command tests, Google Workspace API dependency tests, browser/Camofox tests, Matrix send-message tests, and tirith security tests.
