### PR TITLE
fix: support AWS Bedrock provider for inference and auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1549,6 +1549,17 @@ def resolve_provider_client(
         logger.warning("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
+    if pconfig.auth_type == "aws_sdk":
+        # AWS Bedrock — uses boto3 / AnthropicBedrock SDK, not OpenAI client.
+        # Auxiliary tasks (vision, web extract, compression) should not run
+        # via Bedrock because there is no OpenAI-compatible interface here.
+        # Return None so callers fall back to an OpenAI-compatible provider.
+        logger.debug(
+            "resolve_provider_client: bedrock provider requested for auxiliary "
+            "task — falling back to auto-detection (Bedrock has no OpenAI-compat path)"
+        )
+        return None, None
+
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
             client, default_model = _try_anthropic()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -239,6 +239,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.x.ai": "xai",
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
+    "bedrock-runtime": "bedrock",
+    "bedrock-mantle": "bedrock",
 }
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6290,11 +6290,12 @@ class AIAgent:
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        Bedrock keeps dots — regional inference profile IDs use dot notation (e.g. us.anthropic.claude-sonnet-4-6)."""
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai", "bedrock"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base
+        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base or "bedrock-runtime" in base or "bedrock-mantle" in base
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""


### PR DESCRIPTION
## Summary

- **`agent/model_metadata.py`**: Add `bedrock-runtime` and `bedrock-mantle` to `_URL_TO_PROVIDER` so context-length detection recognizes Bedrock URLs as a known provider and skips the `/models` probe (which Bedrock does not support → was causing an immediate HTTP 400 before any real request was attempted)
- **`run_agent.py`**: Add `"bedrock"` to `_anthropic_preserve_dots()` so regional inference profile IDs (e.g. `us.anthropic.claude-sonnet-4-6`, `eu.anthropic.claude-*`) are not mangled by `normalize_model_name()` into `us-anthropic-claude-sonnet-4-6`, which Bedrock rejects as an invalid model identifier
- **`agent/auxiliary_client.py`**: Handle `aws_sdk` auth type in `resolve_provider_client()` gracefully — previously fell through to an unhandled warning and returned `(None, None)` unexpectedly; now returns `(None, None)` with a debug log so callers fall back to an OpenAI-compatible provider as intended

## Root cause

When using Bedrock as the inference provider with a Claude model (e.g. `us.anthropic.claude-sonnet-4-6`), three things went wrong in sequence:

1. The context-length probe attempted a `GET /models` request against the Bedrock endpoint, which is unsupported → HTTP 400 returned immediately
2. Even if that was fixed, `normalize_model_name()` converted the dot-separated regional prefix `us.` → `us-`, producing an invalid Bedrock model ID
3. Any auxiliary task (vision, compression, web extract) triggered an unhandled `aws_sdk` auth type warning

## Test plan

- [x] Configure Hermes with `provider: bedrock`, `model: us.anthropic.claude-sonnet-4-6`, and IAM credentials (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`)
- [x] Verify agent starts without HTTP 400 errors
- [x] Verify model name is passed to Bedrock unchanged (no dot→hyphen mangling)
- [x] Verify no `unhandled auth_type aws_sdk` warning in logs