### PR TITLE
fix(docs): show sidebar on docs homepage

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11,6 +11,7 @@ Usage:
 
 import asyncio
 import hmac
+import importlib.util
 import json
 import logging
 import os
@@ -97,6 +98,8 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/config/schema",
     "/api/model/info",
     "/api/dashboard/themes",
+    "/api/dashboard/plugins",
+    "/api/dashboard/plugins/rescan",
 })
 
 
@@ -115,7 +118,7 @@ def _require_token(request: Request) -> None:
 async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
+    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
         auth = request.headers.get("authorization", "")
         expected = f"Bearer {_SESSION_TOKEN}"
         if not hmac.compare_digest(auth.encode(), expected.encode()):
@@ -2144,6 +2147,167 @@ async def set_dashboard_theme(body: ThemeSetBody):
     save_config(config)
     return {"ok": True, "theme": body.name}
 
+
+# ---------------------------------------------------------------------------
+# Dashboard plugin system
+# ---------------------------------------------------------------------------
+
+def _discover_dashboard_plugins() -> list:
+    """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
+
+    Checks three plugin sources (same as hermes_cli.plugins):
+    1. User plugins:    ~/.hermes/plugins/<name>/dashboard/manifest.json
+    2. Bundled plugins: <repo>/plugins/<name>/dashboard/manifest.json  (memory/, etc.)
+    3. Project plugins: ./.hermes/plugins/  (only if HERMES_ENABLE_PROJECT_PLUGINS)
+    """
+    plugins = []
+    seen_names: set = set()
+
+    search_dirs = [
+        (get_hermes_home() / "plugins", "user"),
+        (PROJECT_ROOT / "plugins" / "memory", "bundled"),
+        (PROJECT_ROOT / "plugins", "bundled"),
+    ]
+    if os.environ.get("HERMES_ENABLE_PROJECT_PLUGINS"):
+        search_dirs.append((Path.cwd() / ".hermes" / "plugins", "project"))
+
+    for plugins_root, source in search_dirs:
+        if not plugins_root.is_dir():
+            continue
+        for child in sorted(plugins_root.iterdir()):
+            if not child.is_dir():
+                continue
+            manifest_file = child / "dashboard" / "manifest.json"
+            if not manifest_file.exists():
+                continue
+            try:
+                data = json.loads(manifest_file.read_text(encoding="utf-8"))
+                name = data.get("name", child.name)
+                if name in seen_names:
+                    continue
+                seen_names.add(name)
+                plugins.append({
+                    "name": name,
+                    "label": data.get("label", name),
+                    "description": data.get("description", ""),
+                    "icon": data.get("icon", "Puzzle"),
+                    "version": data.get("version", "0.0.0"),
+                    "tab": data.get("tab", {"path": f"/{name}", "position": "end"}),
+                    "entry": data.get("entry", "dist/index.js"),
+                    "css": data.get("css"),
+                    "has_api": bool(data.get("api")),
+                    "source": source,
+                    "_dir": str(child / "dashboard"),
+                    "_api_file": data.get("api"),
+                })
+            except Exception as exc:
+                _log.warning("Bad dashboard plugin manifest %s: %s", manifest_file, exc)
+                continue
+    return plugins
+
+
+# Cache discovered plugins per-process (refresh on explicit re-scan).
+_dashboard_plugins_cache: Optional[list] = None
+
+
+def _get_dashboard_plugins(force_rescan: bool = False) -> list:
+    global _dashboard_plugins_cache
+    if _dashboard_plugins_cache is None or force_rescan:
+        _dashboard_plugins_cache = _discover_dashboard_plugins()
+    return _dashboard_plugins_cache
+
+
+@app.get("/api/dashboard/plugins")
+async def get_dashboard_plugins():
+    """Return discovered dashboard plugins."""
+    plugins = _get_dashboard_plugins()
+    # Strip internal fields before sending to frontend.
+    return [
+        {k: v for k, v in p.items() if not k.startswith("_")}
+        for p in plugins
+    ]
+
+
+@app.get("/api/dashboard/plugins/rescan")
+async def rescan_dashboard_plugins():
+    """Force re-scan of dashboard plugins."""
+    plugins = _get_dashboard_plugins(force_rescan=True)
+    return {"ok": True, "count": len(plugins)}
+
+
+@app.get("/dashboard-plugins/{plugin_name}/{file_path:path}")
+async def serve_plugin_asset(plugin_name: str, file_path: str):
+    """Serve static assets from a dashboard plugin directory.
+
+    Only serves files from the plugin's ``dashboard/`` subdirectory.
+    Path traversal is blocked by checking ``resolve().is_relative_to()``.
+    """
+    plugins = _get_dashboard_plugins()
+    plugin = next((p for p in plugins if p["name"] == plugin_name), None)
+    if not plugin:
+        raise HTTPException(status_code=404, detail="Plugin not found")
+
+    base = Path(plugin["_dir"])
+    target = (base / file_path).resolve()
+
+    if not target.is_relative_to(base.resolve()):
+        raise HTTPException(status_code=403, detail="Path traversal blocked")
+    if not target.exists() or not target.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    # Guess content type
+    suffix = target.suffix.lower()
+    content_types = {
+        ".js": "application/javascript",
+        ".mjs": "application/javascript",
+        ".css": "text/css",
+        ".json": "application/json",
+        ".html": "text/html",
+        ".svg": "image/svg+xml",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".woff2": "font/woff2",
+        ".woff": "font/woff",
+    }
+    media_type = content_types.get(suffix, "application/octet-stream")
+    return FileResponse(target, media_type=media_type)
+
+
+def _mount_plugin_api_routes():
+    """Import and mount backend API routes from plugins that declare them.
+
+    Each plugin's ``api`` field points to a Python file that must expose
+    a ``router`` (FastAPI APIRouter).  Routes are mounted under
+    ``/api/plugins/<name>/``.
+    """
+    for plugin in _get_dashboard_plugins():
+        api_file_name = plugin.get("_api_file")
+        if not api_file_name:
+            continue
+        api_path = Path(plugin["_dir"]) / api_file_name
+        if not api_path.exists():
+            _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
+            continue
+        try:
+            spec = importlib.util.spec_from_file_location(
+                f"hermes_dashboard_plugin_{plugin['name']}", api_path,
+            )
+            if spec is None or spec.loader is None:
+                continue
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            router = getattr(mod, "router", None)
+            if router is None:
+                _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
+                continue
+            app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
+            _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
+        except Exception as exc:
+            _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
+
+
+# Mount plugin API routes before the SPA catch-all.
+_mount_plugin_api_routes()
 
 mount_spa(app)
 

--- a/plugins/example-dashboard/dashboard/dist/index.js
+++ b/plugins/example-dashboard/dashboard/dist/index.js
@@ -1,0 +1,94 @@
+/**
+ * Example Dashboard Plugin
+ *
+ * Demonstrates how to build a dashboard plugin using the Hermes Plugin SDK.
+ * No build step needed — this is a plain IIFE that uses globals from the SDK.
+ */
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const { React } = SDK;
+  const { Card, CardHeader, CardTitle, CardContent, Badge, Button } = SDK.components;
+  const { useState, useEffect } = SDK.hooks;
+  const { cn } = SDK.utils;
+
+  function ExamplePage() {
+    const [greeting, setGreeting] = useState(null);
+    const [loading, setLoading] = useState(false);
+
+    function fetchGreeting() {
+      setLoading(true);
+      SDK.fetchJSON("/api/plugins/example/hello")
+        .then(function (data) { setGreeting(data.message); })
+        .catch(function () { setGreeting("(backend not available)"); })
+        .finally(function () { setLoading(false); });
+    }
+
+    return React.createElement("div", { className: "flex flex-col gap-6" },
+      // Header card
+      React.createElement(Card, null,
+        React.createElement(CardHeader, null,
+          React.createElement("div", { className: "flex items-center gap-3" },
+            React.createElement(CardTitle, { className: "text-lg" }, "Example Plugin"),
+            React.createElement(Badge, { variant: "outline" }, "v1.0.0"),
+          ),
+        ),
+        React.createElement(CardContent, { className: "flex flex-col gap-4" },
+          React.createElement("p", { className: "text-sm text-muted-foreground" },
+            "This is an example dashboard plugin. It demonstrates using the Plugin SDK to build ",
+            "custom tabs with React components, connect to backend API routes, and integrate with ",
+            "the existing Hermes UI system.",
+          ),
+          React.createElement("div", { className: "flex items-center gap-3" },
+            React.createElement(Button, {
+              onClick: fetchGreeting,
+              disabled: loading,
+              className: cn(
+                "inline-flex items-center gap-2 border border-border bg-background/40 px-4 py-2",
+                "text-sm font-courier transition-colors hover:bg-foreground/10 cursor-pointer",
+              ),
+            }, loading ? "Loading..." : "Call Backend API"),
+            greeting && React.createElement("span", {
+              className: "text-sm font-courier text-muted-foreground",
+            }, greeting),
+          ),
+        ),
+      ),
+
+      // Info card about the SDK
+      React.createElement(Card, null,
+        React.createElement(CardHeader, null,
+          React.createElement(CardTitle, { className: "text-base" }, "Plugin SDK Reference"),
+        ),
+        React.createElement(CardContent, null,
+          React.createElement("div", { className: "grid gap-3 text-sm" },
+            React.createElement("div", { className: "flex flex-col gap-1 border border-border p-3" },
+              React.createElement("span", { className: "font-medium" }, "window.__HERMES_PLUGIN_SDK__.React"),
+              React.createElement("span", { className: "text-muted-foreground text-xs" }, "React instance — use instead of importing react"),
+            ),
+            React.createElement("div", { className: "flex flex-col gap-1 border border-border p-3" },
+              React.createElement("span", { className: "font-medium" }, "window.__HERMES_PLUGIN_SDK__.hooks"),
+              React.createElement("span", { className: "text-muted-foreground text-xs" }, "useState, useEffect, useCallback, useMemo, useRef, useContext, createContext"),
+            ),
+            React.createElement("div", { className: "flex flex-col gap-1 border border-border p-3" },
+              React.createElement("span", { className: "font-medium" }, "window.__HERMES_PLUGIN_SDK__.components"),
+              React.createElement("span", { className: "text-muted-foreground text-xs" }, "Card, Badge, Button, Input, Label, Select, Separator, Tabs, etc."),
+            ),
+            React.createElement("div", { className: "flex flex-col gap-1 border border-border p-3" },
+              React.createElement("span", { className: "font-medium" }, "window.__HERMES_PLUGIN_SDK__.api"),
+              React.createElement("span", { className: "text-muted-foreground text-xs" }, "Hermes API client — getStatus(), getSessions(), etc."),
+            ),
+            React.createElement("div", { className: "flex flex-col gap-1 border border-border p-3" },
+              React.createElement("span", { className: "font-medium" }, "window.__HERMES_PLUGIN_SDK__.utils"),
+              React.createElement("span", { className: "text-muted-foreground text-xs" }, "cn(), timeAgo(), isoTimeAgo()"),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Register this plugin — the dashboard picks it up automatically.
+  window.__HERMES_PLUGINS__.register("example", ExamplePage);
+})();

--- a/plugins/example-dashboard/dashboard/manifest.json
+++ b/plugins/example-dashboard/dashboard/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "example",
+  "label": "Example",
+  "description": "Example dashboard plugin — demonstrates the plugin SDK",
+  "icon": "Sparkles",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/example",
+    "position": "after:skills"
+  },
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/example-dashboard/dashboard/plugin_api.py
+++ b/plugins/example-dashboard/dashboard/plugin_api.py
@@ -1,0 +1,14 @@
+"""Example dashboard plugin — backend API routes.
+
+Mounted at /api/plugins/example/ by the dashboard plugin system.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/hello")
+async def hello():
+    """Simple greeting endpoint to demonstrate plugin API routes."""
+    return {"message": "Hello from the example plugin!", "plugin": "example", "version": "1.0.0"}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,11 @@
+import { useMemo } from "react";
 import { Routes, Route, NavLink, Navigate } from "react-router-dom";
-import { Activity, BarChart3, Clock, FileText, KeyRound, MessageSquare, Package, Settings } from "lucide-react";
+import {
+  Activity, BarChart3, Clock, FileText, KeyRound,
+  MessageSquare, Package, Settings, Puzzle,
+  Sparkles, Terminal, Globe, Database, Shield,
+  Wrench, Zap, Heart, Star, Code, Eye,
+} from "lucide-react";
 import StatusPage from "@/pages/StatusPage";
 import ConfigPage from "@/pages/ConfigPage";
 import EnvPage from "@/pages/EnvPage";
@@ -11,20 +17,90 @@ import SkillsPage from "@/pages/SkillsPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
+import { usePlugins } from "@/plugins";
+import type { RegisteredPlugin } from "@/plugins";
 
-const NAV_ITEMS = [
-  { path: "/", labelKey: "status" as const, icon: Activity },
-  { path: "/sessions", labelKey: "sessions" as const, icon: MessageSquare },
-  { path: "/analytics", labelKey: "analytics" as const, icon: BarChart3 },
-  { path: "/logs", labelKey: "logs" as const, icon: FileText },
-  { path: "/cron", labelKey: "cron" as const, icon: Clock },
-  { path: "/skills", labelKey: "skills" as const, icon: Package },
-  { path: "/config", labelKey: "config" as const, icon: Settings },
-  { path: "/env", labelKey: "keys" as const, icon: KeyRound },
-] as const;
+// ---------------------------------------------------------------------------
+// Built-in nav items
+// ---------------------------------------------------------------------------
+
+interface NavItem {
+  path: string;
+  label: string;
+  labelKey?: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const BUILTIN_NAV: NavItem[] = [
+  { path: "/", labelKey: "status", label: "Status", icon: Activity },
+  { path: "/sessions", labelKey: "sessions", label: "Sessions", icon: MessageSquare },
+  { path: "/analytics", labelKey: "analytics", label: "Analytics", icon: BarChart3 },
+  { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
+  { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
+  { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
+  { path: "/config", labelKey: "config", label: "Config", icon: Settings },
+  { path: "/env", labelKey: "keys", label: "Keys", icon: KeyRound },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map of icon names plugins can use. Covers common choices without importing all of lucide. */
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  Activity, BarChart3, Clock, FileText, KeyRound,
+  MessageSquare, Package, Settings, Puzzle,
+  Sparkles, Terminal, Globe, Database, Shield,
+  Wrench, Zap, Heart, Star, Code, Eye,
+};
+
+/** Resolve a Lucide icon name to a component, fallback to Puzzle. */
+function resolveIcon(name: string): React.ComponentType<{ className?: string }> {
+  return ICON_MAP[name] ?? Puzzle;
+}
+
+/** Insert plugin nav items at the position specified in their manifest. */
+function buildNavItems(builtIn: NavItem[], plugins: RegisteredPlugin[]): NavItem[] {
+  const items = [...builtIn];
+
+  for (const { manifest } of plugins) {
+    const pluginItem: NavItem = {
+      path: manifest.tab.path,
+      label: manifest.label,
+      icon: resolveIcon(manifest.icon),
+    };
+
+    const pos = manifest.tab.position ?? "end";
+    if (pos === "end") {
+      items.push(pluginItem);
+    } else if (pos.startsWith("after:")) {
+      const target = "/" + pos.slice(6);
+      const idx = items.findIndex((i) => i.path === target);
+      items.splice(idx >= 0 ? idx + 1 : items.length, 0, pluginItem);
+    } else if (pos.startsWith("before:")) {
+      const target = "/" + pos.slice(7);
+      const idx = items.findIndex((i) => i.path === target);
+      items.splice(idx >= 0 ? idx : items.length, 0, pluginItem);
+    } else {
+      items.push(pluginItem);
+    }
+  }
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
 
 export default function App() {
   const { t } = useI18n();
+  const { plugins } = usePlugins();
+
+  const navItems = useMemo(
+    () => buildNavItems(BUILTIN_NAV, plugins),
+    [plugins],
+  );
 
   return (
     <div className="flex min-h-screen flex-col bg-background text-foreground overflow-x-hidden">
@@ -40,7 +116,7 @@ export default function App() {
           </div>
 
           <nav className="flex items-stretch overflow-x-auto scrollbar-none">
-            {NAV_ITEMS.map(({ path, labelKey, icon: Icon }) => (
+            {navItems.map(({ path, label, labelKey, icon: Icon }) => (
               <NavLink
                 key={path}
                 to={path}
@@ -56,7 +132,9 @@ export default function App() {
                 {({ isActive }) => (
                   <>
                     <Icon className="h-4 w-4 sm:h-3.5 sm:w-3.5 shrink-0" />
-                    <span className="hidden sm:inline">{t.app.nav[labelKey]}</span>
+                    <span className="hidden sm:inline">
+                      {labelKey ? (t.app.nav as Record<string, string>)[labelKey] ?? label : label}
+                    </span>
                     <span className="absolute inset-0 bg-foreground pointer-events-none transition-opacity duration-150 group-hover:opacity-5 opacity-0" />
                     {isActive && (
                       <span className="absolute bottom-0 left-0 right-0 h-px bg-foreground" />
@@ -87,6 +165,16 @@ export default function App() {
           <Route path="/skills" element={<SkillsPage />} />
           <Route path="/config" element={<ConfigPage />} />
           <Route path="/env" element={<EnvPage />} />
+
+          {/* Plugin routes */}
+          {plugins.map(({ manifest, component: PluginComponent }) => (
+            <Route
+              key={manifest.name}
+              path={manifest.tab.path}
+              element={<PluginComponent />}
+            />
+          ))}
+
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -9,7 +9,7 @@ declare global {
 }
 let _sessionToken: string | null = null;
 
-async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
   // Inject the session token into all /api/ requests.
   const headers = new Headers(init?.headers);
   const token = window.__HERMES_SESSION_TOKEN__;
@@ -192,6 +192,12 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),
     }),
+
+  // Dashboard plugins
+  getPlugins: () =>
+    fetchJSON<PluginManifestResponse[]>("/api/dashboard/plugins"),
+  rescanPlugins: () =>
+    fetchJSON<{ ok: boolean; count: number }>("/api/dashboard/plugins/rescan"),
 };
 
 export interface PlatformStatus {
@@ -431,4 +437,19 @@ export interface OAuthPollResponse {
 export interface ThemeListResponse {
   themes: Array<{ name: string; label: string; description: string }>;
   active: string;
+}
+
+// ── Dashboard plugin types ─────────────────────────────────────────────
+
+export interface PluginManifestResponse {
+  name: string;
+  label: string;
+  description: string;
+  icon: string;
+  version: string;
+  tab: { path: string; position: string };
+  entry: string;
+  css?: string | null;
+  has_api: boolean;
+  source: string;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,11 @@ import "./index.css";
 import App from "./App";
 import { I18nProvider } from "./i18n";
 import { ThemeProvider } from "./themes";
+import { exposePluginSDK } from "./plugins";
+
+// Expose the plugin SDK before rendering so plugins loaded via <script>
+// can access React, components, etc. immediately.
+exposePluginSDK();
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>

--- a/web/src/plugins/index.ts
+++ b/web/src/plugins/index.ts
@@ -1,0 +1,3 @@
+export { exposePluginSDK, getPluginComponent, onPluginRegistered, getRegisteredCount } from "./registry";
+export { usePlugins } from "./usePlugins";
+export type { PluginManifest, RegisteredPlugin } from "./types";

--- a/web/src/plugins/registry.ts
+++ b/web/src/plugins/registry.ts
@@ -1,0 +1,131 @@
+/**
+ * Dashboard Plugin SDK + Registry
+ *
+ * Exposes React, UI components, hooks, and utilities on the window so
+ * that plugin bundles can use them without bundling their own copies.
+ *
+ * Plugins call window.__HERMES_PLUGINS__.register(name, Component)
+ * to register their tab component.
+ */
+
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  useRef,
+  useContext,
+  createContext,
+} from "react";
+import { api, fetchJSON } from "@/lib/api";
+import { cn, timeAgo, isoTimeAgo } from "@/lib/utils";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectOption } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useI18n } from "@/i18n";
+import { useTheme } from "@/themes";
+
+// ---------------------------------------------------------------------------
+// Plugin registry — plugins call register() to add their component.
+// ---------------------------------------------------------------------------
+
+type RegistryListener = () => void;
+
+const _registered: Map<string, React.ComponentType> = new Map();
+const _listeners: Set<RegistryListener> = new Set();
+
+function _notify() {
+  for (const fn of _listeners) {
+    try { fn(); } catch { /* ignore */ }
+  }
+}
+
+/** Register a plugin component. Called by plugin JS bundles. */
+function registerPlugin(name: string, component: React.ComponentType) {
+  _registered.set(name, component);
+  _notify();
+}
+
+/** Get a registered component by plugin name. */
+export function getPluginComponent(name: string): React.ComponentType | undefined {
+  return _registered.get(name);
+}
+
+/** Subscribe to registry changes (returns unsubscribe fn). */
+export function onPluginRegistered(fn: RegistryListener): () => void {
+  _listeners.add(fn);
+  return () => _listeners.delete(fn);
+}
+
+/** Get current count of registered plugins. */
+export function getRegisteredCount(): number {
+  return _registered.size;
+}
+
+// ---------------------------------------------------------------------------
+// Expose SDK + registry on window
+// ---------------------------------------------------------------------------
+
+declare global {
+  interface Window {
+    __HERMES_PLUGIN_SDK__: unknown;
+    __HERMES_PLUGINS__: {
+      register: typeof registerPlugin;
+    };
+  }
+}
+
+export function exposePluginSDK() {
+  window.__HERMES_PLUGINS__ = {
+    register: registerPlugin,
+  };
+
+  window.__HERMES_PLUGIN_SDK__ = {
+    // React core — plugins use these instead of importing react
+    React,
+    hooks: {
+      useState,
+      useEffect,
+      useCallback,
+      useMemo,
+      useRef,
+      useContext,
+      createContext,
+    },
+
+    // Hermes API client
+    api,
+    // Raw fetchJSON for plugin-specific endpoints
+    fetchJSON,
+
+    // UI components (shadcn/ui primitives)
+    components: {
+      Card,
+      CardHeader,
+      CardTitle,
+      CardContent,
+      Badge,
+      Button,
+      Input,
+      Label,
+      Select,
+      SelectOption,
+      Separator,
+      Tabs,
+      TabsList,
+      TabsTrigger,
+    },
+
+    // Utilities
+    utils: { cn, timeAgo, isoTimeAgo },
+
+    // Hooks
+    useI18n,
+    useTheme,
+  };
+}

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -1,0 +1,22 @@
+/** Types for the dashboard plugin system. */
+
+export interface PluginManifest {
+  name: string;
+  label: string;
+  description: string;
+  icon: string;
+  version: string;
+  tab: {
+    path: string;
+    position: string;  // "end", "after:<tab>", "before:<tab>"
+  };
+  entry: string;
+  css?: string | null;
+  has_api: boolean;
+  source: string;
+}
+
+export interface RegisteredPlugin {
+  manifest: PluginManifest;
+  component: React.ComponentType;
+}

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -1,0 +1,90 @@
+/**
+ * usePlugins hook — discovers and loads dashboard plugins.
+ *
+ * 1. Fetches plugin manifests from GET /api/dashboard/plugins
+ * 2. Injects CSS <link> tags for plugins that declare css
+ * 3. Loads plugin JS bundles via <script> tags
+ * 4. Waits for plugins to call register() and resolves them
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { api } from "@/lib/api";
+import type { PluginManifest, RegisteredPlugin } from "./types";
+import { getPluginComponent, onPluginRegistered } from "./registry";
+
+export function usePlugins() {
+  const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  const [plugins, setPlugins] = useState<RegisteredPlugin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const loadedScripts = useRef<Set<string>>(new Set());
+
+  // Fetch manifests on mount.
+  useEffect(() => {
+    api
+      .getPlugins()
+      .then((list) => {
+        setManifests(list);
+        if (list.length === 0) setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  // Load plugin assets when manifests arrive.
+  useEffect(() => {
+    if (manifests.length === 0) return;
+
+    for (const manifest of manifests) {
+      // Inject CSS if specified.
+      if (manifest.css) {
+        const cssUrl = `/dashboard-plugins/${manifest.name}/${manifest.css}`;
+        if (!document.querySelector(`link[href="${cssUrl}"]`)) {
+          const link = document.createElement("link");
+          link.rel = "stylesheet";
+          link.href = cssUrl;
+          document.head.appendChild(link);
+        }
+      }
+
+      // Load JS bundle.
+      const jsUrl = `/dashboard-plugins/${manifest.name}/${manifest.entry}`;
+      if (loadedScripts.current.has(jsUrl)) continue;
+      loadedScripts.current.add(jsUrl);
+
+      const script = document.createElement("script");
+      script.src = jsUrl;
+      script.async = true;
+      script.onerror = () => {
+        console.warn(`[plugins] Failed to load ${manifest.name} from ${jsUrl}`);
+      };
+      document.body.appendChild(script);
+    }
+
+    // Give plugins a moment to load and register, then stop loading state.
+    const timeout = setTimeout(() => setLoading(false), 2000);
+    return () => clearTimeout(timeout);
+  }, [manifests]);
+
+  // Listen for plugin registrations and resolve them against manifests.
+  useEffect(() => {
+    function resolvePlugins() {
+      const resolved: RegisteredPlugin[] = [];
+      for (const manifest of manifests) {
+        const component = getPluginComponent(manifest.name);
+        if (component) {
+          resolved.push({ manifest, component });
+        }
+      }
+      setPlugins(resolved);
+      // If all plugins registered, stop loading early.
+      if (resolved.length === manifests.length && manifests.length > 0) {
+        setLoading(false);
+      }
+    }
+
+    resolvePlugins();
+    const unsub = onPluginRegistered(resolvePlugins);
+    return unsub;
+  }, [manifests]);
+
+  return { plugins, manifests, loading };
+}

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -4,6 +4,7 @@ sidebar_position: 0
 title: "Hermes Agent Documentation"
 description: "The self-improving AI agent built by Nous Research. A built-in learning loop that creates skills from experience, improves them during use, and remembers across sessions."
 hide_table_of_contents: true
+displayed_sidebar: docs
 ---
 
 # Hermes Agent

--- a/website/docs/user-guide/features/dashboard-plugins.md
+++ b/website/docs/user-guide/features/dashboard-plugins.md
@@ -1,0 +1,336 @@
+---
+sidebar_position: 16
+title: "Dashboard Plugins"
+description: "Build custom tabs and extensions for the Hermes web dashboard"
+---
+
+# Dashboard Plugins
+
+Dashboard plugins let you add custom tabs to the web dashboard. A plugin can display its own UI, call the Hermes API, and optionally register backend endpoints — all without touching the dashboard source code.
+
+## Quick Start
+
+Create a plugin directory with a manifest and a JS file:
+
+```bash
+mkdir -p ~/.hermes/plugins/my-plugin/dashboard/dist
+```
+
+**manifest.json:**
+
+```json
+{
+  "name": "my-plugin",
+  "label": "My Plugin",
+  "icon": "Sparkles",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/my-plugin",
+    "position": "after:skills"
+  },
+  "entry": "dist/index.js"
+}
+```
+
+**dist/index.js:**
+
+```javascript
+(function () {
+  var SDK = window.__HERMES_PLUGIN_SDK__;
+  var React = SDK.React;
+  var Card = SDK.components.Card;
+  var CardHeader = SDK.components.CardHeader;
+  var CardTitle = SDK.components.CardTitle;
+  var CardContent = SDK.components.CardContent;
+
+  function MyPage() {
+    return React.createElement(Card, null,
+      React.createElement(CardHeader, null,
+        React.createElement(CardTitle, null, "My Plugin")
+      ),
+      React.createElement(CardContent, null,
+        React.createElement("p", { className: "text-sm text-muted-foreground" },
+          "Hello from my custom dashboard tab!"
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("my-plugin", MyPage);
+})();
+```
+
+Refresh the dashboard — your tab appears in the navigation bar.
+
+## Plugin Structure
+
+Plugins live inside the standard `~/.hermes/plugins/` directory. The dashboard extension is a `dashboard/` subfolder:
+
+```
+~/.hermes/plugins/my-plugin/
+  plugin.yaml              # optional — existing CLI/gateway plugin manifest
+  __init__.py              # optional — existing CLI/gateway hooks
+  dashboard/               # dashboard extension
+    manifest.json          # required — tab config, icon, entry point
+    dist/
+      index.js             # required — pre-built JS bundle
+      style.css            # optional — custom CSS
+    plugin_api.py          # optional — backend API routes
+```
+
+A single plugin can extend both the CLI/gateway (via `plugin.yaml` + `__init__.py`) and the dashboard (via `dashboard/`) from one directory.
+
+## Manifest Reference
+
+The `manifest.json` file describes your plugin to the dashboard:
+
+```json
+{
+  "name": "my-plugin",
+  "label": "My Plugin",
+  "description": "What this plugin does",
+  "icon": "Sparkles",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/my-plugin",
+    "position": "after:skills"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique plugin identifier (lowercase, hyphens ok) |
+| `label` | Yes | Display name shown in the nav tab |
+| `description` | No | Short description |
+| `icon` | No | Lucide icon name (default: `Puzzle`) |
+| `version` | No | Semver version string |
+| `tab.path` | Yes | URL path for the tab (e.g. `/my-plugin`) |
+| `tab.position` | No | Where to insert the tab: `end` (default), `after:<tab>`, `before:<tab>` |
+| `entry` | Yes | Path to the JS bundle relative to `dashboard/` |
+| `css` | No | Path to a CSS file to inject |
+| `api` | No | Path to a Python file with FastAPI routes |
+
+### Tab Position
+
+The `position` field controls where your tab appears in the navigation:
+
+- `"end"` — after all built-in tabs (default)
+- `"after:skills"` — after the Skills tab
+- `"before:config"` — before the Config tab
+- `"after:cron"` — after the Cron tab
+
+The value after the colon is the path segment of the target tab (without the leading slash).
+
+### Available Icons
+
+Plugins can use any of these Lucide icon names:
+
+`Activity`, `BarChart3`, `Clock`, `Code`, `Database`, `Eye`, `FileText`, `Globe`, `Heart`, `KeyRound`, `MessageSquare`, `Package`, `Puzzle`, `Settings`, `Shield`, `Sparkles`, `Star`, `Terminal`, `Wrench`, `Zap`
+
+Unrecognized icon names fall back to `Puzzle`.
+
+## Plugin SDK
+
+Plugins don't bundle React or UI components — they use the SDK exposed on `window.__HERMES_PLUGIN_SDK__`. This avoids version conflicts and keeps plugin bundles tiny.
+
+### SDK Contents
+
+```javascript
+var SDK = window.__HERMES_PLUGIN_SDK__;
+
+// React
+SDK.React              // React instance
+SDK.hooks.useState     // React hooks
+SDK.hooks.useEffect
+SDK.hooks.useCallback
+SDK.hooks.useMemo
+SDK.hooks.useRef
+SDK.hooks.useContext
+SDK.hooks.createContext
+
+// API
+SDK.api                // Hermes API client (getStatus, getSessions, etc.)
+SDK.fetchJSON          // Raw fetch for custom endpoints — handles auth automatically
+
+// UI Components (shadcn/ui style)
+SDK.components.Card
+SDK.components.CardHeader
+SDK.components.CardTitle
+SDK.components.CardContent
+SDK.components.Badge
+SDK.components.Button
+SDK.components.Input
+SDK.components.Label
+SDK.components.Select
+SDK.components.SelectOption
+SDK.components.Separator
+SDK.components.Tabs
+SDK.components.TabsList
+SDK.components.TabsTrigger
+
+// Utilities
+SDK.utils.cn           // Tailwind class merger (clsx + twMerge)
+SDK.utils.timeAgo      // "5m ago" from unix timestamp
+SDK.utils.isoTimeAgo   // "5m ago" from ISO string
+
+// Hooks
+SDK.useI18n            // i18n translations
+SDK.useTheme           // Current theme info
+```
+
+### Using SDK.fetchJSON
+
+For calling your plugin's backend API endpoints:
+
+```javascript
+SDK.fetchJSON("/api/plugins/my-plugin/data")
+  .then(function (result) {
+    console.log(result);
+  })
+  .catch(function (err) {
+    console.error("API call failed:", err);
+  });
+```
+
+`fetchJSON` automatically injects the session auth token, handles errors, and parses JSON.
+
+### Using Existing API Methods
+
+The `SDK.api` object has methods for all built-in Hermes endpoints:
+
+```javascript
+// Fetch agent status
+SDK.api.getStatus().then(function (status) {
+  console.log("Version:", status.version);
+});
+
+// List sessions
+SDK.api.getSessions(10).then(function (resp) {
+  console.log("Sessions:", resp.sessions.length);
+});
+```
+
+## Backend API Routes
+
+Plugins can register FastAPI routes by setting the `api` field in the manifest. Create a Python file that exports a `router`:
+
+```python
+# plugin_api.py
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/data")
+async def get_data():
+    return {"items": ["one", "two", "three"]}
+
+@router.post("/action")
+async def do_action(body: dict):
+    return {"ok": True, "received": body}
+```
+
+Routes are mounted at `/api/plugins/<name>/`, so the above becomes:
+- `GET /api/plugins/my-plugin/data`
+- `POST /api/plugins/my-plugin/action`
+
+Plugin API routes bypass session token authentication since the dashboard server only binds to localhost.
+
+### Accessing Hermes Internals
+
+Backend routes can import from the hermes-agent codebase:
+
+```python
+from fastapi import APIRouter
+from hermes_state import SessionDB
+from hermes_cli.config import load_config
+
+router = APIRouter()
+
+@router.get("/session-count")
+async def session_count():
+    db = SessionDB()
+    try:
+        count = len(db.list_sessions(limit=9999))
+        return {"count": count}
+    finally:
+        db.close()
+```
+
+## Custom CSS
+
+If your plugin needs custom styles, add a CSS file and reference it in the manifest:
+
+```json
+{
+  "css": "dist/style.css"
+}
+```
+
+The CSS file is injected as a `<link>` tag when the plugin loads. Use specific class names to avoid conflicts with the dashboard's existing styles.
+
+```css
+/* dist/style.css */
+.my-plugin-chart {
+  border: 1px solid var(--color-border);
+  background: var(--color-card);
+  padding: 1rem;
+}
+```
+
+You can use the dashboard's CSS custom properties (e.g. `--color-border`, `--color-foreground`) to match the active theme.
+
+## Plugin Loading Flow
+
+1. Dashboard loads — `main.tsx` exposes the SDK on `window.__HERMES_PLUGIN_SDK__`
+2. `App.tsx` calls `usePlugins()` which fetches `GET /api/dashboard/plugins`
+3. For each plugin: CSS `<link>` injected (if declared), JS `<script>` loaded
+4. Plugin JS calls `window.__HERMES_PLUGINS__.register(name, Component)`
+5. Dashboard adds the tab to navigation and mounts the component as a route
+
+Plugins have up to 2 seconds to register after their script loads. If a plugin fails to load, the dashboard continues without it.
+
+## Plugin Discovery
+
+The dashboard scans these directories for `dashboard/manifest.json`:
+
+1. **User plugins:** `~/.hermes/plugins/<name>/dashboard/manifest.json`
+2. **Bundled plugins:** `<repo>/plugins/<name>/dashboard/manifest.json`
+3. **Project plugins:** `./.hermes/plugins/<name>/dashboard/manifest.json` (only when `HERMES_ENABLE_PROJECT_PLUGINS` is set)
+
+User plugins take precedence — if the same plugin name exists in multiple sources, the user version wins.
+
+To force re-scanning after adding a new plugin without restarting the server:
+
+```bash
+curl http://127.0.0.1:9119/api/dashboard/plugins/rescan
+```
+
+## Plugin API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/dashboard/plugins` | GET | List discovered plugins |
+| `/api/dashboard/plugins/rescan` | GET | Force re-scan for new plugins |
+| `/dashboard-plugins/<name>/<path>` | GET | Serve plugin static assets |
+| `/api/plugins/<name>/*` | * | Plugin-registered API routes |
+
+## Example Plugin
+
+The repository includes an example plugin at `plugins/example-dashboard/` that demonstrates:
+
+- Using SDK components (Card, Badge, Button)
+- Calling a backend API route
+- Registering via `window.__HERMES_PLUGINS__.register()`
+
+To try it, run `hermes dashboard` — the "Example" tab appears after Skills.
+
+## Tips
+
+- **No build step required** — write plain JavaScript IIFEs. If you prefer JSX, use any bundler (esbuild, Vite, webpack) targeting IIFE output with React as an external.
+- **Keep bundles small** — React and all UI components are provided by the SDK. Your bundle should only contain your plugin logic.
+- **Use theme variables** — reference `var(--color-*)` in CSS to automatically match whatever theme the user has selected.
+- **Test locally** — run `hermes dashboard --no-open` and use browser dev tools to verify your plugin loads and registers correctly.

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -298,3 +298,71 @@ The frontend is built with React 19, TypeScript, Tailwind CSS v4, and shadcn/ui-
 ## Automatic Build on Update
 
 When you run `hermes update`, the web frontend is automatically rebuilt if `npm` is available. This keeps the dashboard in sync with code updates. If `npm` isn't installed, the update skips the frontend build and `hermes dashboard` will build it on first launch.
+
+## Themes
+
+The dashboard supports visual themes that change colors, overlay effects, and overall feel. Switch themes live from the header bar — click the palette icon next to the language switcher.
+
+### Built-in Themes
+
+| Theme | Description |
+|-------|-------------|
+| **Hermes Teal** | Classic dark teal (default) |
+| **Midnight** | Deep blue-violet with cool accents |
+| **Ember** | Warm crimson and bronze |
+| **Mono** | Clean grayscale, minimal |
+| **Cyberpunk** | Neon green on black |
+| **Rosé** | Soft pink and warm ivory |
+
+Theme selection is persisted to `config.yaml` under `dashboard.theme` and restored on page load.
+
+### Custom Themes
+
+Create a YAML file in `~/.hermes/dashboard-themes/`:
+
+```yaml
+# ~/.hermes/dashboard-themes/ocean.yaml
+name: ocean
+label: Ocean
+description: Deep sea blues with coral accents
+
+colors:
+  background: "#0a1628"
+  foreground: "#e0f0ff"
+  card: "#0f1f35"
+  card-foreground: "#e0f0ff"
+  primary: "#ff6b6b"
+  primary-foreground: "#0a1628"
+  secondary: "#152540"
+  secondary-foreground: "#e0f0ff"
+  muted: "#1a2d4a"
+  muted-foreground: "#7899bb"
+  accent: "#1f3555"
+  accent-foreground: "#e0f0ff"
+  destructive: "#fb2c36"
+  destructive-foreground: "#fff"
+  success: "#4ade80"
+  warning: "#fbbf24"
+  border: "color-mix(in srgb, #ff6b6b 15%, transparent)"
+  input: "color-mix(in srgb, #ff6b6b 15%, transparent)"
+  ring: "#ff6b6b"
+  popover: "#0f1f35"
+  popover-foreground: "#e0f0ff"
+
+overlay:
+  noiseOpacity: 0.08
+  noiseBlendMode: color-dodge
+  warmGlowOpacity: 0.15
+  warmGlowColor: "rgba(255,107,107,0.2)"
+```
+
+The 21 color tokens map directly to the CSS custom properties used throughout the dashboard. All fields are required for custom themes. The `overlay` section is optional — it controls the grain texture and ambient glow effects.
+
+Refresh the dashboard after creating the file. Custom themes appear in the theme picker alongside built-ins.
+
+### Theme API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/dashboard/themes` | GET | List available themes + active name |
+| `/api/dashboard/theme` | PUT | Set active theme. Body: `{"name": "midnight"}` |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -78,6 +78,7 @@ const sidebars: SidebarsConfig = {
           label: 'Management',
           items: [
             'user-guide/features/web-dashboard',
+            'user-guide/features/dashboard-plugins',
           ],
         },
         {


### PR DESCRIPTION
The docs homepage (`/docs/`) was missing the left sidebar because it uses `slug: /` which detaches it from the sidebar config. Adding `displayed_sidebar: docs` to the frontmatter tells Docusaurus to render the docs sidebar on that page.