### PR TITLE
fix(runtime): honour providers-dict api_key/api_mode when resolving

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -284,20 +284,29 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
+            # Resolve the API key: prefer the literal "api_key" field on the
+            # providers entry; fall back to resolving from the env var name
+            # stored in "key_env".  Also surface api_mode/transport so
+            # downstream code can use the provider's preferred transport.
+            direct_api_key = str(entry.get("api_key", "") or "").strip()
             key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            env_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            resolved_api_key = direct_api_key or env_api_key
+            api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
-                    return {
+                    result = {
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    if api_mode:
+                        result["api_mode"] = api_mode
+                    return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
             if display_name:
@@ -306,12 +315,15 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
-                        return {
+                        result = {
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
+                        if api_mode:
+                            result["api_mode"] = api_mode
+                        return result
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_providers_dict_when_list_missing
...
>       assert resolved["api_key"] == "dir-key"
E       AssertionError: assert 'no-key-required' == 'dir-key'
```

The test sets up a v12 `providers` dict with an inline API key and
explicit transport:

```python
"providers": {
    "openai-direct-primary": {
        "api": "https://api.openai.com/v1",
        "api_key": "dir-key",
        "default_model": "gpt-5-mini",
        "transport": "codex_responses",
    }
}
```

and expects `resolve_runtime_provider(requested="openai-direct-primary")`
to come back with `api_key="dir-key"` and `api_mode="codex_responses"`.
Instead it gets `api_key="no-key-required"` and the default
`chat_completions` mode.

## Root cause

`_get_named_custom_provider` (in `hermes_cli/runtime_provider.py`) only
resolved the API key by reading the env var whose name is stored in the
providers entry's `key_env` field:

```python
key_env = str(entry.get("key_env", "") or "").strip()
resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
```

It never looked at the literal `api_key` field on the entry. When
users wrote `api_key` directly (the natural thing given the field
name), the returned dict had `api_key=""`. Downstream,
`_resolve_named_custom_runtime` walked its fallback chain, found no
candidate, and stamped the final result with `"no-key-required"` —
which the HTTP client treats as "skip auth" and the remote API then
rejects.

Similarly, `api_mode`/`transport` was read out of the entry but never
placed in the returned dict, so downstream always fell back to
`_detect_api_mode_for_url(base_url)` / `chat_completions`, ignoring
the user's explicit choice.

## Fix

In `_get_named_custom_provider`:

* Prefer the literal `api_key` field on the providers entry; fall back
  to the `key_env` lookup when `api_key` is missing.
* Read `api_mode` (or its `transport` alias) and include it in the
  returned dict when present.

Both `custom_providers:`-list-style and `providers:`-dict-style user
endpoints now behave the same way with respect to API keys and
transport selection.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/hermes_cli/test_runtime_provider_resolution.py
...................................................................      [100%]
67 passed in 0.44s
```

All 67 runtime-provider resolution tests pass, including the previously
failing `test_named_custom_provider_uses_providers_dict_when_list_missing`.
