### PR TITLE
fix(gateway): guard pending_event.channel_prompt against None in recursive _run_agent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9432,6 +9432,7 @@ class GatewayRunner:
                 next_source = source
                 next_message = pending
                 next_message_id = None
+                next_channel_prompt = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     next_message = await self._prepare_inbound_message_text(
@@ -9442,6 +9443,7 @@ class GatewayRunner:
                     if next_message is None:
                         return result
                     next_message_id = getattr(pending_event, "message_id", None)
+                    next_channel_prompt = getattr(pending_event, "channel_prompt", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -9465,7 +9467,7 @@ class GatewayRunner:
                     session_key=session_key,
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
-                    channel_prompt=pending_event.channel_prompt,
+                    channel_prompt=next_channel_prompt,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/tests/gateway/test_pending_event_none.py
+++ b/tests/gateway/test_pending_event_none.py
@@ -1,0 +1,42 @@
+"""Tests for the pending_event None guard in recursive _run_agent calls.
+
+When pending_event is None (Path B: pending comes from interrupt_message),
+accessing pending_event.channel_prompt previously raised AttributeError.
+This verifies the fix: channel_prompt is captured inside the
+`if pending_event is not None:` block and falls back to None otherwise.
+"""
+
+from types import SimpleNamespace
+
+
+def _extract_channel_prompt(pending_event):
+    """Reproduce the fixed logic from gateway/run.py.
+
+    Mirrors the variable-capture pattern used before the recursive
+    _run_agent call so we can test both paths without a full runner.
+    """
+    next_channel_prompt = None
+    if pending_event is not None:
+        next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+    return next_channel_prompt
+
+
+class TestPendingEventNoneChannelPrompt:
+    """Guard against AttributeError when pending_event is None."""
+
+    def test_none_pending_event_returns_none_channel_prompt(self):
+        """Path B: pending_event is None — must not raise AttributeError."""
+        result = _extract_channel_prompt(None)
+        assert result is None
+
+    def test_pending_event_with_channel_prompt_passes_through(self):
+        """Path A: pending_event present — channel_prompt is forwarded."""
+        event = SimpleNamespace(channel_prompt="You are a helpful bot.")
+        result = _extract_channel_prompt(event)
+        assert result == "You are a helpful bot."
+
+    def test_pending_event_without_channel_prompt_returns_none(self):
+        """Path A: pending_event present but has no channel_prompt attribute."""
+        event = SimpleNamespace()
+        result = _extract_channel_prompt(event)
+        assert result is None


### PR DESCRIPTION
## What does this PR do?

Guards against `AttributeError: 'NoneType' object has no attribute 'channel_prompt'` when the gateway processes a pending follow-up message that came from `interrupt_message` (Path B) rather than a dequeued adapter event (Path A).

## Related Issue

Fixes #10909

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`gateway/run.py`** (~line 9435):
- Added `next_channel_prompt = None` before the `if pending_event is not None:` guard
- Captured `next_channel_prompt = getattr(pending_event, "channel_prompt", None)` inside the guard
- Changed recursive `_run_agent()` call from `channel_prompt=pending_event.channel_prompt` to `channel_prompt=next_channel_prompt`

This is consistent with how `next_source`, `next_message`, and `next_message_id` are already handled in the same block.

**`tests/gateway/test_pending_event_none.py`**:
- 3 focused unit tests covering: None event (Path B), event with channel_prompt (Path A), event without channel_prompt attribute

## How to Test

1. Start a long-running tool call (e.g. `terminal` command that takes > 30 min)
2. Let the agent hit the idle timeout (`gateway_timeout`, default 1800s)
3. Send a new message to the same session before the timeout error is fully handled
4. Previously: gateway crashes with AttributeError
5. Now: follow-up message is processed with `channel_prompt=None` (the `_run_agent` signature already defaults it to `None`)

## Checklist

- [x] I've read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My code follows the project's code style
- [x] I've tested my changes locally
- [x] I've added tests that prove my fix works
- [x] All existing tests pass
- [x] My changes don't introduce new warnings
- [x] I've checked the fatal code policies (no hardcoded paths, no simple_term_menu, no ANSI erase, no cross-toolset schema refs, JSON tool returns, no cache-breaking)

## AI Disclosure

This bug was identified and fixed with AI assistance.