### PR TITLE
Fix context compression fallback when the summary model is unavailable

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -730,7 +730,9 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(
+                    turns_to_summarize, focus_topic=focus_topic
+                )  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -241,6 +241,43 @@ class TestSummaryFailureCooldown:
         assert second is None
         assert mock_call.call_count == 1
 
+    def test_missing_summary_model_falls_back_to_main_model(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="main-model",
+                summary_model_override="missing-summary-model",
+                quiet_mode=True,
+            )
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        err = Exception("model_not_found")
+        err.status_code = 404
+        calls = []
+
+        def mock_call_llm(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise err
+            response = MagicMock()
+            response.choices = [MagicMock()]
+            response.choices[0].message.content = "## Goal\nRecovered."
+            return response
+
+        with patch("agent.context_compressor.call_llm", side_effect=mock_call_llm):
+            summary = c._generate_summary(messages, focus_topic="database schema")
+
+        assert summary == f"{SUMMARY_PREFIX}\n## Goal\nRecovered."
+        assert len(calls) == 2
+        assert calls[0]["model"] == "missing-summary-model"
+        assert "model" not in calls[1]
+        assert 'FOCUS TOPIC: "database schema"' in calls[1]["messages"][0]["content"]
+        assert c.summary_model == ""
+        assert c._summary_model_fallen_back is False
+
 
 class TestSummaryPrefixNormalization:
     def test_legacy_prefix_is_replaced(self):


### PR DESCRIPTION
This fixes a bug in context compression when Hermes is configured with a separate summary model.

If that summary model returns a permanent availability error (for example `404` or `503`), the fallback path is supposed to retry summarization with the main model. Instead, it was recursively calling `_generate_summary(messages, summary_budget)`, which passes an undefined local and the wrong second argument. In practice that means the fallback raises `NameError` instead of recovering.

This change does two things:

- retry with the original `turns_to_summarize`
- preserve `focus_topic` when falling back, so guided compression still behaves the same after the retry

I also added a regression test for the `404` path to make sure we actually fall back to the main model and keep the focus prompt intact.

## Testing

- `source venv/bin/activate && python -m pytest tests/agent/test_context_compressor.py -q`
- `source venv/bin/activate && python -m pytest tests/agent/test_compress_focus.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

The targeted compressor tests pass.

The full local suite is not green on this checkout/environment (`66 failed, 11769 passed, 98 skipped, 60 errors`), but the remaining failures appear unrelated to this change and include existing ACP import errors, optional Discord dependency issues, and unrelated web/gateway/CLI failures.
