### PR TITLE
fix(runtime): preserve explicit custom API key precedence

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -234,8 +234,11 @@ def _try_resolve_from_custom_pool(
     base_url: str,
     provider_label: str,
     api_mode_override: Optional[str] = None,
+    preferred_api_key: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
+    if has_usable_secret(preferred_api_key):
+        return None
     pool_key = get_custom_provider_pool_key(base_url)
     if not pool_key:
         return None
@@ -388,7 +391,12 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    pool_result = _try_resolve_from_custom_pool(
+        base_url,
+        "custom",
+        custom_provider.get("api_mode"),
+        preferred_api_key=explicit_api_key,
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -500,7 +508,10 @@ def _resolve_openrouter_runtime(
     # For custom endpoints, check if a credential pool exists
     if effective_provider == "custom" and base_url:
         pool_result = _try_resolve_from_custom_pool(
-            base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
+            base_url,
+            effective_provider,
+            _parse_api_mode(model_cfg.get("api_mode")),
+            preferred_api_key=explicit_api_key or (cfg_api_key if use_config_base_url else ""),
         )
         if pool_result:
             return pool_result

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -536,6 +536,39 @@ def test_custom_endpoint_explicit_custom_prefers_config_key(monkeypatch):
     assert resolved["api_key"] == "sk-vllm-key"
 
 
+def test_custom_endpoint_config_api_key_skips_ambiguous_custom_pool(monkeypatch):
+    """model.api_key should win over base_url-matched custom pools (#9315)."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "key-bbbbb",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "get_custom_provider_pool_key",
+        lambda base_url: (_ for _ in ()).throw(
+            AssertionError(f"custom pool lookup should be skipped for {base_url}")
+        ),
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://api.example.com/v1"
+    assert resolved["api_key"] == "key-bbbbb"
+    assert resolved["source"] == "env/config"
+    assert resolved.get("credential_pool") is None
+
+
 def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
@@ -1364,6 +1397,36 @@ def test_named_custom_runtime_propagates_model_direct_path(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert resolved["model"] == "qwen3.6-plus"
     assert resolved["provider"] == "custom"
+
+
+def test_named_custom_runtime_explicit_api_key_skips_pool(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")
+    monkeypatch.setattr(
+        rp, "_get_named_custom_provider",
+        lambda p: {
+            "name": "my-server",
+            "base_url": "http://localhost:8000/v1",
+            "api_key": "saved-key",
+            "model": "qwen3.6-plus",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "get_custom_provider_pool_key",
+        lambda base_url: (_ for _ in ()).throw(
+            AssertionError(f"custom pool lookup should be skipped for {base_url}")
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="my-server",
+        explicit_api_key="explicit-key",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "explicit-key"
+    assert resolved["source"] == "custom_provider:my-server"
+    assert resolved["model"] == "qwen3.6-plus"
 
 
 def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):


### PR DESCRIPTION
## Summary
- skip ambiguous custom pool lookup when a custom runtime already has an explicit API key
- preserve existing custom pool fallback behavior when no explicit key is configured
- add regressions for both model.api_key and explicit named custom runtime overrides

## Why
When multiple custom_providers share the same base_url, resolving by URL can pick the first pool entry and silently override an explicit key. This PR keeps explicit custom credentials as the highest-precedence source.

Fixes #9315

## Testing
- pytest -o addopts='' tests/hermes_cli/test_runtime_provider_resolution.py