### PR TITLE
docs(nix): clarify SOUL.md location

### DIFF
--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -267,7 +267,6 @@ Run `nix build .#configKeys && cat result` to see every leaf config key extracte
 
     # ── Documents ──────────────────────────────────────────────────────
     documents = {
-      "SOUL.md" = builtins.readFile /home/user/.hermes/SOUL.md;
       "USER.md" = ./documents/USER.md;
     };
 
@@ -316,7 +315,7 @@ Quick reference for the most common things Nix users want to customize:
 | Change the LLM model | `settings.model.default` | `"anthropic/claude-sonnet-4"` |
 | Use a different provider endpoint | `settings.model.base_url` | `"https://openrouter.ai/api/v1"` |
 | Add API keys | `environmentFiles` | `[ config.sops.secrets."hermes-env".path ]` |
-| Give the agent a personality | `documents."SOUL.md"` | `builtins.readFile ./my-soul.md` |
+| Give the agent a personality | `${services.hermes-agent.stateDir}/.hermes/SOUL.md` | manage the file directly |
 | Add MCP tool servers | `mcpServers.<name>` | See [MCP Servers](#mcp-servers) |
 | Mount host directories into container | `container.extraVolumes` | `[ "/data:/data:rw" ]` |
 | Pass GPU access to container | `container.extraOptions` | `[ "--gpus" "all" ]` |
@@ -397,17 +396,14 @@ The file is only copied if `auth.json` doesn't already exist (unless `authFileFo
 
 The `documents` option installs files into the agent's working directory (the `workingDirectory`, which the agent reads as its workspace). Hermes looks for specific filenames by convention:
 
-- **`SOUL.md`** — the agent's system prompt / personality. Hermes reads this on startup and uses it as persistent instructions that shape its behavior across all conversations.
 - **`USER.md`** — context about the user the agent is interacting with.
 - Any other files you place here are visible to the agent as workspace files.
+
+The agent identity file is separate: Hermes loads its primary `SOUL.md` from `$HERMES_HOME/SOUL.md`, which in the NixOS module is `${services.hermes-agent.stateDir}/.hermes/SOUL.md`. Putting `SOUL.md` in `documents` only creates a workspace file and will not replace the main persona file.
 
 ```nix
 {
   services.hermes-agent.documents = {
-    "SOUL.md" = ''
-      You are a helpful research assistant specializing in NixOS packaging.
-      Always cite sources and prefer reproducible solutions.
-    '';
     "USER.md" = ./documents/USER.md;  # path reference, copied from Nix store
   };
 }


### PR DESCRIPTION
## What does this PR do?

Clarifies the NixOS docs around `SOUL.md` so they match the current implementation.

The existing Nix setup page implied that `services.hermes-agent.documents."SOUL.md"` configures the agent's primary persona. In code, `documents` are installed into the workspace (`workingDirectory`), while Hermes loads its actual identity file from `$HERMES_HOME/SOUL.md`.

This updates the docs to stop presenting `documents."SOUL.md"` as the persona mechanism and explicitly points users at `${services.hermes-agent.stateDir}/.hermes/SOUL.md` instead.

## Related Issue

Support-reported docs mismatch. No tracked issue number.

## Type of Change

- [x] 📝 Documentation update
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed the misleading `documents."SOUL.md"` example from the Nix setup page
- Updated the customization cheatsheet entry for agent personality
- Added an explicit note that the real identity file is `$HERMES_HOME/SOUL.md`, which is `${services.hermes-agent.stateDir}/.hermes/SOUL.md` in the NixOS module

## How to Test

1. Read `website/docs/getting-started/nix-setup.md`
2. Confirm the page no longer implies that `documents."SOUL.md"` changes the main persona file
3. Confirm the page now points users to `${services.hermes-agent.stateDir}/.hermes/SOUL.md` for the actual identity file

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: N/A (docs only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Docs-only change. No test run needed.
