### PR TITLE
fix(session): degrade gracefully when SQLite lacks FTS5

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -141,6 +141,7 @@ class SessionDB:
 
         self._lock = threading.Lock()
         self._write_count = 0
+        self._fts_enabled = False
         self._conn = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
@@ -343,8 +344,22 @@ class SessionDB:
         # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
         try:
             cursor.execute("SELECT * FROM messages_fts LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_SQL)
+            self._fts_enabled = True
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc).lower():
+                raise
+            try:
+                cursor.executescript(FTS_SQL)
+                self._fts_enabled = True
+            except sqlite3.OperationalError as fts_exc:
+                err = str(fts_exc).lower()
+                if "fts5" not in err and "no such module" not in err:
+                    raise
+                logger.warning(
+                    "SQLite FTS5 unavailable for %s; full-text search disabled: %s",
+                    self.db_path,
+                    fts_exc,
+                )
 
         self._conn.commit()
 
@@ -1008,6 +1023,9 @@ class SessionDB:
         Returns matching messages with session metadata, content snippet,
         and surrounding context (1 message before and after the match).
         """
+        if not self._fts_enabled:
+            return []
+
         if not query or not query.strip():
             return []
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,10 +1,30 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import sqlite3
 import time
 import pytest
 from pathlib import Path
 
 from hermes_state import SessionDB
+
+
+class _NoFtsCursor(sqlite3.Cursor):
+    """Simulate a SQLite build without the fts5 module."""
+
+    def execute(self, sql, parameters=()):
+        if sql.strip() == "SELECT * FROM messages_fts LIMIT 0":
+            raise sqlite3.OperationalError("no such table: messages_fts")
+        return super().execute(sql, parameters)
+
+    def executescript(self, sql_script):
+        if "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5" in sql_script:
+            raise sqlite3.OperationalError("no such module: fts5")
+        return super().executescript(sql_script)
+
+
+class _NoFtsConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _NoFtsCursor)
 
 
 @pytest.fixture()
@@ -82,6 +102,29 @@ class TestSessionLifecycle:
 
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
+
+    def test_db_initializes_without_fts5_module(self, tmp_path, monkeypatch):
+        real_connect = sqlite3.connect
+
+        def connect_without_fts(*args, **kwargs):
+            kwargs["factory"] = _NoFtsConnection
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr("hermes_state.sqlite3.connect", connect_without_fts)
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert db._fts_enabled is False
+
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="hello from sqlite without fts")
+
+            messages = db.get_messages("s1")
+            assert len(messages) == 1
+            assert messages[0]["content"] == "hello from sqlite without fts"
+            assert db.search_messages("hello") == []
+        finally:
+            db.close()
 
 
 # =========================================================================


### PR DESCRIPTION
Summary
- keep SessionDB usable when the bundled SQLite build does not provide FTS5
- disable only full-text search in that case instead of dropping the entire SQLite session store
- add regression coverage for a simulated no-FTS5 SQLite runtime

Why
- some Python/SQLite builds do not ship the fts5 module, which currently makes gateway session storage fall back to JSONL entirely
- the store can still handle normal session/message persistence without FTS5, so failing the whole initialization is unnecessary

Fixes #10897

Testing
- pytest -o addopts='' tests/test_hermes_state.py -k 'db_initializes_without_fts5_module or search_messages'
- pytest -o addopts='' tests/test_hermes_state.py