### PR TITLE
feat(telegram): add dedicated TELEGRAM_PROXY env var and config.yaml proxy support (#9414, #6530, #9074, #7786)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -638,6 +638,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+                if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
+                    os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
                 if "disable_link_previews" in telegram_cfg:
                     plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
                     if not isinstance(plat_data, dict):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -575,7 +575,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
 
-            proxy_url = resolve_proxy_url()
+            proxy_url = resolve_proxy_url("TELEGRAM_PROXY")
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in ("1", "true", "yes", "on"))
             fallback_ips = self._fallback_ips()
             if not fallback_ips:

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -46,7 +46,7 @@ _SEED_FALLBACK_IPS: list[str] = ["149.154.167.220"]
 def _resolve_proxy_url() -> str | None:
     # Delegate to shared implementation (env vars + macOS system proxy detection)
     from gateway.platforms.base import resolve_proxy_url
-    return resolve_proxy_url()
+    return resolve_proxy_url("TELEGRAM_PROXY")
 
 
 class TelegramFallbackTransport(httpx.AsyncBaseTransport):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1252,6 +1252,12 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "messaging",
     },
+    "TELEGRAM_PROXY": {
+        "description": "Proxy URL for Telegram connections (overrides HTTPS_PROXY). Supports http://, https://, socks5://",
+        "prompt": "Telegram proxy URL (optional)",
+        "password": False,
+        "category": "messaging",
+    },
     "DISCORD_BOT_TOKEN": {
         "description": "Discord bot token from Developer Portal",
         "prompt": "Discord bot token",

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -300,6 +300,42 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["disable_link_previews"] is True
 
+    def test_bridges_telegram_proxy_url_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  proxy_url: socks5://127.0.0.1:1080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TELEGRAM_PROXY", raising=False)
+
+        load_gateway_config()
+
+        import os
+        assert os.environ.get("TELEGRAM_PROXY") == "socks5://127.0.0.1:1080"
+
+    def test_telegram_proxy_env_takes_precedence_over_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  proxy_url: http://from-config:8080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TELEGRAM_PROXY", "socks5://from-env:1080")
+
+        load_gateway_config()
+
+        import os
+        assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -170,6 +170,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_WEBHOOK_SECRET` | Secret token for verifying updates come from Telegram |
 | `TELEGRAM_REACTIONS` | Enable emoji reactions on messages during processing (default: `false`) |
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
+| `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |
 | `DISCORD_BOT_TOKEN` | Discord bot token |
 | `DISCORD_ALLOWED_USERS` | Comma-separated Discord user IDs allowed to use the bot |
 | `DISCORD_HOME_CHANNEL` | Default Discord channel for cron delivery |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -172,6 +172,27 @@ fly deploy
 
 The gateway log should show: `[telegram] Connected to Telegram (webhook mode)`.
 
+## Proxy Support
+
+If Telegram's API is blocked or you need to route traffic through a proxy, set a Telegram-specific proxy URL. This takes priority over the generic `HTTPS_PROXY` / `HTTP_PROXY` env vars.
+
+**Option 1: config.yaml (recommended)**
+
+```yaml
+telegram:
+  proxy_url: "socks5://127.0.0.1:1080"
+```
+
+**Option 2: environment variable**
+
+```bash
+TELEGRAM_PROXY=socks5://127.0.0.1:1080
+```
+
+Supported schemes: `http://`, `https://`, `socks5://`.
+
+The proxy applies to both the main Telegram connection and the fallback IP transport. If no Telegram-specific proxy is set, the gateway falls back to `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` (or macOS system proxy auto-detection).
+
 ## Home Channel
 
 Use the `/sethome` command in any Telegram chat (DM or group) to designate it as the **home channel**. Scheduled tasks (cron jobs) deliver their results to this channel.


### PR DESCRIPTION
## Summary

Adds Telegram-specific proxy support via `TELEGRAM_PROXY` env var and `telegram.proxy_url` in config.yaml. This overrides the generic `HTTPS_PROXY` when you need a separate proxy for Telegram connections (common in regions where Telegram is blocked but other services are not).

### What changed

| File | Change |
|------|--------|
| `gateway/platforms/telegram.py` | Pass `"TELEGRAM_PROXY"` to `resolve_proxy_url()` in `connect()` |
| `gateway/platforms/telegram_network.py` | Same for fallback transport (both call sites patched) |
| `gateway/config.py` | Bridge `telegram.proxy_url` from config.yaml → `TELEGRAM_PROXY` env var |
| `hermes_cli/config.py` | Add `TELEGRAM_PROXY` to `OPTIONAL_ENV_VARS` |
| `website/docs/user-guide/messaging/telegram.md` | New "Proxy Support" section |
| `website/docs/reference/environment-variables.md` | Add env var row |
| `tests/gateway/test_config.py` | Config bridging + env precedence tests |

### Priority chain
`TELEGRAM_PROXY` env var > `telegram.proxy_url` config > `HTTPS_PROXY` / `HTTP_PROXY` > macOS system proxy

Follows the same `<PLATFORM>_PROXY` convention established by `DISCORD_PROXY`.

### Composite salvage — four community PRs

| PR | Contributor | Contribution taken |
|----|-------------|-------------------|
| #9414 | @leeyang1990 | Core approach — both call sites (telegram.py + telegram_network.py) |
| #6530 | @WhiteWorld | config.yaml bridging, documentation |
| #9074 | @brantzh6 | Naming convention awareness (HERMES_TELEGRAM_* prefix discussion) |
| #7786 | @ten-ltw | Earlier proxy refactoring work |

Primary authorship attributed to @leeyang1990 (#9414) as the cleanest and most complete implementation. All four contributors credited via Co-authored-by.

### Test plan
- `pytest tests/gateway/test_config.py` — config bridging + env precedence (2 new tests, both pass)
- Manual: set `TELEGRAM_PROXY=socks5://...` and verify gateway log shows proxy URL

**Merge via rebase** to preserve contributor authorship.