### PR TITLE
fix(auxiliary): fall back to OPENROUTER_API_KEY when pool entry is missing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -759,12 +759,15 @@ def _try_openrouter() -> Tuple[Optional[OpenAI], Optional[str]]:
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = _pool_runtime_api_key(entry)
-        if not or_key:
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=_OR_HEADERS), _OPENROUTER_MODEL
+        logger.debug(
+            "Auxiliary client: OpenRouter pool present but no usable selected "
+            "entry; falling back to OPENROUTER_API_KEY"
+        )
 
     or_key = os.getenv("OPENROUTER_API_KEY")
     if not or_key:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -263,6 +263,25 @@ class TestTryCodex:
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
+class TestTryOpenRouter:
+    def test_pool_without_selected_entry_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-fallback")
+
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import _try_openrouter
+
+            client, model = _try_openrouter()
+
+        assert client is not None
+        assert model == "google/gemini-3-flash-preview"
+        assert mock_openai.call_args.kwargs["api_key"] == "or-fallback"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://openrouter.ai/api/v1"
+
+
 class TestExpiredCodexFallback:
     """Test that expired Codex tokens don't block the auto chain."""
 


### PR DESCRIPTION
## Summary
- fall back to `OPENROUTER_API_KEY` when an OpenRouter credential pool exists but cannot currently select a usable entry
- keep pool credentials as the first choice when they are valid
- add a regression test for the pool-present-but-empty path

## Why
Issue #10149 reports `No auxiliary LLM provider configured` even after setting `OPENROUTER_API_KEY` in `~/.hermes/.env`.

That can happen when Hermes detects an OpenRouter credential pool, but the selected pool entry is unavailable or missing. `_try_openrouter()` returned `(None, None)` immediately in that case, so the auto auxiliary path never reached the env-backed key.

## Verification
- `python3 -m pytest -o addopts= tests/agent/test_auxiliary_client.py -k "openrouter or compression"`
- `python3 -m pytest -o addopts= tests/run_agent/test_compression_feasibility.py`

Fixes #10149