### PR TITLE
fix(gateway): evict cached agent on auto-reset to prevent stale conte…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3211,6 +3211,11 @@ class GatewayRunner:
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
 
+            # Evict cached agent to prevent stale context_compressor._previous_summary
+            # from leaking into the new session after auto-reset (daily/idle/suspended).
+            # Follow-up to #9893 which only handled compression_exhausted case.
+            self._evict_cached_agent(session_key)
+
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.
         # Only inject on NEW sessions — ongoing conversations already have the


### PR DESCRIPTION
…xt summary leak

When a session is auto-reset by daily schedule, idle timeout, or suspended state, the agent cache was not being cleared. This caused the old agent's context_compressor._previous_summary to leak into the new session, mixing old conversation history into new compaction summaries.

This was the root cause of the "skin making history" appearing after compaction in fresh sessions reported by the user.

Follow-up to #9893 which only handled compression_exhausted case.

Changes:
- Add _evict_cached_agent(session_key) call after was_auto_reset check
- Covers daily, idle, and suspended auto-reset scenarios
- Matches the behavior of manual /reset command

Related tests: test_session_boundary_hooks, test_async_memory_flush, test_session_reset_notify, test_session_reset_fix - all passing.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

fix(gateway): evict cached agent on auto-reset to prevent stale context summary leak
**Description:**
### Problem
When sessions are auto-reset (daily schedule, idle timeout, or suspended state), the cached agent instance is not cleared. This causes the `_previous_summary` from `context_compressor.py` to persist across session boundaries.

**Symptom:** After context compaction in a new session, summaries contain content from previous sessions (e.g., old conversations leaking into unrelated sessions).

### Root Cause
- `AIAgent` instances are cached in `_agent_cache` for performance
- Auto-reset logic clears session state but **not** the cached agent
- The `context_compressor._previous_summary` persists in the cached agent
- Manual `/reset` command correctly evicts the cached agent, but auto-reset paths did not

### Solution
Add `_evict_cached_agent(session_key)` call after `was_auto_reset` handling, mirroring the behavior of manual `/reset` command.

This follows the same pattern introduced in #9893 which fixed the `compression_exhausted` case.

### Changes
- `gateway/run.py`: Added agent cache eviction on auto-reset

### Testing
- All existing tests pass
```

---