### PR TITLE
fix(honcho): remove top-level anyOf from conclude schema and harden validation

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -76,7 +76,7 @@ SEARCH_SCHEMA = {
             },
             "peer": {
                 "type": "string",
-                "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
+                "description": "Peer whose conclusion is being written or deleted. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
         "required": ["query"],
@@ -171,10 +171,7 @@ CONCLUDE_SCHEMA = {
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
-        "anyOf": [
-            {"required": ["conclusion"]},
-            {"required": ["delete_id"]},
-        ],
+        "required": [],
     },
 }
 
@@ -1011,16 +1008,24 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": "\n\n".join(parts) or "No context available."})
 
             elif tool_name == "honcho_conclude":
+                delete_id_provided = "delete_id" in args
+                conclusion_provided = "conclusion" in args
                 delete_id = args.get("delete_id")
+                conclusion = args.get("conclusion")
                 peer = args.get("peer", "user")
-                if delete_id:
+                if delete_id_provided == conclusion_provided:
+                    return tool_error("Must pass exactly one of: conclusion or delete_id")
+                if delete_id_provided:
+                    if not isinstance(delete_id, str) or not delete_id.strip():
+                        return tool_error("delete_id must be a non-empty string")
+                    delete_id = delete_id.strip()
                     ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
-                conclusion = args.get("conclusion", "")
-                if not conclusion:
-                    return tool_error("Missing required parameter: conclusion or delete_id")
+                if not isinstance(conclusion, str) or not conclusion.strip():
+                    return tool_error("conclusion must be a non-empty string")
+                conclusion = conclusion.strip()
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,5 +1,6 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
+import json
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -8,7 +9,7 @@ from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
 )
-from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho import CONCLUDE_SCHEMA, HonchoMemoryProvider
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +367,12 @@ class TestPeerLookupHelpers:
 
 
 class TestConcludeToolDispatch:
+    def test_honcho_conclude_schema_uses_plain_object_parameters(self):
+        forbidden_top_level_keys = {"anyOf", "oneOf", "allOf", "enum", "not"}
+
+        assert CONCLUDE_SCHEMA["parameters"]["type"] == "object"
+        assert forbidden_top_level_keys.isdisjoint(CONCLUDE_SCHEMA["parameters"])
+
     def test_honcho_conclude_defaults_to_user_peer(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
@@ -459,9 +466,113 @@ class TestConcludeToolDispatch:
             peer="hermes",
         )
 
+    def test_honcho_conclude_rejects_both_params(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "User prefers dark mode", "delete_id": "conc-123"},
+        )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "exactly one" in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
+    def test_honcho_conclude_delete_id_succeeds(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.delete_conclusion.return_value = True
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"delete_id": "conc-123"},
+        )
+
+        assert "Conclusion conc-123 deleted." in result
+        provider._manager.delete_conclusion.assert_called_once_with(
+            "telegram:123",
+            "conc-123",
+            peer="user",
+        )
+        provider._manager.create_conclusion.assert_not_called()
+
+    def test_honcho_conclude_rejects_conclusion_with_empty_delete_id(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "User prefers dark mode", "delete_id": ""},
+        )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "exactly one" in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
+    def test_honcho_conclude_rejects_delete_id_with_empty_conclusion(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"delete_id": "conc-123", "conclusion": ""},
+        )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "exactly one" in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
+    def test_honcho_conclude_rejects_empty_delete_id(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"delete_id": ""},
+        )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "non-empty string" in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
+    def test_honcho_conclude_rejects_blank_conclusion(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "   "},
+        )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "non-empty string" in parsed["error"]
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
     def test_honcho_conclude_missing_both_params_returns_error(self):
         """Calling honcho_conclude with neither conclusion nor delete_id returns a tool error."""
-        import json
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
         provider._session_key = "telegram:123"


### PR DESCRIPTION
## Summary

This fixes the `honcho_conclude` startup/session-init failure on strict OpenAI-compatible providers by removing the top-level `anyOf` from the tool schema at the source, while preserving the original create-vs-delete contract with explicit runtime validation.

## Root Cause

`honcho_conclude` originally shipped as a simple memory-provider tool in `924bc67`, where `conclusion` was the only required parameter.

In `cc6e8941` (`feat(honcho): context injection overhaul, 5-tool surface, cost safety, session isolation`), `delete_id` support was added and the schema was changed to:

- keep `parameters.type = object`
- add both `conclusion` and `delete_id` properties
- add a top-level `anyOf` requiring one or the other

That shape is rejected by stricter OpenAI-compatible function-schema validators, which require the top-level parameters object to avoid `oneOf` / `anyOf` / `allOf` / `enum` / `not`.

Hermes forwards memory-provider tool schemas through to the tool surface unchanged, so this breaks session startup before the tool can ever be called.

## Why This Patch

This patch fixes the schema where it originates instead of only normalizing a downstream API-specific path.

It also closes a follow-up correctness gap: once the schema-level exclusivity is removed, the handler must enforce the contract itself. The old runtime path also had ambiguous behavior when both `conclusion` and `delete_id` were present.

## What Changes

- removes top-level `anyOf` from `honcho_conclude.parameters`
- keeps the exported schema as a plain object with `type`, `properties`, and `required`
- validates `conclusion` / `delete_id` by key presence and non-empty normalized string content
- rejects malformed mixed payloads instead of relying on truthiness
- adds regression tests for:
  - provider-compatible schema shape
  - successful delete dispatch
  - both-present rejection
  - mixed malformed payloads
  - single-key blank/empty payloads

## Verification

Baseline on clean `origin/main` worktree before applying the patch:

```bash
/Users/admin/.hermes/hermes-agent/venv/bin/python -m pytest tests/honcho_plugin/test_session.py -q
```

Result:

```text
84 passed in 0.56s
```

After applying this patch on a clean worktree:

```bash
/Users/admin/.hermes/hermes-agent/venv/bin/python -m pytest tests/honcho_plugin/test_session.py -q
```

Result:

```text
91 passed in 0.55s
```

Schema verification:

```bash
/Users/admin/.hermes/hermes-agent/venv/bin/python - <<'PY'
from plugins.memory.honcho import CONCLUDE_SCHEMA
forbidden = {'anyOf', 'oneOf', 'allOf', 'enum', 'not'}
params = CONCLUDE_SCHEMA['parameters']
print('type=', params.get('type'))
print('keys=', sorted(params.keys()))
print('forbidden=', sorted(forbidden & set(params.keys())))
PY
```

Result:

```text
type= object
keys= ['properties', 'required', 'type']
forbidden= []
```

## Risk

GitNexus review on the isolated PR worktree marked this patch as `low` risk with `0` affected execution flows relative to `origin/main`.

Closes #10723