### PR TITLE
fix(status): bootstrap user systemd env for gateway checks

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -360,11 +360,14 @@ def show_status(args):
             print("  Manager:      docker (foreground)")
         else:
             try:
-                from hermes_cli.gateway import get_service_name
+                from hermes_cli.gateway import get_service_name, _ensure_user_systemd_env
                 _gw_svc = get_service_name()
             except Exception:
                 _gw_svc = "hermes-gateway"
+                _ensure_user_systemd_env = None
             try:
+                if _ensure_user_systemd_env is not None:
+                    _ensure_user_systemd_env()
                 result = subprocess.run(
                     ["systemctl", "--user", "is-active", _gw_svc],
                     capture_output=True,

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,3 +1,4 @@
+import os
 from types import SimpleNamespace
 
 from hermes_cli.status import show_status
@@ -42,3 +43,51 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_linux_gateway_section_bootstraps_user_systemd_env(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+    import hermes_constants as hermes_constants_mod
+
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("DBUS_SESSION_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr(status_mod.sys, "platform", "linux", raising=False)
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(status_mod, "managed_nous_tools_enabled", lambda: False, raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(hermes_constants_mod, "is_container", lambda: False, raising=False)
+    monkeypatch.setattr(gateway_mod, "get_service_name", lambda: "hermes-gateway", raising=False)
+
+    calls = []
+
+    def _fake_ensure():
+        calls.append("ensure")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/42")
+        monkeypatch.setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/42/bus")
+
+    def _fake_run(cmd, capture_output=False, text=False, timeout=None):
+        assert cmd == ["systemctl", "--user", "is-active", "hermes-gateway"]
+        assert os.environ["XDG_RUNTIME_DIR"] == "/run/user/42"
+        assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/42/bus"
+        calls.append("run")
+        return SimpleNamespace(stdout="active\n", returncode=0)
+
+    monkeypatch.setattr(gateway_mod, "_ensure_user_systemd_env", _fake_ensure, raising=False)
+    monkeypatch.setattr(status_mod.subprocess, "run", _fake_run)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert calls == ["ensure", "run"]
+    assert "Status:       " in output
+    assert "running" in output
+    assert "Manager:      systemd (user)" in output


### PR DESCRIPTION
## Summary
- bootstrap the user systemd D-Bus environment before `hermes status` runs `systemctl --user is-active`
- keep the Linux non-container gateway status check aligned with the existing gateway-service helpers
- add a regression test covering shells where `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` start unset

## Why
Issue #10851 reports that `hermes status` can falsely show the gateway as stopped in SSH or other non-interactive shells where the user-systemd D-Bus environment is not inherited.

`hermes_cli.gateway` already has `_ensure_user_systemd_env()` for this exact case, but `hermes_cli.status` was calling `systemctl --user` directly without first preparing that environment.

Fixes #10851

## Tests
- `python3 -m pytest -o addopts= tests/hermes_cli/test_status.py tests/hermes_cli/test_gateway_service.py -k "status or ensure_user_systemd_env"`
- `python3 -m py_compile hermes_cli/status.py tests/hermes_cli/test_status.py`