### PR TITLE
fix(gateway): preserve explicit delivery target IDs in delivery parsing

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -53,9 +53,10 @@ class DeliveryTarget:
         - "telegram" → Telegram home channel
         - "telegram:123456" → specific Telegram chat
         """
-        target = target.strip().lower()
-        
-        if target == "origin":
+        raw_target = target.strip()
+        normalized_target = raw_target.lower()
+
+        if normalized_target == "origin":
             if origin:
                 return cls(
                     platform=origin.platform,
@@ -66,26 +67,41 @@ class DeliveryTarget:
             else:
                 # Fallback to local if no origin
                 return cls(platform=Platform.LOCAL, is_origin=True)
-        
-        if target == "local":
+
+        if normalized_target == "local":
             return cls(platform=Platform.LOCAL)
-        
+
         # Check for platform:chat_id or platform:chat_id:thread_id format
-        if ":" in target:
-            parts = target.split(":", 2)
-            platform_str = parts[0]
-            chat_id = parts[1] if len(parts) > 1 else None
-            thread_id = parts[2] if len(parts) > 2 else None
+        if ":" in raw_target:
+            platform_token, target_ref = raw_target.split(":", 1)
+            platform_str = platform_token.strip().lower()
             try:
                 platform = Platform(platform_str)
+                target_ref = target_ref.strip()
+
+                # Matrix IDs inherently contain ":" (homeserver separator), so
+                # preserve the full remainder as chat_id instead of treating it
+                # as a thread suffix.
+                if platform == Platform.MATRIX and (
+                    target_ref.startswith("!") or target_ref.startswith("@")
+                ):
+                    return cls(
+                        platform=platform,
+                        chat_id=target_ref or None,
+                        is_explicit=True,
+                    )
+
+                parts = target_ref.split(":", 1)
+                chat_id = parts[0] if len(parts) > 0 else None
+                thread_id = parts[1] if len(parts) > 1 else None
                 return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)
-        
+
         # Just a platform name (use home channel)
         try:
-            platform = Platform(target)
+            platform = Platform(normalized_target)
             return cls(platform=platform)
         except ValueError:
             # Unknown platform, treat as local

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -12,6 +12,34 @@ class TestParseTargetPlatformChat:
         assert target.chat_id == "12345"
         assert target.is_explicit is True
 
+    def test_explicit_telegram_thread_target(self):
+        target = DeliveryTarget.parse("telegram:12345:678")
+        assert target.platform == Platform.TELEGRAM
+        assert target.chat_id == "12345"
+        assert target.thread_id == "678"
+        assert target.is_explicit is True
+
+    def test_explicit_slack_chat_preserves_case(self):
+        target = DeliveryTarget.parse("slack:C123ABC")
+        assert target.platform == Platform.SLACK
+        assert target.chat_id == "C123ABC"
+        assert target.thread_id is None
+        assert target.is_explicit is True
+
+    def test_explicit_matrix_room_preserves_full_id(self):
+        target = DeliveryTarget.parse("matrix:!RoomABC:example.org")
+        assert target.platform == Platform.MATRIX
+        assert target.chat_id == "!RoomABC:example.org"
+        assert target.thread_id is None
+        assert target.is_explicit is True
+
+    def test_explicit_matrix_user_preserves_full_id(self):
+        target = DeliveryTarget.parse("matrix:@Alice:example.org")
+        assert target.platform == Platform.MATRIX
+        assert target.chat_id == "@Alice:example.org"
+        assert target.thread_id is None
+        assert target.is_explicit is True
+
     def test_platform_only_no_chat_id(self):
         target = DeliveryTarget.parse("discord")
         assert target.platform == Platform.DISCORD
@@ -63,6 +91,25 @@ class TestTargetToStringRoundtrip:
         reparsed = DeliveryTarget.parse(s)
         assert reparsed.platform == Platform.TELEGRAM
         assert reparsed.chat_id == "999"
+
+    def test_explicit_slack_chat_roundtrip_preserves_case(self):
+        target = DeliveryTarget.parse("slack:C123ABC")
+        s = target.to_string()
+        assert s == "slack:C123ABC"
+
+        reparsed = DeliveryTarget.parse(s)
+        assert reparsed.platform == Platform.SLACK
+        assert reparsed.chat_id == "C123ABC"
+
+    def test_explicit_matrix_room_roundtrip_preserves_full_id(self):
+        target = DeliveryTarget.parse("matrix:!RoomABC:example.org")
+        s = target.to_string()
+        assert s == "matrix:!RoomABC:example.org"
+
+        reparsed = DeliveryTarget.parse(s)
+        assert reparsed.platform == Platform.MATRIX
+        assert reparsed.chat_id == "!RoomABC:example.org"
+        assert reparsed.thread_id is None
 
 
 


### PR DESCRIPTION
## Summary

This fixes `DeliveryTarget.parse()` so explicit delivery targets preserve the original ID payload instead of lowercasing and mis-splitting it.

Before this change:
- `slack:C123ABC` was parsed as `chat_id="c123abc"`
- `matrix:!RoomABC:example.org` was parsed as `chat_id="!roomabc"` and `thread_id="example.org"`
- `matrix:@Alice:example.org` was parsed the same lossy way

After this change:
- only the platform token is normalized
- explicit target payloads are preserved verbatim
- Matrix room/user IDs keep their full homeserver-qualified form
- existing unambiguous thread syntax like `telegram:12345:678` still works

## Why

`DeliveryTarget.parse()` was lowercasing the entire target string and then using `split(":", 2)` for every platform. That works for simple numeric targets, but it breaks:
- case-sensitive channel IDs like Slack channel IDs
- platform IDs that legitimately contain `:`, especially Matrix room/user IDs

This is a small gateway bugfix with direct impact on cron delivery and explicit cross-platform routing.

## Changes

- updated `gateway/delivery.py` to normalize only the platform segment
- preserved the explicit target payload as-is
- treated Matrix `!room:server` and `@user:server` targets as full `chat_id` values instead of interpreting the homeserver colon as a thread separator
- added regression coverage in `tests/gateway/test_delivery.py`

## Tests

Passed:
- `python -m pytest tests/gateway/test_delivery.py -q`
- `python -m pytest tests/gateway/ -k delivery -q`

