### PR TITLE
fix(browser): suppress KeyboardInterrupt in atexit cleanup thread stop

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -637,7 +637,10 @@ def _stop_browser_cleanup_thread():
     global _cleanup_running
     _cleanup_running = False
     if _cleanup_thread is not None:
-        _cleanup_thread.join(timeout=5)
+        try:
+            _cleanup_thread.join(timeout=5)
+        except KeyboardInterrupt:
+            pass
 
 
 def _update_session_activity(task_id: str):


### PR DESCRIPTION
## What does this PR do?

Suppresses a noisy `KeyboardInterrupt` traceback that appears when a user presses Ctrl+C multiple times to exit the Hermes TUI. The `_stop_browser_cleanup_thread()` function is registered via `atexit.register()` and calls `_cleanup_thread.join(timeout=5)`. During the 5-second wait, a subsequent Ctrl+C interrupts `lock.acquire()` inside `threading.Thread.join()`, producing an "Exception ignored in atexit callback" traceback. Since the cleanup thread is a daemon thread that will be killed on process exit anyway, silently swallowing the `KeyboardInterrupt` is safe and produces a clean shutdown.

## Related Issue

Fixes #10764

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/browser_tool.py`: Wrapped `_cleanup_thread.join(timeout=5)` in `try/except KeyboardInterrupt: pass` inside `_stop_browser_cleanup_thread()`

## How to Test

1. Start Hermes TUI (`hermes`)
2. Begin any conversation or tool execution
3. Press Ctrl+C once to interrupt — works as before
4. Press Ctrl+C multiple times quickly during shutdown
5. **Before fix**: Noisy traceback with "Exception ignored in atexit callback" printed to terminal
6. **After fix**: Clean exit with no error output

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Ubuntu 24.04 x86_64, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A (atexit + threading is cross-platform)
