### PR TITLE
feat(tts): add Gemini TTS provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -597,7 +597,7 @@ platform_toolsets:
 #   skills_hub   - skill_hub (search/install/manage from online registries — user-driven only)
 #   moa          - mixture_of_agents  (requires OPENROUTER_API_KEY)
 #   todo         - todo (in-memory task planning, no deps)
-#   tts          - text_to_speech  (Edge TTS free, or ELEVENLABS/OPENAI/MINIMAX/MISTRAL key)
+#   tts          - text_to_speech  (Edge TTS free, or ELEVENLABS/OPENAI/MINIMAX/MISTRAL/GEMINI key)
 #   cronjob      - cronjob (create/list/update/pause/resume/run/remove scheduled tasks)
 #   rl           - rl_list_environments, rl_start_training, etc. (requires TINKER_API_KEY)
 #
@@ -626,7 +626,7 @@ platform_toolsets:
 #   todo         - Task planning and tracking for multi-step work
 #   memory       - Persistent memory across sessions (personal notes + user profile)
 #   session_search - Search and recall past conversations (FTS5 + Gemini Flash summarization)
-#   tts          - Text-to-speech (Edge TTS free, ElevenLabs, OpenAI, MiniMax, Mistral)
+#   tts          - Text-to-speech (Edge TTS free, ElevenLabs, OpenAI, MiniMax, Mistral, Gemini)
 #   cronjob      - Schedule and manage automated tasks (CLI-only)
 #   rl           - RL training tools (Tinker-Atropos)
 #

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -566,7 +566,7 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "minimax" | "mistral" | "neutts" (local) | "gemini"
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -589,6 +589,15 @@ DEFAULT_CONFIG = {
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
+        },
+        "gemini": {
+            "model": "gemini-2.5-flash-preview-tts",
+            "voice": "Kore",
+            # 30 prebuilt voices: Zephyr, Puck, Charon, Kore, Fenrir, Leda,
+            # Orus, Aoede, Callirrhoe, Autonoe, Enceladus, Iapetus, Umbriel,
+            # Algieba, Despina, Erinome, Algenib, Rasalgethi, Laomedeia,
+            # Achernar, Alnilam, Schedar, Gacrux, Pulcherrima, Achird,
+            # Zubenelgenubi, Vindemiatrix, Sadachbia, Sadaltager, Sulafat
         },
     },
     

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -433,6 +433,10 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (MiniMax)", True, None))
     elif tts_provider == "mistral" and get_env_value("MISTRAL_API_KEY"):
         tool_status.append(("Text-to-Speech (Mistral Voxtral)", True, None))
+    elif tts_provider == "gemini" and (
+        get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")
+    ):
+        tool_status.append(("Text-to-Speech (Gemini)", True, None))
     elif tts_provider == "neutts":
         try:
             import importlib.util
@@ -923,6 +927,7 @@ def _setup_tts_provider(config: dict):
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
         "neutts": "NeuTTS",
+        "gemini": "Gemini TTS",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -944,9 +949,10 @@ def _setup_tts_provider(config: dict):
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
+            "Gemini TTS (Google speech generation, 30 voices, needs GEMINI_API_KEY)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts"])
+    providers.extend(["edge", "elevenlabs", "openai", "minimax", "mistral", "neutts", "gemini"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1032,6 +1038,19 @@ def _setup_tts_provider(config: dict):
             if api_key:
                 save_env_value("MISTRAL_API_KEY", api_key)
                 print_success("Mistral TTS API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "gemini":
+        existing = get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")
+        if not existing:
+            print()
+            print_info("Get a key at https://aistudio.google.com/apikey")
+            api_key = prompt("Gemini API key for TTS", password=True)
+            if api_key:
+                save_env_value("GEMINI_API_KEY", api_key)
+                print_success("Gemini API key saved")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -1,0 +1,221 @@
+"""Tests for the Gemini TTS provider in tools/tts_tool.py."""
+
+import base64
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "HERMES_SESSION_PLATFORM",
+        "MINIMAX_API_KEY",
+        "ELEVENLABS_API_KEY",
+        "OPENAI_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "MISTRAL_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _gemini_response(pcm_bytes: bytes) -> dict:
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"inlineData": {"data": base64.b64encode(pcm_bytes).decode()}}
+                    ]
+                }
+            }
+        ]
+    }
+
+
+def _mock_urlopen(response_payload: dict):
+    resp_body = __import__("json").dumps(response_payload).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = resp_body
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestGenerateGeminiTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        from tools.tts_tool import _generate_gemini_tts
+
+        with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+            _generate_gemini_tts("Hello", str(tmp_path / "out.wav"), {})
+
+    def test_google_api_key_fallback_accepted(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        pcm = b"\x01\x00\x02\x00\x03\x00"
+        with patch(
+            "tools.tts_tool.urllib.request.urlopen",
+            return_value=_mock_urlopen(_gemini_response(pcm)),
+        ):
+            result = _generate_gemini_tts("Hi", str(tmp_path / "out.wav"), {})
+
+        assert result == str(tmp_path / "out.wav")
+
+    def test_writes_wav_with_correct_pcm_params(self, tmp_path, monkeypatch):
+        import wave
+
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        pcm = struct.pack("<6h", 0, 1, 2, 3, 4, 5)
+        with patch(
+            "tools.tts_tool.urllib.request.urlopen",
+            return_value=_mock_urlopen(_gemini_response(pcm)),
+        ):
+            out = tmp_path / "out.wav"
+            _generate_gemini_tts("Hi", str(out), {})
+
+        with wave.open(str(out), "rb") as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getframerate() == 24000
+            assert wf.readframes(wf.getnframes()) == pcm
+
+    def test_default_model_and_voice_in_payload(self, tmp_path, monkeypatch):
+        import json as _json
+
+        from tools.tts_tool import (
+            DEFAULT_GEMINI_TTS_MODEL,
+            DEFAULT_GEMINI_TTS_VOICE,
+            _generate_gemini_tts,
+        )
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["body"] = _json.loads(req.data.decode())
+            captured["headers"] = dict(req.headers)
+            return _mock_urlopen(_gemini_response(b"\x00\x00"))
+
+        with patch("tools.tts_tool.urllib.request.urlopen", side_effect=fake_urlopen):
+            _generate_gemini_tts("hello", str(tmp_path / "out.wav"), {})
+
+        assert DEFAULT_GEMINI_TTS_MODEL in captured["url"]
+        voice_cfg = captured["body"]["generationConfig"]["speechConfig"]["voiceConfig"][
+            "prebuiltVoiceConfig"
+        ]
+        assert voice_cfg["voiceName"] == DEFAULT_GEMINI_TTS_VOICE
+        # Header keys normalize to capitalized form via urllib
+        assert captured["headers"].get("X-goog-api-key") == "test-key"
+
+    def test_config_overrides(self, tmp_path, monkeypatch):
+        import json as _json
+
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["body"] = _json.loads(req.data.decode())
+            return _mock_urlopen(_gemini_response(b"\x00\x00"))
+
+        with patch("tools.tts_tool.urllib.request.urlopen", side_effect=fake_urlopen):
+            config = {"gemini": {"model": "gemini-2.5-pro-preview-tts", "voice": "Puck"}}
+            _generate_gemini_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert "gemini-2.5-pro-preview-tts" in captured["url"]
+        voice_cfg = captured["body"]["generationConfig"]["speechConfig"]["voiceConfig"][
+            "prebuiltVoiceConfig"
+        ]
+        assert voice_cfg["voiceName"] == "Puck"
+
+    def test_http_error_surfaced_as_runtime_error(self, tmp_path, monkeypatch):
+        import urllib.error
+
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        err = urllib.error.HTTPError(
+            "https://example", 429, "Too Many Requests", {}, None
+        )
+        err.read = MagicMock(return_value=b'{"error": "rate limit"}')
+
+        with patch("tools.tts_tool.urllib.request.urlopen", side_effect=err):
+            with pytest.raises(RuntimeError, match="429"):
+                _generate_gemini_tts("hi", str(tmp_path / "out.wav"), {})
+
+    def test_missing_audio_payload_raises_runtime_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        bad_response = {"candidates": [{"content": {"parts": []}}]}
+        with patch(
+            "tools.tts_tool.urllib.request.urlopen",
+            return_value=_mock_urlopen(bad_response),
+        ):
+            with pytest.raises(RuntimeError, match="missing audio payload"):
+                _generate_gemini_tts("hi", str(tmp_path / "out.wav"), {})
+
+
+class TestTtsDispatcherGemini:
+    def test_dispatcher_routes_to_gemini(self, tmp_path, monkeypatch):
+        import json
+
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        pcm = struct.pack("<2h", 100, -100)
+        with patch(
+            "tools.tts_tool.urllib.request.urlopen",
+            return_value=_mock_urlopen(_gemini_response(pcm)),
+        ), patch(
+            "tools.tts_tool._load_tts_config", return_value={"provider": "gemini"}
+        ):
+            # Force .wav output so we skip the ffmpeg / Opus conversion branch
+            output_path = str(tmp_path / "out.wav")
+            result = json.loads(text_to_speech_tool("Hello", output_path=output_path))
+
+        assert result["success"] is True
+        assert result["provider"] == "gemini"
+
+
+class TestCheckTtsRequirementsGemini:
+    def test_gemini_key_returns_true(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), patch(
+            "tools.tts_tool._import_elevenlabs", side_effect=ImportError
+        ), patch("tools.tts_tool._import_openai_client", side_effect=ImportError), patch(
+            "tools.tts_tool._import_mistral_client", side_effect=ImportError
+        ), patch("tools.tts_tool._check_neutts_available", return_value=False):
+            assert check_tts_requirements() is True
+
+    def test_google_api_key_also_accepted(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), patch(
+            "tools.tts_tool._import_elevenlabs", side_effect=ImportError
+        ), patch("tools.tts_tool._import_openai_client", side_effect=ImportError), patch(
+            "tools.tts_tool._import_mistral_client", side_effect=ImportError
+        ), patch("tools.tts_tool._check_neutts_available", return_value=False):
+            assert check_tts_requirements() is True
+
+    def test_no_key_returns_false(self):
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), patch(
+            "tools.tts_tool._import_elevenlabs", side_effect=ImportError
+        ), patch("tools.tts_tool._import_openai_client", side_effect=ImportError), patch(
+            "tools.tts_tool._import_mistral_client", side_effect=ImportError
+        ), patch("tools.tts_tool._check_neutts_available", return_value=False):
+            assert check_tts_requirements() is False

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -8,7 +8,16 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
-    for key in ("MISTRAL_API_KEY", "HERMES_SESSION_PLATFORM"):
+    for key in (
+        "MISTRAL_API_KEY",
+        "HERMES_SESSION_PLATFORM",
+        "MINIMAX_API_KEY",
+        "ELEVENLABS_API_KEY",
+        "OPENAI_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,13 +2,14 @@
 """
 Text-to-Speech Tool Module
 
-Supports six TTS providers:
+Supports seven TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- Gemini TTS: Google speech generation, 30 prebuilt voices, needs GEMINI_API_KEY or GOOGLE_API_KEY
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -35,7 +36,10 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import urllib.error
+import urllib.request
 import uuid
+import wave
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
@@ -93,6 +97,12 @@ DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
 DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603"
 DEFAULT_MISTRAL_TTS_VOICE_ID = "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral
+DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
+DEFAULT_GEMINI_TTS_VOICE = "Kore"
+DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+GEMINI_TTS_SAMPLE_RATE = 24000
+GEMINI_TTS_CHANNELS = 1
+GEMINI_TTS_SAMPLE_WIDTH = 2  # signed 16-bit PCM
 
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
@@ -512,6 +522,101 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
 
 # ===========================================================================
+# Provider: Gemini TTS
+# ===========================================================================
+def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Google's Gemini speech-generation API.
+
+    Gemini returns base64-encoded PCM (signed 16-bit, 24 kHz, mono). This
+    function wraps the PCM in a WAV container natively (no ffmpeg needed
+    for the base case), then converts to the caller's requested extension
+    via ffmpeg if available. Mirrors the NeuTTS output handling.
+
+    Reference: https://ai.google.dev/gemini-api/docs/speech-generation
+    """
+    api_key = (
+        os.getenv("GEMINI_API_KEY")
+        or os.getenv("GOOGLE_API_KEY")
+        or ""
+    ).strip()
+    if not api_key:
+        raise ValueError(
+            "GEMINI_API_KEY (or GOOGLE_API_KEY) not set. "
+            "Get one at https://aistudio.google.com/apikey"
+        )
+
+    gm_config = tts_config.get("gemini", {})
+    model = gm_config.get("model", DEFAULT_GEMINI_TTS_MODEL)
+    voice = gm_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)
+    base_url = gm_config.get("base_url", DEFAULT_GEMINI_TTS_BASE_URL).rstrip("/")
+
+    endpoint = f"{base_url}/models/{model}:generateContent"
+    payload = {
+        "contents": [{"parts": [{"text": text}]}],
+        "generationConfig": {
+            "responseModalities": ["AUDIO"],
+            "speechConfig": {
+                "voiceConfig": {
+                    "prebuiltVoiceConfig": {"voiceName": voice},
+                },
+            },
+        },
+    }
+
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "x-goog-api-key": api_key,
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            response_data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        err_body = exc.read().decode("utf-8", errors="ignore")[:500]
+        raise RuntimeError(f"Gemini TTS HTTP {exc.code}: {err_body}") from exc
+
+    try:
+        audio_part = response_data["candidates"][0]["content"]["parts"][0]
+        audio_b64 = audio_part["inlineData"]["data"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise RuntimeError(
+            f"Gemini TTS response missing audio payload: {str(response_data)[:300]}"
+        ) from exc
+
+    pcm_bytes = base64.b64decode(audio_b64)
+
+    # Write PCM as WAV natively — ffmpeg is only needed if the caller
+    # asked for a non-WAV extension (mp3/ogg).
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with wave.open(wav_path, "wb") as wf:
+        wf.setnchannels(GEMINI_TTS_CHANNELS)
+        wf.setsampwidth(GEMINI_TTS_SAMPLE_WIDTH)
+        wf.setframerate(GEMINI_TTS_SAMPLE_RATE)
+        wf.writeframes(pcm_bytes)
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            # No ffmpeg — keep WAV content but honor the caller's path.
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -622,6 +727,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with NeuTTS (local)...")
             _generate_neutts(text, file_str, tts_config)
 
+        elif provider == "gemini":
+            logger.info("Generating speech with Gemini TTS...")
+            _generate_gemini_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -661,7 +770,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "gemini") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -740,6 +849,8 @@ def check_tts_requirements() -> bool:
             return True
     except ImportError:
         pass
+    if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
+        return True
     if _check_neutts_available():
         return True
     return False

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -10,7 +10,7 @@ Hermes Agent supports both text-to-speech output and voice message transcription
 
 ## Text-to-Speech
 
-Convert text to speech with six providers:
+Convert text to speech with seven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -20,6 +20,7 @@ Convert text to speech with six providers:
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **NeuTTS** | Good | Free | None needed |
+| **Gemini TTS** | Excellent | Paid (free tier) | `GEMINI_API_KEY` |
 
 ### Platform Delivery
 
@@ -62,6 +63,9 @@ tts:
     ref_text: ''
     model: neuphonic/neutts-air-q4-gguf
     device: cpu
+  gemini:
+    model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
+    voice: "Kore"                          # 30 prebuilt voices (Zephyr, Puck, Charon, ...)
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
@@ -74,6 +78,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Gemini TTS** returns raw PCM (wrapped in WAV natively) and needs **ffmpeg** to convert for Telegram voice bubbles
 
 ```bash
 # Ubuntu/Debian


### PR DESCRIPTION
## What does this PR do?

Adds Google's Gemini speech-generation API as a seventh TTS backend in `tools/tts_tool.py`, alongside Edge, ElevenLabs, OpenAI, MiniMax, Mistral, and NeuTTS. Requested in #10918.

Gemini returns base64-encoded signed 16-bit PCM at 24 kHz mono. The new provider wraps the PCM in a WAV container natively via Python's stdlib `wave` module (no extra dependency), then optionally converts to mp3/ogg via ffmpeg — mirroring the existing NeuTTS/MiniMax output-handling path.

## Related Issue

Fixes #10918

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/tts_tool.py`
  - New `_generate_gemini_tts()` function — calls `generateContent` endpoint, decodes base64 PCM, writes WAV natively, converts to the caller's requested extension via ffmpeg when available.
  - Dispatcher branch `elif provider == "gemini":` added after the `neutts` branch.
  - Post-creation Opus conversion list now includes `gemini` so Telegram voice bubbles work.
  - `check_tts_requirements()` returns `True` when `GEMINI_API_KEY` or `GOOGLE_API_KEY` is set.
  - New constants: `DEFAULT_GEMINI_TTS_MODEL`, `DEFAULT_GEMINI_TTS_VOICE`, `DEFAULT_GEMINI_TTS_BASE_URL`, `GEMINI_TTS_SAMPLE_RATE/CHANNELS/SAMPLE_WIDTH`.
  - `wave`, `urllib.request`, `urllib.error` promoted to module-level imports.
- `hermes_cli/setup.py` — interactive provider picker, status-display arm, secure key prompt (points to https://aistudio.google.com/apikey).
- `hermes_cli/config.py` — default `tts.gemini` block (`gemini-2.5-flash-preview-tts`, voice `Kore`).
- `cli-config.yaml.example` — list Gemini in the two `tts` toolset doc lines.
- `website/docs/user-guide/features/tts.md` — provider table + config example + ffmpeg note.
- `tests/tools/test_tts_gemini.py` — **11 new unit tests** covering: missing key raises `ValueError`, `GOOGLE_API_KEY` fallback, WAV header (channels/sample width/frame rate/frames), default model+voice in payload, config overrides, HTTP error mapping to `RuntimeError`, missing audio payload, dispatcher routing, `check_tts_requirements()` arm.
- `tests/tools/test_tts_mistral.py` — widen `clean_env` fixture to clear all TTS-related env vars (otherwise `test_mistral_key_missing_returns_false` could flake on dev shells that have a Gemini key set).

## How to Test

1. `pytest tests/tools/test_tts_gemini.py -v` — 11 tests pass locally.
2. `pytest tests/tools/test_tts_mistral.py tests/tools/test_tts_gemini.py tests/tools/test_tts_speed.py tests/tools/test_managed_media_gateways.py tests/tools/test_registry.py -q` — 76 pass, no regressions.
3. Manual: `export GEMINI_API_KEY=...; hermes setup tts` → choose Gemini → synth a short clip.
4. Telegram platform: set `HERMES_SESSION_PLATFORM=telegram`, verify output is `.ogg` and `voice_compatible=True` in the returned JSON (ffmpeg must be installed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tts):`, `test(tts):`)
- [x] I searched for existing PRs — no duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/tools/test_tts_*.py -q` and all tests pass
- [x] I've added tests (11 new unit tests)
- [x] I've tested on: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] Updated docs (`website/docs/user-guide/features/tts.md`)
- [x] Updated `cli-config.yaml.example`
- [ ] N/A — `CONTRIBUTING.md` / `AGENTS.md` unchanged
- [x] Cross-platform: pure stdlib for WAV writing; ffmpeg conversion is opt-in and already the pattern for Edge/NeuTTS/MiniMax
- [ ] N/A — no tool schema changes

## Config

```yaml
tts:
  provider: gemini
  gemini:
    model: gemini-2.5-flash-preview-tts   # or gemini-2.5-pro-preview-tts
    voice: Kore                           # 30 prebuilt voices
```

Auth: `GEMINI_API_KEY` or `GOOGLE_API_KEY` (https://aistudio.google.com/apikey).

30 prebuilt voices: Zephyr, Puck, Charon, Kore, Fenrir, Leda, Orus, Aoede, Callirrhoe, Autonoe, Enceladus, Iapetus, Umbriel, Algieba, Despina, Erinome, Algenib, Rasalgethi, Laomedeia, Achernar, Alnilam, Schedar, Gacrux, Pulcherrima, Achird, Zubenelgenubi, Vindemiatrix, Sadachbia, Sadaltager, Sulafat.

Ref: https://ai.google.dev/gemini-api/docs/speech-generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)