### PR TITLE
test(cli): initialise _execution_thread_id in the manually-built parent agent

### DIFF
--- a/tests/cli/test_cli_interrupt_subagent.py
+++ b/tests/cli/test_cli_interrupt_subagent.py
@@ -38,10 +38,15 @@ class TestCLISubagentInterrupt(unittest.TestCase):
         child_started = threading.Event()
         child_api_call_count = 0
 
-        # Create a real-enough parent agent
+        # Create a real-enough parent agent.  We bypass AIAgent.__init__ so
+        # the fake parent doesn't need real credentials/clients, but that
+        # means we have to set every attribute interrupt() and the delegate
+        # path touch — including the execution-thread sentinel added in
+        # commit-history so that _set_interrupt() can scope correctly.
         parent = AIAgent.__new__(AIAgent)
         parent._interrupt_requested = False
         parent._interrupt_message = None
+        parent._execution_thread_id = None
         parent._active_children = []
         parent._active_children_lock = threading.Lock()
         parent.quiet_mode = True


### PR DESCRIPTION
## Problem

`tests/cli/test_cli_interrupt_subagent.py::TestCLISubagentInterrupt::test_full_delegate_interrupt_flow` fails on v2026.4.13:

```
AttributeError: 'AIAgent' object has no attribute '_execution_thread_id'
  run_agent.py:2902: in interrupt
    _set_interrupt(True, self._execution_thread_id)
  tests/cli/test_cli_interrupt_subagent.py:149: parent.interrupt("Hey stop that")
```

## Root cause

`AIAgent.__init__` sets `self._execution_thread_id: int | None = None` (run_agent.py:748). `AIAgent.interrupt()` reads it at run_agent.py:2902 to scope the cross-thread interrupt signal correctly.

`test_full_delegate_interrupt_flow` builds its parent agent with `AIAgent.__new__(AIAgent)` — bypassing `__init__` — so it can assemble a minimal fake that doesn't need real credentials/clients. It then manually initialises every attribute that `interrupt()` and the delegate path touch:

```python
parent = AIAgent.__new__(AIAgent)
parent._interrupt_requested = False
parent._interrupt_message = None
parent._active_children = []
...
```

`_execution_thread_id` was missing from that list, so the subsequent `parent.interrupt("Hey stop that")` raises AttributeError before it can propagate to the child agent.

Upstream CI may silently "pass" if the pytest collector happens to short-circuit earlier on unrelated failures, but locally on v2026.4.13 this is a clean, reproducible failure.

## Fix

Test-only. Add `parent._execution_thread_id = None` to the manual-init block. `None` is the correct sentinel because `_set_interrupt(True, None)` interrupts every thread, which matches the test's intent (there is no real `run_conversation` to register a specific thread id).

## Verification

```
$ pytest -q tests/cli/test_cli_interrupt_subagent.py
1 passed in 1.27s
```

Down from 1 failing to 0.
