### PR TITLE
fix(memory): warn when loaded memory exceeds char limit

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -208,6 +208,34 @@ class TestMemoryStorePersistence:
         assert len(store.memory_entries) == 2
 
 
+class TestMemoryStoreCharLimitOnLoad:
+    def test_warns_when_loaded_content_exceeds_limit(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("x" * 2500)  # exceeds default 2200
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore()
+            store.load_from_disk()
+
+        assert "exceeds char limit" in caplog.text
+        # Content still loaded (no truncation)
+        assert len(store.memory_entries) == 1
+
+    def test_no_warning_when_under_limit(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("short entry")
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore()
+            store.load_from_disk()
+
+        assert "exceeds char limit" not in caplog.text
+
+
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):
         store.add("memory", "loaded at start")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -503,6 +503,45 @@ class TestMemoryStorePersistence:
         assert len(store.memory_entries) == 2
 
 
+class TestMemoryStoreCharLimitOnLoad:
+    @pytest.mark.parametrize(
+        "filename,target,label",
+        [
+            ("MEMORY.md", "memory", "MEMORY.md"),
+            ("USER.md", "user", "USER.md"),
+        ],
+    )
+    def test_warns_when_loaded_content_exceeds_limit(
+        self, tmp_path, monkeypatch, caplog, filename, target, label
+    ):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        # 600 chars exceeds both fixture-style limits (memory=500, user=300)
+        (tmp_path / filename).write_text("x" * 600, encoding="utf-8")
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+            store.load_from_disk()
+
+        assert "exceeds char limit" in caplog.text
+        assert label in caplog.text
+        # Content still loaded (no truncation) — snapshot sanitization applies
+        # separately at snapshot-build time.
+        assert len(store._entries_for(target)) == 1
+
+    def test_no_warning_when_under_limit(self, tmp_path, monkeypatch, caplog):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        (tmp_path / "MEMORY.md").write_text("short entry", encoding="utf-8")
+        (tmp_path / "USER.md").write_text("short user note", encoding="utf-8")
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="tools.memory_tool"):
+            store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+            store.load_from_disk()
+
+        assert "exceeds char limit" not in caplog.text
+
+
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):
         store.add("memory", "loaded at start")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -133,6 +133,17 @@ class MemoryStore:
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
 
+        # Warn if loaded content exceeds char limits (can happen from external writes)
+        for target in ("memory", "user"):
+            count = self._char_count(target)
+            limit = self._char_limit(target)
+            if count > limit:
+                logger.warning(
+                    "%s.md exceeds char limit on load: %d/%d chars (%.0f%%). "
+                    "Content will be injected as-is but further additions will be blocked.",
+                    target.upper(), count, limit, count / limit * 100,
+                )
+
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {
             "memory": self._render_block("memory", self.memory_entries),

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -202,6 +202,21 @@ class MemoryStore:
         self.memory_entries = list(dict.fromkeys(self.memory_entries))
         self.user_entries = list(dict.fromkeys(self.user_entries))
 
+        # Warn if loaded content exceeds char limits (can happen from external
+        # writes).  Entries remain loaded — the snapshot below still passes
+        # through normal sanitization — but further additions will be blocked
+        # until the store is back under its limit.
+        for target in ("memory", "user"):
+            count = self._char_count(target)
+            limit = self._char_limit(target)
+            if count > limit:
+                logger.warning(
+                    "%s.md exceeds char limit on load: %d/%d chars (%.0f%%). "
+                    "Entries remain loaded (snapshot sanitization still applies); "
+                    "further additions will be blocked until under the limit.",
+                    target.upper(), count, limit, count / limit * 100,
+                )
+
         # Sanitize entries for the system-prompt snapshot only.  Live state
         # (memory_entries / user_entries) keeps the raw text so the user
         # can see + remove poisoned entries via the memory tool.


### PR DESCRIPTION
## What does this PR do?

Add a warning log when `load_from_disk` detects that MEMORY.md or USER.md content exceeds the configured char limit. Previously, externally written files exceeding limits were silently accepted.

## Related Issue

Fixes #10877

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`: After deduplication in `load_from_disk`, check `_char_count` vs `_char_limit` for both stores. Log `logger.warning()` if exceeded. No truncation (avoids data loss), but the over-budget state is now visible in logs.

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My PR contains **only** changes related to this fix (1 file, 11 lines added)
- [x] I've tested on my platform: macOS 15, Python 3.12.8