### PR TITLE
fix(gateway): restore WeCom callback setup helper

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2222,6 +2222,12 @@ def _setup_wecom():
     _setup_standard_platform(wecom_platform)
 
 
+def _setup_wecom_callback():
+    """Configure WeCom Callback (self-built app) via the standard platform setup."""
+    wecom_callback_platform = next(p for p in _PLATFORMS if p["key"] == "wecom_callback")
+    _setup_standard_platform(wecom_callback_platform)
+
+
 def _is_service_installed() -> bool:
     """Check if the gateway is installed as a system service."""
     if supports_systemd_services():

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -223,6 +223,19 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_setup_wecom_callback_delegates_to_gateway_helper(monkeypatch):
+    """WeCom callback setup wrapper should import and call the gateway helper."""
+    called = []
+
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(gateway_mod, "_setup_wecom_callback", lambda: called.append(True))
+
+    setup_mod._setup_wecom_callback()
+
+    assert called == [True]
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Fixes a setup-wizard regression for WeCom Callback. `hermes_cli.setup._setup_wecom_callback()` imports `_setup_wecom_callback` from `hermes_cli.gateway`, but that bridge function was missing after a refactor. As a result, `hermes setup` crashed with an `ImportError` immediately after configuring WeCom.

This PR restores the missing gateway helper and adds a regression test so the setup wrapper must continue delegating correctly.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Restored `hermes_cli.gateway._setup_wecom_callback()` so the setup wizard can delegate WeCom Callback configuration through the shared standard platform flow.
- Added a regression test in `tests/hermes_cli/test_setup.py` that verifies `hermes_cli.setup._setup_wecom_callback()` imports and calls the gateway helper.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_setup.py -q`
2. Run `python -m pytest tests/hermes_cli/test_setup_noninteractive.py -q`
3. Run `hermes setup`, choose the gateway section, configure WeCom / WeCom Callback, and verify setup no longer crashes with `ImportError: cannot import name '_setup_wecom_callback'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant targeted tests passed locally:

- `python -m pytest tests/hermes_cli/test_setup.py -q` → `19 passed`
- `python -m pytest tests/hermes_cli/test_setup_noninteractive.py -q` → `9 passed`
- `python -m pytest tests/gateway/test_wecom.py -q -k connect_records_missing_credentials` → `1 passed`

Note: `python -m pytest tests/ -q` is currently not green in this environment. It finished with `64 failed, 11950 passed, 37 skipped, 54 errors`; the failures were spread across unrelated areas such as Discord reply mode, web server endpoints, CLI provider detection, and gateway progress tests, not this setup-path change.
