### PR TITLE
fix: honor custom provider context overrides for display and runtime

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4538,15 +4538,11 @@ class HermesCLI:
         _cprint(f"    Provider: {provider_label}")
 
         mi = result.model_info
-        if mi:
-            if mi.context_window:
-                _cprint(f"    Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                _cprint(f"    Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                _cprint(f"    Cost: {mi.format_cost()}")
-            _cprint(f"    Capabilities: {mi.format_capabilities()}")
-        else:
+        if result.display_context_length:
+            _cprint(f"    Context: {result.display_context_length:,} tokens")
+        elif mi and mi.context_window:
+            _cprint(f"    Context: {mi.context_window:,} tokens")
+        elif not mi:
             try:
                 from agent.model_metadata import get_model_context_length
                 ctx = get_model_context_length(
@@ -4558,6 +4554,13 @@ class HermesCLI:
                 _cprint(f"    Context: {ctx:,} tokens")
             except Exception:
                 pass
+
+        if mi:
+            if mi.max_output:
+                _cprint(f"    Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                _cprint(f"    Cost: {mi.format_cost()}")
+            _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
         cache_enabled = (
             ("openrouter" in (result.base_url or "").lower() and "claude" in result.new_model.lower())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4421,9 +4421,11 @@ class GatewayRunner:
                         lines = [f"Model switched to `{result.new_model}`"]
                         lines.append(f"Provider: {plabel}")
                         mi = result.model_info
+                        if result.display_context_length:
+                            lines.append(f"Context: {result.display_context_length:,} tokens")
+                        elif mi and mi.context_window:
+                            lines.append(f"Context: {mi.context_window:,} tokens")
                         if mi:
-                            if mi.context_window:
-                                lines.append(f"Context: {mi.context_window:,} tokens")
                             if mi.max_output:
                                 lines.append(f"Max output: {mi.max_output:,} tokens")
                             if mi.has_cost_data():
@@ -4558,15 +4560,11 @@ class GatewayRunner:
 
         # Rich metadata from models.dev
         mi = result.model_info
-        if mi:
-            if mi.context_window:
-                lines.append(f"Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                lines.append(f"Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                lines.append(f"Cost: {mi.format_cost()}")
-            lines.append(f"Capabilities: {mi.format_capabilities()}")
-        else:
+        if result.display_context_length:
+            lines.append(f"Context: {result.display_context_length:,} tokens")
+        elif mi and mi.context_window:
+            lines.append(f"Context: {mi.context_window:,} tokens")
+        elif not mi:
             try:
                 from agent.model_metadata import get_model_context_length
                 ctx = get_model_context_length(
@@ -4578,6 +4576,12 @@ class GatewayRunner:
                 lines.append(f"Context: {ctx:,} tokens")
             except Exception:
                 pass
+        if mi:
+            if mi.max_output:
+                lines.append(f"Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                lines.append(f"Cost: {mi.format_cost()}")
+            lines.append(f"Capabilities: {mi.format_capabilities()}")
 
         # Cache notice
         cache_enabled = (

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -291,13 +291,17 @@ def _resolve_custom_provider_display_context_length(
 
         models = entry.get("models")
         if not isinstance(models, dict):
-            return None
+            continue
 
         model_cfg = models.get(model_name)
         if not isinstance(model_cfg, dict):
-            return None
+            continue
 
-        return _coerce_positive_int(model_cfg.get("context_length"))
+        context_length = _coerce_positive_int(model_cfg.get("context_length"))
+        if context_length is None:
+            continue
+
+        return context_length
 
     return None
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -240,7 +240,66 @@ class ModelSwitchResult:
     resolved_via_alias: str = ""
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
+    display_context_length: Optional[int] = None
     is_global: bool = False
+
+
+def _coerce_positive_int(value) -> Optional[int]:
+    """Return a positive int or None for invalid/empty values."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _resolve_custom_provider_display_context_length(
+    *,
+    target_provider: str,
+    new_model: str,
+    base_url: str,
+    custom_providers: list | None,
+) -> Optional[int]:
+    """Return per-model context_length from custom_providers for display."""
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_norm = (target_provider or "").strip().lower()
+    model_name = (new_model or "").strip()
+    base_norm = (base_url or "").strip().rstrip("/")
+    if not model_name:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+
+        display_name = (entry.get("name") or "").strip()
+        entry_name_norm = display_name.lower()
+        entry_slug = custom_provider_slug(display_name) if display_name else ""
+        entry_url = (
+            entry.get("base_url", "")
+            or entry.get("url", "")
+            or entry.get("api", "")
+            or ""
+        ).strip().rstrip("/")
+
+        provider_match = bool(target_norm) and target_norm in {entry_name_norm, entry_slug}
+        url_match = bool(base_norm and entry_url and base_norm == entry_url)
+        if not provider_match and not url_match:
+            continue
+
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            return None
+
+        model_cfg = models.get(model_name)
+        if not isinstance(model_cfg, dict):
+            return None
+
+        return _coerce_positive_int(model_cfg.get("context_length"))
+
+    return None
 
 
 @dataclass
@@ -722,6 +781,12 @@ def switch_model(
 
     # --- Get full model info from models.dev ---
     model_info = get_model_info(target_provider, new_model)
+    display_context_length = _resolve_custom_provider_display_context_length(
+        target_provider=target_provider,
+        new_model=new_model,
+        base_url=base_url,
+        custom_providers=custom_providers,
+    )
 
     # --- Collect warnings ---
     warnings: list[str] = []
@@ -745,6 +810,7 @@ def switch_model(
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,
         model_info=model_info,
+        display_context_length=display_context_length,
         is_global=is_global,
     )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1538,6 +1538,68 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
     
+    def _get_runtime_config_context_length(self) -> int | None:
+        """Resolve the active model's explicit context_length override.
+
+        Keep runtime model switches aligned with the startup path: prefer
+        per-model overrides from ``custom_providers`` for the active provider /
+        base_url + model, otherwise fall back to the persisted top-level
+        ``model.context_length`` override captured at init time.
+        """
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            from hermes_cli.providers import custom_provider_slug
+
+            cfg = load_config()
+            custom_providers = get_compatible_custom_providers(cfg)
+            if isinstance(custom_providers, list):
+                current_provider = (self.provider or "").strip().lower()
+                current_url = (self.base_url or "").rstrip("/")
+
+                for match_mode in ("provider", "url"):
+                    for entry in custom_providers:
+                        if not isinstance(entry, dict):
+                            continue
+
+                        display_name = (entry.get("name") or "").strip()
+                        entry_name = display_name.lower()
+                        entry_slug = custom_provider_slug(display_name) if display_name else ""
+                        entry_url = (
+                            entry.get("base_url", "")
+                            or entry.get("url", "")
+                            or entry.get("api", "")
+                            or ""
+                        ).rstrip("/")
+
+                        provider_match = bool(current_provider) and current_provider in {entry_name, entry_slug}
+                        url_match = bool(current_url and entry_url and current_url == entry_url)
+                        if match_mode == "provider" and not provider_match:
+                            continue
+                        if match_mode == "url" and provider_match:
+                            continue
+                        if match_mode == "url" and not url_match:
+                            continue
+
+                        models = entry.get("models", {})
+                        if not isinstance(models, dict):
+                            continue
+                        model_cfg = models.get(self.model, {})
+                        if not isinstance(model_cfg, dict):
+                            continue
+
+                        context_length = model_cfg.get("context_length")
+                        if context_length is None:
+                            continue
+
+                        try:
+                            return int(context_length)
+                        except (TypeError, ValueError):
+                            continue
+        except Exception:
+            pass
+
+        return getattr(self, "_config_context_length", None)
+
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
 
@@ -1619,7 +1681,7 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=self._get_runtime_config_context_length(),
             )
             self.context_compressor.update_model(
                 model=self.model,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1592,9 +1592,14 @@ class AIAgent:
                             continue
 
                         try:
-                            return int(context_length)
+                            parsed = int(context_length)
                         except (TypeError, ValueError):
                             continue
+
+                        if parsed <= 0:
+                            continue
+
+                        return parsed
         except Exception:
             pass
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -142,6 +142,50 @@ def test_switch_model_sets_display_context_length_from_custom_provider_models(mo
     assert result.display_context_length == 524288
 
 
+def test_switch_model_display_context_skips_invalid_matching_entry(monkeypatch):
+    """Display context lookup should continue past invalid matching entries."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "***",
+            "base_url": "http://127.0.0.1:4141/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="rotator-openrouter-coding",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        current_api_key="",
+        explicit_provider="custom:local-(127.0.0.1:4141)",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:4141)",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "models": {
+                    "rotator-openrouter-coding": {"context_length": 0}
+                },
+            },
+            {
+                "name": "Local (127.0.0.1:4141)",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "models": {
+                    "rotator-openrouter-coding": {"context_length": 524288}
+                },
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.display_context_length == 524288
+
+
 def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     """Multiple custom_providers entries sharing a name should produce one row
     with all models collected, not N duplicate rows."""

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -104,6 +104,44 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.api_key == "no-key-required"
 
 
+def test_switch_model_sets_display_context_length_from_custom_provider_models(monkeypatch):
+    """/model confirmation should prefer custom_providers per-model context_length."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "***",
+            "base_url": "http://127.0.0.1:4141/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="rotator-openrouter-coding",
+        current_provider="openai-codex",
+        current_model="gpt-5.4",
+        current_base_url="https://chatgpt.com/backend-api/codex",
+        current_api_key="",
+        explicit_provider="custom:local-(127.0.0.1:4141)",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:4141)",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "model": "rotator-openrouter-coding",
+                "models": {
+                    "rotator-openrouter-coding": {"context_length": 524288}
+                },
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.display_context_length == 524288
+
+
 def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     """Multiple custom_providers entries sharing a name should produce one row
     with all models collected, not N duplicate rows."""

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -101,3 +101,39 @@ def test_switch_model_prefers_custom_provider_model_context_length(mock_ctx_len)
     mock_ctx_len.assert_called_once()
     call_kwargs = mock_ctx_len.call_args.kwargs
     assert call_kwargs.get("config_context_length") == 524_288
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=524_288)
+def test_switch_model_runtime_context_skips_non_positive_override(mock_ctx_len):
+    """Runtime /model switches should skip non-positive overrides and continue scanning."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+
+    custom_providers = [
+        {
+            "name": "YunfeiPlus",
+            "base_url": "https://api.example.com/v1",
+            "models": {
+                "gpt-5.4": {"context_length": 0}
+            },
+        },
+        {
+            "name": "YunfeiPlus",
+            "base_url": "https://api.example.com/v1",
+            "models": {
+                "gpt-5.4": {"context_length": 524288}
+            },
+        },
+    ]
+
+    with patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=custom_providers):
+        agent.switch_model(
+            "gpt-5.4",
+            "custom:yunfeiplus",
+            api_key="sk-new",
+            base_url="https://api.example.com/v1",
+        )
+
+    mock_ctx_len.assert_called_once()
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") == 524_288

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -72,3 +72,32 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=524_288)
+def test_switch_model_prefers_custom_provider_model_context_length(mock_ctx_len):
+    """Runtime /model switches should use per-model custom_providers overrides."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+
+    custom_providers = [
+        {
+            "name": "YunfeiPlus",
+            "base_url": "https://api.example.com/v1",
+            "models": {
+                "gpt-5.4": {"context_length": 524288}
+            },
+        }
+    ]
+
+    with patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=custom_providers):
+        agent.switch_model(
+            "gpt-5.4",
+            "custom:yunfeiplus",
+            api_key="sk-new",
+            base_url="https://api.example.com/v1",
+        )
+
+    mock_ctx_len.assert_called_once()
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") == 524_288


### PR DESCRIPTION
## Summary
- honor custom provider context overrides in display logic
- honor the same override path in runtime context resolution
- include regression coverage for custom provider context display/runtime behavior

## Notes
- opened as a draft to verify the fork/push/create-PR flow with the refreshed GitHub token