### PR TITLE
Fix API server notify_on_complete session context

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -46,6 +46,7 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from gateway.session import SessionContext, SessionSource, build_session_key
 
 logger = logging.getLogger(__name__)
 
@@ -395,6 +396,27 @@ class APIServerAdapter(BasePlatformAdapter):
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._gateway_runner: Optional[Any] = None
+
+    def bind_gateway_runner(self, gateway_runner: Any) -> None:
+        """Attach the owning GatewayRunner for shared watcher delivery."""
+        self._gateway_runner = gateway_runner
+
+    def _build_session_context(self, session_id: Optional[str]) -> SessionContext:
+        """Build a synthetic session context for API-server initiated turns."""
+        chat_id = str(session_id or "api_server")
+        source = SessionSource(
+            platform=Platform.API_SERVER,
+            chat_id=chat_id,
+            chat_type="dm",
+        )
+        return SessionContext(
+            source=source,
+            connected_platforms=[],
+            home_channels={},
+            session_id=chat_id,
+            session_key=build_session_key(source),
+        )
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -2004,9 +2026,28 @@ class APIServerAdapter(BasePlatformAdapter):
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
         """
-        loop = asyncio.get_event_loop()
+        session_context = self._build_session_context(session_id)
+        if self._gateway_runner is not None:
+            session_env_tokens = self._gateway_runner._set_session_env(session_context)
+        else:
+            from gateway.session_context import set_session_vars
+
+            session_env_tokens = set_session_vars(
+                platform=session_context.source.platform.value,
+                chat_id=session_context.source.chat_id,
+                chat_name=session_context.source.chat_name or "",
+                thread_id=session_context.source.thread_id or "",
+                user_id=session_context.source.user_id or "",
+                user_name=session_context.source.user_name or "",
+                session_key=session_context.session_key,
+            )
 
         def _run():
+            from tools.approval import (
+                reset_current_session_key,
+                set_current_session_key,
+            )
+
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
@@ -2017,11 +2058,15 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
-            result = agent.run_conversation(
-                user_message=user_message,
-                conversation_history=conversation_history,
-                task_id="default",
-            )
+            approval_session_token = set_current_session_key(session_context.session_key)
+            try:
+                result = agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=conversation_history,
+                    task_id="default",
+                )
+            finally:
+                reset_current_session_key(approval_session_token)
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
@@ -2029,7 +2074,25 @@ class APIServerAdapter(BasePlatformAdapter):
             }
             return result, usage
 
-        return await loop.run_in_executor(None, _run)
+        try:
+            result = await asyncio.to_thread(_run)
+            if self._gateway_runner is not None:
+                try:
+                    from tools.process_registry import process_registry
+
+                    while process_registry.pending_watchers:
+                        watcher = process_registry.pending_watchers.pop(0)
+                        asyncio.create_task(self._gateway_runner._run_process_watcher(watcher))
+                except Exception as exc:
+                    logger.error("API server process watcher setup error: %s", exc)
+            return result
+        finally:
+            if self._gateway_runner is not None:
+                self._gateway_runner._clear_session_env(session_env_tokens)
+            else:
+                from gateway.session_context import clear_session_vars
+
+                clear_session_vars(session_env_tokens)
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2534,7 +2534,9 @@ class GatewayRunner:
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            return APIServerAdapter(config)
+            adapter = APIServerAdapter(config)
+            adapter.bind_gateway_runner(self)
+            return adapter
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -12,6 +12,7 @@ Tests cover:
 - Error handling (invalid JSON, missing fields)
 """
 
+import asyncio
 import json
 import time
 import uuid
@@ -31,6 +32,9 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+from gateway.session_context import _UNSET, _VAR_MAP, get_session_env
 
 
 # ---------------------------------------------------------------------------
@@ -240,6 +244,13 @@ def auth_adapter():
     return _make_adapter(api_key="sk-secret")
 
 
+@pytest.fixture(autouse=True)
+def _reset_session_contextvars():
+    yield
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+
+
 # ---------------------------------------------------------------------------
 # /health endpoint
 # ---------------------------------------------------------------------------
@@ -256,6 +267,94 @@ class TestHealthEndpoint:
             assert resp.headers.get("X-Content-Type-Options") == "nosniff"
             assert resp.headers.get("Referrer-Policy") == "no-referrer"
 
+
+class TestGatewayBinding:
+    def test_gateway_runner_binds_api_server_adapter(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        config = PlatformConfig(enabled=True)
+
+        adapter = runner._create_adapter(Platform.API_SERVER, config)
+
+        assert isinstance(adapter, APIServerAdapter)
+        assert adapter._gateway_runner is runner
+
+
+class TestRunAgentSessionContext:
+    @pytest.mark.asyncio
+    async def test_run_agent_propagates_session_context_and_drains_notify_watchers(self, adapter):
+        from tools.process_registry import process_registry
+
+        runner = object.__new__(GatewayRunner)
+        runner._run_process_watcher = AsyncMock()
+        adapter.bind_gateway_runner(runner)
+
+        process_registry.pending_watchers.clear()
+        captured = {}
+        session_id = "api-session-42"
+        expected_session_key = build_session_key(
+            SessionSource(
+                platform=Platform.API_SERVER,
+                chat_id=session_id,
+                chat_type="dm",
+            )
+        )
+
+        class _FakeAgent:
+            session_prompt_tokens = 11
+            session_completion_tokens = 7
+            session_total_tokens = 18
+
+            def run_conversation(self, user_message, conversation_history, task_id):
+                from tools.approval import get_current_session_key
+                from tools.process_registry import process_registry as _pr
+
+                captured["platform"] = get_session_env("HERMES_SESSION_PLATFORM")
+                captured["chat_id"] = get_session_env("HERMES_SESSION_CHAT_ID")
+                captured["session_key"] = get_current_session_key(default="")
+                _pr.pending_watchers.append(
+                    {
+                        "session_id": "proc_123",
+                        "check_interval": 5,
+                        "session_key": captured["session_key"],
+                        "platform": captured["platform"],
+                        "chat_id": captured["chat_id"],
+                        "user_id": "",
+                        "user_name": "",
+                        "thread_id": "",
+                        "notify_on_complete": True,
+                    }
+                )
+                return {"final_response": "done", "messages": [], "api_calls": 1}
+
+        with patch.object(adapter, "_create_agent", return_value=_FakeAgent()):
+            result, usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id=session_id,
+            )
+
+        await asyncio.sleep(0)
+
+        assert result["final_response"] == "done"
+        assert usage == {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+        assert captured == {
+            "platform": "api_server",
+            "chat_id": session_id,
+            "session_key": expected_session_key,
+        }
+        runner._run_process_watcher.assert_awaited_once()
+        watcher = runner._run_process_watcher.await_args.args[0]
+        assert watcher["notify_on_complete"] is True
+        assert watcher["platform"] == "api_server"
+        assert watcher["chat_id"] == session_id
+        assert watcher["session_key"] == expected_session_key
+        assert process_registry.pending_watchers == []
+        assert get_session_env("HERMES_SESSION_PLATFORM") == ""
+        assert get_session_env("HERMES_SESSION_CHAT_ID") == ""
+
+
+class TestHealthAliases:
     @pytest.mark.asyncio
     async def test_health_returns_ok(self, adapter):
         app = _create_app(adapter)


### PR DESCRIPTION
## Summary
- bind the API server adapter to the owning GatewayRunner so it can reuse the existing process watcher delivery path
- establish API-server session context before running the agent, and propagate that context into the worker thread with asyncio.to_thread
- register the API-server session key in the approval context so background terminal sessions carry the right watcher metadata
- add regression tests covering the runner binding and the API-server notify_on_complete watcher drain

## Testing
- python3 -m py_compile gateway/platforms/api_server.py gateway/run.py tests/gateway/test_api_server.py
- python3 -m pytest -o addopts='' tests/gateway/test_api_server.py -k 'gateway_runner_binds_api_server_adapter or run_agent_propagates_session_context_and_drains_notify_watchers or health_returns_ok or v1_health_alias_returns_ok'
- python3 -m pytest -o addopts='' tests/tools/test_notify_on_complete.py -k 'schema_has_notify_on_complete or passes_notify_on_complete or recover_requeues_notify_watchers'

Addresses #10760