### PR TITLE
[codex] Fix SSH-backed profile creation on SSH backends

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4466,7 +4466,7 @@ def cmd_profile(args):
         list_profiles, create_profile, delete_profile, seed_profile_skills,
         set_active_profile, get_active_profile_name,
         check_alias_collision, create_wrapper_script, remove_wrapper_script,
-        _is_wrapper_dir_in_path, _get_wrapper_dir,
+        _is_wrapper_dir_in_path, _get_wrapper_dir, sync_profile_to_ssh,
     )
     from hermes_constants import display_hermes_home
 
@@ -4571,6 +4571,7 @@ def cmd_profile(args):
                     print("⚠ Skills could not be seeded. Run `{} update` to retry.".format(name))
 
             # Create wrapper alias
+            wrapper_path = None
             if not no_alias:
                 collision = check_alias_collision(name)
                 if collision:
@@ -4585,6 +4586,19 @@ def cmd_profile(args):
                             print(f"\n⚠ {_get_wrapper_dir()} is not in your PATH.")
                             print(f'  Add to your shell config (~/.bashrc or ~/.zshrc):')
                             print(f'    export PATH="$HOME/.local/bin:$PATH"')
+
+            try:
+                remote_sync = sync_profile_to_ssh(
+                    profile_dir,
+                    name,
+                    create_alias=wrapper_path is not None,
+                )
+                if remote_sync:
+                    print(f"SSH mirror created: {remote_sync['remote_profile_dir']}")
+                    if remote_sync.get("remote_wrapper_path"):
+                        print(f"Remote wrapper created: {remote_sync['remote_wrapper_path']}")
+            except RuntimeError as e:
+                print(f"⚠ SSH profile mirror failed: {e}")
 
             # Profile dir for display
             try:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -23,9 +23,12 @@ import json
 import os
 import re
 import shutil
+import shlex
 import stat
 import subprocess
 import sys
+import tarfile
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional
@@ -259,6 +262,188 @@ def remove_wrapper_script(name: str) -> bool:
         except Exception:
             pass
     return False
+
+
+# ---------------------------------------------------------------------------
+# SSH mirror helpers
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _SSHProfileMirrorConfig:
+    """Resolved SSH backend settings for remote profile mirroring."""
+    host: str
+    user: str
+    port: int = 22
+    key_path: str = ""
+
+
+def _load_terminal_env_from_config() -> None:
+    """Populate TERMINAL_* env vars from config.yaml if they aren't loaded yet."""
+    if (
+        os.getenv("TERMINAL_ENV")
+        and os.getenv("TERMINAL_SSH_HOST")
+        and os.getenv("TERMINAL_SSH_USER")
+    ):
+        return
+
+    try:
+        from hermes_cli.config import load_config
+        load_config()
+    except Exception:
+        pass
+
+
+def _get_ssh_profile_mirror_config() -> Optional[_SSHProfileMirrorConfig]:
+    """Return SSH mirror settings when the active terminal backend is SSH."""
+    _load_terminal_env_from_config()
+
+    env_type = (os.getenv("TERMINAL_ENV", "") or "").strip().lower()
+    if env_type != "ssh":
+        return None
+
+    host = (os.getenv("TERMINAL_SSH_HOST", "") or "").strip()
+    user = (os.getenv("TERMINAL_SSH_USER", "") or "").strip()
+    if not host or not user:
+        return None
+
+    try:
+        port = int((os.getenv("TERMINAL_SSH_PORT", "22") or "22").strip())
+    except (AttributeError, TypeError, ValueError):
+        port = 22
+
+    return _SSHProfileMirrorConfig(
+        host=host,
+        user=user,
+        port=port,
+        key_path=(os.getenv("TERMINAL_SSH_KEY", "") or "").strip(),
+    )
+
+
+def _build_ssh_command(config: _SSHProfileMirrorConfig, remote_command: str) -> list[str]:
+    """Build a one-shot SSH command suitable for remote profile mirroring."""
+    cmd = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=10",
+    ]
+    if config.port != 22:
+        cmd.extend(["-p", str(config.port)])
+    if config.key_path:
+        cmd.extend(["-i", config.key_path])
+    cmd.append(f"{config.user}@{config.host}")
+    cmd.append(remote_command)
+    return cmd
+
+
+def _run_ssh_text(
+    config: _SSHProfileMirrorConfig,
+    remote_command: str,
+    *,
+    timeout: int = 20,
+) -> subprocess.CompletedProcess:
+    """Run a text-mode SSH command and raise a clear error on failure."""
+    result = subprocess.run(
+        _build_ssh_command(config, remote_command),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
+        raise RuntimeError(detail)
+    return result
+
+
+def _detect_ssh_remote_home(config: _SSHProfileMirrorConfig) -> str:
+    """Resolve the remote user's home directory over SSH."""
+    result = _run_ssh_text(config, "printf '%s\\n' \"$HOME\"")
+    remote_home = result.stdout.strip()
+    if remote_home:
+        return remote_home
+    if config.user == "root":
+        return "/root"
+    return f"/home/{config.user}"
+
+
+def _sync_profile_tree_to_ssh(
+    profile_dir: Path,
+    config: _SSHProfileMirrorConfig,
+    remote_profile_dir: str,
+) -> None:
+    """Upload a fully prepared local profile directory to the SSH host."""
+    with tempfile.TemporaryDirectory(prefix="hermes-profile-ssh-") as tmpdir:
+        archive_path = Path(tmpdir) / f"{profile_dir.name}.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            for child in sorted(profile_dir.iterdir()):
+                tf.add(child, arcname=child.name)
+
+        remote_cmd = (
+            f"mkdir -p {shlex.quote(remote_profile_dir)} && "
+            f"tar xzf - -C {shlex.quote(remote_profile_dir)}"
+        )
+        with open(archive_path, "rb") as archive:
+            result = subprocess.run(
+                _build_ssh_command(config, remote_cmd),
+                stdin=archive,
+                capture_output=True,
+                timeout=120,
+            )
+
+    if result.returncode != 0:
+        detail = (
+            result.stderr.decode(errors="replace")
+            or result.stdout.decode(errors="replace")
+        ).strip() or f"exit code {result.returncode}"
+        raise RuntimeError(detail)
+
+
+def _create_remote_wrapper_script(
+    config: _SSHProfileMirrorConfig,
+    name: str,
+    remote_home: str,
+) -> str:
+    """Create the profile wrapper on the SSH host and return its path."""
+    wrapper_dir = str(PurePosixPath(remote_home) / ".local" / "bin")
+    wrapper_path = str(PurePosixPath(wrapper_dir) / name)
+    wrapper_content = f'#!/bin/sh\nexec hermes -p {name} "$@"\n'
+    remote_cmd = (
+        f"mkdir -p {shlex.quote(wrapper_dir)} && "
+        f"printf %s {shlex.quote(wrapper_content)} > {shlex.quote(wrapper_path)} && "
+        f"chmod +x {shlex.quote(wrapper_path)}"
+    )
+    _run_ssh_text(config, remote_cmd)
+    return wrapper_path
+
+
+def sync_profile_to_ssh(
+    profile_dir: Path,
+    name: str,
+    *,
+    create_alias: bool = True,
+) -> Optional[dict]:
+    """Mirror a newly created profile to the configured SSH backend.
+
+    Returns ``None`` when the active terminal backend is not SSH. Otherwise
+    returns a dict with ``remote_profile_dir`` and, when applicable,
+    ``remote_wrapper_path``.
+    """
+    config = _get_ssh_profile_mirror_config()
+    if config is None:
+        return None
+
+    remote_home = _detect_ssh_remote_home(config)
+    remote_profile_dir = str(PurePosixPath(remote_home) / ".hermes" / "profiles" / name)
+    _sync_profile_tree_to_ssh(profile_dir, config, remote_profile_dir)
+
+    remote_wrapper_path = None
+    if create_alias:
+        remote_wrapper_path = _create_remote_wrapper_script(config, name, remote_home)
+
+    return {
+        "remote_profile_dir": remote_profile_dir,
+        "remote_wrapper_path": remote_wrapper_path,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -9,6 +9,7 @@ import json
 import io
 import os
 import tarfile
+from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -32,6 +33,7 @@ from hermes_cli.profiles import (
     generate_zsh_completion,
     _get_profiles_root,
     _get_default_hermes_home,
+    sync_profile_to_ssh,
 )
 
 
@@ -869,3 +871,126 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+
+class TestSSHProfileMirror:
+    """Tests for SSH-backed profile mirroring."""
+
+    def test_sync_profile_to_ssh_noops_when_backend_is_not_ssh(self, profile_env, monkeypatch):
+        profile_dir = create_profile("coder", no_alias=True)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        assert sync_profile_to_ssh(profile_dir, "coder") is None
+
+    def test_sync_profile_to_ssh_mirrors_profile_and_wrapper(self, profile_env, monkeypatch):
+        profile_dir = create_profile("coder", no_alias=True)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "box.example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "hermes")
+
+        calls = {}
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles._detect_ssh_remote_home",
+            lambda cfg: "/home/hermes",
+        )
+
+        def _fake_sync(local_dir, cfg, remote_dir):
+            calls["sync"] = {
+                "local_dir": local_dir,
+                "host": cfg.host,
+                "user": cfg.user,
+                "remote_dir": remote_dir,
+            }
+
+        monkeypatch.setattr("hermes_cli.profiles._sync_profile_tree_to_ssh", _fake_sync)
+        monkeypatch.setattr(
+            "hermes_cli.profiles._create_remote_wrapper_script",
+            lambda cfg, name, remote_home: f"{remote_home}/.local/bin/{name}",
+        )
+
+        result = sync_profile_to_ssh(profile_dir, "coder", create_alias=True)
+
+        assert calls["sync"]["local_dir"] == profile_dir
+        assert calls["sync"]["host"] == "box.example.com"
+        assert calls["sync"]["user"] == "hermes"
+        assert calls["sync"]["remote_dir"] == "/home/hermes/.hermes/profiles/coder"
+        assert result == {
+            "remote_profile_dir": "/home/hermes/.hermes/profiles/coder",
+            "remote_wrapper_path": "/home/hermes/.local/bin/coder",
+        }
+
+    def test_sync_profile_to_ssh_can_skip_remote_wrapper(self, profile_env, monkeypatch):
+        profile_dir = create_profile("coder", no_alias=True)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setenv("TERMINAL_SSH_HOST", "box.example.com")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "hermes")
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles._detect_ssh_remote_home",
+            lambda cfg: "/home/hermes",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._sync_profile_tree_to_ssh",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.profiles._create_remote_wrapper_script",
+            lambda *args, **kwargs: pytest.fail("wrapper should not be created"),
+        )
+
+        result = sync_profile_to_ssh(profile_dir, "coder", create_alias=False)
+
+        assert result == {
+            "remote_profile_dir": "/home/hermes/.hermes/profiles/coder",
+            "remote_wrapper_path": None,
+        }
+
+
+class TestProfileCreateCommand:
+    """Integration coverage for `hermes profile create`."""
+
+    def test_cmd_profile_create_reports_ssh_mirror(self, profile_env, monkeypatch, capsys):
+        import hermes_cli.main as main_mod
+        import hermes_cli.profiles as profiles_mod
+
+        profile_dir = create_profile("coder", no_alias=True)
+        wrapper_path = profile_env / ".local" / "bin" / "coder"
+        mirror_calls = {}
+
+        monkeypatch.setattr(profiles_mod, "create_profile", lambda **kwargs: profile_dir)
+        monkeypatch.setattr(profiles_mod, "seed_profile_skills", lambda _: {"copied": ["skill-a"]})
+        monkeypatch.setattr(profiles_mod, "check_alias_collision", lambda _: None)
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda _: wrapper_path)
+        monkeypatch.setattr(profiles_mod, "_is_wrapper_dir_in_path", lambda: True)
+        monkeypatch.setattr(profiles_mod, "_get_wrapper_dir", lambda: wrapper_path.parent)
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "default")
+
+        def _fake_sync(path, name, *, create_alias=True):
+            mirror_calls["path"] = path
+            mirror_calls["name"] = name
+            mirror_calls["create_alias"] = create_alias
+            return {
+                "remote_profile_dir": "/home/hermes/.hermes/profiles/coder",
+                "remote_wrapper_path": "/home/hermes/.local/bin/coder",
+            }
+
+        monkeypatch.setattr(profiles_mod, "sync_profile_to_ssh", _fake_sync)
+
+        args = Namespace(
+            profile_action="create",
+            profile_name="coder",
+            clone=False,
+            clone_all=False,
+            clone_from=None,
+            no_alias=False,
+        )
+        main_mod.cmd_profile(args)
+
+        out = capsys.readouterr().out
+        assert mirror_calls == {
+            "path": profile_dir,
+            "name": "coder",
+            "create_alias": True,
+        }
+        assert "SSH mirror created: /home/hermes/.hermes/profiles/coder" in out
+        assert "Remote wrapper created: /home/hermes/.local/bin/coder" in out


### PR DESCRIPTION
## Summary
- mirror newly created profiles to the configured SSH host when `terminal.backend` is `ssh`
- create the remote profile wrapper only when the local wrapper was created successfully
- add SSH profile mirroring coverage plus command-level regression coverage

## Root Cause
`hermes profile create` only created profiles on the local machine, while the SSH backend sync path does not sync `~/.hermes/profiles`. That left the remote runtime without the new profile or wrapper.

## Testing
- `source .venv-ci/bin/activate && python -m pytest tests/hermes_cli/test_profiles.py -q`
- `source .venv-ci/bin/activate && python -m pytest tests/hermes_cli/test_backup.py -q`
- `source .venv-ci/bin/activate && python -m pytest tests/hermes_cli/test_profiles.py tests/hermes_cli/test_backup.py -q`
