### PR TITLE
fix: pass correct arguments in summary model fallback retry

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -730,7 +730,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60


### PR DESCRIPTION
## Problem

In `agent/context_compressor.py`, when the configured summary model becomes unavailable (404/503), the fallback path attempts to retry with the main model:

```python
return self._generate_summary(messages, summary_budget)  # retry immediately
```

But the method signature is:
```python
def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None)
```

**Two issues:**
1. `messages` is **not defined** in `_generate_summary()` scope — causes `NameError`
2. `summary_budget` (an int) is passed as `focus_topic` (expects string or None)

**Result:** The summary model fallback *never works*. Instead of gracefully falling back to the main model, compression crashes with a `NameError`.

## Fix

```python
return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
```

Pass the correct variables that are in scope:
- `turns_to_summarize` — the conversation turns to summarize (was `messages`, which does not exist)
- `focus_topic=focus_topic` — the optional focus topic from `/compress <focus>` (was `summary_budget`, an integer)

Closes #10721