### PR TITLE
fix(pairing): preserve file ownership after root approvals

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -46,6 +46,16 @@ MAX_FAILED_ATTEMPTS = 5             # Failed approvals before lockout
 PAIRING_DIR = get_hermes_dir("platforms/pairing", "pairing")
 
 
+def _ownership_hint(path: Path) -> Optional[tuple[int, int]]:
+    """Return the owner/group we should preserve for an atomic rewrite."""
+    try:
+        stat_source = path if path.exists() else path.parent
+        stat_result = stat_source.stat()
+    except OSError:
+        return None
+    return stat_result.st_uid, stat_result.st_gid
+
+
 def _secure_write(path: Path, data: str) -> None:
     """Write data to file with restrictive permissions (owner read/write only).
 
@@ -53,6 +63,7 @@ def _secure_write(path: Path, data: str) -> None:
     complete file or the new one — never a partial write.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
+    ownership = _ownership_hint(path)
     fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -60,6 +71,11 @@ def _secure_write(path: Path, data: str) -> None:
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, str(path))
+        if ownership is not None and hasattr(os, "geteuid") and os.geteuid() == 0:
+            try:
+                os.chown(path, *ownership)
+            except OSError:
+                pass
         try:
             os.chmod(path, 0o600)
         except OSError:

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -43,6 +43,25 @@ class TestSecureWrite:
         mode = oct(target.stat().st_mode & 0o777)
         assert mode == "0o600"
 
+    def test_root_write_preserves_existing_file_ownership(self, tmp_path):
+        target = tmp_path / "approved.json"
+        target.write_text("{}")
+        owner = target.stat()
+
+        with patch("gateway.pairing.os.geteuid", return_value=0), patch("gateway.pairing.os.chown") as mock_chown:
+            _secure_write(target, '{"user": "alice"}')
+
+        mock_chown.assert_called_once_with(target, owner.st_uid, owner.st_gid)
+
+    def test_root_write_uses_parent_dir_ownership_for_new_files(self, tmp_path):
+        target = tmp_path / "approved.json"
+        owner = tmp_path.stat()
+
+        with patch("gateway.pairing.os.geteuid", return_value=0), patch("gateway.pairing.os.chown") as mock_chown:
+            _secure_write(target, '{"user": "alice"}')
+
+        mock_chown.assert_called_once_with(target, owner.st_uid, owner.st_gid)
+
 
 # ---------------------------------------------------------------------------
 # Code generation


### PR DESCRIPTION
## Summary
- preserve existing pairing file ownership when root rewrites pairing JSON files
- fall back to the pairing directory owner for first-time approved files created by `hermes pairing approve`
- add regression tests covering both ownership paths

Fixes #10270.

## Testing
- pytest -o addopts= tests/gateway/test_pairing.py