### PR TITLE
Fix gateway /resume leaking cached agent state across session switches

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6383,6 +6383,46 @@ class GatewayRunner:
         if session_key in self._running_agents:
             del self._running_agents[session_key]
 
+        # Session boundaries must also clear cached runtime state keyed by the
+        # stable chat session_key. Otherwise /resume can inherit the previous
+        # session's cached agent/session_id or /model override.
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            with _cache_lock:
+                _cached = self._agent_cache.get(session_key)
+                _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
+            if _old_agent is not None:
+                try:
+                    if hasattr(_old_agent, "shutdown_memory_provider"):
+                        _old_agent.shutdown_memory_provider()
+                except Exception:
+                    pass
+                try:
+                    if hasattr(_old_agent, "close"):
+                        _old_agent.close()
+                except Exception:
+                    pass
+        self._evict_cached_agent(session_key)
+
+        try:
+            from tools.env_passthrough import clear_env_passthrough
+            clear_env_passthrough()
+        except Exception:
+            pass
+
+        try:
+            from tools.credential_files import clear_credential_files
+            clear_credential_files()
+        except Exception:
+            pass
+
+        _session_model_overrides = getattr(self, "_session_model_overrides", None)
+        if _session_model_overrides is not None:
+            _session_model_overrides.pop(session_key, None)
+        _pending_model_notes = getattr(self, "_pending_model_notes", None)
+        if _pending_model_notes is not None:
+            _pending_model_notes.pop(session_key, None)
+
         # Switch the session entry to point at the old session
         new_entry = self.session_store.switch_session(session_key, target_id)
         if not new_entry:

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -4,6 +4,7 @@ Tests the _handle_resume_command handler (switch to a previously-named session)
 across gateway messenger platforms.
 """
 
+import threading
 from unittest.mock import MagicMock, AsyncMock
 
 import pytest
@@ -55,6 +56,11 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
 
     # Stub out memory flushing
     runner._async_flush_memories = AsyncMock()
+    runner._background_tasks = set()
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
 
     return runner
 
@@ -223,4 +229,69 @@ class TestHandleResumeCommand:
             "current_session_001",
             "agent:main:telegram:dm:67890",
         )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_evicts_cached_agent(self, tmp_path):
+        """Resume must evict cached AIAgent state keyed by the chat session key."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session", "telegram")
+        db.set_session_title("old_session", "Old Work")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Old Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        real_key = _session_key_for_event(event)
+        cached_agent = MagicMock()
+        with runner._agent_cache_lock:
+            runner._agent_cache[real_key] = (cached_agent, "sig123")
+
+        await runner._handle_resume_command(event)
+
+        with runner._agent_cache_lock:
+            assert real_key not in runner._agent_cache
+        cached_agent.shutdown_memory_provider.assert_called_once()
+        cached_agent.close.assert_called_once()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_clears_session_model_state(self, tmp_path):
+        """Resume must not carry session-scoped model state into the restored session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session", "telegram")
+        db.set_session_title("old_session", "Old Work")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Old Work")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        real_key = _session_key_for_event(event)
+        runner._session_model_overrides[real_key] = {
+            "model": "gpt-5",
+            "provider": "openai",
+            "api_key": "sk-test",
+            "base_url": "",
+            "api_mode": "codex_responses",
+        }
+        runner._pending_model_notes[real_key] = "[Note: switched]"
+        runner._session_model_overrides["other"] = {"model": "keep-me"}
+        runner._pending_model_notes["other"] = "[Note: keep-me]"
+
+        await runner._handle_resume_command(event)
+
+        assert real_key not in runner._session_model_overrides
+        assert real_key not in runner._pending_model_notes
+        assert "other" in runner._session_model_overrides
+        assert "other" in runner._pending_model_notes
         db.close()


### PR DESCRIPTION
## Summary

Fixes a gateway session-boundary bug where `/resume` could carry over runtime state from the previously active session in the same chat.

Before this change, `/resume` updated the session pointer in `SessionStore`, but it did not clear other state keyed by the stable chat `session_key`. That meant a resumed session could inherit:

- a cached `AIAgent` instance still bound to the old `session_id`
- a session-scoped `/model` override from the previous session
- pending model switch notes and related transient runtime state

This is a cross-session contamination issue and breaks the expected semantics of `/resume`.

## What changed

In the gateway `/resume` flow, we now treat the session switch as a real session boundary and clear chat-keyed runtime state before switching:

- shut down and evict any cached agent for the current `session_key`
- clear transient env/credential helper state
- clear session-scoped model overrides
- clear pending model switch notes

The actual session switch behavior is otherwise unchanged.

## Why this matters

`session_key` is chat-scoped, but `session_id` is conversation-scoped.

`/resume` switches conversations, so leaving cached agent/runtime state attached to the same `session_key` can cause the next turn to run with stale state from the wrong session. This patch makes `/resume` consistent with `/new` / session reset behavior and closes that leak.

## Tests

Added regression coverage for:

- evicting cached agent state on `/resume`
- clearing session-scoped model override state on `/resume`
- preserving unrelated session state entries

Validated with:

- `python -m pytest tests/gateway/test_resume_command.py -q`
- `python -m pytest tests/gateway/test_agent_cache.py -q`
- `python -m pytest tests/gateway/test_session_model_reset.py -q`

All passed.
