### PR TITLE
fix: enable TCP keepalives to detect dead provider connections

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4366,6 +4366,29 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
+        # Inject TCP keepalives to detect dead connections faster (#10324).
+        # Without keepalives, a provider that drops mid-stream leaves the
+        # socket in CLOSE-WAIT and epoll_wait may never fire, causing the
+        # agent to hang indefinitely.  Keepalive probes detect the dead
+        # peer within ~60s (30s idle + 3×10s probes).
+        if "http_client" not in client_kwargs:
+            try:
+                import httpx as _httpx
+                import socket as _socket
+                _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+                if hasattr(_socket, "TCP_KEEPIDLE"):
+                    # Linux
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
+                elif hasattr(_socket, "TCP_KEEPALIVE"):
+                    # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+                client_kwargs["http_client"] = _httpx.Client(
+                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                )
+            except Exception:
+                pass  # Fall through to default transport if socket opts fail
         client = OpenAI(**client_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",


### PR DESCRIPTION
## Summary

Fixes #10324 — When a custom provider drops a connection mid-stream, the TCP socket enters CLOSE-WAIT and `epoll_wait` blocks indefinitely. The agent hangs until manually killed.

## Why Existing Defenses Don't Catch This

The codebase already has:
- **httpx read timeout** (120s) — only fires when the socket layer reports no data. In CLOSE-WAIT, the kernel may not signal an error.
- **Stale stream detector** (180s) — calls `_force_close_tcp_sockets()`, but `sock.shutdown(SHUT_RDWR)` on CLOSE-WAIT may not unblock a concurrent blocked `read()` on some kernels.
- **`_cleanup_dead_connections()`** — only runs between requests, not during streaming.

All three are time-based and work once triggered, but they depend on the socket layer detecting the dead connection. Without keepalives, a silent CLOSE-WAIT socket generates no signal.

## Fix

Inject `SO_KEEPALIVE` + keepalive parameters into the httpx transport:

| Parameter | Value | Effect |
|-----------|-------|--------|
| `SO_KEEPALIVE` | 1 | Enable keepalive probes |
| `TCP_KEEPIDLE` | 30s | Start probing after 30s idle |
| `TCP_KEEPINTVL` | 10s | Probe every 10s |
| `TCP_KEEPCNT` | 3 | Give up after 3 failed probes |

Dead peer detected within **~60s** instead of hanging forever. Platform-aware: `TCP_KEEPIDLE` on Linux, `TCP_KEEPALIVE` on macOS. Falls back silently on unsupported platforms.

## Verification

Confirmed on a real socket that keepalive parameters are applied:
```
Socket keepalive: 1, idle=30s, interval=10s, count=3
```

23 lines added. 75 provider parity tests pass.