### PR TITLE
fix(cli): handle null/non-dict display config in skin initialization

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -708,7 +708,9 @@ def init_skin_from_config(config: dict) -> None:
 
     Call this once during CLI init with the loaded config dict.
     """
-    display = config.get("display", {})
+    display = config.get("display") or {}
+    if not isinstance(display, dict):
+        display = {}
     skin_name = display.get("skin", "default")
     if isinstance(skin_name, str) and skin_name.strip():
         set_active_skin(skin_name.strip())

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -152,6 +152,24 @@ class TestSkinManagement:
         init_skin_from_config({})
         assert get_active_skin_name() == "default"
 
+    def test_init_skin_from_null_display(self):
+        """display: null should fall back to default, not crash."""
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        init_skin_from_config({"display": None})
+        assert get_active_skin_name() == "default"
+
+    def test_init_skin_from_non_dict_display(self):
+        """display: <non-dict> should fall back to default."""
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        init_skin_from_config({"display": "invalid"})
+        assert get_active_skin_name() == "default"
+
+        init_skin_from_config({"display": 42})
+        assert get_active_skin_name() == "default"
+
+        init_skin_from_config({"display": []})
+        assert get_active_skin_name() == "default"
+
 
 class TestUserSkins:
     def test_load_user_skin_from_yaml(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Normalize `display` to an empty dict when it is `None` or any non-dict type in `init_skin_from_config()`
- Falls back to `default` skin gracefully instead of crashing

Fixes #10846.

## Root Cause
`init_skin_from_config()` assumed `config['display']` was always a dict. When config.yaml contains `display: null` (from migrations, manual edits, or YAML tooling), calling `.get()` on `NoneType` raises `AttributeError` and crashes the CLI at startup.

## Fix
Two-line guard:
1. `config.get('display') or {}` — handles `None` (the reported case)
2. `if not isinstance(display, dict): display = {}` — handles strings, ints, lists, etc.

## Validation
```
pytest -q -o addopts= tests/hermes_cli/test_skin_engine.py -k test_init_skin
4 passed, 27 deselected
```

New tests added:
- `test_init_skin_from_null_display` — `{"display": None}`
- `test_init_skin_from_non_dict_display` — strings, ints, lists

## Notes
- No docs change needed (internal fallback behavior)
- Existing tests still pass