### PR TITLE
fix(backup): allow pre-1980 file timestamps

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -183,7 +183,15 @@ def run_backup(args) -> None:
     errors = []
     t0 = time.monotonic()
 
-    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+    # Clamp pre-1980 mtimes to the earliest ZIP-compatible timestamp instead
+    # of aborting the entire backup on older files.
+    with zipfile.ZipFile(
+        out_path,
+        "w",
+        zipfile.ZIP_DEFLATED,
+        compresslevel=6,
+        strict_timestamps=False,
+    ) as zf:
         for i, (abs_path, rel_path) in enumerate(files_to_add, 1):
             try:
                 # Safe copy for SQLite databases (handles WAL mode)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -233,6 +233,29 @@ class TestBackup:
         zips = list(tmp_path.glob("hermes-backup-*.zip"))
         assert len(zips) == 1
 
+    def test_clamps_pre_1980_timestamps_in_backup(self, tmp_path, monkeypatch):
+        """Files older than 1980 should not abort the backup archive."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        legacy_file = hermes_home / "sessions" / "legacy.txt"
+        legacy_file.write_text("legacy\n")
+        os.utime(legacy_file, (1, 1))
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            assert "sessions/legacy.txt" in zf.namelist()
+            assert zf.getinfo("sessions/legacy.txt").date_time[0] == 1980
+
 
 # ---------------------------------------------------------------------------
 # _validate_backup_zip tests


### PR DESCRIPTION
## Summary
- write backup archives with non-strict ZIP timestamps so legacy files do not abort the whole backup
- add a regression that covers a file with a pre-1980 mtime and verifies it is archived successfully

## Why
Python's zipfile module raises ValueError for mtimes before 1980 in strict mode. That currently breaks hermes backup for users who have older files in their Hermes home.

Fixes #9298

## Testing
- pytest -o addopts='' tests/hermes_cli/test_backup.py