### PR TITLE
Add script_skip_if_empty for cron jobs with pre-run scripts

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -417,6 +417,7 @@ def create_job(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     script: Optional[str] = None,
+    script_skip_if_empty: bool = False,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
@@ -439,6 +440,8 @@ def create_job(
         script: Optional path to a Python script whose stdout is injected into the
                 prompt each run.  The script runs before the agent turn, and its output
                 is prepended as context.  Useful for data collection / change detection.
+        script_skip_if_empty: When True, a successful script run with empty stdout
+                skips the LLM turn entirely and suppresses delivery.
         context_from: Optional job ID (or list of job IDs) whose most recent output
                       is injected into the prompt as context before each run.
                       Useful for chaining cron jobs: job A finds data, job B processes it.
@@ -504,6 +507,7 @@ def create_job(
         "provider": normalized_provider,
         "base_url": normalized_base_url,
         "script": normalized_script,
+        "script_skip_if_empty": bool(script_skip_if_empty),
         "context_from": context_from,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -378,6 +378,7 @@ def create_job(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     script: Optional[str] = None,
+    script_skip_if_empty: bool = False,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -397,6 +398,8 @@ def create_job(
         script: Optional path to a Python script whose stdout is injected into the
                 prompt each run.  The script runs before the agent turn, and its output
                 is prepended as context.  Useful for data collection / change detection.
+        script_skip_if_empty: When True, a successful script run with empty stdout
+                skips the LLM turn entirely and suppresses delivery.
 
     Returns:
         The created job dict
@@ -439,6 +442,7 @@ def create_job(
         "provider": normalized_provider,
         "base_url": normalized_base_url,
         "script": normalized_script,
+        "script_skip_if_empty": bool(script_skip_if_empty),
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -814,6 +814,24 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
             return True, silent_doc, SILENT_MARKER, None
+        # Opt-in skip: when ``script_skip_if_empty`` is set, treat a
+        # successful run with empty stdout the same as ``wakeAgent=false``.
+        if (
+            _ran_ok
+            and job.get("script_skip_if_empty")
+            and not _script_output.strip()
+        ):
+            logger.info(
+                "Job '%s' (ID: %s): script_skip_if_empty matched empty stdout, skipping agent run",
+                job_name, job_id,
+            )
+            silent_doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                "Pre-run script produced no output and `script_skip_if_empty` is enabled — agent skipped.\n"
+            )
+            return True, silent_doc, SILENT_MARKER, None
 
     prompt = _build_job_prompt(job, prerun_script=prerun_script)
     origin = _resolve_origin(job)
@@ -860,6 +878,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     if _job_workdir:
         os.environ["TERMINAL_CWD"] = _job_workdir
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
+
 
     try:
         # Re-read .env and config.yaml fresh every run so provider/key

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -487,7 +487,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         return False, f"Script execution failed: {exc}"
 
 
-def _build_job_prompt(job: dict) -> str:
+def _build_job_prompt(job: dict, script_result: Optional[tuple[bool, str]] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first."""
     prompt = job.get("prompt", "")
     skills = job.get("skills")
@@ -495,7 +495,7 @@ def _build_job_prompt(job: dict) -> str:
     # Run data-collection script if configured, inject output as context.
     script_path = job.get("script")
     if script_path:
-        success, script_output = _run_job_script(script_path)
+        success, script_output = script_result or _run_job_script(script_path)
         if success:
             if script_output:
                 prompt = (
@@ -597,12 +597,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     
     job_id = job["id"]
     job_name = job["name"]
-    prompt = _build_job_prompt(job)
+    prompt = ""
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
-
-    logger.info("Running job '%s' (ID: %s)", job_name, job_id)
-    logger.info("Prompt: %s", prompt[:100])
 
     try:
         # Inject origin context so the agent's send_message tool knows the chat.
@@ -626,6 +623,40 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
             if delivery_target.get("thread_id") is not None:
                 os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+
+        script_result = None
+        script_path = job.get("script")
+        if script_path:
+            script_result = _run_job_script(script_path)
+            if (
+                job.get("script_skip_if_empty")
+                and script_result[0]
+                and not script_result[1]
+            ):
+                logger.info(
+                    "Job '%s' skipped LLM execution because the pre-run script produced no output",
+                    job_name,
+                )
+                output = f"""# Cron Job: {job_name}
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Prompt
+
+{job.get("prompt", "")}
+
+## Result
+
+[Skipped LLM execution because the pre-run script produced no output and script_skip_if_empty is enabled.]
+"""
+                return True, output, "", None
+
+        prompt = _build_job_prompt(job, script_result=script_result)
+
+        logger.info("Running job '%s' (ID: %s)", job_name, job_id)
+        logger.info("Prompt: %s", prompt[:100])
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -539,6 +539,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -69,6 +69,20 @@ class TestJobScriptField:
         job = create_job(prompt="Hello", schedule="every 1h", script="  ")
         assert job.get("script") is None
 
+    def test_create_job_script_skip_if_empty_stored(self, cron_env):
+        from cron.jobs import create_job, get_job
+
+        job = create_job(
+            prompt="Hello",
+            schedule="every 1h",
+            script="noop.py",
+            script_skip_if_empty=True,
+        )
+        assert job["script_skip_if_empty"] is True
+
+        loaded = get_job(job["id"])
+        assert loaded["script_skip_if_empty"] is True
+
     def test_update_job_add_script(self, cron_env):
         from cron.jobs import create_job, update_job
 
@@ -244,6 +258,20 @@ class TestCronjobToolScript:
         assert result["success"] is True
         assert result["job"]["script"] == "monitor.py"
 
+    def test_create_with_script_skip_if_empty(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+            script_skip_if_empty=True,
+        ))
+        assert result["success"] is True
+        assert result["job"]["script_skip_if_empty"] is True
+
     def test_update_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         from tools.cronjob_tools import cronjob
@@ -262,6 +290,26 @@ class TestCronjobToolScript:
         ))
         assert update_result["success"] is True
         assert update_result["job"]["script"] == "new_script.py"
+
+    def test_update_script_skip_if_empty(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="monitor.py",
+        ))
+        job_id = create_result["job_id"]
+
+        update_result = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_skip_if_empty=True,
+        ))
+        assert update_result["success"] is True
+        assert update_result["job"]["script_skip_if_empty"] is True
 
     def test_clear_script(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
@@ -298,6 +346,22 @@ class TestCronjobToolScript:
         assert list_result["success"] is True
         assert len(list_result["jobs"]) == 1
         assert list_result["jobs"][0]["script"] == "data_collector.py"
+
+    def test_list_shows_script_skip_if_empty(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="data_collector.py",
+            script_skip_if_empty=True,
+        )
+
+        list_result = json.loads(cronjob(action="list"))
+        assert list_result["success"] is True
+        assert list_result["jobs"][0]["script_skip_if_empty"] is True
 
 
 class TestScriptPathContainment:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -959,6 +959,68 @@ class TestRunJobConfigLogging:
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
 
 
+class TestRunJobScriptSkipIfEmpty:
+    def test_run_job_skips_llm_when_script_output_is_empty(self, tmp_path):
+        from cron.scheduler import SILENT_MARKER
+
+        job = {
+            "id": "skip-empty-job",
+            "name": "skip empty",
+            "prompt": "Check for changes.",
+            "script": "empty.py",
+            "script_skip_if_empty": True,
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("cron.scheduler._run_job_script", return_value=(True, "")), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == SILENT_MARKER
+        assert "script_skip_if_empty" in output
+        mock_agent_cls.assert_not_called()
+
+    def test_run_job_runs_when_script_output_is_non_empty(self, tmp_path):
+        job = {
+            "id": "skip-empty-job-2",
+            "name": "skip empty 2",
+            "prompt": "Check for changes.",
+            "script": "non_empty.py",
+            "script_skip_if_empty": True,
+        }
+        fake_db = MagicMock()
+        fake_runtime = {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "http://127.0.0.1:4000/v1",
+            "api_key": "***",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("cron.scheduler._run_job_script", return_value=(True, "actual output")), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_runtime), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ran"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ran"
+        mock_agent_cls.assert_called_once()
+
+
+
 class TestRunJobSkillBacked:
     def test_run_job_preserves_skill_env_passthrough_into_worker_thread(self, tmp_path):
         job = {

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -827,6 +827,34 @@ class TestRunJobConfigLogging:
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
 
 
+class TestRunJobScriptSkipIfEmpty:
+    def test_run_job_skips_llm_when_script_output_is_empty(self, tmp_path):
+        job = {
+            "id": "skip-empty-job",
+            "name": "skip empty",
+            "prompt": "Check for changes.",
+            "script": "empty.py",
+            "script_skip_if_empty": True,
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("cron.scheduler._run_job_script", return_value=(True, "")), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == ""
+        assert "Skipped LLM execution" in output
+        mock_agent_cls.assert_not_called()
+        fake_db.end_session.assert_called_once()
+        fake_db.close.assert_called_once()
+
+
 class TestRunJobPerJobOverrides:
     def test_job_level_model_provider_and_base_url_overrides_are_used(self, tmp_path):
         config_yaml = tmp_path / "config.yaml"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -215,6 +215,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     }
     if job.get("script"):
         result["script"] = job["script"]
+    if job.get("script_skip_if_empty"):
+        result["script_skip_if_empty"] = True
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
@@ -238,6 +240,7 @@ def cronjob(
     base_url: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
+    script_skip_if_empty: Optional[bool] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
@@ -290,6 +293,7 @@ def cronjob(
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                 script=_normalize_optional_job_value(script),
+                script_skip_if_empty=bool(script_skip_if_empty),
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
@@ -382,6 +386,8 @@ def cronjob(
                     if script_error:
                         return tool_error(script_error, success=False)
                 updates["script"] = _normalize_optional_job_value(script) if script else None
+            if script_skip_if_empty is not None:
+                updates["script_skip_if_empty"] = bool(script_skip_if_empty)
             if context_from is not None:
                 # Empty string / empty list clears the field; otherwise validate
                 # each referenced job exists before storing. Normalized to a list
@@ -505,6 +511,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a Python script that runs before each cron job execution. Its stdout is injected into the prompt as context. Use for data collection and change detection. Relative paths resolve under {display_hermes_home()}/scripts/. On update, pass empty string to clear."
             },
+            "script_skip_if_empty": {
+                "type": "boolean",
+                "description": "Optional. When true, if the pre-run script succeeds but produces empty stdout, skip the LLM run entirely and suppress delivery. On update, pass false to disable."
+            },
             "context_from": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -571,6 +581,7 @@ registry.register(
         base_url=args.get("base_url"),
         reason=args.get("reason"),
         script=args.get("script"),
+        script_skip_if_empty=args.get("script_skip_if_empty"),
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -215,6 +215,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     }
     if job.get("script"):
         result["script"] = job["script"]
+    if job.get("script_skip_if_empty"):
+        result["script_skip_if_empty"] = True
     return result
 
 
@@ -234,6 +236,7 @@ def cronjob(
     base_url: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
+    script_skip_if_empty: Optional[bool] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -271,6 +274,7 @@ def cronjob(
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                 script=_normalize_optional_job_value(script),
+                script_skip_if_empty=bool(script_skip_if_empty),
             )
             return json.dumps(
                 {
@@ -360,6 +364,8 @@ def cronjob(
                     if script_error:
                         return tool_error(script_error, success=False)
                 updates["script"] = _normalize_optional_job_value(script) if script else None
+            if script_skip_if_empty is not None:
+                updates["script_skip_if_empty"] = bool(script_skip_if_empty)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -459,6 +465,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a Python script that runs before each cron job execution. Its stdout is injected into the prompt as context. Use for data collection and change detection. Relative paths resolve under {display_hermes_home()}/scripts/. On update, pass empty string to clear."
             },
+            "script_skip_if_empty": {
+                "type": "boolean",
+                "description": "Optional. When true, if the pre-run script succeeds but produces empty stdout, skip the LLM run entirely and suppress delivery. On update, pass false to disable."
+            },
         },
         "required": ["action"]
     }
@@ -503,6 +513,7 @@ registry.register(
         base_url=args.get("base_url"),
         reason=args.get("reason"),
         script=args.get("script"),
+        script_skip_if_empty=args.get("script_skip_if_empty"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
This adds an opt-in `script_skip_if_empty` flag for cron jobs with pre-run scripts.

Right now a cron job always goes on to invoke the LLM after the script runs, even when the script exits successfully with empty stdout. That makes change-detection style jobs noisy and wastes model calls when there is nothing to report.

With this change:

- cron jobs can store `script_skip_if_empty: true`
- if the script exits successfully and stdout is empty, `run_job()` returns early without creating an `AIAgent`
- delivery is automatically suppressed because the returned `final_response` is empty
- the run is still treated as successful, and the saved output log makes it clear that execution was skipped because the script produced no output

The default behavior is unchanged. If the flag is not set, empty script output still follows the existing path and the LLM receives the "no output" notice in the prompt.

The change is wired through all three layers:

- `cron/jobs.py` stores the flag on the job
- `cron/scheduler.py` performs the early skip and avoids running the script twice
- `tools/cronjob_tools.py` exposes the flag on create/update/list

I also added regression coverage for:

- job storage of the new field
- create/update/list behavior in the cronjob tool
- the scheduler short-circuit path where the script succeeds with empty output and the LLM should not run

## Testing

- `source venv/bin/activate && python -m pytest tests/cron/test_cron_script.py -q`
- `source venv/bin/activate && python -m pytest tests/cron/test_scheduler.py -q`
- `source venv/bin/activate && python -m pytest tests/tools/test_cronjob_tools.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

The targeted cron tests pass.

The full local suite is still not green on this checkout/environment (`68 failed, 11771 passed, 98 skipped, 60 errors`), but the failures are outside this change and match the broader ACP / optional Discord / web-server / gateway noise already present locally.
