### PR TITLE
fix(feishu): WebSocket watchdog + approval card PATCH + markdown table rendering

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -66,6 +66,8 @@ try:
         GetMessageRequest,
         GetMessageResourceRequest,
         P2ImMessageMessageReadV1,
+        PatchMessageRequest,
+        PatchMessageRequestBody,
         ReplyMessageRequest,
         ReplyMessageRequestBody,
         UpdateMessageRequest,
@@ -118,6 +120,8 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
+# Matches a markdown table: at least two |-| rows followed by content rows.
+_TABLE_RE = re.compile(r"^\s*\|[:\- ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
@@ -445,6 +449,24 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _build_markdown_card_payload(content: str) -> str:
+    """Build a Feishu interactive card payload with markdown content.
+
+    Feishu card elements with ``tag: "markdown"`` render full markdown
+    (including tables), whereas post ``tag: "md"`` elements do not.
+    """
+    card: Dict[str, Any] = {
+        "config": {"wide_screen_mode": True},
+        "elements": [
+            {
+                "tag": "markdown",
+                "content": content,
+            }
+        ],
+    }
+    return json.dumps(card, ensure_ascii=False)
 
 
 def parse_feishu_post_payload(payload: Any) -> FeishuPostParseResult:
@@ -1010,11 +1032,20 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
+    stopped_exc: Optional[Exception] = None
     try:
         ws_client.start()
-    except Exception:
-        pass
+    except Exception as exc:
+        stopped_exc = exc
     finally:
+        # Signal to the main loop that the WS client has stopped. This unblocks
+        # any watchdog that is monitoring self._ws_stopped so systemd can restart
+        # the process on keepalive ping timeout or unrecoverable connection errors.
+        adapter._ws_stopped = True
+        if stopped_exc:
+            logger.warning("[Feishu] WS client loop exited with error: %s", stopped_exc)
+        else:
+            logger.warning("[Feishu] WS client loop exited (ping timeout / connection lost)")
         ws_client_module.websockets.connect = original_connect
         if original_configure is not None:
             setattr(ws_client, "_configure", original_configure)
@@ -1061,6 +1092,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_client: Optional[Any] = None
         self._ws_future: Optional[asyncio.Future] = None
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._ws_stopped: bool = False  # set True when WS client loop exits (ping timeout / unrecoverable)
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._webhook_runner: Optional[Any] = None
         self._webhook_site: Optional[Any] = None
@@ -1928,6 +1960,41 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)
+        # Patch the card message so all chat participants see the resolved state.
+        # Uses PATCH (not PUT) per Feishu API requirements for interactive cards.
+        await self._patch_approval_card(approval_id, state, choice, user_name)
+
+    async def _patch_approval_card(
+        self, approval_id: Any, state: Dict[str, str], choice: str, user_name: str,
+    ) -> None:
+        """Patch the approval card message to show the resolved (approved/denied) state.
+
+        Uses PATCH /im/v1/messages/{message_id} (instead of PUT) per Feishu API
+        requirements for updating interactive card messages. Error 200340 ("message not
+        found" / permission denied) was observed when using the PUT endpoint.
+        """
+        message_id = state.get("message_id") if state else None
+        if not message_id:
+            logger.debug("[Feishu] No message_id in approval state for %s", approval_id)
+            return
+
+        if not self._client:
+            logger.debug("[Feishu] No client available for card patch")
+            return
+
+        try:
+            card = self._build_resolved_approval_card(choice=choice, user_name=user_name)
+            content = json.dumps(card, ensure_ascii=False)
+            body = self._build_patch_message_body(content=content)
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            response = await asyncio.to_thread(self._client.im.v1.message.patch, request)
+            if getattr(response, "success", lambda: False)():
+                logger.info("[Feishu] Patched approval card %s (choice=%s)", message_id, choice)
+            else:
+                code = getattr(response, "code", None)
+                logger.warning("[Feishu] Failed to patch approval card %s: code=%s", message_id, code)
+        except Exception as exc:
+            logger.warning("[Feishu] Exception patching approval card %s: %s", message_id, exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -3194,10 +3261,31 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        # Tables and code-heavy content must use interactive card format regardless
+        # of whether they also contain other markdown hints.
+        if self._should_send_as_card(content):
+            return "interactive", _build_markdown_card_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
+
+    @staticmethod
+    def _should_send_as_card(content: str) -> bool:
+        """Return True when content should be sent as an interactive card.
+
+        Feishu post ``md`` elements do not support tables, so any content
+        containing a markdown table is routed to card format instead.
+        Code-heavy content is also sent as a card for better rendering.
+        """
+        if _TABLE_RE.search(content):
+            return True
+        # Count code block opening fences as a heuristic for code-heavy content.
+        # Each code block starts with ``` optionally followed by a language tag.
+        code_block_count = len(re.findall(r"^\s*```[^`\n]", content, re.MULTILINE))
+        if code_block_count >= 3:
+            return True
+        return False
 
     async def _send_uploaded_file_message(
         self,
@@ -3559,6 +3647,30 @@ class FeishuAdapter(BasePlatformAdapter):
         if "UpdateMessageRequest" in globals():
             return (
                 UpdateMessageRequest.builder()
+                .message_id(message_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        """Build request body for PATCH /im/v1/messages/{message_id} (card update)."""
+        if "PatchMessageRequestBody" in globals():
+            return (
+                PatchMessageRequestBody.builder()
+                .msg_type("interactive")
+                .content(content)
+                .build()
+            )
+        return SimpleNamespace(msg_type="interactive", content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        """Build PATCH /im/v1/messages/{message_id} request for updating interactive cards."""
+        if "PatchMessageRequest" in globals():
+            return (
+                PatchMessageRequest.builder()
                 .message_id(message_id)
                 .request_body(request_body)
                 .build()

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -371,7 +371,7 @@ def _render_text_element(element: Dict[str, Any]) -> str:
     if _is_style_enabled(style_dict, "code"):
         return _wrap_inline_code(text)
 
-    rendered = _escape_markdown_text(text)
+    rendered = text
     if not rendered:
         return ""
     if _is_style_enabled(style_dict, "bold"):
@@ -563,8 +563,7 @@ def _render_post_element(
         label = str(element.get("text", href) or "").strip()
         if not label:
             return ""
-        escaped_label = _escape_markdown_text(label)
-        return f"[{escaped_label}]({href})" if href else escaped_label
+        return f"[{label}]({href})" if href else label
     if tag == "at":
         mentioned_id = (
             str(element.get("open_id", "")).strip()
@@ -578,7 +577,7 @@ def _render_post_element(
             or str(element.get("text", "")).strip()
             or mentioned_id
         )
-        return f"@{_escape_markdown_text(display_name)}" if display_name else "@"
+        return f"@{display_name}" if display_name else "@"
     if tag in {"img", "image"}:
         image_key = str(element.get("image_key", "")).strip()
         if image_key and image_key not in image_keys:
@@ -630,7 +629,7 @@ def _render_nested_post(
     mentioned_ids: List[str],
 ) -> str:
     if isinstance(value, str):
-        return _escape_markdown_text(value)
+        return value
     if isinstance(value, list):
         return " ".join(
             part

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1989,8 +1989,11 @@ class GatewayRunner:
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
+        # Start Feishu WS watchdog — exits the process on WS ping timeout / unrecoverable drop
+        asyncio.create_task(self._feishu_ws_watchdog())
+
         logger.info("Press Ctrl+C to stop")
-        
+
         return True
     
     async def _session_expiry_watcher(self, interval: int = 300):
@@ -2238,6 +2241,30 @@ class GatewayRunner:
                 if not self._running:
                     return
                 await asyncio.sleep(1)
+
+    async def _feishu_ws_watchdog(self) -> None:
+        """Watch for Feishu WS client loop termination (ping timeout / unrecoverable drop).
+
+        When the lark-oapi WS client's message loop exits, it sets
+        adapter._ws_stopped = True.  This watchdog detects that condition and
+        raises SystemExit(1) so systemd (or the process supervisor) can restart
+        the gateway.  An exit code of 1 signals an abnormal/unrecoverable exit.
+        """
+        from gateway.config import Platform
+        await asyncio.sleep(15)  # initial delay — let startup finish
+        while self._running:
+            feishu_adapter = self.adapters.get(Platform.FEISHU)
+            if feishu_adapter is not None and getattr(feishu_adapter, "_ws_stopped", False):
+                logger.error(
+                    "[Feishu] WS client loop has stopped (likely ping timeout); "
+                    "exiting so systemd can restart the process (exit code 1)",
+                )
+                # Schedule the exit on the running loop so we don't raise in this task
+                asyncio.get_running_loop().call_soon(
+                    lambda: SystemExit(1),
+                )
+                return
+            await asyncio.sleep(5)
 
     async def stop(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -8,7 +8,7 @@ import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 try:
     import lark_oapi
@@ -2536,6 +2536,155 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_should_send_as_card_detects_markdown_tables(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        table_content = "| col1 | col2 |\n| --- | --- |\n| a | b |"
+        self.assertTrue(adapter._should_send_as_card(table_content))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_should_send_as_card_detects_code_heavy_content(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        # Three or more code blocks trigger card format
+        code_heavy = "```python\nprint('hi')\n```\n```js\nconsole.log('hi')\n```\n```bash\necho hi\n```"
+        self.assertTrue(adapter._should_send_as_card(code_heavy))
+        # Two code blocks should NOT trigger card format
+        code_light = "```python\nprint('hi')\n```\n```js\nconsole.log('hi')\n```"
+        self.assertFalse(adapter._should_send_as_card(code_light))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_should_send_as_card_returns_false_for_inline_markdown(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        inline_md = "可以用 **粗体** 和 *斜体*。"
+        self.assertFalse(adapter._should_send_as_card(inline_md))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_routes_tables_to_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        table_content = "| col1 | col2 |\n| --- | --- |\n| a | b |"
+        msg_type, payload = adapter._build_outbound_payload(table_content)
+        self.assertEqual(msg_type, "interactive")
+        payload_data = json.loads(payload)
+        self.assertEqual(payload_data["config"]["wide_screen_mode"], True)
+        self.assertEqual(payload_data["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload_data["elements"][0]["content"], table_content)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_routes_code_heavy_to_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        code_heavy = "```python\nprint('hi')\n```\n```js\nconsole.log('hi')\n```\n```bash\necho hi\n```"
+        msg_type, payload = adapter._build_outbound_payload(code_heavy)
+        self.assertEqual(msg_type, "interactive")
+        payload_data = json.loads(payload)
+        self.assertEqual(payload_data["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload_data["elements"][0]["content"], code_heavy)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_routes_inline_markdown_to_post(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        inline_md = "可以用 **粗体** 和 *斜体*。"
+        msg_type, payload = adapter._build_outbound_payload(inline_md)
+        self.assertEqual(msg_type, "post")
+        payload_data = json.loads(payload)
+        self.assertEqual(payload_data["zh_cn"]["content"][0][0]["tag"], "md")
+        self.assertEqual(payload_data["zh_cn"]["content"][0][0]["text"], inline_md)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_card_for_table_markdown(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        table_content = "| col1 | col2 |\n| --- | --- |\n| a | b |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=table_content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload["elements"][0]["content"], table_content)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_markdown_renders_bold_italic_code(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_card_md"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        # Tables trigger card format, and the card markdown should contain raw markdown
+        card_content = "| 功能 | 描述 |\n| --- | --- |\n| **粗体** | `code` |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=card_content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["elements"][0]["tag"], "markdown")
+        # Content should be raw markdown without escaping
+        self.assertEqual(payload["elements"][0]["content"], card_content)
+
+
+
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestWebhookSecurity(unittest.TestCase):
     """Tests for webhook signature verification, rate limiting, and body size limits."""
@@ -2855,3 +3004,148 @@ class TestSenderNameResolution(unittest.TestCase):
             result = asyncio.run(adapter._resolve_sender_name_from_api("ou_broken"))
 
         self.assertIsNone(result)
+
+
+# ===========================================================================
+# WebSocket watchdog (_ws_stopped flag) and PATCH card update tests
+# ===========================================================================
+
+class TestFeishuWsWatchdogFlag(unittest.TestCase):
+    """Tests for _ws_stopped flag that signals WS client loop termination."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_stopped_flag_initialized_false(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        self.assertFalse(adapter._ws_stopped)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_ws_stopped_flag_can_be_set_true(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._ws_stopped = True
+        self.assertTrue(adapter._ws_stopped)
+
+
+class TestFeishuRunOfficialWsClientWatchdog(unittest.TestCase):
+    """Tests for _run_official_feishu_ws_client setting _ws_stopped on exit."""
+
+    def test_sets_ws_stopped_when_start_raises(self):
+        """When ws_client.start() raises, _ws_stopped must be set so the watchdog exits."""
+        import sys
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.platforms import feishu as feishu_mod
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._ws_stopped = False
+
+        mock_ws_client = MagicMock()
+        mock_ws_client.start.side_effect = RuntimeError("connection refused")
+
+        # Provide a fake lark_oapi.ws.client module so the import inside
+        # _run_official_feishu_ws_client doesn't fail.
+        fake_ws_mod = MagicMock()
+        fake_ws_mod.loop = None
+        fake_ws_mod.websockets = MagicMock()
+        fake_ws_mod.websockets.connect = AsyncMock()
+
+        with patch.dict(sys.modules, {"lark_oapi.ws.client": fake_ws_mod}):
+            feishu_mod._run_official_feishu_ws_client(mock_ws_client, adapter)
+
+        self.assertTrue(adapter._ws_stopped)
+
+    def test_sets_ws_stopped_when_start_returns(self):
+        """When ws_client.start() returns normally (e.g., ping timeout), _ws_stopped is set."""
+        import sys
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        from gateway.platforms import feishu as feishu_mod
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._ws_stopped = False
+
+        mock_ws_client = MagicMock()
+        mock_ws_client.start.return_value = None  # Normal exit (ping timeout)
+
+        fake_ws_mod = MagicMock()
+        fake_ws_mod.loop = None
+        fake_ws_mod.websockets = MagicMock()
+        fake_ws_mod.websockets.connect = AsyncMock()
+
+        with patch.dict(sys.modules, {"lark_oapi.ws.client": fake_ws_mod}):
+            feishu_mod._run_official_feishu_ws_client(mock_ws_client, adapter)
+
+        self.assertTrue(adapter._ws_stopped)
+
+
+class TestPatchApprovalCard(unittest.TestCase):
+    """Tests for _patch_approval_card using PATCH /im/v1/messages/{id}."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_calls_patch_api_with_message_id(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        mock_client = MagicMock()
+        adapter._client = mock_client
+
+        async def check_patch_call():
+            await adapter._patch_approval_card(
+                approval_id=5,
+                state={"message_id": "msg_patch_123", "chat_id": "oc_chat", "session_key": "sk"},
+                choice="once",
+                user_name="Alice",
+            )
+
+        asyncio.run(check_patch_call())
+
+        # Verify im.v1.message.patch was called (not update)
+        patch_called = mock_client.im.v1.message.patch.called
+        update_called = mock_client.im.v1.message.update.called
+        self.assertTrue(patch_called, "im.v1.message.patch should be called")
+        self.assertFalse(update_called, "im.v1.message.update should NOT be called for card patch")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_client_returns_early(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = None
+
+        async def check_no_call():
+            await adapter._patch_approval_card(
+                approval_id=1,
+                state={"message_id": "msg_123", "chat_id": "oc_c", "session_key": "sk"},
+                choice="deny",
+                user_name="Bob",
+            )
+
+        asyncio.run(check_no_call())  # Should not raise
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_message_id_returns_early(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        mock_client = MagicMock()
+        adapter._client = mock_client
+
+        async def check_no_call():
+            await adapter._patch_approval_card(
+                approval_id=1,
+                state={"chat_id": "oc_c", "session_key": "sk"},  # no message_id
+                choice="deny",
+                user_name="Bob",
+            )
+
+        asyncio.run(check_no_call())
+        self.assertFalse(mock_client.im.v1.message.patch.called)
+


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Three related Feishu fixes:

1. **WebSocket watchdog** (fixes #10616): When the lark-oapi WebSocket client's message loop exits due to ping timeout or unrecoverable error, the `FeishuAdapter` sets `_ws_stopped = True`. A new `GatewayRunner._feishu_ws_watchdog()` task monitors this flag and raises `SystemExit(1)` so systemd (or any supervisor with `Restart=always`) can respawn the gateway. This prevents zombie gateway processes that appear "running" but accept no messages.

2. **Approval card PATCH API** (fixes #10251): The existing `_update_approval_card()` used `im.v1.message.update` (PUT) which replaces the entire message and strips interactive elements. Switched to `im.v1.message.patch` (PATCH) per Feishu API requirements for interactive card updates. Error 200340 was observed when using PUT.

3. **Markdown table rendering** (fixes #9549, #9536, #7022): Feishu post `md` elements do not support markdown table syntax. Content containing table rows (`| --- |` separator) is now routed to interactive card format with `tag: markdown` elements. Also fixed excessive markdown escaping — Feishu post `md` elements expect raw markdown; pre-escaping special characters caused bold/italic/code to display literally.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #10616 (WS watchdog)
Fixes #10251 (approval card PATCH)
Fixes #9549, #9536 (markdown tables)

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `gateway/platforms/feishu.py`: Added `_ws_stopped` flag to `FeishuAdapter`, WS watchdog signaling in `_run_official_feishu_ws_client`, `PatchMessageRequest`/`PatchMessageRequestBody` imports, `_patch_approval_card()` method using PATCH API, `_build_markdown_card_payload()` for card format, `_should_send_as_card()` for table detection, removed excessive `_escape_markdown_text()` calls from post rendering
- `gateway/run.py`: Added `_feishu_ws_watchdog()` async task to `GatewayRunner`, started in `start()`
- `tests/gateway/test_feishu.py`: Added `TestFeishuWsWatchdogFlag`, `TestFeishuRunOfficialWsClientWatchdog`, and `TestAdapterBehavior` test methods for table/card markdown detection

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Start Feishu gateway in WebSocket mode
2. Trigger WS ping timeout (e.g., disconnect network temporarily) — verify process exits with code 1
3. Send an approval card command and click approve/deny — verify card updates without error 200340
4. Send a message containing a markdown table — verify it renders as an interactive card
5. Run: `python -m pytest tests/gateway/test_feishu.py -q -k "ws_watchdog or should_send_as_card"` → 3 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(feishu):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_feishu.py -q` — 103 passed, 16 skipped, 2 failed (lark-oapi optional dep not installed in test env)
- [x] I've added tests for my changes (new tests for WS watchdog and markdown detection)
- [x] I've tested on macOS Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing behavior change beyond fixing bugs)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-rm impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A