### PR TITLE
fix(auxiliary): named provider should take precedence over base_url in config

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2164,7 +2164,10 @@ def _resolve_task_provider_model(
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
-        if cfg_base_url:
+        # Named providers (nous, openrouter, anthropic, etc.) have built-in
+        # auth chains and should NOT be overridden by a base_url in config.
+        # Only route to "custom" when provider is absent/auto/explicitly "custom".
+        if cfg_base_url and (not cfg_provider or cfg_provider in ("auto", "custom")):
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, None, None, resolved_api_mode

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -252,3 +252,80 @@ class TestVisionPathApiMode:
         mock_gcc.assert_called_once()
         _, kwargs = mock_gcc.call_args
         assert kwargs.get("api_mode") == "chat_completions"
+
+
+class TestResolveTaskProviderBaseUrlPriority:
+    """Named provider should take precedence over base_url in config.
+
+    Regression tests for the bug where auxiliary.vision.base_url in config.yaml
+    would override the provider to 'custom', bypassing the named provider's
+    standard auth chain (e.g. auth.json credentials for nous).
+    """
+
+    def test_named_provider_ignores_base_url(self, tmp_path):
+        """provider: nous + base_url → should return 'nous', not 'custom'."""
+        _write_config(tmp_path, {
+            "auxiliary": {"vision": {
+                "provider": "nous",
+                "model": "xiaomi/mimo-v2-omni",
+                "base_url": "https://inference.nousresearch.com/v1",
+            }},
+        })
+        from agent.auxiliary_client import _resolve_task_provider_model
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+        assert provider == "nous"
+        assert base_url is None
+
+    def test_custom_provider_uses_base_url(self, tmp_path):
+        """provider: custom + base_url → should return 'custom' with base_url."""
+        _write_config(tmp_path, {
+            "auxiliary": {"vision": {
+                "provider": "custom",
+                "base_url": "http://localhost:8080/v1",
+                "api_key": "my-key",
+            }},
+        })
+        from agent.auxiliary_client import _resolve_task_provider_model
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+        assert provider == "custom"
+        assert base_url == "http://localhost:8080/v1"
+        assert api_key == "my-key"
+
+    def test_base_url_without_provider_is_custom(self, tmp_path):
+        """No provider, only base_url → should return 'custom'."""
+        _write_config(tmp_path, {
+            "auxiliary": {"vision": {
+                "base_url": "http://localhost:8080/v1",
+                "api_key": "test-key",
+            }},
+        })
+        from agent.auxiliary_client import _resolve_task_provider_model
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+        assert provider == "custom"
+        assert base_url == "http://localhost:8080/v1"
+
+    def test_named_provider_without_base_url(self, tmp_path):
+        """provider: nous, no base_url → standard behavior."""
+        _write_config(tmp_path, {
+            "auxiliary": {"vision": {
+                "provider": "nous",
+                "model": "xiaomi/mimo-v2-omni",
+            }},
+        })
+        from agent.auxiliary_client import _resolve_task_provider_model
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+        assert provider == "nous"
+        assert base_url is None
+
+    def test_openrouter_provider_ignores_base_url(self, tmp_path):
+        """provider: openrouter + base_url → should return 'openrouter'."""
+        _write_config(tmp_path, {
+            "auxiliary": {"vision": {
+                "provider": "openrouter",
+                "base_url": "https://some-proxy.example.com/v1",
+            }},
+        })
+        from agent.auxiliary_client import _resolve_task_provider_model
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+        assert provider == "openrouter"
+        assert base_url is None


### PR DESCRIPTION

    ## What does this PR do?

    Fixes a provider resolution bug in `_resolve_task_provider_model()` where a `base_url` set in `auxiliary.vision` config would unconditionally override the provider to "custom", bypassing the named provider's standard auth chain. For example, a config with `provider: nous` + `base_url: ...` would silently skip Nous auth.json credentials and attempt a raw custom endpoint call. The fix adds a one-condition guard: only route to the "custom" base_url path when provider is absent, "auto", or explicitly "custom". Named providers with built-in auth chains now correctly ignore irrelevant base_url values.

    ## Related Issue

    N/A

    ## Type of Change

    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

    ## Changes Made

    - `agent/auxiliary_client.py`: Expanded the `cfg_base_url` guard in `_resolve_task_provider_model()` (line 2167) to check `cfg_provider` before routing to "custom" path.
    - `tests/agent/test_auxiliary_named_custom_providers.py`: Added `TestResolveTaskProviderBaseUrlPriority` with 5 regression tests covering named provider + base_url, custom provider + base_url, base_url only, named provider only, and openrouter + base_url.

    ## How to Test

    1. Run `pytest tests/agent/test_auxiliary_named_custom_providers.py::TestResolveTaskProviderBaseUrlPriority -v` — all 5 tests should pass.
    2. With `provider: nous` + `base_url` in config, verify `_resolve_task_provider_model("vision")` returns `("nous", ...)` not `("custom", ...)`.
    3. With only `base_url` (no provider) or `provider: custom` + `base_url`, verify it still correctly returns `("custom", ...)`.

    ## Checklist

    ### Code

    - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
    - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(auxiliary):`)
    - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
    - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
    - [x] I've run `pytest tests/agent/test_auxiliary_*.py -q` and all relevant tests pass
    - [x] I've added tests for my changes
    - [x] I've tested on my platform: macOS 15

    ### Documentation & Housekeeping

    - [x] N/A — no config keys, docs, or schemas changed