### PR TITLE
fix(file-tools): ensure OS-agnostic sensitive path protection

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -107,5 +107,37 @@ class TestCheckSensitivePathMacOSBypass:
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
 
+class TestCheckSensitivePathWindowsHostSemantics:
+    """Sensitive POSIX targets should stay blocked even on Windows hosts."""
+
+    @staticmethod
+    def _windowsize(path: str) -> str:
+        return path.replace("/", "\\")
+
+    def test_exact_sensitive_path_blocked_with_windows_normalization(self, monkeypatch):
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(mod.os.path, "realpath", self._windowsize)
+        monkeypatch.setattr(mod.os.path, "normpath", self._windowsize)
+
+        assert mod._check_sensitive_path("/var/run/docker.sock") is not None
+
+    def test_prefix_sensitive_path_blocked_with_windows_normalization(self, monkeypatch):
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(mod.os.path, "realpath", self._windowsize)
+        monkeypatch.setattr(mod.os.path, "normpath", self._windowsize)
+
+        assert mod._check_sensitive_path("/private/etc/hosts") is not None
+
+    def test_safe_path_still_allowed_with_windows_normalization(self, monkeypatch):
+        from tools import file_tools as mod
+
+        monkeypatch.setattr(mod.os.path, "realpath", self._windowsize)
+        monkeypatch.setattr(mod.os.path, "normpath", self._windowsize)
+
+        assert mod._check_sensitive_path("/tmp/safe_file.txt") is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -99,13 +99,23 @@ _SENSITIVE_PATH_PREFIXES = (
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
+def _normalize_sensitive_path(path: str) -> str:
+    """Normalize a path for host-OS-agnostic sensitive-path comparisons."""
+    normalized = os.path.normpath(os.path.expanduser(path))
+    normalized = normalized.replace("\\", "/")
+    if normalized != "/":
+        normalized = normalized.rstrip("/")
+    return normalized
+
+
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
         resolved = os.path.realpath(os.path.expanduser(filepath))
     except (OSError, ValueError):
         resolved = filepath
-    normalized = os.path.normpath(os.path.expanduser(filepath))
+    resolved = _normalize_sensitive_path(resolved)
+    normalized = _normalize_sensitive_path(filepath)
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."


### PR DESCRIPTION
## Summary

Normalize `_check_sensitive_path()` comparisons so sensitive POSIX targets stay blocked even when Hermes is running on a Windows host.

## Problem

`_check_sensitive_path()` compared `realpath()` / `normpath()` output directly against POSIX-sensitive prefixes and exact paths such as:

- `/private/etc/`
- `/private/var/`
- `/var/run/docker.sock`

On Windows hosts, those path helpers can produce backslash-normalized paths, which makes direct string comparisons host-OS dependent and risks missing sensitive POSIX targets.

## Fix

- Add a small path normalizer that:
  - expands `~`
  - normalizes the path
  - converts backslashes to forward slashes
  - strips trailing slashes consistently
- Use that normalized form for both `resolved` and literal-path comparisons in `_check_sensitive_path()`

## Tests

Added regression coverage for Windows-host semantics by monkeypatching `realpath()` / `normpath()` to return backslash-normalized paths and verifying that:

- `/var/run/docker.sock` is still blocked
- `/private/etc/hosts` is still blocked
- `/tmp/safe_file.txt` is still allowed

## Verification

Passed locally via:

- `uv run pytest tests/tools/test_file_write_safety.py -q`
- `uv run pytest tests/tools/test_write_deny.py -q`
