### PR TITLE
feat(macos): add macOS launcher app and gateway startup script

### DIFF
--- a/assets/hermes-gateway-launcher.svg
+++ b/assets/hermes-gateway-launcher.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="Hermes Gateway Launcher">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0F172A"/>
+      <stop offset="100%" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F59E0B"/>
+      <stop offset="100%" stop-color="#FCD34D"/>
+    </linearGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <rect x="32" y="32" width="960" height="960" rx="220" fill="url(#bg)"/>
+
+  <circle cx="512" cy="512" r="290" fill="none" stroke="url(#ring)" stroke-width="28" opacity="0.95"/>
+  <circle cx="512" cy="512" r="220" fill="#0B1220" stroke="#334155" stroke-width="10"/>
+
+  <g filter="url(#glow)">
+    <path d="M360 470 L512 350 L664 470 L625 520 L512 432 L399 520 Z" fill="#FBBF24"/>
+    <path d="M399 560 H625 V600 H399 Z" fill="#FBBF24"/>
+    <path d="M430 650 H594 V690 H430 Z" fill="#F59E0B"/>
+  </g>
+
+  <g opacity="0.9">
+    <circle cx="278" cy="398" r="12" fill="#60A5FA"/>
+    <circle cx="746" cy="398" r="12" fill="#60A5FA"/>
+    <circle cx="235" cy="512" r="9" fill="#93C5FD"/>
+    <circle cx="789" cy="512" r="9" fill="#93C5FD"/>
+    <circle cx="278" cy="626" r="12" fill="#60A5FA"/>
+    <circle cx="746" cy="626" r="12" fill="#60A5FA"/>
+  </g>
+
+  <path d="M512 173 C698 173 851 326 851 512 C851 698 698 851 512 851"
+        fill="none" stroke="#38BDF8" stroke-width="10" stroke-linecap="round" opacity="0.7"/>
+  <path d="M512 173 C326 173 173 326 173 512 C173 698 326 851 512 851"
+        fill="none" stroke="#38BDF8" stroke-width="10" stroke-linecap="round" opacity="0.35"/>
+</svg>

--- a/scripts/macos/create-hermes-gateway-app.sh
+++ b/scripts/macos/create-hermes-gateway-app.sh
@@ -1,0 +1,64 @@
+#!/bin/zsh
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+SVG_PATH="$REPO_DIR/assets/hermes-gateway-launcher.svg"
+APP_DIR="$HOME/Applications"
+APP_NAME="Hermes Gateway.app"
+APP_PATH="$APP_DIR/$APP_NAME"
+
+mkdir -p "$APP_DIR"
+TMP_DIR="$(mktemp -d)"
+ICONSET_DIR="$TMP_DIR/HermesGateway.iconset"
+mkdir -p "$ICONSET_DIR"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [[ ! -f "$SVG_PATH" ]]; then
+  echo "Missing SVG icon: $SVG_PATH"
+  exit 1
+fi
+
+cat > "$TMP_DIR/launcher.applescript" <<'APPLESCRIPT'
+on run
+  set scriptPath to "__REPO_DIR__/scripts/macos/hermes-gateway.command"
+  set ghosttyPath to "/Applications/Ghostty.app"
+
+  if (do shell script "test -d " & quoted form of ghosttyPath & " && echo yes || echo no") is "yes" then
+    do shell script "open -na " & quoted form of ghosttyPath & " --args -e " & quoted form of scriptPath
+  else
+    tell application "Terminal"
+      activate
+      do script quoted form of scriptPath
+    end tell
+  end if
+end run
+APPLESCRIPT
+
+sed -i '' "s|__REPO_DIR__|$REPO_DIR|g" "$TMP_DIR/launcher.applescript"
+osacompile -o "$APP_PATH" "$TMP_DIR/launcher.applescript"
+
+# Render svg -> png via Quick Look, then make iconset and icns
+qlmanage -t -s 1024 -o "$TMP_DIR" "$SVG_PATH" >/dev/null 2>&1 || true
+THUMB_PATH="$TMP_DIR/$(basename "$SVG_PATH").png"
+
+if [[ -f "$THUMB_PATH" ]]; then
+  cp "$THUMB_PATH" "$ICONSET_DIR/icon_512x512@2x.png"
+  sips -z 16 16     "$THUMB_PATH" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null
+  sips -z 32 32     "$THUMB_PATH" --out "$ICONSET_DIR/icon_16x16@2x.png" >/dev/null
+  sips -z 32 32     "$THUMB_PATH" --out "$ICONSET_DIR/icon_32x32.png" >/dev/null
+  sips -z 64 64     "$THUMB_PATH" --out "$ICONSET_DIR/icon_32x32@2x.png" >/dev/null
+  sips -z 128 128   "$THUMB_PATH" --out "$ICONSET_DIR/icon_128x128.png" >/dev/null
+  sips -z 256 256   "$THUMB_PATH" --out "$ICONSET_DIR/icon_128x128@2x.png" >/dev/null
+  sips -z 256 256   "$THUMB_PATH" --out "$ICONSET_DIR/icon_256x256.png" >/dev/null
+  sips -z 512 512   "$THUMB_PATH" --out "$ICONSET_DIR/icon_256x256@2x.png" >/dev/null
+  sips -z 512 512   "$THUMB_PATH" --out "$ICONSET_DIR/icon_512x512.png" >/dev/null
+  iconutil -c icns "$ICONSET_DIR" -o "$TMP_DIR/HermesGateway.icns"
+  cp "$TMP_DIR/HermesGateway.icns" "$APP_PATH/Contents/Resources/applet.icns"
+fi
+
+touch "$APP_PATH"
+echo "Created launcher app: $APP_PATH"

--- a/scripts/macos/hermes-gateway.command
+++ b/scripts/macos/hermes-gateway.command
@@ -1,0 +1,79 @@
+#!/bin/zsh
+set -euo pipefail
+
+trap 'echo; echo "❌ Script failed at line $LINENO (exit $?)"; read -k1 "?Press any key to close..."' ERR
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_DIR"
+
+if [[ ! -x "./venv/bin/hermes" ]]; then
+  echo "Hermes venv not found at: $REPO_DIR/venv"
+  echo "Run: ./setup-hermes.sh"
+  read -k1 "?Press any key to close..."
+  echo
+  exit 1
+fi
+
+missing="$(
+./venv/bin/python - <<'PY'
+from pathlib import Path
+import os
+import yaml
+
+cfg = Path.home() / ".hermes" / "config.yaml"
+envp = Path.home() / ".hermes" / ".env"
+
+def parse_env(path: Path):
+    data = {}
+    if not path.exists():
+        return data
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        k, v = s.split("=", 1)
+        data[k.strip()] = v.strip()
+    return data
+
+env = parse_env(envp)
+cfg_data = {}
+if cfg.exists():
+    try:
+        cfg_data = yaml.safe_load(cfg.read_text(encoding="utf-8")) or {}
+    except Exception:
+        cfg_data = {}
+
+platforms = cfg_data.get("platforms", {})
+feishu_enabled = bool((platforms.get("feishu") or {}).get("enabled"))
+weixin_enabled = bool((platforms.get("weixin") or {}).get("enabled"))
+
+missing = []
+if feishu_enabled:
+    if not env.get("FEISHU_APP_ID"):
+        missing.append("FEISHU_APP_ID")
+    if not env.get("FEISHU_APP_SECRET"):
+        missing.append("FEISHU_APP_SECRET")
+if weixin_enabled:
+    if not env.get("WEIXIN_ACCOUNT_ID"):
+        missing.append("WEIXIN_ACCOUNT_ID")
+    if not env.get("WEIXIN_TOKEN"):
+        missing.append("WEIXIN_TOKEN")
+
+print(",".join(missing))
+PY
+)"
+
+if [[ -n "${missing}" ]]; then
+  echo "Gateway credentials are incomplete: ${missing}"
+  echo "Opening gateway setup wizard..."
+  ./venv/bin/hermes setup gateway
+fi
+
+LOG_DIR="$HOME/.hermes"
+LOG_FILE="$LOG_DIR/gateway.log"
+mkdir -p "$LOG_DIR"
+
+echo "Starting hermes gateway... (close window to stop)"
+echo "Log: $LOG_FILE"
+echo "----------------------------------------"
+./venv/bin/hermes gateway run --replace 2>&1 | tee "$LOG_FILE"


### PR DESCRIPTION
## Summary

- **`scripts/macos/hermes-gateway.command`** — 双击或由 Ghostty 启动的脚本，通过 `hermes gateway run --replace` 启动 gateway，用 `tee` 实时输出日志，关闭终端窗口时自动停止 gateway 进程
- **`scripts/macos/create-hermes-gateway-app.sh`** — 生成原生 macOS `.app`（`~/Applications/Hermes Gateway.app`），由 AppleScript 驱动；用 qlmanage + sips + iconutil 将 SVG 图标渲染为 `.icns`
- **`assets/hermes-gateway-launcher.svg`** — launcher app 自定义图标

## 使用方式

```bash
# 生成 ~/Applications/Hermes Gateway.app
bash scripts/macos/create-hermes-gateway-app.sh

# 或直接双击 / 通过 Ghostty 运行
scripts/macos/hermes-gateway.command
```

## Test plan

- [ ] 运行 `create-hermes-gateway-app.sh`，确认 `~/Applications/Hermes Gateway.app` 生成并带有自定义图标
- [ ] 双击 `.app`，确认 Ghostty 打开并实时显示 gateway 日志
- [ ] 关闭 Ghostty 窗口，确认 `hermes gateway run` 进程同步退出
- [ ] 再次打开 `.app`，确认通过 `--replace` 自动替换旧进程

🤖 Generated with [Claude Code](https://claude.ai/claude-code)