### PR TITLE
fix: ensure google_token.json includes 'type' field (#10913)

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -167,6 +167,12 @@ def get_credentials():
     from google.oauth2.credentials import Credentials
     from google.auth.transport.requests import Request
 
+    # Normalize tokens written before the 'type' field fix (#10913).
+    raw = json.loads(TOKEN_PATH.read_text())
+    if raw.get("type") != "authorized_user":
+        raw["type"] = "authorized_user"
+        TOKEN_PATH.write_text(json.dumps(raw, indent=2))
+
     creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), _stored_token_scopes())
     if creds.expired and creds.refresh_token:
         creds.refresh(Request())

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -315,6 +315,10 @@ def exchange_auth_code(code: str):
     creds = flow.credentials
     token_payload = json.loads(creds.to_json())
 
+    # Ensure 'type' is present — google.oauth2.Credentials.from_authorized_user_file
+    # requires it, but creds.to_json() does not always include it.
+    token_payload.setdefault("type", "authorized_user")
+
     # Store only the scopes actually granted by the user, not what was requested.
     # creds.to_json() writes the requested scopes, which causes refresh to fail
     # with invalid_scope if the user only authorized a subset.

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -238,3 +238,14 @@ class TestExchangeAuthCode:
         assert setup_module.TOKEN_PATH.exists()
         # Pending auth is cleaned up
         assert not setup_module.PENDING_AUTH_PATH.exists()
+
+    def test_token_includes_type_authorized_user(self, setup_module):
+        """exchange_auth_code writes 'type': 'authorized_user' into the token (#10913)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        setup_module.exchange_auth_code("4/test-auth-code")
+
+        saved = json.loads(setup_module.TOKEN_PATH.read_text())
+        assert saved.get("type") == "authorized_user"

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -182,3 +182,52 @@ def test_api_calendar_list_respects_date_range(api_module):
     params = json.loads(cmd[params_idx + 1])
     assert params["timeMin"] == "2026-04-01T00:00:00Z"
     assert params["timeMax"] == "2026-04-07T23:59:59Z"
+
+
+def test_get_credentials_normalizes_missing_type(api_module, tmp_path):
+    """get_credentials adds 'type': 'authorized_user' when missing (#10913)."""
+    from unittest.mock import MagicMock
+
+    token_path = api_module.TOKEN_PATH
+    # Write a token WITHOUT the 'type' field (pre-fix setup.py output)
+    token_data = {
+        "token": "ya29.test",
+        "refresh_token": "1//refresh",
+        "client_id": "123.apps.googleusercontent.com",
+        "client_secret": "secret",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+    }
+    token_path.write_text(json.dumps(token_data))
+
+    fake_creds = MagicMock()
+    fake_creds.expired = False
+    fake_creds.valid = True
+
+    # Inject fake google.oauth2.credentials module (not installed in CI)
+    fake_mod = types.ModuleType("google.oauth2.credentials")
+    fake_mod.Credentials = MagicMock()
+    fake_mod.Credentials.from_authorized_user_file = MagicMock(return_value=fake_creds)
+    fake_req_mod = types.ModuleType("google.auth.transport.requests")
+    fake_req_mod.Request = MagicMock
+
+    orig = dict(sys.modules)
+    sys.modules.setdefault("google", types.ModuleType("google"))
+    sys.modules.setdefault("google.oauth2", types.ModuleType("google.oauth2"))
+    sys.modules["google.oauth2.credentials"] = fake_mod
+    sys.modules.setdefault("google.auth", types.ModuleType("google.auth"))
+    sys.modules.setdefault("google.auth.transport", types.ModuleType("google.auth.transport"))
+    sys.modules["google.auth.transport.requests"] = fake_req_mod
+    try:
+        api_module._ensure_authenticated = lambda: None
+        api_module.get_credentials()
+    finally:
+        # Restore only the modules we added
+        for key in list(sys.modules):
+            if key not in orig:
+                del sys.modules[key]
+
+    # Token file should now contain 'type'
+    saved = json.loads(token_path.read_text())
+    assert saved["type"] == "authorized_user"
+


### PR DESCRIPTION
## Problem
Google Workspace OAuth setup (`setup.py --auth-code`) writes `google_token.json` without a `type` field. The GWS runtime path rejects this token because `type` is missing.

## Fix
- **setup.py**: Add `type: authorized_user` to the token payload before writing
- **google_api.py**: Defensive normalization — if an existing token file is missing `type`, backfill it before loading credentials

## Tests
- New test verifying setup writes the `type` field
- New test verifying runtime normalizes old tokens missing `type`

Closes #10913