### PR TITLE
fix(feishu): user_id fallback for sender prefix + document Contact Scope

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3797,8 +3797,15 @@ class GatewayRunner:
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
         )
-        if _is_shared_multi_user and source.user_name:
-            message_text = f"[{source.user_name}] {message_text}"
+        if _is_shared_multi_user:
+            # Fall back to user_id when the display name is unavailable
+            # (e.g. Feishu Contact API returned 41050 for users outside
+            # the app's Contact Scope).  Without this fallback, shared
+            # sessions with unresolved names silently drop the prefix
+            # and lose speaker attribution entirely.
+            _sender_label = source.user_name or source.user_id
+            if _sender_label:
+                message_text = f"[{_sender_label}] {message_text}"
 
         if event.media_urls:
             image_paths = []

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -49,10 +49,33 @@ If scan-to-create is not available, the wizard falls back to manual input:
 2. Create a new app.
 3. In **Credentials & Basic Info**, copy the **App ID** and **App Secret**.
 4. Enable the **Bot** capability for the app.
-5. Run `hermes gateway setup`, select **Feishu / Lark**, and enter the credentials when prompted.
+5. Grant the required permission scopes (see [Required Permissions](#required-permissions) below).
+6. Run `hermes gateway setup`, select **Feishu / Lark**, and enter the credentials when prompted.
 
 :::warning
 Keep the App Secret private. Anyone with it can impersonate your app.
+:::
+
+### Required Permissions
+
+Grant these permission scopes in the Feishu/Lark developer console under **Permissions & Scopes**:
+
+| Scope | Purpose |
+|-------|---------|
+| `im:message` | Receive and read messages |
+| `im:message:send` | Send messages and interactive cards |
+| `im:resource` | Receive images and file attachments |
+| `contact:user.base:readonly` | Resolve sender display names in group chats |
+| `admin:app.info:readonly` | Auto-detect bot identity for @mention gating (optional) |
+
+:::warning Contact Scope
+The `contact:user.base:readonly` permission controls **API access**, but there is a separate **Contact Scope** (sometimes called "Data Access Scope") that controls **which users** the app can see. If group chat participants show up as raw IDs (e.g., `ou_abc123`) instead of display names, expand the contact scope:
+
+1. In the developer console, go to **Security** (or **Permissions & Scopes**) → **Data Access Scope** / **Contact Scope**.
+2. Set the visible range to **All employees**, or add the specific departments that contain your group chat participants.
+3. Publish a new app version.
+
+Without this, the Contact API returns error `41050 (no user authority)` for users outside the configured scope, even though the permission itself is granted.
 :::
 
 ## Step 2: Choose a Connection Mode
@@ -488,6 +511,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
 | Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |
+| Group chat users show as raw IDs (`ou_xxx`) | Error `41050 (no user authority)` — the app has `contact:user.base:readonly` but the user is outside the app's **Contact Scope**. Expand the scope in **Security → Data Access Scope** to include the user's department, or set to "All employees". See [Required Permissions](#required-permissions). |
 | Error 200340 when clicking approval buttons | Enable **Interactive Card** capability and configure **Card Request URL** in the Feishu Developer Console. See [Required Feishu App Configuration](#required-feishu-app-configuration) above. |
 | `Webhook rate limit exceeded` | More than 120 requests/minute from the same IP. This is usually a misconfiguration or loop. |
 


### PR DESCRIPTION
## Summary

Follow-up to #13XXX (Awsh1's `fix(gateway): preserve sender attribution in shared group sessions`). That PR correctly adds the `[sender name]` prefix for shared multi-user sessions, but the prefix is silently dropped when `source.user_name` is empty — which happens in the wild for Feishu/Lark when the Contact API returns error `41050`.

- Fall back to `source.user_id` when the display name can't be resolved, so shared sessions always carry a distinguishable speaker label.
- Document the required Feishu permission scopes and the separate **Contact Scope** (Data Access Scope) in the Feishu setup guide — this is a common footgun that causes raw `ou_xxx` IDs to appear instead of display names.
- Add a troubleshooting entry for error 41050.

## Problem observed

On a production Feishu/Lark deployment, a new user joined a shared group chat. The bot consistently misidentified their messages, greeting everyone as the group admin. Log showed:

```
inbound message: platform=feishu user=ou_292e6c441fca6edb3ece27f20741b827 chat=oc_xxx msg='@bot 我是谁'
```

Direct probe of the Contact API confirmed:

```
GetUserRequest(open_id=ou_292e...): success=False code=41050 msg=no user authority error
```

The app had `contact:user.base:readonly` granted, but the user was outside the app's configured Contact Scope. With an empty `user_name`, the newly-added `if _is_shared_multi_user and source.user_name:` check fell through and no prefix was attached — so the LLM saw an unattributed message and defaulted to whatever identity was in SOUL.md / session context.

## Changes

- **`gateway/run.py`**: Use `source.user_name or source.user_id` for the prefix label. The prefix becomes `[ou_xxx]` when names can't be resolved — not pretty, but the LLM can still distinguish speakers.
- **`website/docs/user-guide/messaging/feishu.md`**: Added **Required Permissions** section listing the scopes (`im:message`, `im:message:send`, `im:resource`, `contact:user.base:readonly`, `admin:app.info:readonly`), plus a prominent warning explaining the Contact Scope gate and how to expand it. Added troubleshooting row for error 41050.

## Test plan

- [x] All existing tests pass (`pytest tests/gateway/test_session.py` — 63/63)
- [x] Verified end-to-end on a live Feishu group: after fixing Contact Scope, display name resolves; if Contact Scope is still misconfigured, the `[ou_xxx]` fallback prevents cross-user attribution drift.

## Related

- Follows-up #13XXX (sender attribution in shared groups)
- Related to #7781 (MemoryProvider multi-user identities)
- Related to #5195 (per-topic system prompt for Telegram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)