### PR TITLE
fix(memory): handle BOM and non-UTF-8 bytes in memory files

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -208,6 +208,28 @@ class TestMemoryStorePersistence:
         assert len(store.memory_entries) == 2
 
 
+class TestMemoryStoreEncoding:
+    def test_bom_stripped_on_load(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("\ufeffUser prefers dark mode", encoding="utf-8")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        assert len(store.memory_entries) == 1
+        assert store.memory_entries[0].startswith("User")  # no BOM
+
+    def test_non_utf8_loads_with_replacement(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_bytes(b"User prefers caf\xe9 mode")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        assert len(store.memory_entries) == 1
+        assert "User prefers caf" in store.memory_entries[0]  # loaded, not empty
+
+
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):
         store.add("memory", "loaded at start")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -524,6 +524,51 @@ class TestMemoryStoreEncoding:
         assert len(store.memory_entries) == 1
         assert "User prefers caf" in store.memory_entries[0]  # loaded, not empty
 
+    # ── Mutations must survive the same files load survives ──
+    # replace/remove/apply_batch call _detect_external_drift() BEFORE
+    # _read_file() (via _reload_target), so drift detection needs the same
+    # decoding policy or the mutation crashes before the resilient reader runs.
+
+    def test_replace_succeeds_on_bom_file(self, store):
+        store.add("memory", "User likes brevity.")
+        path = store._path_for("memory")
+        # External writer (e.g. Windows editor) re-saves the file with a BOM.
+        path.write_bytes(b"\xef\xbb\xbf" + path.read_bytes())
+
+        result = store.replace("memory", "User likes", "User prefers concise.")
+
+        assert result["success"] is True
+        # BOM neither crashes the mutation nor false-positives the drift guard.
+        assert "drift_backup" not in result
+        assert "User prefers concise." in path.read_text(encoding="utf-8")
+
+    def test_remove_succeeds_on_invalid_byte_file(self, store):
+        store.add("memory", "Keep this entry.")
+        store.add("memory", "Drop this entry.")
+        path = store._path_for("memory")
+        # External writer appends latin-1 bytes into an existing entry.
+        path.write_bytes(path.read_bytes().replace(b"Drop this entry.", b"Drop this caf\xe9 entry."))
+
+        result = store.remove("memory", "Drop this")
+
+        assert result["success"] is True  # no UnicodeDecodeError
+        remaining = path.read_text(encoding="utf-8")
+        assert "Keep this entry." in remaining
+        assert "Drop this" not in remaining
+
+    def test_batch_succeeds_on_bom_and_invalid_bytes(self, store):
+        store.add("memory", "Original entry.")
+        path = store._path_for("memory")
+        path.write_bytes(b"\xef\xbb\xbfOriginal caf\xe9 entry.")
+
+        result = store.apply_batch(
+            "memory",
+            [{"action": "replace", "old_text": "Original caf", "content": "Rewritten caf"}],
+        )
+
+        assert result["success"] is True
+        assert "Rewritten caf" in path.read_text(encoding="utf-8")
+
 
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -503,6 +503,28 @@ class TestMemoryStorePersistence:
         assert len(store.memory_entries) == 2
 
 
+class TestMemoryStoreEncoding:
+    def test_bom_stripped_on_load(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_text("\ufeffUser prefers dark mode", encoding="utf-8")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        assert len(store.memory_entries) == 1
+        assert store.memory_entries[0].startswith("User")  # no BOM
+
+    def test_non_utf8_loads_with_replacement(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        mem_file = tmp_path / "MEMORY.md"
+        mem_file.write_bytes(b"User prefers caf\xe9 mode")
+
+        store = MemoryStore()
+        store.load_from_disk()
+        assert len(store.memory_entries) == 1
+        assert "User prefers caf" in store.memory_entries[0]  # loaded, not empty
+
+
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):
         store.add("memory", "loaded at start")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -416,7 +416,11 @@ class MemoryStore:
         if not path.exists():
             return []
         try:
-            raw = path.read_text(encoding="utf-8")
+            # Use utf-8-sig to auto-strip BOM if present (common on Windows).
+            # Fall back to replacement characters for non-UTF-8 bytes rather
+            # than raising UnicodeDecodeError (which was previously swallowed
+            # by a bare except, silently emptying all memory).
+            raw = path.read_text(encoding="utf-8-sig", errors="replace")
         except (OSError, IOError):
             return []
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -699,7 +699,11 @@ class MemoryStore:
         if not path.exists():
             return []
         try:
-            raw = path.read_text(encoding="utf-8")
+            # Use utf-8-sig to auto-strip BOM if present (common on Windows).
+            # Fall back to replacement characters for non-UTF-8 bytes rather
+            # than raising UnicodeDecodeError (which was previously swallowed
+            # by a bare except, silently emptying all memory).
+            raw = path.read_text(encoding="utf-8-sig", errors="replace")
         except (OSError, IOError):
             return []
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -743,7 +743,13 @@ class MemoryStore:
         if not path.exists():
             return None
         try:
-            raw = path.read_text(encoding="utf-8")
+            # Same decoding policy as _read_file: strip BOM, replace invalid
+            # bytes.  This runs BEFORE _read_file on the replace/remove/batch
+            # paths (via _reload_target), so a strict decode here would raise
+            # UnicodeDecodeError on the exact files _read_file was made
+            # resilient to — crashing the mutation before the resilient
+            # reader ever runs.
+            raw = path.read_text(encoding="utf-8-sig", errors="replace")
         except (OSError, IOError):
             return None
         if not raw.strip():


### PR DESCRIPTION
## What does this PR do?

Change `_read_file` encoding from `utf-8` to `utf-8-sig` (auto-strips BOM) and add `errors="replace"` to handle non-UTF-8 bytes gracefully.

## Related Issue

Fixes #10878, fixes #10879

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py` line 419: `path.read_text(encoding="utf-8-sig", errors="replace")`

**Before:**
- BOM (`\ufeff`) at file start survived into the system prompt, potentially confusing the model
- Non-UTF-8 bytes raised `UnicodeDecodeError`, which was caught by a bare `except Exception: pass` in `run_agent.py:1229`, causing the agent to start with **completely empty memory and no diagnostic**

**After:**
- BOM is auto-stripped by the `utf-8-sig` codec
- Non-UTF-8 bytes are replaced with U+FFFD instead of crashing

## How to Test

```bash
# Test BOM handling
python3 -c "
from pathlib import Path
p = Path.home() / '.hermes' / 'memories' / 'MEMORY.md'
p.write_text('\ufeffUser prefers dark mode', encoding='utf-8')
"
# Start hermes — entry should load without leading BOM character

# Test non-UTF-8 handling
python3 -c "
from pathlib import Path
p = Path.home() / '.hermes' / 'memories' / 'MEMORY.md'
p.write_bytes(b'User prefers caf\xe9 mode')
"
# Start hermes — entry should load with replacement char, not empty memory
```

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My PR contains **only** changes related to this fix (1 file, 5 lines changed)
- [x] I've considered cross-platform impact — BOM is most common on Windows, this fix is platform-neutral
- [x] I've tested on my platform: macOS 15, Python 3.12.8