### PR TITLE
fix: register missing Feishu WebSocket event handlers

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1219,6 +1219,8 @@ class FeishuAdapter(BasePlatformAdapter):
             .register_p2_card_action_trigger(self._on_card_action_trigger)
             .register_p2_im_chat_member_bot_added_v1(self._on_bot_added_to_chat)
             .register_p2_im_chat_member_bot_deleted_v1(self._on_bot_removed_from_chat)
+            .register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(self._on_p2p_chat_entered)
+            .register_p2_im_message_recalled_v1(self._on_message_recalled)
             .build()
         )
 
@@ -1819,6 +1821,12 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = str(getattr(event, "chat_id", "") or "")
         logger.info("[Feishu] Bot removed from chat: %s", chat_id)
         self._chat_info_cache.pop(chat_id, None)
+
+    def _on_p2p_chat_entered(self, data: Any) -> None:
+        logger.debug("[Feishu] User entered P2P chat with bot")
+
+    def _on_message_recalled(self, data: Any) -> None:
+        logger.debug("[Feishu] Message recalled by user")
 
     def _on_reaction_event(self, event_type: str, data: Any) -> None:
         """Route user reactions on bot messages as synthetic text events."""


### PR DESCRIPTION
## Summary

The Feishu adapter's WebSocket event dispatcher was missing handlers for two common events that the lark-oapi SDK pushes over the long-connection, causing persistent `processor not found` ERROR logs:

- `im.chat.access_event.bot_p2p_chat_entered_v1` — fired when a user opens a P2P chat with the bot
- `im.message.recalled_v1` — fired when a user unsends/recalls a message

The webhook dispatch path already had an `else: logger.debug("Ignoring...")` fallback for unknown events, but the WebSocket path uses the SDK's `EventDispatcherHandler` which raises an error when no processor is registered for an event type.

## Changes

- Register `register_p2_im_chat_access_event_bot_p2p_chat_entered_v1` with a no-op debug-logged handler
- Register `register_p2_im_message_recalled_v1` with a no-op debug-logged handler

Both handlers log at `debug` level (consistent with how other non-critical events are handled) and return immediately — no behavior change beyond silencing the ERROR logs.

## Testing

- Verified the event handler builder produces 8 registered processors (was 6)
- Confirmed `bot_p2p_chat_entered_v1` and `im.message.recalled_v1` events are no longer logged as ERROR
- Gateway starts and connects normally with the new handlers