### PR TITLE
fix: escape command content in Telegram exec approval prompt

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import os
+import html as _html
 import re
 from typing import Dict, List, Optional, Any
 
@@ -1129,13 +1130,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
-            # Escape backticks that would break Markdown v1 inline code parsing
-            safe_cmd = cmd_preview.replace("`", "'")
-            safe_desc = description.replace("`", "'").replace("*", "∗")
             text = (
-                f"⚠️ *Command Approval Required*\n\n"
-                f"`{safe_cmd}`\n\n"
-                f"Reason: {safe_desc}"
+                f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
+                f"Reason: {_html.escape(description)}"
             )
 
             # Resolve thread context for thread replies
@@ -1163,7 +1161,7 @@ class TelegramAdapter(BasePlatformAdapter):
             kwargs: Dict[str, Any] = {
                 "chat_id": int(chat_id),
                 "text": text,
-                "parse_mode": ParseMode.MARKDOWN,
+                "parse_mode": ParseMode.HTML,
                 "reply_markup": keyboard,
                 **self._link_preview_kwargs(),
             }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8799,7 +8799,7 @@ class GatewayRunner:
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
-                        asyncio.run_coroutine_threadsafe(
+                        _approval_result = asyncio.run_coroutine_threadsafe(
                             _status_adapter.send_exec_approval(
                                 chat_id=_status_chat_id,
                                 command=cmd,
@@ -8809,7 +8809,12 @@ class GatewayRunner:
                             ),
                             _loop_for_step,
                         ).result(timeout=15)
-                        return
+                        if _approval_result.success:
+                            return
+                        logger.warning(
+                            "Button-based approval failed (send returned error), falling back to text: %s",
+                            _approval_result.error,
+                        )
                     except Exception as _e:
                         logger.warning(
                             "Button-based approval failed, falling back to text: %s", _e


### PR DESCRIPTION
## Problem

`send_exec_approval` on the Telegram adapter builds the approval message using `ParseMode.MARKDOWN` with the command text inside a backtick span:

```python
f"`{safe_cmd}`\n\nReason: {safe_desc}"
```

The existing mitigation replaces backticks and asterisks with lookalike characters, but other Markdown specials — `_`, `[`, `]`, `(`, `)` — are not handled. When a command contains any of these, Telegram rejects the send with:

> `Can't parse entities: can't find end of the entity starting at byte offset N`

`send_exec_approval` catches this internally and returns `SendResult(success=False)`, but `run.py` ignores the return value and unconditionally `return`s — skipping the plain-text `/approve` fallback. The agent then waits for a button click that was never delivered, stalling until the 5-minute approval timeout fires.

## Fix

**`gateway/platforms/telegram.py`** — switch to `ParseMode.HTML` and wrap content in `html.escape()` inside a `<pre>` block. HTML parse mode has no ambiguous entity rules; `html.escape()` makes any content safe with no character-by-character special-casing.

**`gateway/run.py`** — capture the `SendResult` from `send_exec_approval` and only `return` if `result.success` is `True`. A `False` result now falls through to the plain-text `/approve` fallback.

## Test plan
- [ ] Send a command containing backticks, underscores, and square brackets through an agent — approval prompt should render correctly in Telegram
- [ ] Simulate a `send_exec_approval` failure (e.g. wrong chat_id) — confirm the plain-text fallback fires and the agent is not left waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)