### PR TITLE
fix(matrix): register MembershipEventDispatcher for invite auto-join

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -537,6 +537,12 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Register event handlers.
         from mautrix.client import InternalEventType as IntEvt
+        from mautrix.client.dispatcher import MembershipEventDispatcher
+
+        # MembershipEventDispatcher converts raw ROOM_MEMBER state events
+        # into InternalEventType.INVITE / JOIN / LEAVE etc.  Without it,
+        # the INVITE handler below never fires and the bot cannot auto-join.
+        client.add_dispatcher(MembershipEventDispatcher)
 
         client.add_event_handler(EventType.ROOM_MESSAGE, self._on_room_message)
         client.add_event_handler(EventType.REACTION, self._on_reaction)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -108,12 +108,23 @@ def _make_fake_mautrix():
         def add_event_handler(self, event_type, handler):
             self._event_handlers.setdefault(event_type, []).append(handler)
 
+        def add_dispatcher(self, dispatcher_type):
+            pass
+
     class InternalEventType:
         INVITE = "internal.invite"
 
     mautrix_client.Client = Client
     mautrix_client.InternalEventType = InternalEventType
     mautrix.client = mautrix_client
+
+    # --- mautrix.client.dispatcher ---
+    mautrix_client_dispatcher = types.ModuleType("mautrix.client.dispatcher")
+
+    class MembershipEventDispatcher:
+        pass
+
+    mautrix_client_dispatcher.MembershipEventDispatcher = MembershipEventDispatcher
 
     # --- mautrix.client.state_store ---
     mautrix_client_state_store = types.ModuleType("mautrix.client.state_store")
@@ -200,6 +211,7 @@ def _make_fake_mautrix():
         "mautrix.api": mautrix_api,
         "mautrix.types": mautrix_types,
         "mautrix.client": mautrix_client,
+        "mautrix.client.dispatcher": mautrix_client_dispatcher,
         "mautrix.client.state_store": mautrix_client_state_store,
         "mautrix.crypto": mautrix_crypto,
         "mautrix.crypto.store": mautrix_crypto_store,


### PR DESCRIPTION
## Summary

- Register `MembershipEventDispatcher` on the mautrix `Client` so that `InternalEventType.INVITE` events are dispatched and the bot can auto-join rooms
- Add corresponding stub module and method to the test mock

Since the matrix-nio to mautrix-python migration in #7518, `InternalEventType.INVITE` was never dispatched because `MembershipEventDispatcher` — which converts raw `ROOM_MEMBER` state events into `INVITE`/`JOIN`/`LEAVE` internal events — was not registered on the client. The bot connected and synced successfully but silently ignored all room invites, so it never joined rooms or processed messages.

Fixes #10725

## Test plan

- [x] 156 Matrix-related tests pass (test_matrix, test_matrix_mention, test_matrix_voice, test_setup_matrix_e2ee)
- [x] Manually verified on a live Matrix homeserver — bot now auto-joins on invite and processes messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)