### PR TITLE
Handle null display config in skin initialization

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -709,6 +709,8 @@ def init_skin_from_config(config: dict) -> None:
     Call this once during CLI init with the loaded config dict.
     """
     display = config.get("display", {})
+    if not isinstance(display, dict):
+        display = {}
     skin_name = display.get("skin", "default")
     if isinstance(skin_name, str) and skin_name.strip():
         set_active_skin(skin_name.strip())

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -152,6 +152,16 @@ class TestSkinManagement:
         init_skin_from_config({})
         assert get_active_skin_name() == "default"
 
+    def test_init_skin_from_null_display(self):
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        init_skin_from_config({"display": None})
+        assert get_active_skin_name() == "default"
+
+    def test_init_skin_from_non_dict_display(self):
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        init_skin_from_config({"display": "broken"})
+        assert get_active_skin_name() == "default"
+
 
 class TestUserSkins:
     def test_load_user_skin_from_yaml(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

`init_skin_from_config()` assumed `config["display"]` was always a dict. If a config file contained `display: null` or another malformed value, CLI startup crashed before skin fallback logic could run.

This normalizes non-dict `display` values to an empty mapping so skin initialization falls back to `default` instead of raising `AttributeError`.

## What changed

- guard `display` in `init_skin_from_config()` so only dict values are read
- added regression tests for `display: null` and other non-dict values

## Validation

- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_skin_engine.py -q`
- `source venv/bin/activate && python -m pytest tests/test_cli_skin_integration.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

The targeted skin tests passed. The full suite is still red in this environment with unrelated existing failures (`60 failed, 11788 passed, 98 skipped, 60 errors`), mostly in ACP, Discord, and web server coverage.

Fixes #10846
