### PR TITLE
fix(discord): cap /skill payload size before sync

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -10,6 +10,7 @@ To add an alias: set ``aliases=("short",)`` on the existing ``CommandDef``.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -582,6 +583,62 @@ def discord_skill_commands(
     )
 
 
+def _estimate_discord_skill_group_payload_chars(
+    categories: dict[str, list[tuple[str, str, str]]],
+    uncategorized: list[tuple[str, str, str]],
+) -> int:
+    """Approximate the serialized Discord ``/skill`` payload size.
+
+    Discord rejects oversize application-command payloads with
+    ``Command exceeds maximum size (8000)``. The exact size check happens after
+    discord.py serializes the group/subcommands to JSON, so we mirror that shape
+    closely enough to enforce a conservative budget before sync.
+    """
+
+    def _subcommand_payload(name: str, description: str) -> dict[str, Any]:
+        return {
+            "type": 1,
+            "name": name,
+            "description": description or f"Run the {name} skill",
+            "options": [
+                {
+                    "type": 3,
+                    "name": "args",
+                    "description": "Optional arguments for the skill",
+                    "required": False,
+                }
+            ],
+        }
+
+    payload = {
+        "type": 1,
+        "name": "skill",
+        "description": "Run a Hermes skill",
+        "options": [],
+    }
+
+    for name, description, _cmd_key in uncategorized:
+        payload["options"].append(_subcommand_payload(name, description))
+
+    for cat_name in sorted(categories):
+        cat_desc = f"{cat_name.replace('-', ' ').title()} skills"
+        if len(cat_desc) > 100:
+            cat_desc = cat_desc[:97] + "..."
+        payload["options"].append(
+            {
+                "type": 2,
+                "name": cat_name,
+                "description": cat_desc,
+                "options": [
+                    _subcommand_payload(name, description)
+                    for name, description, _cmd_key in categories[cat_name]
+                ],
+            }
+        )
+
+    return len(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+
+
 def discord_skill_commands_by_category(
     reserved_names: set[str],
 ) -> tuple[dict[str, list[tuple[str, str, str]]], list[tuple[str, str, str]], int]:
@@ -688,6 +745,38 @@ def discord_skill_commands_by_category(
     if len(uncategorized) > remaining_slots:
         hidden += len(uncategorized) - remaining_slots
         uncategorized = uncategorized[:remaining_slots]
+
+    # Discord also enforces an overall serialized command payload limit (8000
+    # chars). A skill catalog can fit the group-count limits and still fail to
+    # sync if the combined names/descriptions/options are too large. Trim from
+    # the largest buckets until we're comfortably under the payload cap.
+    _PAYLOAD_BUDGET = 7900
+    while _estimate_discord_skill_group_payload_chars(trimmed_categories, uncategorized) > _PAYLOAD_BUDGET:
+        non_empty_categories = [cat for cat, entries in trimmed_categories.items() if entries]
+        uncategorized_size = len(uncategorized)
+        largest_category = max(
+            non_empty_categories,
+            key=lambda cat: (len(trimmed_categories[cat]), cat),
+            default=None,
+        )
+
+        if largest_category is None and not uncategorized:
+            break
+
+        largest_category_size = len(trimmed_categories[largest_category]) if largest_category else 0
+        if uncategorized_size >= largest_category_size and uncategorized:
+            uncategorized.pop()
+            hidden += 1
+            continue
+
+        if largest_category:
+            trimmed_categories[largest_category].pop()
+            hidden += 1
+            if not trimmed_categories[largest_category]:
+                del trimmed_categories[largest_category]
+            continue
+
+        break
 
     return trimmed_categories, uncategorized, hidden
 

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hermes-whatsapp-bridge",
       "version": "1.0.0",
       "dependencies": {
-        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#fix/abprops-abt-fetch",
+        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
         "express": "^4.21.0",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1179,3 +1179,42 @@ class TestDiscordSkillCommandsByCategory:
         assert "axolotl" in names
         assert "vllm" in names
         assert len(uncategorized) == 0
+
+    def test_trims_to_fit_discord_group_payload_budget(self, tmp_path, monkeypatch):
+        """Large skill sets should be trimmed so the /skill payload stays under Discord's size cap."""
+        from unittest.mock import patch
+        from hermes_cli.commands import _estimate_discord_skill_group_payload_chars
+
+        fake_skills_dir = tmp_path / "skills"
+        fake_cmds = {}
+
+        # Build a deliberately oversized skill catalog: many categories and long
+        # descriptions. This previously produced a /skill group too large for
+        # Discord to sync.
+        for cat_idx in range(1, 21):
+            category = f"category-{cat_idx:02d}"
+            for skill_idx in range(1, 6):
+                skill_name = f"skill-{cat_idx:02d}-{skill_idx:02d}"
+                skill_dir = fake_skills_dir / category / skill_name
+                skill_dir.mkdir(parents=True, exist_ok=True)
+                (skill_dir / "SKILL.md").write_text("---\nname: test\n---\n")
+                fake_cmds[f"/{skill_name}"] = {
+                    "name": skill_name,
+                    "description": (
+                        "This is an intentionally long description for Discord payload budgeting tests. "
+                        "It should be truncated and, if needed, hidden to keep the command schema under budget."
+                    ),
+                    "skill_md_path": str(skill_dir / "SKILL.md"),
+                }
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", fake_skills_dir),
+        ):
+            categories, uncategorized, hidden = discord_skill_commands_by_category(
+                reserved_names=set(),
+            )
+
+        assert hidden > 0
+        assert _estimate_discord_skill_group_payload_chars(categories, uncategorized) <= 7900


### PR DESCRIPTION
## Summary
- estimate the serialized Discord /skill command payload size before sync
- trim oversized skill groups until they fit under a conservative budget
- add regression coverage for oversized skill catalogs

## Verification
- python -m pytest tests/hermes_cli/test_commands.py -q
- python -m pytest tests/gateway/test_discord_slash_commands.py -q -k 'register_skill_group'
- python -m pytest tests/gateway/test_discord_slash_commands.py -q -k 'auto_registers_missing_gateway_commands or auto_registered_command_dispatches_correctly or auto_registered_command_with_args'

## Notes
- broader gateway/tools suites currently have unrelated baseline failures in this repo