### PR TITLE
test(aux): use resolve_vision_provider_client instead of removed helper

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -786,7 +786,7 @@ class TestAuxiliaryPoolAwareness:
             patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
             patch("agent.anthropic_adapter.resolve_anthropic_token", return_value="***"),
         ):
-            client, model = get_vision_auxiliary_client()
+            provider, client, model = resolve_vision_provider_client()
 
         assert client is not None
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/agent/test_auxiliary_client.py::TestAuxiliaryPoolAwareness::test_vision_auto_uses_active_provider_as_fallback
...
tests/agent/test_auxiliary_client.py:798: in test_vision_auto_uses_active_provider_as_fallback
    client, model = get_vision_auxiliary_client()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   NameError: name 'get_vision_auxiliary_client' is not defined
```

## Root cause

`get_vision_auxiliary_client()` was removed from
`agent/auxiliary_client.py` during the Apr-2026 dead-code audit
(PR #8064, commit 96c06001) — along with the matching test and its
import. Some time later the test was reintroduced (commit c1af6142,
PR wrapping Copilot Responses-API models) without restoring either
the helper or the import, so the call raises `NameError` every run.

The surviving public helper is `resolve_vision_provider_client()`,
which returns `(provider, client, model)`. The sibling test
`test_vision_auto_prefers_active_provider_over_openrouter` already uses
this helper — the failing test should too.

## Fix

Call `resolve_vision_provider_client()` and unpack the triple. The
behaviour under test (vision auto falls back to the active provider's
Anthropic backend when no OpenRouter/Nous creds exist) is unchanged.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/agent/test_auxiliary_client.py::TestAuxiliaryPoolAwareness::test_vision_auto_uses_active_provider_as_fallback
.                                                                        [100%]
1 passed in 0.70s
```
