### PR TITLE
Make terminal foreground timeouts activity-aware

### DIFF
--- a/tests/tools/test_terminal_timeout_output.py
+++ b/tests/tools/test_terminal_timeout_output.py
@@ -1,4 +1,5 @@
 """Verify that terminal command timeouts preserve partial output."""
+import tools.environments.base as base_module
 from tools.environments.local import LocalEnvironment
 
 
@@ -25,3 +26,45 @@ class TestTimeoutPreservesPartialOutput:
         assert result["returncode"] == 124
         assert "timed out" in result["output"].lower()
         assert not result["output"].startswith("\n")
+
+    def test_output_activity_extends_foreground_timeout(self):
+        """Periodic output should reset the inactivity timer for foreground runs."""
+        env = LocalEnvironment()
+        result = env.execute(
+            (
+                "python3 -c \"import sys,time; "
+                "print('tick-1', flush=True); "
+                "time.sleep(0.6); "
+                "print('tick-2', flush=True); "
+                "time.sleep(0.6); "
+                "print('done', flush=True)\""
+            ),
+            timeout=1,
+        )
+
+        assert result["returncode"] == 0
+        assert "tick-1" in result["output"]
+        assert "tick-2" in result["output"]
+        assert "done" in result["output"]
+
+    def test_chatty_command_still_hits_hard_wall_timeout(self, monkeypatch):
+        """Continuous output should not bypass the hard wall-clock cap."""
+        monkeypatch.setattr(base_module, "_ACTIVITY_TIMEOUT_WALL_MULTIPLIER", 2)
+        monkeypatch.setattr(base_module, "_ACTIVITY_TIMEOUT_WALL_MIN_GRACE_SECONDS", 0)
+
+        env = LocalEnvironment()
+        result = env.execute(
+            (
+                "python3 -c \"import sys,time; "
+                "i = 0\n"
+                "while True:\n"
+                " print(f'tick-{i}', flush=True)\n"
+                " i += 1\n"
+                " time.sleep(0.2)\""
+            ),
+            timeout=1,
+        )
+
+        assert result["returncode"] == 124
+        assert "hard timeout" in result["output"].lower()
+        assert "tick-" in result["output"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -23,6 +23,15 @@ from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
 
+_ACTIVITY_TIMEOUT_WALL_MULTIPLIER = max(
+    1,
+    int(os.getenv("TERMINAL_ACTIVITY_TIMEOUT_WALL_MULTIPLIER", "4")),
+)
+_ACTIVITY_TIMEOUT_WALL_MIN_GRACE_SECONDS = max(
+    0,
+    int(os.getenv("TERMINAL_ACTIVITY_TIMEOUT_WALL_MIN_GRACE_SECONDS", "300")),
+)
+
 # Thread-local activity callback.  The agent sets this before a tool call so
 # long-running _wait_for_process loops can report liveness to the gateway.
 _activity_callback_local = threading.local()
@@ -106,6 +115,22 @@ def _save_json_store(path: Path, data: dict) -> None:
     """Write *data* as pretty-printed JSON to *path*."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2))
+
+
+def _compute_wall_timeout(timeout: int | float) -> float:
+    """Return the hard wall-clock cap for a foreground command timeout.
+
+    ``timeout`` is treated as the foreground command's inactivity budget.
+    Commands that continue producing output can run past that budget, but they
+    still stop at a bounded wall-clock cap so a noisy hung command cannot run
+    forever.
+    """
+    timeout = float(timeout)
+    return max(
+        timeout,
+        timeout * _ACTIVITY_TIMEOUT_WALL_MULTIPLIER,
+        timeout + _ACTIVITY_TIMEOUT_WALL_MIN_GRACE_SECONDS,
+    )
 
 
 def _file_mtime_key(host_path: str) -> tuple[float, int] | None:
@@ -387,28 +412,48 @@ class BaseEnvironment(ABC):
         Fires the ``activity_callback`` (if set on this instance) every 10s
         while the process is running so the gateway's inactivity timeout
         doesn't kill long-running commands.
+
+        ``timeout`` is treated as an inactivity budget for foreground
+        commands. Whenever new stdout arrives, the budget resets. A separate
+        hard wall-clock cap still applies so continuously noisy commands cannot
+        run forever.
         """
         output_chunks: list[str] = []
+        activity_lock = threading.Lock()
+        start_time = time.monotonic()
+        last_output_time = start_time
+        saw_output = False
 
         def _drain():
+            nonlocal last_output_time, saw_output
             try:
                 for line in proc.stdout:
-                    output_chunks.append(line)
+                    now = time.monotonic()
+                    with activity_lock:
+                        output_chunks.append(line)
+                        last_output_time = now
+                        saw_output = True
             except UnicodeDecodeError:
-                output_chunks.clear()
-                output_chunks.append(
-                    "[binary output detected — raw bytes not displayable]"
-                )
+                with activity_lock:
+                    output_chunks.clear()
+                    output_chunks.append(
+                        "[binary output detected — raw bytes not displayable]"
+                    )
+                    last_output_time = time.monotonic()
+                    saw_output = True
             except (ValueError, OSError):
                 pass
 
         drain_thread = threading.Thread(target=_drain, daemon=True)
         drain_thread.start()
-        deadline = time.monotonic() + timeout
+        timeout = float(timeout)
+        wall_timeout = _compute_wall_timeout(timeout)
+        wall_deadline = start_time + wall_timeout
         _last_activity_touch = time.monotonic()
         _ACTIVITY_INTERVAL = 10.0  # seconds between activity touches
 
         while proc.poll() is None:
+            _now = time.monotonic()
             if is_interrupted():
                 self._kill_process(proc)
                 drain_thread.join(timeout=2)
@@ -416,11 +461,33 @@ class BaseEnvironment(ABC):
                     "output": "".join(output_chunks) + "\n[Command interrupted]",
                     "returncode": 130,
                 }
-            if time.monotonic() > deadline:
+            with activity_lock:
+                _last_output_time = last_output_time
+                _saw_output = saw_output
+            if _now > wall_deadline:
                 self._kill_process(proc)
                 drain_thread.join(timeout=2)
                 partial = "".join(output_chunks)
-                timeout_msg = f"\n[Command timed out after {timeout}s]"
+                timeout_msg = (
+                    f"\n[Command hit hard timeout after {int(wall_timeout)}s "
+                    f"(inactivity timeout {int(timeout)}s)]"
+                )
+                return {
+                    "output": partial + timeout_msg
+                    if partial
+                    else timeout_msg.lstrip(),
+                    "returncode": 124,
+                }
+            if _now > (_last_output_time + timeout):
+                self._kill_process(proc)
+                drain_thread.join(timeout=2)
+                partial = "".join(output_chunks)
+                if _saw_output:
+                    timeout_msg = (
+                        f"\n[Command timed out after {int(timeout)}s without output]"
+                    )
+                else:
+                    timeout_msg = f"\n[Command timed out after {int(timeout)}s]"
                 return {
                     "output": partial + timeout_msg
                     if partial
@@ -428,13 +495,12 @@ class BaseEnvironment(ABC):
                     "returncode": 124,
                 }
             # Periodic activity touch so the gateway knows we're alive
-            _now = time.monotonic()
             if _now - _last_activity_touch >= _ACTIVITY_INTERVAL:
                 _last_activity_touch = _now
                 _cb = _get_activity_callback()
                 if _cb:
                     try:
-                        _elapsed = int(_now - (deadline - timeout))
+                        _elapsed = int(_now - start_time)
                         _cb(f"terminal command running ({_elapsed}s elapsed)")
                     except Exception:
                         pass
@@ -576,4 +642,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -526,6 +526,7 @@ Background: Set background=true to get a session_id. Two patterns:
 Use process(action="poll") for progress checks, process(action="wait") to block until done.
 Working directory: Use 'workdir' for per-command cwd.
 PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REPL).
+Foreground timeout: For foreground commands, timeout acts as an inactivity limit. New output resets the timer, but Hermes still enforces an internal wall-clock cap. For very long or mostly silent jobs, prefer background=true with notify_on_complete=true.
 
 Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
 """
@@ -1704,7 +1705,7 @@ TERMINAL_SCHEMA = {
             },
             "timeout": {
                 "type": "integer",
-                "description": f"Max seconds to wait (default: 180, foreground max: {FOREGROUND_MAX_TIMEOUT}). Returns INSTANTLY when command finishes — set high for long tasks, you won't wait unnecessarily. Foreground timeout above {FOREGROUND_MAX_TIMEOUT}s is rejected; use background=true for longer commands.",
+                "description": f"Max foreground inactivity window in seconds (default: 180, explicit foreground max: {FOREGROUND_MAX_TIMEOUT}). New output resets the timer, but Hermes still applies an internal wall-clock cap. Returns INSTANTLY when the command finishes. Explicit foreground timeout above {FOREGROUND_MAX_TIMEOUT}s is rejected; use background=true for longer or mostly silent commands.",
                 "minimum": 1
             },
             "workdir": {

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -81,12 +81,14 @@ Hermes supports six terminal backends. Each determines where the agent's shell c
 terminal:
   backend: local    # local | docker | ssh | modal | daytona | singularity
   cwd: "."          # Working directory ("." = current dir for local, "/root" for containers)
-  timeout: 180      # Per-command timeout in seconds
+  timeout: 180      # Foreground command inactivity timeout in seconds (new output resets it)
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
   singularity_image: "docker://nikolaik/python-nodejs:python3.11-nodejs20"  # Container image for Singularity backend
   modal_image: "nikolaik/python-nodejs:python3.11-nodejs20"                 # Container image for Modal backend
   daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Container image for Daytona backend
 ```
+
+For foreground terminal commands, `terminal.timeout` is an inactivity budget rather than a strict wall-clock cutoff. If the command keeps producing output, Hermes extends the wait. A separate internal hard cap still applies so a noisy hung command cannot run forever. For very long or mostly silent jobs, prefer `background: true` with `notify_on_complete: true`.
 
 For cloud sandboxes such as Modal and Daytona, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 


### PR DESCRIPTION
## Summary
- make foreground terminal timeouts activity-aware so long-running active commands are not interrupted mid-output
- keep timing out genuinely stalled foreground commands
- add regression coverage and document the behavior

## Testing
- /Users/lcw/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_terminal_timeout_output.py