### PR TITLE
fix(skills): clarify category-qualified skill_view errors

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -313,6 +313,16 @@ class TestSkillView:
         assert "not found" in result["error"].lower()
         assert "available_skills" in result
 
+    def test_view_category_qualified_skill_shows_helpful_hint(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "hermes-agent", category="autonomous-ai-agents")
+            raw = skill_view("autonomous-ai-agents:hermes-agent")
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "looks like a category-qualified skill" in result["error"]
+        assert result["hint"] == "Use skill_view('hermes-agent') or skills_list(category='autonomous-ai-agents')"
+        assert result["available_skills"] == ["hermes-agent"]
+
     def test_view_reference_file(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "my-skill")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -869,8 +869,43 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                     },
                     ensure_ascii=False,
                 )
-            # Plugin itself not found — fall through to flat-tree scan
-            # which will return a normal "not found" with suggestions.
+            # Plugin itself not found — check whether the prefix looks like a
+            # regular skill category before falling through to flat-tree scan.
+            category_skills = [
+                s["name"]
+                for s in _find_all_skills()
+                if s.get("category") == namespace
+            ]
+            if category_skills:
+                sample = ", ".join(category_skills[:10])
+                if bare in category_skills:
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "error": (
+                                f"'{namespace}:{bare}' looks like a category-qualified skill, "
+                                f"not a plugin skill. Skill '{bare}' is listed under the "
+                                f"'{namespace}' category."
+                            ),
+                            "hint": f"Use skill_view('{bare}') or skills_list(category='{namespace}')",
+                            "available_skills": category_skills[:20],
+                        },
+                        ensure_ascii=False,
+                    )
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"'{namespace}' looks like a regular skill category, not a plugin namespace. "
+                            f"Use skills_list(category='{namespace}') to browse it."
+                        ),
+                        "hint": f"Category '{namespace}' contains: {sample}",
+                        "available_skills": category_skills[:20],
+                    },
+                    ensure_ascii=False,
+                )
+            # No matching category found — fall through to flat-tree scan which
+            # will return a normal "not found" with suggestions.
 
         from agent.skill_utils import get_external_skills_dirs
 


### PR DESCRIPTION
Closes #10713\n\n## Summary\n- Detect category-qualified skill names that are mistaken for plugin namespaces.\n- Return a clearer error and hint when users try category:skill for regular skills.\n- Add regression coverage for the confusion case.