### PR TITLE
fix(cli): pass model.max_tokens into CLI and gateway agents

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2897,6 +2897,7 @@ class HermesCLI:
                 reasoning_config=self.reasoning_config,
                 service_tier=self.service_tier,
                 request_overrides=request_overrides,
+                max_tokens=((CLI_CONFIG.get("model") or {}).get("max_tokens") if isinstance(CLI_CONFIG.get("model"), dict) else None),
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
                 providers_order=self._providers_order,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -926,6 +926,9 @@ class GatewayRunner:
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        model_config = user_config.get("model") if isinstance(user_config, dict) else None
+        if isinstance(model_config, dict) and model_config.get("max_tokens") is not None:
+            runtime_kwargs["max_tokens"] = model_config.get("max_tokens")
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,6 +200,40 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_cli_init_agent_passes_model_max_tokens_from_config(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:8080/v1",
+            "api_key": "test-key",
+            "source": "env/config",
+        }
+
+    class _DummyAgent:
+        last_init = None
+
+        def __init__(self, *args, **kwargs):
+            type(self).last_init = dict(kwargs)
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+    monkeypatch.setitem(cli.CLI_CONFIG, "model", {
+        "default": "local-model",
+        "provider": "custom",
+        "base_url": "http://localhost:8080/v1",
+        "max_tokens": 32768,
+    })
+
+    shell = cli.HermesCLI(model="local-model", compact=True, max_turns=1)
+
+    assert shell._init_agent() is True
+    assert _DummyAgent.last_init is not None
+    assert _DummyAgent.last_init["max_tokens"] == 32768
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -81,6 +81,27 @@ def _explode_runtime_resolution():
     )
 
 
+def test_resolve_session_agent_runtime_passes_model_max_tokens_from_config(monkeypatch):
+    runner = _make_runner()
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "http://localhost:8080/v1",
+            "api_key": "test-key",
+        },
+    )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "local-model")
+
+    model, runtime_kwargs = runner._resolve_session_agent_runtime(
+        user_config={"model": {"default": "local-model", "max_tokens": 32768}}
+    )
+
+    assert model == "local-model"
+    assert runtime_kwargs["max_tokens"] == 32768
+
 def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)


### PR DESCRIPTION
## Summary
- pass `model.max_tokens` from CLI config into new `AIAgent` instances in `cli.py`
- propagate `model.max_tokens` from gateway config into gateway-created agent runtime kwargs
- add regression coverage for both the CLI init path and the gateway session runtime path

## Testing
- verified issue #10917 is still open and has no linked PR in the Development section
- compared the branch against upstream main and confirmed the diff only touches `cli.py`, `gateway/run.py`, and two targeted regression tests
- verified the new tests assert `max_tokens == 32768` reaches the created agent kwargs

Fixes #10917