### PR TITLE
fix(update): warn when configured gateway extras stay missing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3814,6 +3814,63 @@ def _load_installable_optional_extras() -> list[str]:
     return referenced
 
 
+def _warn_about_missing_configured_optional_deps(
+    failed_extras: list[str],
+    install_cmd_prefix: list[str],
+) -> None:
+    """Warn when update fallback leaves configured optional deps unavailable."""
+    if not failed_extras:
+        return
+
+    try:
+        import importlib.util
+        import shlex
+        from gateway.config import Platform, load_gateway_config
+    except Exception:
+        return
+
+    failed = set(failed_extras)
+    platform_checks = {
+        Platform.TELEGRAM: ({"messaging"}, "messaging", "telegram", "python-telegram-bot"),
+        Platform.DISCORD: ({"messaging"}, "messaging", "discord", "discord.py"),
+        Platform.SLACK: ({"messaging", "slack"}, "slack", "slack_bolt", "slack-bolt"),
+        Platform.MATRIX: ({"matrix"}, "matrix", "mautrix", "mautrix"),
+        Platform.DINGTALK: ({"dingtalk"}, "dingtalk", "dingtalk_stream", "dingtalk-stream"),
+        Platform.FEISHU: ({"feishu"}, "feishu", "lark_oapi", "lark-oapi"),
+    }
+
+    try:
+        configured_platforms = load_gateway_config().get_connected_platforms()
+    except Exception:
+        return
+
+    warnings: list[tuple[str, str, str]] = []
+    for platform in configured_platforms:
+        check = platform_checks.get(platform)
+        if not check:
+            continue
+        relevant_extras, preferred_extra, module_name, package_name = check
+        if failed.isdisjoint(relevant_extras):
+            continue
+        if importlib.util.find_spec(module_name) is not None:
+            continue
+        reinstall_cmd = " ".join(
+            shlex.quote(part)
+            for part in install_cmd_prefix + ["install", "-e", f".[{preferred_extra}]"]
+        )
+        warnings.append((platform.value, package_name, reinstall_cmd))
+
+    if not warnings:
+        return
+
+    print("  ⚠ Configured gateway dependencies are still missing after the update:")
+    for platform_name, package_name, reinstall_cmd in warnings:
+        print(
+            f"    - {platform_name} is configured, but `{package_name}` is still unavailable. "
+            "Restarting the gateway now may fail."
+        )
+        print(f"      Reinstall with: {reinstall_cmd}")
+
 
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
@@ -3857,6 +3914,7 @@ def _install_python_dependencies_with_optional_fallback(
         print(f"  ✓ Reinstalled optional extras individually: {', '.join(installed_extras)}")
     if failed_extras:
         print(f"  ⚠ Skipped optional extras that still failed: {', '.join(failed_extras)}")
+        _warn_about_missing_configured_optional_deps(failed_extras, install_cmd_prefix)
 
 
 def cmd_update(args):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -1,3 +1,4 @@
+import importlib.util
 from pathlib import Path
 from subprocess import CalledProcessError
 from types import SimpleNamespace
@@ -351,6 +352,53 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
     assert "retrying extras individually" in out
     assert "Reinstalled optional extras individually: mcp" in out
     assert "Skipped optional extras that still failed: matrix" in out
+
+
+def test_cmd_update_warns_when_configured_gateway_extra_is_still_missing(monkeypatch, tmp_path, capsys):
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda: ["feishu", "mcp"])
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_xxx")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_xxx")
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "lark_oapi":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "fetch", "origin"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
+        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+            return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
+        if cmd == ["git", "pull", "origin", "main"]:
+            return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"]:
+            raise CalledProcessError(returncode=1, cmd=cmd)
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".", "--quiet"]:
+            return SimpleNamespace(returncode=0)
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[feishu]", "--quiet"]:
+            raise CalledProcessError(returncode=1, cmd=cmd)
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]", "--quiet"]:
+            return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    out = capsys.readouterr().out
+    assert "Configured gateway dependencies are still missing after the update" in out
+    assert "feishu is configured" in out
+    assert "lark-oapi" in out
+    assert "Restarting the gateway now may fail" in out
+    assert ".[feishu]" in out
 
 
 def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- keep the optional-extra fallback behavior, but add a high-signal warning when a configured gateway platform still lacks its dependency after fallback installs
- detect configured gateway platforms from the current Hermes config/env and check whether their runtime packages are still unavailable
- print an exact reinstall command so users can recover before restarting the gateway

## Testing
- python3 -m pytest -o addopts='' tests/hermes_cli/test_update_autostash.py

Fixes #10651