### PR TITLE
fix(cli): defer Enter during rapid text input to fix multiline paste splitting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8414,6 +8414,13 @@ class HermesCLI:
                 return
 
             # --- Normal input routing ---
+            # Defer during rapid text input (paste without bracketed-paste support).
+            # When newlines arrive as individual Enter events, _on_text_changed fires
+            # for each character. If the last text change was < 50 ms ago, text is
+            # still arriving — skip submission and let the buffer accumulate.
+            if _last_text_change[0] and (time.monotonic() - _last_text_change[0]) < 0.05:
+                return
+
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
@@ -8908,6 +8915,7 @@ class HermesCLI:
         _prev_text_len = [0]
         _prev_newline_count = [0]
         _paste_just_collapsed = [False]
+        _last_text_change = [0.0]  # [monotonic time] - set by _on_text_changed
 
         def _on_text_changed(buf):
             """Detect large pastes and collapse them to a file reference.
@@ -8924,6 +8932,7 @@ class HermesCLI:
                still batch newlines.  Alt+Enter only adds 1 newline per
                event so it never triggers this.
             """
+            _last_text_change[0] = time.monotonic()
             text = buf.text
             chars_added = len(text) - _prev_text_len[0]
             _prev_text_len[0] = len(text)


### PR DESCRIPTION
## Bug

When pasting multiline text into the prompt while the agent is running (steering queue mode), each line is sent as a separate steering message instead of the full text as one message.

## Root Cause

Without bracketed paste support (tmux strips it, some terminals don't support it), newlines in pasted text arrive as individual `Enter` key events. The `@kb.add('enter')` handler fires for each newline, submitting each line separately to the steering queue.

## Fix

Track `_last_text_change` timestamp in `_on_text_changed` (already fires for every buffer modification). In `handle_enter`, defer submission if text was modified < 50 ms ago — indicates text is still arriving (paste in progress).

```python
# 1. Variable (line ~8915)
_last_text_change = [0.0]  # [monotonic time] - set by _on_text_changed

# 2. Timestamp update (line ~8935)
_last_text_change[0] = time.monotonic()

# 3. Timing guard (line ~8417)
if _last_text_change[0] and (time.monotonic() - _last_text_change[0]) < 0.05:
    return
```

## Why 50 ms?

| Scenario | Character gap |
|----------|--------------|
| Paste (no bracketed paste) | < 1 ms (same event loop tick) |
| Normal typing | > 50 ms (human speed) |
| Fast typing | ~80-100 ms |

50 ms catches paste without affecting normal typing.

## Files Changed

- `cli.py`: +9 lines (1 variable, 1 timestamp update, 7-line timing guard + comments)

Closes #10994
