### PR TITLE
fix(checkpoint): resolve HOME symlinks before matching the skip-home guard

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -205,6 +205,42 @@ class TestTakeCheckpoint:
         r = mgr.ensure_checkpoint(str(Path.home()), "home")
         assert r is False
 
+    def test_skip_home_dir_when_home_is_symlinked(self, mgr, tmp_path, monkeypatch, checkpoint_base, caplog):
+        """HOME on a symlinked mount (e.g. macOS /tmp -> /private/tmp) must still be skipped.
+
+        ``ensure_checkpoint`` resolves the incoming directory with ``.resolve()``,
+        so the guard must compare against a resolved HOME too — otherwise a user
+        whose HOME lives under a symlinked prefix would silently snapshot their
+        entire home directory.
+
+        Plain ``assert r is False`` is ambiguous here because ensure_checkpoint
+        swallows every downstream exception and returns False.  Assert instead
+        that the guard's own short-circuit log line fires, which happens only
+        when the guard actually identifies the directory as HOME.
+        """
+        # Build a symlinked HOME: real dir at tmp_path/real_home, symlink
+        # tmp_path/home_link -> real_home. ``Path.home()`` returns the link
+        # path, but ``.resolve()`` resolves to ``real_home``.
+        real_home = tmp_path / "real_home"
+        real_home.mkdir()
+        home_link = tmp_path / "home_link"
+        home_link.symlink_to(real_home)
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home_link))
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.checkpoint_manager"):
+            r = mgr.ensure_checkpoint(str(home_link), "symlinked home")
+
+        assert r is False
+        assert any(
+            "directory too broad" in record.getMessage()
+            for record in caplog.records
+        ), (
+            "HOME guard did not fire; ensure_checkpoint fell through for a "
+            "symlinked HOME path."
+        )
+
 
 # =========================================================================
 # CheckpointManager — listing checkpoints

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -296,8 +296,13 @@ class CheckpointManager:
 
         abs_dir = str(_normalize_path(working_dir))
 
-        # Skip root, home, and other overly broad directories
-        if abs_dir in ("/", str(Path.home())):
+        # Skip root, home, and other overly broad directories.
+        # ``abs_dir`` is fully resolved (symlinks followed), so compare against
+        # the resolved form of HOME too — otherwise on macOS where ``/tmp``
+        # resolves to ``/private/tmp`` (and similarly for other symlinked
+        # mount points) the guard silently lets HOME through.
+        _home_resolved = str(_normalize_path(str(Path.home())))
+        if abs_dir in ("/", _home_resolved):
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 


### PR DESCRIPTION
## Problem

`CheckpointManager.ensure_checkpoint()` has a guard that skips root and HOME to prevent accidentally shadow-snapshotting the user's entire home directory:

```python
abs_dir = str(_normalize_path(working_dir))

# Skip root, home, and other overly broad directories
if abs_dir in ("/", str(Path.home())):
    logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
    return False
```

`_normalize_path(working_dir)` calls `Path(...).expanduser().resolve()`, so `abs_dir` is always fully resolved (symlinks followed). The right-hand side is the raw `str(Path.home())`, which is not resolved.

On macOS, `Path.home()` commonly sits behind a symlinked filesystem prefix:
- `/tmp -> /private/tmp`
- `/var -> /private/var`
- custom NFS / auto-mount points

In those cases the two sides never match and the guard silently lets HOME through. The checkpoint subsystem will then happily snapshot the entire home directory into its shadow git repo.

This is a latent correctness bug independent of any specific test. The associated test `tests/tools/test_checkpoint_manager.py::TestTakeCheckpoint::test_skip_home_dir` fails on any macOS dev host where `Path.home()` is under a symlinked prefix, which is how I noticed it:

```
FAILED tests/tools/test_checkpoint_manager.py::TestTakeCheckpoint::test_skip_home_dir
  tests/tools/test_checkpoint_manager.py:206: assert True is False
```

## Fix

Resolve `Path.home()` the same way `abs_dir` is resolved before comparing:

```python
_home_resolved = str(_normalize_path(str(Path.home())))
if abs_dir in ("/", _home_resolved):
    ...
```

## Regression test

Added `test_skip_home_dir_when_home_is_symlinked`. It builds a symlinked HOME (`tmp_path/home_link -> tmp_path/real_home`), patches `Path.home()` to return the symlink path, and calls `ensure_checkpoint(str(home_link), ...)`.

Plain `assert r is False` is not sufficient here because `ensure_checkpoint` swallows every downstream exception and always returns False. The test therefore asserts on the guard's own short-circuit log line ("directory too broad"), which only fires when the guard actually identifies the directory as HOME.

Without the fix the regression test fails; with the fix it passes.

## Verification

```
$ pytest -q tests/tools/test_checkpoint_manager.py
49 passed in 2.72s
```

Up from 48 passing to 49 (1 new regression test). No existing tests regressed.
