### PR TITLE
fix(mcp): preserve ImageContent tool results

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,6 +4,7 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import base64
 import json
 import os
 import threading
@@ -224,6 +225,68 @@ class TestToolHandler:
                 result = json.loads(handler({}))
             assert "error" in result
             assert "something went wrong" in result["error"]
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_image_only_result_is_cached_as_media_tag(self, tmp_path, monkeypatch):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        img_block = SimpleNamespace(
+            data=base64.b64encode(png_bytes).decode("ascii"),
+            mimeType="image/png",
+        )
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=SimpleNamespace(content=[img_block], isError=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "take_screenshot", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({}))
+
+            media_line = next(
+                line for line in result["result"].splitlines()
+                if line.startswith("MEDIA:")
+            )
+            image_path = media_line.removeprefix("MEDIA:")
+
+            assert os.path.exists(image_path)
+            assert image_path.startswith(str(tmp_path))
+            assert image_path.endswith(".png")
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_text_and_image_result_preserves_text_and_media_tag(self, tmp_path, monkeypatch):
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        text_block = SimpleNamespace(text="Screenshot captured")
+        img_block = SimpleNamespace(
+            data=base64.b64encode(png_bytes).decode("ascii"),
+            mimeType="image/png",
+        )
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(
+            return_value=SimpleNamespace(content=[text_block, img_block], isError=False)
+        )
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "take_screenshot", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({}))
+
+            assert "Screenshot captured" in result["result"]
+            assert "MEDIA:" in result["result"]
         finally:
             _servers.pop("test_srv", None)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -70,10 +70,12 @@ Thread safety:
 """
 
 import asyncio
+import base64
 import concurrent.futures
 import inspect
 import json
 import logging
+import mimetypes
 import math
 import os
 import re
@@ -319,6 +321,42 @@ def _resolve_stdio_command(command: str, env: dict) -> tuple[str, dict]:
         resolved_env = _prepend_path(resolved_env, command_dir)
 
     return resolved_command, resolved_env
+
+
+def _image_extension_for_mime_type(mime_type: str) -> str:
+    """Return a reasonable file extension for an MCP image MIME type."""
+    normalized = (mime_type or "").split(";", 1)[0].strip().lower()
+    if normalized in {"image/jpeg", "image/jpg"}:
+        return ".jpg"
+    return mimetypes.guess_extension(normalized) or ".png"
+
+
+def _cache_image_content_block(block) -> str:
+    """Cache an MCP ImageContent block and return a MEDIA tag, or empty string."""
+    data = getattr(block, "data", None)
+    mime_type = getattr(block, "mimeType", None)
+    normalized_mime = str(mime_type or "").split(";", 1)[0].strip().lower()
+    if data is None or not normalized_mime.startswith("image/"):
+        return ""
+
+    try:
+        raw_bytes = base64.b64decode(data)
+    except (TypeError, ValueError) as exc:
+        logger.warning("MCP image block decode failed: %s", exc)
+        return ""
+
+    try:
+        from gateway.platforms.base import cache_image_from_bytes
+
+        image_path = cache_image_from_bytes(
+            raw_bytes,
+            ext=_image_extension_for_mime_type(normalized_mime),
+        )
+    except Exception as exc:
+        logger.warning("MCP image block cache failed: %s", exc)
+        return ""
+
+    return f"MEDIA:{image_path}"
 
 
 def _format_connect_error(exc: BaseException) -> str:
@@ -1391,7 +1429,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             if result.isError:
                 error_text = ""
                 for block in (result.content or []):
-                    if hasattr(block, "text"):
+                    if getattr(block, "text", ""):
                         error_text += block.text
                 return json.dumps({
                     "error": _sanitize_error(
@@ -1402,8 +1440,11 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # Collect text from content blocks
             parts: List[str] = []
             for block in (result.content or []):
-                if hasattr(block, "text"):
+                if getattr(block, "text", ""):
                     parts.append(block.text)
+                media_tag = _cache_image_content_block(block)
+                if media_tag:
+                    parts.append(media_tag)
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.


### PR DESCRIPTION
## Summary
- cache MCP `ImageContent` blocks into the existing Hermes image cache
- append `MEDIA:/absolute/path` tags to MCP tool results so the gateway can deliver returned images natively
- keep text blocks intact and ignore non-image binary content for this minimal fix

Fixes #10759.

## Root Cause
`_make_tool_handler()` only collected `block.text` from `CallToolResult.content`. MCP image blocks carry `data` + `mimeType` instead, so screenshot-style tool results were reduced to an empty string and silently disappeared.

## Why this fix
Hermes already has a media-delivery path keyed off `MEDIA:/absolute/path` tags and an existing image cache under `HERMES_HOME`. Reusing that path avoids inventing a second transport for MCP-returned images and keeps the change isolated to MCP result parsing.

## Validation
- `pytest -q -o addopts= tests/tools/test_mcp_tool.py -k "TestToolHandler or TestConvertMessages"`
  - `13 passed, 155 deselected`
- `pytest -q -o addopts= tests/gateway/test_media_extraction.py`
  - `4 passed`

## Notes
- scoped intentionally to `ImageContent`; `EmbeddedResource` handling remains unchanged
- no README update needed for this internal transport fix
