### PR TITLE
feat(skins): add hide_info option to suppress info panel

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -370,6 +370,34 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     except Exception:
         _bskin = None
         _hero = HERMES_CADUCEUS
+
+    # When the skin sets hide_info, show only the logo — skip the info panel
+    _hide_info = getattr(_bskin, 'hide_info', False) if _bskin else False
+    if _hide_info:
+        agent_name = _skin_branding("agent_name", "Hermes Agent")
+        title_color = _skin_color("banner_title", "#FFD700")
+        border_color = _skin_color("banner_border", "#CD7F32")
+        console.print()
+        term_width = shutil.get_terminal_size().columns
+        if term_width >= 95:
+            _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
+            console.print(_logo)
+            console.print()
+        model_short = model.split("/")[-1] if "/" in model else model
+        if model_short.endswith(".gguf"):
+            model_short = model_short[:-5]
+        if len(model_short) > 28:
+            model_short = model_short[:25] + "..."
+        ctx_str = f" · {_format_context_length(context_length)} context" if context_length else ""
+        summary = f"[dim {dim}]{model_short}{ctx_str} · /help for commands[/]"
+        console.print(Panel(
+            summary,
+            title=f"[bold {title_color}]{format_banner_version_label()}[/]",
+            border_style=border_color,
+            padding=(0, 2),
+        ))
+        return
+
     left_lines = ["", _hero, ""]
     model_short = model.split("/")[-1] if "/" in model else model
     if model_short.endswith(".gguf"):

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -72,6 +72,9 @@ All fields are optional. Missing values inherit from the ``default`` skin.
       web_search: "🔮"        # Override web_search tool emoji
       # Any tool not listed here uses its registry default
 
+    # Hide info: suppress tools/skills/MCP info panel in the welcome banner
+    hide_info: true              # Default: false
+
 USAGE
 =====
 
@@ -129,6 +132,7 @@ class SkinConfig:
     tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
+    hide_info: bool = False  # When True, suppress the info panel (tools, skills, MCP) in the banner
 
     def get_color(self, key: str, fallback: str = "") -> str:
         """Get a color value with fallback."""
@@ -629,6 +633,7 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
         tool_emojis=data.get("tool_emojis", {}),
         banner_logo=data.get("banner_logo", ""),
         banner_hero=data.get("banner_hero", ""),
+        hide_info=bool(data.get("hide_info", False)),
     )
 
 


### PR DESCRIPTION
## Summary
- Adds `hide_info: bool` field to `SkinConfig` — when `true`, the welcome banner shows only the logo and a minimal summary line, suppressing the full tools/skills/MCP info panel.
- Wired through `_build_skin_config()` for YAML-driven skins and documented in the schema docstring.

## Test plan
- [x] `test_skin_engine.py` — 29 tests pass
- [ ] Manual: set `display.skin: logo-only` with a `~/.hermes/skins/logo-only.yaml` that has `hide_info: true`, verify banner only shows logo + one-line summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)