### PR TITLE
fix: home channel auto-prompt now checks yaml config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3806,7 +3806,12 @@ class GatewayRunner:
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-            if not os.getenv(env_key):
+            # Check env var first, then fall back to yaml config (#10581)
+            home_channel_set = (
+                os.getenv(env_key)
+                or self.config.get_home_channel(source.platform)
+            )
+            if not home_channel_set:
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     await adapter.send(


### PR DESCRIPTION
## Summary
Fixes the home channel auto-prompt to check yaml config in addition to env var.

## Root Cause
The one-time home channel prompt only checked the env var (`os.getenv(f"{PLATFORM}_HOME_CHANNEL")`) but never consulted the yaml-persisted config that `/sethome` writes. This caused the prompt to re-fire for fresh sessions even after a user had already run `/sethome`.

## Fix
Check both env var and `config.get_home_channel()` before showing the prompt. The prompt now only appears if neither source has a home channel set.

## Changes
- Modified home channel check in `gateway/run.py` to check both env var and yaml config before showing the one-time prompt

## Test Plan
- [x] All home channel related tests pass (8 tests)
- [x] Manual verification of the fix logic

Closes NousResearch/hermes-agent#10581