### PR TITLE
fix(gateway): re-inject topic-bound skill after /new session reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4685,7 +4685,12 @@ class GatewayRunner:
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at
             or getattr(session_entry, "was_auto_reset", False)
+            or getattr(session_entry, "is_fresh_reset", False)
         )
+        # Consume the is_fresh_reset flag immediately so it doesn't leak
+        # onto subsequent messages in the same session (issue #6508).
+        if getattr(session_entry, "is_fresh_reset", False):
+            session_entry.is_fresh_reset = False
         if _is_new_session:
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -454,6 +454,12 @@ class SessionEntry:
     # restarts — prevents redundant finalization runs.
     expiry_finalized: bool = False
 
+    # Set by reset_session() when the user explicitly sends /new.
+    # Consumed once by the message handler to trigger skill re-injection.
+    # Avoids the race where updated_at diverges from created_at before the
+    # next message arrives, causing _is_new_session = False (issue #6508).
+    is_fresh_reset: bool = False
+
     # When True the next call to get_or_create_session() will auto-reset
     # this session (create a new session_id) so the user starts fresh.
     # Set by /stop to break stuck-resume loops (#7536).
@@ -497,6 +503,7 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "is_fresh_reset": self.is_fresh_reset,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -545,6 +552,7 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            is_fresh_reset=data.get("is_fresh_reset", False),
         )
 
 
@@ -1121,6 +1129,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                is_fresh_reset=True,
             )
 
             self._entries[session_key] = new_entry

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -460,6 +460,12 @@ class SessionEntry:
     # next message arrives, causing _is_new_session = False (issue #6508).
     is_fresh_reset: bool = False
 
+    # Set by reset_session() when the user explicitly sends /new.
+    # Consumed once by the message handler to trigger skill re-injection.
+    # Avoids the race where updated_at diverges from created_at before the
+    # next message arrives, causing _is_new_session = False (issue #6508).
+    is_fresh_reset: bool = False
+
     # When True the next call to get_or_create_session() will auto-reset
     # this session (create a new session_id) so the user starts fresh.
     # Set by /stop to break stuck-resume loops (#7536).

--- a/tests/gateway/test_fresh_reset_skill_injection.py
+++ b/tests/gateway/test_fresh_reset_skill_injection.py
@@ -1,0 +1,153 @@
+"""Regression tests for topic/channel skill auto-injection after /new or /reset.
+
+Covers the fix in PR #6521 (Issue #6508):
+
+Before the fix:
+    1. User sends ``/new`` — ``reset_session`` creates a fresh SessionEntry
+       with ``created_at == updated_at``.
+    2. User sends the next message.
+    3. ``get_or_create_session`` finds the entry and mutates
+       ``entry.updated_at = now`` (microseconds after ``created_at``).
+    4. ``run._handle_message_with_agent`` checks
+       ``_is_new_session = (created_at == updated_at) or was_auto_reset``.
+       Both are False → ``_is_new_session = False`` → topic/channel skills
+       are silently skipped for the first message of a manually reset session.
+
+After the fix:
+    ``reset_session`` stamps the new entry with ``is_fresh_reset=True``.
+    ``run._handle_message_with_agent`` ORs this into ``_is_new_session`` and
+    consumes the flag immediately after the check, so subsequent messages are
+    treated as continuing the session.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.session import SessionSource, SessionStore, build_session_key
+
+
+def _make_store(tmp_path, policy=None):
+    config = GatewayConfig()
+    if policy:
+        config.default_reset_policy = policy
+    return SessionStore(sessions_dir=tmp_path, config=config)
+
+
+def _make_source(chat_id="123", user_id="u1"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        user_id=user_id,
+    )
+
+
+def _is_new_session(entry) -> bool:
+    """Mirror of the check in ``run._handle_message_with_agent``.
+
+    Kept in-sync with the production predicate so this test fails loudly if
+    the upstream logic regresses.
+    """
+    return (
+        entry.created_at == entry.updated_at
+        or getattr(entry, "was_auto_reset", False)
+        or getattr(entry, "is_fresh_reset", False)
+    )
+
+
+class TestResetSessionSetsFreshFlag:
+    def test_reset_session_sets_is_fresh_reset(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+
+        original = store.get_or_create_session(source)
+        reset_entry = store.reset_session(original.session_key)
+
+        assert reset_entry is not None
+        assert reset_entry.is_fresh_reset is True
+        assert reset_entry.session_id != original.session_id
+
+    def test_reset_session_returns_none_for_unknown_key(self, tmp_path):
+        store = _make_store(tmp_path)
+
+        assert store.reset_session("no-such-key") is None
+
+    def test_fresh_flag_does_not_leak_to_auto_reset_path(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+
+        assert entry.is_fresh_reset is False
+        assert entry.was_auto_reset is False
+
+
+class TestIsNewSessionAfterManualReset:
+    def test_fresh_flag_wins_even_after_updated_at_bump(self, tmp_path):
+        store = _make_store(
+            tmp_path,
+            policy=SessionResetPolicy(mode="idle", idle_minutes=60),
+        )
+        source = _make_source()
+
+        store.get_or_create_session(source)
+        session_key = build_session_key(source)
+        store.reset_session(session_key)
+
+        entry = store.get_or_create_session(source)
+
+        assert entry.updated_at >= entry.created_at
+        assert entry.is_fresh_reset is True
+        assert _is_new_session(entry) is True
+
+    def test_flag_consumption_restores_normal_behavior(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+
+        store.get_or_create_session(source)
+        store.reset_session(build_session_key(source))
+
+        first_after_reset = store.get_or_create_session(source)
+        assert _is_new_session(first_after_reset) is True
+
+        first_after_reset.is_fresh_reset = False
+
+        import time
+        time.sleep(0.001)
+
+        second_after_reset = store.get_or_create_session(source)
+        assert second_after_reset.is_fresh_reset is False
+        assert _is_new_session(second_after_reset) is False
+
+    def test_vanilla_session_is_not_treated_as_new_on_followup(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+
+        first = store.get_or_create_session(source)
+        assert _is_new_session(first) is True
+
+        import time
+        time.sleep(0.001)
+
+        second = store.get_or_create_session(source)
+        assert second.session_id == first.session_id
+        assert second.is_fresh_reset is False
+        assert _is_new_session(second) is False
+
+
+class TestAutoResetPathsUnaffected:
+    def test_idle_auto_reset_does_not_set_is_fresh_reset(self, tmp_path):
+        store = _make_store(
+            tmp_path,
+            policy=SessionResetPolicy(mode="idle", idle_minutes=1),
+        )
+        source = _make_source()
+
+        first = store.get_or_create_session(source)
+        first.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        second = store.get_or_create_session(source)
+        assert second.session_id != first.session_id
+        assert second.was_auto_reset is True
+        assert second.is_fresh_reset is False


### PR DESCRIPTION
## Problem

When a user sends `/new` in a Telegram forum topic with a configured `group_topics` skill binding, the topic-bound skill is not re-injected into the new session. The bot falls back to its default persona instead of the topic-specific skill/role.

**Root cause:** `reset_session()` creates a new `SessionEntry` with `created_at == updated_at`. The next inbound message triggers `get_or_create_session()` which bumps `updated_at`, causing `_is_new_session = False` and silently skipping skill auto-injection.

## Fix

### `gateway/session.py`
- Add `is_fresh_reset: bool = False` field to `SessionEntry`
- `reset_session()` stamps new entries with `is_fresh_reset=True`
- `to_dict()` / `from_dict()` updated so the flag survives gateway restarts

### `gateway/run.py`
- OR `is_fresh_reset` into the `_is_new_session` check
- Consume the flag immediately after reading — prevents leakage onto subsequent messages in the same session

## Tests

Adds `tests/gateway/test_fresh_reset_skill_injection.py` with 7 regression tests (contributed by @warabe1122 in issue #6508 discussion):
- `reset_session` stamps `is_fresh_reset=True` on the new entry
- `reset_session` returns `None` for unknown keys
- `is_fresh_reset` does not leak onto vanilla first-time sessions
- Core regression: `_is_new_session` stays `True` on the follow-up message even after `updated_at` is bumped
- After the flag is consumed, the next message is not treated as new
- Vanilla ongoing sessions are unaffected
- Idle auto-resets go through `was_auto_reset` and do not accidentally set `is_fresh_reset`

Fixes #6508