### PR TITLE
fix(cli): force UTF-8 stdio bootstrap

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
+from hermes_cli.stdio import ensure_utf8_stdio
+
+ensure_utf8_stdio()
+
 from gateway.status import terminate_pid
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -50,6 +50,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+
 def _require_tty(command_name: str) -> None:
     """Exit with a clear error if stdin is not a terminal.
 
@@ -70,6 +71,10 @@ def _require_tty(command_name: str) -> None:
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
+
+from hermes_cli.stdio import ensure_utf8_stdio
+
+ensure_utf8_stdio()
 
 # ---------------------------------------------------------------------------
 # Profile override — MUST happen before any hermes module import.

--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -1,0 +1,32 @@
+"""Process-wide stdio bootstrap helpers for Hermes CLI entrypoints."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def ensure_utf8_stdio() -> None:
+    """Reconfigure stdout/stderr to use UTF-8 and tolerate unencodable output.
+
+    Hermes prints a number of Unicode symbols and box-drawing characters during
+    startup. On Windows services and other legacy console environments the
+    default stream encoding can be cp1252 (or otherwise non-UTF-8), which would
+    otherwise raise ``UnicodeEncodeError`` and abort startup.
+
+    The helper is intentionally idempotent and best-effort: if a stream does not
+    support ``reconfigure`` it is left untouched.
+    """
+    os.environ["PYTHONIOENCODING"] = "utf-8"
+    os.environ["PYTHONUTF8"] = "1"
+
+    for stream_name in ("stdout", "stderr"):
+        stream = getattr(sys, stream_name, None)
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (OSError, ValueError, TypeError):
+                # Keep startup resilient even if a wrapper stream refuses to
+                # be reconfigured (e.g. some test doubles or redirected pipes).
+                pass

--- a/tests/hermes_cli/test_stdio.py
+++ b/tests/hermes_cli/test_stdio.py
@@ -1,0 +1,32 @@
+"""Tests for stdio bootstrap helpers."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+
+
+def test_ensure_utf8_stdio_reconfigures_streams(monkeypatch):
+    from hermes_cli.stdio import ensure_utf8_stdio
+
+    stdout_buffer = io.BytesIO()
+    stderr_buffer = io.BytesIO()
+    stdout = io.TextIOWrapper(stdout_buffer, encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(stderr_buffer, encoding="cp1252", errors="strict")
+
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    monkeypatch.delenv("PYTHONIOENCODING", raising=False)
+    monkeypatch.delenv("PYTHONUTF8", raising=False)
+
+    ensure_utf8_stdio()
+
+    assert sys.stdout.encoding.lower().replace("-", "") == "utf8"
+    assert sys.stderr.encoding.lower().replace("-", "") == "utf8"
+    assert os.environ["PYTHONIOENCODING"] == "utf-8"
+    assert os.environ["PYTHONUTF8"] == "1"
+
+    print("┌──┐ ✓ ⚠")
+    sys.stdout.flush()
+    assert stdout_buffer.getvalue() == "┌──┐ ✓ ⚠\n".encode("utf-8")


### PR DESCRIPTION
Closes #10956

## Summary
- Reconfigure Hermes stdout/stderr to UTF-8 before startup prints run
- Apply the bootstrap from both the main CLI entrypoint and gateway path
- Add a regression test that prints Unicode through a simulated cp1252 stream without crashing