### PR TITLE
fix: pass resolved args to resolve_vision_provider_client()

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2387,10 +2387,10 @@ def call_llm(
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
-            provider=provider,
-            model=model,
-            base_url=base_url,
-            api_key=api_key,
+            provider=resolved_provider if resolved_provider != "auto" else provider,
+            model=resolved_model or model,
+            base_url=resolved_base_url or base_url,
+            api_key=resolved_api_key or api_key,
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -2595,10 +2595,10 @@ async def async_call_llm(
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
-            provider=provider,
-            model=model,
-            base_url=base_url,
-            api_key=api_key,
+            provider=resolved_provider if resolved_provider != "auto" else provider,
+            model=resolved_model or model,
+            base_url=resolved_base_url or base_url,
+            api_key=resolved_api_key or api_key,
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:


### PR DESCRIPTION
## Problem

The `resolve_vision_provider_client()` function in `auxiliary_client.py` was receiving raw `provider`, `model`, `base_url`, and `api_key` arguments instead of the resolved values from the configuration. This caused vision calls to fall back to the wrong model that doesn't support images.

When a user specifies a model alias or shorthand in their config, the system resolves it to the full provider/model combination. However, the vision call sites in `call_llm()` and `async_call_llm()` were passing the unresolved raw arguments to `resolve_vision_provider_client()`, bypassing the config resolution entirely.

## Changes

Modified `agent/auxiliary_client.py` at two call sites:
- `call_llm()` function (line ~2387)
- `async_call_llm()` function (line ~2595)

Changed from:
```python
resolve_vision_provider_client(
    provider=provider,
    model=model,
    base_url=base_url,
    api_key=api_key,
    ...
)
```

To:
```python
resolve_vision_provider_client(
    provider=resolved_provider if resolved_provider != "auto" else provider,
    model=resolved_model or model,
    base_url=resolved_base_url or base_url,
    api_key=resolved_api_key or api_key,
    ...
)
```

This ensures that when config resolution produces values (e.g., resolving "claude" to "anthropic/claude-sonnet-4-20250514"), those resolved values are used for vision provider selection instead of the raw input.

## Testing

- Verified syntax with Python parser (lint passed)
- The fix follows the same pattern used elsewhere in the codebase for resolved vs raw argument handling

## Impact

This fix ensures vision calls use the correct provider/model configuration, preventing fallback to models that don't support image inputs.
