### PR TITLE
test(session-hygiene): include user_id on the synthetic MessageEvent

### DIFF
--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -374,6 +374,7 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
             chat_id="-1001",
             chat_type="group",
             thread_id="17585",
+            user_id="795544298",
         ),
         message_id="1",
     )


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/gateway/test_session_hygiene.py::test_session_hygiene_messages_stay_in_originating_topic
...
>       assert result == "ok"
E       AssertionError: assert None == 'ok'
```

## Root cause

PR #8280 (commit cac61781, "fix(gateway): propagate user identity
through process watcher pipeline") added an early-return guard at the
top of `GatewayRunner._handle_message`:

```python
elif source.user_id is None:
    logger.debug("Ignoring message with no user_id from %s", ...)
    return None
```

Real-world motivation: Telegram service messages, channel forwards, and
anonymous admin actions arrive without a `from_user` and were
triggering spurious pairing flows with `user_id=None`. The guard drops
them before any auth or agent work happens.

`test_session_hygiene_messages_stay_in_originating_topic` builds a
synthetic `MessageEvent` whose `SessionSource` has `chat_id="-1001"`,
`thread_id="17585"`, and no `user_id`. After the guard landed, the
handler returns `None` before reaching the mocked `_run_agent` (which
returns `"ok"`), so the assertion fails.

## Fix

Set `user_id="795544298"` on the synthetic `SessionSource` — the same
numeric user the test already uses as `TELEGRAM_HOME_CHANNEL`. With a
valid user_id the handler clears the guard and reaches the agent path
the test is meant to exercise (session-hygiene message stays in its
originating topic).

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/gateway/test_session_hygiene.py::test_session_hygiene_messages_stay_in_originating_topic
.                                                                        [100%]
1 passed in 0.25s
```
