### PR TITLE
fix(gateway): prevent streaming mode from silently dropping final response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9476,6 +9476,12 @@ class GatewayRunner:
                 or getattr(_sc, "already_sent", False)
             ):
                 response["already_sent"] = True
+            # Propagate final_response_sent separately so the gateway can
+            # distinguish "stream sent tool progress" from "stream sent the
+            # final answer".  Fixes silent response drops when already_sent
+            # was set by earlier edits but the final text was never delivered.
+            if getattr(_sc, "final_response_sent", False):
+                response["final_response_sent"] = True
         
         return response
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -322,7 +322,7 @@ class GatewayStreamConsumer:
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            self._final_response_sent = self._already_sent
+                            self._final_response_sent = True  # chunks were just successfully sent
                             return
                         if got_segment_break:
                             self._message_id = None
@@ -368,12 +368,17 @@ class GatewayStreamConsumer:
                     if self._accumulated:
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
+                            self._final_response_sent = True
                         elif current_update_visible:
                             self._final_response_sent = True
                         elif self._message_id:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
+                    elif self._last_sent_text.strip():
+                        # No remaining text but the user already saw the
+                        # final answer via a previous progressive edit.
+                        self._final_response_sent = True
                     return
 
                 if commentary_text is not None:
@@ -408,13 +413,12 @@ class GatewayStreamConsumer:
                     await self._send_or_edit(self._accumulated)
                 except Exception:
                     pass
-            # If we delivered any content before being cancelled, mark the
-            # final response as sent so the gateway's already_sent check
-            # doesn't trigger a duplicate message.  The 5-second
-            # stream_task timeout (gateway/run.py) can cancel us while
-            # waiting on a slow Telegram API call — without this flag the
-            # gateway falls through to the normal send path.
-            if self._already_sent:
+            # If we attempted to deliver accumulated content before being
+            # cancelled, mark the final response as sent to prevent the
+            # gateway from re-sending it.  Only set the flag when we
+            # actually had content and an active message — not merely
+            # because earlier tool-progress edits set _already_sent.
+            if self._accumulated and self._message_id:
                 self._final_response_sent = True
         except Exception as e:
             logger.error("Stream consumer error: %s", e)


### PR DESCRIPTION
## What

Fix streaming mode silently dropping the final assistant response when earlier tool-progress edits had set `_already_sent = True`.

## Root Cause

The stream consumer conflated "some content was streamed" with "the final response was delivered" in three places:

1. **Overflow split path (line 325)**: After successfully sending all chunks via `_send_new_chunk`, the code set `_final_response_sent = self._already_sent`. Since `_already_sent` was already `True` from earlier tool-progress message edits, `_final_response_sent` became `True` even though the final text was just sent.

2. **CancelledError path (lines 417-418)**: When the 5-second `stream_task` timeout cancelled the consumer, the handler set `_final_response_sent = True` whenever `_already_sent` was `True` — even if no accumulated content was delivered (e.g., `_accumulated` was empty because the model hadn't produced final text yet).

3. **got_done with empty accumulated**: When `got_done` fired but `_accumulated` was empty (already delivered via a prior edit, or model produced no text after tools), the `got_done` block was entirely skipped, leaving `_final_response_sent = False` even though the user had seen the final text.

The gateway then checked `already_sent` at line 4129 and returned `None`, skipping independent delivery. The response was stored in the database but never reached the user.

## Fix

**stream_consumer.py:**
- **Line 325**: Set `_final_response_sent = True` directly (chunks were just successfully sent)
- **Lines 417-418**: Only set `_final_response_sent = True` when `self._accumulated and self._message_id` (actual content was delivered, not just tool progress)
- **got_done block**: Added `elif self._last_sent_text.strip()` branch to set `_final_response_sent = True` when the final answer was already visible via a prior edit
- **_send_fallback_final path**: Added `_final_response_sent = True` after fallback send

**gateway/run.py:**
- Propagate `final_response_sent` from stream consumer to the agent result dict so the gateway can distinguish "stream sent tool progress" from "stream sent the final answer"

## Testing

- `tests/gateway/test_stream_consumer.py` — 57 passed
- `tests/gateway/test_update_streaming.py` + `tests/run_agent/test_streaming.py` — 41 passed
- Full `tests/gateway/` suite — 2953 passed (13 failures are pre-existing, unrelated: Discord slash commands, approval buttons, etc.)

Closes #10748
