### PR TITLE
Fix gateway status detection inside Docker containers

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -171,6 +171,15 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
     """
     _exclude = exclude_pids or set()
     pids = [pid for pid in _get_service_pids() if pid not in _exclude]
+    if not all_profiles:
+        try:
+            from gateway.status import get_running_pid
+
+            current_pid = get_running_pid()
+        except Exception:
+            current_pid = None
+        if current_pid is not None and current_pid not in pids and current_pid not in _exclude and current_pid != os.getpid():
+            pids.append(current_pid)
     patterns = [
         "hermes_cli.main gateway",
         "hermes_cli.main --profile",
@@ -221,12 +230,21 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                             pass
                     current_cmd = ""
         else:
-            result = subprocess.run(
+            result = None
+            for cmd in (
                 ["ps", "-A", "eww", "-o", "pid=,command="],
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
+                ["ps", "ax", "-o", "pid=,command="],
+            ):
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    break
+            if result is None or result.returncode != 0:
+                return pids
             for line in result.stdout.split('\n'):
                 stripped = line.strip()
                 if not stripped or 'grep' in stripped:
@@ -3119,6 +3137,15 @@ def gateway_command(args):
         else:
             # Check for manually running processes
             pids = find_gateway_pids()
+            if not pids:
+                try:
+                    from gateway.status import get_running_pid
+
+                    running_pid = get_running_pid()
+                except Exception:
+                    running_pid = None
+                if running_pid is not None:
+                    pids = [running_pid]
             if pids:
                 print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
                 print("  (Running manually, not as a system service)")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -568,6 +568,31 @@ class TestGatewaySystemServiceRouting:
         assert "nohup hermes gateway" in out
         assert "install as user service" not in out
 
+    def test_gateway_status_uses_pid_file_when_process_scan_misses(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda exclude_pids=None: [])
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_systemd_unit_path",
+            lambda system=False: SimpleNamespace(exists=lambda: False),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_launchd_plist_path",
+            lambda: SimpleNamespace(exists=lambda: False),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+
+        out = capsys.readouterr().out
+        assert "Gateway is running (PID: 4242)" in out
+        assert "Running manually, not as a system service" in out
+
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("plist\n", encoding="utf-8")

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -799,6 +799,36 @@ class TestFindGatewayPidsExclude:
 
         assert pids == [100]
 
+    def test_falls_back_to_portable_ps_when_env_listing_fails(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ["ps", "-A", "eww", "-o", "pid=,command="]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="unsupported")
+            if cmd == ["ps", "ax", "-o", "pid=,command="]:
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout="300 python gateway/run.py\n",
+                    stderr="",
+                )
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli.find_gateway_pids()
+
+        assert pids == [300]
+        assert calls[:2] == [
+            ["ps", "-A", "eww", "-o", "pid=,command="],
+            ["ps", "ax", "-o", "pid=,command="],
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Gateway mode writes exit code before restart (#8300)


### PR DESCRIPTION
## Summary
- fall back to a portable `ps ax -o pid=,command=` scan when `ps -A eww` is unavailable
- treat the gateway PID file as a status fallback before reporting that the manual gateway is down
- cover the fallback `ps` path and PID-file status path with regression tests

Fixes #10761

## Testing
- pytest -q tests/hermes_cli/test_update_gateway_restart.py -k "FindGatewayPidsExclude or falls_back_to_portable_ps"
- pytest -q tests/hermes_cli/test_gateway_service.py -k "pid_file_when_process_scan_misses or termux_shows_manual_guidance"