### PR TITLE
fix(run_agent): prevent _create_openai_client from mutating caller's kwargs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4353,6 +4353,15 @@ class AIAgent:
 
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+        # Treat client_kwargs as read-only. Callers pass self._client_kwargs (or shallow
+        # copies of it) in; any in-place mutation leaks back into the stored dict and is
+        # reused on subsequent requests. #10933 hit this by injecting an httpx.Client
+        # transport that was torn down after the first request, so the next request
+        # wrapped a closed transport and raised "Cannot send a request, as the client
+        # has been closed" on every retry. The revert resolved that specific path; this
+        # copy locks the contract so future transport/keepalive work can't reintroduce
+        # the same class of bug.
+        client_kwargs = dict(client_kwargs)
         _validate_proxy_env_urls()
         _validate_base_url(client_kwargs.get("base_url"))
         if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -1,0 +1,35 @@
+"""Guardrail: _create_openai_client must not mutate its input kwargs.
+
+#10933 injected an httpx.Client directly into the caller's ``client_kwargs``.
+When the dict was ``self._client_kwargs``, the shared transport was torn down
+after the first request_complete close and subsequent request-scoped clients
+wrapped a closed transport, raising ``APIConnectionError('Connection error.')``
+with cause ``RuntimeError: Cannot send a request, as the client has been closed``
+on every retry. That PR has since been reverted, but the underlying issue
+(#10324, connections hanging in CLOSE-WAIT) is still open, so another transport
+tweak inside this function is likely. This test pins the contract that the
+function must treat its input dict as read-only.
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = {"api_key": "test-key", "base_url": "https://api.example.com/v1"}
+    snapshot = dict(kwargs)
+
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    assert kwargs == snapshot, (
+        f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
+    )


### PR DESCRIPTION
## Summary

- Copy `client_kwargs` at entry of `_create_openai_client` so the function can't leak injected transport state back to callers (notably `self._client_kwargs`).
- Add a regression test that pins the contract.

## Why

This is **preventive hardening**, not a fix for a live bug. The class of bug it prevents was demonstrated by #10933 (reverted in `e07dbde5`), and the underlying issue it tried to solve (#10324 — connections hanging in `CLOSE-WAIT`) is still open, so another transport tweak inside this function is likely.

**The regression pattern:**

1. `__init__` stores `self._client_kwargs = client_kwargs` (line 1036), then calls `self._create_openai_client(client_kwargs, ...)` at line 1059. Same dict reference.
2. `_create_openai_client` mutated `client_kwargs` by writing an `httpx.Client` into it (the block that #10933 added, now reverted).
3. After that first mutation, `self._client_kwargs["http_client"]` pointed to the same `httpx.Client` wrapped by `self.client`.
4. On each request, `_create_request_openai_client` did `request_kwargs = dict(self._client_kwargs)` — a shallow copy that carried the `http_client` reference forward. `_create_openai_client` then saw `"http_client" in client_kwargs` and skipped creating a fresh one, so the request OpenAI client wrapped the same transport.
5. `_close_request_openai_client(request_client, reason="request_complete")` ran after the request and closed that transport.
6. The next request repeated step 4 — but now the transport was already closed. The request OpenAI client wrapped a dead httpx.Client, and every attempt raised `APIConnectionError('Connection error.')` with cause `RuntimeError: Cannot send a request, as the client has been closed`, through all 3 retries.

I hit this on Hermes v0.9.0 running against `openai-codex`:

```
ERROR root: API call failed after 3 retries. Connection error. | provider=openai-codex model=gpt-5.4 msgs=5 tokens=~6,288
DIAG: cause=RuntimeError:Cannot send a request, as the client has been closed. repr=APIConnectionError('Connection error.')
```

Single-turn chats (no tool calls → no second API call) worked. Any tool use (`terminal`, cron jobs, etc. → second API call required) failed every time. `curl` with the same request body succeeded, and the OpenAI Python SDK with the same body succeeded, which pointed at hermes-specific client state rather than the payload or endpoint.

## Fix

`client_kwargs = dict(client_kwargs)` at the top of `_create_openai_client`. Any mutation further down now stays on a local copy, so callers' dicts are untouched regardless of what transport customization lands inside the function next.

## Test plan

- [x] New test `tests/run_agent/test_create_openai_client_kwargs_isolation.py` — snapshots the input dict, calls `_create_openai_client`, asserts it's unchanged. Passes with the fix; fails against a version that reintroduces the #10933 mutation.
- [x] `pytest tests/run_agent/` — 785 passed on my machine. The only two failures I saw are environment-related (`OPENROUTER_API_KEY` not set in test env) and reproduce against `main` without this patch, so they're unrelated.