### PR TITLE
feat(agent): add user confirmation hook for skill creation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7364,6 +7364,25 @@ class AIAgent:
                 choices=function_args.get("choices"),
                 callback=self.clarify_callback,
             )
+        elif function_name == "skill_manage" and function_args.get("action") == "create":
+            # Intercept skill creation to add user confirmation
+            from tools.skill_manager_tool import skill_manage as _skill_manage
+
+            def _skill_confirm(skill_name: str) -> str:
+                """Ask user whether to keep or delete a newly created skill."""
+                if not self.clarify_callback:
+                    return "保留"  # No callback available, keep by default
+                question = f"Skill '{skill_name}' 已创建。保留还是删除？"
+                choices = ["保留", "删除"]
+                return self.clarify_callback(question, choices)
+
+            return _skill_manage(
+                action=function_args.get("action", ""),
+                name=function_args.get("name", ""),
+                content=function_args.get("content"),
+                category=function_args.get("category"),
+                confirm_callback=_skill_confirm,
+            )
         elif function_name == "delegate_task":
             from tools.delegate_tool import delegate_task as _delegate_task
             return _delegate_task(

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -301,7 +301,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
 # Core actions
 # =============================================================================
 
-def _create_skill(name: str, content: str, category: str = None) -> Dict[str, Any]:
+def _create_skill(name: str, content: str, category: str = None, confirm_callback=None) -> Dict[str, Any]:
     """Create a new user skill with SKILL.md content."""
     # Validate name
     err = _validate_name(name)
@@ -342,6 +342,20 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     if scan_error:
         shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
+
+    # --- User confirmation hook ---
+    if confirm_callback:
+        try:
+            user_response = confirm_callback(name)
+            if user_response and "删除" in str(user_response).lower():
+                shutil.rmtree(skill_dir, ignore_errors=True)
+                return {
+                    "success": False,
+                    "error": f"User chose to delete the newly created skill '{name}'.",
+                    "deleted": True,
+                }
+        except Exception:
+            pass  # If callback fails, keep the skill (fail-open)
 
     result = {
         "success": True,
@@ -623,6 +637,7 @@ def skill_manage(
     old_string: str = None,
     new_string: str = None,
     replace_all: bool = False,
+    confirm_callback=None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
@@ -632,7 +647,7 @@ def skill_manage(
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
+        result = _create_skill(name, content, category, confirm_callback=confirm_callback)
 
     elif action == "edit":
         if not content:
@@ -784,6 +799,7 @@ registry.register(
         file_content=args.get("file_content"),
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False)),
+        replace_all=args.get("replace_all", False),
+        confirm_callback=kw.get("confirm_callback")),
     emoji="📝",
 )


### PR DESCRIPTION
## What
Add a post-creation confirmation hook for skills created via skill_manage(action='create'). When the agent creates a skill, a TUI dialog prompts the user to '保留' (keep) or '删除' (delete) the newly created skill, preventing unwanted auto-generated skills from accumulating.

## How to test
1. Run the agent and trigger a skill creation (e.g., ask to create a simple test skill).
2. A clarify-style dialog should appear with options '保留' and '删除'.
3. Selecting '删除' should remove the skill file and return an error to the agent.
4. Run existing tests: ============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/jorkeyliu/.hermes/hermes-agent
configfile: pyproject.toml
plugins: xdist-3.8.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
created: 8/8 workers
8 workers [54 items]

......................................................                   [100%]
============================== 54 passed in 0.66s ============================== (all pass).

## Platforms
- macOS (tested)
- Linux (expected compatible)
- Windows (expected compatible, but TUI may vary)

## Reference
Addresses the issue of agent auto-creating redundant skills without user review.