### PR TITLE
feat(discord): add channel history tool

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -18,7 +18,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, Dict, Optional, Any
+from typing import Callable, Dict, Optional, Any, List
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +54,8 @@ from gateway.platforms.base import (
     cache_audio_from_url,
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
+    resolve_proxy_url,
+    proxy_kwargs_for_aiohttp,
 )
 from tools.url_safety import is_safe_url
 
@@ -78,6 +80,133 @@ def _clean_discord_id(entry: str) -> str:
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available."""
     return DISCORD_AVAILABLE
+
+
+def _discord_history_content(message: Dict[str, Any]) -> str:
+    """Return a useful content string for Discord history messages."""
+    content = (message.get("content") or "").strip()
+    if content:
+        return content
+
+    parts: List[str] = []
+    attachments = message.get("attachments") or []
+    if attachments:
+        names = [a.get("filename") or "attachment" for a in attachments[:3] if isinstance(a, dict)]
+        if names:
+            parts.append("attachments: " + ", ".join(names))
+        extra = len(attachments) - len(names)
+        if extra > 0:
+            parts.append(f"+{extra} more attachment(s)")
+
+    embeds = message.get("embeds") or []
+    if embeds:
+        embed_titles = [e.get("title") for e in embeds[:2] if isinstance(e, dict) and e.get("title")]
+        if embed_titles:
+            parts.append("embeds: " + "; ".join(embed_titles))
+        elif not attachments:
+            parts.append(f"{len(embeds)} embed(s)")
+
+    stickers = message.get("sticker_items") or []
+    if stickers:
+        parts.append(f"{len(stickers)} sticker(s)")
+
+    return " | ".join(parts)
+
+
+def _normalize_discord_history_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a Discord API message payload for Hermes tool output."""
+    author = message.get("author") or {}
+    reference = message.get("message_reference") or {}
+    attachments = message.get("attachments") or []
+    return {
+        "message_id": str(message.get("id") or ""),
+        "channel_id": str(message.get("channel_id") or ""),
+        "timestamp": message.get("timestamp") or "",
+        "author": author.get("global_name") or author.get("username") or author.get("id") or "unknown",
+        "author_id": str(author.get("id") or ""),
+        "is_bot": bool(author.get("bot", False)),
+        "content": _discord_history_content(message),
+        "raw_content": message.get("content") or "",
+        "reply_to_message_id": str(reference.get("message_id") or "") if reference.get("message_id") else None,
+        "attachment_names": [a.get("filename") or "attachment" for a in attachments if isinstance(a, dict)],
+        "type": int(message.get("type") or 0),
+    }
+
+
+async def fetch_channel_history_via_api(
+    token: str,
+    channel_id: str,
+    *,
+    limit: int = 20,
+    before_message_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Fetch recent Discord channel/thread messages via the official REST API."""
+    if not token:
+        raise ValueError("Discord bot token is missing")
+
+    channel_id = str(channel_id or "").strip()
+    if not channel_id or not channel_id.isdigit():
+        raise ValueError("Discord channel_id must be a numeric snowflake")
+
+    try:
+        limit_value = int(limit)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer") from exc
+    limit_value = max(1, min(limit_value, 50))
+
+    if before_message_id:
+        before_message_id = str(before_message_id).strip()
+        if not before_message_id.isdigit():
+            raise ValueError("before_message_id must be a numeric snowflake")
+
+    try:
+        import aiohttp
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise RuntimeError("aiohttp not installed. Run: pip install aiohttp") from exc
+
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Accept": "application/json",
+    }
+    params = {"limit": str(limit_value)}
+    if before_message_id:
+        params["before"] = before_message_id
+
+    proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+    session_kwargs, request_kwargs = proxy_kwargs_for_aiohttp(proxy_url)
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=30),
+        **session_kwargs,
+    ) as session:
+        async with session.get(url, headers=headers, params=params, **request_kwargs) as resp:
+            if resp.status == 401:
+                raise PermissionError("Discord bot token is invalid or unauthorized")
+            if resp.status == 403:
+                raise PermissionError(
+                    "Discord denied channel history access. Check View Channel and Read Message History permissions for this bot."
+                )
+            if resp.status == 404:
+                raise LookupError(f"Discord channel {channel_id} was not found or is not visible to the bot")
+            if resp.status >= 400:
+                detail = (await resp.text()).strip()
+                if len(detail) > 200:
+                    detail = detail[:200] + "..."
+                raise RuntimeError(
+                    f"Discord API request failed with HTTP {resp.status}: {detail or 'no response body'}"
+                )
+            payload = await resp.json(content_type=None)
+
+    if not isinstance(payload, list):
+        raise RuntimeError("Discord API returned an unexpected payload while fetching history")
+
+    normalized = [
+        _normalize_discord_history_message(message)
+        for message in reversed(payload)
+        if isinstance(message, dict)
+    ]
+    return normalized
 
 
 class VoiceReceiver:

--- a/tests/gateway/test_discord_history_api.py
+++ b/tests/gateway/test_discord_history_api.py
@@ -1,0 +1,117 @@
+import json
+
+import pytest
+
+from gateway.platforms.discord import fetch_channel_history_via_api
+
+
+class _FakeResponse:
+    def __init__(self, status, payload):
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self, content_type=None):
+        return self._payload
+
+    async def text(self):
+        return json.dumps(self._payload)
+
+
+class _FakeSession:
+    def __init__(self, payload, recorder):
+        self._payload = payload
+        self._recorder = recorder
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None, params=None, **kwargs):
+        self._recorder["url"] = url
+        self._recorder["headers"] = headers
+        self._recorder["params"] = params
+        self._recorder["kwargs"] = kwargs
+        return _FakeResponse(200, self._payload)
+
+
+class _FakeAioHttp:
+    class ClientTimeout:
+        def __init__(self, total):
+            self.total = total
+
+    def __init__(self, payload, recorder):
+        self._payload = payload
+        self._recorder = recorder
+
+    def ClientSession(self, **kwargs):
+        self._recorder["session_kwargs"] = kwargs
+        return _FakeSession(self._payload, self._recorder)
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_history_via_api_normalizes_order_and_bot_messages(monkeypatch):
+    recorder = {}
+    payload = [
+        {
+            "id": "2",
+            "channel_id": "123",
+            "timestamp": "2026-04-16T00:00:02Z",
+            "content": "bot reply",
+            "author": {"id": "900", "username": "Friday", "bot": True},
+            "type": 0,
+        },
+        {
+            "id": "1",
+            "channel_id": "123",
+            "timestamp": "2026-04-16T00:00:01Z",
+            "content": "",
+            "attachments": [{"filename": "note.png"}],
+            "author": {"id": "100", "username": "Trouble", "global_name": "Trouble", "bot": False},
+            "type": 0,
+        },
+    ]
+
+    monkeypatch.setattr("gateway.platforms.discord.resolve_proxy_url", lambda platform_env_var=None: None)
+    monkeypatch.setattr("gateway.platforms.discord.proxy_kwargs_for_aiohttp", lambda proxy_url: ({}, {}))
+    monkeypatch.setattr("aiohttp.ClientSession", _FakeAioHttp(payload, recorder).ClientSession)
+    monkeypatch.setattr("aiohttp.ClientTimeout", _FakeAioHttp.ClientTimeout)
+
+    messages = await fetch_channel_history_via_api("TOKEN", "123", limit=20)
+
+    assert [m["message_id"] for m in messages] == ["1", "2"]
+    assert messages[0]["author"] == "Trouble"
+    assert messages[0]["content"] == "attachments: note.png"
+    assert messages[1]["is_bot"] is True
+    assert recorder["params"] == {"limit": "20"}
+    assert recorder["headers"]["Authorization"] == "Bot TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_history_via_api_reports_permission_error(monkeypatch):
+    class _ForbiddenResponse(_FakeResponse):
+        async def text(self):
+            return '{"message":"Missing Access"}'
+
+    class _ForbiddenSession(_FakeSession):
+        def get(self, url, headers=None, params=None, **kwargs):
+            return _ForbiddenResponse(403, {"message": "Missing Access"})
+
+    class _ForbiddenAioHttp(_FakeAioHttp):
+        def ClientSession(self, **kwargs):
+            return _ForbiddenSession([], {})
+
+    monkeypatch.setattr("gateway.platforms.discord.resolve_proxy_url", lambda platform_env_var=None: None)
+    monkeypatch.setattr("gateway.platforms.discord.proxy_kwargs_for_aiohttp", lambda proxy_url: ({}, {}))
+    monkeypatch.setattr("aiohttp.ClientSession", _ForbiddenAioHttp([], {}).ClientSession)
+    monkeypatch.setattr("aiohttp.ClientTimeout", _FakeAioHttp.ClientTimeout)
+
+    with pytest.raises(PermissionError, match="Read Message History"):
+        await fetch_channel_history_via_api("TOKEN", "123", limit=20)

--- a/tests/tools/test_discord_channel_history_tool.py
+++ b/tests/tools/test_discord_channel_history_tool.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import Platform
+from tools.discord_channel_history_tool import (
+    _check_discord_channel_history,
+    discord_channel_history_tool,
+)
+
+
+def _discord_config(enabled=True, token="TOKEN"):
+    return SimpleNamespace(platforms={Platform.DISCORD: SimpleNamespace(enabled=enabled, token=token)})
+
+
+def test_tool_defaults_to_current_thread(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "111")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "222")
+
+    fetch_mock = AsyncMock(return_value=[{"message_id": "1", "author": "Trouble", "content": "hi", "timestamp": "2026-04-16T00:00:00Z"}])
+
+    with patch("gateway.config.load_gateway_config", return_value=_discord_config()), \
+         patch("tools.discord_channel_history_tool._run_async_tool", side_effect=lambda coro: asyncio.run(coro)), \
+         patch("gateway.platforms.discord.fetch_channel_history_via_api", fetch_mock):
+        result = json.loads(discord_channel_history_tool({}))
+
+    assert result["success"] is True
+    assert result["channel_id"] == "222"
+    assert result["source"] == "current_thread"
+    assert result["count"] == 1
+    fetch_mock.assert_awaited_once_with("TOKEN", "222", limit=20, before_message_id=None)
+
+
+def test_tool_errors_without_discord_context(monkeypatch):
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
+
+    with patch("gateway.config.load_gateway_config", return_value=_discord_config()), \
+         patch("tools.discord_channel_history_tool._run_async_tool", side_effect=lambda coro: asyncio.run(coro)):
+        result = json.loads(discord_channel_history_tool({}))
+
+    assert "No Discord channel context found" in result["error"]
+
+
+def test_tool_supports_explicit_channel_id(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "111")
+    fetch_mock = AsyncMock(return_value=[])
+
+    with patch("gateway.config.load_gateway_config", return_value=_discord_config()), \
+         patch("tools.discord_channel_history_tool._run_async_tool", side_effect=lambda coro: asyncio.run(coro)), \
+         patch("gateway.platforms.discord.fetch_channel_history_via_api", fetch_mock):
+        result = json.loads(discord_channel_history_tool({"channel_id": "333", "limit": 25, "before_message_id": "999"}))
+
+    assert result["success"] is True
+    assert result["channel_id"] == "333"
+    assert result["source"] == "explicit_channel"
+    fetch_mock.assert_awaited_once_with("TOKEN", "333", limit=25, before_message_id="999")
+
+
+def test_check_fn_only_exposes_tool_in_discord_sessions(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    assert _check_discord_channel_history() is True
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    assert _check_discord_channel_history() is False

--- a/tools/discord_channel_history_tool.py
+++ b/tools/discord_channel_history_tool.py
@@ -1,0 +1,154 @@
+"""Discord-only tool for reading recent channel/thread history."""
+
+from __future__ import annotations
+
+from tools.registry import registry, tool_error, tool_result
+
+
+DISCORD_CHANNEL_HISTORY_SCHEMA = {
+    "name": "discord_channel_history",
+    "description": (
+        "Read recent messages from the current Discord channel or thread. "
+        "Omit channel_id/thread_id to use the current conversation context. "
+        "Returns the most recent messages including other bots, with author/content/timestamp/message_id."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "limit": {
+                "type": "integer",
+                "description": "How many recent messages to fetch. Default 20, max 50.",
+            },
+            "channel_id": {
+                "type": "string",
+                "description": "Optional Discord parent channel ID. Omit to use the current channel.",
+            },
+            "thread_id": {
+                "type": "string",
+                "description": "Optional Discord thread ID. If provided, reads that thread instead of the parent channel.",
+            },
+            "before_message_id": {
+                "type": "string",
+                "description": "Optional message ID anchor. When provided, fetches messages before that message.",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _run_async_tool(coro):
+    from model_tools import _run_async
+
+    return _run_async(coro)
+
+
+def _check_discord_channel_history():
+    """Expose the tool inside Discord sessions, or from CLI when Discord gateway is running."""
+    from gateway.session_context import get_session_env
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    if platform:
+        return platform == "discord"
+
+    try:
+        from gateway.status import is_gateway_running
+        if not is_gateway_running():
+            return False
+
+        from gateway.config import load_gateway_config, Platform
+
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.DISCORD)
+        return bool(pconfig and pconfig.enabled and pconfig.token)
+    except Exception:
+        return False
+
+
+def _resolve_limit(raw_value) -> int:
+    if raw_value in (None, ""):
+        return 20
+    try:
+        limit = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer") from exc
+    return max(1, min(limit, 50))
+
+
+def _resolve_target_ids(args: dict) -> tuple[str, str]:
+    from gateway.session_context import get_session_env
+
+    explicit_thread_id = str(args.get("thread_id") or "").strip()
+    explicit_channel_id = str(args.get("channel_id") or "").strip()
+
+    if explicit_thread_id:
+        return explicit_thread_id, "explicit_thread"
+    if explicit_channel_id:
+        return explicit_channel_id, "explicit_channel"
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    if platform and platform != "discord":
+        raise ValueError("discord_channel_history is only available in Discord sessions")
+
+    current_thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip()
+    if current_thread_id:
+        return current_thread_id, "current_thread"
+
+    current_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    if current_chat_id:
+        return current_chat_id, "current_channel"
+
+    raise ValueError(
+        "No Discord channel context found. Provide channel_id/thread_id explicitly or call this tool from a Discord conversation."
+    )
+
+
+async def _read_discord_channel_history(args: dict) -> dict:
+    from gateway.config import load_gateway_config, Platform
+    from gateway.platforms.discord import fetch_channel_history_via_api
+
+    limit = _resolve_limit(args.get("limit"))
+    channel_id, source = _resolve_target_ids(args)
+    before_message_id = args.get("before_message_id")
+
+    config = load_gateway_config()
+    pconfig = config.platforms.get(Platform.DISCORD)
+    if not pconfig or not pconfig.enabled or not pconfig.token:
+        raise RuntimeError("Discord is not configured in the Hermes gateway")
+
+    messages = await fetch_channel_history_via_api(
+        pconfig.token,
+        channel_id,
+        limit=limit,
+        before_message_id=before_message_id,
+    )
+
+    return {
+        "success": True,
+        "platform": "discord",
+        "channel_id": channel_id,
+        "source": source,
+        "limit": limit,
+        "count": len(messages),
+        "order": "oldest_to_newest",
+        "messages": messages,
+    }
+
+
+def discord_channel_history_tool(args, **_kw):
+    try:
+        payload = _run_async_tool(_read_discord_channel_history(args or {}))
+        return tool_result(payload)
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+registry.register(
+    name="discord_channel_history",
+    toolset="messaging",
+    schema=DISCORD_CHANNEL_HISTORY_SCHEMA,
+    handler=discord_channel_history_tool,
+    check_fn=_check_discord_channel_history,
+    emoji="🧵",
+    max_result_size_chars=50_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -57,7 +57,7 @@ _HERMES_CORE_TOOLS = [
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
-    "send_message",
+    "send_message", "discord_channel_history",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 ]
@@ -127,8 +127,8 @@ TOOLSETS = {
     },
     
     "messaging": {
-        "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "description": "Cross-platform messaging: send messages and inspect Discord channel history when available.",
+        "tools": ["send_message", "discord_channel_history"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary
- add a  builtin tool for reading recent messages from the current Discord channel or thread
- expose a Discord REST helper that returns normalized message history including author, content, timestamp, message_id, and bot authors
- cover the new tool and REST normalization paths with tests

## Why
Hermes can already send messages in Discord, but it cannot inspect the recent channel context on demand. This blocks instructions like look at the message Trouble sent above unless the user manually forwards the content.

This change adds a bounded read-history capability so Discord sessions can reference recent channel context directly.

## Testing
- pytest -q tests/tools/test_discord_channel_history_tool.py tests/gateway/test_discord_history_api.py tests/hermes_cli/test_tools_config.py
- live smoke test against a real Discord channel, confirming the tool returned the latest 20 messages including bot messages
