### PR TITLE
fix(gateway): clear session-scoped approval state on /new and /reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4329,6 +4329,13 @@ class GatewayRunner:
         except Exception:
             pass
 
+        try:
+            from tools.approval import clear_session as clear_approval_session
+            clear_approval_session(session_key)
+        except Exception:
+            pass
+        self._pending_approvals.pop(session_key, None)
+
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -2,12 +2,23 @@
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+import threading
+import time
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
+from tools.approval import (
+    _ApprovalEntry,
+    _gateway_queues,
+    approve_session,
+    clear_session,
+    enable_session_yolo,
+    is_approved,
+    is_session_yolo_enabled,
+)
 
 
 def _make_source() -> SessionSource:
@@ -63,6 +74,14 @@ def _make_runner():
     runner._format_session_info = lambda: ""
 
     return runner
+
+
+@pytest.fixture(autouse=True)
+def _clear_gateway_approval_state():
+    session_key = build_session_key(_make_source())
+    clear_session(session_key)
+    yield
+    clear_session(session_key)
 
 
 @pytest.mark.asyncio
@@ -124,3 +143,53 @@ async def test_new_command_only_clears_own_session():
 
     assert session_key not in runner._session_model_overrides
     assert other_key in runner._session_model_overrides
+
+
+@pytest.mark.asyncio
+async def test_new_command_clears_session_scoped_approval_and_yolo_state():
+    """/new must drop session-scoped approval state so the next session starts clean."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    pattern_key = "recursive delete"
+
+    approve_session(session_key, pattern_key)
+    enable_session_yolo(session_key)
+    runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
+
+    assert is_approved(session_key, pattern_key) is True
+    assert is_session_yolo_enabled(session_key) is True
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert is_approved(session_key, pattern_key) is False
+    assert is_session_yolo_enabled(session_key) is False
+    assert session_key not in runner._pending_approvals
+
+
+@pytest.mark.asyncio
+async def test_new_command_unblocks_pending_gateway_approval_waiters():
+    """/new must release any blocked approval waiters for the session."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    entry = _ApprovalEntry({"command": "rm -rf /tmp/demo"})
+    _gateway_queues[session_key] = [entry]
+
+    waiter_done = threading.Event()
+    waiter_result = {"resolved": False, "choice": None}
+
+    def _waiter():
+        waiter_result["resolved"] = entry.event.wait(timeout=2)
+        waiter_result["choice"] = entry.result
+        waiter_done.set()
+
+    thread = threading.Thread(target=_waiter, daemon=True)
+    thread.start()
+
+    time.sleep(0.05)
+    await runner._handle_reset_command(_make_event("/new"))
+    waiter_done.wait(timeout=2)
+    thread.join(timeout=2)
+
+    assert waiter_result["resolved"] is True
+    assert waiter_result["choice"] == "deny"
+    assert session_key not in _gateway_queues

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -322,11 +322,16 @@ def clear_session(session_key: str) -> None:
     """Remove all approval and yolo state for a given session."""
     if not session_key:
         return
+    entries = []
     with _lock:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
-        _gateway_queues.pop(session_key, None)
+        entries = list(_gateway_queues.pop(session_key, []))
+
+    for entry in entries:
+        entry.result = "deny"
+        entry.event.set()
 
 
 def is_session_yolo_enabled(session_key: str) -> bool:


### PR DESCRIPTION
## Summary

`/new` and `/reset` were rotating the gateway session transcript, but they were not clearing session-scoped dangerous-command approval state.

That left two stale-state problems behind:
1. session-only approvals could survive into the next conversation
2. `/yolo` could remain enabled after a reset even though the user had started a fresh session

There was also a blocked-waiter edge case: if a gateway approval was still waiting when the session was reset, the waiter could remain stuck behind stale session state.

## What changed

- clear session-scoped approval state during gateway `/new` and `/reset`
- drop stale `_pending_approvals` entries during reset
- make `tools.approval.clear_session()` actively unblock queued gateway approval waiters by resolving them as `deny`

## Why this matters

Gateway reset commands are conversation boundaries. Session-scoped safety state should not leak across them.

Without this fix, a user could:
- approve a dangerous pattern for the current session
- reset the conversation
- still have that approval apply in the next session

The same applied to `/yolo`, which is explicitly described as session-only.

## Tests

Added regression coverage for:
- clearing session-scoped approvals on `/new`
- clearing session-scoped YOLO state on `/new`
- removing stale pending approval metadata on `/new`
- unblocking queued gateway approval waiters during reset

Validated with:
- `py -m pytest tests/gateway/test_session_model_reset.py -q`
- `py -m pytest tests/gateway/test_approve_deny_commands.py -q`
- `py -m pytest tests/gateway/test_yolo_command.py -q`

