### PR TITLE
docs: update quick start install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 ---
 
-## Quick Install
+## Quick Start
+
+Fetch and run the installer directly from the GitHub raw URL:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -10,7 +10,7 @@ This guide walks you through installing Hermes Agent, setting up a provider, and
 
 ## 1. Install Hermes Agent
 
-Run the one-line installer:
+Fetch and run the installer directly from the GitHub raw URL:
 
 ```bash
 # Linux / macOS / WSL2 / Android (Termux)


### PR DESCRIPTION
## Summary
- rename README install section from Quick Install to Quick Start
- clarify that the installer is fetched from the GitHub raw URL
- align the quickstart doc wording with the README

## Test Plan
- docs-only change
- verified staged diff locally