### PR TITLE
fix(acp): preserve falsey tool results in step callback

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -135,7 +135,7 @@ def make_step_cb(
 
                 if isinstance(tool_info, dict):
                     tool_name = tool_info.get("name") or tool_info.get("function_name")
-                    result = tool_info.get("result") or tool_info.get("output")
+                    result = tool_info.get("result") if "result" in tool_info else tool_info.get("output")
                 elif isinstance(tool_info, str):
                     tool_name = tool_info
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -246,6 +246,63 @@ class TestStepCallback:
 
         mock_btc.assert_called_once_with("tc-aaa", "web_search", result=None)
 
+    def test_empty_string_result_preserved(self, mock_conn, event_loop_fixture):
+        """Empty string tool result should be preserved, not collapsed to None."""
+        from collections import deque
+
+        tool_call_ids = {"terminal": deque(["tc-empty"])}
+        loop = event_loop_fixture
+
+        cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb(1, [{"name": "terminal", "result": ""}])
+
+        mock_btc.assert_called_once_with("tc-empty", "terminal", result="")
+
+    def test_zero_result_preserved(self, mock_conn, event_loop_fixture):
+        """Zero (0) tool result should be preserved, not collapsed to None."""
+        from collections import deque
+
+        tool_call_ids = {"calculate": deque(["tc-zero"])}
+        loop = event_loop_fixture
+
+        cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb(1, [{"name": "calculate", "result": 0}])
+
+        mock_btc.assert_called_once_with("tc-zero", "calculate", result="0")
+
+    def test_output_fallback_when_no_result_key(self, mock_conn, event_loop_fixture):
+        """When 'result' key is missing, fall back to 'output' key."""
+        from collections import deque
+
+        tool_call_ids = {"terminal": deque(["tc-out"])}
+        loop = event_loop_fixture
+
+        cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids)
+
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            future = MagicMock(spec=Future)
+            future.result.return_value = None
+            mock_rcts.return_value = future
+
+            cb(1, [{"name": "terminal", "output": "some output"}])
+
+        mock_btc.assert_called_once_with("tc-out", "terminal", result="some output")
+
 
 # ---------------------------------------------------------------------------
 # Message callback


### PR DESCRIPTION
## Summary
- Fix `make_step_cb()` to preserve valid falsey tool results (`""`, `0`, `False`) instead of collapsing them to `None`
- Use explicit key presence check instead of Python `or` operator for fallback

Fixes #10845.

## Root Cause
`make_step_cb()` used Python's `or` operator to fall back between keys:
```python
result = tool_info.get('result') or tool_info.get('output')
```

This treats any falsey value as \missing\ and falls through to the next key. For tool results like `""`, `0`, or `False`, the actual result was silently replaced with `None` (or the value from `output` if it existed).

## Fix
One-line change — check key existence explicitly:
```python
result = tool_info.get('result') if 'result' in tool_info else tool_info.get('output')
```

This preserves the actual value when `result` key is present (even if falsey), and only falls back to `output` when `result` is truly absent from the dict.

## Validation
```
pytest -q -o addopts= tests/acp/test_events.py -k TestStepCallback
8 passed, 8 deselected
```

New tests:
- `test_empty_string_result_preserved` — `{"result": ""}` → `result=""`
- `test_zero_result_preserved` — `{"result": 0}` → `result="0"`
- `test_output_fallback_when_no_result_key` — `{"output": ".."}` → falls back correctly

## Notes
- No docs change needed (internal callback behavior)
- All existing tests continue to pass