### PR TITLE
fix(mcp): preserve OAuth server URL paths

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -169,6 +169,18 @@ class TestBuildOAuthAuth:
         assert provider is not None
         assert provider.context.client_metadata.scope == "read write admin"
 
+    def test_preserves_server_url_path_for_oauth_resource_validation(self, tmp_path, monkeypatch):
+        try:
+            from mcp.client.auth import OAuthClientProvider
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = build_oauth_auth("granola", "https://mcp.granola.ai/mcp/")
+
+        assert isinstance(provider, OAuthClientProvider)
+        assert provider.context.server_url == "https://mcp.granola.ai/mcp"
+
 
 # ---------------------------------------------------------------------------
 # Utility functions

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -465,13 +465,9 @@ def build_oauth_auth(
         _write_json(storage._client_info_path(), client_info.model_dump(exclude_none=True))
         logger.debug("Pre-registered client_id=%s for '%s'", client_id, server_name)
 
-    # --- Base URL for discovery ---
-    parsed = urlparse(server_url)
-    base_url = f"{parsed.scheme}://{parsed.netloc}"
-
     # --- Build provider ---
     provider = OAuthClientProvider(
-        server_url=base_url,
+        server_url=server_url.rstrip("/"),
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,


### PR DESCRIPTION
## Summary
- pass the full MCP server URL to `OAuthClientProvider` instead of stripping its path
- trim only a trailing slash so RFC 8707 / protected-resource validation still matches path-based endpoints
- add regression coverage for MCP servers hosted below a path such as `/mcp`

Fixes #10271.

## Testing
- pytest -o addopts= tests/tools/test_mcp_oauth.py