### PR TITLE
Isolate cron delivery context per scheduled job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -585,6 +585,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         Tuple of (success, full_output_doc, final_response, error_message)
     """
     from run_agent import AIAgent
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.send_message_tool import (
+        clear_cron_auto_delivery_target,
+        set_cron_auto_delivery_target,
+    )
     
     # Initialize SQLite session store so cron job messages are persisted
     # and discoverable via session_search (same pattern as gateway/run.py).
@@ -600,6 +605,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prompt = _build_job_prompt(job)
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _session_tokens = []
+    _delivery_tokens = []
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -608,10 +615,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Inject origin context so the agent's send_message tool knows the chat.
         # Must be INSIDE the try block so the finally cleanup always runs.
         if origin:
-            os.environ["HERMES_SESSION_PLATFORM"] = origin["platform"]
-            os.environ["HERMES_SESSION_CHAT_ID"] = str(origin["chat_id"])
-            if origin.get("chat_name"):
-                os.environ["HERMES_SESSION_CHAT_NAME"] = origin["chat_name"]
+            _session_tokens = set_session_vars(
+                platform=origin["platform"],
+                chat_id=str(origin["chat_id"]),
+                chat_name=origin.get("chat_name", "") or "",
+            )
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
@@ -622,10 +630,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            os.environ["HERMES_CRON_AUTO_DELIVER_PLATFORM"] = delivery_target["platform"]
-            os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
-            if delivery_target.get("thread_id") is not None:
-                os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+            _delivery_tokens = set_cron_auto_delivery_target(
+                platform=delivery_target["platform"],
+                chat_id=str(delivery_target["chat_id"]),
+                thread_id="" if delivery_target.get("thread_id") is None else str(delivery_target["thread_id"]),
+            )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -882,16 +891,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return False, output, "", error_msg
 
     finally:
-        # Clean up injected env vars so they don't leak to other jobs
-        for key in (
-            "HERMES_SESSION_PLATFORM",
-            "HERMES_SESSION_CHAT_ID",
-            "HERMES_SESSION_CHAT_NAME",
-            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
-            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
-            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
-        ):
-            os.environ.pop(key, None)
+        clear_cron_auto_delivery_target(_delivery_tokens)
+        clear_session_vars(_session_tokens)
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,15 +1,22 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import concurrent.futures
 import json
 import logging
 import os
+import sys
+import threading
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from gateway.session_context import get_session_env
+from tools.send_message_tool import _get_cron_auto_delivery_target
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+sys.modules.setdefault("fire", MagicMock())
 
 
 class TestResolveOrigin:
@@ -735,9 +742,7 @@ class TestRunJobSessionPersistence:
                 pass
 
             def run_conversation(self, *args, **kwargs):
-                seen["platform"] = os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM")
-                seen["chat_id"] = os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID")
-                seen["thread_id"] = os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID")
+                seen.update(_get_cron_auto_delivery_target() or {})
                 return {"final_response": "ok"}
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
@@ -763,10 +768,99 @@ class TestRunJobSessionPersistence:
             "chat_id": "-2002",
             "thread_id": None,
         }
+        assert _get_cron_auto_delivery_target() is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         fake_db.close.assert_called_once()
+
+    def test_run_job_isolates_origin_and_delivery_context_per_concurrent_job(self, tmp_path, monkeypatch):
+        jobs = [
+            {
+                "id": "job-a",
+                "name": "job a",
+                "prompt": "alpha prompt",
+                "deliver": "telegram:-1001:100",
+                "origin": {
+                    "platform": "telegram",
+                    "chat_id": "origin-a",
+                    "chat_name": "Origin A",
+                },
+            },
+            {
+                "id": "job-b",
+                "name": "job b",
+                "prompt": "beta prompt",
+                "deliver": "telegram:-1002:200",
+                "origin": {
+                    "platform": "telegram",
+                    "chat_id": "origin-b",
+                    "chat_name": "Origin B",
+                },
+            },
+        ]
+        fake_db = MagicMock()
+        started = threading.Barrier(2)
+        seen = {}
+
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                self.job_id = kwargs["session_id"].split("_", 2)[1]
+
+            def run_conversation(self, *args, **kwargs):
+                started.wait(timeout=5)
+                seen[self.job_id] = {
+                    "origin_platform": get_session_env("HERMES_SESSION_PLATFORM"),
+                    "origin_chat_id": get_session_env("HERMES_SESSION_CHAT_ID"),
+                    "origin_chat_name": get_session_env("HERMES_SESSION_CHAT_NAME"),
+                    "delivery_target": _get_cron_auto_delivery_target(),
+                }
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                futures = [pool.submit(run_job, job) for job in jobs]
+                results = [future.result(timeout=10) for future in futures]
+
+        assert all(success is True and error is None and final_response == "ok" for success, _output, final_response, error in results)
+        assert seen == {
+            "job-a": {
+                "origin_platform": "telegram",
+                "origin_chat_id": "origin-a",
+                "origin_chat_name": "Origin A",
+                "delivery_target": {
+                    "platform": "telegram",
+                    "chat_id": "-1001",
+                    "thread_id": "100",
+                },
+            },
+            "job-b": {
+                "origin_platform": "telegram",
+                "origin_chat_id": "origin-b",
+                "origin_chat_name": "Origin B",
+                "delivery_target": {
+                    "platform": "telegram",
+                    "chat_id": "-1002",
+                    "thread_id": "200",
+                },
+            },
+        }
+        assert _get_cron_auto_delivery_target() is None
 
 
 class TestRunJobConfigLogging:

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -10,12 +10,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.config import Platform
 from tools.send_message_tool import (
+    _get_cron_auto_delivery_target,
     _parse_target_ref,
     _send_discord,
     _send_matrix_via_adapter,
     _send_telegram,
     _send_to_platform,
+    clear_cron_auto_delivery_target,
     send_message_tool,
+    set_cron_auto_delivery_target,
 )
 
 
@@ -136,6 +139,47 @@ class TestSendMessageTool:
             media_files=[],
         )
         mirror_mock.assert_called_once_with("telegram", "-1002", "hello", source_label="cli", thread_id=None)
+
+    def test_context_target_overrides_stale_env_when_checking_duplicates(self):
+        config, _telegram_cfg = _make_config()
+        tokens = set_cron_auto_delivery_target(
+            platform="telegram",
+            chat_id="-1002",
+            thread_id="",
+        )
+
+        try:
+            with patch.dict(
+                os.environ,
+                {
+                    "HERMES_CRON_AUTO_DELIVER_PLATFORM": "telegram",
+                    "HERMES_CRON_AUTO_DELIVER_CHAT_ID": "-1001",
+                },
+                clear=False,
+            ), \
+                 patch("gateway.config.load_gateway_config", return_value=config), \
+                 patch("tools.interrupt.is_interrupted", return_value=False), \
+                 patch("model_tools._run_async", side_effect=_run_async_immediately), \
+                 patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+                 patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+                result = json.loads(
+                    send_message_tool(
+                        {
+                            "action": "send",
+                            "target": "telegram:-1002",
+                            "message": "hello",
+                        }
+                    )
+                )
+        finally:
+            clear_cron_auto_delivery_target(tokens)
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["target"] == "telegram:-1002"
+        assert _get_cron_auto_delivery_target() is None
+        send_mock.assert_not_awaited()
+        mirror_mock.assert_not_called()
 
     def test_cron_same_chat_different_thread_still_sends(self):
         config, telegram_cfg = _make_config()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -5,12 +5,14 @@ Sends a message to a user or channel on any connected messaging platform
 human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
+from contextvars import ContextVar
 import json
 import logging
 import os
 import re
 import ssl
 import time
+from typing import Any
 
 from agent.redact import redact_sensitive_text
 
@@ -32,6 +34,20 @@ _URL_SECRET_QUERY_RE = re.compile(
 _GENERIC_SECRET_ASSIGN_RE = re.compile(
     r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
     re.IGNORECASE,
+)
+_UNSET: Any = object()
+
+_CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar(
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+    default=_UNSET,
+)
+_CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar(
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+    default=_UNSET,
+)
+_CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar(
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+    default=_UNSET,
 )
 
 
@@ -273,8 +289,58 @@ def _describe_media_for_mirror(media_files):
     return f"[Sent {len(media_files)} media attachments]"
 
 
+def set_cron_auto_delivery_target(
+    platform: str = "",
+    chat_id: str = "",
+    thread_id: str = "",
+) -> list:
+    """Set cron auto-delivery context for the current task and return tokens."""
+    return [
+        _CRON_AUTO_DELIVER_PLATFORM.set(platform),
+        _CRON_AUTO_DELIVER_CHAT_ID.set(chat_id),
+        _CRON_AUTO_DELIVER_THREAD_ID.set(thread_id),
+    ]
+
+
+def clear_cron_auto_delivery_target(tokens: list) -> None:
+    """Mark cron auto-delivery context as cleared for this task."""
+    for var in (
+        _CRON_AUTO_DELIVER_PLATFORM,
+        _CRON_AUTO_DELIVER_CHAT_ID,
+        _CRON_AUTO_DELIVER_THREAD_ID,
+    ):
+        var.set("")
+
+
+def _get_cron_auto_delivery_target_from_context():
+    """Read the current task's cron auto-delivery target, if one was set."""
+    platform = _CRON_AUTO_DELIVER_PLATFORM.get()
+    chat_id = _CRON_AUTO_DELIVER_CHAT_ID.get()
+    thread_id = _CRON_AUTO_DELIVER_THREAD_ID.get()
+
+    if platform is _UNSET and chat_id is _UNSET and thread_id is _UNSET:
+        return None
+
+    platform_value = "" if platform is _UNSET else str(platform).strip().lower()
+    chat_id_value = "" if chat_id is _UNSET else str(chat_id).strip()
+    thread_id_value = None if thread_id is _UNSET else (str(thread_id).strip() or None)
+
+    if not platform_value or not chat_id_value:
+        return None
+
+    return {
+        "platform": platform_value,
+        "chat_id": chat_id_value,
+        "thread_id": thread_id_value,
+    }
+
+
 def _get_cron_auto_delivery_target():
     """Return the cron scheduler's auto-delivery target for the current run, if any."""
+    context_target = _get_cron_auto_delivery_target_from_context()
+    if context_target is not None:
+        return context_target
+
     platform = os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip().lower()
     chat_id = os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
     if not platform or not chat_id:


### PR DESCRIPTION
## Summary
- move cron origin and auto-delivery routing state off process-global env vars and into task-local context
- make `send_message` prefer the task-local auto-delivery target while preserving env fallback for non-scheduler callers
- add regressions for concurrent cron jobs and stale-env duplicate-send checks

Fixes #10769

## Testing
- pytest -q tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_sets_auto_delivery_env_from_dotenv_home_channel tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_isolates_origin_and_delivery_context_per_concurrent_job
- pytest -q tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_duplicate_target_is_skipped_and_explained tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_different_target_still_sends tests/tools/test_send_message_tool.py::TestSendMessageTool::test_context_target_overrides_stale_env_when_checking_duplicates tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_same_chat_different_thread_still_sends