### PR TITLE
test(aux): use real OAuth token formats in is_oauth_flag tests

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -363,9 +363,12 @@ class TestExpiredCodexFallback:
 
 
     def test_hermes_oauth_file_sets_oauth_flag(self, monkeypatch):
-        """OAuth-style tokens should get is_oauth=*** (token is not sk-ant-api-*)."""
-        # Mock resolve_anthropic_token to return an OAuth-style token
-        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="hermes-oauth-jwt-token"), \
+        """Anthropic OAuth tokens (sk-ant-*/eyJ*) should set is_oauth=True."""
+        # Use a token that agent.anthropic_adapter._is_oauth_token() actually
+        # recognises as OAuth.  "sk-ant-oat-*" is the setup-token format and
+        # "eyJ*" is the JWT format; "hermes-oauth-jwt-token" matches neither.
+        oauth_token = "sk-ant-oat-01-fake-for-test"
+        with patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=oauth_token), \
              patch("agent.anthropic_adapter.build_anthropic_client") as mock_build, \
              patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
             mock_build.return_value = MagicMock()
@@ -373,7 +376,7 @@ class TestExpiredCodexFallback:
             client, model = _try_anthropic()
             assert client is not None, "Should resolve token"
             adapter = client.chat.completions
-            assert adapter._is_oauth is True, "Non-sk-ant-api token should set is_oauth=True"
+            assert adapter._is_oauth is True, "sk-ant-oat-* token should set is_oauth=True"
 
     def test_jwt_missing_exp_passes_through(self, tmp_path, monkeypatch):
         """JWT with valid JSON but no exp claim should pass through."""
@@ -420,7 +423,13 @@ class TestExpiredCodexFallback:
 
     def test_claude_code_oauth_env_sets_flag(self, monkeypatch):
         """CLAUDE_CODE_OAUTH_TOKEN env var should get is_oauth=True."""
-        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "cc-oauth-token-test")
+        # Tokens issued by the Claude Code OAuth flow use the sk-ant-oat-*
+        # setup-token format, which agent.anthropic_adapter._is_oauth_token()
+        # recognises as OAuth.  The previous literal "cc-oauth-token-test"
+        # string matched neither the sk-ant-* nor the eyJ* prefix and so was
+        # (correctly) classified as a non-OAuth key, which is how the bug
+        # escaped — the test asserted OAuth on a non-OAuth token.
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-01-fake-for-test")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
             mock_build.return_value = MagicMock()


### PR DESCRIPTION
## Problem

Two tests in `tests/agent/test_auxiliary_client.py::TestExpiredCodexFallback` fail on a fresh v2026.4.13 checkout:

```
FAILED tests/agent/test_auxiliary_client.py::TestExpiredCodexFallback::test_hermes_oauth_file_sets_oauth_flag
  AssertionError: Non-sk-ant-api token should set is_oauth=True
  assert False is True

FAILED tests/agent/test_auxiliary_client.py::TestExpiredCodexFallback::test_claude_code_oauth_env_sets_flag
  assert False is True
```

## Root cause

`agent.anthropic_adapter._is_oauth_token()` only classifies a token as OAuth when it matches one of two well-defined prefixes:

```python
def _is_oauth_token(key: str) -> bool:
    if not key:
        return False
    if key.startswith("sk-ant-api"):   # Console API key, never OAuth
        return False
    if key.startswith("sk-ant-"):      # setup tokens / managed keys
        return True
    if key.startswith("eyJ"):          # JWT from OAuth flow
        return True
    return False
```

The two tests pass literal placeholder strings that match neither prefix:

- `"hermes-oauth-jwt-token"` 
- `"cc-oauth-token-test"` 

`_is_oauth_token()` correctly returns False for both, the adapter sets `_is_oauth=False`, and the assertion `adapter._is_oauth is True` fails.

These tests appear to have been copied from a version of `_is_oauth_token()` that used a looser heuristic. In the current implementation, only real OAuth-format tokens exercise the is_oauth code path.

## Fix

Test-only. Replace the non-conforming placeholders with `sk-ant-oat-01-fake-for-test`, which matches the `sk-ant-` prefix and is the exact format of setup tokens issued by the Claude Code OAuth flow.

## Verification

```
$ pytest -q tests/agent/test_auxiliary_client.py::TestExpiredCodexFallback
7 passed in 1.02s
```

Down from 2 failing to 0.
