### PR TITLE
fix(gateway): prevent streaming mode from silently dropping final response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4127,13 +4127,24 @@ class GatewayRunner:
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
             if agent_result.get("already_sent") and not agent_result.get("failed"):
-                if response:
-                    _media_adapter = self.adapters.get(source.platform)
-                    if _media_adapter:
-                        await self._deliver_media_from_response(
-                            response, event, _media_adapter,
-                        )
-                return None
+                # Only skip independent delivery if the stream consumer
+                # confirmed it delivered the final response content.
+                # If final_response_sent is False, the final text was NOT
+                # streamed — fall through to deliver it normally.
+                if agent_result.get("final_response_sent", False):
+                    if response:
+                        _media_adapter = self.adapters.get(source.platform)
+                        if _media_adapter:
+                            await self._deliver_media_from_response(
+                                response, event, _media_adapter,
+                            )
+                    return None
+                else:
+                    logger.warning(
+                        "Stream had already_sent=True but final_response_sent=False — "
+                        "falling through to independent delivery for session %s",
+                        event.session_id,
+                    )
 
             return response
             
@@ -9476,6 +9487,7 @@ class GatewayRunner:
                 or getattr(_sc, "already_sent", False)
             ):
                 response["already_sent"] = True
+                response["final_response_sent"] = getattr(_sc, "final_response_sent", False)
         
         return response
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -322,7 +322,10 @@ class GatewayStreamConsumer:
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            self._final_response_sent = self._already_sent
+                            # Only mark final response as sent if we actually
+                            # delivered content in this final flush (not just
+                            # earlier tool-progress messages).
+                            self._final_response_sent = self._already_sent and bool(chunks)
                             return
                         if got_segment_break:
                             self._message_id = None
@@ -409,13 +412,18 @@ class GatewayStreamConsumer:
                 except Exception:
                     pass
             # If we delivered any content before being cancelled, mark the
-            # final response as sent so the gateway's already_sent check
-            # doesn't trigger a duplicate message.  The 5-second
-            # stream_task timeout (gateway/run.py) can cancel us while
-            # waiting on a slow Telegram API call — without this flag the
-            # gateway falls through to the normal send path.
+            # final response as sent ONLY if the accumulated content matches
+            # what was last sent/edited (user already saw it).  If there's
+            # new unsent text beyond what was displayed, the gateway's
+            # fallback path should deliver it.
             if self._already_sent:
-                self._final_response_sent = True
+                # Strip cursor suffix for comparison — last_sent_text may
+                # include the cursor from progressive edits.
+                _last = self._last_sent_text
+                if _last.endswith(self.cfg.cursor):
+                    _last = _last[: -len(self.cfg.cursor)]
+                _unsent = len(self._accumulated) > 0 and self._accumulated != _last
+                self._final_response_sent = not _unsent
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
 


### PR DESCRIPTION
## What Changed

Fixed a bug where the gateway silently drops the final assistant response in streaming mode. The stream consumer incorrectly set `final_response_sent=True` based on `already_sent` (which only tracks whether *any* message was ever sent, including tool-progress edits), causing the gateway to skip independent delivery of the actual final response.

### Changes:

**`gateway/stream_consumer.py`:**
- Line 325: Only mark `final_response_sent` when content was actually delivered in the final flush (`bool(chunks)`), not just because earlier messages were sent
- `CancelledError` handler: Compare accumulated buffer against last-sent text to detect unsent content, instead of blindly trusting `already_sent`

**`gateway/run.py`:**
- Check `final_response_sent` (not just `already_sent`) before skipping independent delivery
- Fall through to normal delivery path with a warning log when final response was not confirmed delivered
- Propagate `final_response_sent` into the agent result dict

## Why

Users experience the agent "going silent" after tool calls — the complete response is generated and stored in the database but never delivered. This is a data-loss bug in the delivery pipeline.

Root cause: `already_sent` conflates "tool progress was streamed" with "final response was delivered." When tool-progress edits set `already_sent=True`, the gateway assumes the final response was already streamed and returns `None`.

Closes #10748

## How to Test

1. Enable `streaming: true` in config.yaml
2. Send a message that triggers multiple tool calls followed by a text response
3. Verify the final response is delivered (previously it would be silently dropped)
4. Also verify normal streaming (no tool calls) still works without duplicate messages
5. Run stream_consumer tests: `python -m pytest tests/gateway/test_stream_consumer.py -q`

### Test Results
- **Functional**: Confirmed fix with live Telegram session — multi-tool-call messages now deliver final response consistently
- **Regression**: 57/57 `test_stream_consumer.py` tests pass (no new failures)
- **Manual**: Ran `hermes` gateway with streaming enabled, exercised multi-tool and single-tool code paths

## Platforms Tested
- Ubuntu 24.04 (x86_64)
- Telegram adapter
- Python 3.11, Hermes v0.9.0