### PR TITLE
docs: remove nonexistent CAMOFOX_PROFILE_DIR env var references

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -420,8 +420,7 @@ DEFAULT_CONFIG = {
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
         "camofox": {
             # When true, Hermes sends a stable profile-scoped userId to Camofox
-            # so the server can map it to a persistent browser profile directory.
-            # Requires Camofox server to be configured with CAMOFOX_PROFILE_DIR.
+            # so the server maps it to a persistent Firefox profile automatically.
             # When false (default), each session gets a random userId (ephemeral).
             "managed_persistence": False,
         },

--- a/tests/tools/test_browser_camofox_persistence.py
+++ b/tests/tools/test_browser_camofox_persistence.py
@@ -1,8 +1,8 @@
 """Persistence tests for the Camofox browser backend.
 
 Tests that managed persistence uses stable identity while default mode
-uses random identity. The actual browser profile persistence is handled
-by the Camofox server (when CAMOFOX_PROFILE_DIR is set).
+uses random identity. Camofox automatically maps each userId to a
+dedicated persistent Firefox profile on the server side.
 """
 
 import json

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -116,11 +116,7 @@ browser:
     managed_persistence: true
 ```
 
-When enabled, Hermes sends a stable profile-scoped identity to Camofox. The Camofox server maps this identity to a persistent browser profile directory, so cookies, logins, and localStorage survive across restarts. Different Hermes profiles get different browser profiles (profile isolation).
-
-:::note
-The Camofox server must also be configured with `CAMOFOX_PROFILE_DIR` on the server side for persistence to work.
-:::
+When enabled, Hermes sends a stable profile-scoped `userId` to Camofox. The Camofox server automatically maps each `userId` to a dedicated persistent Firefox profile, so cookies, logins, and localStorage survive across restarts. Different Hermes profiles get different browser profiles (profile isolation).
 
 #### VNC live view
 


### PR DESCRIPTION
## Summary

Our docs told users to configure `CAMOFOX_PROFILE_DIR` on the Camofox server for persistence to work. This env var doesn't exist in Camofox — [confirmed against the full env vars reference](https://mintlify.wiki/jo-inc/camofox-browser/advanced/environment-variables).

Camofox handles profile persistence automatically per `userId`. When we send a stable userId (via `managed_persistence: true`), the server maps it to a dedicated Firefox profile directory without any additional configuration.

## Changes

- **browser.md**: Removed the false `:::note` block about CAMOFOX_PROFILE_DIR, updated description to accurately reflect automatic per-userId persistence
- **config.py**: Fixed DEFAULT_CONFIG comment to remove the fabricated requirement  
- **test_browser_camofox_persistence.py**: Updated docstring to match reality

## Test plan

Docs/comments-only change. No behavioral changes.