### PR TITLE
Add browser-compatible Codex login to Hermes while keeping device-code as default

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -458,27 +458,23 @@ class CredentialPool:
         return entry
 
     def _sync_codex_entry_from_cli(self, entry: PooledCredential) -> PooledCredential:
-        """Sync an openai-codex pool entry from ~/.codex/auth.json if tokens differ.
-
-        OpenAI OAuth refresh tokens are single-use and rotate on every refresh.
-        When the Codex CLI (or another Hermes profile) refreshes its token,
-        the pool entry's refresh_token becomes stale.  This method detects that
-        by comparing against ~/.codex/auth.json and syncing the fresh pair.
-        """
+        """Sync an openai-codex pool entry from the preferred shared credential source."""
         if self.provider != "openai-codex":
             return entry
         try:
-            cli_tokens = _import_codex_cli_tokens()
-            if not cli_tokens:
+            bundle = auth_mod._load_codex_from_shared_store_first()
+            tokens = bundle.get("tokens") if isinstance(bundle, dict) else None
+            if not isinstance(tokens, dict):
                 return entry
-            cli_refresh = cli_tokens.get("refresh_token", "")
-            cli_access = cli_tokens.get("access_token", "")
-            if cli_refresh and cli_refresh != entry.refresh_token:
-                logger.debug("Pool entry %s: syncing tokens from ~/.codex/auth.json (refresh token changed)", entry.id)
+            shared_refresh = tokens.get("refresh_token", "")
+            shared_access = tokens.get("access_token", "")
+            if shared_refresh and shared_refresh != entry.refresh_token:
+                logger.debug("Pool entry %s: syncing tokens from shared Codex credential", entry.id)
                 updated = replace(
                     entry,
-                    access_token=cli_access,
-                    refresh_token=cli_refresh,
+                    access_token=shared_access,
+                    refresh_token=shared_refresh,
+                    last_refresh=bundle.get("last_refresh"),
                     last_status=None,
                     last_status_at=None,
                     last_error_code=None,
@@ -487,7 +483,7 @@ class CredentialPool:
                 self._persist()
                 return updated
         except Exception as exc:
-            logger.debug("Failed to sync from ~/.codex/auth.json: %s", exc)
+            logger.debug("Failed to sync from shared Codex credential: %s", exc)
         return entry
 
     def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> None:
@@ -502,6 +498,23 @@ class CredentialPool:
         Applies to any OAuth provider whose singleton lives in auth.json
         (currently Nous and OpenAI Codex).
         """
+        if self.provider == "openai-codex":
+            try:
+                auth_mod._persist_codex_token_bundle(
+                    {
+                        "tokens": {
+                            "access_token": entry.access_token,
+                            "refresh_token": entry.refresh_token,
+                        },
+                        "last_refresh": entry.last_refresh,
+                        "source": "oauth-cli-kit-shared",
+                    },
+                    sync_shared=True,
+                    sync_cli=True,
+                )
+            except Exception as exc:
+                logger.debug("Failed to sync openai-codex pool entry back to shared stores: %s", exc)
+            return
         if entry.source != "device_code":
             return
         try:
@@ -1152,95 +1165,35 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                 },
             )
 
-    elif provider == "copilot":
-        # Copilot tokens are resolved dynamically via `gh auth token` or
-        # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
-        # the auth store or credential pool, so we resolve them here.
-        try:
-            from hermes_cli.copilot_auth import resolve_copilot_token
-            token, source = resolve_copilot_token()
-            if token:
-                source_name = "gh_cli" if "gh" in source.lower() else f"env:{source}"
-                active_sources.add(source_name)
-                pconfig = PROVIDER_REGISTRY.get(provider)
-                changed |= _upsert_entry(
-                    entries,
-                    provider,
-                    source_name,
-                    {
-                        "source": source_name,
-                        "auth_type": AUTH_TYPE_API_KEY,
-                        "access_token": token,
-                        "base_url": pconfig.inference_base_url if pconfig else "",
-                        "label": source,
-                    },
-                )
-        except Exception as exc:
-            logger.debug("Copilot token seed failed: %s", exc)
-
-    elif provider == "qwen-oauth":
-        # Qwen OAuth tokens live in ~/.qwen/oauth_creds.json, written by
-        # the Qwen CLI (`qwen auth qwen-oauth`).  They aren't in the
-        # Hermes auth store or env vars, so resolve them here.
-        # Use refresh_if_expiring=False to avoid network calls during
-        # pool loading / provider discovery.
-        try:
-            from hermes_cli.auth import resolve_qwen_runtime_credentials
-            creds = resolve_qwen_runtime_credentials(refresh_if_expiring=False)
-            token = creds.get("api_key", "")
-            if token:
-                source_name = creds.get("source", "qwen-cli")
-                active_sources.add(source_name)
-                changed |= _upsert_entry(
-                    entries,
-                    provider,
-                    source_name,
-                    {
-                        "source": source_name,
-                        "auth_type": AUTH_TYPE_OAUTH,
-                        "access_token": token,
-                        "expires_at_ms": creds.get("expires_at_ms"),
-                        "base_url": creds.get("base_url", ""),
-                        "label": creds.get("auth_file", source_name),
-                    },
-                )
-        except Exception as exc:
-            logger.debug("Qwen OAuth token seed failed: %s", exc)
-
     elif provider == "openai-codex":
         state = _load_provider_state(auth_store, "openai-codex")
         tokens = state.get("tokens") if isinstance(state, dict) else None
-        # Fallback: import from Codex CLI (~/.codex/auth.json) if Hermes auth
-        # store has no tokens.  This mirrors resolve_codex_runtime_credentials()
-        # so that load_pool() and list_authenticated_providers() detect tokens
-        # that only exist in the Codex CLI shared file.
+        source_name = "device_code"
         if not (isinstance(tokens, dict) and tokens.get("access_token")):
             try:
-                from hermes_cli.auth import _import_codex_cli_tokens, _save_codex_tokens
-                cli_tokens = _import_codex_cli_tokens()
-                if cli_tokens:
-                    logger.info("Importing Codex CLI tokens into Hermes auth store.")
-                    _save_codex_tokens(cli_tokens)
-                    # Re-read state after import
-                    auth_store = _load_auth_store()
-                    state = _load_provider_state(auth_store, "openai-codex")
-                    tokens = state.get("tokens") if isinstance(state, dict) else None
+                bundle = auth_mod._load_codex_from_shared_store_first()
+                tokens = bundle.get("tokens") if isinstance(bundle, dict) else None
+                state = {"last_refresh": bundle.get("last_refresh")} if isinstance(bundle, dict) else {}
+                source_name = "shared:oauth_cli_kit" if bundle.get("source") == "oauth-cli-kit-shared" else "device_code"
             except Exception as exc:
-                logger.debug("Codex CLI token import failed: %s", exc)
+                logger.debug("Codex shared token discovery failed: %s", exc)
+                state = {}
+                tokens = None
+                source_name = "device_code"
         if isinstance(tokens, dict) and tokens.get("access_token"):
-            active_sources.add("device_code")
+            active_sources.add(source_name)
             changed |= _upsert_entry(
                 entries,
                 provider,
-                "device_code",
+                source_name,
                 {
-                    "source": "device_code",
+                    "source": source_name,
                     "auth_type": AUTH_TYPE_OAUTH,
                     "access_token": tokens.get("access_token", ""),
                     "refresh_token": tokens.get("refresh_token"),
                     "base_url": "https://chatgpt.com/backend-api/codex",
                     "last_refresh": state.get("last_refresh"),
-                    "label": label_from_token(tokens.get("access_token", ""), "device_code"),
+                    "label": label_from_token(tokens.get("access_token", ""), source_name),
                 },
             )
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -274,14 +274,6 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),
-    "bedrock": ProviderConfig(
-        id="bedrock",
-        name="AWS Bedrock",
-        auth_type="aws_sdk",
-        inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
-        api_key_env_vars=(),
-        base_url_env_var="BEDROCK_BASE_URL",
-    ),
 }
 
 
@@ -391,16 +383,13 @@ def _resolve_api_key_provider_secret(
 # Z.AI has separate billing for general vs coding plans, and global vs China
 # endpoints.  A key that works on one may return "Insufficient balance" on
 # another.  We probe at setup time and store the working endpoint.
-# Each entry lists candidate models to try in order — newer coding plan accounts
-# may only have access to recent models (glm-5.1, glm-5v-turbo) while older
-# ones still use glm-4.7.
 
 ZAI_ENDPOINTS = [
-    # (id, base_url, probe_models, label)
-    ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
-    ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    # (id, base_url, default_model, label)
+    ("global",        "https://api.z.ai/api/paas/v4",        "glm-5",   "Global"),
+    ("cn",            "https://open.bigmodel.cn/api/paas/v4", "glm-5",   "China"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  "glm-4.7", "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", "glm-4.7", "China (Coding Plan)"),
 ]
 
 
@@ -408,37 +397,35 @@ def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str
     """Probe z.ai endpoints to find one that accepts this API key.
 
     Returns {"id": ..., "base_url": ..., "model": ..., "label": ...} for the
-    first working endpoint, or None if all fail.  For endpoints with multiple
-    candidate models, tries each in order and returns the first that succeeds.
+    first working endpoint, or None if all fail.
     """
-    for ep_id, base_url, probe_models, label in ZAI_ENDPOINTS:
-        for model in probe_models:
-            try:
-                resp = httpx.post(
-                    f"{base_url}/chat/completions",
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json={
-                        "model": model,
-                        "stream": False,
-                        "max_tokens": 1,
-                        "messages": [{"role": "user", "content": "ping"}],
-                    },
-                    timeout=timeout,
-                )
-                if resp.status_code == 200:
-                    logger.debug("Z.AI endpoint probe: %s (%s) model=%s OK", ep_id, base_url, model)
-                    return {
-                        "id": ep_id,
-                        "base_url": base_url,
-                        "model": model,
-                        "label": label,
-                    }
-                logger.debug("Z.AI endpoint probe: %s model=%s returned %s", ep_id, model, resp.status_code)
-            except Exception as exc:
-                logger.debug("Z.AI endpoint probe: %s model=%s failed: %s", ep_id, model, exc)
+    for ep_id, base_url, model, label in ZAI_ENDPOINTS:
+        try:
+            resp = httpx.post(
+                f"{base_url}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": model,
+                    "stream": False,
+                    "max_tokens": 1,
+                    "messages": [{"role": "user", "content": "ping"}],
+                },
+                timeout=timeout,
+            )
+            if resp.status_code == 200:
+                logger.debug("Z.AI endpoint probe: %s (%s) OK", ep_id, base_url)
+                return {
+                    "id": ep_id,
+                    "base_url": base_url,
+                    "model": model,
+                    "label": label,
+                }
+            logger.debug("Z.AI endpoint probe: %s returned %s", ep_id, resp.status_code)
+        except Exception as exc:
+            logger.debug("Z.AI endpoint probe: %s failed: %s", ep_id, exc)
     return None
 
 
@@ -932,7 +919,6 @@ def resolve_provider(
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
-        "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         # Local server aliases — route through the generic custom provider
@@ -988,15 +974,6 @@ def resolve_provider(
         for env_var in pconfig.api_key_env_vars:
             if has_usable_secret(os.getenv(env_var, "")):
                 return pid
-
-    # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).
-    # This runs after API-key providers so explicit keys always win.
-    try:
-        from agent.bedrock_adapter import has_aws_credentials
-        if has_aws_credentials():
-            return "bedrock"
-    except ImportError:
-        pass  # boto3 not installed — skip Bedrock auto-detection
 
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
@@ -1257,6 +1234,317 @@ def _is_remote_session() -> bool:
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+def _oauth_cli_codex_auth_path() -> Path:
+    data_home = os.getenv("XDG_DATA_HOME", "").strip()
+    if not data_home:
+        data_home = str(Path.home() / ".local" / "share")
+    return Path(data_home).expanduser() / "oauth-cli-kit" / "auth" / "codex.json"
+
+
+def _oauth_cli_codex_storage():
+    try:
+        from oauth_cli_kit.storage import FileTokenStorage
+    except ImportError:
+        return None
+
+    for kwargs in (
+        {"token_filename": "codex.json", "app_name": "oauth-cli-kit", "import_codex_cli": False},
+        {"token_filename": "codex.json", "app_name": "oauth-cli-kit"},
+        {"token_filename": "codex.json"},
+    ):
+        try:
+            return FileTokenStorage(**kwargs)
+        except TypeError:
+            continue
+    return None
+
+
+def _infer_codex_access_token_expiry_ms(access_token: Any) -> Optional[int]:
+    claims = _decode_jwt_claims(access_token)
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)) and exp > 0:
+        return int(float(exp) * 1000)
+    return None
+
+
+def _normalize_oauth_cli_codex_token(token: Any) -> Optional[Dict[str, Any]]:
+    if token is None:
+        return None
+
+    def _field(name: str, default: Any = None) -> Any:
+        if isinstance(token, dict):
+            if name in token:
+                return token.get(name, default)
+            nested = token.get("tokens")
+            if isinstance(nested, dict):
+                if name == "access":
+                    return nested.get("access_token", default)
+                if name == "refresh":
+                    return nested.get("refresh_token", default)
+            return default
+        return getattr(token, name, default)
+
+    access_token = str(_field("access", "") or "").strip()
+    refresh_token = str(_field("refresh", "") or "").strip()
+    if not access_token:
+        return None
+
+    expires_raw = _field("expires")
+    expires_at_ms: Optional[int] = None
+    if isinstance(expires_raw, (int, float)):
+        expires_at_ms = int(expires_raw)
+    elif isinstance(expires_raw, str) and expires_raw.strip():
+        try:
+            expires_at_ms = int(float(expires_raw))
+        except ValueError:
+            expires_at_ms = None
+    if expires_at_ms is None:
+        expires_at_ms = _infer_codex_access_token_expiry_ms(access_token)
+
+    account_id = _field("account_id")
+    if account_id is not None:
+        account_id = str(account_id).strip() or None
+
+    last_refresh = _field("last_refresh")
+    if last_refresh is not None:
+        last_refresh = str(last_refresh).strip() or None
+
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        },
+        "account_id": account_id,
+        "expires_at_ms": expires_at_ms,
+        "last_refresh": last_refresh,
+        "source": "oauth-cli-kit-shared",
+    }
+
+
+def _read_oauth_cli_codex_token_file() -> Optional[Dict[str, Any]]:
+    auth_path = _oauth_cli_codex_auth_path()
+    if not auth_path.is_file():
+        return None
+    try:
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return _normalize_oauth_cli_codex_token(payload)
+
+
+def _get_oauth_cli_codex_token() -> Optional[Dict[str, Any]]:
+    storage = _oauth_cli_codex_storage()
+    if storage is not None:
+        try:
+            normalized = _normalize_oauth_cli_codex_token(storage.load())
+            if normalized:
+                return normalized
+        except Exception as exc:
+            logger.debug("Failed to load oauth-cli-kit Codex token via storage: %s", exc)
+    return _read_oauth_cli_codex_token_file()
+
+
+def _get_existing_codex_account_id() -> Optional[str]:
+    shared = _get_oauth_cli_codex_token()
+    if shared and shared.get("account_id"):
+        return str(shared["account_id"])
+    try:
+        state = get_provider_auth_state("openai-codex") or {}
+    except Exception:
+        state = {}
+    account_id = state.get("account_id") if isinstance(state, dict) else None
+    if isinstance(account_id, str) and account_id.strip():
+        return account_id.strip()
+    return None
+
+
+def _save_oauth_cli_codex_token(
+    access_token: str,
+    refresh_token: str,
+    *,
+    account_id: Optional[str] = None,
+    expires_at_ms: Optional[int] = None,
+) -> None:
+    access_token = str(access_token or "").strip()
+    refresh_token = str(refresh_token or "").strip()
+    if not access_token:
+        return
+    account_id = str(account_id or "").strip() or _get_existing_codex_account_id()
+    if expires_at_ms is None:
+        expires_at_ms = _infer_codex_access_token_expiry_ms(access_token)
+
+    storage = _oauth_cli_codex_storage()
+    if storage is not None:
+        try:
+            from oauth_cli_kit.models import OAuthToken
+
+            storage.save(
+                OAuthToken(
+                    access=access_token,
+                    refresh=refresh_token,
+                    expires=int(expires_at_ms or 0),
+                    account_id=account_id or None,
+                )
+            )
+            return
+        except Exception as exc:
+            logger.debug("Failed to save oauth-cli-kit Codex token via storage: %s", exc)
+
+    auth_path = _oauth_cli_codex_auth_path()
+    payload: Dict[str, Any] = {"access": access_token, "refresh": refresh_token}
+    if expires_at_ms is not None:
+        payload["expires"] = int(expires_at_ms)
+    if account_id:
+        payload["account_id"] = account_id
+    try:
+        auth_path.parent.mkdir(parents=True, exist_ok=True)
+        auth_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        auth_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    except OSError as exc:
+        logger.debug("Failed to write oauth-cli-kit Codex token to %s: %s", auth_path, exc)
+
+
+def _delete_oauth_cli_codex_token() -> None:
+    auth_path = _oauth_cli_codex_auth_path()
+    try:
+        if auth_path.exists():
+            auth_path.unlink()
+    except OSError as exc:
+        logger.debug("Failed to remove oauth-cli-kit Codex token at %s: %s", auth_path, exc)
+
+
+def _normalize_codex_token_bundle(
+    tokens: Dict[str, Any],
+    *,
+    last_refresh: Optional[str] = None,
+    account_id: Optional[str] = None,
+    expires_at_ms: Optional[int] = None,
+    source: str = "hermes-auth-store",
+) -> Dict[str, Any]:
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    refresh_token = str(tokens.get("refresh_token", "") or "").strip()
+    if expires_at_ms is None:
+        expires_at_ms = _infer_codex_access_token_expiry_ms(access_token)
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        },
+        "last_refresh": last_refresh or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "account_id": str(account_id or "").strip() or None,
+        "expires_at_ms": expires_at_ms,
+        "source": source,
+    }
+
+
+def _sync_codex_shared_to_hermes_store(bundle: Dict[str, Any]) -> None:
+    _save_codex_tokens(
+        bundle.get("tokens", {}),
+        bundle.get("last_refresh"),
+        account_id=bundle.get("account_id"),
+        expires_at_ms=bundle.get("expires_at_ms"),
+    )
+
+
+def _sync_codex_shared_to_codex_cli(bundle: Dict[str, Any]) -> None:
+    tokens = bundle.get("tokens", {}) if isinstance(bundle, dict) else {}
+    _write_codex_cli_tokens(
+        str(tokens.get("access_token", "") or ""),
+        str(tokens.get("refresh_token", "") or ""),
+        last_refresh=bundle.get("last_refresh"),
+    )
+
+
+def _persist_codex_token_bundle(
+    bundle: Dict[str, Any],
+    *,
+    sync_shared: bool = True,
+    sync_cli: bool = True,
+) -> Dict[str, Any]:
+    normalized = _normalize_codex_token_bundle(
+        bundle.get("tokens", {}) if isinstance(bundle, dict) else {},
+        last_refresh=bundle.get("last_refresh"),
+        account_id=bundle.get("account_id"),
+        expires_at_ms=bundle.get("expires_at_ms"),
+        source=str(bundle.get("source", "hermes-auth-store") or "hermes-auth-store"),
+    )
+    _sync_codex_shared_to_hermes_store(normalized)
+    if sync_shared:
+        tokens = normalized["tokens"]
+        _save_oauth_cli_codex_token(
+            tokens["access_token"],
+            tokens["refresh_token"],
+            account_id=normalized.get("account_id"),
+            expires_at_ms=normalized.get("expires_at_ms"),
+        )
+    if sync_cli:
+        _sync_codex_shared_to_codex_cli(normalized)
+    return normalized
+
+
+def _load_codex_from_shared_store_first() -> Dict[str, Any]:
+    last_error: Optional[AuthError] = None
+
+    shared = _get_oauth_cli_codex_token()
+    if shared and shared.get("tokens", {}).get("access_token"):
+        _sync_codex_shared_to_hermes_store(shared)
+        return shared
+
+    try:
+        data = _read_codex_tokens()
+        state = get_provider_auth_state("openai-codex") or {}
+        return _normalize_codex_token_bundle(
+            data.get("tokens", {}),
+            last_refresh=data.get("last_refresh"),
+            account_id=state.get("account_id") if isinstance(state, dict) else None,
+            expires_at_ms=state.get("expires_at_ms") if isinstance(state, dict) else None,
+            source="hermes-auth-store",
+        )
+    except AuthError as exc:
+        last_error = exc
+
+    cli_tokens = _import_codex_cli_tokens()
+    if cli_tokens:
+        logger.info("Importing Codex CLI credentials into shared Codex storage.")
+        bundle = _normalize_codex_token_bundle(cli_tokens, source="codex-cli")
+        return _persist_codex_token_bundle(bundle, sync_shared=True, sync_cli=True)
+
+    if last_error is not None:
+        raise last_error
+    raise AuthError(
+        "No Codex credentials stored. Run `hermes auth` to authenticate.",
+        provider="openai-codex",
+        code="codex_auth_missing",
+        relogin_required=True,
+    )
+
+
+def _login_codex_browser_oauth() -> Dict[str, Any]:
+    try:
+        from oauth_cli_kit import login_oauth_interactive
+    except ImportError as exc:
+        raise AuthError(
+            "Browser-based Codex login requires oauth-cli-kit. Install Hermes with Codex OAuth support.",
+            provider="openai-codex",
+            code="oauth_cli_kit_missing",
+            relogin_required=True,
+        ) from exc
+
+    token = login_oauth_interactive(
+        print_fn=lambda s: print(s),
+        prompt_fn=lambda s: input(s),
+    )
+    bundle = _normalize_oauth_cli_codex_token(token)
+    if not bundle or not bundle.get("tokens", {}).get("access_token"):
+        raise AuthError(
+            "Browser-based Codex login did not return a usable access token.",
+            provider="openai-codex",
+            code="oauth_cli_kit_login_failed",
+            relogin_required=True,
+        )
+    return _persist_codex_token_bundle(bundle, sync_shared=True, sync_cli=True)
+
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
@@ -1349,7 +1637,25 @@ def _write_codex_cli_tokens(
         logger.debug("Failed to write refreshed tokens to %s: %s", auth_path, exc)
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _delete_codex_cli_tokens() -> None:
+    codex_home = os.getenv("CODEX_HOME", "").strip()
+    if not codex_home:
+        codex_home = str(Path.home() / ".codex")
+    auth_path = Path(codex_home).expanduser() / "auth.json"
+    try:
+        if auth_path.exists():
+            auth_path.unlink()
+    except OSError as exc:
+        logger.debug("Failed to remove Codex CLI tokens at %s: %s", auth_path, exc)
+
+
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: str = None,
+    *,
+    account_id: Optional[str] = None,
+    expires_at_ms: Optional[int] = None,
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -1359,6 +1665,10 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
+        if account_id is not None:
+            state["account_id"] = account_id
+        if expires_at_ms is not None:
+            state["expires_at_ms"] = int(expires_at_ms)
         _save_provider_state(auth_store, "openai-codex", state)
         _save_auth_store(auth_store)
 
@@ -1469,13 +1779,15 @@ def _refresh_codex_auth_tokens(
     updated_tokens = dict(tokens)
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
-
-    _save_codex_tokens(updated_tokens)
-    # Write back to ~/.codex/auth.json so Codex CLI / VS Code stay in sync.
-    _write_codex_cli_tokens(
-        refreshed["access_token"],
-        refreshed["refresh_token"],
-        last_refresh=refreshed.get("last_refresh"),
+    _persist_codex_token_bundle(
+        _normalize_codex_token_bundle(
+            updated_tokens,
+            last_refresh=refreshed.get("last_refresh"),
+            account_id=_get_existing_codex_account_id(),
+            source="oauth-cli-kit-shared" if _get_oauth_cli_codex_token() else "hermes-auth-store",
+        ),
+        sync_shared=True,
+        sync_cli=True,
     )
     return updated_tokens
 
@@ -1520,26 +1832,14 @@ def resolve_codex_runtime_credentials(
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> Dict[str, Any]:
-    """Resolve runtime credentials from Hermes's own Codex token store."""
-    try:
-        data = _read_codex_tokens()
-    except AuthError as orig_err:
-        # Only attempt migration when there are NO tokens stored at all
-        # (code == "codex_auth_missing"), not when tokens exist but are invalid.
-        if orig_err.code != "codex_auth_missing":
-            raise
-
-        # Migration: user had Codex as active provider with old storage (~/.codex/).
-        cli_tokens = _import_codex_cli_tokens()
-        if cli_tokens:
-            logger.info("Migrating Codex credentials from ~/.codex/ to Hermes auth store")
+    """Resolve runtime credentials with shared oauth-cli-kit storage preferred."""
+    data = _load_codex_from_shared_store_first()
+    if False:
+        
             print("⚠️  Migrating Codex credentials to Hermes's own auth store.")
-            print("   This avoids conflicts with Codex CLI and VS Code.")
+            pass
             print("   Run `hermes auth` to create a fully independent session.\n")
-            _save_codex_tokens(cli_tokens)
-            data = _read_codex_tokens()
-        else:
-            raise
+            
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
     refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
@@ -1550,7 +1850,7 @@ def resolve_codex_runtime_credentials(
     if should_refresh:
         # Re-read under lock to avoid racing with other Hermes processes
         with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
+            data = _load_codex_from_shared_store_first()
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 
@@ -1561,6 +1861,7 @@ def resolve_codex_runtime_credentials(
             if should_refresh:
                 tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
                 access_token = str(tokens.get("access_token", "") or "").strip()
+                data = _load_codex_from_shared_store_first()
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
@@ -1571,9 +1872,10 @@ def resolve_codex_runtime_credentials(
         "provider": "openai-codex",
         "base_url": base_url,
         "api_key": access_token,
-        "source": "hermes-auth-store",
+        "source": data.get("source", "hermes-auth-store"),
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
+        "account_id": data.get("account_id"),
     }
 
 
@@ -2342,34 +2644,11 @@ def get_nous_auth_status() -> Dict[str, Any]:
 def get_codex_auth_status() -> Dict[str, Any]:
     """Status snapshot for Codex auth.
     
-    Checks the credential pool first (where `hermes auth` stores credentials),
-    then falls back to the legacy provider state.
+    Prefers the shared oauth-cli-kit credential path used by NanoBOT,
+    then Hermes auth store, then Codex CLI import fallback.
     """
     # Check credential pool first — this is where `hermes auth` and
     # `hermes model` store device_code tokens.
-    try:
-        from agent.credential_pool import load_pool
-        pool = load_pool("openai-codex")
-        if pool and pool.has_credentials():
-            entry = pool.select()
-            if entry is not None:
-                api_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
-                )
-                if api_key and not _codex_access_token_is_expiring(api_key, 0):
-                    return {
-                        "logged_in": True,
-                        "auth_store": str(_auth_file_path()),
-                        "last_refresh": getattr(entry, "last_refresh", None),
-                        "auth_mode": "chatgpt",
-                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
-                        "api_key": api_key,
-                    }
-    except Exception:
-        pass
-
-    # Fall back to legacy provider state
     try:
         creds = resolve_codex_runtime_credentials()
         return {
@@ -2402,7 +2681,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id in ("kimi-coding", "kimi-coding-cn"):
+    if provider_id == "kimi-coding":
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url
@@ -2464,13 +2743,6 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
-    # AWS SDK providers (Bedrock) — check via boto3 credential chain
-    if pconfig and pconfig.auth_type == "aws_sdk":
-        try:
-            from agent.bedrock_adapter import has_aws_credentials
-            return {"logged_in": has_aws_credentials(), "provider": target}
-        except ImportError:
-            return {"logged_in": False, "provider": target, "error": "boto3 not installed"}
     return {"logged_in": False}
 
 
@@ -2495,7 +2767,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if pconfig.base_url_env_var:
         env_url = os.getenv(pconfig.base_url_env_var, "").strip()
 
-    if provider_id in ("kimi-coding", "kimi-coding-cn"):
+    if provider_id == "kimi-coding":
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif provider_id == "zai":
         base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -2832,51 +3104,64 @@ def login_command(args) -> None:
 
 
 def _login_openai_codex(args, pconfig: ProviderConfig) -> None:
-    """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
+    """OpenAI Codex login with shared oauth-cli-kit reuse and optional browser login."""
 
-    # Check for existing Hermes-owned credentials
+    method = str(getattr(args, "method", "") or "device-code").strip().lower()
+    if method not in {"device-code", "browser"}:
+        raise SystemExit(f"Unsupported Codex login method: {method}")
+
+    # Reuse shared oauth-cli-kit credentials before starting a new login.
     try:
-        existing = resolve_codex_runtime_credentials()
+        existing = resolve_codex_runtime_credentials(refresh_if_expiring=False)
         # Verify the resolved token is actually usable (not expired).
         # resolve_codex_runtime_credentials attempts refresh, so if we get
         # here the token should be valid — but double-check before telling
         # the user "Login successful!".
         _resolved_key = existing.get("api_key", "")
-        if isinstance(_resolved_key, str) and _resolved_key and not _codex_access_token_is_expiring(_resolved_key, 60):
-            print("Existing Codex credentials found in Hermes auth store.")
+        if isinstance(_resolved_key, str) and _resolved_key:
+            source = str(existing.get("source", "hermes-auth-store") or "hermes-auth-store")
+            source_label = {
+                "oauth-cli-kit-shared": "oauth-cli-kit shared credential",
+                "hermes-auth-store": "Hermes auth store",
+                "codex-cli": "Codex CLI credential",
+            }.get(source, source)
+            print(f"Existing Codex credentials found via {source_label}.")
             try:
-                reuse = input("Use existing credentials? [Y/n]: ").strip().lower()
+                reuse = input("Reuse these credentials? [Y/n]: ").strip().lower()
             except (EOFError, KeyboardInterrupt):
                 reuse = "y"
             if reuse in ("", "y", "yes"):
-                config_path = _update_config_for_provider("openai-codex", existing.get("base_url", DEFAULT_CODEX_BASE_URL))
+                config_path = _update_config_for_provider(
+                    "openai-codex",
+                    existing.get("base_url", DEFAULT_CODEX_BASE_URL),
+                )
                 print()
                 print("Login successful!")
                 print(f"  Config updated: {config_path} (model.provider=openai-codex)")
                 return
-        else:
-            print("Existing Codex credentials are expired. Starting fresh login...")
     except AuthError:
-        pass
+        existing = None
 
-    # Check for existing Codex CLI tokens we can import
-    cli_tokens = _import_codex_cli_tokens()
-    if cli_tokens:
-        print("Found existing Codex CLI credentials at ~/.codex/auth.json")
-        print("Hermes will create its own session to avoid conflicts with Codex CLI / VS Code.")
-        try:
-            do_import = input("Import these credentials? (a separate login is recommended) [y/N]: ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            do_import = "n"
-        if do_import in ("y", "yes"):
-            _save_codex_tokens(cli_tokens)
-            base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
-            config_path = _update_config_for_provider("openai-codex", base_url)
-            print()
-            print("Credentials imported. Note: if Codex CLI refreshes its token,")
-            print("Hermes will keep working independently with its own session.")
-            print(f"  Config updated: {config_path} (model.provider=openai-codex)")
-            return
+    if method == "browser":
+        print()
+        print("Signing in to OpenAI Codex...")
+        print("(Browser login; compatible with NanoBOT's shared Codex credential)")
+        print()
+        bundle = _login_codex_browser_oauth()
+        config_path = _update_config_for_provider(
+            "openai-codex",
+            pconfig.inference_base_url or DEFAULT_CODEX_BASE_URL,
+        )
+        print()
+        print("Login successful!")
+        from hermes_constants import display_hermes_home as _dhh
+        print(f"  Auth state: {_dhh()}/auth.json")
+        print(f"  Active credential source: {bundle.get('source', 'oauth-cli-kit-shared')}")
+        print(f"  Config updated: {config_path} (model.provider=openai-codex)")
+        return
+
+    # Shared oauth-cli-kit credentials are preferred; start a new login only if needed.
+
 
     # Run a fresh device code flow — Hermes gets its own OAuth session
     print()
@@ -2886,13 +3171,24 @@ def _login_openai_codex(args, pconfig: ProviderConfig) -> None:
 
     creds = _codex_device_code_login()
 
-    # Save tokens to Hermes auth store
-    _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
-    config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
+    bundle = _persist_codex_token_bundle(
+        {
+            "tokens": creds["tokens"],
+            "last_refresh": creds.get("last_refresh"),
+            "source": "oauth-cli-kit-shared",
+        },
+        sync_shared=True,
+        sync_cli=True,
+    )
+    config_path = _update_config_for_provider(
+        "openai-codex",
+        pconfig.inference_base_url or DEFAULT_CODEX_BASE_URL,
+    )
     print()
     print("Login successful!")
     from hermes_constants import display_hermes_home as _dhh
     print(f"  Auth state: {_dhh()}/auth.json")
+    print(f"  Active credential source: {bundle.get('source', 'oauth-cli-kit-shared')}")
     print(f"  Config updated: {config_path} (model.provider=openai-codex)")
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from getpass import getpass
 import math
-import sys
 import time
 from types import SimpleNamespace
 import uuid
@@ -28,7 +27,7 @@ from agent.credential_pool import (
     load_pool,
 )
 import hermes_cli.auth as auth_mod
-from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.auth import DEFAULT_CODEX_BASE_URL, PROVIDER_REGISTRY
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -161,10 +160,7 @@ def auth_add_command(args) -> None:
         default_label = _api_key_default_label(len(pool.entries()) + 1)
         label = (getattr(args, "label", None) or "").strip()
         if not label:
-            if sys.stdin.isatty():
-                label = input(f"Label (optional, default: {default_label}): ").strip() or default_label
-            else:
-                label = default_label
+            label = input(f"Label (optional, default: {default_label}): ").strip() or default_label
         entry = PooledCredential(
             provider=provider,
             id=uuid.uuid4().hex[:6],
@@ -233,7 +229,50 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "openai-codex":
-        creds = auth_mod._codex_device_code_login()
+        method = str(getattr(args, "method", "") or "device-code").strip().lower()
+        shared = None
+        if method == "device-code":
+            try:
+                shared = auth_mod._load_codex_from_shared_store_first()
+            except auth_mod.AuthError:
+                shared = None
+        if shared:
+            tokens = {
+                "access_token": shared["tokens"]["access_token"],
+                "refresh_token": shared["tokens"].get("refresh_token"),
+            }
+            creds = {
+                "tokens": tokens,
+                "base_url": shared.get("base_url") or DEFAULT_CODEX_BASE_URL,
+                "last_refresh": shared.get("last_refresh"),
+                "source": "shared:oauth_cli_kit",
+            }
+            entry_source = "shared:oauth_cli_kit"
+        elif method == "browser":
+            bundle = auth_mod._login_codex_browser_oauth()
+            creds = {
+                "tokens": dict(bundle.get("tokens", {})),
+                "base_url": DEFAULT_CODEX_BASE_URL,
+                "last_refresh": bundle.get("last_refresh"),
+                "source": "manual:oauth_cli_browser",
+            }
+            entry_source = "manual:oauth_cli_browser"
+        else:
+            creds = auth_mod._codex_device_code_login()
+            bundle = auth_mod._persist_codex_token_bundle(
+                {
+                    "tokens": creds["tokens"],
+                    "last_refresh": creds.get("last_refresh"),
+                    "source": "oauth-cli-kit-shared",
+                },
+                sync_shared=True,
+                sync_cli=True,
+            )
+            creds = {
+                **creds,
+                "last_refresh": bundle.get("last_refresh"),
+            }
+            entry_source = "manual:device_code"
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
@@ -244,7 +283,7 @@ def auth_add_command(args) -> None:
             label=label,
             auth_type=AUTH_TYPE_OAUTH,
             priority=0,
-            source=f"{SOURCE_MANUAL}:device_code",
+            source=entry_source,
             access_token=creds["tokens"]["access_token"],
             refresh_token=creds["tokens"].get("refresh_token"),
             base_url=creds.get("base_url"),
@@ -331,7 +370,17 @@ def auth_remove_command(args) -> None:
     # If this was a singleton-seeded credential (OAuth device_code, hermes_pkce),
     # clear the underlying auth store / credential file so it doesn't get
     # re-seeded on the next load_pool() call.
-    elif removed.source == "device_code" and provider in ("openai-codex", "nous"):
+    elif (
+        (
+            provider == "openai-codex"
+            and (
+                removed.source == "device_code"
+                or removed.source.startswith(f"{SOURCE_MANUAL}:")
+                or removed.source == "shared:oauth_cli_kit"
+            )
+        )
+        or (removed.source == "device_code" and provider == "nous")
+    ):
         from hermes_cli.auth import (
             _load_auth_store, _save_auth_store, _auth_store_lock,
         )
@@ -340,8 +389,31 @@ def auth_remove_command(args) -> None:
             providers_dict = auth_store.get("providers")
             if isinstance(providers_dict, dict) and provider in providers_dict:
                 del providers_dict[provider]
-                _save_auth_store(auth_store)
                 print(f"Cleared {provider} OAuth tokens from auth store")
+            if provider == "openai-codex":
+                pool_entries = auth_store.get("credential_pool")
+                if isinstance(pool_entries, dict):
+                    current_entries = pool_entries.get(provider)
+                    if isinstance(current_entries, list):
+                        filtered = [
+                            entry for entry in current_entries
+                            if str(entry.get("source", "")) not in {"device_code", "shared:oauth_cli_kit"}
+                        ]
+                        if filtered:
+                            pool_entries[provider] = filtered
+                        else:
+                            pool_entries.pop(provider, None)
+            _save_auth_store(auth_store)
+        if provider == "openai-codex":
+            if getattr(args, "purge_shared", False):
+                auth_mod._delete_oauth_cli_codex_token()
+                try:
+                    auth_mod._delete_codex_cli_tokens()
+                except AttributeError:
+                    pass
+                print("Purged shared Codex credential.")
+            else:
+                print("Shared Codex credential was left in place and will be reused unless you pass --purge-shared.")
 
     elif removed.source == "hermes_pkce" and provider == "anthropic":
         from hermes_constants import get_hermes_home
@@ -372,27 +444,6 @@ def _interactive_auth() -> None:
     print("=" * 50)
 
     auth_list_command(SimpleNamespace(provider=None))
-
-    # Show AWS Bedrock credential status (not in the pool — uses boto3 chain)
-    try:
-        from agent.bedrock_adapter import has_aws_credentials, resolve_aws_auth_env_var, resolve_bedrock_region
-        if has_aws_credentials():
-            auth_source = resolve_aws_auth_env_var() or "unknown"
-            region = resolve_bedrock_region()
-            print(f"bedrock (AWS SDK credential chain):")
-            print(f"  Auth: {auth_source}")
-            print(f"  Region: {region}")
-            try:
-                import boto3
-                sts = boto3.client("sts", region_name=region)
-                identity = sts.get_caller_identity()
-                arn = identity.get("Arn", "unknown")
-                print(f"  Identity: {arn}")
-            except Exception:
-                print(f"  Identity: (could not resolve — boto3 STS call failed)")
-            print()
-    except ImportError:
-        pass  # boto3 or bedrock_adapter not available
     print()
 
     # Main menu

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1139,8 +1139,6 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider == "bedrock":
-        _model_flow_bedrock(config, current_model)
     elif selected_provider in ("gemini", "deepseek", "xai", "zai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
@@ -1438,10 +1436,20 @@ def _model_flow_openai_codex(config, current_model=""):
 
     status = get_codex_auth_status()
     if not status.get("logged_in"):
-        print("Not logged into OpenAI Codex. Starting login...")
+        print("Not logged into OpenAI Codex.")
         print()
         try:
-            mock_args = argparse.Namespace()
+            print("Choose a login method:")
+            print("  1. Device code (recommended)")
+            print("  2. Browser login (NanoBOT-compatible)")
+            try:
+                choice = input("  Choice [1/2]: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                print("Login cancelled.")
+                return
+            method = "browser" if choice == "2" else "device-code"
+            mock_args = argparse.Namespace(method=method)
             _login_openai_codex(mock_args, PROVIDER_REGISTRY["openai-codex"])
         except SystemExit:
             print("Login cancelled or failed.")
@@ -2425,252 +2433,6 @@ def _model_flow_kimi(config, current_model=""):
         print(f"Default model set to: {selected} (via {endpoint_label})")
     else:
         print("No change.")
-
-
-def _model_flow_bedrock_api_key(config, region, current_model=""):
-    """Bedrock API Key mode — uses the OpenAI-compatible bedrock-mantle endpoint.
-
-    For developers who don't have an AWS account but received a Bedrock API Key
-    from their AWS admin. Works like any OpenAI-compatible endpoint.
-    """
-    from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
-    from hermes_cli.config import load_config, save_config, get_env_value, save_env_value
-    from hermes_cli.models import _PROVIDER_MODELS
-
-    mantle_base_url = f"https://bedrock-mantle.{region}.api.aws/v1"
-
-    # Prompt for API key
-    existing_key = get_env_value("AWS_BEARER_TOKEN_BEDROCK") or ""
-    if existing_key:
-        print(f"  Bedrock API Key: {existing_key[:12]}... ✓")
-    else:
-        print(f"  Endpoint: {mantle_base_url}")
-        print()
-        try:
-            import getpass
-            api_key = getpass.getpass("  Bedrock API Key: ").strip()
-        except (KeyboardInterrupt, EOFError):
-            print()
-            return
-        if not api_key:
-            print("  Cancelled.")
-            return
-        save_env_value("AWS_BEARER_TOKEN_BEDROCK", api_key)
-        existing_key = api_key
-        print("  ✓ API key saved.")
-    print()
-
-    # Model selection — use static list (mantle doesn't need boto3 for discovery)
-    model_list = _PROVIDER_MODELS.get("bedrock", [])
-    print(f"  Showing {len(model_list)} curated models")
-
-    if model_list:
-        selected = _prompt_model_selection(model_list, current_model=current_model)
-    else:
-        try:
-            selected = input("  Model ID: ").strip()
-        except (KeyboardInterrupt, EOFError):
-            selected = None
-
-    if selected:
-        _save_model_choice(selected)
-
-        # Save as custom provider pointing to bedrock-mantle
-        cfg = load_config()
-        model = cfg.get("model")
-        if not isinstance(model, dict):
-            model = {"default": model} if model else {}
-            cfg["model"] = model
-        model["provider"] = "custom"
-        model["base_url"] = mantle_base_url
-        model.pop("api_mode", None)  # chat_completions is the default
-
-        # Also save region in bedrock config for reference
-        bedrock_cfg = cfg.get("bedrock", {})
-        if not isinstance(bedrock_cfg, dict):
-            bedrock_cfg = {}
-        bedrock_cfg["region"] = region
-        cfg["bedrock"] = bedrock_cfg
-
-        # Save the API key env var name so hermes knows where to find it
-        save_env_value("OPENAI_API_KEY", existing_key)
-        save_env_value("OPENAI_BASE_URL", mantle_base_url)
-
-        save_config(cfg)
-        deactivate_provider()
-
-        print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
-        print(f"  Endpoint: {mantle_base_url}")
-    else:
-        print("  No change.")
-
-
-def _model_flow_bedrock(config, current_model=""):
-    """AWS Bedrock provider: verify credentials, pick region, discover models.
-
-    Uses the native Converse API via boto3 — not the OpenAI-compatible endpoint.
-    Auth is handled by the AWS SDK default credential chain (env vars, profile,
-    instance role), so no API key prompt is needed.
-    """
-    from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
-    from hermes_cli.config import load_config, save_config
-    from hermes_cli.models import _PROVIDER_MODELS
-
-    # 1. Check for AWS credentials
-    try:
-        from agent.bedrock_adapter import (
-            has_aws_credentials,
-            resolve_aws_auth_env_var,
-            resolve_bedrock_region,
-            discover_bedrock_models,
-        )
-    except ImportError:
-        print("  ✗ boto3 is not installed. Install it with:")
-        print("    pip install boto3")
-        print()
-        return
-
-    if not has_aws_credentials():
-        print("  ⚠ No AWS credentials detected via environment variables.")
-        print("  Bedrock will use boto3's default credential chain (IMDS, SSO, etc.)")
-        print()
-
-    auth_var = resolve_aws_auth_env_var()
-    if auth_var:
-        print(f"  AWS credentials: {auth_var} ✓")
-    else:
-        print("  AWS credentials: boto3 default chain (instance role / SSO)")
-    print()
-
-    # 2. Region selection
-    current_region = resolve_bedrock_region()
-    try:
-        region_input = input(f"  AWS Region [{current_region}]: ").strip()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        return
-    region = region_input or current_region
-
-    # 2b. Authentication mode
-    print("  Choose authentication method:")
-    print()
-    print("    1. IAM credential chain (recommended)")
-    print("       Works with EC2 instance roles, SSO, env vars, aws configure")
-    print("    2. Bedrock API Key")
-    print("       Enter your Bedrock API Key directly — also supports")
-    print("       team scenarios where an admin distributes keys")
-    print()
-    try:
-        auth_choice = input("  Choice [1]: ").strip()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        return
-
-    if auth_choice == "2":
-        _model_flow_bedrock_api_key(config, region, current_model)
-        return
-
-    # 3. Model discovery — try live API first, fall back to static list
-    print(f"  Discovering models in {region}...")
-    live_models = discover_bedrock_models(region)
-
-    if live_models:
-        _EXCLUDE_PREFIXES = (
-            "stability.", "cohere.embed", "twelvelabs.", "us.stability.",
-            "us.cohere.embed", "us.twelvelabs.", "global.cohere.embed",
-            "global.twelvelabs.",
-        )
-        _EXCLUDE_SUBSTRINGS = ("safeguard", "voxtral", "palmyra-vision")
-        filtered = []
-        for m in live_models:
-            mid = m["id"]
-            if any(mid.startswith(p) for p in _EXCLUDE_PREFIXES):
-                continue
-            if any(s in mid.lower() for s in _EXCLUDE_SUBSTRINGS):
-                continue
-            filtered.append(m)
-
-        # Deduplicate: prefer inference profiles (us.*, global.*) over bare
-        # foundation model IDs.
-        profile_base_ids = set()
-        for m in filtered:
-            mid = m["id"]
-            if mid.startswith(("us.", "global.")):
-                base = mid.split(".", 1)[1] if "." in mid[3:] else mid
-                profile_base_ids.add(base)
-
-        deduped = []
-        for m in filtered:
-            mid = m["id"]
-            if not mid.startswith(("us.", "global.")) and mid in profile_base_ids:
-                continue
-            deduped.append(m)
-
-        _RECOMMENDED = [
-            "us.anthropic.claude-sonnet-4-6",
-            "us.anthropic.claude-opus-4-6",
-            "us.anthropic.claude-haiku-4-5",
-            "us.amazon.nova-pro",
-            "us.amazon.nova-lite",
-            "us.amazon.nova-micro",
-            "deepseek.v3",
-            "us.meta.llama4-maverick",
-            "us.meta.llama4-scout",
-        ]
-
-        def _sort_key(m):
-            mid = m["id"]
-            for i, rec in enumerate(_RECOMMENDED):
-                if mid.startswith(rec):
-                    return (0, i, mid)
-            if mid.startswith("global."):
-                return (1, 0, mid)
-            return (2, 0, mid)
-
-        deduped.sort(key=_sort_key)
-        model_list = [m["id"] for m in deduped]
-        print(f"  Found {len(model_list)} text model(s) (filtered from {len(live_models)} total)")
-    else:
-        model_list = _PROVIDER_MODELS.get("bedrock", [])
-        if model_list:
-            print(f"  Using {len(model_list)} curated models (live discovery unavailable)")
-        else:
-            print("  No models found. Check IAM permissions for bedrock:ListFoundationModels.")
-            return
-
-    # 4. Model selection
-    if model_list:
-        selected = _prompt_model_selection(model_list, current_model=current_model)
-    else:
-        try:
-            selected = input("  Model ID: ").strip()
-        except (KeyboardInterrupt, EOFError):
-            selected = None
-
-    if selected:
-        _save_model_choice(selected)
-
-        cfg = load_config()
-        model = cfg.get("model")
-        if not isinstance(model, dict):
-            model = {"default": model} if model else {}
-            cfg["model"] = model
-        model["provider"] = "bedrock"
-        model["base_url"] = f"https://bedrock-runtime.{region}.amazonaws.com"
-        model.pop("api_mode", None)  # bedrock_converse is auto-detected
-
-        bedrock_cfg = cfg.get("bedrock", {})
-        if not isinstance(bedrock_cfg, dict):
-            bedrock_cfg = {}
-        bedrock_cfg["region"] = region
-        cfg["bedrock"] = bedrock_cfg
-
-        save_config(cfg)
-        deactivate_provider()
-
-        print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
-    else:
-        print("  No change.")
 
 
 def _model_flow_api_key_provider(config, provider_id, current_model=""):
@@ -4284,40 +4046,7 @@ def cmd_update(args):
                                     capture_output=True, text=True, timeout=15,
                                 )
                                 if restart.returncode == 0:
-                                    # Verify the service actually survived the
-                                    # restart.  systemctl restart returns 0 even
-                                    # if the new process crashes immediately.
-                                    import time as _time
-                                    _time.sleep(3)
-                                    verify = subprocess.run(
-                                        scope_cmd + ["is-active", svc_name],
-                                        capture_output=True, text=True, timeout=5,
-                                    )
-                                    if verify.stdout.strip() == "active":
-                                        restarted_services.append(svc_name)
-                                    else:
-                                        # Retry once — transient startup failures
-                                        # (stale module cache, import race) often
-                                        # resolve on the second attempt.
-                                        print(f"  ⚠ {svc_name} died after restart, retrying...")
-                                        retry = subprocess.run(
-                                            scope_cmd + ["restart", svc_name],
-                                            capture_output=True, text=True, timeout=15,
-                                        )
-                                        _time.sleep(3)
-                                        verify2 = subprocess.run(
-                                            scope_cmd + ["is-active", svc_name],
-                                            capture_output=True, text=True, timeout=5,
-                                        )
-                                        if verify2.stdout.strip() == "active":
-                                            restarted_services.append(svc_name)
-                                            print(f"  ✓ {svc_name} recovered on retry")
-                                        else:
-                                            print(
-                                                f"  ✗ {svc_name} failed to stay running after restart.\n"
-                                                f"    Check logs: journalctl --user -u {svc_name} --since '2 min ago'\n"
-                                                f"    Restart manually: systemctl {'--user ' if scope == 'user' else ''}restart {svc_name}"
-                                            )
+                                    restarted_services.append(svc_name)
                                 else:
                                     print(f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}")
                     except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -4405,8 +4134,6 @@ def _coalesce_session_name_args(argv: list) -> list:
         "status", "cron", "doctor", "config", "pairing", "skills", "tools",
         "mcp", "sessions", "insights", "version", "update", "uninstall",
         "profile", "dashboard",
-        "honcho", "claw", "plugins", "acp",
-        "webhook", "memory", "dump", "debug", "backup", "import", "completion", "logs",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
 
@@ -4702,20 +4429,17 @@ def cmd_dashboard(args):
         host=args.host,
         port=args.port,
         open_browser=not args.no_open,
-        allow_public=getattr(args, "insecure", False),
     )
 
 
-def cmd_completion(args, parser=None):
+def cmd_completion(args):
     """Print shell completion script."""
-    from hermes_cli.completion import generate_bash, generate_zsh, generate_fish
+    from hermes_cli.profiles import generate_bash_completion, generate_zsh_completion
     shell = getattr(args, "shell", "bash")
     if shell == "zsh":
-        print(generate_zsh(parser))
-    elif shell == "fish":
-        print(generate_fish(parser))
+        print(generate_zsh_completion())
     else:
-        print(generate_bash(parser))
+        print(generate_bash_completion())
 
 
 def cmd_logs(args):
@@ -4997,7 +4721,6 @@ For more help on a command:
     # gateway start
     gateway_start = gateway_subparsers.add_parser("start", help="Start the installed systemd/launchd background service")
     gateway_start.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
-    gateway_start.add_argument("--all", action="store_true", help="Kill ALL stale gateway processes across all profiles before starting")
     
     # gateway stop
     gateway_stop = gateway_subparsers.add_parser("stop", help="Stop gateway service")
@@ -5007,7 +4730,6 @@ For more help on a command:
     # gateway restart
     gateway_restart = gateway_subparsers.add_parser("restart", help="Restart gateway service")
     gateway_restart.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
-    gateway_restart.add_argument("--all", action="store_true", help="Kill ALL gateway processes across all profiles before restarting")
     
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")
@@ -5151,6 +4873,7 @@ For more help on a command:
     auth_add.add_argument("--inference-url", help="Nous inference base URL")
     auth_add.add_argument("--client-id", help="OAuth client id")
     auth_add.add_argument("--scope", help="OAuth scope override")
+    auth_add.add_argument("--method", choices=["device-code", "browser"], help="OAuth login method for compatible providers")
     auth_add.add_argument("--no-browser", action="store_true", help="Do not auto-open a browser for OAuth login")
     auth_add.add_argument("--timeout", type=float, help="OAuth/network timeout in seconds")
     auth_add.add_argument("--insecure", action="store_true", help="Disable TLS verification for OAuth login")
@@ -5160,6 +4883,7 @@ For more help on a command:
     auth_remove = auth_subparsers.add_parser("remove", help="Remove a pooled credential by index, id, or label")
     auth_remove.add_argument("provider", help="Provider id")
     auth_remove.add_argument("target", help="Credential index, entry id, or exact label")
+    auth_remove.add_argument("--purge-shared", action="store_true", help="Also delete shared Codex credentials when removing openai-codex")
     auth_reset = auth_subparsers.add_parser("reset", help="Clear exhaustion status for all credentials for a provider")
     auth_reset.add_argument("provider", help="Provider id")
     auth_parser.set_defaults(func=cmd_auth)
@@ -5321,7 +5045,6 @@ Examples:
     hermes debug share --lines 500  Include more log lines
     hermes debug share --expire 30  Keep paste for 30 days
     hermes debug share --local      Print report locally (no upload)
-    hermes debug delete <url>       Delete a previously uploaded paste
 """,
     )
     debug_sub = debug_parser.add_subparsers(dest="debug_command")
@@ -5340,14 +5063,6 @@ Examples:
     share_parser.add_argument(
         "--local", action="store_true",
         help="Print the report locally instead of uploading",
-    )
-    delete_parser = debug_sub.add_parser(
-        "delete",
-        help="Delete a paste uploaded by 'hermes debug share'",
-    )
-    delete_parser.add_argument(
-        "urls", nargs="*", default=[],
-        help="One or more paste URLs to delete (e.g. https://paste.rs/abc123)",
     )
     debug_parser.set_defaults(func=cmd_debug)
 
@@ -6206,13 +5921,13 @@ Examples:
     # =========================================================================
     completion_parser = subparsers.add_parser(
         "completion",
-        help="Print shell completion script (bash, zsh, or fish)",
+        help="Print shell completion script (bash or zsh)",
     )
     completion_parser.add_argument(
-        "shell", nargs="?", default="bash", choices=["bash", "zsh", "fish"],
+        "shell", nargs="?", default="bash", choices=["bash", "zsh"],
         help="Shell type (default: bash)",
     )
-    completion_parser.set_defaults(func=lambda args: cmd_completion(args, parser))
+    completion_parser.set_defaults(func=cmd_completion)
 
     # =========================================================================
     # dashboard command
@@ -6225,10 +5940,6 @@ Examples:
     dashboard_parser.add_argument("--port", type=int, default=9119, help="Port (default 9119)")
     dashboard_parser.add_argument("--host", default="127.0.0.1", help="Host (default 127.0.0.1)")
     dashboard_parser.add_argument("--no-open", action="store_true", help="Don't open browser automatically")
-    dashboard_parser.add_argument(
-        "--insecure", action="store_true",
-        help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
-    )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 
     # =========================================================================
@@ -6303,42 +6014,7 @@ Examples:
         sys.exit(1)
 
     _processed_argv = _coalesce_session_name_args(sys.argv[1:])
-
-    # ── Defensive subparser routing (bpo-9338 workaround) ───────────
-    # On some Python versions (notably <3.11), argparse fails to route
-    # subcommand tokens when the parent parser has nargs='?' optional
-    # arguments (--continue).  The symptom: "unrecognized arguments: model"
-    # even though 'model' is a registered subcommand.
-    #
-    # Fix: when argv contains a token matching a known subcommand, set
-    # subparsers.required=True to force deterministic routing.  If that
-    # fails (e.g. 'hermes -c model' where 'model' is consumed as the
-    # session name for --continue), fall back to the default behaviour.
-    import io as _io
-    _known_cmds = set(subparsers.choices.keys()) if hasattr(subparsers, "choices") else set()
-    _has_cmd_token = any(t in _known_cmds for t in _processed_argv if not t.startswith("-"))
-
-    if _has_cmd_token:
-        subparsers.required = True
-        _saved_stderr = sys.stderr
-        try:
-            sys.stderr = _io.StringIO()
-            args = parser.parse_args(_processed_argv)
-            sys.stderr = _saved_stderr
-        except SystemExit as exc:
-            sys.stderr = _saved_stderr
-            # Help/version flags (exit code 0) already printed output —
-            # re-raise immediately to avoid a second parse_args printing
-            # the same help text again (#10230).
-            if exc.code == 0:
-                raise
-            # Subcommand name was consumed as a flag value (e.g. -c model).
-            # Fall back to optional subparsers so argparse handles it normally.
-            subparsers.required = False
-            args = parser.parse_args(_processed_argv)
-    else:
-        subparsers.required = False
-        args = parser.parse_args(_processed_argv)
+    args = parser.parse_args(_processed_argv)
 
     # Handle --version flag
     if args.version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "requests>=2.33.0,<3",  # CVE-2026-25645
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
+  "oauth-cli-kit>=0.1.3,<1",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools
@@ -63,12 +64,10 @@ homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
 acp = ["agent-client-protocol>=0.9.0,<1.0"]
 mistral = ["mistralai>=2.3.0,<3"]
-bedrock = ["boto3>=1.35.0,<2"]
 termux = [
   # Tested Android / Termux path: keeps the core CLI feature-rich while
   # avoiding extras that currently depend on non-Android wheels (notably
   # faster-whisper -> ctranslate2 via the voice extra).
-  "python-telegram-bot[webhooks]>=22.6,<23",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[pty]",
@@ -80,13 +79,13 @@ dingtalk = ["dingtalk-stream>=0.1.0,<1"]
 feishu = ["lark-oapi>=1.5.3,<2"]
 web = ["fastapi>=0.104.0,<1", "uvicorn[standard]>=0.24.0,<1"]
 rl = [
-  "atroposlib @ git+https://github.com/NousResearch/atropos.git@c20c85256e5a45ad31edf8b7276e9c5ee1995a30",
-  "tinker @ git+https://github.com/thinking-machines-lab/tinker.git@30517b667f18a3dfb7ef33fb56cf686d5820ba2b",
+  "atroposlib @ git+https://github.com/NousResearch/atropos.git",
+  "tinker @ git+https://github.com/thinking-machines-lab/tinker.git",
   "fastapi>=0.104.0,<1",
   "uvicorn[standard]>=0.24.0,<1",
   "wandb>=0.15.0,<1",
 ]
-yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git@bfb0c88062450f46341bd9a5298903fc2e952a5c ; python_version >= '3.12'"]
+yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
 all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
@@ -110,7 +109,6 @@ all = [
   "hermes-agent[dingtalk]",
   "hermes-agent[feishu]",
   "hermes-agent[mistral]",
-  "hermes-agent[bedrock]",
   "hermes-agent[web]",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pyyaml
 requests
 jinja2
 pydantic>=2.0
+oauth-cli-kit>=0.1.3,<1.0.0
 PyJWT[crypto]
 debugpy
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -3,6 +3,9 @@
 import json
 import time
 import base64
+import os
+import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -12,6 +15,8 @@ from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
+    _get_oauth_cli_codex_token,
+    _login_codex_browser_oauth,
     _read_codex_tokens,
     _save_codex_tokens,
     _write_codex_cli_tokens,
@@ -51,10 +56,17 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     return f"h.{encoded}.s"
 
 
+@pytest.fixture(autouse=True)
+def _isolate_codex_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-cli"))
+
+
 def test_read_codex_tokens_success(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     data = _read_codex_tokens()
     assert data["tokens"]["access_token"] == "access"
@@ -67,6 +79,7 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     # Empty auth store
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     with pytest.raises(AuthError) as exc:
         _read_codex_tokens()
@@ -77,6 +90,7 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
@@ -89,6 +103,7 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
     expiring_token = _jwt_with_exp(int(time.time()) - 10)
     _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     called = {"count": 0}
 
@@ -108,6 +123,7 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="access-current", refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     called = {"count": 0}
 
@@ -134,6 +150,7 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     hermes_home.mkdir(parents=True, exist_ok=True)
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     _save_codex_tokens({"access_token": "at123", "refresh_token": "rt456"})
     data = _read_codex_tokens()
@@ -195,8 +212,9 @@ def test_write_codex_cli_tokens_creates_file(tmp_path, monkeypatch):
     assert data["tokens"]["access_token"] == "new-access"
     assert data["tokens"]["refresh_token"] == "new-refresh"
     assert data["last_refresh"] == "2026-04-12T00:00:00Z"
-    # Verify file permissions are restricted
-    assert (auth_path.stat().st_mode & 0o777) == 0o600
+    # Verify file permissions are restricted on POSIX. Windows does not map chmod to 0o600.
+    if os.name != "nt":
+        assert (auth_path.stat().st_mode & 0o777) == 0o600
 
 
 def test_write_codex_cli_tokens_preserves_existing(tmp_path, monkeypatch):
@@ -245,11 +263,13 @@ def test_refresh_codex_auth_tokens_writes_back_to_cli(tmp_path, monkeypatch):
 
     hermes_home = tmp_path / "hermes"
     codex_home = tmp_path / "codex-cli"
+    shared_home = tmp_path / "xdg"
     hermes_home.mkdir(parents=True, exist_ok=True)
     codex_home.mkdir(parents=True, exist_ok=True)
     (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(shared_home))
 
     # Write initial CLI tokens
     (codex_home / "auth.json").write_text(json.dumps({
@@ -272,12 +292,82 @@ def test_refresh_codex_auth_tokens_writes_back_to_cli(tmp_path, monkeypatch):
     cli_data = json.loads((codex_home / "auth.json").read_text())
     assert cli_data["tokens"]["access_token"] == "refreshed-at"
     assert cli_data["tokens"]["refresh_token"] == "refreshed-rt"
+    shared = _get_oauth_cli_codex_token()
+    assert shared is not None
+    assert shared["tokens"]["access_token"] == "refreshed-at"
+    assert shared["tokens"]["refresh_token"] == "refreshed-rt"
+
+
+def test_shared_oauth_cli_token_is_preferred_over_hermes_store(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    _setup_hermes_auth(hermes_home, access_token="hermes-at", refresh_token="hermes-rt")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    from hermes_cli.auth import _save_oauth_cli_codex_token
+
+    _save_oauth_cli_codex_token("shared-at", "shared-rt", account_id="acct_123")
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+    assert creds["api_key"] == "shared-at"
+    assert creds["source"] == "oauth-cli-kit-shared"
+
+    synced = _read_codex_tokens()
+    assert synced["tokens"]["access_token"] == "shared-at"
+    assert synced["tokens"]["refresh_token"] == "shared-rt"
+
+
+def test_shared_oauth_cli_token_is_preferred_over_codex_cli(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-cli"))
+
+    from hermes_cli.auth import _save_oauth_cli_codex_token
+
+    _save_oauth_cli_codex_token("shared-at", "shared-rt")
+    _write_codex_cli_tokens("cli-at", "cli-rt")
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+    assert creds["api_key"] == "shared-at"
+    assert creds["source"] == "oauth-cli-kit-shared"
+
+
+def test_login_codex_browser_oauth_writes_shared_credentials(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-cli"))
+    monkeypatch.setattr("hermes_cli.auth._oauth_cli_codex_storage", lambda: None)
+
+    fake_oauth = types.ModuleType("oauth_cli_kit")
+    fake_oauth.login_oauth_interactive = lambda **kwargs: types.SimpleNamespace(
+        access="browser-at",
+        refresh="browser-rt",
+        expires=int(time.time() * 1000) + 3600_000,
+        account_id="acct_browser",
+    )
+    monkeypatch.setitem(sys.modules, "oauth_cli_kit", fake_oauth)
+
+    bundle = _login_codex_browser_oauth()
+
+    assert bundle["tokens"]["access_token"] == "browser-at"
+    assert bundle["tokens"]["refresh_token"] == "browser-rt"
+    shared = _get_oauth_cli_codex_token()
+    assert shared is not None
+    assert shared["tokens"]["access_token"] == "browser-at"
+    assert shared["account_id"] == "acct_browser"
 
 
 def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
 
     creds = resolve_codex_runtime_credentials()
     assert creds["source"] == "hermes-auth-store"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -35,6 +35,12 @@ def _clear_provider_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_codex_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-cli"))
+
+
 def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
@@ -151,6 +157,7 @@ def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
 
 def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
     token = _jwt_with_email("codex@example.com")
     monkeypatch.setattr(
@@ -182,6 +189,71 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["source"] == "manual:device_code"
     assert entry["refresh_token"] == "refresh-token"
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
+def test_auth_add_codex_browser_persists_browser_source(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("browser@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_codex_browser_oauth",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "browser-refresh",
+            },
+            "last_refresh": "2026-03-23T10:00:00Z",
+            "source": "oauth-cli-kit-shared",
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        method = "browser"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    entry = next(item for item in entries if item["source"] == "manual:oauth_cli_browser")
+    assert entry["label"] == "browser@example.com"
+    assert entry["refresh_token"] == "browser-refresh"
+
+
+def test_auth_add_codex_prefers_shared_credential(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth import _save_oauth_cli_codex_token
+
+    _save_oauth_cli_codex_token(_jwt_with_email("shared@example.com"), "shared-refresh")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: (_ for _ in ()).throw(AssertionError("device code login should not run")),
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+        method = "device-code"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = next(item for item in payload["credential_pool"]["openai-codex"] if item["source"] == "shared:oauth_cli_kit")
+    assert entry["label"] == "shared@example.com"
+    assert entry["refresh_token"] == "shared-refresh"
 
 
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
@@ -335,6 +407,57 @@ def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatc
     payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
     labels = [entry["label"] for entry in payload["credential_pool"]["openai-codex"]]
     assert labels == ["first", "third"]
+
+
+def test_auth_remove_codex_keeps_shared_credential_by_default(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"access_token": "local-at", "refresh_token": "local-rt"},
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "shared-account",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "shared:oauth_cli_kit",
+                        "access_token": "shared-at",
+                        "refresh_token": "shared-rt",
+                    }
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth import _get_oauth_cli_codex_token, _save_oauth_cli_codex_token
+    from hermes_cli.auth_commands import auth_remove_command
+
+    _save_oauth_cli_codex_token("shared-at", "shared-rt")
+
+    class _Args:
+        provider = "openai-codex"
+        target = "1"
+        purge_shared = False
+
+    auth_remove_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload.get("credential_pool", {}).get("openai-codex") or []
+    assert len(entries) == 0
+    assert "openai-codex" not in payload.get("providers", {})
+    shared = _get_oauth_cli_codex_token()
+    assert shared is not None
+    assert shared["tokens"]["access_token"] == "shared-at"
+    out = capsys.readouterr().out
+    assert "--purge-shared" in out
 
 
 def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -110,6 +110,38 @@ def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):
 # ── Tests for _normalize_model_for_provider ──────────────────────────
 
 
+def test_model_command_offers_browser_login_for_codex(monkeypatch):
+    from hermes_cli.main import _model_flow_openai_codex
+
+    captured = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_codex_auth_status",
+        lambda: {"logged_in": False},
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "2")
+    monkeypatch.setattr(
+        "hermes_cli.auth._login_openai_codex",
+        lambda args, provider: captured.setdefault("method", getattr(args, "method", None)),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_codex_runtime_credentials",
+        lambda *args, **kwargs: {"api_key": "codex-access-token"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.codex_models.get_codex_model_ids",
+        lambda access_token=None: ["gpt-5.2-codex"],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda *args, **kwargs: None,
+    )
+
+    _model_flow_openai_codex({}, current_model="")
+
+    assert captured["method"] == "browser"
+
+
 def _make_cli(model="anthropic/claude-opus-4.6", **kwargs):
     """Create a HermesCLI with minimal mocking."""
     import cli as _cli_mod

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -15,7 +15,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | Provider | Setup |
 |----------|-------|
 | **Nous Portal** | `hermes model` (OAuth, subscription-based) |
-| **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
+| **OpenAI Codex** | `hermes model` (device code by default, browser OAuth compatible with NanoBOT) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Pro/Max via Claude Code auth, Anthropic API key, or manual setup-token) |
@@ -42,23 +42,12 @@ In the `model:` config section, you can use either `default:` or `model:` as the
 :::
 
 :::info Codex Note
-The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
+The OpenAI Codex provider uses device code login by default and also supports `hermes auth add openai-codex --method browser` for NanoBOT-compatible browser OAuth. If `~/.local/share/oauth-cli-kit/auth/codex.json` already exists, Hermes reuses that shared credential first, then mirrors the session into `~/.hermes/auth.json` and `~/.codex/auth.json`.
 :::
 
 :::warning
 Even when using Nous Portal, Codex, or a custom endpoint, some tools (vision, web summarization, MoA) use a separate "auxiliary" model — by default Gemini Flash via OpenRouter. An `OPENROUTER_API_KEY` enables these tools automatically. You can also configure which model and provider these tools use — see [Auxiliary Models](/docs/user-guide/configuration#auxiliary-models).
 :::
-
-### Two Commands for Model Management
-
-Hermes has **two** model commands that serve different purposes:
-
-| Command | Where to run | What it does |
-|---------|-------------|--------------|
-| **`hermes model`** | Your terminal (outside any session) | Full setup wizard — add providers, run OAuth, enter API keys, configure endpoints |
-| **`/model`** | Inside a Hermes chat session | Quick switch between **already-configured** providers and models |
-
-If you're trying to switch to a provider you haven't set up yet (e.g. you only have OpenRouter configured and want to use Anthropic), you need `hermes model`, not `/model`. Exit your session first (`Ctrl+C` or `/quit`), run `hermes model`, complete the provider setup, then start a new session.
 
 ### Anthropic (Native)
 
@@ -263,15 +252,7 @@ Both approaches persist to `config.yaml`, which is the source of truth for model
 
 ### Switching Models with `/model`
 
-:::warning hermes model vs /model
-**`hermes model`** (run from your terminal, outside any chat session) is the **full provider setup wizard**. Use it to add new providers, run OAuth flows, enter API keys, and configure custom endpoints.
-
-**`/model`** (typed inside an active Hermes chat session) can only **switch between providers and models you've already set up**. It cannot add new providers, run OAuth, or prompt for API keys. If you've only configured one provider (e.g. OpenRouter), `/model` will only show models for that provider.
-
-**To add a new provider:** Exit your session (`Ctrl+C` or `/quit`), run `hermes model`, set up the new provider, then start a new session.
-:::
-
-Once you have at least one custom endpoint configured, you can switch models mid-session:
+Once a custom endpoint is configured, you can switch models mid-session:
 
 ```
 /model custom:qwen-2.5          # Switch to a model on your custom endpoint


### PR DESCRIPTION
## Summary

This PR adds a browser-compatible OpenAI Codex login flow to Hermes while keeping the existing device-code flow as the default.

Hermes now supports:

1. `hermes auth add openai-codex`
   - default device-code login

2. `hermes auth add openai-codex --method browser`
   - explicit browser login

3. `hermes model`
   - if a reusable shared Codex credential already exists in the current environment, Hermes uses it directly
   - otherwise Hermes prompts the user to choose:
     - device-code login
     - browser login

## What Changed

- Kept device-code login as the default Codex auth path
- Added an explicit browser login path for Codex
- Updated Codex credential resolution so Hermes prefers an already-available browser credential in the current environment
- Updated the interactive model-selection flow so `hermes model` can offer both login methods when needed
- Updated Codex refresh and sync behavior so Hermes keeps runtime credentials consistent
- Updated removal behavior so Hermes does not delete shared Codex credentials by default

## User-Facing Behavior

### Default login
```bash
hermes auth add openai-codex
