### PR TITLE
fix(gateway): silence unapproved Signal DMs when allowlists are active

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2562,6 +2562,30 @@ class GatewayRunner:
 
         return None
 
+    def _get_platform_user_allowlist(self, platform: Optional[Platform]) -> tuple[str, str]:
+        """Return platform/global allowlist env values for a user-facing platform."""
+        platform_env_map = {
+            Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
+            Platform.DISCORD: "DISCORD_ALLOWED_USERS",
+            Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
+            Platform.SLACK: "SLACK_ALLOWED_USERS",
+            Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
+            Platform.EMAIL: "EMAIL_ALLOWED_USERS",
+            Platform.SMS: "SMS_ALLOWED_USERS",
+            Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
+            Platform.MATRIX: "MATRIX_ALLOWED_USERS",
+            Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
+            Platform.FEISHU: "FEISHU_ALLOWED_USERS",
+            Platform.WECOM: "WECOM_ALLOWED_USERS",
+            Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
+            Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
+            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
+            Platform.QQBOT: "QQ_ALLOWED_USERS",
+        }
+        platform_allowlist = os.getenv(platform_env_map.get(platform, ""), "").strip()
+        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+        return platform_allowlist, global_allowlist
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -2585,24 +2609,6 @@ class GatewayRunner:
         if not user_id:
             return False
 
-        platform_env_map = {
-            Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
-            Platform.DISCORD: "DISCORD_ALLOWED_USERS",
-            Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
-            Platform.SLACK: "SLACK_ALLOWED_USERS",
-            Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
-            Platform.EMAIL: "EMAIL_ALLOWED_USERS",
-            Platform.SMS: "SMS_ALLOWED_USERS",
-            Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
-            Platform.MATRIX: "MATRIX_ALLOWED_USERS",
-            Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
-            Platform.FEISHU: "FEISHU_ALLOWED_USERS",
-            Platform.WECOM: "WECOM_ALLOWED_USERS",
-            Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
-            Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
-            Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
-            Platform.QQBOT: "QQ_ALLOWED_USERS",
-        }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
             Platform.DISCORD: "DISCORD_ALLOW_ALL_USERS",
@@ -2633,8 +2639,7 @@ class GatewayRunner:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
-        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+        platform_allowlist, global_allowlist = self._get_platform_user_allowlist(source.platform)
 
         if not platform_allowlist and not global_allowlist:
             # No allowlists configured -- check global allow-all flag
@@ -2674,6 +2679,15 @@ class GatewayRunner:
     def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
         """Return how unauthorized DMs should be handled for a platform."""
         config = getattr(self, "config", None)
+        if platform == Platform.SIGNAL:
+            platform_cfg = config.platforms.get(platform) if config else None
+            if not (platform_cfg and "unauthorized_dm_behavior" in platform_cfg.extra):
+                platform_allowlist, global_allowlist = self._get_platform_user_allowlist(platform)
+                if platform_allowlist or global_allowlist:
+                    # Signal often runs on a personal phone number. When an
+                    # explicit allowlist is configured, default to silently
+                    # dropping strangers instead of sending pairing spam.
+                    return "ignore"
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
             return config.get_unauthorized_dm_behavior(platform)
         return "pair"

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -184,6 +184,64 @@ async def test_unauthorized_whatsapp_dm_can_be_ignored(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_signal_allowlist_suppresses_pairing_reply_by_default(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550000001")
+    config = GatewayConfig(
+        platforms={Platform.SIGNAL: PlatformConfig(enabled=True, extra={"http_url": "http://localhost:8080"})},
+    )
+    runner, adapter = _make_runner(Platform.SIGNAL, config)
+
+    result = await runner._handle_message(
+        _make_event(
+            Platform.SIGNAL,
+            "+15559999999",
+            "+15559999999",
+        )
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_signal_allowlist_can_explicitly_keep_pairing(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550000001")
+    config = GatewayConfig(
+        platforms={
+            Platform.SIGNAL: PlatformConfig(
+                enabled=True,
+                extra={
+                    "http_url": "http://localhost:8080",
+                    "unauthorized_dm_behavior": "pair",
+                },
+            ),
+        },
+    )
+    runner, adapter = _make_runner(Platform.SIGNAL, config)
+    runner.pairing_store.generate_code.return_value = "SIGCODE1"
+
+    result = await runner._handle_message(
+        _make_event(
+            Platform.SIGNAL,
+            "+15559999999",
+            "+15559999999",
+        )
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_called_once_with(
+        "signal",
+        "+15559999999",
+        "tester",
+    )
+    adapter.send.assert_awaited_once()
+    assert "SIGCODE1" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
 async def test_rate_limited_user_gets_no_response(monkeypatch):
     """When a user is already rate-limited, pairing messages are silently ignored."""
     _clear_auth_env(monkeypatch)


### PR DESCRIPTION
## Summary
- default Signal unauthorized DMs to silent ignore when a user allowlist is configured
- keep the existing pairing flow available via explicit `unauthorized_dm_behavior: pair`
- add regression coverage for the silent default and explicit override

## Why
Signal often runs on a personal phone number. With `SIGNAL_ALLOWED_USERS` set, strangers were still receiving pairing-code onboarding messages instead of being silently dropped. That makes the allowlist non-strict in practice and creates accidental spam/privacy issues.

Fixes #9337

## Testing
- pytest -o addopts= tests/gateway/test_unauthorized_dm_behavior.py
