### PR TITLE
fix(gateway): report permission-limited manual gateways

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -430,11 +430,17 @@ def get_running_pid() -> Optional[int]:
         remove_pid_file()
         return None
 
+    permission_limited = False
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except ProcessLookupError:
         remove_pid_file()
         return None
+    except PermissionError:
+        # The PID exists but belongs to another user or is hidden by procfs.
+        # Keep the PID record so status checks can still report a running
+        # gateway even when the current session cannot manage it directly.
+        permission_limited = True
 
     recorded_start = record.get("start_time")
     current_start = _get_process_start_time(pid)
@@ -442,10 +448,12 @@ def get_running_pid() -> Optional[int]:
         remove_pid_file()
         return None
 
-    if not _looks_like_gateway_process(pid):
+    if not permission_limited and not _looks_like_gateway_process(pid):
         if not _record_looks_like_gateway(record):
             remove_pid_file()
             return None
+    elif permission_limited and not _record_looks_like_gateway(record):
+        return None
 
     return pid
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
-from gateway.status import terminate_pid
+from gateway.status import get_running_pid, terminate_pid
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
@@ -3119,9 +3119,17 @@ def gateway_command(args):
         else:
             # Check for manually running processes
             pids = find_gateway_pids()
+            pid_file_fallback = False
+            if not pids:
+                pid = get_running_pid()
+                if pid is not None:
+                    pids = [pid]
+                    pid_file_fallback = True
             if pids:
                 print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
                 print("  (Running manually, not as a system service)")
+                if pid_file_fallback:
+                    print("  Process details are only visible via the PID file; it may be owned by another user or hidden by system permissions.")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
                     print()

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -63,6 +63,25 @@ class TestGatewayPidState:
 
         assert status.get_running_pid() == os.getpid()
 
+    def test_get_running_pid_keeps_permission_limited_gateway_pid(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 4242,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise PermissionError("operation not permitted")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+
+        assert status.get_running_pid() == 4242
+        assert pid_path.exists()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -267,3 +267,20 @@ class TestWaitForGatewayExit:
 
         assert killed == 2
         assert calls == [(11, True), (22, True)]
+
+
+def test_gateway_status_falls_back_to_pid_file_when_process_visibility_is_limited(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_termux", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda exclude_pids=None, all_profiles=False: [])
+    monkeypatch.setattr(gateway, "get_running_pid", lambda: 4242)
+    monkeypatch.setattr(gateway, "_runtime_health_lines", lambda: [])
+
+    gateway.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+
+    out = capsys.readouterr().out
+    assert "Gateway is running (PID: 4242)" in out
+    assert "PID file" in out
+    assert "owned by another user" in out


### PR DESCRIPTION
## Summary
- fall back to the gateway PID file when manual status cannot enumerate the process via ps
- treat PermissionError from PID probes as a visibility boundary instead of deleting the PID record
- add regression coverage for permission-limited PID detection and status output

## Testing
- python3 -m pytest -o addopts='' tests/gateway/test_status.py tests/hermes_cli/test_gateway.py

Fixes #10669