### PR TITLE
fix(state): show compression continuations in session list and dashboard

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -737,7 +737,14 @@ class SessionDB:
         params = []
 
         if not include_children:
-            where_clauses.append("s.parent_session_id IS NULL")
+            # Hide subagent delegation children, but show compression continuations.
+            # Compression continuations have parent_session_id pointing to a session
+            # with end_reason='compression' — these should appear in the session list
+            # since they are the active continuation of a conversation.
+            where_clauses.append(
+                "(s.parent_session_id IS NULL OR "
+                "s.parent_session_id IN (SELECT id FROM sessions WHERE end_reason = 'compression'))"
+            )
 
         if source:
             where_clauses.append("s.source = ?")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1219,6 +1219,54 @@ class TestListSessionsRich:
 # Session source exclusion (--source flag for third-party isolation)
 # =========================================================================
 
+class TestCompressionContinuationVisibility:
+    """Tests for showing compression continuations while hiding subagent children."""
+
+    def test_subagent_children_hidden_by_default(self, db):
+        """Subagent children (parent_session_id set) should be hidden by default."""
+        db.create_session("parent", "cli")
+        db.create_session("child", "cli", parent_session_id="parent")
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "parent" in ids
+        assert "child" not in ids
+
+    def test_subagent_children_visible_with_include_children(self, db):
+        """Subagent children should be visible when include_children=True."""
+        db.create_session("parent", "cli")
+        db.create_session("child", "cli", parent_session_id="parent")
+        sessions = db.list_sessions_rich(include_children=True)
+        ids = [s["id"] for s in sessions]
+        assert "parent" in ids
+        assert "child" in ids
+
+    def test_compression_continuation_visible_by_default(self, db):
+        """Compression continuations should be visible in the session list even
+        though they have a parent_session_id, because they represent the active
+        branch of an ongoing conversation."""
+        db.create_session("original", "cli")
+        db.end_session("original", "compression")
+        db.create_session("continuation", "cli", parent_session_id="original")
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "original" in ids
+        assert "continuation" in ids
+
+    def test_mixed_parent_sessions(self, db):
+        """Root sessions, compression continuations visible; subagent children hidden."""
+        db.create_session("root", "cli")
+        db.create_session("compressed_orig", "cli")
+        db.end_session("compressed_orig", "compression")
+        db.create_session("continuation", "cli", parent_session_id="compressed_orig")
+        db.create_session("subagent", "cli", parent_session_id="root")
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "root" in ids
+        assert "compressed_orig" in ids
+        assert "continuation" in ids
+        assert "subagent" not in ids
+
+
 class TestExcludeSources:
     """Tests for exclude_sources on list_sessions_rich and search_messages."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where compression continuations were hidden from the session list and dashboard. When context compression occurs mid-conversation, the agent creates a new continuation session with `parent_session_id` pointing back to the original. The existing filter `parent_session_id IS NULL` excluded these continuations, making active conversations disappear from the dashboard once they compressed.

## Related Issue

Fixes #5122

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `list_sessions_rich()`: Changed the `parent_session_id` filter from a simple `IS NULL` check to include compression continuations:
  ```python
  # Before: hides ALL child sessions (subagent + compression continuations)
  where_clauses.append("s.parent_session_id IS NULL")
  
  # After: shows compression continuations, still hides subagent children
  where_clauses.append(
      "(s.parent_session_id IS NULL OR "
      "s.parent_session_id IN (SELECT id FROM sessions WHERE end_reason = 'compression'))"
  )
  ```
- `tests/test_hermes_state.py` — Added `TestCompressionContinuationVisibility` test class (4 tests):
  - `test_subagent_children_hidden_by_default` — verifies subagent children are hidden
  - `test_subagent_children_visible_with_include_children` — verifies `include_children=True` shows them
  - `test_compression_continuation_visible_by_default` — verifies compression continuations appear in default listing
  - `test_mixed_parent_sessions` — verifies the mixed case: roots + continuations visible, subagent children hidden

## How to Test

1. Start a conversation that triggers context compression (long session)
2. Observe that the compression continuation session appears in the dashboard session list
3. Verify subagent delegation sessions (from `delegate_task`) remain hidden
4. Run: `pytest tests/test_hermes_state.py::TestCompressionContinuationVisibility -v`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_state.py::TestCompressionContinuationVisibility -v` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu Server

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (internal filter change, no API/user-facing change)
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — N/A (SQLite-only change)
- [x] I've updated tool descriptions/schemas — or N/A
