### PR TITLE
feat(api-server): honor request-level model field for per-request model selection

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -517,6 +517,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -525,6 +526,10 @@ class APIServerAdapter(BasePlatformAdapter):
         base_url, etc. from config.yaml / env vars.  Toolsets are resolved
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
+
+        If *model_override* is a non-empty string (from the request's
+        ``model`` field), it takes precedence over the config-resolved
+        default so that API clients can select a model per request.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
@@ -532,6 +537,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         model = _resolve_gateway_model()
+
+        # Honor the request-level model when provided.
+        if model_override and model_override.strip():
+            model = model_override.strip()
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -712,7 +721,8 @@ class APIServerAdapter(BasePlatformAdapter):
             # history already set from request body above
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
-        model_name = body.get("model", self._model_name)
+        requested_model = body.get("model") or ""
+        model_name = requested_model or self._model_name
         created = int(time.time())
 
         if stream:
@@ -772,6 +782,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
+                model_override=requested_model,
             ))
 
             return await self._write_sse_chat_completion(
@@ -786,6 +797,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                model_override=requested_model,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1488,6 +1500,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # groups the entire conversation under one session entry.
         session_id = stored_session_id or str(uuid.uuid4())
 
+        requested_model = body.get("model") or ""
         stream = bool(body.get("stream", False))
         if stream:
             # Streaming branch — emit OpenAI Responses SSE events as the
@@ -1540,10 +1553,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
+                model_override=requested_model,
             ))
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
-            model_name = body.get("model", self._model_name)
+            model_name = requested_model or self._model_name
             created_at = int(time.time())
 
             return await self._write_sse_responses(
@@ -1568,6 +1582,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                model_override=requested_model,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1620,7 +1635,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "status": "completed",
             "created_at": created_at,
-            "model": body.get("model", self._model_name),
+            "model": requested_model or self._model_name,
             "output": output_items,
             "usage": {
                 "input_tokens": usage.get("input_tokens", 0),
@@ -1992,6 +2007,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
+        model_override: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2014,6 +2030,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
+                model_override=model_override,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -2176,6 +2193,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         session_id = body.get("session_id") or stored_session_id or run_id
         ephemeral_system_prompt = instructions
+        requested_model = body.get("model") or ""
 
         async def _run_and_close():
             try:
@@ -2184,6 +2202,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
+                    model_override=requested_model,
                 )
                 def _run_sync():
                     r = agent.run_conversation(


### PR DESCRIPTION
## Summary

The API server's `/v1/chat/completions`, `/v1/responses`, and `/v1/runs` endpoints accept a `model` field in the request body, but currently use it **only for response metadata** — the actual `AIAgent` always uses the globally configured model from `config.yaml` via `_resolve_gateway_model()`.

This patch threads the request's `model` value through `_run_agent` → `_create_agent` as `model_override`, which takes precedence over the config-resolved default when non-empty.

**Before:** `model` in request body is cosmetic — all requests use the same global model.
**After:** Sending `"model": "anthropic/claude-sonnet-4"` in the request body actually routes to that model.

When the request omits `model` or sends an empty string, behavior is **unchanged** — the global `config.yaml` model is used as before.

## Motivation

We're building an AI evaluation framework ([HolyEval](https://github.com/anthropics/holyeval)) that integrates Hermes as a target agent. We need to benchmark the same Hermes agent stack across different underlying models (e.g. `gpt-5.4` vs `claude-sonnet-4` vs `gemini-3-pro`) without reconfiguring the Hermes instance between runs.

The `AIAgent` class already supports per-instance model selection (`AIAgent(model=xxx)`), and the Python library docs show this as a supported pattern. The gateway's `/model` slash command also supports per-session overrides via `_session_model_overrides`. The API server is the only surface where the request-level `model` field is silently ignored.

## Relationship to #3155 / PR #3176

This PR **partially addresses** #3155 but takes a deliberately minimal, complementary approach:

| | PR #3176 (model_routes) | This PR (model pass-through) |
|---|---|---|
| **Approach** | Config-driven alias routing table | Direct model field pass-through |
| **Config required** | Yes — predefine aliases in `config.yaml` | No — any model string works |
| **Use case** | Multi-client routing (Xiaozhi → MiniMax, others → GPT) | Programmatic/dynamic model selection |
| **Scope** | 229 additions, new config schema, new tests | 22 additions, zero config changes |
| **Conflicts** | Currently has merge conflicts | Clean on latest main |

The two approaches are **complementary, not competing**:
- `model_routes` is great for **operators** who want to pin specific clients to specific backends via config
- Direct pass-through is great for **programmatic clients** (evaluation frameworks, CI pipelines, custom integrations) that need dynamic model selection

If both are merged, `model_routes` could take priority (resolve alias first, fall back to direct pass-through), giving operators config-level control while still enabling dynamic selection for unmapped model strings.

## Changes

**`gateway/platforms/api_server.py`** (1 file, +22 / -3)

- `_create_agent`: new `model_override` parameter — when non-empty, overrides `_resolve_gateway_model()`
- `_run_agent`: propagates `model_override` to `_create_agent`
- `_handle_chat_completions`: extracts `body["model"]`, passes to `_run_agent` (streaming + non-streaming)
- `_handle_responses`: same for `/v1/responses` (streaming + non-streaming)
- `_handle_runs`: same for `/v1/runs`

## Test plan

- [ ] Verify `POST /v1/chat/completions` with `"model": "anthropic/claude-sonnet-4"` uses that model (not config default)
- [ ] Verify `POST /v1/chat/completions` without `model` field still uses config default (backward compat)
- [ ] Verify `POST /v1/responses` with `model` field honors it
- [ ] Verify `POST /v1/runs` with `model` field honors it
- [ ] Verify streaming mode passes model through correctly

Partially addresses #3155.

Closes #3155 (core ask: honor incoming model field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)