### PR TITLE
Use gateway systemctl helper in status command

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -360,19 +360,28 @@ def show_status(args):
             print("  Manager:      docker (foreground)")
         else:
             try:
-                from hermes_cli.gateway import get_service_name
+                from hermes_cli.gateway import _run_systemctl, get_service_name
                 _gw_svc = get_service_name()
             except Exception:
+                _run_systemctl = None
                 _gw_svc = "hermes-gateway"
             try:
-                result = subprocess.run(
-                    ["systemctl", "--user", "is-active", _gw_svc],
-                    capture_output=True,
-                    text=True,
-                    timeout=5
-                )
+                if _run_systemctl is not None:
+                    result = _run_systemctl(
+                        ["is-active", _gw_svc],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                else:
+                    result = subprocess.run(
+                        ["systemctl", "--user", "is-active", _gw_svc],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
                 is_active = result.stdout.strip() == "active"
-            except (FileNotFoundError, subprocess.TimeoutExpired):
+            except (FileNotFoundError, subprocess.TimeoutExpired, RuntimeError):
                 is_active = False
             print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
             print("  Manager:      systemd (user)")

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -42,3 +42,51 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_linux_gateway_section_uses_systemctl_helper(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+    import hermes_constants
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setattr(status_mod.sys, "platform", "linux")
+    monkeypatch.setattr(hermes_constants, "is_container", lambda: False, raising=False)
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+
+    calls = []
+
+    def _fake_run_systemctl(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(stdout="active\n")
+
+    monkeypatch.setattr(gateway_mod, "get_service_name", lambda: "hermes-gateway", raising=False)
+    monkeypatch.setattr(gateway_mod, "_run_systemctl", _fake_run_systemctl, raising=False)
+
+    def _unexpected_status_subprocess(*args, **kwargs):
+        cmd = args[0] if args else []
+        if isinstance(cmd, list) and cmd[:2] == ["systemctl", "--user"]:
+            raise AssertionError("show_status should use gateway._run_systemctl for user systemd checks")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", _unexpected_status_subprocess)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert calls == [(
+        ["is-active", "hermes-gateway"],
+        {"capture_output": True, "text": True, "timeout": 5},
+    )]
+    assert "Status:       " in output
+    assert "running" in output
+    assert "Manager:      systemd (user)" in output


### PR DESCRIPTION
## Summary

`hermes status` was checking the Linux user gateway service with a direct `systemctl --user is-active` call. On headless shells where `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` are missing, that path reports the gateway as stopped even when the user service is actually running.

This switches the status command to reuse the existing gateway `systemctl` helper so it gets the same D-Bus environment bootstrapping as `hermes gateway status`.

## What changed

- reused `hermes_cli.gateway._run_systemctl()` in the Linux user-service branch of `show_status()`
- kept the existing direct `systemctl` fallback for import failure, with explicit timeout handling
- added a regression test that asserts `show_status()` uses the gateway helper on Linux non-container status checks

## Validation

- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_status.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_gateway.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_gateway_service.py -q`
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_subprocess_timeouts.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

The targeted tests passed. The full suite is still red in this environment with unrelated existing failures (`58 failed, 11789 passed, 98 skipped, 60 errors`), mostly in ACP, Discord, and web server coverage.

Fixes #10851
