### PR TITLE
fix(honcho): remove anyOf from honcho_conclude schema (fixes HTTP 400 with Anthropic API)

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -171,6 +171,10 @@ CONCLUDE_SCHEMA = {
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
+        # anyOf removed — Anthropic API rejects anyOf/oneOf/allOf at the top
+        # level of input_schema (HTTP 400). Runtime validation in the handler
+        # already enforces that exactly one of conclusion/delete_id is provided.
+        # See issue #10812.
         "required": [],
     },
 }


### PR DESCRIPTION
## Problem

The `honcho_conclude` tool schema uses `anyOf` at the root of its `parameters` object. Anthropic's tool API rejects this with HTTP 400, blocking **all** agent calls when the Honcho plugin is enabled:

```
HTTP 400: tools.32.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

## Fix

Remove the `anyOf` block from `CONCLUDE_SCHEMA`.

Runtime validation already exists in the handler:
```python
if not conclusion:
    return tool_error("Missing required parameter: conclusion or delete_id")
```

The tool description also already tells the model `"You MUST pass exactly one of: conclusion or delete_id"`, so no safety is lost.

## Result

Schema is now valid for Anthropic API. Agent calls succeed when Honcho plugin is enabled.

Fixes #10812