### PR TITLE
feat(config): add auxiliary.default for config inheritance

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2149,14 +2149,34 @@ def _resolve_task_provider_model(
             config = {}
 
         aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}
+        if not isinstance(aux, dict):
+            aux = {}
+        
+        # Get default config (inherited by all tasks)
+        default_config = aux.get("default", {}) if isinstance(aux, dict) else {}
+        if not isinstance(default_config, dict):
+            default_config = {}
+        
+        # Get task-specific config
         task_config = aux.get(task, {}) if isinstance(aux, dict) else {}
         if not isinstance(task_config, dict):
             task_config = {}
-        cfg_provider = str(task_config.get("provider", "")).strip() or None
-        cfg_model = str(task_config.get("model", "")).strip() or None
-        cfg_base_url = str(task_config.get("base_url", "")).strip() or None
-        cfg_api_key = str(task_config.get("api_key", "")).strip() or None
-        cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
+        
+        # Resolution order: task-specific → default → "auto"/"" 
+        # For each field, prefer task_config, then default_config
+        def _get_config_value(key: str) -> str:
+            """Get config value with inheritance: task → default → empty."""
+            task_val = str(task_config.get(key, "")).strip()
+            if task_val:
+                return task_val
+            default_val = str(default_config.get(key, "")).strip()
+            return default_val if default_val else ""
+        
+        cfg_provider = _get_config_value("provider") or None
+        cfg_model = _get_config_value("model") or None
+        cfg_base_url = _get_config_value("base_url") or None
+        cfg_api_key = _get_config_value("api_key") or None
+        cfg_api_mode = _get_config_value("api_mode") or None
 
     resolved_model = model or cfg_model
     resolved_api_mode = cfg_api_mode
@@ -2182,7 +2202,10 @@ _DEFAULT_AUX_TIMEOUT = 30.0
 
 
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
-    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
+    """Read timeout from auxiliary.{task}.timeout in config, falling back to default.timeout, then *default*.
+    
+    Resolution order: task-specific timeout → default timeout → function default.
+    """
     if not task:
         return default
     try:
@@ -2191,13 +2214,29 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     except ImportError:
         return default
     aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}
+    if not isinstance(aux, dict):
+        return default
+    
+    # Check task-specific timeout first
     task_config = aux.get(task, {}) if isinstance(aux, dict) else {}
-    raw = task_config.get("timeout")
-    if raw is not None:
-        try:
-            return float(raw)
-        except (ValueError, TypeError):
-            pass
+    if isinstance(task_config, dict):
+        raw = task_config.get("timeout")
+        if raw is not None:
+            try:
+                return float(raw)
+            except (ValueError, TypeError):
+                pass
+    
+    # Fall back to default timeout
+    default_config = aux.get("default", {})
+    if isinstance(default_config, dict):
+        raw = default_config.get("timeout")
+        if raw is not None:
+            try:
+                return float(raw)
+            except (ValueError, TypeError):
+                pass
+    
     return default
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -475,68 +475,55 @@ DEFAULT_CONFIG = {
         "cheap_model": {},
     },
     
-    # Auxiliary model config — provider:model for each side task.
-    # Format: provider is the provider name, model is the model slug.
+    # Auxiliary model config — provider:model for side tasks (vision, compression, etc).
+    #
+    # SIMPLIFIED CONFIGURATION (recommended):
+    # Set "default" once, all tasks inherit from it:
+    #   auxiliary:
+    #     default:
+    #       provider: "openrouter"
+    #       model: "google/gemini-2.5-flash"
+    #     vision:
+    #       timeout: 120  # only override what differs
+    #
+    # FULL CONFIGURATION (legacy, still supported):
+    # Each task can have its own provider/model/base_url/api_key.
+    #
+    # Resolution order: task-specific → default → "auto"
     # "auto" for provider = auto-detect best available provider.
     # Empty model = use provider's default auxiliary model.
-    # All tasks fall back to openrouter:google/gemini-3-flash-preview if
-    # the configured provider is unavailable.
     "auxiliary": {
-        "vision": {
-            "provider": "auto",    # auto | openrouter | nous | codex | custom
+        # Default config inherited by all tasks (provider, model, base_url, api_key)
+        "default": {
+            "provider": "auto",    # auto | openrouter | nous | codex | anthropic | custom
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
+        },
+        # Per-task overrides (inherit from default, only specify what differs)
+        "vision": {
             "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
         "web_extract": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
             "timeout": 360,        # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
         },
         "compression": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
         },
         "session_search": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
             "timeout": 30,
         },
         "skills_hub": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
             "timeout": 30,
         },
         "approval": {
-            "provider": "auto",
-            "model": "",           # fast/cheap model recommended (e.g. gemini-flash, haiku)
-            "base_url": "",
-            "api_key": "",
             "timeout": 30,
         },
         "mcp": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
             "timeout": 30,
         },
         "flush_memories": {
-            "provider": "auto",
-            "model": "",
-            "base_url": "",
-            "api_key": "",
             "timeout": 30,
         },
     },

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -952,6 +952,101 @@ model:
             "model": "gpt-5.4",
         }
 
+    def test_default_config_inheritance(self, monkeypatch, tmp_path):
+        """Tasks inherit provider/model/base_url/api_key from auxiliary.default."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """auxiliary:
+  default:
+    provider: openrouter
+    model: google/gemini-2.5-flash
+  compression:
+    timeout: 120
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(MagicMock(), "google/gemini-2.5-flash")) as mock_resolve:
+            client, model = get_text_auxiliary_client("compression")
+
+        assert model == "google/gemini-2.5-flash"
+        # The provider from default should be passed through (first positional arg)
+        assert mock_resolve.call_args.args[0] == "openrouter"
+        # Model passed as keyword arg
+        assert mock_resolve.call_args.kwargs["model"] == "google/gemini-2.5-flash"
+
+    def test_task_config_overrides_default(self, monkeypatch, tmp_path):
+        """Task-specific config overrides default config."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """auxiliary:
+  default:
+    provider: openrouter
+    model: google/gemini-2.5-flash
+  compression:
+    provider: anthropic
+    model: claude-haiku-4-5-20251001
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(MagicMock(), "claude-haiku-4-5-20251001")) as mock_resolve:
+            client, model = get_text_auxiliary_client("compression")
+
+        assert model == "claude-haiku-4-5-20251001"
+        # Task-specific provider should override default
+        assert mock_resolve.call_args.args[0] == "anthropic"
+
+    def test_partial_task_override_inherits_rest_from_default(self, monkeypatch, tmp_path):
+        """Task that only overrides model still inherits provider from default."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """auxiliary:
+  default:
+    provider: openrouter
+    model: google/gemini-2.5-flash
+  vision:
+    model: gpt-4o
+    timeout: 120
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(MagicMock(), "gpt-4o")) as mock_resolve:
+            client, model = get_text_auxiliary_client("vision")
+
+        assert model == "gpt-4o"
+        # Provider inherited from default (first positional arg)
+        assert mock_resolve.call_args.args[0] == "openrouter"
+        # Model overridden by task - passed as keyword arg
+        assert mock_resolve.call_args.kwargs["model"] == "gpt-4o"
+
+    def test_default_base_url_inheritance(self, monkeypatch, tmp_path):
+        """base_url from default is inherited by tasks."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        (hermes_home / "config.yaml").write_text(
+            """auxiliary:
+  default:
+    base_url: http://localhost:8080/v1
+    api_key: my-local-key
+    model: llama-3.3
+  session_search:
+    timeout: 30
+"""
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            client, model = get_text_auxiliary_client("session_search")
+
+        assert model == "llama-3.3"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:8080/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "my-local-key"
+
 
 def test_resolve_provider_client_supports_copilot_acp_external_process():
     fake_client = MagicMock()


### PR DESCRIPTION
## Summary

Reduce repetitive configuration in auxiliary model settings by allowing all auxiliary tasks to inherit from a shared `default` configuration block.

## Problem

Currently, users who want to use a custom provider/model for all auxiliary tasks (vision, compression, web_extract, etc.) need to repeat the same `provider`, `model`, `base_url`, `api_key` for each of the 8 task types. This leads to verbose, error-prone configuration:

```yaml
auxiliary:
  vision:
    provider: openrouter
    model: google/gemini-2.5-flash
    base_url: ''
    api_key: ''
    timeout: 120
  compression:
    provider: openrouter  # repeated
    model: google/gemini-2.5-flash  # repeated  
    base_url: ''  # repeated
    api_key: ''   # repeated
    timeout: 120
  # ... 6 more tasks with same provider/model/base_url/api_key
```

## Solution

Add an `auxiliary.default` block that all tasks inherit from:

```yaml
auxiliary:
  default:
    provider: openrouter
    model: google/gemini-2.5-flash
  vision:
    timeout: 120  # only specify what differs
  compression:
    timeout: 120
  # tasks only need to specify task-specific settings
```

### Resolution Order

task-specific → default → 'auto'/empty

- If a task has its own `provider` value, that wins
- Otherwise, use `default.provider`
- If neither is set, fall back to "auto"

## Changes

- Add `auxiliary.default` config block in `DEFAULT_CONFIG`
- Update `_resolve_task_provider_model()` in `auxiliary_client.py` to support inheritance chain
- Update `_get_task_timeout()` to also check `default.timeout`  
- Simplify `DEFAULT_CONFIG` by removing duplicate fields from per-task configs
- Add 4 comprehensive tests for inheritance behavior

## Backward Compatibility

✅ Fully backward compatible - existing configs with per-task provider/model/base_url/api_key continue to work exactly as before.

## Testing

- All 102 existing `test_auxiliary_client.py` tests pass
- All 49 `test_config.py` tests pass
- Added 4 new tests specifically for inheritance behavior:
  - `test_default_config_inheritance` - basic inheritance
  - `test_task_config_overrides_default` - task overrides default
  - `test_partial_task_override_inherits_rest_from_default` - partial override
  - `test_default_base_url_inheritance` - base_url/api_key inheritance