### PR TITLE
fix(profiles): ignore hidden skill directories when counting skills

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -323,8 +323,9 @@ def _count_skills(profile_dir: Path) -> int:
         return 0
     count = 0
     for md in skills_dir.rglob("SKILL.md"):
-        if "/.hub/" not in str(md) and "/.git/" not in str(md):
-            count += 1
+        if any(part in (".git", ".github", ".hub") for part in md.parts):
+            continue
+        count += 1
     return count
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -9,7 +9,7 @@ import json
 import io
 import os
 import tarfile
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -30,6 +30,7 @@ from hermes_cli.profiles import (
     import_profile,
     generate_bash_completion,
     generate_zsh_completion,
+    _count_skills,
     _get_profiles_root,
     _get_default_hermes_home,
 )
@@ -238,6 +239,48 @@ class TestListProfiles:
         profiles = list_profiles()
         assert profiles[0].name == "default"
         assert profiles[0].is_default is True
+
+    def test_count_skills_excludes_hidden_dirs(self, profile_env):
+        tmp_path = profile_env
+        skills_dir = tmp_path / ".hermes" / "skills"
+        (skills_dir / "visible" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / "visible" / "SKILL.md").write_text("visible")
+        (skills_dir / ".hub" / "quarantine" / "hidden" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / ".hub" / "quarantine" / "hidden" / "SKILL.md").write_text("hidden")
+        (skills_dir / ".git" / "hooks" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / ".git" / "hooks" / "SKILL.md").write_text("hidden")
+
+        assert _count_skills(tmp_path / ".hermes") == 1
+
+    def test_count_skills_ignores_hidden_dirs_for_windows_style_paths(self, profile_env, monkeypatch):
+        tmp_path = profile_env
+        visible_skill = tmp_path / ".hermes" / "skills" / "visible" / "SKILL.md"
+        hidden_skill = tmp_path / ".hermes" / "skills" / ".hub" / "quarantine" / "hidden" / "SKILL.md"
+        visible_skill.parent.mkdir(parents=True)
+        visible_skill.write_text("visible")
+        hidden_skill.parent.mkdir(parents=True)
+        hidden_skill.write_text("hidden")
+
+        def fake_rglob(_self, _pattern):
+            return [
+                PureWindowsPath(r"C:\Users\tester\.hermes\skills\visible\SKILL.md"),
+                PureWindowsPath(r"C:\Users\tester\.hermes\skills\.hub\quarantine\hidden\SKILL.md"),
+            ]
+
+        monkeypatch.setattr(Path, "rglob", fake_rglob)
+
+        assert _count_skills(tmp_path / ".hermes") == 1
+
+    def test_list_profiles_reports_skill_count_without_hidden_dirs(self, profile_env):
+        tmp_path = profile_env
+        skills_dir = tmp_path / ".hermes" / "skills"
+        (skills_dir / "visible" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / "visible" / "SKILL.md").write_text("visible")
+        (skills_dir / ".hub" / "quarantine" / "hidden" / "SKILL.md").parent.mkdir(parents=True)
+        (skills_dir / ".hub" / "quarantine" / "hidden" / "SKILL.md").write_text("hidden")
+
+        default = next(profile for profile in list_profiles() if profile.name == "default")
+        assert default.skill_count == 1
 
 
 # ===================================================================


### PR DESCRIPTION
 ## Summary

  - fix `hermes_cli/profiles.py` so profile skill counting ignores skills under hidden directories using `Path.parts`
  instead of POSIX-only string matching
  - exclude `.git`, `.github`, and `.hub` consistently when computing `skill_count`
  - add regression coverage in `tests/hermes_cli/test_profiles.py` for:
    - hidden directories not being counted
    - Windows-style path handling
    - `list_profiles()` reporting the correct `skill_count`

  ## Why

  `_count_skills()` previously filtered hidden directories by checking for substrings like `"/.hub/"` and `"/.git/"` in
  `str(Path)`. That works on Unix-style paths, but it breaks on Windows where paths use backslashes.

  As a result, `SKILL.md` files under hidden directories such as `.hub` or `.git` could be counted incorrectly in
  profile listings. This change makes the filtering cross-platform and aligns it with the existing hidden-directory
  filtering pattern already used elsewhere in the codebase.

  ## Testing

  - `uv run --extra dev python -m pytest tests/hermes_cli/test_profiles.py -n 0`
  - `uv run --extra dev python -m pytest tests/tools/test_hidden_dir_filter.py -n 0`

