### PR TITLE
test(feishu): stub new bot-membership registrations in event-handler fake

### DIFF
--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -699,6 +699,14 @@ class TestAdapterBehavior(unittest.TestCase):
                 calls.append("card_action")
                 return self
 
+            def register_p2_im_chat_member_bot_added_v1(self, _handler):
+                calls.append("bot_added")
+                return self
+
+            def register_p2_im_chat_member_bot_deleted_v1(self, _handler):
+                calls.append("bot_deleted")
+                return self
+
             def build(self):
                 calls.append("build")
                 return "handler"
@@ -722,6 +730,8 @@ class TestAdapterBehavior(unittest.TestCase):
                 "reaction_created",
                 "reaction_deleted",
                 "card_action",
+                "bot_added",
+                "bot_deleted",
                 "build",
             ],
         )


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/gateway/test_feishu.py::TestAdapterBehavior::test_build_event_handler_registers_reaction_and_card_processors
...
AttributeError: '_Builder' object has no attribute 'register_p2_im_chat_member_bot_added_v1'
```

## Root cause

PR #6975 (commit d8cd7974, "fix(feishu): register group chat member event
handlers") added two new event registrations to
`FeishuAdapter._build_event_handler` so bot-added and bot-removed chat
events are no longer silently dropped:

```python
.register_p2_im_chat_member_bot_added_v1(self._on_bot_added_to_chat)
.register_p2_im_chat_member_bot_deleted_v1(self._on_bot_removed_from_chat)
```

Real `lark-oapi` builders already expose both methods, so production is
fine. The `_Builder` fake in
`test_build_event_handler_registers_reaction_and_card_processors` only
defined the five registration methods the adapter originally used, so
the new calls raise `AttributeError` against the stub.

## Fix

Extend the stub `_Builder` with the two missing registration methods
and append their markers to the expected call sequence so the fake
matches the SDK surface `_build_event_handler` now exercises.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/gateway/test_feishu.py::TestAdapterBehavior::test_build_event_handler_registers_reaction_and_card_processors
.                                                                        [100%]
1 passed in 0.20s
```
