### PR TITLE
fix(acp): persist explicit empty history resets

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -443,7 +443,7 @@ class HermesACPAgent(acp.Agent):
             logger.exception("Executor error for session %s", session_id)
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
+        if "messages" in result:
             state.history = result["messages"]
             # Persist updated history so sessions survive process restarts.
             self.session_manager.save_session(session_id)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -399,6 +399,29 @@ class TestPrompt:
         assert state.history == expected_history
 
     @pytest.mark.asyncio
+    async def test_prompt_can_clear_history_when_agent_returns_empty_messages(self, agent):
+        """An explicit empty transcript should replace stale history."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [{"role": "user", "content": "old"}]
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "cleared",
+            "messages": [],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        with patch.object(agent.session_manager, "save_session") as mock_save:
+            prompt = [TextContentBlock(type="text", text="reset")]
+            await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert state.history == []
+        mock_save.assert_called_once_with(new_resp.session_id)
+
+    @pytest.mark.asyncio
     async def test_prompt_sends_final_message_update(self, agent):
         """The final response should be sent as an AgentMessageChunk."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## Summary
- treat `messages=[]` from `run_conversation()` as an explicit transcript update
- replace stale ACP session history when an agent intentionally clears the conversation
- persist the cleared state so a restart does not resurrect the old transcript

## Why
Issue #10844 reports that ACP sessions keep stale history because `HermesACPAgent.prompt()` only updates state when `result.get("messages")` is truthy. That collapses two different cases:
- no `messages` key was returned
- `messages` was returned and is intentionally empty

This patch distinguishes those cases and adds a regression test for clearing a non-empty history down to `[]`.

Fixes #10844

## Tests
- `.venv/bin/python -m pytest -o addopts= tests/acp/test_server.py`