### PR TITLE
fix: implement api_key_env for delegation and fallback_model, fail fast on missing env var

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -752,6 +752,12 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  #
+  # For custom OpenAI-compatible endpoints:
+  # base_url: "https://my-endpoint.example.com/v1"
+  # api_key: "sk-..."          # Literal key (highest priority)
+  # api_key_env: "MY_API_KEY"  # Env var name (used when api_key is absent)
+  #                            # Falls back to OPENAI_API_KEY if neither is set
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5869,9 +5869,19 @@ class AIAgent:
             fb_base_url_hint = (fb.get("base_url") or "").strip() or None
             fb_api_key_hint = (fb.get("api_key") or "").strip() or None
             # Resolve api_key_env when no literal api_key is provided.
+            # Fail fast: if api_key_env is set but the variable is missing, skip
+            # this entry rather than leaking an unrelated key to the endpoint.
             fb_api_key_env = str(fb.get("api_key_env") or "").strip() or None
             if not fb_api_key_hint and fb_api_key_env:
                 fb_api_key_hint = os.getenv(fb_api_key_env) or None
+                if not fb_api_key_hint:
+                    logging.warning(
+                        "fallback_model.api_key_env '%s' is set but the "
+                        "environment variable is not set or empty; "
+                        "skipping this fallback entry",
+                        fb_api_key_env,
+                    )
+                    return self._try_activate_fallback()
             # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
             # when no explicit key is in the fallback config.
             if fb_base_url_hint and "ollama.com" in fb_base_url_hint.lower() and not fb_api_key_hint:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5868,6 +5868,10 @@ class AIAgent:
             # falling through to OpenRouter defaults.
             fb_base_url_hint = (fb.get("base_url") or "").strip() or None
             fb_api_key_hint = (fb.get("api_key") or "").strip() or None
+            # Resolve api_key_env when no literal api_key is provided.
+            fb_api_key_env = str(fb.get("api_key_env") or "").strip() or None
+            if not fb_api_key_hint and fb_api_key_env:
+                fb_api_key_hint = os.getenv(fb_api_key_env) or None
             # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
             # when no explicit key is in the fallback config.
             if fb_base_url_hint and "ollama.com" in fb_base_url_hint.lower() and not fb_api_key_hint:

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -271,6 +271,22 @@ class TestTryActivateFallback:
                 explicit_api_key="explicit-key",
             )
 
+    def test_api_key_env_skips_fallback_when_env_var_missing(self):
+        """When api_key_env is set but the env var is absent, fallback is skipped."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "my-model",
+                "base_url": "http://localhost:8080/v1",
+                "api_key_env": "NONEXISTENT_FALLBACK_KEY",
+            },
+        )
+        env_without_key = {k: v for k, v in os.environ.items() if k != "NONEXISTENT_FALLBACK_KEY"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            result = agent._try_activate_fallback()
+        assert result is False
+        assert agent._fallback_activated is False
+
     def test_prompt_caching_enabled_for_claude_on_openrouter(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -200,7 +200,7 @@ class TestTryActivateFallback:
                 "provider": "custom",
                 "model": "my-model",
                 "base_url": "http://localhost:8080/v1",
-                "api_key_env": "MY_CUSTOM_KEY",
+                "api_key": "custom-secret",
             },
         )
         mock_client = _mock_resolve(
@@ -210,10 +210,66 @@ class TestTryActivateFallback:
         with patch(
             "agent.auxiliary_client.resolve_provider_client",
             return_value=(mock_client, "my-model"),
-        ):
+        ) as mock_resolve:
             assert agent._try_activate_fallback() is True
             assert agent.client is mock_client
             assert agent.model == "my-model"
+            mock_resolve.assert_called_once_with(
+                "custom", model="my-model", raw_codex=True,
+                explicit_base_url="http://localhost:8080/v1",
+                explicit_api_key="custom-secret",
+            )
+
+    def test_api_key_env_resolved_when_api_key_absent(self):
+        """api_key_env is resolved from the environment when api_key is absent."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "my-model",
+                "base_url": "http://localhost:8080/v1",
+                "api_key_env": "MY_FALLBACK_KEY",
+            },
+        )
+        mock_client = _mock_resolve(
+            api_key="env-secret",
+            base_url="http://localhost:8080/v1",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "my-model"),
+        ) as mock_resolve, patch.dict(os.environ, {"MY_FALLBACK_KEY": "env-secret"}, clear=False):
+            assert agent._try_activate_fallback() is True
+            mock_resolve.assert_called_once_with(
+                "custom", model="my-model", raw_codex=True,
+                explicit_base_url="http://localhost:8080/v1",
+                explicit_api_key="env-secret",
+            )
+
+    def test_api_key_takes_priority_over_api_key_env(self):
+        """Literal api_key wins when both api_key and api_key_env are set."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "my-model",
+                "base_url": "http://localhost:8080/v1",
+                "api_key": "explicit-key",
+                "api_key_env": "MY_FALLBACK_KEY",
+            },
+        )
+        mock_client = _mock_resolve(
+            api_key="explicit-key",
+            base_url="http://localhost:8080/v1",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "my-model"),
+        ) as mock_resolve, patch.dict(os.environ, {"MY_FALLBACK_KEY": "env-secret"}, clear=False):
+            assert agent._try_activate_fallback() is True
+            mock_resolve.assert_called_once_with(
+                "custom", model="my-model", raw_codex=True,
+                explicit_base_url="http://localhost:8080/v1",
+                explicit_api_key="explicit-key",
+            )
 
     def test_prompt_caching_enabled_for_claude_on_openrouter(self):
         agent = _make_agent(

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -683,6 +683,20 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             creds = _resolve_delegation_credentials(cfg, parent)
         self.assertEqual(creds["api_key"], "explicit-key")
 
+    def test_api_key_env_raises_when_env_var_missing(self):
+        """ValueError is raised when api_key_env is set but the env var is absent."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "my-model",
+            "base_url": "https://my-endpoint.example.com/v1",
+            "api_key_env": "NONEXISTENT_DELEGATION_KEY",
+        }
+        env_without_key = {k: v for k, v in os.environ.items() if k != "NONEXISTENT_DELEGATION_KEY"}
+        with patch.dict(os.environ, env_without_key, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_delegation_credentials(cfg, parent)
+        self.assertIn("NONEXISTENT_DELEGATION_KEY", str(ctx.exception))
+
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
         """Nous provider resolves Nous Portal base_url and api_key."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -656,6 +656,33 @@ class TestDelegationCredentialResolution(unittest.TestCase):
                 _resolve_delegation_credentials(cfg, parent)
         self.assertIn("OPENAI_API_KEY", str(ctx.exception))
 
+    def test_direct_endpoint_uses_api_key_env(self):
+        """api_key_env is resolved from the environment when api_key is absent."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "my-model",
+            "base_url": "https://my-endpoint.example.com/v1",
+            "api_key_env": "MY_DELEGATION_KEY",
+        }
+        with patch.dict(os.environ, {"MY_DELEGATION_KEY": "env-secret"}, clear=False):
+            creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "env-secret")
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://my-endpoint.example.com/v1")
+
+    def test_api_key_takes_priority_over_api_key_env(self):
+        """Literal api_key wins when both api_key and api_key_env are set."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "my-model",
+            "base_url": "https://my-endpoint.example.com/v1",
+            "api_key": "explicit-key",
+            "api_key_env": "MY_DELEGATION_KEY",
+        }
+        with patch.dict(os.environ, {"MY_DELEGATION_KEY": "env-secret"}, clear=False):
+            creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "explicit-key")
+
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
         """Nous provider resolves Nous Portal base_url and api_key."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -864,16 +864,18 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_api_key_env = str(cfg.get("api_key_env") or "").strip() or None
 
     if configured_base_url:
         api_key = (
             configured_api_key
+            or (os.getenv(configured_api_key_env) if configured_api_key_env else None)
             or os.getenv("OPENAI_API_KEY", "").strip()
         )
         if not api_key:
             raise ValueError(
                 "Delegation base_url is configured but no API key was found. "
-                "Set delegation.api_key or OPENAI_API_KEY."
+                "Set delegation.api_key, delegation.api_key_env, or OPENAI_API_KEY."
             )
 
         base_lower = configured_base_url.lower()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -867,11 +867,21 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_api_key_env = str(cfg.get("api_key_env") or "").strip() or None
 
     if configured_base_url:
-        api_key = (
-            configured_api_key
-            or (os.getenv(configured_api_key_env) if configured_api_key_env else None)
-            or os.getenv("OPENAI_API_KEY", "").strip()
-        )
+        if configured_api_key:
+            api_key = configured_api_key
+        elif configured_api_key_env:
+            # api_key_env is explicit: fail fast rather than leaking OPENAI_API_KEY
+            # to a third-party endpoint when the named variable is unset.
+            api_key = os.getenv(configured_api_key_env, "").strip()
+            if not api_key:
+                raise ValueError(
+                    f"delegation.api_key_env is set to '{configured_api_key_env}' "
+                    f"but the environment variable is not set or empty. "
+                    f"Set {configured_api_key_env} in your environment or use "
+                    f"delegation.api_key instead."
+                )
+        else:
+            api_key = os.getenv("OPENAI_API_KEY", "").strip()
         if not api_key:
             raise ValueError(
                 "Delegation base_url is configured but no API key was found. "


### PR DESCRIPTION
## Summary

This PR fixes a bug in `api_key_env` credential resolution for both the `delegation` and `fallback_model` config blocks.

The official docs at https://hermes-agent.nousresearch.com/docs/user-guide/features/fallback-providers document `fallback_model.api_key_env`, but the feature was not wired up in the code. The same gap exists in the `delegation` block. This PR implements the feature and adds a fail-fast safety guard.

### What was broken

- `delegation.api_key_env` was not read at all — only `delegation.api_key` was supported
- `fallback_model.api_key_env` was documented but never resolved from the environment
- In the first draft of the fix (chained `or` expression), a missing or misspelled env var silently fell through to `OPENAI_API_KEY`, which could send an unrelated secret to a third-party endpoint

### What this PR does

**`tools/delegate_tool.py` — `_resolve_delegation_credentials()`**
- Reads `delegation.api_key_env` and resolves it via `os.getenv()`
- Priority chain: `api_key` → `os.getenv(api_key_env)` → `OPENAI_API_KEY`
- Fail-fast: when `api_key_env` is explicitly set but the env var is missing/empty, raises `ValueError` with a clear message rather than leaking `OPENAI_API_KEY` to the configured endpoint

**`run_agent.py` — `_try_activate_fallback()`**
- Reads `fallback_model.api_key_env` and resolves it via `os.getenv()`
- Same priority chain as above
- Fail-fast: when `api_key_env` is set but the env var is missing, logs a warning and skips the fallback entry instead of continuing with the wrong key

**`cli-config.yaml.example`**
- Documents `api_key_env` in the `delegation:` config block with usage notes

**Tests**
- `tests/tools/test_delegate.py` — 3 new cases: env var resolved, `api_key` wins over `api_key_env`, `ValueError` on missing env var
- `tests/run_agent/test_fallback_model.py` — 3 new cases: env var resolved, `api_key` wins over `api_key_env`, fallback skipped when env var missing

## Test plan

- `python -m pytest tests/tools/test_delegate.py::TestDelegationCredentialResolution tests/run_agent/test_fallback_model.py --override-ini='addopts=' -v` — all 44 tests pass
- Set `delegation.base_url` + `delegation.api_key_env: MY_KEY` with `MY_KEY` set in env — delegation uses the env var value
- Same config with `MY_KEY` unset — agent raises `ValueError` instead of silently using `OPENAI_API_KEY`
- Set `fallback_model.api_key_env: MY_FB_KEY` with the var unset — warning logged, fallback is skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)