### PR TITLE
feat: Allow to pass COPILOT_GH_USER to use in gh auth token

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -14,6 +14,10 @@ Credential search order (matching Copilot CLI behaviour):
   2. GH_TOKEN env var
   3. GITHUB_TOKEN env var
   4. gh auth token  CLI fallback
+
+Optional env vars for gh CLI fallback:
+  COPILOT_GH_HOST   Override the GitHub hostname (--hostname flag)
+  COPILOT_GH_USER   Select a specific account on the host (--user flag)
 """
 
 from __future__ import annotations
@@ -125,6 +129,7 @@ def _try_gh_cli_token() -> Optional[str]:
     (hosts.yml) instead of just echoing the env var back.
     """
     hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+    user = os.getenv("COPILOT_GH_USER", "").strip()
 
     # Build a clean env so gh doesn't short-circuit on GITHUB_TOKEN / GH_TOKEN
     clean_env = {k: v for k, v in os.environ.items()
@@ -134,6 +139,8 @@ def _try_gh_cli_token() -> Optional[str]:
         cmd = [gh_path, "auth", "token"]
         if hostname:
             cmd += ["--hostname", hostname]
+        if user:
+            cmd += ["--user", user]
         try:
             result = subprocess.run(
                 cmd,

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -14,6 +14,10 @@ Credential search order (matching Copilot CLI behaviour):
   2. GH_TOKEN env var
   3. GITHUB_TOKEN env var
   4. gh auth token  CLI fallback
+
+Optional env vars for gh CLI fallback:
+  COPILOT_GH_HOST   Override the GitHub hostname (--hostname flag)
+  COPILOT_GH_USER   Select a specific account on the host (--user flag)
 """
 
 from __future__ import annotations
@@ -133,6 +137,7 @@ def _try_gh_cli_token() -> Optional[str]:
     (hosts.yml) instead of just echoing the env var back.
     """
     hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+    user = os.getenv("COPILOT_GH_USER", "").strip()
 
     # Build a clean env so gh doesn't short-circuit on GITHUB_TOKEN / GH_TOKEN
     clean_env = {k: v for k, v in os.environ.items()
@@ -143,6 +148,8 @@ def _try_gh_cli_token() -> Optional[str]:
         cmd = [gh_path, "auth", "token"]
         if hostname:
             cmd += ["--hostname", hostname]
+        if user:
+            cmd += ["--user", user]
         try:
             result = subprocess.run(
                 cmd,

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -108,6 +108,140 @@ class TestResolveToken:
         assert source == ""
 
 
+class TestGhCliToken:
+    """_try_gh_cli_token subprocess command construction."""
+
+    def _run_with_env(self, monkeypatch, env_overrides, *, gh_stdout="gho_tok"):
+        """Helper: call _try_gh_cli_token with controlled env and capture the subprocess command."""
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        for var in ("COPILOT_GH_HOST", "COPILOT_GH_USER", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        for k, v in env_overrides.items():
+            monkeypatch.setenv(k, v)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = gh_stdout
+
+        with (
+            patch(
+                "hermes_cli.copilot_auth._gh_cli_candidates",
+                return_value=["/usr/bin/gh"],
+            ),
+            patch(
+                "hermes_cli.copilot_auth.subprocess.run", return_value=mock_result
+            ) as mock_run,
+        ):
+            token = _try_gh_cli_token()
+
+        return token, mock_run
+
+    def test_no_user_flag_when_unset(self, monkeypatch):
+        token, mock_run = self._run_with_env(monkeypatch, {})
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token"]
+        assert token == "gho_tok"
+
+    def test_user_flag_when_set(self, monkeypatch):
+        token, mock_run = self._run_with_env(monkeypatch, {"COPILOT_GH_USER": "myuser"})
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token", "--user", "myuser"]
+        assert token == "gho_tok"
+
+    def test_hostname_flag_when_set(self, monkeypatch):
+        token, mock_run = self._run_with_env(
+            monkeypatch, {"COPILOT_GH_HOST": "github.example.com"}
+        )
+        cmd = mock_run.call_args[0][0]
+        assert cmd == [
+            "/usr/bin/gh",
+            "auth",
+            "token",
+            "--hostname",
+            "github.example.com",
+        ]
+
+    def test_both_hostname_and_user(self, monkeypatch):
+        token, mock_run = self._run_with_env(
+            monkeypatch,
+            {
+                "COPILOT_GH_HOST": "github.example.com",
+                "COPILOT_GH_USER": "myuser",
+            },
+        )
+        cmd = mock_run.call_args[0][0]
+        assert cmd == [
+            "/usr/bin/gh",
+            "auth",
+            "token",
+            "--hostname",
+            "github.example.com",
+            "--user",
+            "myuser",
+        ]
+
+    def test_user_whitespace_stripped(self, monkeypatch):
+        token, mock_run = self._run_with_env(
+            monkeypatch, {"COPILOT_GH_USER": "  myuser  "}
+        )
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token", "--user", "myuser"]
+
+    def test_empty_user_not_passed(self, monkeypatch):
+        token, mock_run = self._run_with_env(monkeypatch, {"COPILOT_GH_USER": "   "})
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token"]
+
+    def test_strips_github_token_from_subprocess_env(self, monkeypatch):
+        """GH_TOKEN and GITHUB_TOKEN must be stripped so gh reads hosts.yml."""
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_should_strip")
+        monkeypatch.setenv("GH_TOKEN", "gho_also_strip")
+        monkeypatch.delenv("COPILOT_GH_HOST", raising=False)
+        monkeypatch.delenv("COPILOT_GH_USER", raising=False)
+
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "gho_from_hosts"
+
+        with (
+            patch(
+                "hermes_cli.copilot_auth._gh_cli_candidates",
+                return_value=["/usr/bin/gh"],
+            ),
+            patch(
+                "hermes_cli.copilot_auth.subprocess.run", return_value=mock_result
+            ) as mock_run,
+        ):
+            _try_gh_cli_token()
+
+        passed_env = mock_run.call_args[1]["env"]
+        assert "GITHUB_TOKEN" not in passed_env
+        assert "GH_TOKEN" not in passed_env
+
+    def test_returns_none_on_failure(self, monkeypatch):
+        """Non-zero exit returns None."""
+        monkeypatch.delenv("COPILOT_GH_HOST", raising=False)
+        monkeypatch.delenv("COPILOT_GH_USER", raising=False)
+
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+
+        with (
+            patch(
+                "hermes_cli.copilot_auth._gh_cli_candidates",
+                return_value=["/usr/bin/gh"],
+            ),
+            patch("hermes_cli.copilot_auth.subprocess.run", return_value=mock_result),
+        ):
+            assert _try_gh_cli_token() is None
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -107,6 +107,140 @@ class TestResolveToken:
         assert source == ""
 
 
+class TestGhCliToken:
+    """_try_gh_cli_token subprocess command construction."""
+
+    def _run_with_env(self, monkeypatch, env_overrides, *, gh_stdout="gho_tok"):
+        """Helper: call _try_gh_cli_token with controlled env and capture the subprocess command."""
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        for var in ("COPILOT_GH_HOST", "COPILOT_GH_USER", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        for k, v in env_overrides.items():
+            monkeypatch.setenv(k, v)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = gh_stdout
+
+        with (
+            patch(
+                "hermes_cli.copilot_auth._gh_cli_candidates",
+                return_value=["/usr/bin/gh"],
+            ),
+            patch(
+                "hermes_cli.copilot_auth.subprocess.run", return_value=mock_result
+            ) as mock_run,
+        ):
+            token = _try_gh_cli_token()
+
+        return token, mock_run
+
+    def test_no_user_flag_when_unset(self, monkeypatch):
+        token, mock_run = self._run_with_env(monkeypatch, {})
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token"]
+        assert token == "gho_tok"
+
+    def test_user_flag_when_set(self, monkeypatch):
+        token, mock_run = self._run_with_env(monkeypatch, {"COPILOT_GH_USER": "myuser"})
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token", "--user", "myuser"]
+        assert token == "gho_tok"
+
+    def test_hostname_flag_when_set(self, monkeypatch):
+        token, mock_run = self._run_with_env(
+            monkeypatch, {"COPILOT_GH_HOST": "github.example.com"}
+        )
+        cmd = mock_run.call_args[0][0]
+        assert cmd == [
+            "/usr/bin/gh",
+            "auth",
+            "token",
+            "--hostname",
+            "github.example.com",
+        ]
+
+    def test_both_hostname_and_user(self, monkeypatch):
+        token, mock_run = self._run_with_env(
+            monkeypatch,
+            {
+                "COPILOT_GH_HOST": "github.example.com",
+                "COPILOT_GH_USER": "myuser",
+            },
+        )
+        cmd = mock_run.call_args[0][0]
+        assert cmd == [
+            "/usr/bin/gh",
+            "auth",
+            "token",
+            "--hostname",
+            "github.example.com",
+            "--user",
+            "myuser",
+        ]
+
+    def test_user_whitespace_stripped(self, monkeypatch):
+        token, mock_run = self._run_with_env(
+            monkeypatch, {"COPILOT_GH_USER": "  myuser  "}
+        )
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token", "--user", "myuser"]
+
+    def test_empty_user_not_passed(self, monkeypatch):
+        token, mock_run = self._run_with_env(monkeypatch, {"COPILOT_GH_USER": "   "})
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["/usr/bin/gh", "auth", "token"]
+
+    def test_strips_github_token_from_subprocess_env(self, monkeypatch):
+        """GH_TOKEN and GITHUB_TOKEN must be stripped so gh reads hosts.yml."""
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_should_strip")
+        monkeypatch.setenv("GH_TOKEN", "gho_also_strip")
+        monkeypatch.delenv("COPILOT_GH_HOST", raising=False)
+        monkeypatch.delenv("COPILOT_GH_USER", raising=False)
+
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "gho_from_hosts"
+
+        with (
+            patch(
+                "hermes_cli.copilot_auth._gh_cli_candidates",
+                return_value=["/usr/bin/gh"],
+            ),
+            patch(
+                "hermes_cli.copilot_auth.subprocess.run", return_value=mock_result
+            ) as mock_run,
+        ):
+            _try_gh_cli_token()
+
+        passed_env = mock_run.call_args[1]["env"]
+        assert "GITHUB_TOKEN" not in passed_env
+        assert "GH_TOKEN" not in passed_env
+
+    def test_returns_none_on_failure(self, monkeypatch):
+        """Non-zero exit returns None."""
+        monkeypatch.delenv("COPILOT_GH_HOST", raising=False)
+        monkeypatch.delenv("COPILOT_GH_USER", raising=False)
+
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+
+        with (
+            patch(
+                "hermes_cli.copilot_auth._gh_cli_candidates",
+                return_value=["/usr/bin/gh"],
+            ),
+            patch("hermes_cli.copilot_auth.subprocess.run", return_value=mock_result),
+        ):
+            assert _try_gh_cli_token() is None
+
+
 class TestRequestHeaders:
     """Copilot API header generation."""
 

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -1,7 +1,7 @@
 """Tests for hermes_cli.copilot_auth — Copilot token validation and resolution."""
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 
 class TestTokenValidation:

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -162,6 +162,11 @@ hermes chat --provider copilot --model gpt-5.4
 3. `GITHUB_TOKEN` environment variable
 4. `gh auth token` CLI fallback
 
+When the `gh` CLI has multiple authenticated accounts, set `COPILOT_GH_USER`
+to the desired account login. Set `COPILOT_GH_HOST` as well when selecting an
+account on a GitHub Enterprise host. Hermes passes these values to
+`gh auth token` as `--user` and `--hostname`, respectively.
+
 If no token is found, `hermes model` offers an **OAuth device code login** — the same flow used by the Copilot CLI and opencode.
 
 :::warning Token types
@@ -207,6 +212,8 @@ model:
 | Environment variable | Description |
 |---------------------|-------------|
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
+| `COPILOT_GH_HOST` | GitHub hostname used by the `gh auth token` fallback |
+| `COPILOT_GH_USER` | GitHub account used by the `gh auth token` fallback |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -26,6 +26,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API — first priority (OAuth `gho_*` or fine-grained PAT `github_pat_*`; classic PATs `ghp_*` are **not supported**) |
 | `GH_TOKEN` | GitHub token — second priority for Copilot (also used by `gh` CLI) |
 | `GITHUB_TOKEN` | GitHub token — third priority for Copilot |
+| `COPILOT_GH_HOST` | GitHub hostname passed to the `gh auth token` fallback with `--hostname` |
+| `COPILOT_GH_USER` | GitHub account passed to the `gh auth token` fallback with `--user`; useful when `gh` has multiple authenticated accounts |
 | `HERMES_COPILOT_ACP_COMMAND` | Override Copilot ACP CLI binary path (default: `copilot`) |
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |


### PR DESCRIPTION
## What does this PR do?

When you have multiple users logged in in `gh`, it will default to the active user and you need to make sure you're using the one with Copilot. There's a parameter in `gh auth token` to specify the username and in this PR I'm adding support to it.

## Related Issue

Fixes #10715 

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hermes_cli/copilot_auth.py
- tests/hermes_cli/test_copilot_auth.py

## How to Test

1. Setup different github users with `gh auth login` and selecting other accounts
2. Set `COPILOT_GH_USER` to the one with Copilot active
3. Profit

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 43

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
