### PR TITLE
fix: reject startup when no provider configured instead of silent OpenRouter fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1021,16 +1021,12 @@ class AIAgent:
                             f"was found. Set the {_env_hint} environment "
                             f"variable, or switch to a different provider with `hermes model`."
                         )
-                    # Final fallback: try raw OpenRouter key
-                    client_kwargs = {
-                        "api_key": os.getenv("OPENROUTER_API_KEY", ""),
-                        "base_url": OPENROUTER_BASE_URL,
-                        "default_headers": {
-                            "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-                            "X-OpenRouter-Title": "Hermes Agent",
-                            "X-OpenRouter-Categories": "productivity,cli-agent",
-                        },
-                    }
+                    # No provider configured — reject with a clear message.
+                    raise RuntimeError(
+                        "No LLM provider configured. Run `hermes model` to "
+                        "select a provider, or run `hermes setup` for first-time "
+                        "configuration."
+                    )
             
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 


### PR DESCRIPTION
## Summary

When no provider was set in config.yaml and `resolve_provider_client("auto")` found no credentials, the agent silently fell back to bare `OPENROUTER_API_KEY` from the environment and sent whatever model name was configured to OpenRouter. Wrong provider, wrong model, wrong routing for compression/vision.

## Fix

Replace the silent fallback with a hard error:

```
RuntimeError: No LLM provider configured. Run `hermes model` to
select a provider, or run `hermes setup` for first-time configuration.
```

The provider must be explicitly set in config.yaml. Env vars are for secrets, not configuration.

1 file, 6 insertions, 10 deletions.