### PR TITLE
fix: honor config.yaml base_url for explicit openrouter requests

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -447,6 +447,9 @@ def _resolve_openrouter_runtime(
                 use_config_base_url = True
         elif requested_norm == "custom" and cfg_provider == "custom":
             use_config_base_url = True
+        elif requested_norm == "openrouter" and cfg_provider == "openrouter":
+            # Honor config base_url for explicit openrouter requests (#10622)
+            use_config_base_url = True
 
     base_url = (
         (explicit_base_url or "").strip()


### PR DESCRIPTION
## Summary
Fixes explicit openrouter runtime ignoring config.yaml base_url mirror settings.

## Root Cause
`_resolve_openrouter_runtime()` only enabled `use_config_base_url` for 'auto' and 'custom' provider requests. When explicitly requesting `openrouter` provider with a config.yaml base_url mirror, the mirror URL was silently ignored and the hardcoded OpenRouter URL was used instead.

## Fix
Add a branch to handle `requested_norm == 'openrouter'` with `cfg_provider == 'openrouter'`, enabling `use_config_base_url` for this case.

## Changes
- Added elif branch in `_resolve_openrouter_runtime()` to honor config base_url when explicitly requesting openrouter provider

## Test Plan
- [x] All runtime provider resolution tests pass (67 tests)
- [x] Manual verification of the fix logic

Closes NousResearch/hermes-agent#10622