### PR TITLE
test(memory): remove dead import of non-existent BuiltinMemoryProvider

### DIFF
--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -109,11 +109,18 @@ class TestMemoryManagerUserIdThreading:
         assert "user_id" not in p._init_kwargs
 
     def test_multiple_providers_all_receive_user_id(self):
-        from agent.builtin_memory_provider import BuiltinMemoryProvider
+        """Both the builtin provider and the one external provider must receive user_id.
 
+        ``MemoryManager`` identifies the builtin provider by ``provider.name ==
+        "builtin"`` and caps the registry at one non-builtin provider.  There
+        is no importable ``BuiltinMemoryProvider`` concrete class in the tree
+        — the built-in role is wired up through the manager's own bookkeeping.
+        For this test we just need *two* providers sharing the registry and
+        to assert both see the user_id on initialize, so use a second
+        RecordingProvider under the reserved "builtin" name.
+        """
         mgr = MemoryManager()
-        # Use builtin + one external (MemoryManager only allows one external)
-        builtin = BuiltinMemoryProvider()
+        builtin = RecordingProvider("builtin")
         ext = RecordingProvider("external")
         mgr.add_provider(builtin)
         mgr.add_provider(ext)
@@ -124,6 +131,8 @@ class TestMemoryManagerUserIdThreading:
             user_id="slack_U12345",
         )
 
+        assert builtin._init_kwargs.get("user_id") == "slack_U12345"
+        assert builtin._init_kwargs.get("platform") == "slack"
         assert ext._init_kwargs.get("user_id") == "slack_U12345"
         assert ext._init_kwargs.get("platform") == "slack"
 


### PR DESCRIPTION
## Problem

`tests/agent/test_memory_user_id.py::TestMemoryManagerUserIdThreading::test_multiple_providers_all_receive_user_id` fails at collection/import on v2026.4.13:

```
ModuleNotFoundError: No module named 'agent.builtin_memory_provider'
```

from the test's own `from agent.builtin_memory_provider import BuiltinMemoryProvider` line.

## Root cause

There is no `agent.builtin_memory_provider` module anywhere in the tree, and no concrete `BuiltinMemoryProvider` class either:

```
$ git grep -n 'class BuiltinMemoryProvider' -- '*.py'
(no output)

$ git grep -n 'BuiltinMemoryProvider' -- '*.py'
tests/agent/test_memory_user_id.py:112:        from agent.builtin_memory_provider import BuiltinMemoryProvider
tests/agent/test_memory_user_id.py:116:        builtin = BuiltinMemoryProvider()
agent/memory_manager.py:7:The BuiltinMemoryProvider is always registered first and cannot be removed.
agent/memory_manager.py:14:    self._memory_manager.add_provider(BuiltinMemoryProvider(...))
agent/memory_provider.py:13:  1. Built-in: BuiltinMemoryProvider — always present, not removable.
```

The references in `agent/memory_manager.py` and `agent/memory_provider.py` are docstring prose. The actual "builtin" role is enforced by `MemoryManager` at runtime:

- `add_provider()` inspects `provider.name`
- If `name == "builtin"`, the provider is marked as the internal entry
- Only one additional non-builtin provider is accepted

## Fix

Test-only. Drop the import of the non-existent `BuiltinMemoryProvider` class and register a second `RecordingProvider` under the reserved `"builtin"` name instead. This gives the test exactly what it was actually trying to assert — two providers sharing the registry, with user_id reaching both — without depending on a class that does not exist.

I also extended the assertions to cover the builtin slot as well, since the test name claims "all providers" receive user_id.

## Verification

```
$ pytest -q tests/agent/test_memory_user_id.py::TestMemoryManagerUserIdThreading
4 passed in 0.03s
```

Down from 1 failing to 0.
