### PR TITLE
fix(cli): prevent profile import from clobbering existing profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -920,13 +920,25 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{inferred_name}' already exists at {profile_dir}")
 
+    # Guard: the archive's top-level directory may differ from the target
+    # name.  Extracting directly into profiles_root would clobber an
+    # existing profile whose name matches the archive root.
+    archive_root = top_dirs.pop() if top_dirs else inferred_name
     profiles_root = _get_profiles_root()
+    if archive_root != inferred_name:
+        existing = profiles_root / archive_root
+        if existing.exists():
+            raise FileExistsError(
+                f"Cannot import: archive top-level directory '{archive_root}' "
+                f"collides with existing profile at {existing}"
+            )
+
     profiles_root.mkdir(parents=True, exist_ok=True)
 
     _safe_extract_profile_archive(archive, profiles_root)
 
     # If the archive extracted under a different name, rename
-    extracted = profiles_root / (top_dirs.pop() if top_dirs else inferred_name)
+    extracted = profiles_root / archive_root
     if extracted != profile_dir and extracted.exists():
         extracted.rename(profile_dir)
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -636,6 +636,34 @@ class TestExportImport:
         assert (imported / "config.yaml").read_text() == "model: opus"
         assert (imported / "memories" / "MEMORY.md").read_text() == "important fact"
 
+    def test_import_rejects_archive_root_colliding_with_existing_profile(
+        self, profile_env, tmp_path
+    ):
+        """Importing bar.tar.gz as 'foo' must not clobber existing 'bar' profile."""
+        # Create an existing profile named "bar"
+        create_profile("bar", no_alias=True)
+        bar_dir = get_profile_dir("bar")
+        (bar_dir / "keep.txt").write_text("original-bar")
+
+        # Build an archive whose top-level directory is "bar/"
+        archive = tmp_path / "export" / "bar.tar.gz"
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(archive, "w:gz") as tf:
+            payload = b"new-from-archive"
+            info = tarfile.TarInfo("bar/new.txt")
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+
+        # Importing under a different name must fail — not silently clobber
+        with pytest.raises(FileExistsError, match="collides with existing profile"):
+            import_profile(str(archive), name="foo")
+
+        # Existing "bar" profile must remain untouched
+        assert (bar_dir / "keep.txt").read_text() == "original-bar"
+        assert not (bar_dir / "new.txt").exists()
+        # Target "foo" must not have been created
+        assert not get_profile_dir("foo").exists()
+
 
 # ===================================================================
 # TestProfileIsolation


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss bug where `hermes profile import bar.tar.gz --name foo` could silently overwrite an existing `bar` profile when the archive's top-level directory name (`bar`) differs from the import target (`foo`).

## Related Issue

Fixes #10623

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`: Added a pre-extraction guard in `import_profile()` that checks whether the archive's top-level directory name collides with any existing profile before extracting
- `tests/hermes_cli/test_profiles.py`: Added regression test `test_import_rejects_archive_root_colliding_with_existing_profile`

## Root Cause

`import_profile()` only validated that the *target* profile name (`--name foo`) didn't already exist, but never checked whether the archive's internal top-level directory (`bar/`) would collide with a different existing profile during extraction. Since `_safe_extract_profile_archive()` creates directories with `exist_ok=True`, the extraction silently overwrote the existing `bar` profile, and the subsequent `rename()` moved the corrupted directory to `foo`.

## How to Test

1. Create a profile named `bar`: `hermes profile create bar`
2. Create an archive with top-level dir `bar/`: `hermes profile export bar`
3. Delete `bar`, recreate it with different content
4. Try: `hermes profile import bar.tar.gz --name foo`
5. **Before fix**: `bar` profile silently clobbered and renamed to `foo`
6. **After fix**: `FileExistsError` raised, both profiles untouched

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (88/88 in test_profiles.py)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] N/A — no config or architecture changes

## AI Disclosure

This bug was identified through code review with AI assistance.