### PR TITLE
fix: emit status notification on credential pool rotation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1885,9 +1885,10 @@ class AIAgent:
             self._vprint(f"{self.log_prefix}{message}", force=True)
         except Exception:
             pass
-        if self.status_callback:
+        status_cb = getattr(self, "status_callback", None)
+        if status_cb:
             try:
-                self.status_callback("lifecycle", message)
+                status_cb("lifecycle", message)
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
 
@@ -4898,6 +4899,11 @@ class AIAgent:
                     getattr(next_entry, "id", "?"),
                 )
                 self._swap_credential(next_entry)
+                # Emit status notification to inform user of provider switch (#10476)
+                self._emit_status(
+                    f"🔄 Credential exhausted ({rotate_status}) — rotated to: "
+                    f"{getattr(next_entry, 'id', 'next credential')}"
+                )
                 return True, False
             return False, has_retried_429
 
@@ -4913,6 +4919,11 @@ class AIAgent:
                     getattr(next_entry, "id", "?"),
                 )
                 self._swap_credential(next_entry)
+                # Emit status notification to inform user of provider switch (#10476)
+                self._emit_status(
+                    f"🔄 Rate limited ({rotate_status}) — rotated to: "
+                    f"{getattr(next_entry, 'id', 'next credential')}"
+                )
                 return True, False
             return False, True
 
@@ -4933,6 +4944,11 @@ class AIAgent:
                     getattr(next_entry, "id", "?"),
                 )
                 self._swap_credential(next_entry)
+                # Emit status notification to inform user of provider switch (#10476)
+                self._emit_status(
+                    f"🔄 Auth failed ({rotate_status}) — rotated to: "
+                    f"{getattr(next_entry, 'id', 'next credential')}"
+                )
                 return True, False
 
         return False, has_retried_429


### PR DESCRIPTION
## Summary
Fixes inconsistent notification behavior when credential pool rotation causes a provider switch.

## Root Cause
When `fallback_model` triggers a provider switch, Hermes correctly notifies the user via `_emit_status()`. However, when credential pool exhaustion causes the same provider switch, no notification was sent. The user had no idea they were talking to a different AI.

## Fix
Add `_emit_status()` calls in `_recover_with_credential_pool()` when credentials are rotated:
- Billing exhaustion (402): "🔄 Credential exhausted (402) — rotated to: {entry_id}"
- Rate limit (429): "🔄 Rate limited (429) — rotated to: {entry_id}"
- Auth failure (401): "🔄 Auth failed (401) — rotated to: {entry_id}"

Also fixed `_emit_status()` to use `getattr()` for `status_callback` to handle edge cases where the attribute doesn't exist (e.g., in test agents).

## Test Plan
- [x] All credential pool routing tests pass
- [x] Manual verification of status emission

Closes NousResearch/hermes-agent#10476