### PR TITLE
fix: normalize Codex Responses tool schemas for Honcho memory tools

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1012,13 +1012,27 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_conclude":
                 delete_id = args.get("delete_id")
+                if delete_id is None:
+                    delete_id = ""
+                elif not isinstance(delete_id, str):
+                    delete_id = str(delete_id)
+                delete_id = delete_id.strip()
+
+                conclusion = args.get("conclusion", "")
+                if conclusion is None:
+                    conclusion = ""
+                elif not isinstance(conclusion, str):
+                    conclusion = str(conclusion)
+                conclusion = conclusion.strip()
+
                 peer = args.get("peer", "user")
+                if delete_id and conclusion:
+                    return tool_error("Pass exactly one of conclusion or delete_id, not both.")
                 if delete_id:
                     ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
-                conclusion = args.get("conclusion", "")
                 if not conclusion:
                     return tool_error("Missing required parameter: conclusion or delete_id")
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3622,6 +3622,51 @@ class AIAgent:
         if self._memory_store:
             self._memory_store.load_from_disk()
 
+    @staticmethod
+    def _normalize_responses_tool_parameters(parameters: Any) -> Dict[str, Any]:
+        """Normalize tool parameter schemas for Responses API compatibility."""
+        if not isinstance(parameters, dict):
+            return {"type": "object", "properties": {}}
+
+        schema = copy.deepcopy(parameters)
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            schema["properties"] = {}
+        if schema.get("type") != "object":
+            schema["type"] = "object"
+
+        merged_required = schema.get("required")
+        if not isinstance(merged_required, list):
+            merged_required = []
+
+        top_level_all_of = schema.pop("allOf", None)
+        if isinstance(top_level_all_of, list):
+            for branch in top_level_all_of:
+                if not isinstance(branch, dict):
+                    continue
+                branch_properties = branch.get("properties")
+                if isinstance(branch_properties, dict):
+                    for key, value in branch_properties.items():
+                        if key not in schema["properties"]:
+                            schema["properties"][key] = copy.deepcopy(value)
+                branch_required = branch.get("required")
+                if isinstance(branch_required, list):
+                    for item in branch_required:
+                        if isinstance(item, str) and item not in merged_required:
+                            merged_required.append(item)
+                if "additionalProperties" in branch and "additionalProperties" not in schema:
+                    schema["additionalProperties"] = branch["additionalProperties"]
+
+        if merged_required:
+            schema["required"] = merged_required
+        elif "required" in schema and not isinstance(schema.get("required"), list):
+            schema.pop("required", None)
+
+        for key in ("anyOf", "oneOf", "enum", "not"):
+            schema.pop(key, None)
+
+        return schema
+
     def _responses_tools(self, tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
         """Convert chat-completions tool schemas to Responses function-tool schemas."""
         source_tools = tools if tools is not None else self.tools
@@ -3639,7 +3684,9 @@ class AIAgent:
                 "name": name,
                 "description": fn.get("description", ""),
                 "strict": False,
-                "parameters": fn.get("parameters", {"type": "object", "properties": {}}),
+                "parameters": self._normalize_responses_tool_parameters(
+                    fn.get("parameters", {"type": "object", "properties": {}})
+                ),
             })
         return converted or None
 
@@ -3967,7 +4014,7 @@ class AIAgent:
                         "name": name.strip(),
                         "description": description,
                         "strict": strict,
-                        "parameters": parameters,
+                        "parameters": self._normalize_responses_tool_parameters(parameters),
                     }
                 )
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -474,6 +474,24 @@ class TestConcludeToolDispatch:
         provider._manager.create_conclusion.assert_not_called()
         provider._manager.delete_conclusion.assert_not_called()
 
+    def test_honcho_conclude_rejects_both_params(self):
+        """Calling honcho_conclude with both conclusion and delete_id returns a tool error."""
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "User prefers dark mode", "delete_id": "conc_123"},
+        )
+
+        parsed = json.loads(result)
+        assert "error" in parsed or "exactly one" in parsed.get("result", "")
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Message chunking

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -735,6 +735,37 @@ def test_preflight_codex_api_kwargs_rejects_unsupported_request_fields(monkeypat
         agent._preflight_codex_api_kwargs(kwargs)
 
 
+def test_preflight_codex_api_kwargs_sanitizes_top_level_parameter_anyof(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["tools"] = [
+        {
+            "type": "function",
+            "name": "honcho_conclude",
+            "description": "Write or delete a conclusion.",
+            "strict": False,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "conclusion": {"type": "string"},
+                    "delete_id": {"type": "string"},
+                },
+                "anyOf": [
+                    {"required": ["conclusion"]},
+                    {"required": ["delete_id"]},
+                ],
+            },
+        }
+    ]
+
+    result = agent._preflight_codex_api_kwargs(kwargs)
+
+    params = result["tools"][0]["parameters"]
+    assert params["type"] == "object"
+    assert sorted(params["properties"].keys()) == ["conclusion", "delete_id"]
+    assert "anyOf" not in params
+
+
 def test_preflight_codex_api_kwargs_allows_reasoning_and_temperature(monkeypatch):
     agent = _build_agent(monkeypatch)
     kwargs = _codex_request_kwargs()


### PR DESCRIPTION
## Summary
- normalize tool parameter schemas before sending them to the Codex Responses API
- preserve Honcho conclude behavior by validating mutually exclusive `conclusion` / `delete_id` arguments at runtime
- add regressions for the sanitized Responses payload and Honcho conclude validation

## Root Cause
`honcho_conclude` exposed a top-level `anyOf` in its parameter schema. The `openai-codex` Responses API now rejects top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` in function schemas, and Hermes was forwarding that schema unchanged on the Responses path.

## Testing
- source venv/bin/activate && python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q
- source venv/bin/activate && python -m pytest tests/honcho_plugin/test_session.py -q
- source venv/bin/activate && python -m pytest tests/run_agent/test_strict_api_validation.py -q

Fixes #10723