### PR TITLE
fix(agent): notify when credential-pool exhaustion activates fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4752,6 +4752,8 @@ class AIAgent:
                 )
                 self._swap_credential(next_entry)
                 return True, False
+            if self._try_activate_fallback():
+                return True, False
             return False, has_retried_429
 
         if effective_reason == FailoverReason.rate_limit:

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -335,6 +335,22 @@ class TestPoolRotationCycle:
         assert has_retried is False
         pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None)
 
+    def test_402_exhausted_pool_activates_fallback(self):
+        """402 with no remaining pool entry should activate fallback chain and count as recovery."""
+        agent, pool, _ = self._make_agent_with_pool(1)
+        agent._fallback_chain = [{"model": "fallback/model"}]
+        agent._fallback_index = 0
+        agent._try_activate_fallback = MagicMock(return_value=True)
+
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=402, has_retried_429=False
+        )
+
+        assert recovered is True
+        assert has_retried is False
+        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None)
+        agent._try_activate_fallback.assert_called_once()
+
     def test_no_pool_returns_false(self):
         """No pool should return (False, unchanged)."""
         from run_agent import AIAgent


### PR DESCRIPTION
## Summary
- activate the existing fallback chain when credential-pool rotation is exhausted during billing recovery
- preserve existing lifecycle notification behavior by reusing `_try_activate_fallback()`
- add a regression test covering exhausted-pool -> fallback activation

## Why
Issue #10476 reports that provider fallback triggered via credential-pool exhaustion is silent, unlike the normal `fallback_model` path. Today `_recover_with_credential_pool()` returns failure immediately when billing rotation has no next credential, so the existing fallback notifier never runs.

## Testing
- added `tests/agent/test_credential_pool_routing.py::test_402_exhausted_pool_activates_fallback`

Fixes #10476