### PR TITLE
test(email): verify session discovery functionally, not via source grep

### DIFF
--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -334,10 +334,29 @@ class TestChannelDirectory(unittest.TestCase):
     """Verify email in channel directory session-based discovery."""
 
     def test_email_in_session_discovery(self):
-        import gateway.channel_directory
-        import inspect
-        source = inspect.getsource(gateway.channel_directory.build_channel_directory)
-        self.assertIn('"email"', source)
+        """build_channel_directory enumerates email (via Platform enum) and
+        falls through to the session-based discovery helper."""
+        from unittest.mock import patch
+
+        import gateway.channel_directory as _cd
+        from gateway.config import Platform
+
+        self.assertEqual(Platform.EMAIL.value, "email")
+
+        seen: list[str] = []
+
+        def _capture(plat_name: str):
+            seen.append(plat_name)
+            return []
+
+        with patch.object(_cd, "_build_from_sessions", side_effect=_capture), \
+             patch.object(_cd, "atomic_json_write", lambda *a, **k: None):
+            directory = _cd.build_channel_directory({})
+
+        # email must be one of the platforms routed through session discovery
+        self.assertIn("email", seen)
+        # and must appear as a top-level key in the built directory
+        self.assertIn("email", directory["platforms"])
 
 
 class TestGatewaySetup(unittest.TestCase):


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/gateway/test_email.py::TestChannelDirectory::test_email_in_session_discovery
...
E   AssertionError: '"email"' not found in 'def build_channel_directory(...):\n    ...'
```

## Root cause

PR #7450 (commit baddb6f7, "fix(gateway): derive channel directory
platforms from enum instead of hardcoded list") replaced the hardcoded
tuple that listed `("telegram", "whatsapp", "signal", "weixin",
"email", "sms", "bluebubbles")` with a dynamic loop over the
`Platform` enum that excludes only infrastructure entries (`local`,
`api_server`, `webhook`). Six platforms that had been missing from the
old tuple are now discovered automatically — a strictly better
behaviour.

But `test_email_in_session_discovery` asserted the literal string
`"email"` appears inside the source of `build_channel_directory` via
`inspect.getsource`. The refactor removed that literal, so the
behaviour-preserving (and behaviour-extending) change triggered the
test failure.

## Fix

Rewrite the test to assert actual behaviour: patch `_build_from_sessions`
to capture the platform names it is called with, patch
`atomic_json_write` to skip disk I/O, invoke `build_channel_directory({})`,
and verify that `"email"` is routed through session discovery AND shows
up as a top-level key in the returned directory. This exercises the
public contract without pinning the test to the specific text of the
implementation.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/gateway/test_email.py::TestChannelDirectory::test_email_in_session_discovery
.                                                                        [100%]
1 passed in 0.06s
```

RED→GREEN confirmed: with the rewritten test on an unmodified
`build_channel_directory`, the test passes; without the rewrite it
still fails for the original reason.
