### PR TITLE
feat(cli): add --exclude-source to sessions list and browse

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5778,6 +5778,7 @@ Examples:
 
     sessions_list = sessions_subparsers.add_parser("list", help="List recent sessions")
     sessions_list.add_argument("--source", help="Filter by source (cli, telegram, discord, etc.)")
+    sessions_list.add_argument("--exclude-source", action="append", help="Exclude sessions from this source (can be specified multiple times)")
     sessions_list.add_argument("--limit", type=int, default=20, help="Max sessions to show")
 
     sessions_export = sessions_subparsers.add_parser("export", help="Export sessions to a JSONL file")
@@ -5805,6 +5806,7 @@ Examples:
         help="Interactive session picker — browse, search, and resume sessions",
     )
     sessions_browse.add_argument("--source", help="Filter by source (cli, telegram, discord, etc.)")
+    sessions_browse.add_argument("--exclude-source", action="append", help="Exclude sessions from this source (can be specified multiple times)")
     sessions_browse.add_argument("--limit", type=int, default=50, help="Max sessions to load (default: 50)")
 
     def _confirm_prompt(prompt: str) -> bool:
@@ -5828,6 +5830,12 @@ Examples:
         # Hide third-party tool sessions by default, but honour explicit --source
         _source = getattr(args, "source", None)
         _exclude = None if _source else ["tool"]
+        
+        _user_exclude = getattr(args, "exclude_source", None)
+        if _user_exclude:
+            if _exclude is None:
+                _exclude = []
+            _exclude.extend(_user_exclude)
 
         if action == "list":
             sessions = db.list_sessions_rich(source=args.source, exclude_sources=_exclude, limit=args.limit)
@@ -5923,8 +5931,7 @@ Examples:
         elif action == "browse":
             limit = getattr(args, "limit", 50) or 50
             source = getattr(args, "source", None)
-            _browse_exclude = None if source else ["tool"]
-            sessions = db.list_sessions_rich(source=source, exclude_sources=_browse_exclude, limit=limit)
+            sessions = db.list_sessions_rich(source=source, exclude_sources=_exclude, limit=limit)
             db.close()
             if not sessions:
                 print("No sessions found.")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11815,6 +11815,12 @@ def main():
         "--source", help="Filter by source (cli, telegram, discord, etc.)"
     )
     sessions_list.add_argument(
+        "--exclude-source",
+        action="append",
+        metavar="SOURCE",
+        help="Exclude sessions from this source (repeatable)",
+    )
+    sessions_list.add_argument(
         "--limit", type=int, default=20, help="Max sessions to show"
     )
     sessions_list.add_argument(
@@ -12176,6 +12182,12 @@ def main():
     )
     sessions_browse.add_argument(
         "--source", help="Filter by source (cli, telegram, discord, etc.)"
+    )
+    sessions_browse.add_argument(
+        "--exclude-source",
+        action="append",
+        metavar="SOURCE",
+        help="Exclude sessions from this source (repeatable)",
     )
     sessions_browse.add_argument(
         "--limit", type=int, default=500, help="Max sessions to load (default: 500)"

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -233,8 +233,17 @@ def cmd_sessions(args, sessions_parser=None):
         return
 
     # Hide third-party tool sessions by default, but honour explicit --source
+    def _combined_excludes(source, user_excludes):
+        """Implicit 'tool' exclusion (skipped when --source is given) plus
+        any --exclude-source values, deduplicated; None when empty."""
+        excludes = [] if source else ["tool"]
+        for src in user_excludes or []:
+            if src not in excludes:
+                excludes.append(src)
+        return excludes or None
+
     _source = getattr(args, "source", None)
-    _exclude = None if _source else ["tool"]
+    _exclude = _combined_excludes(_source, getattr(args, "exclude_source", None))
 
     if action == "list":
         from hermes_state import workspace_key as _ws_key
@@ -983,7 +992,9 @@ def cmd_sessions(args, sessions_parser=None):
     elif action == "browse":
         limit = getattr(args, "limit", 500) or 500
         source = getattr(args, "source", None)
-        _browse_exclude = None if source else ["tool"]
+        _browse_exclude = _combined_excludes(
+            source, getattr(args, "exclude_source", None)
+        )
         sessions = db.list_sessions_rich(
             source=source, exclude_sources=_browse_exclude, limit=limit
         )

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -170,6 +170,7 @@ class TestSessionBrowseArgparse:
         subparsers = parser.add_subparsers(dest="sessions_action")
         browse = subparsers.add_parser("browse")
         browse.add_argument("--source")
+        browse.add_argument("--exclude-source", action="append")
         browse.add_argument("--limit", type=int, default=500)
 
         args = parser.parse_args(["browse"])
@@ -177,6 +178,28 @@ class TestSessionBrowseArgparse:
 
         args = parser.parse_args(["browse", "--limit", "42"])
         assert args.limit == 42
+
+    def test_browse_exclude_source_is_repeatable(self):
+        """--exclude-source appends: absent → None, repeated → all values."""
+        # Mirror the argparse registration cmd_sessions uses.
+        import argparse
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="sessions_action")
+        browse = subparsers.add_parser("browse")
+        browse.add_argument("--source")
+        browse.add_argument("--exclude-source", action="append")
+        browse.add_argument("--limit", type=int, default=500)
+
+        args = parser.parse_args(["browse"])
+        assert args.exclude_source is None
+
+        args = parser.parse_args(["browse", "--exclude-source", "cron"])
+        assert args.exclude_source == ["cron"]
+
+        args = parser.parse_args(
+            ["browse", "--exclude-source", "cron", "--exclude-source", "telegram"]
+        )
+        assert args.exclude_source == ["cron", "telegram"]
 
 
 # ─── Integration: cmd_sessions browse action ────────────────────────────────

--- a/tests/hermes_cli/test_sessions_exclude_source.py
+++ b/tests/hermes_cli/test_sessions_exclude_source.py
@@ -1,0 +1,116 @@
+"""Tests for the repeatable --exclude-source flag on `hermes sessions list`
+and `hermes sessions browse`.
+
+Covers the real CLI parsers (via main()) and the forwarding of the combined
+exclusion list — the implicit 'tool' exclusion plus any user-supplied
+--exclude-source values — to SessionDB.list_sessions_rich. DB-level
+exclusion semantics are covered in tests/test_hermes_state.py.
+"""
+
+import sys
+
+
+def _run_sessions(monkeypatch, capsys, argv_tail):
+    """Run `hermes sessions <argv_tail>` against a FakeDB, capturing the
+    kwargs passed to list_sessions_rich. Returns (kwargs, stdout)."""
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    seen = {}
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            seen.update(kwargs)
+            return []
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", *argv_tail])
+    main_mod.main()
+    return seen, capsys.readouterr().out
+
+
+# ─── sessions list ───────────────────────────────────────────────────────────
+
+class TestSessionsListExcludeSource:
+    def test_default_keeps_implicit_tool_exclusion(self, monkeypatch, capsys):
+        """Bare `sessions list` still hides third-party tool sessions."""
+        seen, _out = _run_sessions(monkeypatch, capsys, ["list"])
+        assert seen["source"] is None
+        assert seen["exclude_sources"] == ["tool"]
+
+    def test_repeated_flag_adds_to_implicit_tool_exclusion(self, monkeypatch, capsys):
+        """Repeated --exclude-source values are forwarded alongside 'tool'."""
+        seen, _out = _run_sessions(
+            monkeypatch,
+            capsys,
+            ["list", "--exclude-source", "cron", "--exclude-source", "telegram"],
+        )
+        assert seen["source"] is None
+        assert seen["exclude_sources"] == ["tool", "cron", "telegram"]
+
+    def test_exclude_tool_is_not_duplicated(self, monkeypatch, capsys):
+        """Explicitly excluding 'tool' doesn't produce a duplicate entry."""
+        seen, _out = _run_sessions(
+            monkeypatch, capsys, ["list", "--exclude-source", "tool"]
+        )
+        assert seen["exclude_sources"] == ["tool"]
+
+    def test_source_alone_still_disables_implicit_exclusion(self, monkeypatch, capsys):
+        """--source without --exclude-source keeps current main's semantics:
+        no exclusion at all (tool sessions are shown for explicit --source)."""
+        seen, _out = _run_sessions(monkeypatch, capsys, ["list", "--source", "cli"])
+        assert seen["source"] == "cli"
+        assert seen["exclude_sources"] is None
+
+    def test_source_with_excludes_forwards_only_user_values(self, monkeypatch, capsys):
+        """With --source, the implicit 'tool' exclusion stays disabled but
+        the user's --exclude-source values are still forwarded."""
+        seen, _out = _run_sessions(
+            monkeypatch,
+            capsys,
+            ["list", "--source", "cli", "--exclude-source", "cron"],
+        )
+        assert seen["source"] == "cli"
+        assert seen["exclude_sources"] == ["cron"]
+
+
+# ─── sessions browse ─────────────────────────────────────────────────────────
+
+class TestSessionsBrowseExcludeSource:
+    def test_default_keeps_implicit_tool_exclusion(self, monkeypatch, capsys):
+        seen, out = _run_sessions(monkeypatch, capsys, ["browse"])
+        assert seen["source"] is None
+        assert seen["exclude_sources"] == ["tool"]
+        assert "No sessions found." in out
+
+    def test_repeated_flag_adds_to_implicit_tool_exclusion(self, monkeypatch, capsys):
+        seen, _out = _run_sessions(
+            monkeypatch,
+            capsys,
+            ["browse", "--exclude-source", "cron", "--exclude-source", "telegram"],
+        )
+        assert seen["source"] is None
+        assert seen["exclude_sources"] == ["tool", "cron", "telegram"]
+
+    def test_exclude_tool_is_not_duplicated(self, monkeypatch, capsys):
+        seen, _out = _run_sessions(
+            monkeypatch, capsys, ["browse", "--exclude-source", "tool"]
+        )
+        assert seen["exclude_sources"] == ["tool"]
+
+    def test_source_alone_still_disables_implicit_exclusion(self, monkeypatch, capsys):
+        seen, _out = _run_sessions(monkeypatch, capsys, ["browse", "--source", "cli"])
+        assert seen["source"] == "cli"
+        assert seen["exclude_sources"] is None
+
+    def test_source_with_excludes_forwards_only_user_values(self, monkeypatch, capsys):
+        seen, _out = _run_sessions(
+            monkeypatch,
+            capsys,
+            ["browse", "--source", "cli", "--exclude-source", "cron"],
+        )
+        assert seen["source"] == "cli"
+        assert seen["exclude_sources"] == ["cron"]

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -190,6 +190,9 @@ hermes sessions list
 # Filter by platform
 hermes sessions list --source telegram
 
+# Exclude specific sources (e.g. hide cron jobs)
+hermes sessions list --exclude-source cron
+
 # Show more sessions
 hermes sessions list --limit 50
 ```

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -288,9 +288,15 @@ hermes sessions list
 # Filter by platform
 hermes sessions list --source telegram
 
+# Exclude sessions from a source (repeatable — pass it once per source)
+hermes sessions list --exclude-source cron
+hermes sessions list --exclude-source cron --exclude-source telegram
+
 # Show more sessions
 hermes sessions list --limit 50
 ```
+
+`--exclude-source` also works with `hermes sessions browse`. Third-party `tool` sessions are hidden by default; your exclusions are applied on top of that.
 
 When sessions have titles, the output shows titles, previews, and relative timestamps:
 


### PR DESCRIPTION
This PR adds a new `--exclude-source` argument to `hermes sessions list` and `hermes sessions browse` commands.

### Changes:
- Added `--exclude-source` to `list` and `browse` subparsers in `hermes_cli/main.py`.
- Updated `cmd_sessions` to combine user-provided exclusions with default ones (like `tool`).
- Added documentation example in `website/docs/user-guide/sessions.md`.

### Motivation:
Allows users to hide specific types of sessions (like `cron` jobs) from the session list to reduce noise.

### Testing:
Verified manually with:
```bash
hermes sessions list --exclude-source cron
```
And verified that the help message displays the new option correctly.