### PR TITLE
Remove unsupported anyOf from honcho_conclude schema

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -171,10 +171,6 @@ CONCLUDE_SCHEMA = {
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
-        "anyOf": [
-            {"required": ["conclusion"]},
-            {"required": ["delete_id"]},
-        ],
     },
 }
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -8,7 +8,7 @@ from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
 )
-from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho import CONCLUDE_SCHEMA, HonchoMemoryProvider
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +366,17 @@ class TestPeerLookupHelpers:
 
 
 class TestConcludeToolDispatch:
+    def test_honcho_conclude_schema_is_provider_compatible(self):
+        params = CONCLUDE_SCHEMA["parameters"]
+
+        assert params["type"] == "object"
+        assert "conclusion" in params["properties"]
+        assert "delete_id" in params["properties"]
+        assert "anyOf" not in params
+        assert "oneOf" not in params
+        assert "allOf" not in params
+        assert "not" not in params
+
     def test_honcho_conclude_defaults_to_user_peer(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True


### PR DESCRIPTION
## Summary

`honcho_conclude` declared a top-level `anyOf` in its input schema. Anthropic and GPT-5 reject that shape, so enabling the Honcho memory plugin can cause every request to fail before the agent loop starts.

This removes the unsupported schema constraint and leaves validation at runtime, which is already where we handle the missing-parameter case for `conclusion` / `delete_id`.

## What changed

- removed the top-level `anyOf` from `CONCLUDE_SCHEMA`
- added a regression test that checks the schema stays provider-compatible

## Validation

- `source venv/bin/activate && python -m pytest tests/honcho_plugin/test_session.py -q`
- `source venv/bin/activate && python -m pytest tests/honcho_plugin -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

The Honcho-targeted tests passed. The full suite is still red in this environment with unrelated existing failures (`59 failed, 11788 passed, 98 skipped, 60 errors`), mostly in ACP, Discord, and web server coverage.

Fixes #10812
Related to #10723
