### PR TITLE
test(wsl): stub is_container and systemctl in WSL gateway tests

### DIFF
--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -122,12 +122,19 @@ class TestWslSystemdOperational:
 # =============================================================================
 
 class TestSupportsSystemdServicesWSL:
-    """Test that supports_systemd_services() handles WSL correctly."""
+    """Test that supports_systemd_services() handles WSL correctly.
+
+    ``supports_systemd_services`` also shortcuts to False when the process is
+    running inside a container or ``systemctl`` is not on PATH.  On non-Linux
+    dev hosts neither can be assumed, so the Linux-specific tests stub both.
+    """
 
     def test_wsl_with_systemd(self, monkeypatch):
         """WSL + working systemd → True."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
         assert gateway.supports_systemd_services() is True
@@ -136,6 +143,8 @@ class TestSupportsSystemdServicesWSL:
         """WSL + no systemd → False."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: False)
         assert gateway.supports_systemd_services() is False
@@ -144,6 +153,8 @@ class TestSupportsSystemdServicesWSL:
         """Native Linux (not WSL) → True without checking systemd."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
         assert gateway.supports_systemd_services() is True
 
@@ -151,6 +162,25 @@ class TestSupportsSystemdServicesWSL:
         """Termux → False regardless of WSL status."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: True)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
+        assert gateway.supports_systemd_services() is False
+
+    def test_container_excluded(self, monkeypatch):
+        """Container → False regardless of systemd availability."""
+        monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: "/usr/bin/systemctl")
+        assert gateway.supports_systemd_services() is False
+
+    def test_no_systemctl_excluded(self, monkeypatch):
+        """systemctl not on PATH → False even on native Linux."""
+        monkeypatch.setattr(gateway, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(gateway, "is_wsl", lambda: False)
         assert gateway.supports_systemd_services() is False
 
 


### PR DESCRIPTION
## Problem

Running `pytest tests/hermes_cli/test_gateway_wsl.py` on a non-Linux host (macOS dev box) against v2026.4.13 fails 2 tests:

```
FAILED tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_wsl_with_systemd
FAILED tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_native_linux
```

Both fail with:

```
assert False is True
 +  where False = <function supports_systemd_services at 0x...>()
```

## Root cause

`supports_systemd_services()` in `hermes_cli/gateway.py` has two short-circuits that the WSL tests do not stub:

```python
def supports_systemd_services() -> bool:
    if not is_linux() or is_termux() or is_container():
        return False
    if shutil.which("systemctl") is None:
        return False
    if is_wsl():
        return _wsl_systemd_operational()
    return True
```

- `is_container()` is a real-process check. On a non-containerized dev host it returns False today, but the tests never pin it — it's brittle.
- `shutil.which("systemctl")` is a real PATH check. On macOS there is no `systemctl`, so the function returns False before the WSL branch runs, and the test that asserts `True` fails.

Upstream CI hides this because it runs in Ubuntu where `systemctl` exists. Any macOS contributor trying to run the test file locally hits it.

## Fix

Test-only. Stub `is_container` and `shutil.which("systemctl")` alongside the existing `is_linux`/`is_termux` stubs so the Linux-branch tests exercise the Linux code path on every host.

Also add two cases that explicitly lock down the two short-circuits we now stub away:

- `test_container_excluded` — `is_container()` True must return False.
- `test_no_systemctl_excluded` — `which("systemctl") is None` must return False.

## Verification

```
$ pytest -q tests/hermes_cli/test_gateway_wsl.py
22 passed in 0.12s
```

Down from 2 failing on macOS, up from 20 to 22 covered cases.
