### PR TITLE
fix(cli): include custom provider model catalogs in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1075,9 +1075,25 @@ def list_authenticated_providers(
                     "api_url": api_url,
                     "models": [],
                 }
+
+            def _append_model(model_name: str) -> None:
+                model_name = (model_name or "").strip()
+                if model_name and model_name not in groups[slug]["models"]:
+                    groups[slug]["models"].append(model_name)
+
             default_model = (entry.get("model") or "").strip()
-            if default_model and default_model not in groups[slug]["models"]:
-                groups[slug]["models"].append(default_model)
+            _append_model(default_model)
+
+            extra_models = entry.get("models")
+            if isinstance(extra_models, dict):
+                for model_name in extra_models.keys():
+                    _append_model(str(model_name))
+            elif isinstance(extra_models, list):
+                for item in extra_models:
+                    if isinstance(item, str):
+                        _append_model(item)
+                    elif isinstance(item, dict):
+                        _append_model(str(item.get("model") or item.get("name") or ""))
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:
@@ -1087,7 +1103,7 @@ def list_authenticated_providers(
                 "name": grp["name"],
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": grp["models"],
+                "models": grp["models"][:max_models] if max_models > 0 else grp["models"],
                 "total_models": len(grp["models"]),
                 "source": "user-config",
                 "api_url": grp["api_url"],

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -116,6 +116,117 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     assert user_prov["models"] == ["single-model"]
 
 
+@pytest.mark.parametrize(
+    ("extra_models", "expected_models"),
+    [
+        pytest.param(
+            {"model-a": {}, "model-b": {}, "model-c": {}},
+            ["model-a", "model-b", "model-c"],
+            id="dict-model-catalog",
+        ),
+        pytest.param(
+            ["model-a", "model-b", "model-c"],
+            ["model-a", "model-b", "model-c"],
+            id="string-list-model-catalog",
+        ),
+        pytest.param(
+            [{"name": "model-a"}, {"model": "model-b"}, {"name": "model-c"}],
+            ["model-a", "model-b", "model-c"],
+            id="object-list-model-catalog",
+        ),
+    ],
+)
+def test_list_authenticated_providers_includes_models_from_custom_providers(monkeypatch, extra_models, expected_models):
+    """custom_providers should expose full model catalogs in the /model picker."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:my-gateway",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Gateway",
+                "base_url": "https://gateway.example/v1",
+                "model": "model-a",
+                "models": extra_models,
+            }
+        ],
+        max_models=50,
+    )
+
+    custom_provider = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "custom:my-gateway"),
+        None,
+    )
+
+    assert custom_provider is not None
+    assert custom_provider["total_models"] == len(expected_models)
+    assert custom_provider["models"] == expected_models
+
+
+def test_list_authenticated_providers_truncates_displayed_custom_provider_models_without_changing_total(monkeypatch):
+    """max_models should limit picker display, not the full collected model count."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:my-gateway",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Gateway",
+                "base_url": "https://gateway.example/v1",
+                "model": "model-a",
+                "models": {
+                    "model-a": {},
+                    "model-b": {},
+                    "model-c": {},
+                },
+            }
+        ],
+        max_models=2,
+    )
+
+    custom_provider = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "custom:my-gateway"),
+        None,
+    )
+
+    assert custom_provider is not None
+    assert custom_provider["models"] == ["model-a", "model-b"]
+    assert custom_provider["total_models"] == 3
+
+
+def test_list_authenticated_providers_dedupes_default_model_from_custom_provider_catalog(monkeypatch):
+    """default model should not be duplicated when it also appears in models."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:my-gateway",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Gateway",
+                "base_url": "https://gateway.example/v1",
+                "model": "model-a",
+                "models": ["model-a", "model-b", "model-c"],
+            }
+        ],
+        max_models=50,
+    )
+
+    custom_provider = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "custom:my-gateway"),
+        None,
+    )
+
+    assert custom_provider is not None
+    assert custom_provider["models"].count("model-a") == 1
+    assert custom_provider["total_models"] == 3
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
## Summary
- include `custom_providers[].models` catalogs in `/model` picker rows
- support dict, string-list, and object-list catalog shapes
- dedupe the default model and preserve `total_models` while respecting `max_models` display truncation

## Test Plan
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_user_providers_model_switch.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_nous_hermes_non_agentic.py tests/hermes_cli/test_user_providers_model_switch.py -q`
