### PR TITLE
fix(security): replace shell=True with shlex.split in config-driven execution paths

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5527,8 +5527,9 @@ class HermesCLI:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            import shlex
                             result = subprocess.run(
-                                exec_cmd, shell=True, capture_output=True,
+                                shlex.split(exec_cmd), capture_output=True,
                                 text=True, timeout=30
                             )
                             output = result.stdout.strip() or result.stderr.strip()

--- a/cli.py
+++ b/cli.py
@@ -5528,8 +5528,17 @@ class HermesCLI:
                     if exec_cmd:
                         try:
                             import shlex
+                            # Use shlex.split to avoid shell injection from
+                            # project-level configs.  Commands needing shell
+                            # features (pipes, redirects) can use explicit
+                            # "sh -c '...'" in config.yaml.
+                            try:
+                                cmd_args = shlex.split(exec_cmd)
+                            except ValueError:
+                                self.console.print("[bold red]Quick command has invalid quoting[/]")
+                                return True
                             result = subprocess.run(
-                                shlex.split(exec_cmd), capture_output=True,
+                                cmd_args, capture_output=True,
                                 text=True, timeout=30
                             )
                             output = result.stdout.strip() or result.stderr.strip()

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -133,8 +133,9 @@ def _install_dependencies(provider_name: str) -> None:
         install_cmd = dep.get("install", "")
         if check_cmd:
             try:
+                import shlex
                 subprocess.run(
-                    check_cmd, shell=True, capture_output=True, timeout=5
+                    shlex.split(check_cmd), capture_output=True, timeout=5
                 )
             except Exception:
                 if install_cmd:


### PR DESCRIPTION
## Summary

Replace `subprocess.run(..., shell=True)` with `shlex.split()` in two config-driven execution paths that bypass the terminal tool's safety infrastructure.

## Changes

### 1. Quick commands (`cli.py:5530-5533`)

```python
# Before
result = subprocess.run(exec_cmd, shell=True, capture_output=True, text=True, timeout=30)

# After
import shlex
result = subprocess.run(shlex.split(exec_cmd), capture_output=True, text=True, timeout=30)
```

`exec_cmd` comes from `config.yaml` under `quick_commands.<name>.command`. In a shared-config scenario (project-level `HERMES.md` or config checked into git), a malicious entry could inject shell metacharacters.

### 2. Memory plugin dependency check (`hermes_cli/memory_setup.py:136-137`)

```python
# Before
subprocess.run(check_cmd, shell=True, capture_output=True, timeout=5)

# After
import shlex
subprocess.run(shlex.split(check_cmd), capture_output=True, timeout=5)
```

`check_cmd` comes from plugin `plugin.yaml` metadata. A compromised or malicious memory plugin could specify arbitrary shell commands.

## Why this matters

SECURITY.md correctly scopes unrestricted shell access via the terminal tool as by-design. The distinction is that these paths:

1. Do not go through the terminal tool's approval flow
2. Are not subject to output redaction (`agent/redact.py`)
3. Are not logged in the conversation audit trail
4. Accept input from files that may originate from untrusted sources

## Files changed (2 files, +4/-2)

| File | Change |
|------|--------|
| `cli.py` | `shlex.split()` for quick command exec |
| `hermes_cli/memory_setup.py` | `shlex.split()` for plugin dependency check |

## Test plan

- [ ] Quick commands with simple strings (`ls`, `echo hello`) → work as before
- [ ] Quick commands with shell metacharacters (`echo $(whoami)`) → executed literally, not interpreted
- [ ] Memory plugin with normal check command (`which redis-server`) → works as before
- [ ] No regression in `hermes memory setup` flow

Closes #10692