### PR TITLE
fix(cli): honor resume_display full mode without truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3083,24 +3083,33 @@ class HermesCLI:
         return True
 
     def _display_resumed_history(self):
-        """Render a compact recap of previous conversation messages.
+        """Render a recap of previous conversation messages.
+
+        Behavior depends on the ``resume_display`` config setting:
+        - ``minimal`` — skip display entirely.
+        - ``compact`` — truncated recap of the last 10 exchanges with
+          message length limits (300 chars user, 200 chars assistant).
+        - ``full`` — show the complete conversation history without
+          content truncation.
 
         Uses Rich markup with dim/muted styling so the recap is visually
-        distinct from the active conversation.  Caps the display at the
-        last ``MAX_DISPLAY_EXCHANGES`` user/assistant exchanges and shows
-        an indicator for earlier hidden messages.
+        distinct from the active conversation.
         """
         if not self.conversation_history:
             return
 
         # Check config: resume_display setting
+        #   "minimal"  → skip display entirely
+        #   "compact"  → truncated recap (last N exchanges, short messages)
+        #   "full"     → full history, no content truncation
         if self.resume_display == "minimal":
             return
 
-        MAX_DISPLAY_EXCHANGES = 10   # max user+assistant pairs to show
-        MAX_USER_LEN = 300           # truncate user messages
-        MAX_ASST_LEN = 200           # truncate assistant text
-        MAX_ASST_LINES = 3           # max lines of assistant text
+        is_compact = self.resume_display == "compact"
+        MAX_DISPLAY_EXCHANGES = 10   # max user+assistant pairs to show (compact only)
+        MAX_USER_LEN = 300           # truncate user messages (compact only)
+        MAX_ASST_LEN = 200           # truncate assistant text (compact only)
+        MAX_ASST_LINES = 3           # max lines of assistant text (compact only)
 
         def _strip_reasoning(text: str) -> str:
             """Remove <REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD> blocks
@@ -3142,7 +3151,7 @@ class HermesCLI:
                         elif isinstance(part, dict) and part.get("type") == "image_url":
                             parts.append("[image]")
                     text = " ".join(parts)
-                if len(text) > MAX_USER_LEN:
+                if len(text) > MAX_USER_LEN and is_compact:
                     text = text[:MAX_USER_LEN] + "..."
                 entries.append(("user", text))
 
@@ -3153,11 +3162,12 @@ class HermesCLI:
                 full_parts = []  # un-truncated version
                 if text:
                     full_parts.append(text)
-                    lines = text.splitlines()
-                    if len(lines) > MAX_ASST_LINES:
-                        text = "\n".join(lines[:MAX_ASST_LINES]) + " ..."
-                    if len(text) > MAX_ASST_LEN:
-                        text = text[:MAX_ASST_LEN] + "..."
+                    if is_compact:
+                        lines = text.splitlines()
+                        if len(lines) > MAX_ASST_LINES:
+                            text = "\n".join(lines[:MAX_ASST_LINES]) + " ..."
+                        if len(text) > MAX_ASST_LEN:
+                            text = text[:MAX_ASST_LEN] + "..."
                     parts.append(text)
                 if tool_calls:
                     tc_count = len(tool_calls)
@@ -3185,9 +3195,9 @@ class HermesCLI:
         if not entries:
             return
 
-        # Determine if we need to truncate
+        # Determine if we need to truncate (compact mode only)
         skipped = 0
-        if len(entries) > MAX_DISPLAY_EXCHANGES * 2:
+        if is_compact and len(entries) > MAX_DISPLAY_EXCHANGES * 2:
             skipped = len(entries) - MAX_DISPLAY_EXCHANGES * 2
             entries = entries[skipped:]
 
@@ -4222,6 +4232,8 @@ class HermesCLI:
                 f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
                 f" {len(self.conversation_history)} total)"
             )
+            # Show previous conversation recap (same as startup resume)
+            self._display_resumed_history()
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -162,8 +162,8 @@ class TestDisplayResumedHistory:
         assert "web_search" in output
         assert "web_extract" in output
 
-    def test_long_user_message_truncated(self):
-        cli = _make_cli()
+    def test_long_user_message_truncated_compact(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         long_text = "A" * 500
         cli.conversation_history = [
             {"role": "user", "content": long_text},
@@ -179,9 +179,9 @@ class TestDisplayResumedHistory:
         a_count = output.count("A")
         assert 200 <= a_count <= 310  # roughly 300 chars (±panel padding)
 
-    def test_long_assistant_message_truncated(self):
-        """Non-last assistant messages are still truncated."""
-        cli = _make_cli()
+    def test_long_assistant_message_truncated_compact(self):
+        """Non-last assistant messages are truncated in compact mode."""
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         long_text = "B" * 400
         cli.conversation_history = [
             {"role": "user", "content": "Tell me a lot."},
@@ -196,9 +196,9 @@ class TestDisplayResumedHistory:
         # The last assistant message shown in full
         assert "Short final reply." in output
 
-    def test_multiline_assistant_truncated(self):
-        """Non-last multiline assistant messages are truncated to 3 lines."""
-        cli = _make_cli()
+    def test_multiline_assistant_truncated_compact(self):
+        """Non-last multiline assistant messages are truncated to 3 lines in compact mode."""
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         multi = "\n".join([f"Line {i}" for i in range(20)])
         cli.conversation_history = [
             {"role": "user", "content": "Show me lines."},
@@ -245,8 +245,8 @@ class TestDisplayResumedHistory:
         assert "Line 10" in output
         assert "Line 19" in output
 
-    def test_large_history_shows_truncation_indicator(self):
-        cli = _make_cli()
+    def test_large_history_shows_truncation_indicator_compact(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         cli.conversation_history = _large_history(n_exchanges=15)
         output = self._capture_display(cli)
 
@@ -278,6 +278,50 @@ class TestDisplayResumedHistory:
         output = self._capture_display(cli)
 
         assert output.strip() == ""
+
+    def test_full_mode_no_user_message_truncation(self):
+        """Full mode (default) shows complete user messages without truncation."""
+        cli = _make_cli()
+        long_text = "A" * 500
+        cli.conversation_history = [
+            {"role": "user", "content": long_text},
+            {"role": "assistant", "content": "OK."},
+        ]
+        output = self._capture_display(cli)
+
+        # All 500 chars should be present (Rich panel may wrap lines)
+        assert output.count("A") >= 490
+        # No truncation indicator
+        assert "A" * 300 + "..." not in output
+
+    def test_full_mode_no_assistant_message_truncation(self):
+        """Full mode shows all assistant messages in full, not just the last."""
+        cli = _make_cli()
+        long_text = "B" * 400
+        cli.conversation_history = [
+            {"role": "user", "content": "Tell me a lot."},
+            {"role": "assistant", "content": long_text},
+            {"role": "user", "content": "And more?"},
+            {"role": "assistant", "content": "Short final reply."},
+        ]
+        output = self._capture_display(cli)
+
+        # All 400 B chars should be present (Rich panel may wrap lines)
+        assert output.count("B") >= 390
+        # No truncation indicator
+        assert "..." not in output.split("And more?")[0]
+        assert "Short final reply." in output
+
+    def test_full_mode_shows_all_exchanges(self):
+        """Full mode shows all exchanges, no exchange count limit."""
+        cli = _make_cli()
+        cli.conversation_history = _large_history(n_exchanges=15)
+        output = self._capture_display(cli)
+
+        # All exchanges should be present (no truncation indicator)
+        assert "earlier messages" not in output
+        assert "Question #1" in output
+        assert "Question #15" in output
 
     def test_panel_has_title(self):
         cli = _make_cli()


### PR DESCRIPTION
**What**: Fix the `resume_display: full` config setting which was still truncating messages despite the name.

**Why**: The 'full' mode applied hard-coded truncation limits:
- User messages: 300 chars max
- Assistant messages: 200 chars / 3 lines max
- Only last 10 exchanges shown
This was misleading — users who set `full` expected complete history.

Additionally, the `/resume` mid-conversation command only printed a one-liner summary without showing the previous conversation recap panel.

**How**:
- `full` mode now shows all messages without content truncation or exchange limits
- Added `compact` mode preserving the old truncated behavior for users who prefer it
- `/resume` command now calls `_display_resumed_history()` to show the recap panel (consistent with startup resume behavior)
- Updated tests: truncation tests explicitly use `compact`, added new tests for `full` mode

**How to test**:
1. Resume a session with long history — should see complete messages
2. Set `resume_display: compact` in config.yaml — should see truncated recap
3. Use `/resume` mid-conversation — should show recap panel

**Platforms tested**: macOS (CLI), 32/32 resume display tests passing