### PR TITLE
fix: preserve Bedrock model ID dots in normalization pipeline

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -80,6 +80,7 @@ _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
 
 # Providers whose native naming is authoritative -- pass through unchanged.
 _AUTHORITATIVE_NATIVE_PROVIDERS: frozenset[str] = frozenset({
+    "bedrock",
     "gemini",
     "huggingface",
 })

--- a/run_agent.py
+++ b/run_agent.py
@@ -6291,7 +6291,7 @@ class AIAgent:
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "bedrock", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1588,3 +1588,101 @@ class TestToolChoice:
             tool_choice="search",
         )
         assert kwargs["tool_choice"] == {"type": "tool", "name": "search"}
+
+
+# ---------------------------------------------------------------------------
+# Bug condition exploration: Bedrock model ID dot preservation
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockDotPreservation:
+    """Exploration tests for Bedrock model ID normalization bug.
+
+    Bedrock model IDs use dots as vendor separators (e.g. anthropic.claude-sonnet-4-6).
+    These tests encode the EXPECTED (correct) behavior — they will fail on unfixed code
+    (confirming the bug) and pass after the fix.
+
+    Validates: Requirements 1.1, 1.2, 1.3, 2.1, 2.2, 2.3
+    """
+
+    @pytest.mark.parametrize("model_id", [
+        "anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-sonnet-4-6",
+        "anthropic.claude-sonnet-4-6-v2:0",
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+    ])
+    def test_bedrock_model_ids_preserve_dots(self, model_id):
+        """normalize_model_name() with preserve_dots=True must return Bedrock IDs unchanged."""
+        result = normalize_model_name(model_id, preserve_dots=True)
+        assert result == model_id, (
+            f"Expected Bedrock model ID to pass through unchanged, "
+            f"but got {result!r} instead of {model_id!r}"
+        )
+
+    def test_bedrock_provider_preserves_dots(self):
+        """_anthropic_preserve_dots() must return True for bedrock provider."""
+        from run_agent import AIAgent
+
+        agent = SimpleNamespace(provider="bedrock", base_url="")
+        result = AIAgent._anthropic_preserve_dots(agent)
+        assert result is True, (
+            "_anthropic_preserve_dots() returned False for bedrock provider — "
+            "this confirms the root cause: bedrock is missing from the provider set"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Preservation: Non-Bedrock provider normalization unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestNonBedrockPreservation:
+    """Preservation tests confirming non-Bedrock providers are unaffected.
+
+    These tests capture baseline behavior on UNFIXED code and must continue
+    to pass after the fix (no regressions).
+
+    Validates: Requirements 3.1, 3.2, 3.3, 3.4
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        ("claude-sonnet-4.6", "claude-sonnet-4-6"),
+        ("claude-opus-4.5", "claude-opus-4-5"),
+        ("anthropic/claude-opus-4.6", "claude-opus-4-6"),
+    ])
+    def test_anthropic_dot_to_hyphen_preserved(self, model, expected):
+        """normalize_model_name() with preserve_dots=False must convert dots to hyphens."""
+        result = normalize_model_name(model, preserve_dots=False)
+        assert result == expected, (
+            f"Expected {expected!r}, got {result!r}"
+        )
+
+    @pytest.mark.parametrize("provider", [
+        "alibaba",
+        "minimax",
+        "minimax-cn",
+        "opencode-go",
+        "opencode-zen",
+        "zai",
+    ])
+    def test_dot_preserving_providers_still_true(self, provider):
+        """_anthropic_preserve_dots() must return True for known dot-preserving providers."""
+        from run_agent import AIAgent
+
+        agent = SimpleNamespace(provider=provider, base_url="")
+        result = AIAgent._anthropic_preserve_dots(agent)
+        assert result is True, (
+            f"_anthropic_preserve_dots() returned False for {provider!r} — "
+            f"expected True"
+        )
+
+    def test_anthropic_provider_does_not_preserve_dots(self):
+        """_anthropic_preserve_dots() must return False for native anthropic provider."""
+        from run_agent import AIAgent
+
+        agent = SimpleNamespace(provider="anthropic", base_url="https://api.anthropic.com")
+        result = AIAgent._anthropic_preserve_dots(agent)
+        assert result is False, (
+            "_anthropic_preserve_dots() returned True for native anthropic — "
+            "expected False"
+        )

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -138,3 +138,59 @@ class TestDetectVendor:
     ])
     def test_detects_known_vendors(self, model, expected):
         assert detect_vendor(model) == expected
+
+
+# ---------------------------------------------------------------------------
+# Bug condition exploration: Bedrock model ID preservation
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockModelIdPreservation:
+    """Exploration tests for Bedrock model ID normalization bug.
+
+    Bedrock model IDs are already in their native AWS format and must pass
+    through normalize_model_for_provider() unchanged.
+
+    Validates: Requirements 2.1, 2.2, 2.3
+    """
+
+    @pytest.mark.parametrize("model_id", [
+        "anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-sonnet-4-6",
+        "anthropic.claude-sonnet-4-6-v2:0",
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+    ])
+    def test_bedrock_model_ids_pass_through(self, model_id):
+        """normalize_model_for_provider() with provider='bedrock' must return IDs unchanged."""
+        result = normalize_model_for_provider(model_id, "bedrock")
+        assert result == model_id, (
+            f"Expected Bedrock model ID to pass through unchanged, "
+            f"but got {result!r} instead of {model_id!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Preservation: Non-Bedrock provider normalization unchanged
+# ---------------------------------------------------------------------------
+
+
+class TestNonBedrockPreservation:
+    """Preservation tests confirming non-Bedrock providers are unaffected.
+
+    These tests capture baseline behavior on UNFIXED code and must continue
+    to pass after the fix (no regressions).
+
+    Validates: Requirements 3.1, 3.2, 3.3, 3.4
+    """
+
+    @pytest.mark.parametrize("model,provider,expected", [
+        ("claude-sonnet-4.6", "anthropic", "claude-sonnet-4-6"),
+        ("claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        ("glm-4.5", "copilot", "glm-4.5"),
+    ])
+    def test_non_bedrock_providers_unchanged(self, model, provider, expected):
+        """normalize_model_for_provider() must produce expected results for non-Bedrock providers."""
+        result = normalize_model_for_provider(model, provider)
+        assert result == expected, (
+            f"Expected {expected!r} for ({model!r}, {provider!r}), got {result!r}"
+        )


### PR DESCRIPTION
Bedrock model IDs use dots as vendor separators (e.g. `anthropic.claude-sonnet-4-6`), but `normalize_model_name()` was replacing all dots with hyphens, producing invalid IDs like `anthropic-claude-sonnet-4-6`.

Root cause: `_anthropic_preserve_dots()` in `run_agent.py` did not include `"bedrock"` in its provider set, so the `anthropic_messages` path called `normalize_model_name()` with `preserve_dots=False`.

Fix:
- Add `"bedrock"` to `_anthropic_preserve_dots()` provider set so Bedrock model IDs keep their vendor dot separators through the Anthropic Messages API adapter.
- Add `"bedrock"` to `_AUTHORITATIVE_NATIVE_PROVIDERS` in `model_normalize.py` so Bedrock model IDs pass through startup normalization unchanged.

Covers standard (`anthropic.claude-*`), cross-region (`us.anthropic.claude-*`), and versioned (`anthropic.claude-*-v2:0`) model ID formats.

Tests: 22 new parametrized tests for bug condition + preservation.

**Note:** Bedrock's inference profile requirement (needing `us.anthropic.claude-*` instead of bare `anthropic.claude-*` for on-demand throughput) is a separate issue — this PR only fixes the dot-mangling that broke Anthropic/Claude model IDs on the Bedrock `anthropic_messages` path. Non-Claude Bedrock models (Nova, Llama, etc.) use the `bedrock_converse` path and were unaffected. Users can work around the inference profile issue by setting the full model ID (e.g. `us.anthropic.claude-sonnet-4-6`) in config.yaml.


## What does this PR do?

When provider is `bedrock` and a Claude model is detected, hermes routes through the `anthropic_messages` API mode using the AnthropicBedrock SDK. The model ID (e.g. `anthropic.claude-sonnet-4-6`) flows through `normalize_model_name()` with `preserve_dots=False`, which replaces the vendor dot separator with a hyphen. The resulting `anthropic-claude-sonnet-4-6` is not a valid Bedrock model identifier, causing API calls to fail with a 400.

Non-Claude Bedrock models (Nova, DeepSeek, Llama, etc.) use the `bedrock_converse` path and were not affected by this bug.

This PR adds `"bedrock"` to two existing provider sets so Bedrock model IDs pass through both normalization layers unchanged. The Anthropic SDK itself does no model ID normalization — it just URL-encodes the model for the Bedrock invoke path — so the fix is entirely within hermes.


## Related Issue

N/A — discovered during Bedrock provider testing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: Added `"bedrock"` to the provider set in `_anthropic_preserve_dots()` (~line 6295)
- `hermes_cli/model_normalize.py`: Added `"bedrock"` to `_AUTHORITATIVE_NATIVE_PROVIDERS` (~line 88)
- `tests/agent/test_anthropic_adapter.py`: Added `TestBedrockDotPreservation` (5 tests) and `TestNonBedrockPreservation` (11 tests)
- `tests/hermes_cli/test_model_normalize.py`: Added `TestBedrockModelIdPreservation` (4 tests) and `TestNonBedrockPreservation` (3 tests)

## How to Test

1. Configure hermes with `provider: bedrock` and a Claude model (e.g. `us.anthropic.claude-sonnet-4-6`)
2. Run `hermes` and send a message — the API call should succeed without model ID errors
3. Verify non-Bedrock providers still work (e.g. `provider: anthropic` with `claude-sonnet-4.6` should still normalize to `claude-sonnet-4-6`)
4. Run `python -m pytest tests/agent/test_anthropic_adapter.py tests/hermes_cli/test_model_normalize.py -q` — 172 tests pass

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (EC2), tested with Bedrock + Claude models

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix:
<img width="2112" height="764" alt="image" src="https://github.com/user-attachments/assets/512e60d0-f70f-424b-adc1-04ecbac0c5d0" />
<img width="1170" height="656" alt="image" src="https://github.com/user-attachments/assets/8489f1e8-dc10-43dd-885b-69c09f24cc48" />


After fix (with inference profile model ID `us.anthropic.claude-sonnet-4-6`):
Model ID passes through unchanged, API calls succeed.
<img width="2104" height="418" alt="image" src="https://github.com/user-attachments/assets/f3890e39-f365-4ded-840a-a992c6d700d6" />

