### PR TITLE
fix(gateway): keep auto vision preprocess concise

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4329,6 +4329,7 @@ async def _retry_same_provider_async(
     messages: list,
     temperature: Optional[float],
     max_tokens: Optional[int],
+    preserve_max_tokens: bool,
     tools: Optional[list],
     effective_timeout: float,
     effective_extra_body: dict,
@@ -4364,6 +4365,7 @@ async def _retry_same_provider_async(
         messages,
         temperature=temperature,
         max_tokens=max_tokens,
+        preserve_max_tokens=preserve_max_tokens,
         tools=tools,
         timeout=effective_timeout,
         extra_body=effective_extra_body,
@@ -4777,6 +4779,7 @@ async def _call_fallback_candidate_async(
     messages: list,
     temperature: Optional[float],
     max_tokens: Optional[int],
+    preserve_max_tokens: bool,
     tools: Optional[list],
     effective_timeout: float,
     effective_extra_body: dict,
@@ -4800,6 +4803,7 @@ async def _call_fallback_candidate_async(
     fb_kwargs = _build_call_kwargs(
         destination.provider, destination.model, fallback_messages,
         temperature=temperature, max_tokens=max_tokens,
+        preserve_max_tokens=preserve_max_tokens,
         tools=fallback_tools, timeout=effective_timeout,
         extra_body=effective_extra_body, reasoning_config=reasoning_config,
         base_url=destination.base_url, task=task)
@@ -4845,6 +4849,7 @@ async def _call_fallback_candidate_async(
                     retry_destination.model,
                     retry_messages,
                     temperature=temperature, max_tokens=max_tokens,
+                    preserve_max_tokens=preserve_max_tokens,
                     tools=retry_tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     reasoning_config=reasoning_config,
@@ -7816,6 +7821,7 @@ def _build_call_kwargs(
     reasoning_config: Optional[dict] = None,
     base_url: Optional[str] = None,
     task: Optional[str] = None,
+    preserve_max_tokens: bool = False,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -7852,7 +7858,13 @@ def _build_call_kwargs(
         # models reject it entirely with error 1210). Omitting it sidesteps all of
         # those wire-format quirks at once.
         #
-        # The one exception is the Anthropic Messages wire (MiniMax and any
+        # A caller can narrowly opt in with preserve_max_tokens when the cap is
+        # part of that call's contract (for example the gateway's concise vision
+        # pre-process). This keeps the default uncapped behavior intact while
+        # allowing explicit, latency-sensitive budgets to reach compatible
+        # OpenAI-style endpoints.
+        #
+        # The other exception is the Anthropic Messages wire (MiniMax and any
         # ``/anthropic`` endpoint reached through the OpenAI SDK wrapper), where
         # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
         # there.
@@ -7897,6 +7909,7 @@ def _build_call_kwargs(
             or _is_nvidia_nim
             or _is_moa
             or _is_gemini_native
+            or preserve_max_tokens
         ):
             # Use auxiliary_max_tokens_param() so models that require
             # max_completion_tokens (GPT-5 family, Copilot) get the right
@@ -9354,6 +9367,7 @@ async def async_call_llm(
     messages: list,
     temperature: Optional[float] = None,
     max_tokens: int = None,
+    preserve_max_tokens: bool = False,
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
@@ -9374,6 +9388,7 @@ async def async_call_llm(
             messages=messages,
             temperature=temperature,
             max_tokens=max_tokens,
+            preserve_max_tokens=preserve_max_tokens,
             tools=tools,
             timeout=timeout,
             extra_body=extra_body,
@@ -9395,6 +9410,7 @@ async def _async_call_llm_impl(
     messages: list,
     temperature: Optional[float] = None,
     max_tokens: int = None,
+    preserve_max_tokens: bool = False,
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
@@ -9403,6 +9419,10 @@ async def _async_call_llm_impl(
     """Centralized asynchronous LLM call.
 
     Same as call_llm() but async. See call_llm() for full documentation.
+
+    ``preserve_max_tokens`` is a narrow opt-in for callers whose explicit
+    output cap is part of their request contract. By default, OpenAI-compatible
+    auxiliary calls continue to omit token caps.
     """
     # Keep every async phase on the same runtime identity, even if another
     # session switches models while this task is awaiting network I/O.
@@ -9488,6 +9508,7 @@ async def _async_call_llm_impl(
     kwargs = _build_call_kwargs(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
+        preserve_max_tokens=preserve_max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=effective_extra_body,
         reasoning_config=reasoning_config,
         base_url=_client_base or resolved_base_url, task=task)
@@ -9739,6 +9760,7 @@ async def _async_call_llm_impl(
                     messages=messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    preserve_max_tokens=preserve_max_tokens,
                     tools=tools,
                     effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
@@ -9782,6 +9804,7 @@ async def _async_call_llm_impl(
                         messages=messages,
                         temperature=temperature,
                         max_tokens=max_tokens,
+                        preserve_max_tokens=preserve_max_tokens,
                         tools=tools,
                         effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
@@ -9885,6 +9908,7 @@ async def _async_call_llm_impl(
                     async_fb, async_fb_model or fb_model, fb_label,
                     task=task, messages=messages,
                     temperature=temperature, max_tokens=max_tokens,
+                    preserve_max_tokens=preserve_max_tokens,
                     tools=tools, effective_timeout=effective_timeout,
                     effective_extra_body=effective_extra_body,
                     reasoning_config=reasoning_config)
@@ -9902,6 +9926,7 @@ async def _async_call_llm_impl(
                         async_fb, async_fb_model or fb_model, fb_label,
                         task=task, messages=messages,
                         temperature=temperature, max_tokens=max_tokens,
+                        preserve_max_tokens=preserve_max_tokens,
                         tools=tools, effective_timeout=effective_timeout,
                         effective_extra_body=effective_extra_body,
                         reasoning_config=reasoning_config)

--- a/contributors/emails/gnani.nutakki@gmail.com
+++ b/contributors/emails/gnani.nutakki@gmail.com
@@ -1,0 +1,1 @@
+gnanirahulnutakki

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7344,9 +7344,11 @@ class GatewayRunner:
         import json as _json
 
         analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
+            "Concisely describe this image in 2-4 sentences "
+            "(~200 Chinese characters or ~150 English words). "
+            "Cover the main subject, key visible text/data/code, and overall context. "
+            "If it is a chart, diagram, or scientific figure, include the important "
+            "labels, legend, and key values. Skip decorative details."
         )
 
         enriched_parts = []
@@ -7356,6 +7358,7 @@ class GatewayRunner:
                 result_json = await vision_analyze_tool(
                     image_url=path,
                     user_prompt=analysis_prompt,
+                    max_tokens=500,
                 )
                 result = _json.loads(result_json)
                 if result.get("success"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21263,9 +21263,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         from agent.memory_manager import sanitize_context
 
         analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
+            "Concisely describe this image in 2-4 sentences "
+            "(~200 Chinese characters or ~150 English words). "
+            "Cover the main subject, key visible text/data/code, and overall context. "
+            "If it is a chart, diagram, or scientific figure, include the important "
+            "labels, legend, and key values. Skip decorative details."
         )
 
         enriched_parts = []
@@ -21275,6 +21277,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result_json = await vision_analyze_tool(
                     image_url=path,
                     user_prompt=analysis_prompt,
+                    max_tokens=500,
                 )
                 result = json.loads(result_json)
                 if result.get("success"):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -370,6 +370,46 @@ class TestBuildCallKwargsMaxTokens:
     """
 
 
+    def test_explicit_cap_can_be_preserved_for_openai_compatible(self):
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="qwen",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=500,
+            preserve_max_tokens=True,
+            base_url="http://localhost:8080/v1",
+            task="vision",
+        )
+
+        assert kwargs["max_tokens"] == 500
+
+    @pytest.mark.asyncio
+    async def test_explicit_vision_cap_reaches_custom_client_request(self):
+        client = MagicMock()
+        client.base_url = "http://localhost:8080/v1"
+        response = MagicMock()
+        response.choices = [
+            MagicMock(message=MagicMock(content="A concise description."))
+        ]
+        client.chat.completions.create = AsyncMock(return_value=response)
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "qwen", client.base_url, "test-key", None),
+        ), patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("custom", client, "qwen"),
+        ):
+            result = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe"}],
+                max_tokens=500,
+                preserve_max_tokens=True,
+            )
+
+        assert result is response
+        assert client.chat.completions.create.await_args.kwargs["max_tokens"] == 500
+
     @pytest.mark.parametrize(
         "provider,model,base_url",
         [
@@ -4354,6 +4394,7 @@ class TestAsynchronousFallbackCachePlans:
             ],
             temperature=None,
             max_tokens=None,
+            preserve_max_tokens=False,
             tools=tools,
             effective_timeout=30.0,
             effective_extra_body={},
@@ -4363,3 +4404,33 @@ class TestAsynchronousFallbackCachePlans:
         wire_tools = client.chat.completions.create.call_args.kwargs["tools"]
         assert "cache_control" in wire_tools[-1]
         assert "cache_control" not in tools[-1]
+
+    @pytest.mark.asyncio
+    async def test_async_fallback_preserves_explicit_token_cap(self, monkeypatch):
+        """An opted-in cap must survive the asynchronous fallback boundary."""
+        from agent.auxiliary_client import _call_fallback_candidate_async
+
+        client = MagicMock()
+        client.base_url = "http://localhost:8080/v1"
+        client.chat.completions.create = AsyncMock(return_value=_DummyResponse())
+        monkeypatch.setattr(
+            "agent.auxiliary_client._replan_synchronous_cache_sections",
+            lambda messages, tools, **kwargs: (messages, tools),
+        )
+
+        await _call_fallback_candidate_async(
+            client,
+            "qwen",
+            "custom",
+            task="vision",
+            messages=[{"role": "user", "content": "describe"}],
+            temperature=None,
+            max_tokens=500,
+            preserve_max_tokens=True,
+            tools=None,
+            effective_timeout=30.0,
+            effective_extra_body={},
+            reasoning_config=None,
+        )
+
+        assert client.chat.completions.create.await_args.kwargs["max_tokens"] == 500

--- a/tests/gateway/test_vision_preprocess.py
+++ b/tests/gateway/test_vision_preprocess.py
@@ -1,0 +1,29 @@
+"""Gateway vision pre-process defaults should stay concise."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_vision_uses_concise_prompt_and_lower_token_cap():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch(
+        "tools.vision_tools.vision_analyze_tool",
+        new_callable=AsyncMock,
+        return_value=json.dumps({"success": True, "analysis": "A cat on a chair."}),
+    ) as mock_vision:
+        result = await runner._enrich_message_with_vision(
+            user_text="What is happening here?",
+            image_paths=["/tmp/cat.png"],
+        )
+
+    assert "A cat on a chair." in result
+    assert "What is happening here?" in result
+    assert mock_vision.await_args.kwargs["max_tokens"] == 500
+    assert "Concisely describe this image in 2-4 sentences" in mock_vision.await_args.kwargs["user_prompt"]
+    assert "Skip decorative details." in mock_vision.await_args.kwargs["user_prompt"]

--- a/tests/gateway/test_vision_preprocess.py
+++ b/tests/gateway/test_vision_preprocess.py
@@ -1,0 +1,32 @@
+"""Gateway vision pre-process defaults should stay concise."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_vision_uses_concise_prompt_and_lower_token_cap():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch(
+        "tools.vision_tools.vision_analyze_tool",
+        new_callable=AsyncMock,
+        return_value=json.dumps({"success": True, "analysis": "A cat on a chair."}),
+    ) as mock_vision:
+        result = await runner._enrich_message_with_vision(
+            user_text="What is happening here?",
+            image_paths=["/tmp/cat.png"],
+        )
+
+    assert "A cat on a chair." in result
+    assert "What is happening here?" in result
+    assert mock_vision.await_args.kwargs["max_tokens"] == 500
+    assert (
+        "Concisely describe this image in 2-4 sentences"
+        in mock_vision.await_args.kwargs["user_prompt"]
+    )
+    assert "Skip decorative details." in mock_vision.await_args.kwargs["user_prompt"]

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -258,6 +258,35 @@ class TestHandleVisionAnalyze:
             result.close()
 
 
+class TestVisionAnalyzeTokenBudget:
+    @pytest.mark.asyncio
+    async def test_max_tokens_override_reaches_async_call(self, tmp_path):
+        img = tmp_path / "small.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Small image"
+        mock_response.choices = [mock_choice]
+
+        with patch(
+            "tools.vision_tools.async_call_llm",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm:
+            result = json.loads(
+                await vision_analyze_tool(
+                    str(img),
+                    "describe this",
+                    "test/model",
+                    max_tokens=321,
+                )
+            )
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["max_tokens"] == 321
+
+
 # ---------------------------------------------------------------------------
 # Error logging with exc_info — verify tracebacks are logged
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -165,6 +165,36 @@ class TestHandleVisionAnalyze:
         ) == "fallback-model"
 
 
+class TestVisionAnalyzeTokenBudget:
+    @pytest.mark.asyncio
+    async def test_max_tokens_override_reaches_async_call(self, tmp_path):
+        img = tmp_path / "small.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Small image"
+        mock_response.choices = [mock_choice]
+
+        with patch(
+            "tools.vision_tools.async_call_llm",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_llm:
+            result = json.loads(
+                await vision_analyze_tool(
+                    str(img),
+                    "describe this",
+                    "test/model",
+                    max_tokens=321,
+                )
+            )
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["max_tokens"] == 321
+        assert mock_llm.await_args.kwargs["preserve_max_tokens"] is True
+
+
 # ---------------------------------------------------------------------------
 # Error logging with exc_info — verify tracebacks are logged
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -406,6 +406,7 @@ async def vision_analyze_tool(
     image_url: str,
     user_prompt: str,
     model: str = None,
+    max_tokens: int = 2000,
 ) -> str:
     """
     Analyze an image from a URL or local file path using vision AI.
@@ -423,6 +424,7 @@ async def vision_analyze_tool(
                          Accepts http://, https:// URLs or absolute/relative file paths.
         user_prompt (str): The pre-formatted prompt for the vision model
         model (str): The vision model to use (default: google/gemini-3-flash-preview)
+        max_tokens (int): Maximum completion tokens for the vision model response
     
     Returns:
         str: JSON string containing the analysis results with the following structure:
@@ -565,7 +567,7 @@ async def vision_analyze_tool(
             "task": "vision",
             "messages": messages,
             "temperature": 0.1,
-            "max_tokens": 2000,
+            "max_tokens": max_tokens,
             "timeout": vision_timeout,
         }
         if model:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1089,6 +1089,7 @@ async def vision_analyze_tool(
     user_prompt: str,
     model: str = None,
     task_id: Optional[str] = None,
+    max_tokens: Optional[int] = None,
 ) -> str:
     """
     Analyze an image from a URL or local file path using vision AI.
@@ -1106,6 +1107,9 @@ async def vision_analyze_tool(
                          Accepts http://, https:// URLs or absolute/relative file paths.
         user_prompt (str): The pre-formatted prompt for the vision model
         model (str): The vision model to use (default: google/gemini-3-flash-preview)
+        task_id (str): Optional task identifier for debug tracing
+        max_tokens (int): Optional per-call output cap. The default vision
+                         behavior remains uncapped at the provider boundary.
     
     Returns:
         str: JSON string containing the analysis results with the following structure:
@@ -1267,7 +1271,8 @@ async def vision_analyze_tool(
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 2000,
+            "max_tokens": max_tokens if max_tokens is not None else 2000,
+            "preserve_max_tokens": max_tokens is not None,
             "timeout": vision_timeout,
         }
         if model:


### PR DESCRIPTION
## Summary
- replace the automatic gateway image-preprocess prompt with a concise 2-4 sentence summary prompt and a 500-token output budget
- add an internal `max_tokens` override to `vision_analyze_tool()` without shortening explicit user-invoked vision analysis
- preserve explicitly requested caps through custom/OpenAI-compatible client requests and retry/fallback paths while retaining the existing uncapped default
- add direct builder, mocked wire-request, tool-wrapper, and gateway regression coverage
- register the required commit-email attribution mapping

Fixes #10809

## Testing
- `python -m pytest -q tests/agent/test_auxiliary_client.py tests/tools/test_vision_tools.py tests/gateway/test_vision_preprocess.py` — 462 passed
- `python -m pytest -q tests/scripts/test_contributor_map.py` — 13 passed
- Ruff check passed for the changed Python files
- `scripts/run_tests.sh -j 8` — 48,637 passed; 24 failed across 13 files outside this PR diff under an isolated macOS home. A focused run of those unchanged files on the main-equivalent worktree also reproduced the environment/baseline failures.

## Notes
- no README or user-facing docs update is needed because this changes only the internal automatic gateway preprocessing path
- timeout behavior remains unchanged and outside this PR