### PR TITLE
fix(runtime): auto-upgrade GPT-5 named custom providers to codex_responses

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -46,6 +46,28 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _model_requires_responses_api(model: str) -> bool:
+    """Return True for models that require the Responses API path.
+
+    Mirrors the generic GPT-5 detection used by the main agent runtime for
+    OpenAI-compatible providers. Provider-specific exceptions should continue
+    to use explicit ``api_mode`` overrides.
+    """
+    normalized = (model or "").strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    return normalized.startswith("gpt-5")
+
+
+def _maybe_upgrade_api_mode_for_model(api_mode: Optional[str], model: str) -> Optional[str]:
+    """Fill in api_mode from model requirements when no explicit mode is set."""
+    if api_mode is not None:
+        return api_mode
+    if _model_requires_responses_api(model):
+        return "codex_responses"
+    return None
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -383,8 +405,13 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
+    resolved_api_mode = _maybe_upgrade_api_mode_for_model(
+        custom_provider.get("api_mode") or _detect_api_mode_for_url(base_url),
+        str(custom_provider.get("model", "") or ""),
+    )
+
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    pool_result = _try_resolve_from_custom_pool(base_url, "custom", resolved_api_mode)
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -404,9 +431,7 @@ def _resolve_named_custom_runtime(
 
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": resolved_api_mode or "chat_completions",
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -883,6 +883,73 @@ def test_named_custom_provider_without_api_mode_defaults(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_named_custom_provider_gpt5_auto_upgrades_to_responses(monkeypatch):
+    """Named custom GPT-5 models should infer codex_responses when api_mode is omitted."""
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "Aixj.vip",
+            "base_url": "https://aixj.vip/v1",
+            "api_key": "***",
+            "model": "gpt-5.4",
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="custom:aixj.vip")
+
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["model"] == "gpt-5.4"
+
+
+def test_named_custom_provider_pool_gpt5_auto_upgrades_to_responses(monkeypatch):
+    """Pool-backed named custom GPT-5 providers should also infer codex_responses."""
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "Aixj.vip",
+            "base_url": "https://aixj.vip/v1",
+            "api_key": "***",
+            "model": "gpt-5.4",
+        },
+    )
+    monkeypatch.setattr(
+        rp, "_try_resolve_from_custom_pool",
+        lambda base_url, provider_label, api_mode_override=None: {
+            "provider": provider_label,
+            "api_mode": api_mode_override or "chat_completions",
+            "base_url": base_url,
+            "api_key": "pool-key",
+            "source": "pool:custom:aixj.vip",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:aixj.vip")
+
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["api_key"] == "pool-key"
+    assert resolved["model"] == "gpt-5.4"
+
+
+def test_named_custom_provider_explicit_chat_completions_is_preserved(monkeypatch):
+    """Explicit api_mode should continue to win over GPT-5 model inference."""
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "Aixj.vip",
+            "base_url": "https://aixj.vip/v1",
+            "api_key": "***",
+            "api_mode": "chat_completions",
+            "model": "gpt-5.4",
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="custom:aixj.vip")
+
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_anthropic_messages_in_valid_api_modes():
     """anthropic_messages should be accepted by _parse_api_mode."""
     assert rp._parse_api_mode("anthropic_messages") == "anthropic_messages"


### PR DESCRIPTION
## Summary
- auto-upgrade named custom GPT-5 providers to `codex_responses` when `api_mode` is omitted
- reuse the resolved mode for both direct and credential-pool custom runtime paths
- preserve explicit `api_mode` overrides such as `chat_completions`

Fixes #10814.

## Root Cause
`_resolve_named_custom_runtime()` only considered an explicit `api_mode` and URL-based detection before falling back to `chat_completions`. That missed the same GPT-5 model-based Responses API upgrade already used by the main agent runtime, so auxiliary paths could mis-route named custom GPT-5 providers.

## Validation
- `pytest -q -o addopts= tests/hermes_cli/test_runtime_provider_resolution.py -k "named_custom_provider or named_custom_runtime_propagates_model or get_named_custom_provider"`
  - `15 passed, 55 deselected`

## Notes
- no README or config-schema updates required; behavior only changes for named custom providers with GPT-5 models and no explicit `api_mode`
