### PR TITLE
fix(cli): fallback to system-level systemd in gateway status check

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -364,6 +364,8 @@ def show_status(args):
                 _gw_svc = get_service_name()
             except Exception:
                 _gw_svc = "hermes-gateway"
+            # Check user-level first, then fall back to system-level
+            _manager = "systemd (user)"
             try:
                 result = subprocess.run(
                     ["systemctl", "--user", "is-active", _gw_svc],
@@ -374,8 +376,21 @@ def show_status(args):
                 is_active = result.stdout.strip() == "active"
             except (FileNotFoundError, subprocess.TimeoutExpired):
                 is_active = False
+            if not is_active:
+                try:
+                    result = subprocess.run(
+                        ["systemctl", "is-active", _gw_svc],
+                        capture_output=True,
+                        text=True,
+                        timeout=5
+                    )
+                    is_active = result.stdout.strip() == "active"
+                    if is_active:
+                        _manager = "systemd (system)"
+                except (FileNotFoundError, subprocess.TimeoutExpired):
+                    pass
             print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-            print("  Manager:      systemd (user)")
+            print(f"  Manager:      {_manager}")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -42,3 +42,75 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def _setup_linux_gateway_mocks(monkeypatch, tmp_path):
+    """Common setup for Linux non-container gateway status tests."""
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr("hermes_cli.status.sys.platform", "linux")
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+
+
+def _mock_run_for_cmds(cmd_responses):
+    """Return a mock subprocess.run that responds based on exact command list."""
+    import subprocess
+
+    def _run(cmd, **kwargs):
+        for key_cmd, stdout, rc in cmd_responses:
+            if tuple(cmd) == tuple(key_cmd):
+                return subprocess.CompletedProcess(cmd, rc, stdout=stdout, stderr="")
+        # Fallback: not active
+        return subprocess.CompletedProcess(cmd, 1, stdout="inactive\n", stderr="")
+
+    return _run
+
+
+def test_gateway_status_user_service_active_shows_user_manager(monkeypatch, capsys, tmp_path):
+    """When user-level service is active, Manager should show 'systemd (user)'."""
+    _setup_linux_gateway_mocks(monkeypatch, tmp_path)
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setattr(
+        status_mod.subprocess, "run",
+        _mock_run_for_cmds([
+            (["systemctl", "--user", "is-active", "hermes-gateway"], "active\n", 0),
+        ])
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "running" in output
+    assert "Manager:      systemd (user)" in output
+    assert "systemd (system)" not in output
+
+
+def test_gateway_status_fallback_to_system_when_user_inactive(monkeypatch, capsys, tmp_path):
+    """When user service is inactive but system service is active, show 'systemd (system)'."""
+    _setup_linux_gateway_mocks(monkeypatch, tmp_path)
+    from hermes_cli import status as status_mod
+
+    monkeypatch.setattr(
+        status_mod.subprocess, "run",
+        _mock_run_for_cmds([
+            (["systemctl", "--user", "is-active", "hermes-gateway"], "inactive\n", 3),
+            (["systemctl", "is-active", "hermes-gateway"], "active\n", 0),
+        ])
+    )
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "running" in output
+    assert "Manager:      systemd (system)" in output


### PR DESCRIPTION
## Problem

When the Hermes gateway runs as a **system-level** systemd service (`/etc/systemd/system/hermes-gateway.service`), `hermes status` incorrectly shows:

```
◆ Gateway Service
  Status:       ✗ stopped
  Manager:      systemd (user)
```

The gateway is actually running fine — the CLI just never checks system-level systemd.

## Root Cause

`hermes_cli/status.py` only calls `systemctl --user is-active <service>`. If the gateway was installed as a system service (not user service), this check always fails.

## Fix

1. Check `systemctl --user is-active` first (existing behavior)
2. If not active, fall back to `systemctl is-active` (system-level)
3. Dynamically set the manager label to `"systemd (system)"` or `"systemd (user)"` based on which scope succeeds

## After Fix

```
◆ Gateway Service
  Status:       ✓ running
  Manager:      systemd (system)
```

## Changes
- `hermes_cli/status.py`: +16/-1 lines