### PR TITLE
fix(tirith): detect Android/Termux as Linux ABI-compatible

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -186,9 +186,10 @@ def _detect_target() -> str | None:
     system = platform.system()
     machine = platform.machine().lower()
 
+    # Android (Termux) is ABI-compatible with Linux — reuse Linux binaries.
     if system == "Darwin":
         plat = "apple-darwin"
-    elif system == "Linux":
+    elif system in ("Linux", "Android"):
         plat = "unknown-linux-gnu"
     else:
         return None


### PR DESCRIPTION
## Summary

In Termux (Android), `platform.system()` returns `"Android"` instead of `"Linux"`. Without this change, tirith's auto-installer skips Android even though the Linux GNU binaries are ABI-compatible.

## Fix

Modified `_detect_target()` in `tools/tirith_security.py` to treat Android as Linux-compatible:

```diff
-    elif system == "Linux":
+    elif system in ("Linux", "Android"):
```

This allows tirith to be auto-downloaded and used on Termux/Android just as it works on regular Linux.