### PR TITLE
fix: summary model fallback crashes with NameError due to wrong arguments

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -730,7 +730,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60


### PR DESCRIPTION
## Summary
Fixes a bug where the summary model fallback path in  crashes with a  when the configured summary model is unavailable.

## Root Cause
The recursive call on line 733 passed:
1.  — a variable that doesn't exist in the scope of 
2.  — an int that was passed as the  parameter (which expects a string or None)

## Fix
Changed the fallback call to pass the correct parameters:
-  — the actual conversation turns to summarize
-  — the optional focus topic string

## Test Plan
- [x] Relevant unit tests pass (test_context_compressor.py: 40 passed)

Closes NousResearch/hermes-agent#10721