### PR TITLE
fix(runtime): propagate configured model max tokens

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -519,6 +519,22 @@ def load_cli_config() -> Dict[str, Any]:
 
     return defaults
 
+
+def _resolve_model_max_tokens(config: Dict[str, Any] | None) -> Optional[int]:
+    """Return model.max_tokens from config when it is a valid integer."""
+    if not isinstance(config, dict):
+        return None
+    model_cfg = config.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return None
+    raw = model_cfg.get("max_tokens")
+    if raw in (None, ""):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
 
@@ -1709,6 +1725,8 @@ class HermesCLI:
             self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
         else:
             self.max_turns = 90
+
+        self.max_tokens = _resolve_model_max_tokens(CLI_CONFIG)
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
@@ -2878,6 +2896,7 @@ class HermesCLI:
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
+                max_tokens=self.max_tokens,
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
@@ -5688,6 +5707,7 @@ class HermesCLI:
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
+                    max_tokens=self.max_tokens,
                     max_iterations=self.max_turns,
                     enabled_toolsets=self.enabled_toolsets,
                     quiet_mode=True,
@@ -5826,6 +5846,7 @@ class HermesCLI:
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
+                    max_tokens=self.max_tokens,
                     max_iterations=8,
                     enabled_toolsets=[],
                     quiet_mode=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -456,6 +456,21 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_gateway_max_tokens(config: dict | None = None) -> Optional[int]:
+    """Read model.max_tokens from config.yaml when it is a valid integer."""
+    cfg = config if config is not None else _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return None
+    raw = model_cfg.get("max_tokens")
+    if raw in (None, ""):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -5682,6 +5697,7 @@ class GatewayRunner:
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            model_max_tokens = _resolve_gateway_max_tokens(user_config)
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
@@ -5691,6 +5707,7 @@ class GatewayRunner:
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
+                    max_tokens=model_max_tokens,
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -5848,6 +5865,7 @@ class GatewayRunner:
                 return
 
             platform_key = _platform_config_key(source.platform)
+            model_max_tokens = _resolve_gateway_max_tokens(user_config)
             reasoning_config = self._load_reasoning_config()
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
@@ -5871,6 +5889,7 @@ class GatewayRunner:
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
+                    max_tokens=model_max_tokens,
                     max_iterations=8,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -8546,6 +8565,7 @@ class GatewayRunner:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            model_max_tokens = _resolve_gateway_max_tokens(user_config)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -8577,6 +8597,7 @@ class GatewayRunner:
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
+                    max_tokens=model_max_tokens,
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -8614,6 +8635,7 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
+            agent.max_tokens = model_max_tokens
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -172,6 +172,45 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell.agent is not None
 
 
+def test_init_agent_passes_model_max_tokens_from_config(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        }
+
+    class _DummyAgent:
+        def __init__(self, *args, **kwargs):
+            self.kwargs = kwargs
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+    monkeypatch.setattr(
+        cli,
+        "CLI_CONFIG",
+        {
+            **cli.CLI_CONFIG,
+            "model": {
+                **cli.CLI_CONFIG.get("model", {}),
+                "max_tokens": 32768,
+            },
+        },
+        raising=False,
+    )
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+
+    assert shell.max_tokens == 32768
+    assert shell._init_agent() is True
+    assert shell.agent.kwargs["max_tokens"] == 32768
+
+
 def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     cli = _import_cli()
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -189,3 +189,48 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_model_max_tokens_to_gateway_agent(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    user_config = {
+        "model": {
+            "default": "gpt-5.4",
+            "max_tokens": 32768,
+        }
+    }
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: user_config)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["max_tokens"] == 32768


### PR DESCRIPTION
## Summary
- read `model.max_tokens` from config for the CLI and gateway runtime paths
- pass that output cap into foreground, background, and `/btw` `AIAgent` instances
- update the cached gateway agent per turn so reused agents honor the configured cap too

## Why
Fixes #10917. `AIAgent` already accepts `max_tokens`, but the CLI and gateway were not forwarding the configured `model.max_tokens`, so local and custom-provider runtimes silently ignored the user's output cap.

## Testing
- `pytest -o addopts= tests/cli/test_cli_provider_resolution.py tests/gateway/test_fast_command.py`