### PR TITLE
fix(gateway): streaming mode silently drops final response when already_sent is true

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -322,7 +322,12 @@ class GatewayStreamConsumer:
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            self._final_response_sent = self._already_sent
+                            # When message was split into chunks, we need to verify
+                            # that the final accumulated text was actually sent.
+                            # Don't rely on _already_sent which may be True from
+                            # earlier tool-progress messages. Since _accumulated
+                            # was just cleared, the chunks were sent via _send_new_chunk.
+                            self._final_response_sent = True
                             return
                         if got_segment_break:
                             self._message_id = None


### PR DESCRIPTION
## Summary
In streaming mode, the final assistant response can be silently dropped when the message is split into chunks due to length limits.

## Root Cause
In `stream_consumer.py` line 325, when a message was split into chunks, `_final_response_sent` was set to `_already_sent` which could be True from earlier tool-progress messages, even though the actual final response content was never sent.

This caused the gateway to skip independent delivery because it thought the final response was already sent, when in fact only earlier progress messages were sent.

## Fix
When message is split into chunks and `got_done` is True, mark `_final_response_sent` as True because the chunks were sent via `_send_new_chunk`. The `_accumulated` being empty indicates the content was sent as chunks.

## Test Plan
- [x] All stream consumer tests pass (57 passed)

Closes NousResearch/hermes-agent#10748