### PR TITLE
fix(cli): honor config base_url mirror for explicit openrouter provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1215,12 +1215,20 @@ def _resolve_openrouter_runtime(
     # provider (issues #420, #560).
     _is_openrouter_url = base_url_host_matches(base_url, "openrouter.ai")
     # Also treat explicitly-configured OpenRouter mirrors/proxies as OpenRouter
-    # for key selection — if the user set OPENROUTER_BASE_URL or requested
-    # provider=openrouter explicitly, OPENROUTER_API_KEY should still be used.
+    # for key selection — if the user set OPENROUTER_BASE_URL, or requested
+    # provider=openrouter explicitly with a config.yaml mirror (#10707),
+    # OPENROUTER_API_KEY should still be used rather than falling through to
+    # the generic custom-endpoint branch (which wouldn't select it at all,
+    # since a non-openrouter.ai mirror host doesn't match `_is_openrouter_url`).
     _is_openrouter_context = _is_openrouter_url or (
         requested_norm == "openrouter"
-        and (env_openrouter_base_url or base_url == env_openrouter_base_url)
-        and base_url == (env_openrouter_base_url or "").rstrip("/")
+        and (
+            (use_config_base_url and cfg_provider == "openrouter")
+            or (
+                (env_openrouter_base_url or base_url == env_openrouter_base_url)
+                and base_url == (env_openrouter_base_url or "").rstrip("/")
+            )
+        )
     )
     if _is_openrouter_context:
         api_key_candidates = [

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1197,6 +1197,8 @@ def _resolve_openrouter_runtime(
             cfg_base_url, cfg_provider
         ):
             use_config_base_url = True
+        elif requested_norm == "openrouter" and cfg_provider == "openrouter":
+            use_config_base_url = True
 
     base_url = (
         (explicit_base_url or "").strip()
@@ -1816,7 +1818,7 @@ def resolve_runtime_provider(
             or env_openai_base_url
             or env_openrouter_base_url
         )
-        if cfg_base_url and cfg_provider in {"auto", "custom"}:
+        if cfg_base_url and cfg_provider in {"auto", "custom", "openrouter"}:
             has_custom_endpoint = True
         has_runtime_override = bool(explicit_api_key or explicit_base_url)
         should_use_pool = (

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -447,6 +447,8 @@ def _resolve_openrouter_runtime(
                 use_config_base_url = True
         elif requested_norm == "custom" and cfg_provider == "custom":
             use_config_base_url = True
+        elif requested_norm == "openrouter" and cfg_provider == "openrouter":
+            use_config_base_url = True
 
     base_url = (
         (explicit_base_url or "").strip()
@@ -691,7 +693,7 @@ def resolve_runtime_provider(
             or env_openai_base_url
             or env_openrouter_base_url
         )
-        if cfg_base_url and cfg_provider in {"auto", "custom"}:
+        if cfg_base_url and cfg_provider in {"auto", "custom", "openrouter"}:
             has_custom_endpoint = True
         has_runtime_override = bool(explicit_api_key or explicit_base_url)
         should_use_pool = (

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -491,7 +491,8 @@ def _openrouter_should_use_pool(requested_provider, model_cfg, explicit_api_key,
     """OpenRouter pool only for a plain openrouter/auto request with no custom endpoint or override."""
     cfg_base_url = str(model_cfg.get("base_url") or "").strip()
     env_base_urls = _getenv("OPENAI_BASE_URL", "").strip() or _getenv("OPENROUTER_BASE_URL", "").strip()
-    has_custom_endpoint = bool(explicit_base_url or env_base_urls or (cfg_base_url and _cfg_provider(model_cfg) in {"auto", "custom"}))
+    has_custom_endpoint = bool(explicit_base_url or env_base_urls
+                               or (cfg_base_url and _cfg_provider(model_cfg) in {"auto", "custom", "openrouter"}))
     return requested_provider in {"openrouter", "auto"} and not has_custom_endpoint and not bool(explicit_api_key or explicit_base_url)
 
 

--- a/hermes_cli/runtime_provider_backends.py
+++ b/hermes_cli/runtime_provider_backends.py
@@ -131,6 +131,8 @@ def _resolve_openrouter_runtime(
     use_config_base_url = bool(cfg_base_url.strip()) and not explicit_base_url and (
         (requested_norm == "auto" and cfg_provider in ("", "auto"))
         or (requested_norm == "custom" and rp._config_base_url_trustworthy_for_bare_custom(cfg_base_url, cfg_provider))
+        # provider: openrouter + base_url in config.yaml is a deliberate mirror/proxy (#10622).
+        or (requested_norm == "openrouter" and cfg_provider == "openrouter")
     )
     base_url = ((explicit_base_url or "").strip() or env_custom_base_url or (cfg_base_url.strip() if use_config_base_url else "")
                 or env_openrouter_base_url or OPENROUTER_BASE_URL).rstrip("/")
@@ -138,11 +140,16 @@ def _resolve_openrouter_runtime(
     # prefer OPENROUTER_API_KEY (issue #289). When hitting a custom endpoint (e.g. Z.ai, local LLM), prefer
     # OPENAI_API_KEY so the OpenRouter key doesn't leak to an unrelated provider (issues #420, #560).
     is_openrouter_url = base_url_host_matches(base_url, "openrouter.ai")
-    # Explicitly-configured OpenRouter mirrors (OPENROUTER_BASE_URL + provider=openrouter) still
-    # count as OpenRouter for key selection.
+    # Explicitly-configured OpenRouter mirrors (OPENROUTER_BASE_URL, or a config.yaml base_url under
+    # provider: openrouter) still count as OpenRouter for key selection — otherwise the mirror's host
+    # fails the openrouter.ai match and the generic custom-endpoint branch never selects
+    # OPENROUTER_API_KEY for it (#10622).
     is_openrouter_context = is_openrouter_url or (
-        requested_norm == "openrouter" and (env_openrouter_base_url or base_url == env_openrouter_base_url)
-        and base_url == (env_openrouter_base_url or "").rstrip("/")
+        requested_norm == "openrouter" and (
+            (use_config_base_url and cfg_provider == "openrouter")
+            or ((env_openrouter_base_url or base_url == env_openrouter_base_url)
+                and base_url == (env_openrouter_base_url or "").rstrip("/"))
+        )
     )
     if is_openrouter_context:
         candidates = [explicit_api_key, rp._getenv("OPENROUTER_API_KEY"), rp._getenv("OPENAI_API_KEY")]

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -426,7 +426,12 @@ def test_explicit_openrouter_skips_openai_base_url(monkeypatch):
 
 
 def test_explicit_openrouter_honors_config_base_url_mirror(monkeypatch):
-    """requested='openrouter' + cfg_provider='openrouter' must use config base_url."""
+    """requested='openrouter' + cfg_provider='openrouter' must use config
+    base_url AND select OPENROUTER_API_KEY for it — a config-sourced mirror
+    is an OpenRouter context for credential selection just like the
+    OPENROUTER_BASE_URL env var path already was, and resolving to the
+    mirror's base_url without the matching key would send an empty/wrong
+    credential (#10707 followup)."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(
         rp,
@@ -445,6 +450,11 @@ def test_explicit_openrouter_honors_config_base_url_mirror(monkeypatch):
 
     assert resolved["provider"] == "openrouter"
     assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+    assert resolved["api_key"] == "router-key"
+    # A config-mirrored explicit provider is a custom endpoint — the
+    # credential pool must be bypassed entirely, not silently substitute a
+    # pooled OpenRouter credential for the mirror's own key.
+    assert not resolved.get("credential_pool")
 
 
 # ── api_mode config override tests ──────────────────────────────────────

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -425,6 +425,26 @@ def test_explicit_openrouter_skips_openai_base_url(monkeypatch):
 
 
 
+def test_explicit_openrouter_honors_config_base_url_mirror(monkeypatch):
+    """requested='openrouter' + cfg_provider='openrouter' must use config base_url."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
 
 
 # ── api_mode config override tests ──────────────────────────────────────

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -767,6 +767,28 @@ def test_explicit_openrouter_honors_openrouter_base_url_over_pool(monkeypatch):
     assert resolved.get("credential_pool") is None
 
 
+def test_explicit_openrouter_honors_config_base_url_mirror(monkeypatch):
+    """requested='openrouter' + cfg_provider='openrouter' must use config base_url."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+
+
 def test_resolve_requested_provider_precedence(monkeypatch):
     monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openai-codex"})

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -868,6 +868,71 @@ def test_explicit_openrouter_skips_openai_base_url(monkeypatch):
     assert resolved["api_key"] == "or-test-key"
 
 
+def test_explicit_openrouter_honors_config_base_url_mirror(monkeypatch):
+    """requested='openrouter' + config provider='openrouter' + config base_url must
+    resolve to that mirror AND still select OPENROUTER_API_KEY for it — a
+    config-sourced mirror is an OpenRouter context for credential selection just
+    like the OPENROUTER_BASE_URL env path already is.  Regression test for #10622."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+    assert resolved["api_key"] == "router-key"
+
+
+def test_explicit_openrouter_config_mirror_bypasses_pool(monkeypatch):
+    """A config.yaml mirror under provider='openrouter' is a custom endpoint: the
+    OpenRouter credential pool must be skipped rather than silently routing the
+    request to openrouter.ai with a pooled key (#10622)."""
+    class _Entry:
+        access_token = "pool-key"
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+    assert resolved["api_key"] == "router-key"
+    assert resolved.get("credential_pool") is None
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `model.base_url` in config.yaml is silently ignored when the provider is explicitly set to `openrouter`, causing all traffic to go to the public OpenRouter endpoint instead of the user's configured mirror/proxy.

## Related Issue

Fixes #10622

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

_Rebased onto current main (`d15ed44452`); the OpenRouter resolver has since moved out of `runtime_provider.py`, so the same three hunks now land in two files._

- `hermes_cli/runtime_provider.py` — `_openrouter_should_use_pool()`: added `"openrouter"` to the `has_custom_endpoint` provider set, so a config `base_url` with `cfg_provider="openrouter"` is recognized as a custom endpoint and the credential pool no longer routes the request to the public endpoint with a pooled key.
- `hermes_cli/runtime_provider_backends.py` — `_resolve_openrouter_runtime()`: added a `requested_norm == "openrouter" and cfg_provider == "openrouter"` branch to `use_config_base_url`, so the config mirror is honored; `is_openrouter_context` is widened to match, so `OPENROUTER_API_KEY` is still selected for a non-`openrouter.ai` mirror host.
- `tests/hermes_cli/test_runtime_provider_resolution.py`: added `test_explicit_openrouter_honors_config_base_url_mirror` (no pool) and `test_explicit_openrouter_config_mirror_bypasses_pool` (pool has credentials). Both fail on current main and pass with the fix; the file is 67/67 locally.

## Root Cause

Two code paths conspired to drop the config `base_url`:

1. `_openrouter_should_use_pool()` (called from the credential-pool rung of `resolve_runtime_provider()`) only treated `cfg_provider in {"auto", "custom"}` as custom endpoints. When `cfg_provider == "openrouter"`, the mirror URL wasn't detected, so `should_use_pool = True` and the credential pool path was taken — which doesn't consult config `base_url`.

2. Even if the pool path was skipped, `_resolve_openrouter_runtime()` (now in `runtime_provider_backends.py`) only enabled `use_config_base_url` for `requested="auto"` or `requested="custom"`, never for `requested="openrouter"`.

## How to Test

```yaml
# config.yaml
model:
  provider: openrouter
  base_url: https://openrouter-mirror.example.com/api/v1
```

```bash
# Before fix: traffic goes to https://openrouter.ai/api/v1
# After fix: traffic goes to https://openrouter-mirror.example.com/api/v1
hermes chat -q "hello"
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (68/68 in test_runtime_provider_resolution.py)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] N/A — no config or architecture changes

## AI Disclosure

This bug was identified through code review with AI assistance.

