### PR TITLE
fix(platforms): add base send_file fallback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1207,6 +1207,30 @@ class BasePlatformAdapter(ABC):
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
+    async def send_file(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a generic file attachment through the document path.
+
+        Some gateway flows call ``send_file()`` while adapters conventionally
+        implement ``send_document()``. Delegate here so native document
+        adapters inherit the correct behavior automatically.
+        """
+        return await self.send_document(
+            chat_id=chat_id,
+            file_path=file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            **kwargs,
+        )
+
     async def send_image_file(
         self,
         chat_id: str,

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,5 +1,6 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
 import os
 from unittest.mock import patch
 
@@ -8,6 +9,7 @@ from gateway.platforms.base import (
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    SendResult,
     safe_url_for_log,
     utf16_len,
     _prefix_within_utf16_limit,
@@ -322,6 +324,75 @@ class TestExtractMedia:
         assert "After" in cleaned
 
 
+class TestSendFileFallback:
+    def _adapter(self):
+        from gateway.config import Platform, PlatformConfig
+
+        class StubAdapter(BasePlatformAdapter):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.document_calls = []
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, *a, **kw):
+                raise AssertionError("send() should not be used by send_file fallback")
+
+            async def get_chat_info(self, *a):
+                return {}
+
+            async def send_document(
+                self,
+                chat_id,
+                file_path,
+                caption=None,
+                file_name=None,
+                reply_to=None,
+                **kwargs,
+            ):
+                self.document_calls.append({
+                    "chat_id": chat_id,
+                    "file_path": file_path,
+                    "caption": caption,
+                    "file_name": file_name,
+                    "reply_to": reply_to,
+                    "kwargs": kwargs,
+                })
+                return SendResult(success=True, message_id="doc-1")
+
+        config = PlatformConfig(enabled=True, token="test")
+        return StubAdapter(config=config, platform=Platform.TELEGRAM)
+
+    def test_send_file_delegates_to_send_document_override(self):
+        adapter = self._adapter()
+
+        result = asyncio.run(
+            adapter.send_file(
+                chat_id="chat-1",
+                file_path="/tmp/report.pdf",
+                caption="Please review",
+                file_name="report.pdf",
+                reply_to="msg-9",
+                metadata={"thread_id": "123"},
+            )
+        )
+
+        assert result.success is True
+        assert result.message_id == "doc-1"
+        assert adapter.document_calls == [{
+            "chat_id": "chat-1",
+            "file_path": "/tmp/report.pdf",
+            "caption": "Please review",
+            "file_name": "report.pdf",
+            "reply_to": "msg-9",
+            "kwargs": {"metadata": {"thread_id": "123"}},
+        }]
+
+
 # ---------------------------------------------------------------------------
 # truncate_message
 # ---------------------------------------------------------------------------
@@ -581,4 +652,3 @@ class TestTruncateMessageUtf16:
             assert fence_count % 2 == 0, (
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
-


### PR DESCRIPTION
## Summary
- add `BasePlatformAdapter.send_file()` as a thin alias to `send_document()`
- preserve adapter-specific native document handling for platforms like Feishu and Weixin
- add a regression test proving `send_file()` dispatches through an overridden `send_document()` implementation

Fixes #10826.

## Root Cause
`gateway/run.py` uses `adapter.send_file()` in the `/btw` media-delivery path, but platform adapters conventionally implement `send_document()` instead. Because `BasePlatformAdapter` had no `send_file()` fallback, adapters like Feishu inherited no method at all and the gateway silently swallowed the resulting exception.

## Why this fix
Adding the fallback on the base adapter is safer than duplicating per-platform `send_file()` methods:
- it fixes every adapter that already supports `send_document()`
- it preserves native platform behavior via normal method dispatch
- it keeps the public adapter contract consistent with the gateway call site

## Validation
- `pytest -q -o addopts= tests/gateway/test_platform_base.py`
  - `77 passed`

## Notes
- README did not need updates for this internal adapter-contract fix
