### PR TITLE
fix(display): hide browser_type text in tool previews

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -230,6 +230,9 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
             return f"-{target}: \"{_oneline(args.get('old_text', '')[:20])}\""
         return action
 
+    if tool_name == "browser_type":
+        return "[hidden text]"
+
     if tool_name == "send_message":
         target = args.get("target", "?")
         msg = _oneline(args.get("message", ""))

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -41,6 +41,11 @@ class TestBuildToolPreview:
         assert result is not None
         assert "/tmp/test.py" in result
 
+    def test_browser_type_hides_typed_text(self):
+        result = build_tool_preview("browser_type", {"ref": "@e1", "text": "supersecret123"})
+        assert result == "[hidden text]"
+        assert "supersecret123" not in result
+
     def test_unknown_tool_with_fallback_key(self):
         """Unknown tool but with a recognized fallback key should still preview."""
         result = build_tool_preview("custom_tool", {"query": "test query"})


### PR DESCRIPTION
## Summary
- hide `browser_type` text previews in CLI/gateway tool-progress output
- prevent plaintext typed values from appearing in chats and logs
- add a regression test for hidden browser input previews

## Testing
- added `tests/agent/test_display.py::test_browser_type_hides_typed_text`

Fixes #10520