### PR TITLE
fix: stop /model from silently rerouting direct providers to OpenRouter

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1064,7 +1064,8 @@ def detect_provider_for_model(
             break
 
     if direct_match:
-        # Check if we have credentials for this provider
+        # Check if we have credentials for this provider — env vars,
+        # credential pool, or auth store entries.
         has_creds = False
         try:
             from hermes_cli.auth import PROVIDER_REGISTRY
@@ -1077,16 +1078,28 @@ def detect_provider_for_model(
                         break
         except Exception:
             pass
+        # Also check credential pool and auth store — covers OAuth,
+        # Claude Code tokens, and other non-env-var credentials (#10300).
+        if not has_creds:
+            try:
+                from agent.credential_pool import load_pool
+                pool = load_pool(direct_match)
+                if pool.has_credentials():
+                    has_creds = True
+            except Exception:
+                pass
+        if not has_creds:
+            try:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                if direct_match in store.get("providers", {}) or direct_match in store.get("credential_pool", {}):
+                    has_creds = True
+            except Exception:
+                pass
 
-        if has_creds:
-            return (direct_match, name)
-
-        # No direct creds — try to find this model on OpenRouter instead
-        or_slug = _find_openrouter_slug(name)
-        if or_slug:
-            return ("openrouter", or_slug)
-        # Still return the direct provider — credential resolution will
-        # give a clear error rather than silently using the wrong provider
+        # Always return the direct provider match.  If credentials are
+        # missing, the client init will give a clear error rather than
+        # silently routing through the wrong provider (#10300).
         return (direct_match, name)
 
     # --- Step 2: check OpenRouter catalog ---


### PR DESCRIPTION
## Summary

Fixes #10300 — `detect_provider_for_model()` silently remapped models to OpenRouter when the direct provider's credentials weren't detected via env vars.

## Bugs Fixed

1. **Credential check too narrow** — only checked env vars from `PROVIDER_REGISTRY`, missing credential pool, auth store, and OAuth tokens
2. **Silent OpenRouter fallback** — when env var check failed, returned `("openrouter", slug)` instead of the direct provider
3. **Wrong provider for pool/OAuth users** — anyone with valid creds via non-env-var mechanisms got silently rerouted

## Fix

- Expanded credential check: env vars → credential pool → auth store
- Removed the silent OpenRouter fallback entirely — always return the direct provider match
- If credentials are truly missing, client init gives a clear error (from the provider-required PR we just merged)

Same philosophy: don't guess, don't silently reroute, error clearly.

1 file, 24 insertions, 11 deletions. 97 model tests pass.