### PR TITLE
fix(cli): avoid Windows console Unicode startup crashes

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -11,5 +11,38 @@ Provides subcommands for:
 - hermes cron          - Manage cron jobs
 """
 
+import sys
+
+
+def _configure_console_error_fallback(stream) -> None:
+    """Avoid startup crashes on Windows consoles that are not UTF-8 capable."""
+    if sys.platform != "win32" or stream is None:
+        return
+
+    reconfigure = getattr(stream, "reconfigure", None)
+    if not callable(reconfigure):
+        return
+
+    encoding = (getattr(stream, "encoding", None) or "").lower().replace("-", "")
+    if encoding == "utf8":
+        return
+
+    errors = (getattr(stream, "errors", None) or "").lower()
+    if errors in {"replace", "backslashreplace", "namereplace", "xmlcharrefreplace"}:
+        return
+
+    try:
+        reconfigure(errors="replace")
+    except Exception:
+        pass
+
+
+def _enable_windows_console_error_fallback() -> None:
+    _configure_console_error_fallback(getattr(sys, "stdout", None))
+    _configure_console_error_fallback(getattr(sys, "stderr", None))
+
+
+_enable_windows_console_error_fallback()
+
 __version__ = "0.9.0"
 __release_date__ = "2026.4.13"

--- a/tests/hermes_cli/test_console_encoding_fallback.py
+++ b/tests/hermes_cli/test_console_encoding_fallback.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import hermes_cli
+
+
+class _FakeStream:
+    def __init__(self, encoding="cp1252", errors="strict"):
+        self.encoding = encoding
+        self.errors = errors
+        self.reconfigure_calls = []
+
+    def reconfigure(self, **kwargs):
+        self.reconfigure_calls.append(kwargs)
+        if "errors" in kwargs:
+            self.errors = kwargs["errors"]
+
+
+def test_windows_non_utf8_console_uses_replace(monkeypatch):
+    stream = _FakeStream(encoding="cp1252", errors="strict")
+    monkeypatch.setattr(hermes_cli.sys, "platform", "win32")
+
+    hermes_cli._configure_console_error_fallback(stream)
+
+    assert stream.reconfigure_calls == [{"errors": "replace"}]
+
+
+def test_utf8_console_is_left_unchanged(monkeypatch):
+    stream = _FakeStream(encoding="utf-8", errors="strict")
+    monkeypatch.setattr(hermes_cli.sys, "platform", "win32")
+
+    hermes_cli._configure_console_error_fallback(stream)
+
+    assert stream.reconfigure_calls == []
+
+
+def test_stream_without_reconfigure_is_ignored(monkeypatch):
+    stream = SimpleNamespace(encoding="cp1252", errors="strict")
+    monkeypatch.setattr(hermes_cli.sys, "platform", "win32")
+
+    hermes_cli._configure_console_error_fallback(stream)
+
+
+def test_existing_safe_error_handler_is_preserved(monkeypatch):
+    stream = _FakeStream(encoding="cp1252", errors="backslashreplace")
+    monkeypatch.setattr(hermes_cli.sys, "platform", "win32")
+
+    hermes_cli._configure_console_error_fallback(stream)
+
+    assert stream.reconfigure_calls == []


### PR DESCRIPTION
Summary
- add a best-effort Windows console fallback that switches stdout/stderr to errors=replace when the console encoding is not UTF-8 capable
- keep UTF-8 consoles unchanged and preserve existing non-strict handlers
- add regression coverage for cp1252-style streams

Why
- Windows service consoles often run with cp1252 or another non-UTF-8 encoding
- startup banners and status output include Unicode characters, so strict encoding can raise UnicodeEncodeError and terminate Hermes before it is usable
- this keeps startup resilient without rewriting the project's CLI output to ASCII

Fixes #10956

Testing
- pytest -o addopts='' tests/hermes_cli/test_console_encoding_fallback.py