### PR TITLE
fix(security): separate OAuth PKCE state from code_verifier

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -663,6 +663,8 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     import webbrowser
 
     verifier, challenge = _generate_pkce()
+    import secrets as _secrets
+    oauth_state = _secrets.token_urlsafe(32)
 
     params = {
         "code": "true",
@@ -672,7 +674,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         "scope": _OAUTH_SCOPES,
         "code_challenge": challenge,
         "code_challenge_method": "S256",
-        "state": verifier,
+        "state": oauth_state,
     }
     from urllib.parse import urlencode
 
@@ -709,7 +711,12 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
 
     splits = auth_code.split("#")
     code = splits[0]
-    state = splits[1] if len(splits) > 1 else ""
+    received_state = splits[1] if len(splits) > 1 else ""
+
+    # Validate state to prevent CSRF (RFC 6749 §10.12)
+    if received_state != oauth_state:
+        logger.warning("OAuth state mismatch — possible CSRF, aborting")
+        return None
 
     try:
         import urllib.request
@@ -718,7 +725,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "grant_type": "authorization_code",
             "client_id": _OAUTH_CLIENT_ID,
             "code": code,
-            "state": state,
+            "state": received_state,
             "redirect_uri": _OAUTH_REDIRECT_URI,
             "code_verifier": verifier,
         }).encode()

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -659,12 +659,12 @@ def _generate_pkce() -> tuple:
 
 def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     """Run Hermes-native OAuth PKCE flow and return credential state."""
+    import secrets
     import time
     import webbrowser
 
     verifier, challenge = _generate_pkce()
-    import secrets as _secrets
-    oauth_state = _secrets.token_urlsafe(32)
+    oauth_state = secrets.token_urlsafe(32)
 
     params = {
         "code": "true",


### PR DESCRIPTION
## Summary

The Anthropic OAuth PKCE flow reused the `code_verifier` as the `state` parameter. This PR generates an independent cryptographic random value for `state` and validates it on callback.

## Changes

`agent/anthropic_adapter.py`:

```python
# Before (line 675)
"state": verifier,

# After
import secrets as _secrets
oauth_state = _secrets.token_urlsafe(32)
# ...
"state": oauth_state,
```

On callback:
```python
# Before — state parsed but never validated
state = splits[1] if len(splits) > 1 else ""

# After — state validated against original value
received_state = splits[1] if len(splits) > 1 else ""
if received_state != oauth_state:
    logger.warning("OAuth state mismatch — possible CSRF, aborting")
    return None
```

## Why this matters

Per RFC 6749 §10.12 and RFC 7636, `state` and `code_verifier` serve fundamentally different purposes:

- **`state`** is an anti-CSRF token, visible in the authorization URL (browser history, referrer headers, server logs)
- **`code_verifier`** must remain secret — known only to the client, used in the token exchange

Reusing the verifier as state leaked it via the authorization URL. Additionally, the state was never validated on callback, so CSRF protection was absent.

## Files changed (1 file, +10/-3)

| File | Change |
|------|--------|
| `agent/anthropic_adapter.py` | Separate state generation + callback validation |

## Test plan

- [ ] `hermes login --anthropic` OAuth flow completes successfully
- [ ] State mismatch on callback → returns None with warning log
- [ ] Token exchange sends correct `code_verifier` (unchanged)

Closes #10693