### PR TITLE
feat(tools): add model parameter to delegate_task for per-task model selection

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -626,6 +626,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
@@ -711,9 +712,11 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            # Model priority: per-task model > top-level model arg > delegation config > parent
+            task_model = t.get("model") or model or creds["model"]
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=task_model,
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
@@ -1059,6 +1062,16 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model override for all subagents in this call "
+                    "(e.g. 'claude-sonnet-4-20250514'). Use lighter models for "
+                    "mechanical tasks (file generation, formatting) and heavier "
+                    "models for complex reasoning. Priority: per-task model > "
+                    "this top-level model > delegation config model > parent model."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -1066,6 +1079,7 @@ DELEGATE_TASK_SCHEMA = {
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {"type": "string", "description": "Task-specific context"},
+                        "model": {"type": "string", "description": "Per-task model override. Takes highest priority."},
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -1135,6 +1149,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         parent_agent=kw.get("parent_agent")),


### PR DESCRIPTION
## What Changed & Why

Adds an optional `model` parameter to `delegate_task()` enabling per-delegation and per-task model selection. Currently children always inherit the parent model or global `delegation.model` config with no way to override at call time.

**Motivation:** When the parent runs on an expensive model (e.g. claude-opus), all subagents inherit it even for trivial tasks like file generation. This wastes cost and causes timeouts.

### Changes (1 file: `tools/delegate_tool.py`)

- Add `model` parameter to `delegate_task()` function signature
- Add `model` to top-level tool schema with usage guidance
- Add `model` to per-task properties in batch mode schema
- Compute `task_model` with priority chain: `per-task > top-level > delegation.model config > parent`
- Pass `model` through handler lambda

### Usage

```python
# All children use a lighter model
delegate_task(goal="Generate template files", model="claude-sonnet-4-20250514")

# Mixed models in batch mode
delegate_task(tasks=[
    {"goal": "Architecture review", "model": "claude-opus-4"},
    {"goal": "Generate boilerplate", "model": "claude-sonnet-4-20250514"},
])
```

Closes #10995

## How to Test

1. Run existing delegate tests: `python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py -q`
   - Result: **72/72 passed** (no regressions)
2. Manual: use `delegate_task` with `model` parameter and verify child agent uses the specified model (visible in logs)

## Platforms Tested

- Ubuntu 24.04 (x86_64), Python 3.12