### PR TITLE
feat(delegate): Add delegation.include_tool_trace config switch to reduce token consumption

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -545,6 +545,9 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "include_tool_trace": True,  # Set false to omit ONLY the tool_trace field from
+                                         # delegate_task results (saves tokens); all other
+                                         # observability fields are always returned
         },
         "onboarding": {
             # First-touch hint flags (see agent/onboarding.py).  Each hint is

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -629,6 +629,7 @@ DEFAULT_CONFIG = {
                                # independent of the parent's max_iterations)
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "include_tool_trace": True,  # When false, omit tool_trace from delegate_task results to save tokens
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1590,6 +1590,17 @@ DEFAULT_CONFIG = {
         # budget still applies.
         "max_summary_chars": 24000,
 
+        # Controls ONLY the tool_trace field of delegate_task results. When
+        # false, each result entry omits its per-child tool_trace (the list of
+        # tool calls with byte counts + sanitized input summaries) to save
+        # parent-context tokens; all other observability fields (status,
+        # model, tokens, api_calls, exit_reason, error diagnostics, and the
+        # summary_truncated/summary_full_path recovery fields above) are
+        # always returned. Enforced at the shared result-aggregation boundary
+        # in tools/delegate_tool.py, so synchronous and background (async)
+        # completions are shaped identically.
+        "include_tool_trace": True,
+
         "child_timeout_seconds": 0,  # optional wall-clock cap per child agent. 0 (default)
                                      # = no timeout: children fail only from real errors
                                      # (API, tools, iteration budget), never a delegation

--- a/tests/hermes_cli/test_config_drift.py
+++ b/tests/hermes_cli/test_config_drift.py
@@ -1,0 +1,89 @@
+"""Regression tests for dead / drifting delegation config keys.
+
+This file guards against accidental re-introduction of config keys that were
+documented or declared at some point but never actually wired up to read code,
+and against declared keys silently losing their reader. Future dead-config
+regressions can accumulate here.
+"""
+
+import inspect
+
+
+def test_delegation_default_toolsets_removed_from_cli_config():
+    """delegation.default_toolsets was dead config — never read by
+    _load_config() or anywhere else. Removed.
+
+    Guards against accidental re-introduction in cli.py's CLI_CONFIG default
+    dict. If this test fails, someone re-added the key without wiring it up
+    to _load_config() in tools/delegate_tool.py.
+
+    We inspect the source of load_cli_config() instead of asserting on the
+    runtime CLI_CONFIG dict because CLI_CONFIG is populated by deep-merging
+    the user's ~/.hermes/config.yaml over the defaults. A contributor who
+    still has the legacy key set in their own config would cause a false
+    failure, and HERMES_HOME patching via conftest doesn't help because
+    cli._hermes_home is frozen at module import time — before any autouse
+    fixture can fire. Source inspection sidesteps all of that: it tests the
+    defaults literal directly.
+    """
+    from cli import load_cli_config
+
+    source = inspect.getsource(load_cli_config)
+    assert '"default_toolsets"' not in source, (
+        "delegation.default_toolsets was removed because it was never read. "
+        "Do not re-add it to cli.py's CLI_CONFIG default dict; "
+        "use tools/delegate_tool.py's DEFAULT_TOOLSETS module constant or "
+        "wire a new config key through _load_config()."
+    )
+
+
+def test_delegation_include_tool_trace_declared_and_wired():
+    """delegation.include_tool_trace must stay declared in BOTH default
+    config blocks (DEFAULT_CONFIG in hermes_cli/config_defaults.py — re-
+    exported by hermes_cli.config — and cli.py's legacy load_cli_config()
+    defaults; _load_config() in tools/delegate_tool.py can fall back to
+    either) with the same default (True), and must actually be read by
+    tools/delegate_tool.py so it never becomes dead config.
+
+    cli.py is checked via source inspection for the same reason as the test
+    above: CLI_CONFIG is deep-merged with the contributor's own
+    ~/.hermes/config.yaml at import time. DEFAULT_CONFIG is a plain module
+    constant, so a runtime assert is safe there.
+    """
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["delegation"]["include_tool_trace"] is True, (
+        "delegation.include_tool_trace default must be True (include the "
+        "trace) in hermes_cli/config_defaults.py's DEFAULT_CONFIG."
+    )
+
+    from cli import load_cli_config
+
+    source = inspect.getsource(load_cli_config)
+    assert '"include_tool_trace": True' in source, (
+        "delegation.include_tool_trace missing (or default changed) in "
+        "cli.py's legacy CLI_CONFIG defaults — keep it mirrored with "
+        "hermes_cli/config_defaults.py DEFAULT_CONFIG (default True)."
+    )
+
+    from tools.delegate_tool import _get_include_tool_trace
+
+    reader_source = inspect.getsource(_get_include_tool_trace)
+    assert '"include_tool_trace"' in reader_source, (
+        "tools/delegate_tool.py no longer reads delegation.include_tool_trace"
+        " — the config key would be dead. Wire it back through "
+        "_get_include_tool_trace()/_load_config() or remove it everywhere."
+    )
+
+    # The switch must stay enforced at the shared aggregate boundary
+    # (_finalize_child_results -> _project_result_entry), not only at entry
+    # construction — that is what keeps synchronous and background
+    # completions shaped identically.
+    from tools.delegate_tool import _finalize_child_results
+
+    finalize_source = inspect.getsource(_finalize_child_results)
+    assert "_project_result_entry" in finalize_source, (
+        "_finalize_child_results no longer applies _project_result_entry — "
+        "delegation.include_tool_trace would stop governing background/late "
+        "completions. Keep the projection at the shared aggregate boundary."
+    )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -558,6 +558,44 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test max iter", parent_agent=parent))
             self.assertEqual(result["results"][0]["exit_reason"], "max_iterations")
 
+    @patch("tools.delegate_tool._load_config")
+    def test_tool_trace_omitted_when_config_disabled(self, mock_cfg):
+        """When include_tool_trace is false, tool_trace should be absent from results."""
+        mock_cfg.return_value = {"include_tool_trace": False}
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 100
+            mock_child.session_completion_tokens = 50
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "web_search", "arguments": '{"query": "test"}'}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1", "content": '{"results": [1,2,3]}'},
+                    {"role": "assistant", "content": "done"},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test no trace", parent_agent=parent))
+            entry = result["results"][0]
+
+            # Other observability fields should still be present
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["model"], "claude-sonnet-4-6")
+            self.assertEqual(entry["exit_reason"], "completed")
+            self.assertIn("tokens", entry)
+
+            # tool_trace should be completely absent
+            self.assertNotIn("tool_trace", entry)
+
 
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,6 +11,7 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
+import tempfile
 import threading
 import time
 import types
@@ -54,6 +55,30 @@ def _make_mock_parent(depth=0):
     parent.tool_progress_callback = None
     parent.thinking_callback = None
     return parent
+
+
+def _make_traced_mock_child(final_response="done"):
+    """Mock child whose conversation contains exactly one paired tool call,
+    so a real tool_trace can be built from it. Shared by the
+    include_tool_trace tests (sync, background, fallback, summary budget)."""
+    mock_child = MagicMock()
+    mock_child.model = "claude-sonnet-4-6"
+    mock_child.session_prompt_tokens = 5000
+    mock_child.session_completion_tokens = 1200
+    mock_child.run_conversation.return_value = {
+        "final_response": final_response,
+        "completed": True,
+        "interrupted": False,
+        "api_calls": 3,
+        "messages": [
+            {"role": "assistant", "tool_calls": [
+                {"id": "tc_1", "function": {"name": "web_search", "arguments": '{"query": "test"}'}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": '{"results": [1,2,3]}'},
+            {"role": "assistant", "content": final_response},
+        ],
+    }
+    return mock_child
 
 
 class TestDelegateRequirements(unittest.TestCase):
@@ -490,6 +515,197 @@ class TestDelegateObservability(unittest.TestCase):
 
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
+
+    def _run_traced_delegation(self):
+        """Run a mocked synchronous delegation whose child made one tool call;
+        return the first result entry. Shared by the include_tool_trace
+        config tests."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = _make_traced_mock_child()
+            result = json.loads(delegate_task(goal="Trace config test", parent_agent=parent))
+        return result["results"][0]
+
+    @patch("tools.delegate_tool._load_config", return_value={"include_tool_trace": False})
+    def test_tool_trace_omitted_when_config_disables_it(self, _mock_cfg):
+        """delegation.include_tool_trace=false omits ONLY tool_trace; every
+        other observability field is still returned."""
+        entry = self._run_traced_delegation()
+
+        self.assertNotIn("tool_trace", entry)
+        # All other observability fields are unaffected.
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["summary"], "done")
+        self.assertEqual(entry["model"], "claude-sonnet-4-6")
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertEqual(entry["api_calls"], 3)
+        self.assertEqual(entry["tokens"]["input"], 5000)
+        self.assertEqual(entry["tokens"]["output"], 1200)
+        self.assertIn("duration_seconds", entry)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_tool_trace_present_by_default(self, _mock_cfg):
+        """When include_tool_trace is absent from config, the default is true
+        and tool_trace is returned as before."""
+        entry = self._run_traced_delegation()
+
+        self.assertIn("tool_trace", entry)
+        self.assertEqual(len(entry["tool_trace"]), 1)
+        self.assertEqual(entry["tool_trace"][0]["tool"], "web_search")
+
+    @patch("tools.delegate_tool._load_config", return_value={"include_tool_trace": True})
+    def test_tool_trace_present_when_explicitly_enabled(self, _mock_cfg):
+        entry = self._run_traced_delegation()
+
+        self.assertIn("tool_trace", entry)
+        self.assertEqual(entry["tool_trace"][0]["tool"], "web_search")
+
+
+class TestIncludeToolTraceAggregateBoundary(unittest.TestCase):
+    """delegation.include_tool_trace is enforced by _project_result_entry
+    inside _finalize_child_results — the shared aggregate boundary that both
+    _execute_and_aggregate (sync path, background runner, forced-sync and
+    pool-at-capacity fallbacks) and _run_child_lifecycle flow through — so a
+    child's completion mode never changes the result-detail contract, and the
+    summary-budget recovery fields (summary_truncated/summary_full_path)
+    survive trace omission."""
+
+    def setUp(self):
+        from tools import async_delegation as ad
+        from tools.process_registry import process_registry
+
+        self._ad = ad
+        self._queue = process_registry.completion_queue
+        ad._reset_for_tests()
+        self._drain_all()
+
+    def tearDown(self):
+        # Let just-released workers finalize before resetting, so their
+        # completion events can't leak into the next test's queue.
+        deadline = time.monotonic() + 2.0
+        while self._ad.active_count() and time.monotonic() < deadline:
+            time.sleep(0.02)
+        self._ad._reset_for_tests()
+        self._drain_all()
+
+    def _drain_all(self):
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except Exception:
+                break
+
+    def _drain_one(self, timeout=10.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self._queue.empty():
+                return self._queue.get_nowait()
+            time.sleep(0.02)
+        return None
+
+    def _background_entry(self, cfg):
+        """Dispatch background=True, wait for the async completion event, and
+        return its first result entry (the background aggregate's output)."""
+        parent = _make_mock_parent(depth=0)
+        parent.session_id = "sess-bg-trace"
+        parent._interrupt_requested = False
+
+        with patch("tools.delegate_tool._load_config", return_value=cfg), \
+                patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = _make_traced_mock_child()
+            out = json.loads(
+                delegate_task(goal="bg trace", background=True, parent_agent=parent)
+            )
+            self.assertEqual(out.get("status"), "dispatched", out)
+            self.assertEqual(out.get("mode"), "background")
+            # Drain INSIDE the patch context: the batch runner executes
+            # _run_single_child + _finalize_child_results on the daemon
+            # executor AFTER delegate_task returned, and must still see the
+            # patched config when it projects the aggregated entries.
+            evt = self._drain_one()
+
+        self.assertIsNotNone(evt, "background completion event never arrived")
+        self.assertEqual(evt["type"], "async_delegation")
+        return evt["results"][0]
+
+    def test_background_completion_omits_trace_when_disabled(self):
+        """A child completing via the background aggregate is projected at the
+        same boundary as sync results: tool_trace omitted, everything else
+        intact."""
+        entry = self._background_entry({"include_tool_trace": False})
+
+        self.assertNotIn("tool_trace", entry)
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["summary"], "done")
+        self.assertEqual(entry["api_calls"], 3)
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertEqual(entry["tokens"]["input"], 5000)
+
+    def test_background_completion_keeps_trace_by_default(self):
+        entry = self._background_entry({})
+
+        self.assertIn("tool_trace", entry)
+        self.assertEqual(len(entry["tool_trace"]), 1)
+        self.assertEqual(entry["tool_trace"][0]["tool"], "web_search")
+
+    def test_forced_sync_fallback_omits_trace_when_disabled(self):
+        """background=True on a runtime without async delivery (and no wakeable
+        session id) falls back to synchronous execution — same boundary,
+        same shape."""
+        parent = _make_mock_parent(depth=0)
+        parent._interrupt_requested = False
+
+        with patch("tools.delegate_tool._load_config",
+                   return_value={"include_tool_trace": False}), \
+                patch("gateway.session_context.async_delivery_supported",
+                      return_value=False), \
+                patch("tools.async_delegation._current_origin_session_id",
+                      return_value=""), \
+                patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = _make_traced_mock_child()
+            out = json.loads(
+                delegate_task(goal="fallback trace", background=True, parent_agent=parent)
+            )
+
+        self.assertNotEqual(out.get("status"), "dispatched")
+        self.assertIn("SYNCHRONOUSLY", out.get("note", ""))
+        entry = out["results"][0]
+        self.assertNotIn("tool_trace", entry)
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["summary"], "done")
+
+    def test_summary_budget_recovery_fields_survive_trace_omission(self):
+        """summary_truncated/summary_full_path (the summary-budget recovery
+        contract, applied by _apply_summary_budget at the same boundary) must
+        still be produced when include_tool_trace is off — the projection
+        drops ONLY tool_trace and never touches the trimmed summary or its
+        spill pointer."""
+        big = "HEAD_MARKER\n" + ("X" * 5000) + "\nTAIL_MARKER"
+
+        with tempfile.TemporaryDirectory() as td, \
+                patch.dict(os.environ, {"HERMES_HOME": os.path.join(td, ".hermes")}), \
+                patch("tools.delegate_tool._load_config",
+                      return_value={"include_tool_trace": False,
+                                    "max_summary_chars": 600}), \
+                patch("run_agent.AIAgent") as MockAgent:
+            parent = _make_mock_parent(depth=0)
+            parent.context_compressor = None  # static char ceiling only
+            MockAgent.return_value = _make_traced_mock_child(final_response=big)
+
+            out = json.loads(delegate_task(goal="budget trace", parent_agent=parent))
+            entry = out["results"][0]
+
+            self.assertNotIn("tool_trace", entry)
+            self.assertIs(entry["summary_truncated"], True)
+            path = entry.get("summary_full_path")
+            self.assertTrue(path and os.path.exists(path), entry)
+            with open(path, encoding="utf-8") as fh:
+                self.assertEqual(fh.read(), big)
+            # Head+tail recovery window plus the read_file paging footer.
+            self.assertIn("HEAD_MARKER", entry["summary"])
+            self.assertIn("TAIL_MARKER", entry["summary"])
+            self.assertIn("read_file", entry["summary"])
 
 
 class TestSubagentCostRollup(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -558,8 +558,13 @@ def _run_single_child(
                 "input": _input_tokens if isinstance(_input_tokens, (int, float)) else 0,
                 "output": _output_tokens if isinstance(_output_tokens, (int, float)) else 0,
             },
-            "tool_trace": tool_trace,
         }
+
+        # Conditionally include tool_trace based on delegation config
+        cfg = _load_config()
+        if cfg.get("include_tool_trace", True):
+            entry["tool_trace"] = tool_trace
+
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -652,6 +652,28 @@ def _get_inherit_mcp_toolsets() -> bool:
     return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
+def _get_include_tool_trace() -> bool:
+    """Whether delegate_task result entries include the tool_trace field.
+
+    Config key: delegation.include_tool_trace (bool, default True). This is a
+    narrow switch that controls ONLY the tool_trace field of delegate_task
+    results: set false to drop the per-child trace (tool names + byte counts +
+    sanitized input summaries) and save parent-context tokens. All other
+    observability fields (status, model, tokens, api_calls, exit_reason, error
+    diagnostics, and the summary-budget recovery fields summary_truncated /
+    summary_full_path) are always returned regardless of this setting.
+
+    Authoritatively enforced by ``_project_result_entry`` inside
+    ``_finalize_child_results`` — the shared aggregate boundary every
+    completion path flows through (synchronous batches, background dispatch,
+    the forced-sync fallbacks, and plugin single-child lifecycles) — with a
+    construction-skip fast path in ``_run_single_child`` so the trace is not
+    built just to be dropped.
+    """
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("include_tool_trace"), default=True)
+
+
 def _is_mcp_toolset_name(name: str) -> bool:
     """Return True for canonical MCP toolsets and their registered aliases."""
     if not name:
@@ -2331,10 +2353,17 @@ def _run_single_child(
 
         # Build tool trace from conversation messages (already in memory).
         # Uses tool_call_id to correctly pair parallel tool calls with results.
+        # delegation.include_tool_trace (default true): when false, skip the
+        # build entirely — don't construct what will be dropped. This is only
+        # an optimization; the authoritative omission of the field happens in
+        # _project_result_entry at the _finalize_child_results aggregate
+        # boundary, which every completion path (sync, background, fallback)
+        # flows through.
+        include_tool_trace = _get_include_tool_trace()
         tool_trace: list[Dict[str, Any]] = []
         trace_by_id: Dict[str, Dict[str, Any]] = {}
         messages = result.get("messages") or []
-        if isinstance(messages, list):
+        if include_tool_trace and isinstance(messages, list):
             for msg in messages:
                 if not isinstance(msg, dict):
                     continue
@@ -2645,6 +2674,34 @@ def _parent_finalization_lock(parent_agent) -> threading.RLock:
     return lock
 
 
+def _project_result_entry(entry: Any, include_tool_trace: bool) -> None:
+    """Apply the model-facing result-detail contract to ONE result entry.
+
+    Single authoritative projection point for delegation.include_tool_trace.
+    Called from _finalize_child_results — the shared aggregate boundary that
+    every completion path flows through: the synchronous batch path, the
+    background (background=true) runner executing on the daemon executor, the
+    forced-sync / pool-at-capacity fallbacks (all via _execute_and_aggregate),
+    and plugin single-child lifecycles (_run_child_lifecycle) — so an entry is
+    shaped identically no matter how (or how late) the child completed.
+
+    Scope is deliberately narrow (the closed detail_level/#20697 projector is
+    NOT revived): when the switch is off, ONLY the per-child ``tool_trace``
+    field is dropped from the entry serialised back to the parent model. All
+    other observability fields — status, summary, model, tokens, api_calls,
+    exit_reason, error diagnostics, and the summary-budget recovery fields
+    ``summary_truncated`` / ``summary_full_path`` (already applied by
+    _apply_summary_budget before projection) — are left untouched. Host-side
+    consumers are unaffected by the projection itself: the subagent_stop
+    hook's redacted tool_call_history is derived from the entry BEFORE this
+    runs (it is empty when the switch is off simply because the trace was
+    never built).
+    """
+    if not isinstance(entry, dict) or include_tool_trace:
+        return
+    entry.pop("tool_trace", None)
+
+
 def _finalize_child_results(
     results: List[Dict[str, Any]],
     task_list: List[Dict[str, Any]],
@@ -2654,6 +2711,7 @@ def _finalize_child_results(
     """Apply host-owned summary, memory, hook, and cost contracts once."""
     with _parent_finalization_lock(parent_agent):
         _apply_summary_budget(results, parent_agent)
+        include_tool_trace = _get_include_tool_trace()
         child_by_index = {index: child for index, _task, child in children}
 
         if parent_agent and getattr(parent_agent, "_memory_manager", None):
@@ -2710,6 +2768,13 @@ def _finalize_child_results(
                 )
             except Exception:
                 logger.debug("subagent_stop hook invocation failed", exc_info=True)
+
+        # Model-facing result-detail contract (delegation.include_tool_trace),
+        # applied last so summary-budget recovery fields and hook payloads are
+        # settled first. Runs here — and only here — so sync, background, and
+        # fallback completions all leave this boundary with the same shape.
+        for entry in results:
+            _project_result_entry(entry, include_tool_trace)
 
         if children_cost_total > 0.0:
             try:

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -355,6 +355,7 @@ delegation:
   # max_concurrent_children: 3              # Parallel children per batch (default: 3)
   # max_spawn_depth: 1                      # Tree depth (floor 1, no ceiling, default 1 = flat). Raise to 2 to allow orchestrator children to spawn leaves; 3+ for deeper trees.
   # orchestrator_enabled: true              # Disable to force all children to leaf role.
+  # include_tool_trace: true                # Set false to omit the per-child tool_trace field from delegate_task results and save tokens. Controls ONLY tool_trace; all other observability fields (status, model, tokens, api_calls, exit_reason, errors, summary_truncated/summary_full_path) are always returned, and it applies identically to synchronous and background (background=true) completions.
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
   api_mode: anthropic_messages                       # optional; auto-detected from base_url for anthropic_messages endpoints


### PR DESCRIPTION
## Summary

Introduces a new delegation config key `include_tool_trace` that controls whether the `tool_trace` field is included in the JSON returned to the parent agent from `delegate_task`.

## Changes

- `tools/delegate_tool.py`: In `_run_single_child()`, reads `_load_config().get("include_tool_trace", True)`. When `false`, the `tool_trace` field is omitted entirely from the returned entry dict.
- `hermes_cli/config.py`: Adds `"include_tool_trace": True` to `DEFAULT_CONFIG["delegation"]` for backward compatibility.
- `tests/tools/test_delegate.py`: Adds `test_tool_trace_omitted_when_config_disabled` to verify the field is absent when the config is set to `false`.

## Rationale

For parent agents that do not need child tool traces, omitting `tool_trace` reduces token consumption without affecting subagent execution logic.