### PR TITLE
Improve skill_view guidance for category-qualified regular skills

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -570,6 +570,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -241,6 +241,24 @@ class TestSkillViewQualifiedName:
         assert result["success"] is False
         assert "not found" in result["error"].lower()
 
+    def test_category_name_reports_helpful_error(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        skills_dir = tmp_path / "local-skills"
+        skill_dir = skills_dir / "autonomous-ai-agents" / "hermes-agent"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: hermes-agent\ndescription: local\n---\nLocal body.\n"
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", skills_dir)
+
+        result = json.loads(skill_view("autonomous-ai-agents:hermes-agent"))
+
+        assert result["success"] is False
+        assert "looks like a skill category" in result["error"]
+        assert result["hint"] == 'Try skill_view("hermes-agent") instead.'
+        assert result["suggested_name"] == "hermes-agent"
+
     def test_stale_entry_self_heals(self, tmp_path):
         from tools.skills_tool import skill_view
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -626,6 +626,14 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
+def _find_regular_skill_by_category(category: str, bare_name: str) -> Optional[Dict[str, Any]]:
+    """Return a regular skill whose category/name look like ``category:skill`` confusion."""
+    for skill in _find_all_skills():
+        if skill.get("category") == category and skill.get("name") == bare_name:
+            return skill
+    return None
+
+
 def _load_category_description(category_dir: Path) -> Optional[str]:
     """
     Load category description from DESCRIPTION.md if it exists.
@@ -923,6 +931,21 @@ def skill_view(
                         "error": f"Skill '{bare}' not found in plugin '{namespace}'.",
                         "available_skills": [f"{namespace}:{s}" for s in available],
                         "hint": f"The '{namespace}' plugin provides {len(available)} skill(s).",
+                    },
+                    ensure_ascii=False,
+                )
+
+            regular_skill = _find_regular_skill_by_category(namespace, bare)
+            if regular_skill:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"'{namespace}' looks like a skill category, not a plugin namespace. "
+                            f"The regular skill '{bare}' exists in that category."
+                        ),
+                        "hint": f'Try skill_view("{bare}") instead.',
+                        "suggested_name": bare,
                     },
                     ensure_ascii=False,
                 )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -601,6 +601,14 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     return skills
 
 
+def _find_regular_skill_by_category(category: str, bare_name: str) -> Optional[Dict[str, Any]]:
+    """Return a regular skill whose category/name look like ``category:skill`` confusion."""
+    for skill in _find_all_skills():
+        if skill.get("category") == category and skill.get("name") == bare_name:
+            return skill
+    return None
+
+
 def _load_category_description(category_dir: Path) -> Optional[str]:
     """
     Load category description from DESCRIPTION.md if it exists.
@@ -866,6 +874,21 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                         "error": f"Skill '{bare}' not found in plugin '{namespace}'.",
                         "available_skills": [f"{namespace}:{s}" for s in available],
                         "hint": f"The '{namespace}' plugin provides {len(available)} skill(s).",
+                    },
+                    ensure_ascii=False,
+                )
+
+            regular_skill = _find_regular_skill_by_category(namespace, bare)
+            if regular_skill:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            f"'{namespace}' looks like a skill category, not a plugin namespace. "
+                            f"The regular skill '{bare}' exists in that category."
+                        ),
+                        "hint": f'Try skill_view("{bare}") instead.',
+                        "suggested_name": bare,
                     },
                     ensure_ascii=False,
                 )


### PR DESCRIPTION
This improves the error that `skill_view()` returns when a regular skill is accidentally addressed as `category:skill`.

Right now any name containing `:` is treated as a plugin-qualified skill name. That makes a natural pattern like `autonomous-ai-agents:hermes-agent` fail in a confusing way, even when `autonomous-ai-agents` is just a regular skill category from `skills_list()` and `hermes-agent` exists as a normal local skill.

This change keeps the existing plugin resolution behavior, but adds a more helpful response when:

- the left-hand side is not a real plugin namespace
- there is a regular skill whose `category` matches the left-hand side
- the bare skill name exists in that category

In that case Hermes now returns a targeted hint like `Try skill_view("hermes-agent") instead.` rather than a generic not-found error.

I also added a regression test for that exact `category:skill` confusion path.

## Testing

- `source venv/bin/activate && python -m pytest tests/test_plugin_skills.py -q`
- `source venv/bin/activate && python -m pytest tests/tools/test_skills_tool.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

The targeted skills/plugin tests pass.

The full local suite is still not green on this checkout/environment (`70 failed, 11765 passed, 98 skipped, 60 errors`), but the failures are outside this change and are consistent with the broader ACP / optional Discord / web-server / gateway noise already present locally.
