### PR TITLE
test(session-env): scrub HERMES_SESSION_KEY before clear-env assertion

### DIFF
--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -169,8 +169,14 @@ def test_session_key_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_KEY") == "env-session-123"
 
 
-def test_set_session_env_includes_session_key():
+def test_set_session_env_includes_session_key(monkeypatch):
     """_set_session_env should propagate session_key from SessionContext."""
+    # get_session_env falls back to os.environ when the contextvar is unset,
+    # so a stray HERMES_SESSION_KEY leaked from another test (via direct
+    # ``os.environ[...] = …`` rather than monkeypatch) would break the final
+    # "== ''" assertion after _clear_session_env.  Scrub it locally.
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
     runner = object.__new__(GatewayRunner)
     source = SessionSource(
         platform=Platform.TELEGRAM,


### PR DESCRIPTION
## Problem

```
$ python -m pytest tests/gateway/test_session_env.py::test_set_session_env_includes_session_key
...
>       assert get_session_env("HERMES_SESSION_KEY") == ""
E       AssertionError: assert 'session-key' == ''
```

The failure only reproduces under `pytest-xdist` (`-n auto`), not when the
test is run on its own.

## Root cause

`get_session_env` is layered:

```python
# gateway/session_context.py
def get_session_env(name, default=""):
    val = _SESSION_KEY.get()  # ContextVar
    if val:
        return val
    return os.environ.get(name, default)  # fallback
```

Several blocking-approval e2e tests in
`tests/gateway/test_approve_deny_commands.py` set the env var
**directly** through `os.environ` (not `monkeypatch`) and rely on a
`finally` block to clean up:

```python
os.environ["HERMES_SESSION_KEY"] = session_key
try:
    ...
finally:
    os.environ.pop("HERMES_SESSION_KEY", None)
```

When xdist places `test_set_session_env_includes_session_key` on the
same worker after one of those tests, the ContextVar fallback reaches
`os.environ` and sees the leaked value before the sibling's `finally`
fires - or in the unhappy case where the sibling died mid-test. The
final `_clear_session_env(tokens)` resets the ContextVar but cannot
unset the env-var fallback the test never owned, so:

```python
assert get_session_env("HERMES_SESSION_KEY") == ""
```

trips on the leaked `'session-key'` value.

## Fix

Have the test scrub `HERMES_SESSION_KEY` through `monkeypatch.delenv(...,
raising=False)` before exercising `_set_session_env`/`_clear_session_env`.
That way the post-clear assertion is independent of any sibling test's
direct `os.environ` mutations and pytest restores the original env at
test exit.

No production change.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/gateway/test_session_env.py
............                                                             [100%]
12 passed in 0.14s

$ python -m pytest tests/gateway/ -q   # xdist parallel
... 0 failures
```
