### PR TITLE
fix: add HERMES_SKIP_PERMISSIONS_SETUP env var for multi-container setups

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -65,7 +65,15 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _secure_dir(path: Path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
+    """Set directory to owner-only access (0700). No-op on Windows.
+    
+    Skipped when HERMES_SKIP_PERMISSIONS_SETUP is set, which is useful
+    for multi-container deployments where the data directory is shared
+    between containers running as different UIDs.
+    """
+    # Skip permission setup when explicitly requested (e.g., multi-container setups)
+    if os.environ.get("HERMES_SKIP_PERMISSIONS_SETUP", "").lower() in ("1", "true", "yes"):
+        return
     try:
         os.chmod(path, 0o700)
     except (OSError, NotImplementedError):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -222,6 +222,10 @@ def _secure_dir(path):
     permissions (0750) so interactive users in the hermes group can
     share state with the gateway service.
 
+    Also skipped when HERMES_SKIP_PERMISSIONS_SETUP is set, which is useful
+    for multi-container deployments where the data directory is shared
+    between containers running as different UIDs.
+
     The mode can be overridden via the HERMES_HOME_MODE environment variable
     (e.g. HERMES_HOME_MODE=0701) for deployments where a web server (nginx,
     caddy, etc.) needs to traverse HERMES_HOME to reach a served subdirectory.
@@ -229,6 +233,9 @@ def _secure_dir(path):
     directory listings.
     """
     if is_managed():
+        return
+    # Skip permission setup when explicitly requested (e.g., multi-container setups)
+    if os.environ.get("HERMES_SKIP_PERMISSIONS_SETUP", "").lower() in ("1", "true", "yes"):
         return
     try:
         mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()


### PR DESCRIPTION
## Summary
Fixes agent repeatedly resetting HERMES_DATA_DIR to mode 700, breaking multi-container setups with hermes-webui.

## Root Cause
The agent unconditionally resets HERMES_DATA_DIR to mode 700 at startup and in cron operations. This breaks multi-container deployments where hermes-webui shares the same data directory but runs as a different UID.

## Fix
Add HERMES_SKIP_PERMISSIONS_SETUP environment variable. When set to '1', 'true', or 'yes', the agent skips the chmod operations on directories. This allows operators to manage permissions externally for shared-volume multi-container deployments.

## Usage
```bash
export HERMES_SKIP_PERMISSIONS_SETUP=1
hermes gateway run
```

Or in docker-compose.yml:
```yaml
environment:
  - HERMES_SKIP_PERMISSIONS_SETUP=1
```

## Test Plan
- [x] File permissions tests pass (8 passed)
- [x] HERMES_SKIP_PERMISSIONS_SETUP=1 correctly skips chmod

Closes NousResearch/hermes-agent#10757