### PR TITLE
feat: improve Firecrawl document parsing and Camofox VNC handling

### DIFF
--- a/WORK_MAP.md
+++ b/WORK_MAP.md
@@ -1,0 +1,47 @@
+# Work Map
+
+Central status/map file for recent repo work.
+Update this file whenever a session makes meaningful changes so the next session can resume without digging through chat logs.
+
+## Current Status
+- recorded_at: 2026-04-16 08:46:41 KST
+- branch: `feat/firecrawl-document-parsing-web-extract`
+- working_tree: clean
+- focus: Firecrawl document parsing support + Camofox VNC URL scheme fix
+
+## Latest Completed Changes
+
+### 2026-04-16 — Firecrawl document parsing + Camofox VNC fix
+1. `ebb73837` — `feat: add Firecrawl document parsing options to web_extract`
+   - file: `tools/web_tools.py`
+   - tests: `tests/tools/test_web_extract_document_parsing.py`
+   - status: done
+   - note: added Firecrawl document parsing options to `web_extract`.
+
+2. `10981a7a` — `feat: support Firecrawl PDF parsers in web_crawl`
+   - file: `tools/web_tools.py`
+   - tests: `tests/tools/test_web_extract_document_parsing.py`
+   - status: done
+   - note: `web_crawl` now forwards Firecrawl PDF parsing options including `pdf_mode` and `pdf_max_pages`.
+
+3. `3dc2fab0` — `fix: preserve camofox VNC URL scheme`
+   - file: `tools/browser_camofox.py`
+   - tests: `tests/tools/test_browser_camofox_persistence.py`
+   - status: done
+   - note: VNC URL generation now preserves the configured `CAMOFOX_URL` scheme instead of forcing `http`.
+
+## Verification
+- `source venv/bin/activate && python -m pytest tests/tools/test_web_extract_document_parsing.py -q`
+  - result: `3 passed`
+- `source venv/bin/activate && python -m pytest tests/tools/test_browser_camofox_persistence.py tests/tools/test_browser_camofox_state.py -q`
+  - result: `29 passed`
+
+## Open Threads
+- This file did not exist before this session; it is now the default central map/status file for repo changes.
+- If future sessions change the repo, append or refresh this file in the same session.
+- Full-suite verification was not run in this recording step.
+
+## Next Practical Step
+1. Keep `WORK_MAP.md` updated whenever a branch lands meaningful changes.
+2. If the branch changes again, add the new commit, touched files, and verification command/results here.
+3. Run broader test coverage before merge if the change surface expands beyond targeted tool behavior.

--- a/WORK_MAP.md
+++ b/WORK_MAP.md
@@ -38,7 +38,7 @@ Update this file whenever a session makes meaningful changes so the next session
 
 ## Open Threads
 - This file did not exist before this session; it is now the default central map/status file for repo changes.
-- If future sessions change the repo, append or refresh this file in the same session.
+- Operational rule now set: meaningful repo changes should end with targeted verification, explicit staging, atomic commit, push, and `WORK_MAP.md` update in the same session.
 - Full-suite verification was not run in this recording step.
 
 ## Next Practical Step

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -203,6 +203,13 @@ class TestVncUrlDiscovery:
             assert check_camofox_available() is True
         assert get_vnc_url() == "http://myhost:6080"
 
+    def test_vnc_url_preserves_https_scheme(self, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "https://secure-browser.example")
+        health_resp = _mock_response(json_data={"ok": True, "vncPort": 6080})
+        with patch("tools.browser_camofox.requests.get", return_value=health_resp):
+            assert check_camofox_available() is True
+        assert get_vnc_url() == "https://secure-browser.example:6080"
+
     def test_vnc_url_none_when_headless(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         health_resp = _mock_response(json_data={"ok": True})

--- a/tests/tools/test_web_extract_document_parsing.py
+++ b/tests/tools/test_web_extract_document_parsing.py
@@ -1,0 +1,58 @@
+import json
+
+import pytest
+
+from tools import web_tools
+
+
+def test_web_extract_schema_exposes_document_parsing_options():
+    schema = web_tools.WEB_EXTRACT_SCHEMA
+    description = schema["description"]
+    properties = schema["parameters"]["properties"]
+
+    assert "DOCX" in description
+    assert "XLSX" in description
+    assert "pdf_mode" in properties
+    assert properties["pdf_mode"]["enum"] == ["auto", "fast", "ocr"]
+    assert "pdf_max_pages" in properties
+
+
+@pytest.mark.asyncio
+async def test_web_extract_passes_pdf_parser_options_to_firecrawl(monkeypatch):
+    calls = []
+
+    class FakeFirecrawlClient:
+        def scrape(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "markdown": "parsed pdf markdown",
+                "metadata": {
+                    "title": "Quarterly Report",
+                    "sourceURL": kwargs["url"],
+                },
+            }
+
+    monkeypatch.setattr(web_tools, "_get_backend", lambda: "firecrawl")
+    monkeypatch.setattr(web_tools, "_get_firecrawl_client", lambda: FakeFirecrawlClient())
+    monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
+    monkeypatch.setattr(web_tools, "check_website_access", lambda url: None)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(
+        await web_tools.web_extract_tool(
+            ["https://example.com/report.pdf"],
+            format="markdown",
+            use_llm_processing=False,
+            pdf_mode="ocr",
+            pdf_max_pages=7,
+        )
+    )
+
+    assert result["results"][0]["content"] == "parsed pdf markdown"
+    assert calls == [
+        {
+            "url": "https://example.com/report.pdf",
+            "formats": ["markdown"],
+            "parsers": [{"type": "pdf", "mode": "ocr", "max_pages": 7}],
+        }
+    ]

--- a/tests/tools/test_web_extract_document_parsing.py
+++ b/tests/tools/test_web_extract_document_parsing.py
@@ -56,3 +56,44 @@ async def test_web_extract_passes_pdf_parser_options_to_firecrawl(monkeypatch):
             "parsers": [{"type": "pdf", "mode": "ocr", "max_pages": 7}],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_web_crawl_passes_pdf_parser_options_to_firecrawl(monkeypatch):
+    calls = []
+
+    class FakeCrawlResult:
+        status = "completed"
+        data = []
+
+    class FakeFirecrawlClient:
+        def crawl(self, **kwargs):
+            calls.append(kwargs)
+            return FakeCrawlResult()
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
+    monkeypatch.setattr(web_tools, "_get_firecrawl_client", lambda: FakeFirecrawlClient())
+    monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
+    monkeypatch.setattr(web_tools, "check_website_access", lambda url: None)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    result = json.loads(
+        await web_tools.web_crawl_tool(
+            "https://example.com/report.pdf",
+            use_llm_processing=False,
+            pdf_mode="fast",
+            pdf_max_pages=3,
+        )
+    )
+
+    assert result["results"] == []
+    assert calls == [
+        {
+            "url": "https://example.com/report.pdf",
+            "limit": 20,
+            "scrape_options": {
+                "formats": ["markdown"],
+                "parsers": [{"type": "pdf", "mode": "fast", "max_pages": 3}],
+            },
+        }
+    ]

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -74,7 +74,8 @@ def check_camofox_available() -> bool:
                     from urllib.parse import urlparse
                     parsed = urlparse(url)
                     host = parsed.hostname or "localhost"
-                    _vnc_url = f"http://{host}:{vnc_port}"
+                    scheme = parsed.scheme or "http"
+                    _vnc_url = f"{scheme}://{host}:{vnc_port}"
             except (ValueError, KeyError):
                 pass
             _vnc_url_checked = True

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1552,7 +1552,9 @@ async def web_crawl_tool(
     depth: str = "basic", 
     use_llm_processing: bool = True,
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+    pdf_mode: Optional[str] = None,
+    pdf_max_pages: Optional[int] = None,
 ) -> str:
     """
     Crawl a website with specific instructions using available crawling API backend.
@@ -1567,6 +1569,8 @@ async def web_crawl_tool(
         use_llm_processing (bool): Whether to process content with LLM for summarization (default: True)
         model (Optional[str]): The model to use for LLM processing (defaults to current auxiliary backend model)
         min_length (int): Minimum content length to trigger LLM processing (default: 5000)
+        pdf_mode (Optional[str]): Firecrawl PDF parser mode for PDF URLs only ("auto", "fast", or "ocr")
+        pdf_max_pages (Optional[int]): Optional page cap for Firecrawl PDF parsing during crawl scrape_options
     
     Returns:
         str: JSON string containing crawled content. If LLM processing is enabled and successful,
@@ -1583,7 +1587,9 @@ async def web_crawl_tool(
             "depth": depth,
             "use_llm_processing": use_llm_processing,
             "model": model,
-            "min_length": min_length
+            "min_length": min_length,
+            "pdf_mode": pdf_mode,
+            "pdf_max_pages": pdf_max_pages,
         },
         "error": None,
         "pages_crawled": 0,
@@ -1716,11 +1722,20 @@ async def web_crawl_tool(
         # The crawl() method automatically waits for completion and returns all data
         
         # Build crawl parameters - keep it simple
+        scrape_options: Dict[str, Any] = {
+            "formats": ["markdown"]  # Just markdown for simplicity
+        }
+        parsers = _build_firecrawl_parsers(
+            url,
+            pdf_mode=pdf_mode,
+            pdf_max_pages=pdf_max_pages,
+        )
+        if parsers is not None:
+            scrape_options["parsers"] = parsers
+
         crawl_params = {
             "limit": 20,  # Limit number of pages to crawl
-            "scrape_options": {
-                "formats": ["markdown"]  # Just markdown for simplicity
-            }
+            "scrape_options": scrape_options,
         }
         
         # Note: The 'prompt' parameter is not documented for crawl

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -46,6 +46,7 @@ import os
 import re
 import asyncio
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlparse
 import httpx
 from firecrawl import Firecrawl
 from agent.auxiliary_client import (
@@ -439,6 +440,45 @@ def _extract_scrape_payload(scrape_result: Any) -> Dict[str, Any]:
         return nested
 
     return result_plain
+
+
+def _is_pdf_like_url(url: str) -> bool:
+    """Return True when the URL path strongly suggests a PDF document."""
+    try:
+        return urlparse(url).path.lower().endswith(".pdf")
+    except Exception:
+        return url.lower().endswith(".pdf")
+
+
+def _build_firecrawl_parsers(
+    url: str,
+    pdf_mode: Optional[str] = None,
+    pdf_max_pages: Optional[int] = None,
+) -> Optional[List[Dict[str, Any]]]:
+    """Build Firecrawl parser options for document scraping.
+
+    Firecrawl document parsing works automatically for supported document URLs.
+    The only parser options we currently expose are PDF-specific controls from:
+    https://docs.firecrawl.dev/features/document-parsing
+    """
+    if pdf_mode is None and pdf_max_pages is None:
+        return None
+
+    if pdf_mode not in (None, "auto", "fast", "ocr"):
+        raise ValueError("pdf_mode must be one of: auto, fast, ocr")
+
+    if pdf_max_pages is not None and pdf_max_pages <= 0:
+        raise ValueError("pdf_max_pages must be a positive integer")
+
+    if not _is_pdf_like_url(url):
+        return None
+
+    parser: Dict[str, Any] = {"type": "pdf"}
+    if pdf_mode is not None:
+        parser["mode"] = pdf_mode
+    if pdf_max_pages is not None:
+        parser["max_pages"] = pdf_max_pages
+    return [parser]
 
 
 DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION = 5000
@@ -1166,7 +1206,9 @@ async def web_extract_tool(
     format: str = None,
     use_llm_processing: bool = True,
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+    pdf_mode: Optional[str] = None,
+    pdf_max_pages: Optional[int] = None,
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -1180,6 +1222,8 @@ async def web_extract_tool(
         use_llm_processing (bool): Whether to process content with LLM for summarization (default: True)
         model (Optional[str]): The model to use for LLM processing (defaults to current auxiliary backend model)
         min_length (int): Minimum content length to trigger LLM processing (default: 5000)
+        pdf_mode (Optional[str]): Firecrawl PDF parser mode for PDF URLs only ("auto", "fast", or "ocr")
+        pdf_max_pages (Optional[int]): Optional page cap for Firecrawl PDF parsing
 
     Security: URLs are checked for embedded secrets before fetching.
     
@@ -1208,7 +1252,9 @@ async def web_extract_tool(
             "format": format,
             "use_llm_processing": use_llm_processing,
             "model": model,
-            "min_length": min_length
+            "min_length": min_length,
+            "pdf_mode": pdf_mode,
+            "pdf_max_pages": pdf_max_pages,
         },
         "error": None,
         "pages_extracted": 0,
@@ -1286,14 +1332,25 @@ async def web_extract_tool(
 
                     try:
                         logger.info("Scraping: %s", url)
+                        parsers = _build_firecrawl_parsers(
+                            url,
+                            pdf_mode=pdf_mode,
+                            pdf_max_pages=pdf_max_pages,
+                        )
+                        scrape_kwargs: Dict[str, Any] = {
+                            "url": url,
+                            "formats": formats,
+                        }
+                        if parsers is not None:
+                            scrape_kwargs["parsers"] = parsers
+
                         # Run synchronous Firecrawl scrape in a thread with a
                         # 60s timeout so a hung fetch doesn't block the session.
                         try:
                             scrape_result = await asyncio.wait_for(
                                 asyncio.to_thread(
                                     _get_firecrawl_client().scrape,
-                                    url=url,
-                                    formats=formats,
+                                    **scrape_kwargs,
                                 ),
                                 timeout=60,
                             )
@@ -2061,7 +2118,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Extract content from web page or document URLs. Returns markdown optimized for LLM use. Firecrawl document parsing also works with PDF, DOC/DOCX/ODT/RTF, and XLS/XLSX links — pass the document URL directly and it converts the file to structured markdown text. For PDF URLs, use pdf_mode='fast' for embedded text only, pdf_mode='auto' for text with OCR fallback, or pdf_mode='ocr' to force OCR; pdf_max_pages limits how many PDF pages Firecrawl parses. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool instead.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2070,6 +2127,16 @@ WEB_EXTRACT_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
                 "maxItems": 5
+            },
+            "pdf_mode": {
+                "type": "string",
+                "enum": ["auto", "fast", "ocr"],
+                "description": "Optional Firecrawl PDF parsing mode for PDF URLs only: auto (text with OCR fallback), fast (text-only), or ocr (force OCR on every page)."
+            },
+            "pdf_max_pages": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional maximum number of PDF pages to parse when scraping a PDF URL with Firecrawl."
             }
         },
         "required": ["urls"]
@@ -2091,7 +2158,11 @@ registry.register(
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
+        "markdown",
+        pdf_mode=args.get("pdf_mode"),
+        pdf_max_pages=args.get("pdf_max_pages"),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     is_async=True,


### PR DESCRIPTION
## Summary
- add Firecrawl document parsing support to web_extract, including PDF parser options
- forward Firecrawl PDF parser options through web_crawl scrape_options
- preserve the configured Camofox URL scheme when deriving the VNC link
- add WORK_MAP.md to record the branch's current status

## Test Plan
- source venv/bin/activate && python -m pytest tests/tools/test_web_extract_document_parsing.py -q
- source venv/bin/activate && python -m pytest tests/tools/test_browser_camofox_persistence.py tests/tools/test_browser_camofox_state.py -q