### PR TITLE
fix(model-picker): prevent duplicate provider buttons in /model command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3635,6 +3635,12 @@ class GatewayRunner:
                 # Must run after runtime resolution so _hyg_base_url is set.
                 if _hyg_config_context_length is None and _hyg_base_url:
                     try:
+                        # Intentionally uses get_compatible_custom_providers (merged
+                        # providers + custom_providers view) for per-model context-length
+                        # lookup — this site needs to find the entry regardless of which
+                        # config format the user is on.  The /model picker path (below)
+                        # deliberately uses the raw cfg.get("custom_providers") instead
+                        # to avoid double-counting providers: dict entries.
                         try:
                             from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
                             _hyg_custom_providers = _gw_gcp(_hyg_data)
@@ -4629,11 +4635,13 @@ class GatewayRunner:
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
                 user_provs = cfg.get("providers")
-                try:
-                    from hermes_cli.config import get_compatible_custom_providers
-                    custom_provs = get_compatible_custom_providers(cfg)
-                except Exception:
-                    custom_provs = cfg.get("custom_providers")
+                # Pass only the raw legacy custom_providers list, not the
+                # compat view from get_compatible_custom_providers().  The
+                # compat view converts the `providers` dict into custom-provider
+                # entries, which would be processed again in section 3 of
+                # list_authenticated_providers (user_providers loop), causing
+                # every `providers:` entry to appear twice in the /model picker.
+                custom_provs = cfg.get("custom_providers") or None
         except Exception:
             pass
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -808,7 +808,9 @@ def list_authenticated_providers(
         # Skip aliases that map to the same models.dev provider (e.g.
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
         # The first one with valid credentials wins (#10526).
+        # Block the slug so later sections (2b, 3) can't re-emit it.
         if mdev_id in seen_mdev_ids:
+            seen_slugs.add(hermes_id.lower())
             continue
         pdata = data.get(mdev_id)
         if not isinstance(pdata, dict):

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -26,6 +26,51 @@ def _make_event(text="/model"):
 
 
 @pytest.mark.asyncio
+async def test_handle_model_command_no_duplicate_when_using_providers_dict(tmp_path, monkeypatch):
+    """Providers defined in providers: dict must not appear twice in the /model picker.
+
+    Regression for the bug where get_compatible_custom_providers() converted the
+    providers dict into custom_providers entries, and list_authenticated_providers
+    then processed the same provider in both the user_providers loop (section 3)
+    and the custom_providers loop (section 4), producing two identical buttons.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "carnice-llama-q6-128k",
+                    "provider": "carnice-llama.cpp",
+                },
+                "providers": {
+                    "carnice-llama.cpp": {
+                        "api": "http://127.0.0.1:8080/v1",
+                        "name": "Carnice llama.cpp",
+                        "default_model": "carnice-llama-q6-128k",
+                        "transport": "chat_completions",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    result = await _make_runner()._handle_model_command(_make_event())
+
+    assert result is not None
+    # "Carnice llama.cpp" should appear exactly once — not twice
+    assert result.count("Carnice llama.cpp") == 1, (
+        f"Expected exactly one 'Carnice llama.cpp' entry in /model output, got:\n{result}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,6 +5,9 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+import os
+
+import agent.models_dev as models_dev_mod
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
@@ -133,6 +136,54 @@ def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     moonshot_rows = [p for p in providers if p["name"] == "Moonshot"]
     assert len(moonshot_rows) == 1
     assert moonshot_rows[0]["models"] == ["kimi-k2-thinking"]
+
+
+def test_list_authenticated_providers_no_duplicate_when_two_hermes_ids_share_mdev_id(monkeypatch):
+    """Two Hermes IDs that map to the same models.dev provider ID must not both
+    appear in the /model picker with identical display names.
+
+    Regression for the bug where PROVIDER_TO_MODELS_DEV contained both
+    "openai"+"openai-codex" → mdev "openai" and "gemini"+"google" → mdev
+    "google", causing two identically-named buttons to appear in section 1 of
+    list_authenticated_providers.  Fixed by tracking seen_mdev_ids so only the
+    first Hermes ID for each mdev_id is processed in section 1; the second
+    flows to section 2/2b with its proper display label.
+    """
+    # Inject two Hermes IDs that share the same mdev ID
+    fake_mdev_id = "fake-provider-mdev"
+    fake_prov_data = {"env": ["FAKE_PROVIDER_API_KEY"], "name": "Fake Provider"}
+
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {fake_mdev_id: fake_prov_data},
+    )
+    monkeypatch.setattr(
+        models_dev_mod,
+        "PROVIDER_TO_MODELS_DEV",
+        {"fake-provider-a": fake_mdev_id, "fake-provider-b": fake_mdev_id},
+    )
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    # Both have the same API key env var set
+    monkeypatch.setenv("FAKE_PROVIDER_API_KEY", "test-key")
+
+    # Stub out PROVIDER_REGISTRY so neither has api_key_env_vars overrides
+    import hermes_cli.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "PROVIDER_REGISTRY", {})
+
+    providers = list_authenticated_providers(
+        current_provider="fake-provider-a",
+        user_providers={},
+        custom_providers=None,
+        max_models=50,
+    )
+
+    # Both Hermes IDs share the same mdev ID → only one row should appear
+    fake_rows = [p for p in providers if "fake-provider" in p["slug"]]
+    assert len(fake_rows) == 1, (
+        f"Expected exactly 1 row for the shared mdev ID, got {len(fake_rows)}: "
+        + str([p["slug"] for p in fake_rows])
+    )
 
 
 def test_list_deduplicates_same_model_in_group(monkeypatch):


### PR DESCRIPTION
## Summary

Two independent bugs caused duplicate provider buttons in the `/model` Telegram inline keyboard:

**Bug 1 — `providers:` dict entries appear twice** (`gateway/run.py`)

`_handle_model_command()` called `get_compatible_custom_providers()`, which converts the `providers:` dict into `custom_providers` entries. `list_authenticated_providers` then processed the same provider in both section 3 (user_providers loop) and section 4 (custom_providers loop), producing two identical buttons.

Fix: pass `cfg.get("custom_providers") or None` directly instead of the compat view. The context-length lookup that legitimately needs the merged view is left unchanged and documented.

**Bug 2 — aliases sharing a models.dev ID re-emitted by later sections** (`hermes_cli/model_switch.py`)

When section 1 skips a Hermes ID because its models.dev alias was already processed (e.g. `"openai-codex"` after `"openai"`, `"google"` after `"gemini"`), the slug was not added to `seen_slugs`. Section 2b or 3 could then emit it again under its own display name, producing a second button with the same underlying provider.

Fix: add `seen_slugs.add(hermes_id.lower())` to the `seen_mdev_ids` guard (extends the fix from #10526).

## Test plan

- [ ] `pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/gateway/test_model_command_custom_providers.py -v` — 8 tests, all pass
- [ ] New regression: `test_handle_model_command_no_duplicate_when_using_providers_dict` — asserts `providers:` dict entry appears exactly once in `/model` output
- [ ] New regression: `test_list_authenticated_providers_no_duplicate_when_two_hermes_ids_share_mdev_id` — asserts two Hermes IDs sharing the same mdev ID produce exactly one row