### PR TITLE
test(models-dev): clear in-memory cache between tests so xdist siblings don't see polluted SAMPLE_REGISTRY

### DIFF
--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -12,6 +12,27 @@ from agent.models_dev import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_models_dev_cache():
+    """Clear the module-level ``_models_dev_cache`` after every test.
+
+    Several tests in this file mutate ``agent.models_dev._models_dev_cache``
+    directly to exercise the in-memory cache code path.  Without cleanup
+    the polluted cache leaks across tests in the same xdist worker -
+    later code that calls ``fetch_models_dev()`` (e.g.
+    ``list_authenticated_providers``) sees ``SAMPLE_REGISTRY`` rather
+    than the real models.dev registry, and any provider not in
+    SAMPLE_REGISTRY (opencode-go, kimi-for-coding, …) silently drops
+    out of the "built-in" section.
+    """
+    import agent.models_dev as md
+    try:
+        yield
+    finally:
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+
+
 SAMPLE_REGISTRY = {
     "anthropic": {
         "id": "anthropic",


### PR DESCRIPTION
## Problem

When running the suite under `pytest-xdist` (`-n auto`), the following
two tests fail intermittently — only when an `agent.models_dev`
in-memory-cache test happens to land earlier on the same worker:

```
FAILED tests/hermes_cli/test_opencode_go_in_model_list.py::test_opencode_go_appears_when_api_key_set
    AssertionError: assert 'hermes' == 'built-in'

FAILED tests/hermes_cli/test_overlay_slug_resolution.py::test_kimi_for_coding_overlay_uses_hermes_slug
    AssertionError: assert None is not None
```

Both target the "built-in" section of `list_authenticated_providers`,
which is driven by `agent.models_dev.fetch_models_dev()`.

## Root cause

`tests/agent/test_models_dev.py::TestFetchModelsDev::test_in_memory_cache_used`
seeds the module-level cache to exercise the cache-hit path, and never
restores it:

```python
def test_in_memory_cache_used(self, mock_get):
    import agent.models_dev as md
    import time
    md._models_dev_cache = SAMPLE_REGISTRY
    md._models_dev_cache_time = time.time()  # fresh — 1 hour TTL
    ...
```

`SAMPLE_REGISTRY` only contains `anthropic`, `github-copilot`, `kilo`,
`deepseek`, and `audio-only`. With the cache marked fresh (1-hour TTL),
every later call to `fetch_models_dev()` on that xdist worker returns
the truncated registry instead of either the network response or the
real disk cache.

When `list_authenticated_providers` walks `PROVIDER_TO_MODELS_DEV`, the
lookup `data.get("opencode-go")` and `data.get("kimi-for-coding")`
return `None`, so those providers silently drop out of the "built-in"
section. They then fall through to the HERMES_OVERLAYS section with
`source="hermes"` (or, for the slug-resolution test, never appear at
all), tripping both assertions.

The companion `_load_disk_cache` path is already isolated by the
autouse `_isolate_hermes_home` fixture (per-test `HERMES_HOME` →
per-test disk cache). The in-memory cache is the remaining shared
mutable global.

## Fix

Add an autouse `_reset_models_dev_cache` fixture at the top of
`tests/agent/test_models_dev.py` that clears
`agent.models_dev._models_dev_cache` and resets
`_models_dev_cache_time` after every test in the file, so the cache
poisoning never escapes the test that did it.

```python
@pytest.fixture(autouse=True)
def _reset_models_dev_cache():
    import agent.models_dev as md
    try:
        yield
    finally:
        md._models_dev_cache = {}
        md._models_dev_cache_time = 0
```

No production change.

## Verification

```
$ python -m pytest --override-ini="addopts=" -q \
    tests/agent/test_models_dev.py \
    tests/hermes_cli/test_opencode_go_in_model_list.py \
    tests/hermes_cli/test_overlay_slug_resolution.py
............................                                            [100%]
28 passed in 1.14s

$ python -m pytest tests/ -q   # full suite under xdist
... 0 failures
```
