### PR TITLE
fix: Ollama Cloud shows 0 models in /model TUI picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -807,6 +807,10 @@ def list_authenticated_providers(
     # "nous" shares OpenRouter's curated list if not separately defined
     if "nous" not in curated:
         curated["nous"] = curated["openrouter"]
+    # Ollama Cloud uses dynamic discovery (no static curated list)
+    if "ollama-cloud" not in curated:
+        from hermes_cli.models import fetch_ollama_cloud_models
+        curated["ollama-cloud"] = fetch_ollama_cloud_models()
 
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1286,6 +1286,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         live = _fetch_ai_gateway_models()
         if live:
             return live
+    if normalized == "ollama-cloud":
+        live = fetch_ollama_cloud_models(force_refresh=force_refresh)
+        if live:
+            return live
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -114,6 +114,65 @@ class TestOllamaCloudModelCatalog:
         assert "ollama-cloud" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["ollama-cloud"] == "Ollama Cloud"
 
+    def test_provider_model_ids_returns_dynamic_models(self, tmp_path, monkeypatch):
+        """provider_model_ids('ollama-cloud') should call fetch_ollama_cloud_models()."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "qwen3.5:397b": {"tool_call": True},
+                    "glm-5": {"tool_call": True},
+                }
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = provider_model_ids("ollama-cloud", force_refresh=True)
+
+        assert len(result) > 0
+        assert "qwen3.5:397b" in result
+
+
+# ── Model Picker (list_authenticated_providers) ──
+
+class TestOllamaCloudModelPicker:
+    def test_ollama_cloud_shows_model_count(self, tmp_path, monkeypatch):
+        """Ollama Cloud should show non-zero model count in provider picker."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "qwen3.5:397b": {"tool_call": True},
+                    "glm-5": {"tool_call": True},
+                }
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            providers = list_authenticated_providers(current_provider="ollama-cloud")
+
+        ollama = next((p for p in providers if p["slug"] == "ollama-cloud"), None)
+        assert ollama is not None, "ollama-cloud should appear when OLLAMA_API_KEY is set"
+        assert ollama["total_models"] > 0, "ollama-cloud should show non-zero model count"
+
+    def test_ollama_cloud_not_shown_without_creds(self, monkeypatch):
+        """Ollama Cloud should not appear without credentials."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        providers = list_authenticated_providers(current_provider="openrouter")
+        ollama = next((p for p in providers if p["slug"] == "ollama-cloud"), None)
+        assert ollama is None, "ollama-cloud should not appear without OLLAMA_API_KEY"
+
 
 # ── Merged Model Discovery ──
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model` TUI picker showing "Ollama Cloud (0 models)" and "No models listed for this provider" when selecting it. The `hermes model` CLI subcommand works fine because it calls `fetch_ollama_cloud_models()` directly, but the TUI picker uses `provider_model_ids()` and `list_authenticated_providers()` which had no case for `"ollama-cloud"`.

## Related Issue

Fixes #10977

Regression introduced in #10782 — `fetch_ollama_cloud_models()` was implemented but not wired into the two functions the `/model` TUI picker depends on.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: Add `ollama-cloud` case to `provider_model_ids()` so it calls `fetch_ollama_cloud_models()` — follows the same pattern as Anthropic, Copilot, Nous, etc.
- `hermes_cli/model_switch.py`: Populate `curated` dict for `ollama-cloud` in `list_authenticated_providers()` — follows the existing `openrouter`/`nous` pattern on lines 806-809.
- `tests/hermes_cli/test_ollama_cloud_provider.py`: Add 3 tests covering `provider_model_ids()`, `list_authenticated_providers()` model count, and negative (no creds) case.

## How to Test

1. Set `OLLAMA_API_KEY` in `~/.hermes/.env`
2. Run `hermes` and type `/model`
3. Ollama Cloud should show a non-zero model count in the provider list
4. Selecting it should show the full model list (not "No models listed")

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc changes needed)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs
### Before
<img width="443" height="320" alt="image" src="https://github.com/user-attachments/assets/7a6fb2cd-77d2-4d12-80bc-35b39e2c67b4" />
<img width="560" height="172" alt="image" src="https://github.com/user-attachments/assets/8162336a-8940-4e50-8319-b82e36ad775f" />

### After

<img width="443" height="228" alt="image" src="https://github.com/user-attachments/assets/6ebcb9a9-b2f3-4542-a730-0d8ff9f5e1ae" />
<img width="583" height="547" alt="image" src="https://github.com/user-attachments/assets/6d0bd501-4335-4269-a40f-cf579f123046" />
