### PR TITLE
Fix/model switch custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -54,6 +54,23 @@ logger = logging.getLogger(__name__)
 # Module-level flag: only warn once per process about stale OPENAI_BASE_URL.
 _stale_base_url_warned = False
 
+# Runtime model/provider override set by /model command — takes precedence over config.yaml.
+_runtime_model_override: str = ""
+_runtime_provider_override: str = ""
+_runtime_base_url_override: str = ""
+
+
+def set_runtime_model(model: str, provider: str = "", base_url: str = "") -> None:
+    """Override the model used by all auxiliary tasks (title gen, compression, etc).
+
+    Called by the /model command handler so auxiliary tasks use the same model
+    as the main agent instead of re-reading the default from config.yaml.
+    """
+    global _runtime_model_override, _runtime_provider_override, _runtime_base_url_override
+    _runtime_model_override = model or ""
+    _runtime_provider_override = provider or ""
+    _runtime_base_url_override = base_url or ""
+
 _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
@@ -807,9 +824,11 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
 def _read_main_model() -> str:
     """Read the user's configured main model from config.yaml.
 
-    config.yaml model.default is the single source of truth for the active
-    model. Environment variables are no longer consulted.
+    Checks runtime override (set by /model) first so all auxiliary tasks
+    (title generation, compression, etc.) use the same model as the main agent.
     """
+    if _runtime_model_override:
+        return _runtime_model_override
     try:
         from hermes_cli.config import load_config
         cfg = load_config()

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -847,9 +847,13 @@ def _read_main_model() -> str:
 def _read_main_provider() -> str:
     """Read the user's configured main provider from config.yaml.
 
+    Checks runtime override (set by /model) first so all auxiliary tasks
+    (title generation, compression, etc.) use the same provider as the main agent.
     Returns the lowercase provider id (e.g. "alibaba", "openrouter") or ""
     if not configured.
     """
+    if _runtime_provider_override:
+        return _runtime_provider_override
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -1234,9 +1238,10 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
-        if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
+        effective_base_url = runtime_base_url or _runtime_base_url_override
+        if effective_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
             resolved_provider = "custom"
-            explicit_base_url = runtime_base_url
+            explicit_base_url = effective_base_url
             explicit_api_key = runtime_api_key or None
         client, resolved = resolve_provider_client(
             resolved_provider,

--- a/cli.py
+++ b/cli.py
@@ -7554,13 +7554,21 @@ class HermesCLI:
         set_secret_capture_callback(self._secret_capture_callback)
 
         # Refresh provider credentials if needed (handles key rotation transparently)
-        # Preserve model if it was explicitly switched via /model — _ensure_runtime_credentials
-        # re-reads model from config.yaml and would overwrite the user's choice.
+        # Preserve model/provider/base_url if explicitly switched via /model —
+        # _ensure_runtime_credentials() re-reads from config.yaml and would overwrite
+        # the user's choice.
         _model_before_creds = self.model
+        _provider_before_creds = self.provider
+        _requested_provider_before_creds = self.requested_provider
+        _base_url_before_creds = self.base_url
         if not self._ensure_runtime_credentials():
             return None
         if _model_before_creds and _model_before_creds != self.model:
             self.model = _model_before_creds
+        if _provider_before_creds and _provider_before_creds != self.provider:
+            self.provider = _provider_before_creds
+            self.requested_provider = _requested_provider_before_creds
+            self.base_url = _base_url_before_creds
 
         turn_route = self._resolve_turn_agent_config(message)
         if turn_route["signature"] != self._active_agent_route_signature:

--- a/cli.py
+++ b/cli.py
@@ -2809,8 +2809,17 @@ class HermesCLI:
         if self.agent is not None:
             return True
 
+        # Preserve model if it was explicitly switched via /model before the agent
+        # was initialized — _ensure_runtime_credentials() re-reads model from
+        # config.yaml and would overwrite the user's choice (line 2739).
+        _model_before_creds = self.model
+
         if not self._ensure_runtime_credentials():
             return False
+
+        # Restore the explicitly switched model if credentials resolution replaced it
+        if _model_before_creds and _model_before_creds != self.model:
+            self.model = _model_before_creds
 
         # Initialize SQLite session store for CLI sessions (if not already done in __init__)
         if self._session_db is None:
@@ -4517,6 +4526,13 @@ class HermesCLI:
             self._explicit_base_url = result.base_url
         if result.api_mode:
             self.api_mode = result.api_mode
+
+        # Propagate model switch to auxiliary tasks (title generation, compression, etc.)
+        try:
+            from agent.auxiliary_client import set_runtime_model
+            set_runtime_model(result.new_model, result.target_provider, result.base_url or "")
+        except Exception:
+            pass
 
         if self.agent is not None:
             try:
@@ -7538,8 +7554,13 @@ class HermesCLI:
         set_secret_capture_callback(self._secret_capture_callback)
 
         # Refresh provider credentials if needed (handles key rotation transparently)
+        # Preserve model if it was explicitly switched via /model — _ensure_runtime_credentials
+        # re-reads model from config.yaml and would overwrite the user's choice.
+        _model_before_creds = self.model
         if not self._ensure_runtime_credentials():
             return None
+        if _model_before_creds and _model_before_creds != self.model:
+            self.model = _model_before_creds
 
         turn_route = self._resolve_turn_agent_config(message)
         if turn_route["signature"] != self._active_agent_route_signature:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1066,6 +1066,12 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            # Also include models from the `models` dict (multi-model entries)
+            models_dict = entry.get("models")
+            if isinstance(models_dict, dict):
+                for m in models_dict.keys():
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
 
         for slug, grp in groups.items():
             if slug in seen_slugs:

--- a/tests/test_model_switch_fixes.py
+++ b/tests/test_model_switch_fixes.py
@@ -142,3 +142,56 @@ def test_set_runtime_model_stores_provider_and_base_url():
     aux._runtime_model_override = ""
     aux._runtime_provider_override = ""
     aux._runtime_base_url_override = ""
+
+
+def test_set_runtime_model_overrides_read_main_provider():
+    """After set_runtime_model(), _read_main_provider() returns the override,
+    not the value from config.yaml."""
+    import agent.auxiliary_client as aux
+
+    aux._runtime_provider_override = ""
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider": "openrouter"}
+    }):
+        assert aux._read_main_provider() == "openrouter"
+
+        aux.set_runtime_model("switched/model", "custom", "http://localhost:1234/v1")
+        assert aux._read_main_provider() == "custom"
+
+    aux._runtime_model_override = ""
+    aux._runtime_provider_override = ""
+    aux._runtime_base_url_override = ""
+
+
+def test_resolve_auto_routes_through_switched_provider():
+    """After set_runtime_model() with a custom provider, _resolve_auto()
+    routes auxiliary tasks through the switched provider/base_url, not config."""
+    import agent.auxiliary_client as aux
+    from unittest.mock import MagicMock
+
+    aux._runtime_model_override = ""
+    aux._runtime_provider_override = ""
+    aux._runtime_base_url_override = ""
+
+    fake_client = MagicMock()
+    fake_client.__class__.__name__ = "OpenAI"
+
+    aux.set_runtime_model("local/model-x", "custom", "http://localhost:5000/v1")
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider": "openrouter", "default": "some/cloud-model"}
+    }):
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "local/model-x")) as mock_resolve:
+            client, model = aux._resolve_auto()
+
+    assert client is fake_client
+    assert model == "local/model-x"
+    call_kwargs = mock_resolve.call_args
+    assert call_kwargs[0][0] == "custom"
+    assert call_kwargs[1].get("explicit_base_url") == "http://localhost:5000/v1"
+
+    aux._runtime_model_override = ""
+    aux._runtime_provider_override = ""
+    aux._runtime_base_url_override = ""

--- a/tests/test_model_switch_fixes.py
+++ b/tests/test_model_switch_fixes.py
@@ -1,0 +1,144 @@
+"""Tests for three model-switch bug fixes.
+
+1. list_authenticated_providers() includes models from the `models` dict
+   in custom_providers entries (not just the single `model` field).
+
+2. set_runtime_model() propagates the switch to auxiliary tasks so that
+   title generation, compression, etc. use the same model as the session.
+"""
+
+from unittest.mock import patch
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: picker detects models from the `models` dict
+# ---------------------------------------------------------------------------
+
+
+def _find_provider(results, name):
+    return next((p for p in results if p["name"] == name), None)
+
+
+def test_list_authenticated_providers_includes_models_dict():
+    """Models listed in the `models` dict of a custom_providers entry must
+    appear in the picker, not just the single `model` field."""
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    custom_providers = [
+        {
+            "name": "LM Studio",
+            "base_url": "http://localhost:1234/v1",
+            "model": "vendor/model-a",
+            "models": {
+                "vendor/model-a": {},
+                "vendor/model-b": {},
+                "vendor/model-c": {},
+            },
+        }
+    ]
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}):
+        results = list_authenticated_providers(custom_providers=custom_providers)
+
+    provider = _find_provider(results, "LM Studio")
+    assert provider is not None
+    assert "vendor/model-a" in provider["models"]
+    assert "vendor/model-b" in provider["models"]
+    assert "vendor/model-c" in provider["models"]
+    assert provider["total_models"] == 3
+
+
+def test_list_authenticated_providers_deduplicates_model_field():
+    """The `model` field must not appear twice when it is also in `models`."""
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    custom_providers = [
+        {
+            "name": "Local",
+            "base_url": "http://localhost:1234/v1",
+            "model": "vendor/model-a",
+            "models": {
+                "vendor/model-a": {},
+                "vendor/model-b": {},
+            },
+        }
+    ]
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}):
+        results = list_authenticated_providers(custom_providers=custom_providers)
+
+    provider = _find_provider(results, "Local")
+    assert provider is not None
+    models = provider["models"]
+    assert models.count("vendor/model-a") == 1
+    assert len(models) == 2
+
+
+def test_list_authenticated_providers_no_models_dict():
+    """Entries without a `models` dict still work — only `model` field shown."""
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    custom_providers = [
+        {
+            "name": "Local Single",
+            "base_url": "http://localhost:1234/v1",
+            "model": "vendor/model-a",
+        }
+    ]
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}):
+        results = list_authenticated_providers(custom_providers=custom_providers)
+
+    provider = _find_provider(results, "Local Single")
+    assert provider is not None
+    assert provider["models"] == ["vendor/model-a"]
+    assert provider["total_models"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: set_runtime_model() propagates switch to auxiliary tasks
+# ---------------------------------------------------------------------------
+
+
+def test_set_runtime_model_overrides_read_main_model():
+    """After set_runtime_model(), _read_main_model() returns the override,
+    not the value from config.yaml."""
+    import agent.auxiliary_client as aux
+
+    aux._runtime_model_override = ""
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"default": "config/default-model"}
+    }):
+        assert aux._read_main_model() == "config/default-model"
+
+        aux.set_runtime_model("switched/model", "custom", "http://localhost:1234/v1")
+        assert aux._read_main_model() == "switched/model"
+
+    aux._runtime_model_override = ""
+
+
+def test_set_runtime_model_empty_clears_override():
+    """set_runtime_model('') clears the override so config.yaml is used again."""
+    import agent.auxiliary_client as aux
+
+    aux.set_runtime_model("some/model")
+    assert aux._runtime_model_override == "some/model"
+
+    aux.set_runtime_model("")
+    assert aux._runtime_model_override == ""
+
+    aux._runtime_model_override = ""
+
+
+def test_set_runtime_model_stores_provider_and_base_url():
+    """set_runtime_model() stores provider and base_url overrides too."""
+    import agent.auxiliary_client as aux
+
+    aux.set_runtime_model("m/model", "custom", "http://localhost:9999/v1")
+    assert aux._runtime_provider_override == "custom"
+    assert aux._runtime_base_url_override == "http://localhost:9999/v1"
+
+    aux._runtime_model_override = ""
+    aux._runtime_provider_override = ""
+    aux._runtime_base_url_override = ""


### PR DESCRIPTION
## What does this PR do?

The `/model` picker was broken for users with `custom_providers` entries that use a `models` dict - only the single `model` field was read, so the picker always showed just one option and switching models was effectively impossible.

This PR fixes model detection in the picker and resolves two additional bugs discovered during testing:

1. **Picker didn't detect models from `models` dict** - `list_authenticated_providers()` only read the `model` field from each `custom_providers` entry. The `models` dict (used for multi-model provider configs) was ignored entirely.
2. **Switched model reverted on next message** - `_ensure_runtime_credentials()` re-read `model.default` from `config.yaml` on every message and overwrote the session switch.
3. **Auxiliary tasks used wrong model** - title generation and other auxiliary tasks always called `_read_main_model()` which reads from config, not the active session model. On single-GPU local LLM setups this caused a second model to be requested into VRAM, resulting in OOM errors.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`: include keys from `models` dict when building the picker's model list for `custom_providers` entries
- `cli.py` (`send_message`): save `self.model` before `_ensure_runtime_credentials()` and restore it if the resolver overwrote it with the config default
- `cli.py` (`_apply_model_switch_result`): call `set_runtime_model()` to propagate the switch to auxiliary tasks
- `agent/auxiliary_client.py`: add `set_runtime_model()` and `_runtime_model_override`; `_read_main_model()` checks the override before falling back to `config.yaml`

## How to Test

1. Add a `custom_providers` entry with a `models` dict containing multiple model IDs, run `/model` - all models should appear in the picker
2. Switch model via `/model`, send a message - verify the switched model is used, not the config default
3. On a local LLM setup (e.g. LM Studio): switch model, send a message, check server logs - only one model should be requested per exchange

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` - 6 new tests pass; 26 pre-existing failures on `main` are unrelated to these changes
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux 43 x86_64, AMD Ryzen 9 7900X, NVIDIA RTX 5070 Ti, LM Studio 0.4.11 (Build 1)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) - Python-only changes, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

LM Studio server logs before fix - two different models requested per exchange:
```
[INFO] [mistralai/devstral-small-2-2512] Running chat completion ...
[INFO] [google/gemma-4-e4b] Running chat completion ...   ← title generation, triggers OOM on single GPU
```

After fix - single model throughout:
```
[INFO] [mistralai/devstral-small-2-2512] Running chat completion ...
[INFO] [mistralai/devstral-small-2-2512] Running chat completion ...
```

Co-developed with Claude Code
