### PR TITLE
fix(slack): keep slash commands in their Slack conversation scope

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1491,6 +1491,7 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = command.get("user_id", "")
         channel_id = command.get("channel_id", "")
         team_id = command.get("team_id", "")
+        container = command.get("container") or {}
 
         # Track which workspace owns this channel
         if team_id and channel_id:
@@ -1511,10 +1512,21 @@ class SlackAdapter(BasePlatformAdapter):
         else:
             text = "/help"
 
+        # Match normal Slack message routing as closely as the slash payload
+        # allows so session-scoped commands (/model, /new, /reasoning, ...)
+        # attach to the same conversation instead of a synthetic DM session.
+        thread_ts = (
+            command.get("thread_ts")
+            or container.get("thread_ts")
+            or container.get("message_ts")
+            or ""
+        )
+        chat_type = "dm" if channel_id.startswith("D") else "group"
         source = self.build_source(
             chat_id=channel_id,
-            chat_type="dm",  # Slash commands are always in DM-like context
+            chat_type=chat_type,
             user_id=user_id,
+            thread_id=thread_ts,
         )
 
         event = MessageEvent(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -22,6 +22,7 @@ from gateway.platforms.base import (
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
 )
+from gateway.session import build_session_key
 
 
 # ---------------------------------------------------------------------------
@@ -1386,6 +1387,43 @@ class TestSlashCommands:
         await adapter._handle_slash_command(command)
         msg = adapter.handle_message.call_args[0][0]
         assert msg.text == "/reasoning"
+
+    @pytest.mark.asyncio
+    async def test_channel_command_uses_group_session_scope(self, adapter):
+        command = {"text": "model gpt-4.1", "user_id": "U1", "channel_id": "C1"}
+
+        await adapter._handle_slash_command(command)
+
+        msg = adapter.handle_message.call_args[0][0]
+        assert msg.source.chat_type == "group"
+        assert msg.source.thread_id is None
+        assert build_session_key(msg.source) == "agent:main:slack:group:C1:U1"
+
+    @pytest.mark.asyncio
+    async def test_dm_command_keeps_dm_session_scope(self, adapter):
+        command = {"text": "model gpt-4.1", "user_id": "U1", "channel_id": "D1"}
+
+        await adapter._handle_slash_command(command)
+
+        msg = adapter.handle_message.call_args[0][0]
+        assert msg.source.chat_type == "dm"
+        assert build_session_key(msg.source) == "agent:main:slack:dm:D1"
+
+    @pytest.mark.asyncio
+    async def test_command_preserves_thread_context_from_container(self, adapter):
+        command = {
+            "text": "model gpt-4.1",
+            "user_id": "U1",
+            "channel_id": "C1",
+            "container": {"thread_ts": "171.000"},
+        }
+
+        await adapter._handle_slash_command(command)
+
+        msg = adapter.handle_message.call_args[0][0]
+        assert msg.source.chat_type == "group"
+        assert msg.source.thread_id == "171.000"
+        assert build_session_key(msg.source) == "agent:main:slack:group:C1:171.000"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route Slack slash commands with the same channel/thread semantics as normal Slack messages
- stop forcing every slash command into a synthetic DM session
- preserve thread context from Slack slash payloads so session-scoped commands target the active thread when present

## Why
Issue #10688 reports that `/model` in Slack can appear to switch successfully but later turns still use the old provider/model. One concrete failure mode is session drift: the slash command writes its override into a DM-shaped session key while subsequent Slack replies resolve under the real channel or thread session.

This change fixes that mismatch by making slash commands build the same session source shape that normal Slack messages already use.

## Scope
This PR intentionally addresses the Slack session-scope part of #10688. It does not claim to fix the dashboard provider-field UX.

Addresses #10688

## Tests
- `python3 -m pytest -o addopts= tests/gateway/test_slack.py -k "SlashCommands or group_session_scope or dm_session_scope or preserves_thread_context"`
- `python3 -m pytest -o addopts= tests/gateway/test_session_model_override_routing.py tests/gateway/test_model_switch_persistence.py`
- `python3 -m pytest -o addopts= tests/gateway/test_session.py -k "distinct_dm_chat_ids_get_distinct_session_keys or group_sessions_are_isolated_per_user_when_user_id_present or group_thread_sessions_are_shared_by_default"`