### PR TITLE
fix(gateway): prevent interim_assistant_messages from suppressing final response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9515,18 +9515,47 @@ class GatewayRunner:
         # tool call, setting already_sent=True, but that text is NOT the
         # final answer.  Suppressing delivery here leaves the user staring
         # at silence.  (#10xxx — "agent stops after web search")
+        #
+        # Never suppress when there were tool calls in the turn AND
+        # interim_assistant_messages is enabled — the interim text (e.g.
+        # "Let me check that skill.") was delivered mid-turn, but the final
+        # response is NEW content produced after the tool calls completed.
+        # Suppressing it would leave the user without the actual answer.
+        # (#10942 — "interim_assistant_messages drops final response")
         _sc = stream_consumer_holder[0]
         if isinstance(response, dict) and not response.get("failed"):
             _final = response.get("final_response") or ""
             _is_empty_sentinel = not _final or _final == "(empty)"
-            _streamed = _sc and (
-                getattr(_sc, "final_response_sent", False)
-                or getattr(_sc, "already_sent", False)
-            )
+            _final_was_streamed = _sc and getattr(_sc, "final_response_sent", False)
+            _something_was_sent = _sc and getattr(_sc, "already_sent", False)
             # response_previewed means the interim_assistant_callback already
             # sent the final text via the adapter (non-streaming path).
             _previewed = bool(response.get("response_previewed"))
-            if not _is_empty_sentinel and (_streamed or _previewed):
+            # Check if there were tool calls in this turn — if so, the final
+            # response is post-tool content that should not be suppressed even
+            # if interim text was already streamed/sent.
+            _msgs = response.get("messages") or []
+            _had_tool_calls = any(
+                m.get("role") == "tool" or m.get("tool_calls")
+                for m in _msgs
+            )
+            # Suppress the final send if:
+            # 1. Response is not empty/sentinel, AND
+            # 2. One of:
+            #    a) The final response itself was already streamed, OR
+            #    b) Response was previewed (non-streaming interim path), OR
+            #    c) Something was sent AND there were NO tool calls
+            #       (if tools ran, the final response is new post-tool content
+            #       that must be delivered even if interim text was sent earlier)
+            _should_suppress = (
+                not _is_empty_sentinel
+                and (
+                    _final_was_streamed
+                    or _previewed
+                    or (_something_was_sent and not _had_tool_calls)
+                )
+            )
+            if _should_suppress:
                 response["already_sent"] = True
         
         return response

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -352,3 +352,176 @@ class TestQueuedMessageAlreadyStreamed:
         )
 
         assert _already_streamed is False
+
+
+# ===================================================================
+# Test 3: run.py — interim messages with tool calls (#10942)
+# ===================================================================
+
+
+class TestInterimMessagesWithToolCalls:
+    """When interim_assistant_messages is enabled, the stream consumer may
+    send a short interim message (e.g. 'Let me check that skill.') before
+    tool calls. The final response after tool calls is NEW content that
+    must be delivered — not suppressed by already_sent=True from the interim.
+
+    Bug #10942: The user only sees the interim message and the tool-call
+    notification, but the actual answer (final response) is silently dropped.
+    """
+
+    def _make_mock_stream_consumer(self, already_sent=False, final_response_sent=False):
+        return SimpleNamespace(
+            already_sent=already_sent,
+            final_response_sent=final_response_sent,
+        )
+
+    def _apply_suppression_logic(self, response, sc):
+        """Reproduce the fixed logic from gateway/run.py return path (#10942)."""
+        if sc and isinstance(response, dict) and not response.get("failed"):
+            _final = response.get("final_response") or ""
+            _is_empty_sentinel = not _final or _final == "(empty)"
+            _final_was_streamed = getattr(sc, "final_response_sent", False)
+            _something_was_sent = getattr(sc, "already_sent", False)
+            _previewed = bool(response.get("response_previewed"))
+            _msgs = response.get("messages") or []
+            _had_tool_calls = any(
+                m.get("role") == "tool" or m.get("tool_calls")
+                for m in _msgs
+            )
+            _should_suppress = (
+                not _is_empty_sentinel
+                and (
+                    _final_was_streamed
+                    or _previewed
+                    or (_something_was_sent and not _had_tool_calls)
+                )
+            )
+            if _should_suppress:
+                response["already_sent"] = True
+
+    def test_interim_sent_with_tool_calls_not_suppressed(self):
+        """When interim message was sent (already_sent=True) but there were
+        tool calls, the final response is NEW content and must NOT be
+        suppressed."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=False)
+        response = {
+            "final_response": "Here is the full documentation for that skill...",
+            "messages": [
+                {"role": "user", "content": "Show me the using-superpowers skill"},
+                {"role": "assistant", "content": "Let me check that skill.", "tool_calls": [{"id": "1", "function": {"name": "skill_view"}}]},
+                {"role": "tool", "content": "# using-superpowers\n...", "tool_call_id": "1"},
+                {"role": "assistant", "content": "Here is the full documentation for that skill..."},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert "already_sent" not in response, (
+            "Final response should NOT be suppressed when tool calls were made"
+        )
+
+    def test_interim_sent_without_tool_calls_suppressed(self):
+        """When something was sent and there were NO tool calls, the response
+        should still be suppressed (existing behavior)."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=False)
+        response = {
+            "final_response": "Here is a simple answer.",
+            "messages": [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": "Here is a simple answer."},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert response.get("already_sent") is True
+
+    def test_final_streamed_still_suppressed_with_tool_calls(self):
+        """If the final response itself was streamed (final_response_sent=True),
+        it should still be suppressed even if there were tool calls."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=True)
+        response = {
+            "final_response": "Final answer after tools",
+            "messages": [
+                {"role": "user", "content": "Run a command"},
+                {"role": "assistant", "tool_calls": [{"id": "1", "function": {"name": "terminal"}}]},
+                {"role": "tool", "content": "output", "tool_call_id": "1"},
+                {"role": "assistant", "content": "Final answer after tools"},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert response.get("already_sent") is True, (
+            "Should suppress when final_response_sent=True even with tool calls"
+        )
+
+    def test_response_previewed_still_suppressed_with_tool_calls(self):
+        """If response_previewed is True, suppress even with tool calls
+        (the full text was already sent via the non-streaming interim path)."""
+        sc = self._make_mock_stream_consumer(already_sent=False, final_response_sent=False)
+        response = {
+            "final_response": "Previewed response",
+            "response_previewed": True,
+            "messages": [
+                {"role": "user", "content": "Do something"},
+                {"role": "assistant", "tool_calls": [{"id": "1", "function": {"name": "web_fetch"}}]},
+                {"role": "tool", "content": "data", "tool_call_id": "1"},
+                {"role": "assistant", "content": "Previewed response"},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert response.get("already_sent") is True
+
+    def test_empty_response_with_tool_calls_not_suppressed(self):
+        """Empty sentinel should never be suppressed, regardless of tool calls."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=False)
+        response = {
+            "final_response": "(empty)",
+            "messages": [
+                {"role": "user", "content": "Search something"},
+                {"role": "assistant", "tool_calls": [{"id": "1", "function": {"name": "web_search"}}]},
+                {"role": "tool", "content": "results", "tool_call_id": "1"},
+                {"role": "assistant", "content": "(empty)"},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert "already_sent" not in response
+
+    def test_failed_response_with_tool_calls_not_suppressed(self):
+        """Failed responses should never be suppressed."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=True)
+        response = {
+            "final_response": "Error: tool failed",
+            "failed": True,
+            "messages": [
+                {"role": "user", "content": "Run command"},
+                {"role": "assistant", "tool_calls": [{"id": "1", "function": {"name": "terminal"}}]},
+                {"role": "tool", "content": "error", "tool_call_id": "1"},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert "already_sent" not in response
+
+    def test_tool_role_message_detected(self):
+        """Messages with role='tool' should be detected as tool calls."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=False)
+        response = {
+            "final_response": "Analysis complete",
+            "messages": [
+                {"role": "user", "content": "Analyze"},
+                {"role": "assistant", "content": "Analyzing..."},
+                {"role": "tool", "content": "result"},
+                {"role": "assistant", "content": "Analysis complete"},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert "already_sent" not in response
+
+    def test_tool_calls_in_assistant_message_detected(self):
+        """Assistant messages with tool_calls key should be detected."""
+        sc = self._make_mock_stream_consumer(already_sent=True, final_response_sent=False)
+        response = {
+            "final_response": "Done",
+            "messages": [
+                {"role": "user", "content": "Run"},
+                {"role": "assistant", "content": "", "tool_calls": [{"id": "x", "function": {"name": "test"}}]},
+                {"role": "assistant", "content": "Done"},
+            ],
+        }
+        self._apply_suppression_logic(response, sc)
+        assert "already_sent" not in response


### PR DESCRIPTION
## Summary

Fixes #10942

When `display.interim_assistant_messages: true` is enabled and tool calls occur, the final response was being silently dropped. The user would only see the short interim message (e.g., "Let me check that skill.") and the tool notification, but never receive the actual answer.

## Root Cause

The `already_sent` flag from the interim message was incorrectly suppressing the post-tool final response. The existing logic treated any sent content as indication that the final response was delivered, but interim messages are sent **before** tool calls while the final response is produced **after** them.

## Solution

The fix distinguishes between:

1. `final_response_sent` — streaming delivered the actual final response
2. `already_sent` — something was sent, possibly just interim text

Now, if tools were called in the turn, the final response is **always** delivered because it is new content produced after the tool calls completed.

### Suppression Logic (After Fix)

Suppress final send if:
1. Response is not empty/sentinel, AND
2. One of:
   - `final_response_sent` is True (streaming delivered the final), OR
   - `response_previewed` is True (non-streaming interim sent the final), OR
   - `already_sent` is True AND there were **no** tool calls

## Testing

- Added comprehensive tests in `tests/gateway/test_duplicate_reply_suppression.py`
- All existing tests pass
- Tested scenarios:
  - Interim sent with tool calls → NOT suppressed ✓
  - Interim sent without tool calls → suppressed (existing behavior) ✓
  - Final streamed with tool calls → suppressed ✓
  - Response previewed with tool calls → suppressed ✓
  - Empty response with tool calls → NOT suppressed ✓
  - Failed response with tool calls → NOT suppressed ✓

## Related Issues

- #10942 — interim_assistant_messages causes final response to be silently dropped
- Related to #10454 — commentary messages should not set already_sent