### PR TITLE
fix(gateway): avoid cli import side effects in tool config loaders

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -772,6 +772,21 @@ class TestLoadConfig(unittest.TestCase):
             result = _load_config()
         self.assertIsInstance(result, dict)
 
+    def test_does_not_import_cli_or_set_terminal_cwd_when_cli_unloaded(self):
+        from tools.code_execution_tool import _load_config
+
+        original_cli = sys.modules.pop("cli", None)
+        original_cwd = os.environ.pop("TERMINAL_CWD", None)
+        try:
+            result = _load_config()
+            self.assertEqual(result, {})
+            self.assertNotIn("TERMINAL_CWD", os.environ)
+        finally:
+            if original_cli is not None:
+                sys.modules["cli"] = original_cli
+            if original_cwd is not None:
+                os.environ["TERMINAL_CWD"] = original_cwd
+
 
 # ---------------------------------------------------------------------------
 # Interrupt event

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -569,6 +569,34 @@ class TestBlockedTools(unittest.TestCase):
         self.assertEqual(MAX_DEPTH, 2)
 
 
+class TestLoadConfig(unittest.TestCase):
+    def test_uses_loaded_cli_module_without_importing(self):
+        from tools.delegate_tool import _load_config
+
+        mock_cli = MagicMock()
+        mock_cli.CLI_CONFIG = {"delegation": {"max_concurrent_children": 9}}
+        with patch.dict(sys.modules, {"cli": mock_cli}):
+            result = _load_config()
+
+        self.assertEqual(result, {"max_concurrent_children": 9})
+
+    def test_fallback_does_not_import_cli_or_set_terminal_cwd(self):
+        from tools.delegate_tool import _load_config
+
+        original_cli = sys.modules.pop("cli", None)
+        original_cwd = os.environ.pop("TERMINAL_CWD", None)
+        try:
+            with patch("hermes_cli.config.load_config", return_value={"delegation": {"max_concurrent_children": 7}}):
+                result = _load_config()
+            self.assertEqual(result, {"max_concurrent_children": 7})
+            self.assertNotIn("TERMINAL_CWD", os.environ)
+        finally:
+            if original_cli is not None:
+                sys.modules["cli"] = original_cli
+            if original_cwd is not None:
+                os.environ["TERMINAL_CWD"] = original_cwd
+
+
 class TestDelegationCredentialResolution(unittest.TestCase):
     """Tests for provider:model credential resolution in delegation config."""
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1253,12 +1253,20 @@ def _kill_process_group(proc, escalate: bool = False):
 
 
 def _load_config() -> dict:
-    """Load code_execution config from CLI_CONFIG if available."""
+    """Load code_execution config from an already-loaded CLI module if available.
+
+    Avoid importing ``cli`` here: in gateway/cron contexts that import has
+    module-level side effects (notably resolving ``terminal.cwd: .`` into
+    ``TERMINAL_CWD`` based on the process CWD).
+    """
     try:
-        from cli import CLI_CONFIG
-        return CLI_CONFIG.get("code_execution", {})
+        cli_mod = sys.modules.get("cli")
+        cli_config = getattr(cli_mod, "CLI_CONFIG", None) if cli_mod else None
+        if isinstance(cli_config, dict):
+            return cli_config.get("code_execution", {})
     except Exception:
-        return {}
+        pass
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -20,6 +20,7 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -941,10 +942,15 @@ def _load_config() -> dict:
     to the persistent config (hermes_cli/config.py load_config()) so that
     ``delegation.model`` / ``delegation.provider`` are picked up regardless
     of the entry point (CLI, gateway, cron).
+
+    Important: do NOT import ``cli`` here in gateway/cron contexts. Importing
+    that module has process-wide side effects, including resolving
+    ``terminal.cwd: .`` into ``TERMINAL_CWD`` based on the process cwd.
     """
     try:
-        from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
+        cli_mod = sys.modules.get("cli")
+        cli_config = getattr(cli_mod, "CLI_CONFIG", None) if cli_mod else None
+        cfg = cli_config.get("delegation", {}) if isinstance(cli_config, dict) else {}
         if cfg:
             return cfg
     except Exception:


### PR DESCRIPTION
Fixes #10817.

## Summary
- avoid importing `cli` from `tools.delegate_tool._load_config()` and `tools.code_execution_tool._load_config()`
- read `CLI_CONFIG` only if the CLI module is already loaded in-process
- add regression tests that verify these config loaders do not set `TERMINAL_CWD` as a side effect when `cli` is not loaded

## Bug context
This PR fixes the gateway regression reported in #10817: in gateway/cron contexts, importing `cli` has module-level side effects that resolve `terminal.cwd: .` to the process cwd and write that into `TERMINAL_CWD`.

When the gateway process is launchd-managed from the Hermes repo root, that can re-poison gateway sessions with the repo path and cause the repo `AGENTS.md` to get injected into messaging prompts.

This keeps the existing CLI behavior intact while removing the import-time side effect from tool config lookups on non-CLI code paths.

## Test Plan
- `source ../hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_delegate.py tests/tools/test_code_execution.py tests/run_agent/test_agent_guardrails.py -q`
- manual sanity check: with `cli` absent from `sys.modules`, calling both `_load_config()` helpers leaves `TERMINAL_CWD` unset
