### PR TITLE
fix(skills): raise snapshot description limit from 60 to 200 chars

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -428,7 +428,7 @@ CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -421,8 +421,8 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 200:
+        return desc[:197] + "..."
     return desc
 
 


### PR DESCRIPTION
## Summary

Raise the hard-coded snapshot description truncation limit from **60 → 200 characters**.

### Problem

`agent/skill_utils.py::extract_skill_description()` truncates at 60 chars (`[:57] + "..."`). For Chinese skills this drops entire keyword groups, breaking Hermes skill matching by natural language.

### Solution

- `agent/skill_utils.py`: `if len(desc) > 60:` → `> 200:`, truncate at 197 chars
- `agent/prompt_builder.py`: `_SKILLS_SNAPSHOT_VERSION` 1 → 2 (forces snapshot rebuild)

### Impact

- ~88% of skills (84/95) were being truncated
- Automatic rebuild on next cold start
- No breaking API changes
