### PR TITLE
fix: auto-upgrade GPT-5 named custom providers to responses API

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -46,6 +46,27 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _model_requires_responses_api(model: str) -> bool:
+    """Return True for models that require the Responses API path.
+
+    Keep this in sync with ``run_agent.AIAgent._model_requires_responses_api`` so
+    runtime provider resolution and the main agent agree on GPT-5.x routing.
+    """
+    normalized = (model or "").strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    return normalized.startswith("gpt-5")
+
+
+def _maybe_upgrade_api_mode_for_model(api_mode: Optional[str], model: str) -> Optional[str]:
+    """Promote chat-completions runtimes to Responses API when the model needs it."""
+    if api_mode not in (None, "chat_completions"):
+        return api_mode
+    if _model_requires_responses_api(model):
+        return "codex_responses"
+    return api_mode
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -382,14 +403,19 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
+    model_name = str(custom_provider.get("model") or "").strip()
+
     # Check if a credential pool exists for this custom endpoint
     pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
-        model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+            pool_result["api_mode"] = _maybe_upgrade_api_mode_for_model(
+                pool_result.get("api_mode"),
+                model_name,
+            ) or pool_result.get("api_mode")
         return pool_result
 
     api_key_candidates = [
@@ -401,19 +427,24 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
+    api_mode = (
+        custom_provider.get("api_mode")
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+    api_mode = _maybe_upgrade_api_mode_for_model(api_mode, model_name) or api_mode
+
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
     # Propagate the model name so callers can override self.model when the
     # provider name differs from the actual model string the API expects.
-    if custom_provider.get("model"):
-        result["model"] = custom_provider["model"]
+    if model_name:
+        result["model"] = model_name
     return result
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -572,6 +572,110 @@ def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     assert resolved["source"] == "custom_provider:Local"
 
 
+def test_named_custom_provider_upgrades_gpt5_models_to_codex_responses(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Aixj.vip",
+                    "base_url": "https://aixj.vip/v1",
+                    "api_key": "masked-aixj-key",
+                    "model": "gpt-5.4",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:aixj.vip")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://aixj.vip/v1"
+    assert resolved["model"] == "gpt-5.4"
+
+
+def test_named_custom_provider_pool_result_also_upgrades_gpt5_models(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Aixj.vip",
+                    "base_url": "https://aixj.vip/v1",
+                    "model": "gpt-5.4",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "_try_resolve_from_custom_pool",
+        lambda *a, **k: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://aixj.vip/v1",
+            "api_key": "pool-token",
+            "source": "pool:custom:https://aixj.vip/v1",
+            "credential_pool": object(),
+        },
+    )
+
+    resolved = rp._resolve_named_custom_runtime(requested_provider="custom:aixj.vip")
+
+    assert resolved is not None
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["model"] == "gpt-5.4"
+    assert resolved["api_key"] == "pool-token"
+
+
+def test_named_custom_provider_keeps_chat_completions_for_non_gpt5_models(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Generic Proxy",
+                    "base_url": "https://proxy.example.com/v1",
+                    "api_key": "proxy-key",
+                    "model": "gpt-4o",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:generic-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["model"] == "gpt-4o"
+
+
 def test_named_custom_provider_uses_providers_dict_when_list_missing(monkeypatch):
     """After v11→v12 migration deletes custom_providers, resolution should
     still find entries in the providers dict via get_compatible_custom_providers."""


### PR DESCRIPTION
## Summary
- auto-upgrade named custom providers to `codex_responses` when their model requires the Responses API
- apply the same upgrade logic to the custom credential-pool path
- add regression tests for GPT-5 positive cases and a non-GPT-5 negative case

## Why
Auxiliary/runtime resolution could leave named custom GPT-5 providers on `chat_completions` when `custom_providers[].api_mode` was omitted, even though the main agent runtime would upgrade the same model to `codex_responses`.

This especially breaks OpenAI-compatible relays that only behave correctly for GPT-5 through `/v1/responses`.

## Test Plan
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`

Closes #10814
