### PR TITLE
fix: make honcho_conclude schema provider-compatible

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -160,21 +160,18 @@ CONCLUDE_SCHEMA = {
         "properties": {
             "conclusion": {
                 "type": "string",
-                "description": "A factual statement to persist. Required when not using delete_id.",
+                "description": "A factual statement to persist. Provide this when creating a conclusion. Do not send it together with delete_id.",
             },
             "delete_id": {
                 "type": "string",
-                "description": "Conclusion ID to delete (for PII removal). Required when not using conclusion.",
+                "description": "Conclusion ID to delete for PII removal. Provide this when deleting a conclusion. Do not send it together with conclusion.",
             },
             "peer": {
                 "type": "string",
                 "description": "Peer to query. Built-in aliases: 'user' (default), 'ai'. Or pass any peer ID from this workspace.",
             },
         },
-        "anyOf": [
-            {"required": ["conclusion"]},
-            {"required": ["delete_id"]},
-        ],
+        "required": [],
     },
 }
 
@@ -1012,15 +1009,20 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_conclude":
                 delete_id = args.get("delete_id")
+                conclusion = args.get("conclusion", "")
                 peer = args.get("peer", "user")
-                if delete_id:
+
+                has_delete_id = bool(delete_id)
+                has_conclusion = bool(conclusion)
+                if has_delete_id == has_conclusion:
+                    return tool_error("Exactly one of conclusion or delete_id must be provided.")
+
+                if has_delete_id:
                     ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
-                conclusion = args.get("conclusion", "")
-                if not conclusion:
-                    return tool_error("Missing required parameter: conclusion or delete_id")
+
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -8,7 +8,7 @@ from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
 )
-from plugins.memory.honcho import HonchoMemoryProvider
+from plugins.memory.honcho import CONCLUDE_SCHEMA, HonchoMemoryProvider
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +366,15 @@ class TestPeerLookupHelpers:
 
 
 class TestConcludeToolDispatch:
+    def test_conclude_schema_uses_plain_object_parameters_for_provider_compatibility(self):
+        params = CONCLUDE_SCHEMA["parameters"]
+
+        assert params["type"] == "object"
+        assert params["required"] == []
+        assert "anyOf" not in params
+        assert "oneOf" not in params
+        assert "allOf" not in params
+
     def test_honcho_conclude_defaults_to_user_peer(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
@@ -470,7 +479,24 @@ class TestConcludeToolDispatch:
         result = provider.handle_tool_call("honcho_conclude", {})
 
         parsed = json.loads(result)
-        assert "error" in parsed or "Missing required" in parsed.get("result", "")
+        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
+    def test_honcho_conclude_rejects_both_params_at_once(self):
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "User prefers dark mode", "delete_id": "conc-123"},
+        )
+
+        parsed = json.loads(result)
+        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
         provider._manager.create_conclusion.assert_not_called()
         provider._manager.delete_conclusion.assert_not_called()
 


### PR DESCRIPTION
## Summary
- remove top-level `anyOf` from `honcho_conclude` tool parameters so the schema stays compatible with stricter tool validators
- preserve the mutual-exclusion contract in runtime by requiring exactly one of `conclusion` or `delete_id`
- add Honcho plugin tests covering the schema shape and the invalid neither/both argument cases

## Why
Some tool providers reject function schemas whose top-level `parameters` object contains combinators like `anyOf`/`oneOf`/`allOf`. `honcho_conclude` currently uses a top-level `anyOf`, which can break tool registration even though the runtime handler already knows how to process the call.

This change keeps the exported schema as a plain object and moves the exact-one validation to runtime, which is the compatibility-safe path.

## Test Plan
- `source venv/bin/activate && python -m pytest tests/honcho_plugin/test_session.py -q`
- `source venv/bin/activate && python -m pytest tests/honcho_plugin -q`
