### PR TITLE
feat: add compression.warnings config option to suppress context pressure alerts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -445,7 +445,7 @@ DEFAULT_CONFIG = {
         "threshold": 0.50,            # compress when context usage exceeds this ratio
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
-
+        "warnings": True,             # show context pressure warnings (disable to suppress repeated alerts)
     },
 
     # AWS Bedrock provider configuration.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1357,6 +1357,7 @@ class AIAgent:
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        compression_warnings = str(_compression_cfg.get("warnings", True)).lower() in ("true", "1", "yes")
 
         # Read explicit context_length override from model config
         _model_cfg = _agent_cfg.get("model", {})
@@ -1499,6 +1500,7 @@ class AIAgent:
                 api_mode=self.api_mode,
             )
         self.compression_enabled = compression_enabled
+        self.compression_warnings = compression_warnings
 
         # Reject models whose context window is below the minimum required
         # for reliable tool-calling workflows (64K tokens).
@@ -10667,7 +10669,7 @@ class AIAgent:
                             _warn_tier = 0.95
                         elif _compaction_progress >= 0.85:
                             _warn_tier = 0.85
-                        if _warn_tier > self._context_pressure_warned_at:
+                        if _warn_tier > self._context_pressure_warned_at and self.compression_warnings:
                             # Class-level dedup: check if this session was already
                             # warned at this tier within the cooldown window.
                             _sid = self.session_id or "default"


### PR DESCRIPTION
## Summary

Adds a new config option `compression.warnings` that allows users to disable the repeated context pressure warning messages that appear during long-running sessions (e.g., on Telegram).

Closes #3784

## Changes

### Config (`hermes_cli/config.py`)
Added `warnings: True` to the `compression` config block:

```yaml
compression:
  enabled: True
  threshold: 0.50
  target_ratio: 0.20
  protect_last_n: 20
  warnings: True  # ← NEW: show context pressure warnings
```

### Agent (`run_agent.py`)
1. Read `compression.warnings` from config (default: `True`)
2. Store as `self.compression_warnings` instance attribute
3. Gate the warning emission check with `self.compression_warnings`

## Usage

To disable the annoying repeated warnings (e.g., on long Telegram sessions):

```yaml
# ~/.hermes/config.yaml
compression:
  warnings: false
```

The warnings remain ON by default, so existing users see no change.

## Testing
- Verified config parsing with both `true` and `false` values
- Warning emission is properly gated by the new flag
- No changes to compression behavior itself