### PR TITLE
fix(slack): add opt-in DM top-level thread sessions

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -366,6 +366,20 @@ class SlackAdapter(BasePlatformAdapter):
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
 
+    def _dm_top_level_threads_as_sessions_enabled(self) -> bool:
+        """Whether top-level Slack DMs should get per-message session threads.
+
+        Default behavior is backward-compatible: top-level DM messages share one
+        continuous session, even though Hermes replies under each message in a
+        visual Slack thread. When this flag is enabled, a top-level DM message's
+        own ``ts`` becomes the session thread id so each visual reply thread is
+        isolated as its own Hermes session.
+        """
+        raw = self.config.extra.get("dm_top_level_threads_as_sessions")
+        if raw is None:
+            raw = os.getenv("SLACK_DM_TOP_LEVEL_THREADS_AS_SESSIONS", "")
+        return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
     def _resolve_thread_ts(
         self,
         reply_to: Optional[str] = None,
@@ -996,10 +1010,14 @@ class SlackAdapter(BasePlatformAdapter):
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
         #   new thread/session (the bot always replies in a thread).
-        # In DMs: only use the real thread_ts — top-level DMs should share
-        #   one continuous session, threaded DMs get their own session.
+        # In DMs: by default only use the real thread_ts so top-level DMs
+        #   share one continuous session. When dm_top_level_threads_as_sessions
+        #   is enabled, fall back to ts so each top-level DM reply thread gets
+        #   its own session key as well.
         if is_dm:
-            thread_ts = event.get("thread_ts") or assistant_meta.get("thread_ts")  # None for top-level DMs
+            thread_ts = event.get("thread_ts") or assistant_meta.get("thread_ts")
+            if not thread_ts and self._dm_top_level_threads_as_sessions_enabled():
+                thread_ts = ts
         else:
             thread_ts = event.get("thread_ts") or ts  # ts fallback for channels
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1708,6 +1708,34 @@ class TestProgressMessageThread:
         )
 
     @pytest.mark.asyncio
+    async def test_dm_toplevel_can_use_message_ts_as_session_thread_when_enabled(self, adapter):
+        """Opt-in mode should isolate top-level Slack DM reply threads as sessions."""
+        adapter.config.extra["dm_top_level_threads_as_sessions"] = True
+
+        event = {
+            "channel": "D_DM",
+            "channel_type": "im",
+            "user": "U_USER",
+            "text": "Hello bot",
+            "ts": "1234567890.000001",
+        }
+
+        captured_events = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured_events.append(e))
+
+        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")):
+            await adapter._handle_slack_message(event)
+
+        assert len(captured_events) == 1
+        msg_event = captured_events[0]
+        source = msg_event.source
+
+        assert source.thread_id == "1234567890.000001", (
+            "source.thread_id should fall back to the message ts when "
+            "dm_top_level_threads_as_sessions is enabled"
+        )
+
+    @pytest.mark.asyncio
     async def test_channel_mention_progress_uses_thread_ts(self, adapter):
         """Progress messages for a channel @mention should go into the reply thread."""
         # Simulate an @mention in a channel: the event ts becomes the thread anchor


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in Slack setting for top-level DMs so each visible reply thread can become its own Hermes session instead of all top-level DM messages accumulating into a single DM-channel session.

To enable it, set either:

```yaml
platforms:
  slack:
    extra:
      dm_top_level_threads_as_sessions: true
```

or the environment variable:

```bash
export SLACK_DM_TOP_LEVEL_THREADS_AS_SESSIONS=1
```

## Related Issue

Fixes a Slack DM session-routing mismatch where Hermes replied in per-message Slack threads but still keyed top-level DM traffic into one continuous session unless Slack sent a real `thread_ts`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Changes Made

- Added `dm_top_level_threads_as_sessions` handling to the Slack adapter.
- Added env var fallback support via `SLACK_DM_TOP_LEVEL_THREADS_AS_SESSIONS`.
- When enabled, top-level Slack DM messages fall back to their own `ts` as the session thread id.
- This makes Hermes session routing line up with Slack's visible per-message reply threads in DMs.
- Left the default behavior unchanged for backward compatibility.
- Added a regression test covering the opt-in DM top-level thread session path.

## How to Test

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_slack.py -q -n 4
python -m pytest tests/gateway/test_session_dm_thread_seeding.py tests/gateway/test_session.py -q -n 4
python -m pytest tests/ -q -n 4
```

To verify the new behavior manually, enable one of the settings above and then send two separate top-level messages in the same Slack DM. With the flag enabled, those messages should seed different Hermes session thread ids instead of accumulating into the same DM-channel session.

Focused validation passed locally:
- `tests/gateway/test_slack.py -q -n 4` -> `126 passed`
- `tests/gateway/test_session_dm_thread_seeding.py tests/gateway/test_session.py -q -n 4` -> `72 passed`

Full suite status on current main baseline:
- `python -m pytest tests/ -q -n 4` -> `44 failed, 12027 passed, 34 skipped, 10 errors`

The full-suite reds were broader existing failures outside this Slack DM change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally, or I have documented unrelated pre-existing failures above
- [x] I have updated relevant documentation if needed, or determined none was required
- [x] My commit messages follow conventional commit format

## Screenshots / Logs

N/A
