### PR TITLE
fix(gworkspace): robust Python detection and dep install for google-workspace skill

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -123,6 +123,7 @@ def _apply_profile_override() -> None:
             print(f"Warning: profile override failed ({exc}), using default", file=sys.stderr)
             return
         os.environ["HERMES_HOME"] = hermes_home
+        os.environ.setdefault("HERMES_PYTHON", sys.executable)
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0:
             for i, arg in enumerate(argv):

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -24,6 +24,7 @@ Agent workflow:
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -31,9 +32,13 @@ from pathlib import Path
 try:
     from hermes_constants import display_hermes_home, get_hermes_home
 except ModuleNotFoundError:
-    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
-    if HERMES_AGENT_ROOT.exists():
-        sys.path.insert(0, str(HERMES_AGENT_ROOT))
+    _script = Path(__file__).resolve()
+    # Skill runs from repo (parents[4]=hermes-agent/) or installed (parents[4]=~/.hermes/).
+    # Try both so the fallback works regardless of install location.
+    for _candidate in (_script.parents[4], _script.parents[4] / "hermes-agent"):
+        if (_candidate / "hermes_constants.py").exists():
+            sys.path.insert(0, str(_candidate))
+            break
     from hermes_constants import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
@@ -95,17 +100,38 @@ def install_deps():
         pass
 
     print("Installing Google API dependencies...")
-    try:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--quiet"] + REQUIRED_PACKAGES,
-            stdout=subprocess.DEVNULL,
-        )
-        print("Dependencies installed.")
-        return True
-    except subprocess.CalledProcessError as e:
-        print(f"ERROR: Failed to install dependencies: {e}")
-        print(f"Try manually: {sys.executable} -m pip install {' '.join(REQUIRED_PACKAGES)}")
-        return False
+
+    # Prefer uv — bypasses PEP 668 externally-managed-environment restriction.
+    # Consistent with hermes_cli/memory_setup.py install pattern.
+    uv_path = shutil.which("uv")
+    if uv_path:
+        try:
+            subprocess.check_call(
+                [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + REQUIRED_PACKAGES,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            print("Dependencies installed.")
+            return True
+        except subprocess.CalledProcessError:
+            pass  # uv failed — fall through to pip
+
+    # pip fallback: plain → --user (PEP 668 safe) → --break-system-packages (last resort).
+    for extra_flags in [[], ["--user"], ["--break-system-packages"]]:
+        try:
+            subprocess.check_call(
+                [sys.executable, "-m", "pip", "install", "--quiet"] + extra_flags + REQUIRED_PACKAGES,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            print("Dependencies installed.")
+            return True
+        except subprocess.CalledProcessError:
+            continue
+
+    print("ERROR: Failed to install dependencies.")
+    print(f"Try manually: uv pip install --python {sys.executable} {' '.join(REQUIRED_PACKAGES)}")
+    return False
 
 
 def _ensure_deps():

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -32,12 +32,14 @@ from pathlib import Path
 try:
     from hermes_constants import display_hermes_home, get_hermes_home
 except ModuleNotFoundError:
-    _script = Path(__file__).resolve()
-    # Skill runs from repo (parents[4]=hermes-agent/) or installed (parents[4]=~/.hermes/).
-    # Try both so the fallback works regardless of install location.
-    for _candidate in (_script.parents[4], _script.parents[4] / "hermes-agent"):
-        if (_candidate / "hermes_constants.py").exists():
-            sys.path.insert(0, str(_candidate))
+    # Walk up from this file until hermes_constants.py is found.
+    # Stop at HERMES_HOME — never search outside the hermes directory.
+    _hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    for _parent in Path(__file__).resolve().parents:
+        if (_parent / "hermes_constants.py").exists():
+            sys.path.insert(0, str(_parent))
+            break
+        if _parent == _hermes_home:
             break
     from hermes_constants import display_hermes_home, get_hermes_home
 

--- a/tests/hermes_cli/test_hermes_python_env.py
+++ b/tests/hermes_cli/test_hermes_python_env.py
@@ -1,0 +1,38 @@
+"""Verify HERMES_PYTHON is exported when hermes applies a profile."""
+import os
+import sys
+from unittest.mock import patch
+
+# Import at module level so the module-level _apply_profile_override() call
+# happens with normal argv (not our test argv), avoiding side effects.
+import hermes_cli.main as _main_mod
+
+
+def test_hermes_python_set_to_sys_executable(monkeypatch, tmp_path):
+    """HERMES_PYTHON must be set to sys.executable so skills use the agent's interpreter."""
+    hermes_home = str(tmp_path / ".hermes")
+
+    monkeypatch.delenv("HERMES_PYTHON", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--profile", "myprofile"])
+
+    with patch("hermes_cli.profiles.resolve_profile_env", return_value=hermes_home):
+        _main_mod._apply_profile_override()
+
+    assert os.environ.get("HERMES_PYTHON") == sys.executable, (
+        f"Expected HERMES_PYTHON={sys.executable!r}, got {os.environ.get('HERMES_PYTHON')!r}"
+    )
+
+
+def test_hermes_python_not_overwritten_if_already_set(monkeypatch, tmp_path):
+    """A user-set HERMES_PYTHON must not be overwritten by the agent."""
+    hermes_home = str(tmp_path / ".hermes")
+
+    monkeypatch.setenv("HERMES_PYTHON", "/custom/python3")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--profile", "myprofile"])
+
+    with patch("hermes_cli.profiles.resolve_profile_env", return_value=hermes_home):
+        _main_mod._apply_profile_override()
+
+    assert os.environ.get("HERMES_PYTHON") == "/custom/python3", (
+        "HERMES_PYTHON should not be overwritten when already set by user"
+    )

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -19,6 +19,26 @@ SCRIPT_PATH = (
 )
 
 
+def test_fallback_path_resolves_to_hermes_agent_root():
+    """Fallback path search finds hermes_constants.py from both repo and installed locations."""
+    from pathlib import Path
+
+    # Repo location: parents[4] directly has hermes_constants.py
+    repo_script = SCRIPT_PATH.resolve()
+    repo_candidate = repo_script.parents[4]
+    assert (repo_candidate / "hermes_constants.py").exists(), (
+        f"Repo path: expected hermes_constants.py at {repo_candidate}"
+    )
+
+    # Installed location: parents[4] is ~/.hermes, need parents[4]/"hermes-agent"
+    # Simulate by computing what parents[4] would be from the installed path
+    installed_parents4 = repo_candidate.parent  # ~/.hermes
+    installed_candidate = installed_parents4 / "hermes-agent"
+    assert (installed_candidate / "hermes_constants.py").exists(), (
+        f"Installed path: expected hermes_constants.py at {installed_candidate}"
+    )
+
+
 class FakeCredentials:
     def __init__(self, payload=None):
         self._payload = payload or {
@@ -238,3 +258,109 @@ class TestExchangeAuthCode:
         assert setup_module.TOKEN_PATH.exists()
         # Pending auth is cleaned up
         assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+class TestInstallDeps:
+    def test_returns_true_when_already_installed(self, setup_module):
+        """No subprocess calls when packages are already importable."""
+        import sys
+        from unittest.mock import patch, MagicMock
+
+        fake_googleapiclient = MagicMock()
+        fake_google_auth = MagicMock()
+
+        with patch.dict(sys.modules, {
+            "googleapiclient": fake_googleapiclient,
+            "google_auth_oauthlib": fake_google_auth,
+        }), patch("subprocess.check_call") as mock_call:
+            result = setup_module.install_deps()
+
+        assert result is True
+        mock_call.assert_not_called()
+
+    def test_uses_uv_when_available(self, setup_module):
+        """uv pip install --python sys.executable is tried first when uv is on PATH."""
+        import subprocess
+        import sys
+        from unittest.mock import patch, MagicMock
+
+        # Remove cached imports so install_deps() sees them as missing
+        saved = {}
+        for mod in ("googleapiclient", "google_auth_oauthlib"):
+            saved[mod] = sys.modules.pop(mod, None)
+
+        calls = []
+        def fake_check_call(cmd, **kwargs):
+            calls.append(list(cmd))
+
+        try:
+            with patch.object(setup_module.shutil, "which", return_value="/usr/bin/uv"), \
+                 patch("subprocess.check_call", side_effect=fake_check_call):
+                result = setup_module.install_deps()
+        finally:
+            for mod, val in saved.items():
+                if val is not None:
+                    sys.modules[mod] = val
+                else:
+                    sys.modules.pop(mod, None)
+
+        assert result is True
+        assert any(c[0] == "/usr/bin/uv" and "pip" in c for c in calls)
+
+    def test_falls_back_to_pip_user_when_uv_missing(self, setup_module):
+        """Falls back through pip → pip --user when uv is not found."""
+        import subprocess
+        import sys
+        from unittest.mock import patch
+
+        saved = {}
+        for mod in ("googleapiclient", "google_auth_oauthlib"):
+            saved[mod] = sys.modules.pop(mod, None)
+
+        calls = []
+        def fake_check_call(cmd, **kwargs):
+            calls.append(list(cmd))
+            if "--user" not in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+
+        try:
+            with patch.object(setup_module.shutil, "which", return_value=None), \
+                 patch("subprocess.check_call", side_effect=fake_check_call):
+                result = setup_module.install_deps()
+        finally:
+            for mod, val in saved.items():
+                if val is not None:
+                    sys.modules[mod] = val
+                else:
+                    sys.modules.pop(mod, None)
+
+        assert result is True
+        assert any("--user" in c for c in calls)
+
+    def test_returns_false_when_all_methods_fail(self, setup_module, capsys):
+        """Returns False and prints error when all install methods fail."""
+        import subprocess
+        import sys
+        from unittest.mock import patch
+
+        saved = {}
+        for mod in ("googleapiclient", "google_auth_oauthlib"):
+            saved[mod] = sys.modules.pop(mod, None)
+
+        def always_fail(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        try:
+            with patch.object(setup_module.shutil, "which", return_value=None), \
+                 patch("subprocess.check_call", side_effect=always_fail):
+                result = setup_module.install_deps()
+        finally:
+            for mod, val in saved.items():
+                if val is not None:
+                    sys.modules[mod] = val
+                else:
+                    sys.modules.pop(mod, None)
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "ERROR" in out or "failed" in out.lower()

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -20,23 +20,13 @@ SCRIPT_PATH = (
 
 
 def test_fallback_path_resolves_to_hermes_agent_root():
-    """Fallback path search finds hermes_constants.py from both repo and installed locations."""
-    from pathlib import Path
-
-    # Repo location: parents[4] directly has hermes_constants.py
-    repo_script = SCRIPT_PATH.resolve()
-    repo_candidate = repo_script.parents[4]
-    assert (repo_candidate / "hermes_constants.py").exists(), (
-        f"Repo path: expected hermes_constants.py at {repo_candidate}"
+    """Upward search finds hermes_constants.py when walking from the script's location."""
+    found = next(
+        (p for p in SCRIPT_PATH.resolve().parents if (p / "hermes_constants.py").exists()),
+        None,
     )
-
-    # Installed location: parents[4] is ~/.hermes, need parents[4]/"hermes-agent"
-    # Simulate by computing what parents[4] would be from the installed path
-    installed_parents4 = repo_candidate.parent  # ~/.hermes
-    installed_candidate = installed_parents4 / "hermes-agent"
-    assert (installed_candidate / "hermes_constants.py").exists(), (
-        f"Installed path: expected hermes_constants.py at {installed_candidate}"
-    )
+    assert found is not None, "hermes_constants.py not found in any parent directory"
+    assert (found / "hermes_constants.py").exists()
 
 
 class FakeCredentials:


### PR DESCRIPTION
## What changed and why

Three cascading bugs cause `ModuleNotFoundError: No module named 'hermes_constants'` and dependency install failures in the google-workspace skill. Repro: run any `setup.py` command from a fresh install.

### Bug 1 — Wrong fallback path in `setup.py`

`parents[4]` resolves differently depending on where the script runs:
- **Repo path** (`hermes-agent/skills/.../setup.py`): `parents[4]` = `hermes-agent/` ✓
- **Installed path** (`~/.hermes/skills/.../setup.py`): `parents[4]` = `~/.hermes/` ✗

The agent always runs from the installed path, so `hermes_constants` was never found.

**Fix:** Replace the single-path guess with a loop that tries both candidates and uses the first one where `hermes_constants.py` exists.

### Bug 2 — `install_deps()` uses bare `pip install`

Fails with `externally-managed-environment` (PEP 668) on Arch, modern Debian/Ubuntu, and macOS with Homebrew Python.

**Fix:** Try `uv pip install --python sys.executable` first (consistent with `hermes_cli/memory_setup.py`), then fall back through `pip install` → `pip install --user` → `pip install --break-system-packages`.

### Bug 3 — `SKILL.md` preferred a broken venv Python / agent never exported `HERMES_PYTHON`

`SKILL.md` contained a shell snippet that detected `hermes-agent/venv/bin/python` and used it if it existed. That venv Python has no pip — causing every dep install to fail regardless of Bug 2's fix. The root cause: hermes never exported `HERMES_PYTHON`, so the `${HERMES_PYTHON:-python3}` fallback was useless.

**Fix (two parts):**
- `hermes_cli/main.py`: add `os.environ.setdefault("HERMES_PYTHON", sys.executable)` alongside the existing `HERMES_HOME` export, so skills automatically use the agent's own interpreter.
- `SKILL.md`: remove the 3-line venv detection blocks from both shell snippets.

## How to test

```bash
# 1. Ensure google_client_secret.json is placed at ~/.hermes/Credentials/
python3 ~/.hermes/skills/productivity/google-workspace/scripts/setup.py --check
python3 ~/.hermes/skills/productivity/google-workspace/scripts/setup.py --install-deps
python3 ~/.hermes/skills/productivity/google-workspace/scripts/setup.py --auth-url
```

All commands should succeed without `ModuleNotFoundError` or pip errors on Arch/Debian/Ubuntu.

Regression tests:
```bash
pytest tests/skills/test_google_oauth_setup.py tests/hermes_cli/test_hermes_python_env.py -v
```

## Testing platforms

- Linux (WSL2, Arch-based, Python 3.14, PEP 668 active — `externally-managed-environment` confirmed fixed)

## Pre-submission checklist

- [x] `pytest tests/ -v` run — 5 pre-existing failures confirmed not caused by this PR (also fail on `main`)
- [x] Code manually tested (google-workspace skill setup completed end-to-end)
- [x] Cross-platform impact: only affects skill Python detection and pip install strategy
- [x] PR focused on one logical fix (three bugs in the same feature, same root cause chain)
- [x] Commit messages follow Conventional Commits