### PR TITLE
test(tirith): only clear HERMES_HOME in the fallback test, not all of os.environ

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -996,11 +996,13 @@ class TestHermesHomeIsolation:
         assert hermes_home is not None, "HERMES_HOME should be set by conftest"
         assert "hermes_test" in hermes_home, "Should point to test temp dir"
 
-    def test_get_hermes_home_fallback(self):
+    def test_get_hermes_home_fallback(self, monkeypatch):
         """Without HERMES_HOME set, falls back to ~/.hermes."""
         from tools.tirith_security import _get_hermes_home
-        with patch.dict(os.environ, {}, clear=True):
-            # Remove HERMES_HOME entirely
-            os.environ.pop("HERMES_HOME", None)
-            result = _get_hermes_home()
+        # Only remove HERMES_HOME — clearing all of os.environ would also
+        # strip HOME, which makes os.path.expanduser('~') fall back to the
+        # passwd-db home (the real invoking user) instead of the test HOME
+        # set by the runner.  The test's intent is "no HERMES_HOME" only.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        result = _get_hermes_home()
         assert result == os.path.join(os.path.expanduser("~"), ".hermes")


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/tools/test_tirith_security.py::TestHermesHomeIsolation::test_get_hermes_home_fallback
...
>       assert result == os.path.join(os.path.expanduser("~"), ".hermes")
E       AssertionError: assert '/Users/someone/.hermes' == '/tmp/hermes-test-home.XXXXXX/.hermes'
E
E         - /tmp/hermes-test-home.XXXXXX/.hermes
E         + /Users/someone/.hermes
```

## Root cause

The test intends to verify that when `HERMES_HOME` is unset,
`_get_hermes_home()` falls back to `~/.hermes`. It does this by
wiping the whole environment:

```python
with patch.dict(os.environ, {}, clear=True):
    os.environ.pop("HERMES_HOME", None)
    result = _get_hermes_home()
assert result == os.path.join(os.path.expanduser("~"), ".hermes")
```

`clear=True` also strips `HOME`. With no `HOME`, Python's
`os.path.expanduser('~')` falls back to the passwd-db home for the
invoking user — a totally different path from the scratch `HOME`
that most test harnesses (and the project's own docs) ask you to
`export` before running the suite.

So LHS is `/Users/<invoker>/.hermes` (computed inside the cleared
env, via pwd) and RHS is `/tmp/…/.hermes` (computed after the `with`
block restores the runner's `HOME`). They never match on a machine
whose invoking user has a real home dir.

## Fix

Use `monkeypatch.delenv("HERMES_HOME", raising=False)` so only
`HERMES_HOME` is removed — exactly what the test's docstring says
it wants — leaving `HOME` intact so the fallback is computed against
the runner's scratch home.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/tools/test_tirith_security.py::TestHermesHomeIsolation
....                                                                     [100%]
4 passed in 0.06s
```
