### PR TITLE
fix(matrix): register MembershipEventDispatcher for invite auto-join

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -537,6 +537,9 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Register event handlers.
         from mautrix.client import InternalEventType as IntEvt
+        from mautrix.client.dispatcher import MembershipEventDispatcher
+
+        client.add_dispatcher(MembershipEventDispatcher)
 
         client.add_event_handler(EventType.ROOM_MESSAGE, self._on_room_message)
         client.add_event_handler(EventType.REACTION, self._on_reaction)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -108,11 +108,24 @@ def _make_fake_mautrix():
         def add_event_handler(self, event_type, handler):
             self._event_handlers.setdefault(event_type, []).append(handler)
 
+        def add_dispatcher(self, dispatcher_class):
+            # Stub for MembershipEventDispatcher registration
+            pass
+
     class InternalEventType:
         INVITE = "internal.invite"
 
+    # --- mautrix.client.dispatcher ---
+    mautrix_client_dispatcher = types.ModuleType("mautrix.client.dispatcher")
+
+    class MembershipEventDispatcher:
+        pass
+
+    mautrix_client_dispatcher.MembershipEventDispatcher = MembershipEventDispatcher
+
     mautrix_client.Client = Client
     mautrix_client.InternalEventType = InternalEventType
+    mautrix_client.dispatcher = mautrix_client_dispatcher
     mautrix.client = mautrix_client
 
     # --- mautrix.client.state_store ---
@@ -201,6 +214,7 @@ def _make_fake_mautrix():
         "mautrix.types": mautrix_types,
         "mautrix.client": mautrix_client,
         "mautrix.client.state_store": mautrix_client_state_store,
+        "mautrix.client.dispatcher": mautrix_client_dispatcher,
         "mautrix.crypto": mautrix_crypto,
         "mautrix.crypto.store": mautrix_crypto_store,
         "mautrix.crypto.store.asyncpg": mautrix_crypto_store_asyncpg,


### PR DESCRIPTION
## Summary
Since migration from matrix-nio to mautrix-python in #7518, the Matrix bot cannot receive messages. It connects and syncs successfully, but never joins rooms — invites are silently ignored.

## Root Cause
The MembershipEventDispatcher is not registered on the mautrix Client instance. In mautrix-python, InternalEventType.INVITE is NOT dispatched directly by handle_sync(). The MembershipEventDispatcher catches EventType.ROOM_MEMBER state events and re-dispatches them as InternalEventType.INVITE, JOIN, LEAVE, etc.

Without this dispatcher, the INVITE handler never fires, so the bot never auto-joins rooms.

## Fix
Register MembershipEventDispatcher on the client before adding event handlers:
```python
from mautrix.client.dispatcher import MembershipEventDispatcher
client.add_dispatcher(MembershipEventDispatcher)
```

## Test Plan
- [x] All Matrix tests pass (112 passed)
- [x] Test mock updated with dispatcher module stub

Closes NousResearch/hermes-agent#10725