### PR TITLE
test(conftest): isolate CODEX_HOME so token-refresh writeback doesn't leak between tests

### DIFF
--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -388,6 +388,72 @@ def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):
     assert secondary["refresh_token"] == "refresh-other"
 
 
+def test_try_refresh_current_does_not_pollute_real_home(tmp_path, monkeypatch):
+    """`_write_codex_cli_tokens` must not write to ``~/.codex/`` during tests.
+
+    Regression for a cross-test leak: ``pool.try_refresh_current()`` calls
+    ``_refresh_codex_auth_tokens`` which calls ``_write_codex_cli_tokens``
+    to keep ``$CODEX_HOME/auth.json`` (the file shared with Codex CLI /
+    VS Code) in sync.  When CODEX_HOME is unset that path resolves to
+    ``Path.home() / ".codex" / "auth.json"`` — i.e. the *real* HOME of
+    the test process.  Under the project's standard
+    ``HOME=$(mktemp -d)`` test wrapper that HOME is shared by every test
+    in the run, so the file persisted for the rest of the session and
+    later ``load_pool("openai-codex")`` calls re-imported the leaked
+    tokens via ``_seed_from_singletons`` -> ``_import_codex_cli_tokens``.
+
+    The conftest autouse fixture now pins CODEX_HOME to a per-test tmp
+    dir, so the writeback lands inside ``tmp_path`` (which pytest
+    cleans up) instead of polluting ``Path.home()``.
+    """
+    from pathlib import Path
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "access-old",
+                        "refresh_token": "refresh-old",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda access_token, refresh_token, timeout_seconds=20.0: {
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+        },
+    )
+
+    pool = load_pool("openai-codex")
+    pool.select()
+    refreshed = pool.try_refresh_current()
+    assert refreshed is not None
+
+    # The shared real HOME must not have grown a .codex/auth.json from this
+    # refresh.  CODEX_HOME (per-conftest) absorbs the writeback into tmp_path.
+    leaked = Path.home() / ".codex" / "auth.json"
+    assert not leaked.exists(), (
+        f"Codex token writeback leaked into Path.home(): {leaked}. "
+        "The conftest CODEX_HOME isolation is missing or has been broken."
+    )
+
+
 def test_load_pool_seeds_env_api_key(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-seeded")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,21 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
     (fake_home / "memories").mkdir()
     (fake_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_home))
+    # Isolate CODEX_HOME the same way.  Production code writes refreshed
+    # OAuth tokens back to ``$CODEX_HOME/auth.json`` (defaulting to
+    # ``~/.codex/auth.json``) so the Codex CLI / VS Code stay in sync.
+    # When a test triggers a refresh without explicitly setting CODEX_HOME,
+    # the writeback lands in the *real* HOME for the test process.  Under
+    # the project's standard ``HOME=$(mktemp -d)`` test wrapper that HOME
+    # is shared by every test in the run, so the file persists for the
+    # remainder of the session and any later test that calls
+    # ``load_pool("openai-codex")`` re-imports those stale tokens via
+    # ``_seed_from_singletons`` -> ``_import_codex_cli_tokens``.  Pin
+    # CODEX_HOME to a per-test scratch dir so writebacks are always
+    # contained to ``tmp_path`` and cleaned up between tests.
+    fake_codex = tmp_path / "codex_test"
+    fake_codex.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(fake_codex))
     # Reset plugin singleton so tests don't leak plugins from ~/.hermes/plugins/
     try:
         import hermes_cli.plugins as _plugins_mod


### PR DESCRIPTION
## Problem

Four tests fail intermittently under `pytest-xdist` whenever the
`openai-codex` token-refresh test happens to run on the same worker
before them:

```
FAILED tests/hermes_cli/test_auth_commands.py::test_auth_remove_accepts_label_target
FAILED tests/hermes_cli/test_auth_commands.py::test_auth_remove_prefers_exact_numeric_label_over_index
FAILED tests/hermes_cli/test_opencode_go_in_model_list.py::test_opencode_go_appears_when_api_key_set
FAILED tests/hermes_cli/test_overlay_slug_resolution.py::test_kimi_for_coding_overlay_uses_hermes_slug
```

Each one observes an extra phantom `openai-codex` credential it never
seeded. For example:

```
>   assert len(entries) == 1
E   AssertionError: assert 2 == 1
```

## Root cause

Production `_refresh_codex_auth_tokens` writes refreshed OAuth tokens
back to `$CODEX_HOME/auth.json` (defaulting to `Path.home() /
".codex" / "auth.json"`) so the Codex CLI / VS Code extension stay in
sync with Hermes:

```python
# hermes_cli/auth.py
def _refresh_codex_auth_tokens(tokens, timeout_seconds):
    refreshed = refresh_codex_oauth_pure(...)
    _save_codex_tokens(updated_tokens)
    # Write back to ~/.codex/auth.json so Codex CLI / VS Code stay in sync.
    _write_codex_cli_tokens(refreshed["access_token"], refreshed["refresh_token"], ...)
```

`tests/agent/test_credential_pool.py::test_try_refresh_current_updates_only_current_entry`
mocks the inner `refresh_codex_oauth_pure` but **not** the outer
`_refresh_codex_auth_tokens`, so the writeback runs for real. The test
only sets `HERMES_HOME`, never `CODEX_HOME`, so
`_write_codex_cli_tokens` falls back to `Path.home() / ".codex" /
"auth.json"`.

Under the project's standard `HOME=$(mktemp -d)` test wrapper that HOME
directory is shared by every test in the run. The leaked
`auth.json` therefore persists for the rest of the session, and any
later test that calls `load_pool("openai-codex")` re-imports those
stale tokens via `_seed_from_singletons` →
`_import_codex_cli_tokens`, ending up with the phantom credential.

## Fix

Pin `CODEX_HOME` to a per-test scratch dir from the autouse
`_isolate_hermes_home` fixture, mirroring the existing `HERMES_HOME`
treatment:

```python
fake_codex = tmp_path / "codex_test"
fake_codex.mkdir()
monkeypatch.setenv("CODEX_HOME", str(fake_codex))
```

The writeback now lands inside `tmp_path`, which pytest cleans up
between tests, so no later test ever sees the file. Add a regression
test in `tests/agent/test_credential_pool.py` that exercises
`pool.try_refresh_current()` for `openai-codex` and asserts
`Path.home() / ".codex" / "auth.json"` is **not** created.

Tests that need a specific `CODEX_HOME` continue to override it via
`monkeypatch.setenv(...)` as before.

## Verification

```
$ python -m pytest tests/ -q
...
11270 passed, 79 skipped in 187.13s
```

(All four originally failing tests pass under both serial and xdist
runs; the new regression test passes; nothing in the rest of the
suite regresses.)
