### PR TITLE
fix(security): JWT label sanitization, cryptographic PRNG, error message redaction

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -173,7 +173,14 @@ class PooledCredential:
         return self.base_url
 
 
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+_CONTROL_CHAR_RE = re.compile(
+    "["
+    "\x00-\x1f\x7f-\x9f"           # C0 / C1 control chars (ANSI escapes, NUL, etc.)
+    "‎‏"                 # LRM, RLM
+    "‪-‮"                # LRE, RLE, PDF, LRO, RLO
+    "⁦-⁩"                # LRI, RLI, FSI, PDI
+    "]"
+)
 
 
 def label_from_token(token: str, fallback: str) -> str:
@@ -181,9 +188,9 @@ def label_from_token(token: str, fallback: str) -> str:
     for key in ("email", "preferred_username", "upn"):
         value = claims.get(key)
         if isinstance(value, str) and value.strip():
-            # Strip control characters (ANSI escapes, null bytes, bidi
-            # overrides) and cap length to prevent terminal injection
-            # via crafted JWT claims.
+            # Strip C0/C1 control characters plus Unicode bidi marks and
+            # isolates (U+200E/F, U+202A-E, U+2066-9) to prevent terminal
+            # spoofing via crafted JWT claims, then cap length.
             return _CONTROL_CHAR_RE.sub("", value.strip())[:120]
     return fallback
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import random
+import re
+import secrets
 import threading
 import time
 import uuid
@@ -171,12 +173,18 @@ class PooledCredential:
         return self.base_url
 
 
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
 def label_from_token(token: str, fallback: str) -> str:
     claims = _decode_jwt_claims(token)
     for key in ("email", "preferred_username", "upn"):
         value = claims.get(key)
         if isinstance(value, str) and value.strip():
-            return value.strip()
+            # Strip control characters (ANSI escapes, null bytes, bidi
+            # overrides) and cap length to prevent terminal injection
+            # via crafted JWT claims.
+            return _CONTROL_CHAR_RE.sub("", value.strip())[:120]
     return fallback
 
 
@@ -835,7 +843,7 @@ class CredentialPool:
             return None
 
         if self._strategy == STRATEGY_RANDOM:
-            entry = random.choice(available)
+            entry = secrets.choice(available)
             self._current_id = entry.id
             return entry
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -813,17 +814,32 @@ def _extract_error_code(body: dict) -> str:
     return ""
 
 
+_PROVIDER_METADATA_RE = re.compile(
+    r"(?:org[-_]?id|organization|account[-_]?id|x-request-id|request[-_]?id)"
+    r"\s*[:=]\s*\S+",
+    re.IGNORECASE,
+)
+
+
 def _extract_message(error: Exception, body: dict) -> str:
-    """Extract the most informative error message."""
+    """Extract the most informative error message.
+
+    Strips provider-specific metadata (org IDs, request IDs) that could
+    leak account details into user-facing error displays.
+    """
+    raw = ""
     # Try structured body first
     if body:
         error_obj = body.get("error", {})
         if isinstance(error_obj, dict):
             msg = error_obj.get("message", "")
             if isinstance(msg, str) and msg.strip():
-                return msg.strip()[:500]
-        msg = body.get("message", "")
-        if isinstance(msg, str) and msg.strip():
-            return msg.strip()[:500]
+                raw = msg.strip()[:500]
+        if not raw:
+            msg = body.get("message", "")
+            if isinstance(msg, str) and msg.strip():
+                raw = msg.strip()[:500]
     # Fallback to str(error)
-    return str(error)[:500]
+    if not raw:
+        raw = str(error)[:500]
+    return _PROVIDER_METADATA_RE.sub("[redacted]", raw)


### PR DESCRIPTION
## Summary

Three minor security hardening fixes in `agent/credential_pool.py` and `agent/error_classifier.py`. No behavior changes for normal operation.

## Changes

### 1. JWT claim label sanitization (`credential_pool.py`)

`label_from_token()` extracts `email`/`preferred_username`/`upn` from JWT claims and uses them as credential labels in CLI output. Previously, these values were used with only `.strip()` — no filtering of control characters.

A crafted JWT with ANSI escape sequences, null bytes, or unicode bidi override characters in the email field could corrupt terminal output or inject misleading content into credential selection displays.

**Fix:** Strip all C0/C1 control characters (`\x00-\x1f`, `\x7f-\x9f`) and cap label length at 120 characters.

```python
# Before
return value.strip()

# After
_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
return _CONTROL_CHAR_RE.sub("", value.strip())[:120]
```

### 2. Cryptographic PRNG for credential selection (`credential_pool.py`)

`STRATEGY_RANDOM` used `random.choice()` (Mersenne Twister) for selecting pool entries. Replaced with `secrets.choice()` which uses the OS CSPRNG. The Mersenne Twister is predictable given ~624 observations of its output; `secrets` is not.

Practical risk was low since credential selection is an internal operation, but the fix is trivial and eliminates a theoretical attack surface.

```python
# Before
entry = random.choice(available)

# After
entry = secrets.choice(available)
```

### 3. Provider metadata redaction in error messages (`error_classifier.py`)

`_extract_message()` truncates upstream error bodies to 500 characters but passes them through without sanitization. Provider error responses may contain organization IDs, request IDs, internal hostnames, or account-specific rate limit details.

**Fix:** Regex-based redaction of `org_id`, `organization`, `account_id`, `x-request-id`, and `request_id` patterns before returning the message.

```python
_PROVIDER_METADATA_RE = re.compile(
    r"(?:org[-_]?id|organization|account[-_]?id|x-request-id|request[-_]?id)"
    r"\s*[:=]\s*\S+",
    re.IGNORECASE,
)

# Applied at end of _extract_message():
return _PROVIDER_METADATA_RE.sub("[redacted]", raw)
```

## Files changed (2 files, +32/-8)

| File | Change |
|------|--------|
| `agent/credential_pool.py` | JWT label sanitization + `secrets.choice()` |
| `agent/error_classifier.py` | Provider metadata redaction in error messages |

## Test plan

- [ ] `label_from_token()` with normal JWT → returns email as before
- [ ] `label_from_token()` with ANSI-escaped email → control chars stripped
- [ ] `label_from_token()` with 200-char email → truncated to 120
- [ ] `STRATEGY_RANDOM` selection → still returns a valid entry
- [ ] `_extract_message()` with `org_id: org-12345` in body → redacted
- [ ] `_extract_message()` with normal error → message preserved