### PR TITLE
fix(compressor): fix NameError in summary model fallback retry

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -730,7 +730,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60


### PR DESCRIPTION
## What

Fix a `NameError` in `agent/context_compressor.py` where the summary model fallback retry passes undefined variables.

## Bug

When the configured summary model is unavailable (404/503/model_not_found), `_generate_summary()` falls back to the main model. The fallback path at line 733 calls:

```python
return self._generate_summary(messages, summary_budget)
```

But `messages` and `summary_budget` don't exist in the method scope. The method signature is:

```python
def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
```

- `messages` → should be `turns_to_summarize` (the first parameter)
- `summary_budget` (an int) → should be `focus_topic=focus_topic` (a string or None)

**Impact:** When the summary model becomes unavailable, compression crashes with `NameError` instead of gracefully falling back to the main model.

## Fix

```python
- return self._generate_summary(messages, summary_budget)
+ return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
```

## Testing

- `tests/run_agent/test_compressor_fallback_update.py` — 2 passed
- `tests/agent/test_context_compressor.py::TestShouldCompress` — 3 passed
- `tests/agent/test_context_compressor.py::TestSummaryFailureCooldown` — 3 passed
- `tests/agent/test_context_compressor.py::TestCompress` — 3 passed

Closes #10721
