### PR TITLE
fix(gateway): use portable ps args for status detection

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -221,8 +221,11 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                             pass
                     current_cmd = ""
         else:
+            # ``ps eww -ax`` fails on procps-ng 4.x (including common Docker
+            # images) with "must set personality to get -x option". The
+            # simpler GNU/BSD-compatible form works across those environments.
             result = subprocess.run(
-                ["ps", "-A", "eww", "-o", "pid=,command="],
+                ["ps", "ax", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -799,6 +799,31 @@ class TestFindGatewayPidsExclude:
 
         assert pids == [100]
 
+    def test_uses_portable_ps_args_on_linux(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda hermes_home=None: "")
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        seen_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            seen_cmds.append(cmd)
+            assert cmd == ["ps", "ax", "-o", "pid=,command="]
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="321 /usr/bin/python3 -m hermes_cli.main gateway run\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli.find_gateway_pids()
+
+        assert seen_cmds == [["ps", "ax", "-o", "pid=,command="]]
+        assert pids == [321]
+
 
 # ---------------------------------------------------------------------------
 # Gateway mode writes exit code before restart (#8300)


### PR DESCRIPTION
## Summary\n- Replace the Docker-incompatible `ps eww -ax` invocation with `ps ax -o pid=,command=` in gateway PID discovery.\n- Add a regression test that asserts the portable ps command is used and still parses gateway PIDs correctly.\n\n## Testing\n- `pytest -q tests/hermes_cli/test_update_gateway_restart.py`\n- `pytest -q tests/hermes_cli/test_status.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_wsl.py`