### PR TITLE
fix(cron): stop cron jobs from leaking chatty agent output into group chats

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -779,8 +779,8 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
-def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
-    """Build the effective prompt for a cron job, optionally loading one or more skills first.
+def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> Optional[tuple[str, str]]:
+    """Build the effective prompt and system hint for a cron job.
 
     Args:
         job: The cron job dict.
@@ -789,6 +789,17 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             When provided, the script is not re-executed and the cached
             result is used for prompt injection. When omitted, the script
             (if any) runs inline as before.
+
+    Returns:
+        ``None`` when the data-collection script ran successfully but
+        produced no output (caller should skip the AI call). Otherwise a
+        ``(prompt, cron_system_hint)`` tuple, where ``prompt`` is the
+        user message and ``cron_system_hint`` is the cron execution
+        guidance to pass as ``system_message`` so models treat it as
+        behavioral instruction rather than content to acknowledge or
+        narrate. Without this split, models (especially Haiku) tend to
+        echo the hint back as preamble like "I'll produce the report
+        now" before the actual artifact.
     """
     prompt = job.get("prompt", "")
     skills = job.get("skills")
@@ -861,27 +872,38 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 logger.warning("context_from: failed to read output for job %r: %s", source_job_id, e)
                 # silent skip — do not pollute the prompt with error messages
 
-    # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
-    cron_hint = (
-        "[IMPORTANT: You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+    # Cron execution guidance is returned separately so the caller can
+    # pass it as ``system_message`` to ``run_conversation`` rather than
+    # prepending it to the user message. Models (especially Haiku) tend
+    # to acknowledge/narrate user-message instructions in their reply,
+    # which leaks preamble into the chat. Routing the same guidance via
+    # the system slot avoids that.
+    cron_system_hint = (
+        "You are running as a scheduled cron job. "
+        "DELIVERY: Your final response is delivered verbatim to the user. "
+        "Do NOT use send_message or try to deliver the output yourself — "
+        "just produce your report/output as your final response and the "
+        "system handles the rest. "
+        "OUTPUT DISCIPLINE: No preamble (\"Here's the report\", \"All "
+        "tasks completed\", \"I'll now produce…\"), no postamble "
+        "(\"Status: ✅ done\", \"Let me know if…\"), no title headers "
+        "unless the task asks for one, no horizontal rules. Ship the "
+        "artifact only — your response IS the message the user sees. "
+        "SILENT: If there is genuinely nothing new to report — including "
+        "when the pre-run script produced no output — respond with "
+        "exactly \"[SILENT]\" (nothing else) to suppress delivery. Do "
+        "NOT ask the user for context, do NOT offer to search logs, do "
+        "NOT narrate what you would do: just say [SILENT] and stop. "
         "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "findings normally, or say [SILENT] and nothing more."
     )
-    prompt = cron_hint + prompt
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []
 
     skill_names = [str(name).strip() for name in skills if str(name).strip()]
     if not skill_names:
-        return _scan_assembled_cron_prompt(prompt, job)
+        return _scan_assembled_cron_prompt(prompt, job), cron_system_hint
 
     from tools.skills_tool import skill_view
     from tools.skill_usage import bump_use
@@ -924,7 +946,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     if prompt:
         parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
-    return _scan_assembled_cron_prompt("\n".join(parts), job)
+    return _scan_assembled_cron_prompt("\n".join(parts), job), cron_system_hint
 
 
 def _scan_assembled_cron_prompt(assembled: str, job: dict) -> str:
@@ -1105,7 +1127,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             return True, silent_doc, SILENT_MARKER, None
 
     try:
-        prompt = _build_job_prompt(job, prerun_script=prerun_script)
+        _built = _build_job_prompt(job, prerun_script=prerun_script)
     except CronPromptInjectionBlocked as block_exc:
         # Assembled prompt (user prompt + loaded skill content) tripped the
         # injection scanner. Refuse to run the agent this tick and surface
@@ -1129,9 +1151,10 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
         return False, blocked_doc, "", str(block_exc)
-    if prompt is None:
+    if _built is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
+    prompt, cron_system_hint = _built
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -1403,7 +1426,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            agent.run_conversation,
+            prompt,
+            system_message=cron_system_hint,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -1663,9 +1691,36 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
+                if should_deliver and success:
+                    if SILENT_MARKER in deliver_content.strip().upper():
+                        logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                        should_deliver = False
+                    else:
+                        # Defensive backstop: some models (notably Haiku) ignore
+                        # the [SILENT] instruction when the script produced no
+                        # output and instead reply with a chatty "I don't have
+                        # access to the script output, could you provide…".
+                        # Cron jobs should never ask the user questions — sniff
+                        # the opening of the response for these patterns and
+                        # suppress delivery so they don't leak into chats.
+                        _sniff = deliver_content.strip().lower()[:400]
+                        _hallucination_markers = (
+                            "i don't have access to",
+                            "i do not have access to",
+                            "could you provide",
+                            "please provide the script",
+                            "please share the script",
+                            "can you share the script",
+                            "to retrieve and report",
+                        )
+                        if any(m in _sniff for m in _hallucination_markers):
+                            logger.warning(
+                                "Job '%s': suppressing delivery — response looks "
+                                "like a model hallucination asking for context "
+                                "(should have been [SILENT])",
+                                job["id"],
+                            )
+                            should_deliver = False
 
                 delivery_error = None
                 if should_deliver:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -487,8 +487,14 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script execution failed: {exc}"
 
 
-def _build_job_prompt(job: dict) -> str:
-    """Build the effective prompt for a cron job, optionally loading one or more skills first."""
+def _build_job_prompt(job: dict) -> tuple[str, str]:
+    """Build the effective prompt and system hint for a cron job.
+
+    Returns:
+        (prompt, system_hint) — prompt is the user message, system_hint
+        is cron execution guidance to pass as the system_message so the
+        model treats it as behavioral instruction (not content to narrate).
+    """
     prompt = job.get("prompt", "")
     skills = job.get("skills")
 
@@ -518,10 +524,11 @@ def _build_job_prompt(job: dict) -> str:
                 f"{prompt}"
             )
 
-    # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
-    cron_hint = (
-        "[SYSTEM: You are running as a scheduled cron job. "
+    # Cron execution guidance — passed as system_message (not prepended
+    # to the user prompt) so the model treats it as behavioral instruction
+    # rather than content to acknowledge/narrate in the response.
+    cron_system_hint = (
+        "You are running as a scheduled cron job. "
         "DELIVERY: Your final response will be automatically delivered "
         "to the user — do NOT use send_message or try to deliver "
         "the output yourself. Just produce your report/output as your "
@@ -529,16 +536,15 @@ def _build_job_prompt(job: dict) -> str:
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "findings normally, or say [SILENT] and nothing more."
     )
-    prompt = cron_hint + prompt
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []
 
     skill_names = [str(name).strip() for name in skills if str(name).strip()]
     if not skill_names:
-        return prompt
+        return prompt, cron_system_hint
 
     from tools.skills_tool import skill_view
 
@@ -574,7 +580,7 @@ def _build_job_prompt(job: dict) -> str:
 
     if prompt:
         parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
-    return "\n".join(parts)
+    return "\n".join(parts), cron_system_hint
 
 
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
@@ -597,7 +603,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     
     job_id = job["id"]
     job_name = job["name"]
-    prompt = _build_job_prompt(job)
+    prompt, cron_system_hint = _build_job_prompt(job)
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
 
@@ -775,7 +781,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt, cron_system_hint)
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -487,16 +487,21 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script execution failed: {exc}"
 
 
-def _build_job_prompt(job: dict) -> tuple[str, str]:
+def _build_job_prompt(job: dict) -> tuple[str, str, bool]:
     """Build the effective prompt and system hint for a cron job.
 
     Returns:
-        (prompt, system_hint) — prompt is the user message, system_hint
-        is cron execution guidance to pass as the system_message so the
-        model treats it as behavioral instruction (not content to narrate).
+        (prompt, system_hint, script_no_output) — prompt is the user
+        message, system_hint is cron execution guidance to pass as the
+        system_message so the model treats it as behavioral instruction
+        (not content to narrate). ``script_no_output`` is True when the
+        job has a data-collection script that ran successfully but
+        returned empty stdout: the caller should short-circuit the
+        agent run and return [SILENT] without burning tokens.
     """
     prompt = job.get("prompt", "")
     skills = job.get("skills")
+    script_no_output = False
 
     # Run data-collection script if configured, inject output as context.
     script_path = job.get("script")
@@ -512,6 +517,12 @@ def _build_job_prompt(job: dict) -> tuple[str, str]:
                     f"{prompt}"
                 )
             else:
+                # Script ran successfully but produced no output — there is
+                # semantically nothing for the agent to report. Flag so the
+                # caller can short-circuit to [SILENT] without an LLM call
+                # (Haiku otherwise tends to narrate "I don't have access to
+                # the script output…" and leak into group chats).
+                script_no_output = True
                 prompt = (
                     "[Script ran successfully but produced no output.]\n\n"
                     f"{prompt}"
@@ -529,12 +540,19 @@ def _build_job_prompt(job: dict) -> tuple[str, str]:
     # rather than content to acknowledge/narrate in the response.
     cron_system_hint = (
         "You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+        "DELIVERY: Your final response is delivered verbatim to the user. "
+        "Do NOT use send_message or try to deliver the output yourself — "
+        "just produce your report/output as your final response and the "
+        "system handles the rest. "
+        "OUTPUT DISCIPLINE: No preamble ('Here's the report', 'All tasks "
+        "completed'), no postamble ('Status: ✅ done', 'Let me know if…'), "
+        "no title headers unless the task asks for one, no horizontal "
+        "rules. Ship the artifact only. "
+        "SILENT: If there is genuinely nothing new to report — including "
+        "when the pre-run script produced no output — respond with exactly "
+        "\"[SILENT]\" (nothing else) to suppress delivery. Do NOT ask the "
+        "user for context, do NOT offer to search logs, do NOT narrate "
+        "what you would do: just say [SILENT] and stop. "
         "Never combine [SILENT] with content — either report your "
         "findings normally, or say [SILENT] and nothing more."
     )
@@ -544,7 +562,7 @@ def _build_job_prompt(job: dict) -> tuple[str, str]:
 
     skill_names = [str(name).strip() for name in skills if str(name).strip()]
     if not skill_names:
-        return prompt, cron_system_hint
+        return prompt, cron_system_hint, script_no_output
 
     from tools.skills_tool import skill_view
 
@@ -580,7 +598,7 @@ def _build_job_prompt(job: dict) -> tuple[str, str]:
 
     if prompt:
         parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
-    return "\n".join(parts), cron_system_hint
+    return "\n".join(parts), cron_system_hint, script_no_output
 
 
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
@@ -603,9 +621,30 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     
     job_id = job["id"]
     job_name = job["name"]
-    prompt, cron_system_hint = _build_job_prompt(job)
+    prompt, cron_system_hint, script_no_output = _build_job_prompt(job)
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+
+    # Short-circuit: if the pre-run script returned success with no output,
+    # there is nothing to report. Skip the LLM call entirely — otherwise
+    # models (especially Haiku) tend to ignore the [SILENT] instruction and
+    # respond with "I don't have access to the script output, could you
+    # provide…", which leaks into group chats.
+    if script_no_output:
+        logger.info(
+            "Job '%s': pre-run script produced no output — short-circuiting to [SILENT] (no LLM call)",
+            job_name,
+        )
+        output = (
+            f"# Cron Job: {job_name}\n\n"
+            f"**Job ID:** {job_id}\n"
+            f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+            f"**Schedule:** {job.get('schedule', {}).get('display', 'unknown')}\n\n"
+            f"## Prompt\n\n{prompt}\n\n"
+            f"## Response\n\n[SILENT]\n"
+            f"_Short-circuited: pre-run script produced no output._\n"
+        )
+        return True, output, "[SILENT]", None
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -970,9 +1009,35 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
-                    should_deliver = False
+                if should_deliver and success:
+                    if SILENT_MARKER in deliver_content.strip().upper():
+                        logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                        should_deliver = False
+                    else:
+                        # Defensive backstop: some models (notably Haiku) ignore
+                        # the [SILENT] instruction and reply with a chatty
+                        # "I don't have access to the script output, could
+                        # you provide…" instead. Cron jobs should never ask
+                        # the user questions — detect these patterns in the
+                        # opening of the response and suppress delivery so
+                        # they don't leak into group chats.
+                        _sniff = deliver_content.strip().lower()[:400]
+                        _hallucination_markers = (
+                            "i don't have access to",
+                            "i do not have access to",
+                            "could you provide",
+                            "please provide the script",
+                            "please share the script",
+                            "can you share the script",
+                            "to retrieve and report",
+                        )
+                        if any(m in _sniff for m in _hallucination_markers):
+                            logger.warning(
+                                "Job '%s': suppressing delivery — response looks like a model "
+                                "hallucination asking for context (should have been [SILENT])",
+                                job["id"],
+                            )
+                            should_deliver = False
 
                 delivery_error = None
                 if should_deliver:

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -80,7 +80,7 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
         type(self).refresh_attempts += 1
         return True
 
-    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+    def run_conversation(self, user_message: str, system_message=None, conversation_history=None, task_id=None):
         calls = {"api": 0}
 
         def _fake_api_call(api_kwargs):
@@ -90,7 +90,7 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
             return _codex_message_response("Recovered via refresh")
 
         self._interruptible_api_call = _fake_api_call
-        return super().run_conversation(user_message, conversation_history=conversation_history, task_id=task_id)
+        return super().run_conversation(user_message, system_message=system_message, conversation_history=conversation_history, task_id=task_id)
 
 
 def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -97,7 +97,7 @@ class TestBuildJobPromptContextFrom:
             context_from=job_a["id"],
         )
 
-        prompt = _build_job_prompt(job_b)
+        prompt, _ = _build_job_prompt(job_b)
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
@@ -119,7 +119,7 @@ class TestBuildJobPromptContextFrom:
         job_b = create_job(
             prompt="Summarize", schedule="every 2h", context_from=job_a["id"]
         )
-        prompt = _build_job_prompt(job_b)
+        prompt, _ = _build_job_prompt(job_b)
         assert "New output" in prompt
         assert "Old output" not in prompt
 
@@ -134,7 +134,7 @@ class TestBuildJobPromptContextFrom:
 
         # job_a never ran — output dir does not exist
         # expect silent skip: no placeholder injected, base prompt intact
-        prompt = _build_job_prompt(job_b)
+        prompt, _ = _build_job_prompt(job_b)
         assert "no output" not in prompt.lower()
         assert "not found" not in prompt.lower()
         assert "Summarize" in prompt
@@ -156,7 +156,7 @@ class TestBuildJobPromptContextFrom:
             schedule="every 2h",
             context_from=[job_a["id"], job_b["id"]],
         )
-        prompt = _build_job_prompt(job_c)
+        prompt, _ = _build_job_prompt(job_c)
         assert "News: AI boom" in prompt
         assert "Weather: Sunny" in prompt
 
@@ -175,7 +175,7 @@ class TestBuildJobPromptContextFrom:
             schedule="every 2h",
             context_from=job_a["id"],
         )
-        prompt = _build_job_prompt(job_b)
+        prompt, _ = _build_job_prompt(job_b)
         context_pos = prompt.find("Context data")
         prompt_pos = prompt.find("Process the data above")
         assert context_pos < prompt_pos
@@ -194,7 +194,7 @@ class TestBuildJobPromptContextFrom:
         job_b = create_job(
             prompt="Process", schedule="every 2h", context_from=job_a["id"]
         )
-        prompt = _build_job_prompt(job_b)
+        prompt, _ = _build_job_prompt(job_b)
         assert "truncated" in prompt
         assert "x" * 10000 not in prompt
 
@@ -221,7 +221,7 @@ class TestBuildJobPromptContextFrom:
             return original_read(self, *args, **kwargs)
 
         with patch.object(Path, "read_text", mock_read_text):
-            prompt = _build_job_prompt(job_b)
+            prompt, _ = _build_job_prompt(job_b)
 
         # Job should not crash, prompt should still contain the base prompt
         assert "Process" in prompt
@@ -249,7 +249,7 @@ class TestBuildJobPromptContextFrom:
             return original_read(self, *args, **kwargs)
 
         with patch.object(Path, "read_text", mock_read_text):
-            prompt = _build_job_prompt(job_b)
+            prompt, _ = _build_job_prompt(job_b)
 
         # Job should not crash, prompt should still contain the base prompt
         assert "Process" in prompt
@@ -262,7 +262,7 @@ class TestBuildJobPromptContextFrom:
         job = create_job(prompt="Process", schedule="every 2h")
         # Manually inject invalid context_from (simulating tampered jobs.json)
         job["context_from"] = ["../../../etc/passwd"]
-        prompt = _build_job_prompt(job)
+        prompt, _ = _build_job_prompt(job)
         # Should not crash and should not inject anything malicious
         assert "Process" in prompt
         assert "etc/passwd" not in prompt

--- a/tests/cron/test_cron_prompt_injection_skill.py
+++ b/tests/cron/test_cron_prompt_injection_skill.py
@@ -123,7 +123,7 @@ class TestBuildJobPromptScansSkillContent:
             "prompt": "run the digest",
             "skills": ["news-digest"],
         }
-        prompt = scheduler._build_job_prompt(job)
+        prompt, _ = scheduler._build_job_prompt(job)
         assert prompt is not None
         assert "news-digest" in prompt
         assert "Fetch the top 5 headlines" in prompt
@@ -212,6 +212,6 @@ class TestBuildJobPromptScansSkillContent:
             "skills": ["does-not-exist"],
         }
         # Should not raise — missing skills are skipped with a notice.
-        prompt = scheduler._build_job_prompt(job)
+        prompt, _ = scheduler._build_job_prompt(job)
         assert prompt is not None
         assert "could not be found" in prompt

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -188,7 +188,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Report any notable changes.",
             "script": str(script),
         }
-        prompt = _build_job_prompt(job)
+        prompt, _ = _build_job_prompt(job)
         assert "## Script Output" in prompt
         assert "new PR: #123 fix typo" in prompt
         assert "Report any notable changes." in prompt
@@ -200,7 +200,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Report status.",
             "script": "nonexistent_monitor.py",
         }
-        prompt = _build_job_prompt(job)
+        prompt, _ = _build_job_prompt(job)
         assert "## Script Error" in prompt
         assert "not found" in prompt.lower()
         assert "Report status." in prompt
@@ -209,11 +209,14 @@ class TestBuildJobPromptWithScript:
         from cron.scheduler import _build_job_prompt
 
         job = {"prompt": "Simple job."}
-        prompt = _build_job_prompt(job)
+        prompt, _ = _build_job_prompt(job)
         assert "## Script Output" not in prompt
         assert "Simple job." in prompt
 
-    def test_script_empty_output_noted(self, cron_env):
+    def test_script_empty_output_returns_none(self, cron_env):
+        """When the data-collection script ran successfully but produced no
+        output, _build_job_prompt returns None so the caller can skip the
+        AI call entirely (no LLM tokens, no hallucinated help-requests)."""
         from cron.scheduler import _build_job_prompt
 
         script = cron_env / "scripts" / "noop.py"
@@ -223,9 +226,8 @@ class TestBuildJobPromptWithScript:
             "prompt": "Check status.",
             "script": str(script),
         }
-        prompt = _build_job_prompt(job)
-        assert "no output" in prompt.lower()
-        assert "Check status." in prompt
+        result = _build_job_prompt(job)
+        assert result is None
 
 
 class TestCronjobToolScript:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -188,7 +188,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Report any notable changes.",
             "script": str(script),
         }
-        prompt, system_hint = _build_job_prompt(job)
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
         assert "## Script Output" in prompt
         assert "new PR: #123 fix typo" in prompt
         assert "Report any notable changes." in prompt
@@ -200,7 +200,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Report status.",
             "script": "nonexistent_monitor.py",
         }
-        prompt, system_hint = _build_job_prompt(job)
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
         assert "## Script Error" in prompt
         assert "not found" in prompt.lower()
         assert "Report status." in prompt
@@ -209,7 +209,7 @@ class TestBuildJobPromptWithScript:
         from cron.scheduler import _build_job_prompt
 
         job = {"prompt": "Simple job."}
-        prompt, system_hint = _build_job_prompt(job)
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
         assert "## Script Output" not in prompt
         assert "Simple job." in prompt
 
@@ -223,9 +223,39 @@ class TestBuildJobPromptWithScript:
             "prompt": "Check status.",
             "script": str(script),
         }
-        prompt, system_hint = _build_job_prompt(job)
+        prompt, system_hint, script_no_output = _build_job_prompt(job)
         assert "no output" in prompt.lower()
         assert "Check status." in prompt
+        # The flag must be set so run_job can short-circuit without an LLM call.
+        assert script_no_output is True
+
+    def test_run_job_short_circuits_on_empty_script_output(self, cron_env):
+        """When the pre-run script produces no output, run_job must return
+        [SILENT] immediately without instantiating AIAgent. This prevents
+        Haiku from narrating 'I don't have access…' into group chats."""
+        from unittest.mock import patch, MagicMock
+        from cron.scheduler import run_job
+
+        script = cron_env / "scripts" / "noop.py"
+        script.write_text("# nothing\n")
+        job = {
+            "id": "test-short-circuit",
+            "name": "test-job",
+            "prompt": "Alert only if script emits data",
+            "script": str(script),
+            "schedule": {"display": "every 30m"},
+        }
+
+        # Patch AIAgent so we can assert it was NEVER constructed.
+        with patch("run_agent.AIAgent") as agent_cls:
+            success, output, final_response, error = run_job(job)
+
+        agent_cls.assert_not_called()
+        assert success is True
+        assert final_response == "[SILENT]"
+        assert error is None
+        assert "[SILENT]" in output
+        assert "Short-circuited" in output
 
 
 class TestCronjobToolScript:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -188,7 +188,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Report any notable changes.",
             "script": str(script),
         }
-        prompt = _build_job_prompt(job)
+        prompt, system_hint = _build_job_prompt(job)
         assert "## Script Output" in prompt
         assert "new PR: #123 fix typo" in prompt
         assert "Report any notable changes." in prompt
@@ -200,7 +200,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Report status.",
             "script": "nonexistent_monitor.py",
         }
-        prompt = _build_job_prompt(job)
+        prompt, system_hint = _build_job_prompt(job)
         assert "## Script Error" in prompt
         assert "not found" in prompt.lower()
         assert "Report status." in prompt
@@ -209,7 +209,7 @@ class TestBuildJobPromptWithScript:
         from cron.scheduler import _build_job_prompt
 
         job = {"prompt": "Simple job."}
-        prompt = _build_job_prompt(job)
+        prompt, system_hint = _build_job_prompt(job)
         assert "## Script Output" not in prompt
         assert "Simple job." in prompt
 
@@ -223,7 +223,7 @@ class TestBuildJobPromptWithScript:
             "prompt": "Check status.",
             "script": str(script),
         }
-        prompt = _build_job_prompt(job)
+        prompt, system_hint = _build_job_prompt(job)
         assert "no output" in prompt.lower()
         assert "Check status." in prompt
 

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -297,7 +297,7 @@ class TestRunJobTerminalCwd:
         )
 
         # Stub scheduler helpers that would otherwise hit the filesystem / config.
-        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: ("hi", "system hint"))
         monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1422,7 +1422,7 @@ class TestRunJobSkillBacked:
             register_env_passthrough(["NOTION_API_KEY"])
             return json.dumps({"success": True, "content": "# notion\nUse Notion."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, system_message=None):
             from tools.env_passthrough import get_all_passthrough
 
             assert "NOTION_API_KEY" in get_all_passthrough()
@@ -1479,7 +1479,7 @@ class TestRunJobSkillBacked:
             register_credential_file("credentials/google_token.json")
             return json.dumps({"success": True, "content": "# google-workspace\nUse Google."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, system_message=None):
             from tools.credential_files import _get_registered
 
             registered = _get_registered()
@@ -1684,35 +1684,94 @@ class TestSilentDelivery:
         save_mock.assert_called_once_with("monitor-job", "# full output")
         deliver_mock.assert_not_called()
 
+    def test_hallucinated_help_request_suppressed(self, caplog):
+        """Defensive backstop: when a model ignores the [SILENT] directive
+        and replies with a chatty 'I don't have access to the script
+        output, could you provide…' instead, the tick-level guard must
+        suppress delivery so the bogus question doesn't leak into the
+        chat where the cron is configured to deliver."""
+        bogus = (
+            "I don't have access to the script output from your previous "
+            "execution. Could you provide:\n- The script path or name\n"
+            "- Where the output is being logged"
+        )
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", bogus, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                tick(verbose=False)
+        deliver_mock.assert_not_called()
+        assert any("hallucination" in r.message.lower() for r in caplog.records)
+
+    def test_legit_response_mentioning_access_still_delivers(self):
+        """The hallucination guard is narrow — it sniffs only the OPENING
+        of the response. A legitimate report that happens to contain the
+        word 'access' later in its body must still go through."""
+        legit = (
+            "**MSFT** earnings beat Q1 by 4%. Discussion of Azure access "
+            "controls headlined the call — no margin impact flagged."
+        )
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", legit, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+
 
 class TestBuildJobPromptSilentHint:
-    """Verify _build_job_prompt always injects [SILENT] guidance."""
+    """Verify _build_job_prompt routes cron execution guidance via the
+    system_hint tuple element rather than prepending it to the user
+    message. The hint must NOT appear in the prompt itself."""
 
-    def test_hint_always_present(self):
+    def test_returns_tuple(self):
         job = {"prompt": "Check for updates"}
         result = _build_job_prompt(job)
-        assert "[SILENT]" in result
-        assert "Check for updates" in result
+        assert isinstance(result, tuple) and len(result) == 2
 
-    def test_hint_present_even_without_prompt(self):
+    def test_user_prompt_in_first_element(self):
+        job = {"prompt": "Check for updates"}
+        prompt, _hint = _build_job_prompt(job)
+        assert "Check for updates" in prompt
+
+    def test_silent_guidance_in_system_hint(self):
+        job = {"prompt": "Check for updates"}
+        _prompt, system_hint = _build_job_prompt(job)
+        assert "[SILENT]" in system_hint
+
+    def test_silent_guidance_present_even_without_prompt(self):
         job = {"prompt": ""}
-        result = _build_job_prompt(job)
-        assert "[SILENT]" in result
+        _prompt, system_hint = _build_job_prompt(job)
+        assert "[SILENT]" in system_hint
 
-    def test_delivery_guidance_present(self):
+    def test_delivery_guidance_in_system_hint(self):
         """Cron hint tells agents their final response is auto-delivered."""
         job = {"prompt": "Generate a report"}
-        result = _build_job_prompt(job)
-        assert "do NOT use send_message" in result
-        assert "automatically delivered" in result
+        _prompt, system_hint = _build_job_prompt(job)
+        assert "Do NOT use send_message" in system_hint
+        assert "delivered verbatim" in system_hint
 
-    def test_delivery_guidance_precedes_user_prompt(self):
-        """System guidance appears before the user's prompt text."""
+    def test_output_discipline_guidance_in_system_hint(self):
+        """The hint forbids preamble/postamble — root cause of leak."""
+        job = {"prompt": "Generate a report"}
+        _prompt, system_hint = _build_job_prompt(job)
+        assert "OUTPUT DISCIPLINE" in system_hint
+        assert "preamble" in system_hint.lower()
+
+    def test_hint_not_prepended_to_user_prompt(self):
+        """The fix: cron guidance must NOT live in the user message
+        anymore — that was what made models acknowledge/narrate it as
+        chat preamble. It belongs in the system slot."""
         job = {"prompt": "My custom prompt"}
-        result = _build_job_prompt(job)
-        system_pos = result.index("do NOT use send_message")
-        prompt_pos = result.index("My custom prompt")
-        assert system_pos < prompt_pos
+        prompt, _hint = _build_job_prompt(job)
+        assert "Do NOT use send_message" not in prompt
+        assert "[SILENT]" not in prompt
+        assert "OUTPUT DISCIPLINE" not in prompt
 
 
 class TestParseWakeGate:
@@ -1922,14 +1981,14 @@ class TestBuildJobPromptMissingSkill:
     def test_missing_skill_does_not_raise(self):
         """Job should run even when a referenced skill is not installed."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            result, _ = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
         # prompt is preserved even though skill was skipped
         assert "do something" in result
 
     def test_missing_skill_injects_user_notice_into_prompt(self):
         """A system notice about the missing skill is injected into the prompt."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            result, _ = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
         assert "ghost-skill" in result
         assert "not found" in result.lower() or "skipped" in result.lower()
 
@@ -1949,7 +2008,7 @@ class TestBuildJobPromptMissingSkill:
             return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
         with patch("tools.skills_tool.skill_view", side_effect=_mixed_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
+            result, _ = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
         assert "Real skill content." in result
         assert "go" in result
 
@@ -1993,7 +2052,7 @@ class TestBuildJobPromptBumpUse:
         with patch("tools.skills_tool.skill_view", side_effect=_skill_view), \
              patch("tools.skill_usage.bump_use", side_effect=RuntimeError("boom")), \
              caplog.at_level(logging.DEBUG, logger="cron.scheduler"):
-            result = _build_job_prompt({"skills": ["good-skill"], "prompt": "go"})
+            result, _ = _build_job_prompt({"skills": ["good-skill"], "prompt": "go"})
 
         # Prompt should still contain the skill content and original instruction
         assert "Works." in result

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1168,34 +1168,103 @@ class TestSilentDelivery:
         save_mock.assert_called_once_with("monitor-job", "# full output")
         deliver_mock.assert_not_called()
 
+    def test_hallucinated_help_request_suppressed(self, caplog):
+        """Haiku sometimes replies 'I don't have access to the script output,
+        could you provide…' instead of [SILENT]. That is never legitimate
+        cron output — it must be suppressed so it doesn't leak into groups."""
+        bad_reply = (
+            "I don't have access to the script output from your previous "
+            "execution. To retrieve and report the alert, I need to:\n\n"
+            "1. Check if there's a log file\n"
+            "Could you provide:\n- The script path\n"
+        )
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", bad_reply, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                tick(verbose=False)
+        deliver_mock.assert_not_called()
+        assert any("hallucination" in r.message.lower() for r in caplog.records)
+
+    def test_legit_response_mentioning_access_still_delivers(self):
+        """The hallucination guard must not accidentally swallow legitimate
+        reports that happen to mention 'access' later in the body."""
+        legit = (
+            "Daily equity digest:\n- SPY +0.3%\n- QQQ -0.2%\n\n"
+            "Risk flag: XYZ lost access to its primary market maker today."
+        )
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", legit, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
+
 
 class TestBuildJobPromptSilentHint:
     """Verify _build_job_prompt always returns [SILENT] guidance in system hint."""
 
     def test_hint_always_present(self):
         job = {"prompt": "Check for updates"}
-        prompt, system_hint = _build_job_prompt(job)
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
         assert "[SILENT]" in system_hint
         assert "Check for updates" in prompt
 
     def test_hint_present_even_without_prompt(self):
         job = {"prompt": ""}
-        prompt, system_hint = _build_job_prompt(job)
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
         assert "[SILENT]" in system_hint
 
     def test_delivery_guidance_present(self):
         """Cron hint tells agents their final response is auto-delivered."""
         job = {"prompt": "Generate a report"}
-        prompt, system_hint = _build_job_prompt(job)
-        assert "do NOT use send_message" in system_hint
-        assert "automatically delivered" in system_hint
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
+        assert "Do NOT use send_message" in system_hint
+        assert "delivered verbatim" in system_hint
 
     def test_delivery_guidance_in_system_hint_not_prompt(self):
         """System guidance is in the system hint, not in the user prompt."""
         job = {"prompt": "My custom prompt"}
-        prompt, system_hint = _build_job_prompt(job)
-        assert "do NOT use send_message" not in prompt
-        assert "do NOT use send_message" in system_hint
+        prompt, system_hint, _script_no_output = _build_job_prompt(job)
+        assert "Do NOT use send_message" not in prompt
+        assert "Do NOT use send_message" in system_hint
+
+
+class TestBuildJobPromptScriptNoOutput:
+    """Verify the script_no_output flag is set correctly so run_job can short-circuit."""
+
+    def test_flag_false_when_no_script(self):
+        """Jobs without a pre-run script never set the no-output flag."""
+        job = {"prompt": "Run something"}
+        _prompt, _hint, script_no_output = _build_job_prompt(job)
+        assert script_no_output is False
+
+    def test_flag_true_when_script_produces_empty_output(self, tmp_path):
+        """Successful-but-empty script output sets the flag so the LLM is skipped."""
+        script = tmp_path / "noop.py"
+        script.write_text("# emits nothing\n")
+        job = {"script": str(script), "prompt": "Report only if something happened"}
+        with patch("cron.scheduler._run_job_script", return_value=(True, "")):
+            _prompt, _hint, script_no_output = _build_job_prompt(job)
+        assert script_no_output is True
+
+    def test_flag_false_when_script_produces_output(self, tmp_path):
+        job = {"script": "anything.py", "prompt": "Parse script output"}
+        with patch("cron.scheduler._run_job_script", return_value=(True, "data here")):
+            _prompt, _hint, script_no_output = _build_job_prompt(job)
+        assert script_no_output is False
+
+    def test_flag_false_when_script_fails(self, tmp_path):
+        job = {"script": "anything.py", "prompt": "Parse script output"}
+        with patch("cron.scheduler._run_job_script", return_value=(False, "boom")):
+            _prompt, _hint, script_no_output = _build_job_prompt(job)
+        # Script failures must surface an error, not be silenced
+        assert script_no_output is False
 
 
 class TestBuildJobPromptMissingSkill:
@@ -1207,14 +1276,14 @@ class TestBuildJobPromptMissingSkill:
     def test_missing_skill_does_not_raise(self):
         """Job should run even when a referenced skill is not installed."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            prompt, system_hint = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            prompt, system_hint, _script_no_output = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
         # prompt is preserved even though skill was skipped
         assert "do something" in prompt
 
     def test_missing_skill_injects_user_notice_into_prompt(self):
         """A system notice about the missing skill is injected into the prompt."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            prompt, system_hint = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            prompt, system_hint, _script_no_output = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
         assert "ghost-skill" in prompt
         assert "not found" in prompt.lower() or "skipped" in prompt.lower()
 
@@ -1234,7 +1303,7 @@ class TestBuildJobPromptMissingSkill:
             return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
         with patch("tools.skills_tool.skill_view", side_effect=_mixed_skill_view):
-            prompt, system_hint = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
+            prompt, system_hint, _script_no_output = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
         assert "Real skill content." in prompt
         assert "go" in prompt
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -896,7 +896,7 @@ class TestRunJobSkillBacked:
             register_env_passthrough(["NOTION_API_KEY"])
             return json.dumps({"success": True, "content": "# notion\nUse Notion."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, system_message=None):
             from tools.env_passthrough import get_all_passthrough
 
             assert "NOTION_API_KEY" in get_all_passthrough()
@@ -953,7 +953,7 @@ class TestRunJobSkillBacked:
             register_credential_file("credentials/google_token.json")
             return json.dumps({"success": True, "content": "# google-workspace\nUse Google."})
 
-        def _run_conversation(prompt):
+        def _run_conversation(prompt, system_message=None):
             from tools.credential_files import _get_registered
 
             registered = _get_registered()
@@ -1170,33 +1170,32 @@ class TestSilentDelivery:
 
 
 class TestBuildJobPromptSilentHint:
-    """Verify _build_job_prompt always injects [SILENT] guidance."""
+    """Verify _build_job_prompt always returns [SILENT] guidance in system hint."""
 
     def test_hint_always_present(self):
         job = {"prompt": "Check for updates"}
-        result = _build_job_prompt(job)
-        assert "[SILENT]" in result
-        assert "Check for updates" in result
+        prompt, system_hint = _build_job_prompt(job)
+        assert "[SILENT]" in system_hint
+        assert "Check for updates" in prompt
 
     def test_hint_present_even_without_prompt(self):
         job = {"prompt": ""}
-        result = _build_job_prompt(job)
-        assert "[SILENT]" in result
+        prompt, system_hint = _build_job_prompt(job)
+        assert "[SILENT]" in system_hint
 
     def test_delivery_guidance_present(self):
         """Cron hint tells agents their final response is auto-delivered."""
         job = {"prompt": "Generate a report"}
-        result = _build_job_prompt(job)
-        assert "do NOT use send_message" in result
-        assert "automatically delivered" in result
+        prompt, system_hint = _build_job_prompt(job)
+        assert "do NOT use send_message" in system_hint
+        assert "automatically delivered" in system_hint
 
-    def test_delivery_guidance_precedes_user_prompt(self):
-        """System guidance appears before the user's prompt text."""
+    def test_delivery_guidance_in_system_hint_not_prompt(self):
+        """System guidance is in the system hint, not in the user prompt."""
         job = {"prompt": "My custom prompt"}
-        result = _build_job_prompt(job)
-        system_pos = result.index("do NOT use send_message")
-        prompt_pos = result.index("My custom prompt")
-        assert system_pos < prompt_pos
+        prompt, system_hint = _build_job_prompt(job)
+        assert "do NOT use send_message" not in prompt
+        assert "do NOT use send_message" in system_hint
 
 
 class TestBuildJobPromptMissingSkill:
@@ -1208,16 +1207,16 @@ class TestBuildJobPromptMissingSkill:
     def test_missing_skill_does_not_raise(self):
         """Job should run even when a referenced skill is not installed."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+            prompt, system_hint = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
         # prompt is preserved even though skill was skipped
-        assert "do something" in result
+        assert "do something" in prompt
 
     def test_missing_skill_injects_user_notice_into_prompt(self):
         """A system notice about the missing skill is injected into the prompt."""
         with patch("tools.skills_tool.skill_view", side_effect=self._missing_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
-        assert "ghost-skill" in result
-        assert "not found" in result.lower() or "skipped" in result.lower()
+            prompt, system_hint = _build_job_prompt({"skills": ["ghost-skill"], "prompt": "do something"})
+        assert "ghost-skill" in prompt
+        assert "not found" in prompt.lower() or "skipped" in prompt.lower()
 
     def test_missing_skill_logs_warning(self, caplog):
         """A warning is logged when a skill cannot be found."""
@@ -1235,9 +1234,9 @@ class TestBuildJobPromptMissingSkill:
             return json.dumps({"success": False, "error": f"Skill '{name}' not found."})
 
         with patch("tools.skills_tool.skill_view", side_effect=_mixed_skill_view):
-            result = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
-        assert "Real skill content." in result
-        assert "go" in result
+            prompt, system_hint = _build_job_prompt({"skills": ["ghost-skill", "real-skill"], "prompt": "go"})
+        assert "Real skill content." in prompt
+        assert "go" in prompt
 
 
 class TestTickAdvanceBeforeRun:

--- a/tests/run_agent/test_exit_cleanup_interrupt.py
+++ b/tests/run_agent/test_exit_cleanup_interrupt.py
@@ -50,7 +50,7 @@ class TestCronJobCleanup:
         }
 
         with patch("hermes_state.SessionDB", return_value=mock_db), \
-             patch.object(scheduler, "_build_job_prompt", return_value="hello"), \
+             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint")), \
              patch.object(scheduler, "_resolve_origin", return_value=None), \
              patch.object(scheduler, "_resolve_delivery_target", return_value=None), \
              patch("dotenv.load_dotenv", return_value=None), \
@@ -78,7 +78,7 @@ class TestCronJobCleanup:
         }
 
         with patch("hermes_state.SessionDB", return_value=mock_db), \
-             patch.object(scheduler, "_build_job_prompt", return_value="hello"), \
+             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint")), \
              patch.object(scheduler, "_resolve_origin", return_value=None), \
              patch.object(scheduler, "_resolve_delivery_target", return_value=None), \
              patch("dotenv.load_dotenv", return_value=None), \

--- a/tests/run_agent/test_exit_cleanup_interrupt.py
+++ b/tests/run_agent/test_exit_cleanup_interrupt.py
@@ -32,7 +32,7 @@ class TestCronJobCleanup:
         }
 
         with patch("hermes_state.SessionDB", return_value=mock_db), \
-             patch.object(scheduler, "_build_job_prompt", return_value="hello"), \
+             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint")), \
              patch.object(scheduler, "_resolve_origin", return_value=None), \
              patch.object(scheduler, "_resolve_delivery_target", return_value=None), \
              patch("dotenv.load_dotenv", return_value=None), \
@@ -60,7 +60,7 @@ class TestCronJobCleanup:
         }
 
         with patch("hermes_state.SessionDB", return_value=mock_db), \
-             patch.object(scheduler, "_build_job_prompt", return_value="hello"), \
+             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint")), \
              patch.object(scheduler, "_resolve_origin", return_value=None), \
              patch.object(scheduler, "_resolve_delivery_target", return_value=None), \
              patch("dotenv.load_dotenv", return_value=None), \

--- a/tests/run_agent/test_exit_cleanup_interrupt.py
+++ b/tests/run_agent/test_exit_cleanup_interrupt.py
@@ -32,7 +32,7 @@ class TestCronJobCleanup:
         }
 
         with patch("hermes_state.SessionDB", return_value=mock_db), \
-             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint")), \
+             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint", False)), \
              patch.object(scheduler, "_resolve_origin", return_value=None), \
              patch.object(scheduler, "_resolve_delivery_target", return_value=None), \
              patch("dotenv.load_dotenv", return_value=None), \
@@ -60,7 +60,7 @@ class TestCronJobCleanup:
         }
 
         with patch("hermes_state.SessionDB", return_value=mock_db), \
-             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint")), \
+             patch.object(scheduler, "_build_job_prompt", return_value=("hello", "system hint", False)), \
              patch.object(scheduler, "_resolve_origin", return_value=None), \
              patch.object(scheduler, "_resolve_delivery_target", return_value=None), \
              patch("dotenv.load_dotenv", return_value=None), \


### PR DESCRIPTION
## Summary

Two layered cron regressions that were leaking chatty agent output into group chats:

### 1. Execution-hint narration (original commit `2d5e02be`)

The cron execution hint (`[SYSTEM: You are running as a scheduled cron job...]`) was prepended directly into the **user message**. Models — especially Haiku — would acknowledge and narrate this pseudo-system block before producing actual output, adding unwanted preamble like:

> The script returned NEW_TWEETS. I'll parse and format the tweet:
>
> **Serenity** (@handle) · tweet
> $HIMS — New peptide product line…

**Fix:** move the guidance to the `system_message` parameter of `run_conversation()` so models treat it as behavioral instruction rather than content to respond to.

### 2. Empty-script-output hallucinations (new commit `42375cc7`)

When a cron job's pre-run script succeeds but produces **no output**, the scheduler prepends `[Script ran successfully but produced no output.]` and the prompt instructs `respond with "[SILENT]"`. Haiku frequently ignores that and replies with a chatty help request instead:

> I don't have access to the script output from your previous execution. To retrieve and report the alert, I need to:
>
> 1. Check if there's a log file or output file from the script
> 2. Run the script again to capture its output
> 3. Extract and report the alert line
>
> Could you provide:
> - The script path or name
> - Where the output is being logged

Because the response contains no `[SILENT]` substring, the existing silence guard passes it straight through to delivery — and users see this fake question appear in the crypto/equities group where the cron is configured to deliver. Observed in production from `strc-monitor`, `twitter-monitor`, and `cortex-price-refresh`.

Three layered fixes:

1. **`_build_job_prompt` now returns `(prompt, system_hint, script_no_output)`.** The new flag is `True` when the pre-run script succeeded with empty stdout.

2. **`run_job` short-circuits on the flag.** Returns `(True, <output-doc>, "[SILENT]", None)` immediately — **AIAgent is never constructed, no LLM tokens are spent, no hallucinated help-request can be generated.** This is the primary fix.

3. **Defensive backstop in `tick`.** Even for non-script jobs, if the model's response opens with classic help-request markers (`i don't have access to`, `could you provide`, `to retrieve and report`, …), suppress delivery and log a warning. Catches remaining Haiku regressions without silencing legitimate reports that happen to contain those words later in the body.

### 3. Strengthened `cron_system_hint`

Added explicit **OUTPUT DISCIPLINE** and expanded **SILENT** guidance. Tells the model: no preamble ("Here's the report…"), no postamble ("Status: ✅…"), no title headers unless asked, no horizontal rules, no asking for context, no offering to search logs — either ship the artifact or say `[SILENT]` and stop.

## Tests

All new tests pass. Test count: 176 → 183 in `tests/cron/` + `tests/run_agent/test_exit_cleanup_interrupt.py`.

- `TestBuildJobPromptScriptNoOutput` (4 cases) — flag behavior across no-script / empty-output / normal-output / script-failure paths
- `test_run_job_short_circuits_on_empty_script_output` — verifies `AIAgent` is **never** constructed when the flag trips
- `test_hallucinated_help_request_suppressed` — backstop catches the exact pattern observed in production
- `test_legit_response_mentioning_access_still_delivers` — guard is narrow enough not to swallow normal reports

## Files changed

- `cron/scheduler.py` (+88 / −21)
- `tests/cron/test_cron_script.py` (+30 / −8)
- `tests/cron/test_scheduler.py` (+83 / −8)
- `tests/run_agent/test_exit_cleanup_interrupt.py` (+2 / −2)
