### PR TITLE
test(compress): re-initialise main_runtime attrs in manually-built compressor

### DIFF
--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -25,6 +25,13 @@ def _make_compressor():
     compressor._previous_summary = None
     compressor._summary_failure_cooldown_until = 0.0
     compressor.summary_model = None
+    # main_runtime attributes used by _generate_summary.  Production sets
+    # these in __init__ but this fixture bypasses it via __new__.
+    compressor.model = "test/model"
+    compressor.provider = ""
+    compressor.base_url = ""
+    compressor.api_key = ""
+    compressor.api_mode = ""
     return compressor
 
 


### PR DESCRIPTION
## Problem

`tests/agent/test_compress_focus.py::test_focus_topic_injected_into_summary_prompt`
and `test_no_focus_topic_no_injection` fail with:

```
WARNING  root:context_compressor.py:477 Failed to generate context summary:
'ContextCompressor' object has no attribute 'model'.  Further summary
attempts paused for 600 seconds.
```

Both tests then report `result is None` / `KeyError: 'messages'` because
`_generate_summary` swallowed the `AttributeError` in its broad-except
cooldown path.

## Root cause

`_make_compressor` in the test file builds a compressor with
`ContextCompressor.__new__(ContextCompressor)`, bypassing `__init__`, and
explicitly sets only the attributes the method used to touch (token
budgets, protect counts, the previous-summary cache, etc.).

PR #7910 ("fix(agent): route compression aux through live session
runtime") added a `main_runtime` dict to the `call_llm` invocation inside
`_generate_summary`:

```python
"main_runtime": {
    "model": self.model,
    "provider": self.provider,
    "base_url": self.base_url,
    "api_key": self.api_key,
    "api_mode": self.api_mode,
},
```

Production sets those attributes in `__init__`, but the test fixture —
which predates the runtime-aware change — never did. Accessing
`self.model` raises `AttributeError`, which the method catches and
converts into a 10-minute cooldown + `None` return.

## Fix

Extend `_make_compressor` to set the five runtime attributes
(`model`, `provider`, `base_url`, `api_key`, `api_mode`) so the fixture
matches the current production surface.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q tests/agent/test_compress_focus.py
....                                                                     [100%]
4 passed in 0.53s
```

All four tests in the module pass, including the previously failing two.
