### PR TITLE
feat(cron): append deliveries to session context

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -260,6 +260,16 @@ terminal:
 #   tirith_fail_open: true      # Allow commands if tirith unavailable
 
 # =============================================================================
+# Scheduled Tasks (Cron)
+# =============================================================================
+# Global defaults for cron delivery behavior.
+#
+# cron:
+#   wrap_response: true                  # Add the cron header/footer to delivered output
+#   append_deliveries_to_session: false  # Mirror successful cron deliveries into the target chat session by default
+#                                        # Per-job override: cronjob(..., append_to_session=true|false)
+
+# =============================================================================
 # Browser Tool Configuration
 # =============================================================================
 browser:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -378,6 +378,7 @@ def create_job(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     script: Optional[str] = None,
+    append_to_session: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -397,6 +398,9 @@ def create_job(
         script: Optional path to a Python script whose stdout is injected into the
                 prompt each run.  The script runs before the agent turn, and its output
                 is prepended as context.  Useful for data collection / change detection.
+        append_to_session: Optional per-job override for whether successful
+                deliveries should be mirrored back into the target session
+                transcript. None inherits the global cron config default.
 
     Returns:
         The created job dict
@@ -457,6 +461,7 @@ def create_job(
         "last_delivery_error": None,
         # Delivery configuration
         "deliver": deliver,
+        "append_to_session": append_to_session,
         "origin": origin,  # Tracks where job was created for "origin" delivery
     }
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -198,6 +198,63 @@ def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: 
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _load_cron_delivery_config() -> dict:
+    """Load cron delivery config with safe fallbacks."""
+    try:
+        user_cfg = load_config() or {}
+    except Exception:
+        return {}
+
+    cron_cfg = user_cfg.get("cron", {})
+    if isinstance(cron_cfg, dict):
+        return cron_cfg
+    return {}
+
+
+def _should_append_delivery_to_session(job: dict, *, cron_cfg: dict) -> bool:
+    """Resolve the effective append-to-session setting for a cron delivery."""
+    job_override = job.get("append_to_session")
+    if job_override is not None:
+        return bool(job_override)
+    return bool(cron_cfg.get("append_deliveries_to_session", False))
+
+
+def _build_delivery_mirror_text(content: str) -> str:
+    """Build the transcript text that should be mirrored for follow-up context."""
+    from gateway.platforms.base import BasePlatformAdapter
+    from tools.send_message_tool import _describe_media_for_mirror
+
+    media_files, cleaned_content = BasePlatformAdapter.extract_media(content)
+    return cleaned_content.strip() or _describe_media_for_mirror(media_files)
+
+
+def _mirror_delivered_result(job: dict, *, target: dict, mirror_text: str) -> None:
+    """Append a successful cron delivery into the matching target session."""
+    if not mirror_text:
+        return
+
+    try:
+        from gateway.mirror import mirror_to_session
+
+        source_label = f"cron:{job.get('name') or job.get('id')}"
+        mirrored = mirror_to_session(
+            target["platform"],
+            target["chat_id"],
+            mirror_text,
+            source_label=source_label,
+            thread_id=target.get("thread_id"),
+        )
+        if mirrored:
+            logger.debug(
+                "Job '%s': mirrored delivery into session for %s:%s",
+                job.get("id", "?"),
+                target["platform"],
+                target["chat_id"],
+            )
+    except Exception as e:
+        logger.debug("Job '%s': delivery mirror failed: %s", job.get("id", "?"), e)
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target (origin chat, specific platform, etc.).
@@ -278,14 +335,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
+    # is a cron delivery. Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
-    wrap_response = True
-    try:
-        user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
-    except Exception:
-        pass
+    cron_cfg = _load_cron_delivery_config()
+    wrap_response = cron_cfg.get("wrap_response", True)
+    append_to_session = _should_append_delivery_to_session(job, cron_cfg=cron_cfg)
+    mirror_text = _build_delivery_mirror_text(content) if append_to_session else ""
 
     if wrap_response:
         task_name = job.get("name", job["id"])
@@ -332,6 +387,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 _send_media_via_adapter(runtime_adapter, chat_id, media_files, send_metadata, loop, job)
 
             if adapter_ok:
+                if append_to_session:
+                    _mirror_delivered_result(job, target=target, mirror_text=mirror_text)
                 logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                 return None
         except Exception as e:
@@ -363,6 +420,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         msg = f"delivery error: {result['error']}"
         logger.error("Job '%s': %s", job["id"], msg)
         return msg
+
+    if append_to_session:
+        _mirror_delivered_result(job, target=target, mirror_text=mirror_text)
 
     logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
     return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -255,6 +255,31 @@ def _mirror_delivered_result(job: dict, *, target: dict, mirror_text: str) -> No
         logger.debug("Job '%s': delivery mirror failed: %s", job.get("id", "?"), e)
 
 
+def _build_wrapped_delivery_content(
+    *,
+    job: dict,
+    content: str,
+    append_to_session: bool,
+) -> str:
+    """Build the user-facing wrapped cron delivery."""
+    task_name = job.get("name", job["id"])
+    job_id = job.get("id", "")
+    footer_lines = []
+    if append_to_session:
+        footer_lines.append("Follow-up replies in this chat can refer to this message.")
+    footer_lines.append(
+        f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+    )
+    footer = "\n".join(footer_lines)
+    return (
+        f"Cronjob Response: {task_name}\n"
+        f"(job_id: {job_id})\n"
+        f"-------------\n\n"
+        f"{content}\n\n"
+        f"{footer}"
+    )
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target (origin chat, specific platform, etc.).
@@ -343,14 +368,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     mirror_text = _build_delivery_mirror_text(content) if append_to_session else ""
 
     if wrap_response:
-        task_name = job.get("name", job["id"])
-        job_id = job.get("id", "")
-        delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+        delivery_content = _build_wrapped_delivery_content(
+            job=job,
+            content=content,
+            append_to_session=append_to_session,
         )
     else:
         delivery_content = content

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -11,6 +11,8 @@ the full SessionStore machinery.
 
 import json
 import logging
+import os
+import tempfile
 from datetime import datetime
 from typing import Optional
 
@@ -39,21 +41,34 @@ def mirror_to_session(
     All errors are caught -- this is never fatal.
     """
     try:
-        session_id = _find_session_id(platform, str(chat_id), thread_id=thread_id)
-        if not session_id:
+        timestamp = datetime.now().isoformat()
+        sessions_data = _load_sessions_index()
+        session_key, session_entry = _find_session_entry(
+            sessions_data,
+            platform,
+            str(chat_id),
+            thread_id=thread_id,
+        )
+        if not session_entry:
             logger.debug("Mirror: no session found for %s:%s:%s", platform, chat_id, thread_id)
+            return False
+        session_id = session_entry.get("session_id")
+        if not session_id:
+            logger.debug("Mirror: matching session entry is missing session_id for %s:%s:%s", platform, chat_id, thread_id)
             return False
 
         mirror_msg = {
             "role": "assistant",
             "content": message_text,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": timestamp,
             "mirror": True,
             "mirror_source": source_label,
         }
 
         _append_to_jsonl(session_id, mirror_msg)
         _append_to_sqlite(session_id, mirror_msg)
+        if session_key is not None:
+            _touch_session_entry(sessions_data, session_key, updated_at=timestamp)
 
         logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
         return True
@@ -64,27 +79,56 @@ def mirror_to_session(
 
 
 def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = None) -> Optional[str]:
+    """Find the active session_id for a platform + chat_id pair."""
+    sessions_data = _load_sessions_index()
+    _session_key, session_entry = _find_session_entry(
+        sessions_data,
+        platform,
+        chat_id,
+        thread_id=thread_id,
+    )
+    if not session_entry:
+        return None
+    return session_entry.get("session_id")
+
+
+def _load_sessions_index() -> dict[str, dict]:
+    if not _SESSIONS_INDEX.exists():
+        return {}
+
+    try:
+        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
+            loaded = json.load(f)
+    except Exception:
+        return {}
+    if isinstance(loaded, dict):
+        return loaded
+    return {}
+
+
+def _find_session_entry(
+    sessions_data: dict[str, dict],
+    platform: str,
+    chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+) -> tuple[Optional[str], Optional[dict]]:
     """
-    Find the active session_id for a platform + chat_id pair.
+    Find the active session entry for a platform + chat_id pair.
 
     Scans sessions.json entries and matches where origin.chat_id == chat_id
     on the right platform.  DM session keys don't embed the chat_id
     (e.g. "agent:main:telegram:dm"), so we check the origin dict.
     """
-    if not _SESSIONS_INDEX.exists():
-        return None
-
-    try:
-        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
-        return None
+    if not sessions_data:
+        return None, None
 
     platform_lower = platform.lower()
-    best_match = None
+    best_match_key = None
+    best_match_entry = None
     best_updated = ""
 
-    for _key, entry in data.items():
+    for entry_key, entry in sessions_data.items():
         origin = entry.get("origin") or {}
         entry_platform = (origin.get("platform") or entry.get("platform", "")).lower()
 
@@ -99,9 +143,45 @@ def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = Non
             updated = entry.get("updated_at", "")
             if updated > best_updated:
                 best_updated = updated
-                best_match = entry.get("session_id")
+                best_match_key = entry_key
+                best_match_entry = entry
 
-    return best_match
+    return best_match_key, best_match_entry
+
+
+def _touch_session_entry(
+    sessions_data: dict[str, dict],
+    session_key: str,
+    *,
+    updated_at: str,
+) -> None:
+    """Refresh the matched session's updated_at in sessions.json."""
+    if session_key not in sessions_data:
+        return
+
+    try:
+        sessions_data[session_key]["updated_at"] = updated_at
+        _write_sessions_index(sessions_data)
+    except Exception as e:
+        logger.debug("Mirror session updated_at refresh failed: %s", e)
+
+
+def _write_sessions_index(sessions_data: dict[str, dict]) -> None:
+    """Atomically rewrite sessions.json with updated metadata."""
+    _SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(_SESSIONS_DIR), suffix=".tmp", prefix=".sessions_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(sessions_data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, _SESSIONS_INDEX)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _append_to_jsonl(session_id: str, message: dict) -> None:

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -11,17 +11,18 @@ the full SessionStore machinery.
 
 import json
 import logging
-import os
-import tempfile
 from datetime import datetime
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
+from gateway.session import (
+    find_session_entry_by_origin,
+    touch_session_updated_at,
+)
 
 logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = get_hermes_home() / "sessions"
-_SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
 
 
 def mirror_to_session(
@@ -42,9 +43,7 @@ def mirror_to_session(
     """
     try:
         timestamp = datetime.now().isoformat()
-        sessions_data = _load_sessions_index()
-        session_key, session_entry = _find_session_entry(
-            sessions_data,
+        session_key, session_entry = find_session_entry_by_origin(
             platform,
             str(chat_id),
             thread_id=thread_id,
@@ -68,7 +67,7 @@ def mirror_to_session(
         _append_to_jsonl(session_id, mirror_msg)
         _append_to_sqlite(session_id, mirror_msg)
         if session_key is not None:
-            _touch_session_entry(sessions_data, session_key, updated_at=timestamp)
+            touch_session_updated_at(session_key, updated_at=timestamp)
 
         logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
         return True
@@ -80,9 +79,7 @@ def mirror_to_session(
 
 def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = None) -> Optional[str]:
     """Find the active session_id for a platform + chat_id pair."""
-    sessions_data = _load_sessions_index()
-    _session_key, session_entry = _find_session_entry(
-        sessions_data,
+    _session_key, session_entry = find_session_entry_by_origin(
         platform,
         chat_id,
         thread_id=thread_id,
@@ -90,98 +87,6 @@ def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = Non
     if not session_entry:
         return None
     return session_entry.get("session_id")
-
-
-def _load_sessions_index() -> dict[str, dict]:
-    if not _SESSIONS_INDEX.exists():
-        return {}
-
-    try:
-        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
-            loaded = json.load(f)
-    except Exception:
-        return {}
-    if isinstance(loaded, dict):
-        return loaded
-    return {}
-
-
-def _find_session_entry(
-    sessions_data: dict[str, dict],
-    platform: str,
-    chat_id: str,
-    *,
-    thread_id: Optional[str] = None,
-) -> tuple[Optional[str], Optional[dict]]:
-    """
-    Find the active session entry for a platform + chat_id pair.
-
-    Scans sessions.json entries and matches where origin.chat_id == chat_id
-    on the right platform.  DM session keys don't embed the chat_id
-    (e.g. "agent:main:telegram:dm"), so we check the origin dict.
-    """
-    if not sessions_data:
-        return None, None
-
-    platform_lower = platform.lower()
-    best_match_key = None
-    best_match_entry = None
-    best_updated = ""
-
-    for entry_key, entry in sessions_data.items():
-        origin = entry.get("origin") or {}
-        entry_platform = (origin.get("platform") or entry.get("platform", "")).lower()
-
-        if entry_platform != platform_lower:
-            continue
-
-        origin_chat_id = str(origin.get("chat_id", ""))
-        if origin_chat_id == str(chat_id):
-            origin_thread_id = origin.get("thread_id")
-            if thread_id is not None and str(origin_thread_id or "") != str(thread_id):
-                continue
-            updated = entry.get("updated_at", "")
-            if updated > best_updated:
-                best_updated = updated
-                best_match_key = entry_key
-                best_match_entry = entry
-
-    return best_match_key, best_match_entry
-
-
-def _touch_session_entry(
-    sessions_data: dict[str, dict],
-    session_key: str,
-    *,
-    updated_at: str,
-) -> None:
-    """Refresh the matched session's updated_at in sessions.json."""
-    if session_key not in sessions_data:
-        return
-
-    try:
-        sessions_data[session_key]["updated_at"] = updated_at
-        _write_sessions_index(sessions_data)
-    except Exception as e:
-        logger.debug("Mirror session updated_at refresh failed: %s", e)
-
-
-def _write_sessions_index(sessions_data: dict[str, dict]) -> None:
-    """Atomically rewrite sessions.json with updated metadata."""
-    _SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(dir=str(_SESSIONS_DIR), suffix=".tmp", prefix=".sessions_")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(sessions_data, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, _SESSIONS_INDEX)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
 
 
 def _append_to_jsonl(session_id: str, message: dict) -> None:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1713,7 +1713,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name",
+        "schedule",
+        "prompt",
+        "deliver",
+        "skills",
+        "skill",
+        "repeat",
+        "enabled",
+        "append_to_session",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -1765,6 +1775,7 @@ class APIServerAdapter(BasePlatformAdapter):
             deliver = body.get("deliver", "local")
             skills = body.get("skills")
             repeat = body.get("repeat")
+            append_to_session = body.get("append_to_session")
 
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
@@ -1780,6 +1791,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
                 return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
+            if append_to_session is not None and not isinstance(append_to_session, bool):
+                return web.json_response(
+                    {"error": "append_to_session must be true, false, or null"},
+                    status=400,
+                )
 
             kwargs = {
                 "prompt": prompt,
@@ -1791,6 +1807,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 kwargs["skills"] = skills
             if repeat is not None:
                 kwargs["repeat"] = repeat
+            if "append_to_session" in body:
+                kwargs["append_to_session"] = append_to_session
 
             job = self._cron_create(**kwargs)
             return web.json_response({"job": job})
@@ -1841,6 +1859,15 @@ class APIServerAdapter(BasePlatformAdapter):
             if "prompt" in sanitized and len(sanitized["prompt"]) > self._MAX_PROMPT_LENGTH:
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
+                )
+            if (
+                "append_to_session" in sanitized
+                and sanitized["append_to_session"] is not None
+                and not isinstance(sanitized["append_to_session"], bool)
+            ):
+                return web.json_response(
+                    {"error": "append_to_session must be true, false, or null"},
+                    status=400,
                 )
             job = self._cron_update(job_id, sanitized)
             if not job:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import json
+import tempfile
 import threading
 import uuid
 from pathlib import Path
@@ -19,12 +20,114 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 
 def _now() -> datetime:
     """Return the current local time."""
     return datetime.now()
+
+
+def _get_sessions_index_path() -> Path:
+    """Return the sessions index path for the active Hermes home."""
+    return get_hermes_home() / "sessions" / "sessions.json"
+
+
+def _load_sessions_index(sessions_file: Optional[Path] = None) -> dict[str, dict]:
+    """Load sessions.json for lightweight helpers that operate outside SessionStore."""
+    path = sessions_file or _get_sessions_index_path()
+    if not path.exists():
+        return {}
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            loaded = json.load(f)
+    except Exception:
+        return {}
+
+    if isinstance(loaded, dict):
+        return loaded
+    return {}
+
+
+def _write_sessions_index(data: dict[str, Any], *, sessions_file: Path) -> None:
+    """Atomically rewrite sessions.json."""
+    sessions_dir = sessions_file.parent
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(sessions_dir), suffix=".tmp", prefix=".sessions_"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, sessions_file)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError as e:
+            logger.debug("Could not remove temp file %s: %s", tmp_path, e)
+        raise
+
+
+def find_session_entry_by_origin(
+    platform: str,
+    chat_id: str,
+    *,
+    thread_id: Optional[str] = None,
+    sessions_file: Optional[Path] = None,
+) -> tuple[Optional[str], Optional[dict]]:
+    """Find the most recently updated session entry for a platform/chat/thread."""
+    data = _load_sessions_index(sessions_file=sessions_file)
+    if not data:
+        return None, None
+
+    platform_lower = platform.lower()
+    best_match_key = None
+    best_match_entry = None
+    best_updated = ""
+
+    for entry_key, entry in data.items():
+        origin = entry.get("origin") or {}
+        entry_platform = (origin.get("platform") or entry.get("platform", "")).lower()
+        if entry_platform != platform_lower:
+            continue
+
+        origin_chat_id = str(origin.get("chat_id", ""))
+        if origin_chat_id != str(chat_id):
+            continue
+
+        origin_thread_id = origin.get("thread_id")
+        if thread_id is not None and str(origin_thread_id or "") != str(thread_id):
+            continue
+
+        updated = entry.get("updated_at", "")
+        if updated > best_updated:
+            best_updated = updated
+            best_match_key = entry_key
+            best_match_entry = entry
+
+    return best_match_key, best_match_entry
+
+
+def touch_session_updated_at(
+    session_key: str,
+    *,
+    updated_at: Optional[str] = None,
+    sessions_file: Optional[Path] = None,
+) -> bool:
+    """Refresh updated_at for a session entry stored in sessions.json."""
+    path = sessions_file or _get_sessions_index_path()
+    data = _load_sessions_index(sessions_file=path)
+    if session_key not in data:
+        return False
+
+    data[session_key]["updated_at"] = updated_at or _now().isoformat()
+    _write_sessions_index(data, sessions_file=path)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -550,26 +653,11 @@ class SessionStore:
     
     def _save(self) -> None:
         """Save sessions index to disk (kept for session key -> ID mapping)."""
-        import tempfile
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
         sessions_file = self.sessions_dir / "sessions.json"
 
         data = {key: entry.to_dict() for key, entry in self._entries.items()}
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(self.sessions_dir), suffix=".tmp", prefix=".sessions_"
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp_path, sessions_file)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError as e:
-                logger.debug("Could not remove temp file %s: %s", tmp_path, e)
-            raise
+        _write_sessions_index(data, sessions_file=sessions_file)
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -781,7 +781,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 19,
+    "_config_version": 18,
 }
 
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -756,9 +756,12 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
-        # Wrap delivered cron responses with a header (task name) and footer
-        # ("The agent cannot see this message").  Set to false for clean output.
+        # Wrap delivered cron responses with a header (task name) and footer.
+        # Set to false for clean output.
         "wrap_response": True,
+        # Default for whether successful cron deliveries should be mirrored into
+        # the target session transcript so follow-up replies can refer to them.
+        "append_deliveries_to_session": False,
     },
 
     # Logging — controls file logging to ~/.hermes/logs/.
@@ -778,7 +781,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 18,
+    "_config_version": 19,
 }
 
 # =============================================================================

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -120,6 +120,7 @@ AUTHOR_MAP = {
     "mrflu1918@proton.me": "SPANISHFLU",
     "morganemoss@gmai.com": "mormio",
     "kopjop926@gmail.com": "cesareth",
+    "oleksiy@kovyrin.net": "kovyrin",
     "fuleinist@gmail.com": "fuleinist",
     "jack.47@gmail.com": "JackTheGit",
     "dalvidjr2022@gmail.com": "Jr-kenny",

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -233,6 +233,10 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_default_append_to_session_inherits_global(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="30m")
+        assert job["append_to_session"] is None
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -274,6 +278,15 @@ class TestUpdateJob:
         assert updated["enabled"] is False
         fetched = get_job(job["id"])
         assert fetched["enabled"] is False
+
+    def test_update_append_to_session(self, tmp_cron_dir):
+        job = create_job(prompt="Check server status", schedule="every 1h")
+        updated = update_job(job["id"], {"append_to_session": True})
+        assert updated is not None
+        assert updated["append_to_session"] is True
+
+        fetched = get_job(job["id"])
+        assert fetched["append_to_session"] is True
 
     def test_update_nonexistent_returns_none(self, tmp_cron_dir):
         result = update_job("nonexistent_id", {"name": "X"})

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -211,7 +211,7 @@ class TestResolveDeliveryTarget:
 
 
 class TestDeliverResultWrapping:
-    """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+    """Verify cron delivery wrapping and optional session mirroring behavior."""
 
     def test_delivery_wraps_content_with_header_and_footer(self):
         """Delivered content should include task name header and agent-invisible note."""
@@ -496,8 +496,8 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
-    def test_no_mirror_to_session_call(self):
-        """Cron deliveries should NOT mirror into the gateway session."""
+    def test_default_does_not_mirror_to_session(self):
+        """Cron deliveries should not mirror unless the effective setting enables it."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -516,6 +516,119 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Hello!")
 
         mirror_mock.assert_not_called()
+
+    def test_job_append_to_session_mirrors_raw_content(self):
+        """Per-job append_to_session should mirror the unwrapped content."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "append_to_session": True,
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Cronjob Response: daily-report" in sent_content
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "123",
+            "Here is today's summary.",
+            source_label="cron:daily-report",
+            thread_id=None,
+        )
+
+    def test_global_append_to_session_default_applies(self):
+        """Jobs inherit cron.append_deliveries_to_session when no override is set."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"append_deliveries_to_session": True, "wrap_response": False}}), \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "test-job",
+                "name": "inbox-watch",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "New email about the event.")
+
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "123",
+            "New email about the event.",
+            source_label="cron:inbox-watch",
+            thread_id=None,
+        )
+
+    def test_job_append_false_overrides_global_true(self):
+        """An explicit false override should win over the global default."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"append_deliveries_to_session": True}}), \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "test-job",
+                "deliver": "origin",
+                "append_to_session": False,
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Hello!")
+
+        mirror_mock.assert_not_called()
+
+    def test_media_only_append_to_session_uses_media_summary(self):
+        """Media-only cron deliveries should mirror a readable attachment summary."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+            job = {
+                "id": "voice-job",
+                "name": "voice-job",
+                "deliver": "origin",
+                "append_to_session": True,
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "[[audio_as_voice]]\nMEDIA:/tmp/test-voice.ogg")
+
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "123",
+            "[Sent voice message]",
+            source_label="cron:voice-job",
+            thread_id=None,
+        )
 
     def test_origin_delivery_preserves_thread_id(self):
         """Origin delivery should forward thread_id to the send helper."""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -214,7 +214,7 @@ class TestDeliverResultWrapping:
     """Verify cron delivery wrapping and optional session mirroring behavior."""
 
     def test_delivery_wraps_content_with_header_and_footer(self):
-        """Delivered content should include task name header and agent-invisible note."""
+        """Delivered content should include task name header and management footer."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -239,6 +239,7 @@ class TestDeliverResultWrapping:
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
         assert "To stop or manage this job" in sent_content
+        assert "Follow-up replies in this chat can refer to this message." not in sent_content
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
@@ -547,6 +548,30 @@ class TestDeliverResultWrapping:
             source_label="cron:daily-report",
             thread_id=None,
         )
+
+    def test_wrapped_delivery_mentions_follow_up_when_mirrored(self):
+        """Wrapped deliveries should state that follow-up replies can refer to them."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session"):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "append_to_session": True,
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Follow-up replies in this chat can refer to this message." in sent_content
 
     def test_global_append_to_session_default_applies(self):
         """Jobs inherit cron.append_deliveries_to_session when no override is set."""

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -160,6 +160,26 @@ class TestCreateJob:
                 assert call_kwargs["prompt"] == "do something"
 
     @pytest.mark.asyncio
+    async def test_create_job_passes_append_to_session(self, adapter):
+        """POST /api/jobs forwards append_to_session when explicitly provided."""
+        app = _create_app(adapter)
+        mock_create = MagicMock(return_value={**SAMPLE_JOB, "append_to_session": True})
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                APIServerAdapter, "_CRON_AVAILABLE", True
+            ), patch.object(
+                APIServerAdapter, "_cron_create", mock_create
+            ):
+                resp = await cli.post("/api/jobs", json={
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "append_to_session": True,
+                })
+                assert resp.status == 200
+                call_kwargs = mock_create.call_args[1]
+                assert call_kwargs["append_to_session"] is True
+
+    @pytest.mark.asyncio
     async def test_create_job_missing_name(self, adapter):
         """POST /api/jobs without name returns 400."""
         app = _create_app(adapter)
@@ -309,6 +329,26 @@ class TestUpdateJob:
                 sanitized = call_args[0][1]
                 assert "name" in sanitized
                 assert "schedule" in sanitized
+
+    @pytest.mark.asyncio
+    async def test_update_job_allows_append_to_session(self, adapter):
+        """PATCH /api/jobs/{id} should pass append_to_session through the whitelist."""
+        app = _create_app(adapter)
+        updated_job = {**SAMPLE_JOB, "append_to_session": False}
+        mock_update = MagicMock(return_value=updated_job)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                APIServerAdapter, "_CRON_AVAILABLE", True
+            ), patch.object(
+                APIServerAdapter, "_cron_update", mock_update
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}",
+                    json={"append_to_session": False},
+                )
+                assert resp.status == 200
+                sanitized = mock_update.call_args[0][1]
+                assert sanitized["append_to_session"] is False
 
     @pytest.mark.asyncio
     async def test_update_job_rejects_unknown_fields(self, adapter):

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -32,7 +32,7 @@ class TestFindSessionId:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+             patch("gateway.session._get_sessions_index_path", return_value=index_file):
             result = _find_session_id("telegram", "12345")
 
         assert result == "sess_abc"
@@ -52,7 +52,7 @@ class TestFindSessionId:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+             patch("gateway.session._get_sessions_index_path", return_value=index_file):
             result = _find_session_id("telegram", "12345")
 
         assert result == "sess_new"
@@ -72,7 +72,7 @@ class TestFindSessionId:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+             patch("gateway.session._get_sessions_index_path", return_value=index_file):
             result = _find_session_id("telegram", "-1001", thread_id="10")
 
         assert result == "sess_topic_a"
@@ -86,13 +86,13 @@ class TestFindSessionId:
             }
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch("gateway.session._get_sessions_index_path", return_value=index_file):
             result = _find_session_id("telegram", "12345")
 
         assert result is None
 
     def test_missing_sessions_file(self, tmp_path):
-        with patch.object(mirror_mod, "_SESSIONS_INDEX", tmp_path / "nope.json"):
+        with patch("gateway.session._get_sessions_index_path", return_value=tmp_path / "nope.json"):
             result = _find_session_id("telegram", "12345")
 
         assert result is None
@@ -106,7 +106,7 @@ class TestFindSessionId:
             }
         })
 
-        with patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+        with patch("gateway.session._get_sessions_index_path", return_value=index_file):
             result = _find_session_id("telegram", "123")
 
         assert result == "sess_1"
@@ -151,7 +151,7 @@ class TestMirrorToSession:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.session._get_sessions_index_path", return_value=index_file), \
              patch("gateway.mirror._append_to_sqlite"):
             result = mirror_to_session("telegram", "12345", "Hello!", source_label="cli")
 
@@ -184,7 +184,7 @@ class TestMirrorToSession:
         })
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.session._get_sessions_index_path", return_value=index_file), \
              patch("gateway.mirror._append_to_sqlite"):
             result = mirror_to_session("telegram", "-1001", "Hello topic!", source_label="cron", thread_id="10")
 
@@ -200,13 +200,13 @@ class TestMirrorToSession:
         sessions_dir, index_file = _setup_sessions(tmp_path, {})
 
         with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
-             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+             patch("gateway.session._get_sessions_index_path", return_value=index_file):
             result = mirror_to_session("telegram", "99999", "Hello!")
 
         assert result is False
 
     def test_error_returns_false(self, tmp_path):
-        with patch("gateway.mirror._find_session_id", side_effect=Exception("boom")):
+        with patch("gateway.mirror.find_session_entry_by_origin", side_effect=Exception("boom")):
             result = mirror_to_session("telegram", "123", "msg")
 
         assert result is False

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -166,6 +166,9 @@ class TestMirrorToSession:
         assert msg["mirror"] is True
         assert msg["mirror_source"] == "cli"
 
+        refreshed_index = json.loads(index_file.read_text())
+        assert refreshed_index["s1"]["updated_at"] != "2026-01-01T00:00:00"
+
     def test_successful_mirror_uses_thread_id(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {
             "topic_a": {
@@ -188,6 +191,10 @@ class TestMirrorToSession:
         assert result is True
         assert (sessions_dir / "sess_topic_a.jsonl").exists()
         assert not (sessions_dir / "sess_topic_b.jsonl").exists()
+
+        refreshed_index = json.loads(index_file.read_text())
+        assert refreshed_index["topic_a"]["updated_at"] != "2026-01-01T00:00:00"
+        assert refreshed_index["topic_b"]["updated_at"] == "2026-02-01T00:00:00"
 
     def test_no_matching_session(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {})

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -231,3 +231,50 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         assert updated["job"]["skills"] == []
         assert updated["job"]["skill"] is None
+
+    def test_create_append_to_session_override(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check inbox",
+                schedule="every 1h",
+                append_to_session=True,
+            )
+        )
+        assert created["success"] is True
+        assert created["append_to_session"] is True
+        assert created["job"]["append_to_session"] is True
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["append_to_session"] is True
+
+    def test_update_append_to_session_can_inherit_global_default(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check inbox",
+                schedule="every 1h",
+                append_to_session=True,
+            )
+        )
+        job_id = created["job_id"]
+
+        disabled = json.loads(
+            cronjob(
+                action="update",
+                job_id=job_id,
+                append_to_session=False,
+            )
+        )
+        assert disabled["success"] is True
+        assert disabled["job"]["append_to_session"] is False
+
+        inherited = json.loads(
+            cronjob(
+                action="update",
+                job_id=job_id,
+                append_to_session=None,
+            )
+        )
+        assert inherited["success"] is True
+        assert inherited["job"]["append_to_session"] is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
+_UNSET = object()
 
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -150,6 +151,14 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _normalize_optional_bool(value: Any, *, field_name: str) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{field_name} must be true, false, or null")
+
+
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
@@ -204,6 +213,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "schedule": job.get("schedule_display"),
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
+        "append_to_session": job.get("append_to_session"),
         "next_run_at": job.get("next_run_at"),
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
@@ -234,6 +244,7 @@ def cronjob(
     base_url: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
+    append_to_session: Any = _UNSET,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -258,6 +269,12 @@ def cronjob(
                 script_error = _validate_cron_script_path(script)
                 if script_error:
                     return tool_error(script_error, success=False)
+            normalized_append_to_session = None
+            if append_to_session is not _UNSET:
+                normalized_append_to_session = _normalize_optional_bool(
+                    append_to_session,
+                    field_name="append_to_session",
+                )
 
             job = create_job(
                 prompt=prompt or "",
@@ -271,6 +288,7 @@ def cronjob(
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                 script=_normalize_optional_job_value(script),
+                append_to_session=normalized_append_to_session,
             )
             return json.dumps(
                 {
@@ -282,6 +300,7 @@ def cronjob(
                     "schedule": job["schedule_display"],
                     "repeat": _repeat_display(job),
                     "deliver": job.get("deliver", "local"),
+                    "append_to_session": job.get("append_to_session"),
                     "next_run_at": job["next_run_at"],
                     "job": _format_job(job),
                     "message": f"Cron job '{job['name']}' created.",
@@ -366,6 +385,11 @@ def cronjob(
                 repeat_state = dict(job.get("repeat") or {})
                 repeat_state["times"] = normalized_repeat
                 updates["repeat"] = repeat_state
+            if append_to_session is not _UNSET:
+                updates["append_to_session"] = _normalize_optional_bool(
+                    append_to_session,
+                    field_name="append_to_session",
+                )
             if schedule is not None:
                 parsed_schedule = parse_schedule(schedule)
                 updates["schedule"] = parsed_schedule
@@ -403,6 +427,11 @@ NOTE: The agent's final response is auto-delivered to the target. Put the primar
 user-facing content in the final response. Cron jobs run autonomously with no user
 present — they cannot ask questions or request clarification.
 
+Optional session mirroring: set append_to_session=true on a job to append
+delivered output into the target session transcript so follow-up replies in that
+chat can refer to the delivered message. Omit it or pass null to inherit the
+global cron.append_deliveries_to_session default from config.yaml.
+
 Important safety rule: cron-run sessions should not recursively schedule more cron jobs.""",
     "parameters": {
         "type": "object",
@@ -434,6 +463,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "deliver": {
                 "type": "string",
                 "description": "Omit this parameter to auto-deliver back to the current chat and topic (recommended). Auto-detection preserves thread/topic context. Only set explicitly when the user asks to deliver somewhere OTHER than the current conversation. Values: 'origin' (same as omitting), 'local' (no delivery, save only), or platform:chat_id:thread_id for a specific destination. Examples: 'telegram:-1001234567890:17585', 'discord:#engineering', 'sms:+15551234567'. WARNING: 'platform:chat_id' without :thread_id loses topic targeting."
+            },
+            "append_to_session": {
+                "type": ["boolean", "null"],
+                "description": "Optional per-job override for whether delivered output should be appended into the target session transcript. true = append so follow-up replies in that chat can refer to it. false = do not append for this job. null or omit = inherit cron.append_deliveries_to_session from config.yaml."
             },
             "skills": {
                 "type": "array",
@@ -503,6 +536,7 @@ registry.register(
         base_url=args.get("base_url"),
         reason=args.get("reason"),
         script=args.get("script"),
+        append_to_session=(args["append_to_session"] if "append_to_session" in args else _UNSET),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -188,13 +188,19 @@ For Telegram topics, use the format `telegram:<chat_id>:<thread_id>` (e.g., `tel
 
 By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 - A header identifying the cron job name and task
-- A footer noting the agent cannot see the delivered message in conversation
+- A footer with job-management guidance for the recipient
 
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
 ### Session Isolation
 
-Cron deliveries are NOT mirrored into gateway session conversation history. They exist only in the cron job's own session. This prevents message alternation violations in the target chat's conversation.
+Cron runs always execute in their own fresh session. Delivery mirroring into the target chat is now opt-in:
+
+- default behavior: no mirroring (`cron.append_deliveries_to_session: false`)
+- global default: `cron.append_deliveries_to_session` in `config.yaml`
+- per-job override: `append_to_session` on the cron job itself
+
+When mirroring is enabled, the scheduler appends the delivered output into the matching target session transcript via `gateway.mirror.mirror_to_session()`. The mirrored transcript entry uses the raw delivered content (not the cron wrapper) so follow-up replies can refer to the substantive message naturally.
 
 ## Recursion Guard
 

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -186,7 +186,7 @@ Outgoing deliveries (`gateway/delivery.py`) handle:
 - **Explicit target delivery** — `send_message` tool specifying `telegram:-1001234567890`
 - **Cross-platform delivery** — deliver to a different platform than the originating message
 
-Cron job deliveries are NOT mirrored into gateway session history — they live in their own cron session only. This is a deliberate design choice to avoid message alternation violations.
+Cron job deliveries still run in their own cron session. Mirroring into the target gateway session is opt-in: the default remains off, but cron jobs can enable it globally (`cron.append_deliveries_to_session`) or per job (`append_to_session`) when follow-up replies in the target chat should refer to the delivered content.
 
 ## Hooks
 

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -97,6 +97,17 @@ cron:
   wrap_response: false
 ```
 
+### Check 5: The follow-up message cannot refer to the delivered cron output
+
+By default, delivered cron output is **not** appended into the target chat session. If you want follow-up replies in that chat to refer to the delivered message, enable session mirroring either globally or per job:
+
+```yaml
+cron:
+  append_deliveries_to_session: true
+```
+
+Or set `append_to_session=true` on the specific cron job. An explicit per-job `false` still disables mirroring for that job even when the global default is enabled.
+
 ---
 
 ## Skill Loading Failures

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -244,6 +244,8 @@ Cronjob Response: Morning feeds
 <agent output here>
 ```
 
+When session mirroring is enabled for that job, the wrapped footer also says that follow-up replies in the same chat can refer to the delivered message.
+
 To deliver the raw agent output without the wrapper, set `cron.wrap_response` to `false`:
 
 ```yaml

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -16,6 +16,7 @@ Cron jobs can:
 - pause, resume, edit, trigger, and remove jobs
 - attach zero, one, or multiple skills to a job
 - deliver results back to the origin chat, local files, or configured platform targets
+- optionally append delivered results into the target chat's session context for follow-up replies
 - run in fresh agent sessions with the normal static tool list
 
 :::warning
@@ -208,6 +209,30 @@ When scheduling jobs, you specify where the output goes:
 
 The agent's final response is automatically delivered. You do not need to call `send_message` in the cron prompt.
 
+### Follow-up context in the delivery chat
+
+By default, a delivered cron message does **not** become part of the live chat session context. If you want follow-up replies like "add that to my calendar" to refer to the delivered cron message, enable session mirroring for that job:
+
+```python
+cronjob(
+    action="create",
+    prompt="Summarize any new event emails and deliver them here.",
+    schedule="every 30m",
+    append_to_session=True,
+)
+```
+
+This appends the delivered output into the target session transcript after a successful send. The next user message in that same chat or topic can refer to it naturally.
+
+You can also set a global default in `~/.hermes/config.yaml`:
+
+```yaml
+cron:
+  append_deliveries_to_session: true
+```
+
+Per-job `append_to_session` overrides the global default. Use `false` on noisy jobs you do not want added to chat context.
+
 ### Response wrapping
 
 By default, delivered cron output is wrapped with a header and footer so the recipient knows it came from a scheduled task:
@@ -217,8 +242,6 @@ Cronjob Response: Morning feeds
 -------------
 
 <agent output here>
-
-Note: The agent cannot see this message, and therefore cannot respond to it.
 ```
 
 To deliver the raw agent output without the wrapper, set `cron.wrap_response` to `false`:


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in way for cron deliveries to become part of the target chat's session context.

Cron jobs can now set `append_to_session` per job, or inherit a new global default `cron.append_deliveries_to_session`. After a successful delivery, the scheduler mirrors the raw delivered content into the matching target session so follow-up replies in that same chat or topic can refer to the cron message naturally.

Wrapped cron deliveries now reflect the effective behavior. When session mirroring is enabled, the wrapper explicitly says follow-up replies in that chat can refer to the message instead of implying the agent cannot see it.

The implementation reuses the existing `gateway.mirror.mirror_to_session()` path instead of inventing a cron-specific context cache. Session freshness updates and sessions-index persistence now live in `gateway.session`, so mirrored cron deliveries also refresh the matched session's `updated_at` without leaving low-level `sessions.json` writes inside `gateway.mirror`.

## Related Issue

N/A

Related upstream context:
- Similar feature area: #5659
- This PR keeps the implementation opt-in, per-job controllable, and based on the existing delivery mirror path.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `append_to_session` to cron job creation/update/listing, job storage, and the API server cron endpoints.
- Add global config support via `cron.append_deliveries_to_session`, document it in `cli-config.yaml.example`, and bump the config schema version.
- Mirror successful cron deliveries into the matching target session when the effective setting resolves `true`; per-job overrides global, raw content is mirrored instead of the cron wrapper, and the matched session `updated_at` is refreshed through `gateway.session`.
- Update wrapped cron delivery text so mirrored deliveries clearly tell the user that follow-up replies in the same chat can refer to the delivered message.
- Update user and developer cron docs plus troubleshooting guidance for the new follow-up-context behavior.
- Add coverage across cron scheduler behavior, cron job storage/tooling, gateway mirroring/session freshness, API server job endpoints, and CLI init/config loading.

## How to Test

1. Create a cron job that delivers back to the current Telegram chat/topic with `append_to_session=true`, let it fire, then reply in that same chat with a follow-up like `add that to my calendar`.
2. Set `cron.append_deliveries_to_session: true` in `~/.hermes/config.yaml`, verify jobs inherit the behavior by default, then set `append_to_session=false` on a noisy job and confirm it no longer appends into session context.
3. With `cron.wrap_response: true`, verify that mirrored deliveries say `Follow-up replies in this chat can refer to this message.` rather than implying the delivered content is detached from session context.
4. Run:

```bash
source .venv/bin/activate
python -m pytest tests/gateway/test_mirror.py tests/gateway/test_session.py tests/cron/test_scheduler.py tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/gateway/test_api_server_jobs.py tests/hermes_cli/test_cron.py tests/cli/test_cli_init.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test result:
- `python -m pytest tests/gateway/test_mirror.py tests/gateway/test_session.py tests/cron/test_scheduler.py tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/gateway/test_api_server_jobs.py tests/hermes_cli/test_cron.py tests/cli/test_cli_init.py -q` → `294 passed, 37 warnings`
