### PR TITLE
fix: fallback vision calls on model_not_supported errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1073,6 +1073,61 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _is_model_not_supported_error(exc: Exception) -> bool:
+    """Detect provider errors indicating the requested model is unsupported."""
+    status = getattr(exc, "status_code", None)
+    err_lower = str(exc).lower()
+    if "model_not_supported" in err_lower:
+        return True
+    if status in (400, 404, None) and any(
+        kw in err_lower
+        for kw in (
+            "requested model is not supported",
+            "does not support vision",
+            "does not support image",
+            "not support image",
+            "multimodal",
+            "unsupported model",
+        )
+    ):
+        return True
+    return False
+
+
+def _try_vision_backend_fallback(
+    failed_provider: str,
+    *,
+    async_mode: bool = False,
+) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
+    """Try strict vision backends after a model-not-supported error."""
+    failed = _normalize_vision_provider(failed_provider)
+    tried: List[str] = []
+    for candidate in _VISION_AUTO_PROVIDER_ORDER:
+        if candidate == failed:
+            continue
+        resolved_provider, client, model = resolve_vision_provider_client(
+            provider=candidate,
+            model=None,
+            async_mode=async_mode,
+        )
+        if client is not None:
+            logger.info(
+                "Auxiliary vision: model unsupported on %s — falling back to %s (%s)",
+                failed_provider,
+                resolved_provider or candidate,
+                model or "default",
+            )
+            return resolved_provider or candidate, client, model
+        tried.append(candidate)
+
+    logger.warning(
+        "Auxiliary vision: no strict fallback backend available after %s (tried: %s)",
+        failed_provider,
+        ", ".join(tried) if tried else "none",
+    )
+    return None, None, None
+
+
 def _try_payment_fallback(
     failed_provider: str,
     task: str = None,
@@ -2120,6 +2175,24 @@ def call_llm(
                     raise
                 first_err = retry_err
 
+        if task == "vision" and _is_model_not_supported_error(first_err):
+            fb_provider, fb_client, fb_model = _try_vision_backend_fallback(
+                resolved_provider,
+                async_mode=False,
+            )
+            if fb_client is not None:
+                fb_kwargs = _build_call_kwargs(
+                    fb_provider or "auto",
+                    fb_model,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=effective_timeout,
+                    extra_body=extra_body,
+                )
+                return fb_client.chat.completions.create(**fb_kwargs)
+
         # ── Payment / credit exhaustion fallback ──────────────────────
         # When the resolved provider returns 402 or a credit-related error,
         # try alternative providers instead of giving up.  This handles the
@@ -2292,5 +2365,26 @@ async def async_call_llm(
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
             kwargs["max_completion_tokens"] = max_tokens
-            return await client.chat.completions.create(**kwargs)
+            try:
+                return await client.chat.completions.create(**kwargs)
+            except Exception as retry_err:
+                first_err = retry_err
+
+        if task == "vision" and _is_model_not_supported_error(first_err):
+            fb_provider, fb_client, fb_model = _try_vision_backend_fallback(
+                resolved_provider,
+                async_mode=True,
+            )
+            if fb_client is not None:
+                fb_kwargs = _build_call_kwargs(
+                    fb_provider or "auto",
+                    fb_model,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=effective_timeout,
+                    extra_body=extra_body,
+                )
+                return await fb_client.chat.completions.create(**fb_kwargs)
         raise

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -15,6 +15,7 @@ from agent.auxiliary_client import (
     resolve_provider_client,
     auxiliary_max_tokens_param,
     call_llm,
+    async_call_llm,
     _read_codex_access_token,
     _get_auxiliary_provider,
     _get_provider_chain,
@@ -1337,3 +1338,78 @@ class TestCallLlmPaymentFallback:
                     task="compression",
                     messages=[{"role": "user", "content": "hello"}],
                 )
+
+
+class TestVisionModelUnsupportedFallback:
+    """Vision calls should fall back to strict vision backends on model_not_supported."""
+
+    def _make_model_not_supported(self):
+        exc = Exception("Error code: 400 - {'error': {'message': 'The requested model is not supported.', 'code': 'model_not_supported'}}")
+        exc.status_code = 400
+        return exc
+
+    def test_call_llm_vision_falls_back_on_model_not_supported(self):
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_model_not_supported()
+
+        fallback_client = MagicMock()
+        fallback_response = MagicMock()
+        fallback_client.chat.completions.create.return_value = fallback_response
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("copilot", "gpt-5.4", None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            side_effect=[
+                ("copilot", primary_client, "gpt-5.4"),
+                ("openrouter", fallback_client, "google/gemini-3-flash-preview"),
+            ],
+        ):
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": [{"type": "text", "text": "describe"}]}],
+            )
+
+        assert result is fallback_response
+        assert fallback_client.chat.completions.create.called
+
+    def test_async_call_llm_vision_falls_back_on_model_not_supported(self):
+        class _AsyncCreate:
+            def __init__(self, effect):
+                self._effect = effect
+
+            async def create(self, **kwargs):
+                if isinstance(self._effect, Exception):
+                    raise self._effect
+                return self._effect
+
+        class _AsyncClient:
+            def __init__(self, effect):
+                self.chat = MagicMock()
+                self.chat.completions = _AsyncCreate(effect)
+
+        primary_client = _AsyncClient(self._make_model_not_supported())
+        fallback_response = MagicMock()
+        fallback_client = _AsyncClient(fallback_response)
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("copilot", "gpt-5.4", None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            side_effect=[
+                ("copilot", primary_client, "gpt-5.4"),
+                ("openrouter", fallback_client, "google/gemini-3-flash-preview"),
+            ],
+        ):
+            import asyncio
+
+            result = asyncio.run(
+                async_call_llm(
+                    task="vision",
+                    messages=[{"role": "user", "content": [{"type": "text", "text": "describe"}]}],
+                )
+            )
+
+        assert result is fallback_response


### PR DESCRIPTION
## Summary
- detect `model_not_supported` / unsupported vision model failures in auxiliary routing
- for `task=vision`, retry on strict vision backends (`openrouter`/`nous`) when the first provider/model is unsupported
- apply fallback in both sync (`call_llm`) and async (`async_call_llm`) paths
- add regression tests for sync + async vision fallback behavior

## Why
Issue reports show Holly vision calls failing with HTTP 400 `model_not_supported` when the initially selected provider/model cannot handle image inputs. Before this patch, the call failed immediately.

## Validation
- `python -m pytest tests/agent/test_auxiliary_client.py -k "VisionModelUnsupportedFallback or TestCallLlmPaymentFallback" -q`
- result: `5 passed`

## Notes
- no behavior change for non-vision tasks
- no change to existing payment/connection fallback behavior
