### PR TITLE
chore(gateway): replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -902,7 +902,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             while True:
                 try:
                     delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
@@ -1241,7 +1241,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     await _emit_text_delta(it)
                 # Other types (non-string, non-tuple) are silently dropped.
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             while True:
                 try:
                     item = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
@@ -2004,7 +2004,7 @@ class APIServerAdapter(BasePlatformAdapter):
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
         """
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def _run():
             agent = self._create_agent(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -835,7 +835,7 @@ class GatewayRunner:
         session_key: Optional[str] = None,
     ):
         """Run the sync memory flush in a thread pool so it won't block the event loop."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(
             None,
             self._flush_memories_for_session,
@@ -3746,7 +3746,7 @@ class GatewayRunner:
                                 )
                                 _hyg_agent._print_fn = lambda *a, **kw: None
 
-                                loop = asyncio.get_event_loop()
+                                loop = asyncio.get_running_loop()
                                 _compressed, _ = await loop.run_in_executor(
                                     None,
                                     lambda: _hyg_agent._compress_context(
@@ -6234,7 +6234,7 @@ class GatewayRunner:
             if compress_start >= compress_end:
                 return "Nothing to compress yet (the transcript is still all protected context)."
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             compressed, _ = await loop.run_in_executor(
                 None,
                 lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
@@ -6619,7 +6619,7 @@ class GatewayRunner:
             from hermes_state import SessionDB
             from agent.insights import InsightsEngine
 
-            loop = _asyncio.get_event_loop()
+            loop = _asyncio.get_running_loop()
 
             def _run_insights():
                 db = SessionDB()
@@ -6636,7 +6636,7 @@ class GatewayRunner:
 
     async def _handle_reload_mcp_command(self, event: MessageEvent) -> str:
         """Handle /reload-mcp command -- disconnect and reconnect all MCP servers."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             from tools.mcp_tool import shutdown_mcp_servers, discover_mcp_tools, _servers, _lock
 
@@ -8357,7 +8357,7 @@ class GatewayRunner:
         stream_consumer_holder = [None]  # Mutable container for stream consumer
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
-        _loop_for_step = asyncio.get_event_loop()
+        _loop_for_step = asyncio.get_running_loop()
         _hooks_ref = self.hooks
 
         def _step_callback_sync(iteration: int, prev_tools: list) -> None:
@@ -9692,7 +9692,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     def restart_signal_handler():
         runner.request_restart(detached=False, via_service=True)
     
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     if threading.current_thread() is threading.main_thread():
         for sig in (signal.SIGINT, signal.SIGTERM):
             try:


### PR DESCRIPTION
## Summary

Replace all 10 `asyncio.get_event_loop()` calls in the gateway with `asyncio.get_running_loop()`.

`get_event_loop()` is deprecated since Python 3.10 — it silently creates a new event loop when none is running, masking bugs. `get_running_loop()` raises `RuntimeError` instead, which is the correct behavior for code that must run inside an async context.

All 10 call sites are inside `async` functions where a running loop is guaranteed, so this is a safe mechanical replacement with no behavioral change.

Surfaced during review of PRs #10533 and #10647.

## Changes

- `gateway/run.py` — 7 replacements (memory flush, context compression, insights, MCP reload, step callback bridge, signal handler setup)
- `gateway/platforms/api_server.py` — 3 replacements (SSE streaming loops, agent executor)

## Test Results

```
tests/gateway/test_session_env.py                         12 passed
tests/gateway/test_run_progress_topics.py                 19 passed, 1 pre-existing failure
tests/gateway/test_internal_event_bypass_pairing.py        8 passed
tests/gateway/test_background_process_notifications.py    26 passed
tests/tools/test_notify_on_complete.py                    21 passed
tests/gateway/test_usage_command.py                        7 passed
tests/gateway/test_api_server*.py                        195 passed
───────────────────────────────────────────────────────────────────────
Total                                                    288 passed (0 new failures)
```
