### PR TITLE
test(write-deny): assert captured-at-import HERMES_HOME/.env instead of ~/.hermes

### DIFF
--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -33,8 +33,17 @@ class TestWriteDenyExactPaths:
         assert _is_write_denied(path) is True
 
     def test_hermes_env(self):
-        path = os.path.join(str(Path.home()), ".hermes", ".env")
-        assert _is_write_denied(path) is True
+        # HERMES_HOME/.env is captured in WRITE_DENIED_PATHS at import time
+        # via ``get_hermes_home() / ".env"``.  In production, HERMES_HOME
+        # defaults to ~/.hermes, but under test isolation it points at a
+        # scratch tmp dir, so we cannot assume the path is ~/.hermes/.env.
+        # Assert that *some* .env path was captured and that it is denied.
+        from tools.file_operations import WRITE_DENIED_PATHS
+        env_paths = [p for p in WRITE_DENIED_PATHS if p.endswith(os.sep + ".env")]
+        assert env_paths, (
+            "HERMES_HOME/.env should be captured in WRITE_DENIED_PATHS at import time"
+        )
+        assert _is_write_denied(env_paths[0]) is True
 
     def test_shell_profiles(self):
         home = str(Path.home())


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/tools/test_write_deny.py::TestWriteDenyExactPaths::test_hermes_env
...
>       assert _is_write_denied(path) is True
E       AssertionError: assert False is True
```

## Root cause

`tools/file_operations.py` captures the Hermes env-file path into
`WRITE_DENIED_PATHS` **at import time**:

```python
str(get_hermes_home() / ".env"),
```

In production, `get_hermes_home()` resolves to `~/.hermes`, so the
captured path is `~/.hermes/.env`.

In tests, the autouse `_isolate_hermes_home` fixture redirects
`HERMES_HOME` to a scratch tmp dir *before* `tools.file_operations`
is imported. So the captured path ends up looking like
`/tmp/pytest-.../hermes-home-xxx/.env`, not `~/.hermes/.env`.

The test, however, asserted against `os.path.join(str(Path.home()), ".hermes", ".env")` —
a path that was never added to the deny list under isolation — and
naturally got `False`.

## Fix

Rewrite the test to match the behavior it actually cares about:
*the HERMES_HOME `.env` was captured at import time and is denied*.
We don't care **which** `.env` path was captured — only that one was,
and that `_is_write_denied` returns `True` for it.

```python
def test_hermes_env(self):
    from tools.file_operations import WRITE_DENIED_PATHS
    env_paths = [p for p in WRITE_DENIED_PATHS if p.endswith(os.sep + ".env")]
    assert env_paths, (
        "HERMES_HOME/.env should be captured in WRITE_DENIED_PATHS at import time"
    )
    assert _is_write_denied(env_paths[0]) is True
```

This test now works correctly under any HERMES_HOME (default,
profile-scoped, or test-isolated).

## Verification

```
$ python -m pytest --override-ini="addopts=" -q tests/tools/test_write_deny.py
...................                                                      [100%]
19 passed in 0.07s
```
