### PR TITLE
fix(installer): reuse existing newer Python before downloading 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run this in PowerShell:
 iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ```
 
-The installer handles everything: uv, Python 3.11, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). Hermes uses this bundled Git Bash to run shell commands.
+The installer handles everything: uv, compatible Python 3.11–3.13, Node.js, ripgrep, ffmpeg, **and a portable Git Bash** (MinGit, unpacked to `%LOCALAPPDATA%\hermes\git` — no admin required, completely isolated from any system Git install). Hermes uses this bundled Git Bash to run shell commands.
 
 If you already have Git installed, the installer detects it and uses that instead. Otherwise a ~45MB MinGit download is all you need — it won't touch or interfere with any system Git.
 

--- a/contributors/emails/gnani.nutakki@gmail.com
+++ b/contributors/emails/gnani.nutakki@gmail.com
@@ -1,0 +1,1 @@
+gnanirahulnutakki

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1093,6 +1093,8 @@ function Resolve-UvCmd {
 }
 
 function Resolve-AvailablePythonVersion {
+    param([switch]$SupportedFallbackOnly)
+
     # Return the first Python minor version uv can actually find, preferring the
     # requested $PythonVersion and then $PythonFallbackVersions.  Returns $null
     # when none are available.
@@ -1104,7 +1106,17 @@ function Resolve-AvailablePythonVersion {
     # survive into the ``venv`` stage's process -- there $PythonVersion is back
     # at its "3.11" default.  Consumers re-resolve here instead of trusting that
     # default, which is exactly the propagation gap behind issue #50769.
-    $candidates = @($PythonVersion) + $PythonFallbackVersions
+    # Test-Python uses the restricted form before downloading 3.11.  Keep the
+    # legacy 3.10 recovery candidate out of that path because pyproject.toml
+    # supports only >=3.11,<3.14; it remains available to the existing
+    # post-install-failure recovery path below.
+    $candidates = if ($SupportedFallbackOnly) {
+        @($PythonFallbackVersions | Where-Object {
+            ([version]$_) -ge ([version]$PythonVersion)
+        })
+    } else {
+        @($PythonVersion) + $PythonFallbackVersions
+    }
     $seen = @{}
     foreach ($ver in $candidates) {
         if (-not $ver -or $seen.ContainsKey($ver)) { continue }
@@ -1129,6 +1141,23 @@ function Test-Python {
             return $true
         }
     } catch { }
+
+    # Reuse an already-installed supported Python before making a network
+    # request for the preferred 3.11 runtime.  This mirrors install.sh while
+    # retaining the minor-version token that later PowerShell stages re-resolve
+    # in their own process.
+    $compatibleVersion = Resolve-AvailablePythonVersion -SupportedFallbackOnly
+    if ($compatibleVersion) {
+        try {
+            $pythonPath = & $UvCmd python find $compatibleVersion 2>$null
+            if ($pythonPath) {
+                $ver = & $pythonPath --version 2>$null
+                Write-Success "Compatible Python found: $ver"
+                $script:PythonVersion = $compatibleVersion
+                return $true
+            }
+        } catch { }
+    }
     
     # Python not found -- use uv to install it (no admin needed!)
     Write-Info "Python $PythonVersion not found, installing via uv..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -285,6 +285,14 @@ check_python() {
         return 0
     fi
 
+    local compatible_request=">=$PYTHON_VERSION"
+    if $UV_CMD python find "$compatible_request" &> /dev/null; then
+        PYTHON_PATH=$($UV_CMD python find "$compatible_request")
+        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        log_success "Compatible Python found: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
     # Python not found — use uv to install it (no sudo needed!)
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
     if $UV_CMD python install "$PYTHON_VERSION"; then
@@ -783,17 +791,19 @@ setup_venv() {
         return 0
     fi
 
-    log_info "Creating virtual environment with Python $PYTHON_VERSION..."
+    local venv_python="${PYTHON_PATH:-$PYTHON_VERSION}"
+    local venv_label="${PYTHON_FOUND_VERSION:-Python $PYTHON_VERSION}"
+    log_info "Creating virtual environment with $venv_label..."
 
     if [ -d "venv" ]; then
         log_info "Virtual environment already exists, recreating..."
         rm -rf venv
     fi
 
-    # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    # uv creates the venv with the resolved interpreter in one step
+    $UV_CMD venv venv --python "$venv_python"
 
-    log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+    log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null || printf '%s' "$venv_label"))"
 }
 
 install_deps() {
@@ -1399,4 +1409,6 @@ main() {
     print_success
 }
 
-main
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,8 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
+# Keep this exclusive ceiling aligned with pyproject.toml's requires-python.
+PYTHON_MAX_VERSION="3.14"
 NODE_VERSION="22"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
@@ -629,6 +631,13 @@ check_python() {
     if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"; then
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python found: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
+    local compatible_request=">=$PYTHON_VERSION,<$PYTHON_MAX_VERSION"
+    if PYTHON_PATH="$("$UV_CMD" python find "$compatible_request" 2>/dev/null)"; then
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        log_success "Compatible Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
 
@@ -1338,15 +1347,17 @@ setup_venv() {
         return 0
     fi
 
-    log_info "Creating virtual environment with Python $PYTHON_VERSION..."
+    local venv_python="${PYTHON_PATH:-$PYTHON_VERSION}"
+    local venv_label="${PYTHON_FOUND_VERSION:-Python $PYTHON_VERSION}"
+    log_info "Creating virtual environment with $venv_label..."
 
     if [ -d "venv" ]; then
         log_info "Virtual environment already exists, recreating..."
         rm -rf venv
     fi
 
-    # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    # uv creates the venv with the resolved interpreter in one step
+    $UV_CMD venv venv --python "$venv_python"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
@@ -1359,7 +1370,7 @@ setup_venv() {
         export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
     fi
 
-    log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+    log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null || printf '%s' "$venv_label"))"
 }
 
 install_deps() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,8 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
+# Keep this exclusive ceiling aligned with pyproject.toml's requires-python.
+PYTHON_MAX_VERSION="3.14"
 NODE_VERSION="26"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
@@ -642,6 +644,13 @@ check_python() {
     if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"; then
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python found: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
+    local compatible_request=">=$PYTHON_VERSION,<$PYTHON_MAX_VERSION"
+    if PYTHON_PATH="$("$UV_CMD" python find "$compatible_request" 2>/dev/null)"; then
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        log_success "Compatible Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
 
@@ -1547,15 +1556,17 @@ setup_venv() {
         return 0
     fi
 
-    log_info "Creating virtual environment with Python $PYTHON_VERSION..."
+    local venv_python="${PYTHON_PATH:-$PYTHON_VERSION}"
+    local venv_label="${PYTHON_FOUND_VERSION:-Python $PYTHON_VERSION}"
+    log_info "Creating virtual environment with $venv_label..."
 
     if [ -d "venv" ]; then
         log_info "Virtual environment already exists, recreating..."
         rm -rf venv
     fi
 
-    # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    # uv creates the venv with the resolved interpreter in one step
+    $UV_CMD venv venv --python "$venv_python"
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the
@@ -1568,7 +1579,7 @@ setup_venv() {
         export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
     fi
 
-    log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+    log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null || printf '%s' "$venv_label"))"
 }
 
 install_deps() {

--- a/tests/hermes_cli/test_install_script.py
+++ b/tests/hermes_cli/test_install_script.py
@@ -1,0 +1,129 @@
+from pathlib import Path
+import subprocess
+import textwrap
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _make_executable(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _run_bash(command: str, *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", command],
+        cwd=cwd or REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_install_script_is_valid_shell():
+    result = subprocess.run(["bash", "-n", str(INSTALL_SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_check_python_prefers_existing_compatible_python_over_download(tmp_path):
+    fake_python = _make_executable(
+        tmp_path / "python313",
+        """#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "Python 3.13.12"
+    exit 0
+fi
+exit 0
+""",
+    )
+    install_marker = tmp_path / "uv-install-called"
+    fake_uv = _make_executable(
+        tmp_path / "uv",
+        f"""#!/bin/bash
+set -e
+if [ "$1" = "python" ] && [ "$2" = "find" ] && [ "$3" = "3.11" ]; then
+    exit 1
+fi
+if [ "$1" = "python" ] && [ "$2" = "find" ] && [ "$3" = ">=3.11" ]; then
+    echo "{fake_python}"
+    exit 0
+fi
+if [ "$1" = "python" ] && [ "$2" = "install" ] && [ "$3" = "3.11" ]; then
+    touch "{install_marker}"
+    exit 0
+fi
+echo "unexpected uv invocation: $*" >&2
+exit 2
+""",
+    )
+
+    command = textwrap.dedent(
+        f"""
+        source "{INSTALL_SCRIPT}"
+        UV_CMD="{fake_uv}"
+        DISTRO="macos"
+        check_python
+        printf 'PYTHON_PATH=%s\\n' "$PYTHON_PATH"
+        printf 'PYTHON_FOUND_VERSION=%s\\n' "$PYTHON_FOUND_VERSION"
+        """
+    )
+
+    result = _run_bash(command)
+
+    assert result.returncode == 0, result.stderr
+    assert f"PYTHON_PATH={fake_python}" in result.stdout
+    assert "PYTHON_FOUND_VERSION=Python 3.13.12" in result.stdout
+    assert not install_marker.exists()
+
+
+def test_setup_venv_uses_resolved_python_path(tmp_path):
+    fake_python = _make_executable(
+        tmp_path / "python313",
+        """#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "Python 3.13.12"
+    exit 0
+fi
+exit 0
+""",
+    )
+    uv_args = tmp_path / "uv-args.txt"
+    fake_uv = _make_executable(
+        tmp_path / "uv",
+        f"""#!/bin/bash
+set -e
+printf '%s\\n' "$@" > "{uv_args}"
+mkdir -p venv/bin
+cat > venv/bin/python <<'EOF'
+#!/bin/bash
+echo "Python 3.13.12"
+EOF
+chmod +x venv/bin/python
+""",
+    )
+
+    command = textwrap.dedent(
+        f"""
+        cd "{tmp_path}"
+        source "{INSTALL_SCRIPT}"
+        UV_CMD="{fake_uv}"
+        DISTRO="macos"
+        USE_VENV=true
+        PYTHON_VERSION="3.11"
+        PYTHON_PATH="{fake_python}"
+        PYTHON_FOUND_VERSION="Python 3.13.12"
+        setup_venv
+        """
+    )
+
+    result = _run_bash(command, cwd=tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert uv_args.read_text(encoding="utf-8").splitlines() == [
+        "venv",
+        "venv",
+        "--python",
+        str(fake_python),
+    ]

--- a/tests/hermes_cli/test_install_script.py
+++ b/tests/hermes_cli/test_install_script.py
@@ -1,0 +1,178 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _make_executable(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _make_python(path: Path, version: str) -> Path:
+    return _make_executable(
+        path,
+        f"""#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "Python {version}"
+    exit 0
+fi
+exit 0
+""",
+    )
+
+
+def _run_venv_stage(
+    tmp_path: Path,
+    *,
+    compatible_python: Path | None,
+) -> tuple[subprocess.CompletedProcess[str], list[list[str]], dict[str, Path]]:
+    test_home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-home"
+    install_dir = tmp_path / "install"
+    managed_bin = hermes_home / "bin"
+    for directory in (test_home, managed_bin, install_dir):
+        directory.mkdir(parents=True)
+
+    python311 = _make_python(tmp_path / "python311", "3.11.12")
+    python314 = _make_python(tmp_path / "python314", "3.14.0")
+    install_marker = tmp_path / "python-installed"
+    call_log = tmp_path / "uv-calls.tsv"
+
+    compatible_result = (
+        f'echo "{compatible_python}"\n    exit 0'
+        if compatible_python is not None
+        else "exit 1"
+    )
+    _make_executable(
+        managed_bin / "uv",
+        f"""#!/bin/bash
+set -e
+{{
+    printf '%s' "${{UV_PYTHON:-}}"
+    for arg in "$@"; do
+        printf '\\t%s' "$arg"
+    done
+    printf '\\n'
+}} >> "{call_log}"
+
+if [ "$1" = "--version" ]; then
+    echo "uv 0.test"
+    exit 0
+fi
+
+if [ "$1" = "python" ] && [ "$2" = "find" ] && [ "$3" = "3.11" ]; then
+    if [ -f "{install_marker}" ]; then
+        echo "{python311}"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [ "$1" = "python" ] && [ "$2" = "find" ] && [ "$3" = ">=3.11,<3.14" ]; then
+    {compatible_result}
+fi
+
+if [ "$1" = "python" ] && [ "$2" = "install" ] && [ "$3" = "3.11" ]; then
+    touch "{install_marker}"
+    exit 0
+fi
+
+if [ "$1" = "venv" ] && [ "$3" = "--python" ]; then
+    mkdir -p "$2/bin"
+    cp "$4" "$2/bin/python"
+    chmod +x "$2/bin/python"
+    exit 0
+fi
+
+echo "unexpected uv invocation: $*" >&2
+exit 2
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        HOME=str(test_home),
+        HERMES_HOME=str(hermes_home),
+        UV_PYTHON=str(python314),
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            "--stage",
+            "venv",
+            "--json",
+            "--non-interactive",
+            "--dir",
+            str(install_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    calls = [
+        line.split("\t")
+        for line in call_log.read_text(encoding="utf-8").splitlines()
+    ]
+    paths = {
+        "install_dir": install_dir,
+        "install_marker": install_marker,
+        "python311": python311,
+        "python314": python314,
+    }
+    return result, calls, paths
+
+
+def test_install_script_is_valid_shell():
+    result = subprocess.run(
+        ["bash", "-n", str(INSTALL_SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_venv_stage_reuses_existing_supported_python(tmp_path):
+    python313 = _make_python(tmp_path / "python313", "3.13.12")
+
+    result, calls, paths = _run_venv_stage(
+        tmp_path,
+        compatible_python=python313,
+    )
+    args = [call[1:] for call in calls]
+
+    assert result.returncode == 0, result.stderr
+    assert ["python", "find", "3.11"] in args
+    assert ["python", "find", ">=3.11,<3.14"] in args
+    assert ["python", "install", "3.11"] not in args
+    assert ["venv", "venv", "--python", str(python313)] in args
+    assert not paths["install_marker"].exists()
+    assert (
+        subprocess.check_output(
+            [paths["install_dir"] / "venv/bin/python", "--version"],
+            text=True,
+        ).strip()
+        == "Python 3.13.12"
+    )
+
+
+def test_venv_stage_rejects_python314_and_installs_supported_floor(tmp_path):
+    result, calls, paths = _run_venv_stage(
+        tmp_path,
+        compatible_python=None,
+    )
+    args = [call[1:] for call in calls]
+
+    assert result.returncode == 0, result.stderr
+    assert ["python", "find", ">=3.11,<3.14"] in args
+    assert ["python", "install", "3.11"] in args
+    assert ["venv", "venv", "--python", str(paths["python311"])] in args
+    assert all(str(paths["python314"]) not in call for call in args)
+    assert paths["install_marker"].exists()

--- a/tests/hermes_cli/test_install_script.py
+++ b/tests/hermes_cli/test_install_script.py
@@ -1,0 +1,264 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SCRIPT = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+POWERSHELL = next(
+    (candidate for candidate in ("pwsh", "powershell") if shutil.which(candidate)),
+    None,
+)
+
+
+def _make_executable(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _make_python(path: Path, version: str) -> Path:
+    return _make_executable(
+        path,
+        f"""#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "Python {version}"
+    exit 0
+fi
+exit 0
+""",
+    )
+
+
+def _run_venv_stage(
+    tmp_path: Path,
+    *,
+    compatible_python: Path | None,
+) -> tuple[subprocess.CompletedProcess[str], list[list[str]], dict[str, Path]]:
+    test_home = tmp_path / "home"
+    hermes_home = tmp_path / "hermes-home"
+    install_dir = tmp_path / "install"
+    managed_bin = hermes_home / "bin"
+    for directory in (test_home, managed_bin, install_dir):
+        directory.mkdir(parents=True)
+
+    python311 = _make_python(tmp_path / "python311", "3.11.12")
+    python314 = _make_python(tmp_path / "python314", "3.14.0")
+    install_marker = tmp_path / "python-installed"
+    call_log = tmp_path / "uv-calls.tsv"
+
+    compatible_result = (
+        f'echo "{compatible_python}"\n    exit 0'
+        if compatible_python is not None
+        else "exit 1"
+    )
+    _make_executable(
+        managed_bin / "uv",
+        f"""#!/bin/bash
+set -e
+{{
+    printf '%s' "${{UV_PYTHON:-}}"
+    for arg in "$@"; do
+        printf '\\t%s' "$arg"
+    done
+    printf '\\n'
+}} >> "{call_log}"
+
+if [ "$1" = "--version" ]; then
+    echo "uv 0.test"
+    exit 0
+fi
+
+if [ "$1" = "python" ] && [ "$2" = "find" ] && [ "$3" = "3.11" ]; then
+    if [ -f "{install_marker}" ]; then
+        echo "{python311}"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [ "$1" = "python" ] && [ "$2" = "find" ] && [ "$3" = ">=3.11,<3.14" ]; then
+    {compatible_result}
+fi
+
+if [ "$1" = "python" ] && [ "$2" = "install" ] && [ "$3" = "3.11" ]; then
+    touch "{install_marker}"
+    exit 0
+fi
+
+if [ "$1" = "venv" ] && [ "$3" = "--python" ]; then
+    mkdir -p "$2/bin"
+    cp "$4" "$2/bin/python"
+    chmod +x "$2/bin/python"
+    exit 0
+fi
+
+echo "unexpected uv invocation: $*" >&2
+exit 2
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        HOME=str(test_home),
+        HERMES_HOME=str(hermes_home),
+        UV_PYTHON=str(python314),
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SCRIPT),
+            "--stage",
+            "venv",
+            "--json",
+            "--non-interactive",
+            "--dir",
+            str(install_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    calls = [
+        line.split("\t") for line in call_log.read_text(encoding="utf-8").splitlines()
+    ]
+    paths = {
+        "install_dir": install_dir,
+        "install_marker": install_marker,
+        "python311": python311,
+        "python314": python314,
+    }
+    return result, calls, paths
+
+
+def test_install_script_is_valid_shell():
+    result = subprocess.run(
+        ["bash", "-n", str(INSTALL_SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_venv_stage_reuses_existing_supported_python(tmp_path):
+    python313 = _make_python(tmp_path / "python313", "3.13.12")
+
+    result, calls, paths = _run_venv_stage(
+        tmp_path,
+        compatible_python=python313,
+    )
+    args = [call[1:] for call in calls]
+
+    assert result.returncode == 0, result.stderr
+    assert ["python", "find", "3.11"] in args
+    assert ["python", "find", ">=3.11,<3.14"] in args
+    assert ["python", "install", "3.11"] not in args
+    assert ["venv", "venv", "--python", str(python313)] in args
+    assert not paths["install_marker"].exists()
+    assert (
+        subprocess.check_output(
+            [paths["install_dir"] / "venv/bin/python", "--version"],
+            text=True,
+        ).strip()
+        == "Python 3.13.12"
+    )
+
+
+def test_venv_stage_rejects_python314_and_installs_supported_floor(tmp_path):
+    result, calls, paths = _run_venv_stage(
+        tmp_path,
+        compatible_python=None,
+    )
+    args = [call[1:] for call in calls]
+
+    assert result.returncode == 0, result.stderr
+    assert ["python", "find", ">=3.11,<3.14"] in args
+    assert ["python", "install", "3.11"] in args
+    assert ["venv", "venv", "--python", str(paths["python311"])] in args
+    assert all(str(paths["python314"]) not in call for call in args)
+    assert paths["install_marker"].exists()
+
+
+@pytest.mark.skipif(POWERSHELL is None, reason="needs PowerShell")
+def test_windows_python_stage_reuses_supported_python_before_install(tmp_path):
+    call_log = tmp_path / "uv-calls.tsv"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv.ps1"
+    fake_uv.write_text(
+        r"""
+$line = $args -join "`t"
+[System.IO.File]::AppendAllText(
+    $env:HERMES_TEST_UV_LOG,
+    $line + [Environment]::NewLine
+)
+
+if ($args.Count -eq 1 -and $args[0] -eq "--version") {
+    Write-Output "uv 0.test"
+    exit 0
+}
+
+if ($args.Count -eq 3 -and $args[0] -eq "python" -and $args[1] -eq "find") {
+    if ($args[2] -eq "3.12") {
+        Write-Output $env:HERMES_TEST_COMPATIBLE_PYTHON
+        exit 0
+    }
+    exit 1
+}
+
+if ($args.Count -ge 2 -and $args[0] -eq "python" -and $args[1] -eq "install") {
+    [System.IO.File]::WriteAllText($env:HERMES_TEST_INSTALL_MARKER, "called")
+    exit 0
+}
+
+exit 2
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    install_marker = tmp_path / "python-installed"
+    env = os.environ.copy()
+    env.update(
+        HERMES_TEST_COMPATIBLE_PYTHON=sys.executable,
+        HERMES_TEST_INSTALL_MARKER=str(install_marker),
+        HERMES_TEST_UV_LOG=str(call_log),
+        PATH=os.pathsep.join((str(fake_bin), env["PATH"])),
+    )
+    result = subprocess.run(
+        [
+            POWERSHELL,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(INSTALL_PS1),
+            "-Stage",
+            "python",
+            "-Json",
+            "-NonInteractive",
+            "-HermesHome",
+            str(tmp_path / "hermes-home"),
+            "-InstallDir",
+            str(tmp_path / "install"),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"{result.stdout}\n{result.stderr}"
+    calls = [
+        line.split("\t") for line in call_log.read_text(encoding="utf-8").splitlines()
+    ]
+    assert ["python", "find", "3.11"] in calls
+    assert ["python", "find", "3.12"] in calls
+    assert not any(call[:2] == ["python", "install"] for call in calls)
+    assert not install_marker.exists()


### PR DESCRIPTION
## Summary
- reuse an installed interpreter only when it satisfies the supported `>=3.11,<3.14` range before downloading Python 3.11 via `uv`
- carry the resolved interpreter path into the POSIX `uv venv` stage while preserving `UV_PYTHON` repinning
- apply the same policy to the PowerShell installer using its cross-process-safe version resolution; the legacy Python 3.10 recovery candidate remains post-install-failure only
- document the installer’s existing Python 3.11–3.13 compatibility range

Fixes #10778

## Regression proof

Against current upstream `main` (`a0795acc831210970586a99f2263de5486eab245`), the new behavioral harness fails on both untouched installers: they attempt to install exact Python 3.11 before reusing an available Python 3.12/3.13. The same harness passes on this PR head (`3ee7c709738b40b84683c6d03b8f73e2b1d5f0fd`).

The tests exercise real installer stages with a deterministic fake `uv` executable and verify:
- an installed Python 3.13 is reused without a `uv python install 3.11` call
- Python 3.14 is rejected and the supported 3.11 floor is installed
- the resolved POSIX interpreter path is passed to `uv venv`
- native PowerShell 7.6.5 arm64 reuses Python 3.12 before download

## Validation
- canonical `scripts/run_tests.sh` across the new regression plus all `tests/test_install_sh_*.py` and `tests/test_install_ps1_*.py`: 91 passed, 1 skipped across 27 files
  - three temporary-repository tests initially inherited local `commit.gpgsign=true`; rerunning that file with a PATH-local `git -c commit.gpgsign=false` wrapper produced 5/5 passes without changing global Git configuration
- `ruff check tests/hermes_cli/test_install_script.py`
- `ruff format --check tests/hermes_cli/test_install_script.py`
- `bash -n scripts/install.sh`
- DCO sign-off and SSH commit signature verified on the exact head
