### PR TITLE
fix(cron): Load .env file to fix authentication error for scheduled jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+from dotenv import load_dotenv
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -57,6 +58,9 @@ SILENT_MARKER = "[SILENT]"
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
+
+# Load environment variables from .env file for cron jobs
+load_dotenv(_hermes_home / ".env")
 
 # File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
 _LOCK_DIR = _hermes_home / "cron"


### PR DESCRIPTION
## What does this PR do?

Fixes `401 AuthenticationError: API key format is incorrect` errors for scheduled cron jobs, even when interactive sessions work correctly. The root cause is that the cron scheduler process was not loading the `.env` file from the Hermes home directory, so it was missing required API key and provider configuration environment variables that regular interactive sessions have access to. This approach ensures cron runs with the exact same environment context as normal sessions, eliminating configuration inconsistencies between interactive and scheduled execution.

## Related Issue

<!-- If you created an issue for this bug, fill in the issue number below, otherwise you can leave it as is -->
Fixes #

## Type of Change

<!-- Check the one that applies. -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added `python-dotenv` import to `cron/scheduler.py`
- Added `.env` file loading logic after resolving the Hermes home directory is initialized in `cron/scheduler.py`
- Ensures cron processes have identical environment variables as interactive sessions

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure valid LLM API keys in your `~/.hermes/.env` file and verify interactive sessions work correctly
2. Create a cron job that requires calling LLM APIs (e.g. `hermes cron create "say hello" --in 1m`)
3. Wait for the job to execute - it will run successfully without 401 authentication errors, while previously it would fail with the API call.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.) - `fix(cron): Load .env file to fix authentication error for scheduled jobs`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.x

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - This change works cross-platform as dotenv handles all OS paths correctly
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix, cron job failed with:
```
2026-04-16 13:15:50,604 ERROR [cron_8a361a8435ac] root: Non-retryable client error: Error code: 401 - {'error': {'code': 'AuthenticationError', 'message': 'The API key format is incorrect.'}}
```

After fix, cron job executes successfully, calls API correctly, and delivers messages as expected.