### PR TITLE
fix(codex): harden responses stream normalization

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4038,35 +4038,72 @@ class AIAgent:
 
     def _extract_responses_message_text(self, item: Any) -> str:
         """Extract assistant text from a Responses message output item."""
-        content = getattr(item, "content", None)
+        content = item.get("content") if isinstance(item, dict) else getattr(item, "content", None)
         if not isinstance(content, list):
             return ""
 
         chunks: List[str] = []
         for part in content:
-            ptype = getattr(part, "type", None)
+            if isinstance(part, dict):
+                ptype = part.get("type")
+                text = part.get("text")
+            else:
+                ptype = getattr(part, "type", None)
+                text = getattr(part, "text", None)
             if ptype not in {"output_text", "text"}:
                 continue
-            text = getattr(part, "text", None)
             if isinstance(text, str) and text:
                 chunks.append(text)
         return "".join(chunks).strip()
 
     def _extract_responses_reasoning_text(self, item: Any) -> str:
         """Extract a compact reasoning text from a Responses reasoning item."""
-        summary = getattr(item, "summary", None)
+        summary = item.get("summary") if isinstance(item, dict) else getattr(item, "summary", None)
         if isinstance(summary, list):
             chunks: List[str] = []
             for part in summary:
-                text = getattr(part, "text", None)
+                text = part.get("text") if isinstance(part, dict) else getattr(part, "text", None)
                 if isinstance(text, str) and text:
                     chunks.append(text)
             if chunks:
                 return "\n".join(chunks).strip()
-        text = getattr(item, "text", None)
+        text = item.get("text") if isinstance(item, dict) else getattr(item, "text", None)
         if isinstance(text, str) and text:
             return text.strip()
         return ""
+
+    def _response_stream_item_with_arguments(self, item: Any, arguments_text: str | None):
+        """Return a copy of a streamed tool-call item with arguments/input backfilled."""
+        if item is None or not isinstance(arguments_text, str) or not arguments_text:
+            return item
+
+        if isinstance(item, dict):
+            item_type = item.get("type")
+            if item_type not in {"function_call", "custom_tool_call"}:
+                return item
+            field_name = "input" if item_type == "custom_tool_call" else "arguments"
+            existing = item.get(field_name)
+            if isinstance(existing, str) and existing.strip():
+                return item
+            patched = dict(item)
+            patched[field_name] = arguments_text
+            return patched
+
+        item_type = getattr(item, "type", None)
+        if item_type not in {"function_call", "custom_tool_call"}:
+            return item
+
+        field_name = "input" if item_type == "custom_tool_call" else "arguments"
+        existing = getattr(item, field_name, None)
+        if isinstance(existing, str) and existing.strip():
+            return item
+
+        item_dict = getattr(item, "__dict__", None)
+        if isinstance(item_dict, dict):
+            patched = dict(item_dict)
+            patched[field_name] = arguments_text
+            return SimpleNamespace(**patched)
+        return item
 
     def _normalize_codex_response(self, response: Any) -> tuple[Any, str]:
         """Normalize a Responses API object to an assistant_message-like object."""
@@ -4112,8 +4149,9 @@ class AIAgent:
         saw_final_answer_phase = False
 
         for item in output:
-            item_type = getattr(item, "type", None)
-            item_status = getattr(item, "status", None)
+            is_dict_item = isinstance(item, dict)
+            item_type = item.get("type") if is_dict_item else getattr(item, "type", None)
+            item_status = item.get("status") if is_dict_item else getattr(item, "status", None)
             if isinstance(item_status, str):
                 item_status = item_status.strip().lower()
             else:
@@ -4123,7 +4161,7 @@ class AIAgent:
                 has_incomplete_items = True
 
             if item_type == "message":
-                item_phase = getattr(item, "phase", None)
+                item_phase = item.get("phase") if is_dict_item else getattr(item, "phase", None)
                 if isinstance(item_phase, str):
                     normalized_phase = item_phase.strip().lower()
                     if normalized_phase in {"commentary", "analysis"}:
@@ -4140,18 +4178,18 @@ class AIAgent:
                 # Capture the full reasoning item for multi-turn continuity.
                 # encrypted_content is an opaque blob the API needs back on
                 # subsequent turns to maintain coherent reasoning chains.
-                encrypted = getattr(item, "encrypted_content", None)
+                encrypted = item.get("encrypted_content") if is_dict_item else getattr(item, "encrypted_content", None)
                 if isinstance(encrypted, str) and encrypted:
                     raw_item = {"type": "reasoning", "encrypted_content": encrypted}
-                    item_id = getattr(item, "id", None)
+                    item_id = item.get("id") if is_dict_item else getattr(item, "id", None)
                     if isinstance(item_id, str) and item_id:
                         raw_item["id"] = item_id
                     # Capture summary — required by the API when replaying reasoning items
-                    summary = getattr(item, "summary", None)
+                    summary = item.get("summary") if is_dict_item else getattr(item, "summary", None)
                     if isinstance(summary, list):
                         raw_summary = []
                         for part in summary:
-                            text = getattr(part, "text", None)
+                            text = part.get("text") if isinstance(part, dict) else getattr(part, "text", None)
                             if isinstance(text, str):
                                 raw_summary.append({"type": "summary_text", "text": text})
                         raw_item["summary"] = raw_summary
@@ -4159,12 +4197,12 @@ class AIAgent:
             elif item_type == "function_call":
                 if item_status in {"queued", "in_progress", "incomplete"}:
                     continue
-                fn_name = getattr(item, "name", "") or ""
-                arguments = getattr(item, "arguments", "{}")
+                fn_name = (item.get("name") if is_dict_item else getattr(item, "name", "")) or ""
+                arguments = item.get("arguments", "{}") if is_dict_item else getattr(item, "arguments", "{}")
                 if not isinstance(arguments, str):
                     arguments = json.dumps(arguments, ensure_ascii=False)
-                raw_call_id = getattr(item, "call_id", None)
-                raw_item_id = getattr(item, "id", None)
+                raw_call_id = item.get("call_id") if is_dict_item else getattr(item, "call_id", None)
+                raw_item_id = item.get("id") if is_dict_item else getattr(item, "id", None)
                 embedded_call_id, _ = self._split_responses_tool_id(raw_item_id)
                 call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
                 if not isinstance(call_id, str) or not call_id.strip():
@@ -4180,12 +4218,12 @@ class AIAgent:
                     function=SimpleNamespace(name=fn_name, arguments=arguments),
                 ))
             elif item_type == "custom_tool_call":
-                fn_name = getattr(item, "name", "") or ""
-                arguments = getattr(item, "input", "{}")
+                fn_name = (item.get("name") if is_dict_item else getattr(item, "name", "")) or ""
+                arguments = item.get("input", "{}") if is_dict_item else getattr(item, "input", "{}")
                 if not isinstance(arguments, str):
                     arguments = json.dumps(arguments, ensure_ascii=False)
-                raw_call_id = getattr(item, "call_id", None)
-                raw_item_id = getattr(item, "id", None)
+                raw_call_id = item.get("call_id") if is_dict_item else getattr(item, "call_id", None)
+                raw_item_id = item.get("id") if is_dict_item else getattr(item, "id", None)
                 embedded_call_id, _ = self._split_responses_tool_id(raw_item_id)
                 call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
                 if not isinstance(call_id, str) or not call_id.strip():
@@ -4519,6 +4557,7 @@ class AIAgent:
         self._codex_streamed_text_parts: list = []
         for attempt in range(max_stream_retries + 1):
             collected_output_items: list = []
+            streamed_tool_arguments: dict[str, list[str]] = {}
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
                     for event in stream:
@@ -4540,8 +4579,14 @@ class AIAgent:
                                         except Exception:
                                             pass
                                 self._fire_stream_delta(delta_text)
+                        elif event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
+                            has_tool_calls = True
+                            item_id = getattr(event, "item_id", None)
+                            delta_text = getattr(event, "delta", "")
+                            if isinstance(item_id, str) and item_id and isinstance(delta_text, str) and delta_text:
+                                streamed_tool_arguments.setdefault(item_id, []).append(delta_text)
                         # Track tool calls to suppress text streaming
-                        elif "function_call" in event_type:
+                        elif "function_call" in event_type or "custom_tool_call" in event_type:
                             has_tool_calls = True
                         # Fire reasoning callbacks
                         elif "reasoning" in event_type and "delta" in event_type:
@@ -4555,6 +4600,12 @@ class AIAgent:
                         elif event_type == "response.output_item.done":
                             done_item = getattr(event, "item", None)
                             if done_item is not None:
+                                done_item_id = getattr(done_item, "id", None)
+                                if isinstance(done_item_id, str) and done_item_id in streamed_tool_arguments:
+                                    done_item = self._response_stream_item_with_arguments(
+                                        done_item,
+                                        "".join(streamed_tool_arguments[done_item_id]),
+                                    )
                                 collected_output_items.append(done_item)
                         # Log non-completed terminal events for diagnostics
                         elif event_type in ("response.incomplete", "response.failed"):
@@ -4645,6 +4696,7 @@ class AIAgent:
         terminal_response = None
         collected_output_items: list = []
         collected_text_deltas: list = []
+        streamed_tool_arguments: dict[str, list[str]] = {}
         try:
             for event in stream_or_response:
                 self._touch_activity("receiving stream response")
@@ -4658,6 +4710,14 @@ class AIAgent:
                     if done_item is None and isinstance(event, dict):
                         done_item = event.get("item")
                     if done_item is not None:
+                        done_item_id = getattr(done_item, "id", None)
+                        if done_item_id is None and isinstance(done_item, dict):
+                            done_item_id = done_item.get("id")
+                        if isinstance(done_item_id, str) and done_item_id in streamed_tool_arguments:
+                            done_item = self._response_stream_item_with_arguments(
+                                done_item,
+                                "".join(streamed_tool_arguments[done_item_id]),
+                            )
                         collected_output_items.append(done_item)
                 elif event_type in ("response.output_text.delta",):
                     delta = getattr(event, "delta", "")
@@ -4665,6 +4725,15 @@ class AIAgent:
                         delta = event.get("delta", "")
                     if delta:
                         collected_text_deltas.append(delta)
+                elif event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
+                    item_id = getattr(event, "item_id", None)
+                    delta = getattr(event, "delta", "")
+                    if item_id is None and isinstance(event, dict):
+                        item_id = event.get("item_id")
+                    if not delta and isinstance(event, dict):
+                        delta = event.get("delta", "")
+                    if isinstance(item_id, str) and item_id and isinstance(delta, str) and delta:
+                        streamed_tool_arguments.setdefault(item_id, []).append(delta)
 
                 if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                     continue

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -179,6 +179,39 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _FakeStreamingToolCallResponsesStream(_FakeResponsesStream):
+    def __init__(self, *, final_response=None, tool_name="clarify", arguments='{"question":"What should I update?"}'):
+        super().__init__(final_response=final_response)
+        self._tool_name = tool_name
+        self._arguments = arguments
+
+    def __iter__(self):
+        item = SimpleNamespace(
+            type="function_call",
+            id="fc_stream_1",
+            call_id="call_stream_1",
+            name=self._tool_name,
+            status="completed",
+        )
+        return iter(
+            [
+                SimpleNamespace(type="response.output_item.added", output_index=0, item=item),
+                SimpleNamespace(
+                    type="response.function_call_arguments.delta",
+                    output_index=0,
+                    item_id="fc_stream_1",
+                    delta=self._arguments,
+                ),
+                SimpleNamespace(
+                    type="response.function_call_arguments.done",
+                    output_index=0,
+                    item_id="fc_stream_1",
+                ),
+                SimpleNamespace(type="response.output_item.done", output_index=0, item=item),
+            ]
+        )
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -474,6 +507,104 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_salvages_function_call_arguments_when_final_response_is_empty(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeStreamingToolCallResponsesStream(
+                final_response=SimpleNamespace(
+                    output=[],
+                    output_text="",
+                    usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+                    status="completed",
+                    model="gpt-5-codex",
+                )
+            ),
+            create=lambda **kwargs: _codex_message_response("unused fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assistant_message, finish_reason = agent._normalize_codex_response(response)
+
+    assert finish_reason == "tool_calls"
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].function.name == "clarify"
+    assert assistant_message.tool_calls[0].function.arguments == '{"question":"What should I update?"}'
+
+
+def test_codex_create_stream_fallback_salvages_function_call_arguments(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(
+                type="response.function_call_arguments.delta",
+                output_index=0,
+                item_id="fc_stream_1",
+                delta='{"question":"What should I update?"}',
+            ),
+            SimpleNamespace(
+                type="response.output_item.done",
+                output_index=0,
+                item=SimpleNamespace(
+                    type="function_call",
+                    id="fc_stream_1",
+                    call_id="call_stream_1",
+                    name="clarify",
+                    status="completed",
+                ),
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    output=[],
+                    output_text="",
+                    usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+                    status="completed",
+                    model="gpt-5-codex",
+                ),
+            ),
+        ]
+    )
+    agent.client = SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: create_stream))
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assistant_message, finish_reason = agent._normalize_codex_response(response)
+
+    assert finish_reason == "tool_calls"
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].function.name == "clarify"
+    assert assistant_message.tool_calls[0].function.arguments == '{"question":"What should I update?"}'
+
+
+def test_normalize_codex_response_supports_dict_tool_items(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    response = SimpleNamespace(
+        output=[
+            {
+                "type": "function_call",
+                "id": "fc_dict_1",
+                "call_id": "call_dict_1",
+                "name": "clarify",
+                "arguments": '{"question":"What should I update?"}',
+                "status": "completed",
+            }
+        ],
+        output_text="",
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+    assistant_message, finish_reason = agent._normalize_codex_response(response)
+
+    assert finish_reason == "tool_calls"
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].function.name == "clarify"
+    assert assistant_message.tool_calls[0].function.arguments == '{"question":"What should I update?"}'
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

This is a follow-up hardening patch in the same area as earlier Responses-stream work such as #5935 and #6236, but it is not intended as a replacement for those changes.

It fixes two adjacent Codex/Responses robustness issues in the streaming path:
- tolerate dict-shaped Responses output items/content parts during normalization
- salvage streamed tool-call arguments when the backend emits argument deltas but returns empty final output items

This prevents Hermes from dropping tool calls or normalizing them with `{}` arguments in edge-case Codex streaming responses.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - make `_extract_responses_message_text()` dict-safe
  - make `_extract_responses_reasoning_text()` dict-safe
  - make `_normalize_codex_response()` handle dict-shaped `message`, `reasoning`, `function_call`, and `custom_tool_call` items
  - add `_response_stream_item_with_arguments()` helper to backfill streamed tool-call arguments/input
  - capture `response.function_call_arguments.delta` and `response.custom_tool_call_input.delta`
  - patch `response.output_item.done` items before backfilling empty final output
- `tests/run_agent/test_run_agent_codex_responses.py`
  - add regressions for streamed function-call argument salvage in both stream paths
  - add regression for dict-shaped tool items

## How to Test

1. `source venv/bin/activate`
2. `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o addopts=`
3. Confirm all tests pass, including:
   - streamed function-call arg salvage when final response output is empty
   - create(stream=True) fallback arg salvage
   - dict-shaped tool item normalization

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification:
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o addopts=`
- result: passing locally

Note: the full repository suite currently has unrelated baseline failures in this environment on `origin/main`, so targeted verification was used for this scoped bugfix.
