### PR TITLE
fix(copilot): eliminate redundant catalog fetch in api_mode resolution

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1570,6 +1570,11 @@ def copilot_model_api_mode(
     primary signal.  Falls back to the catalog's ``supported_endpoints``
     only for models not covered by the pattern check.
     """
+    # Fetch the catalog once so normalize + endpoint check share it
+    # (avoids two redundant network calls for non-GPT-5 models).
+    if catalog is None and api_key:
+        catalog = fetch_github_model_catalog(api_key=api_key)
+
     normalized = normalize_copilot_model_id(model_id, catalog=catalog, api_key=api_key)
     if not normalized:
         return "chat_completions"
@@ -1579,9 +1584,6 @@ def copilot_model_api_mode(
         return "codex_responses"
 
     # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
-    if catalog is None and api_key:
-        catalog = fetch_github_model_catalog(api_key=api_key)
-
     if catalog:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
         if isinstance(catalog_entry, dict):


### PR DESCRIPTION
## Problem

`copilot_model_api_mode()` makes **two redundant HTTP calls** to `fetch_github_model_catalog()` for non-GPT-5 models (Claude, Gemini) during interactive `/model` switches:

1. `normalize_copilot_model_id()` → `_copilot_catalog_ids()` → `fetch_github_model_catalog()` — **FETCH #1**
2. Back in `copilot_model_api_mode()`, `catalog is None` (never passed through) → `fetch_github_model_catalog()` — **FETCH #2**

Each fetch has a 5-second timeout, so a Claude model switch on Copilot could block for up to 10 seconds in the worst case.

## Fix

Fetch the catalog once at the top of `copilot_model_api_mode()` and pass it to `normalize_copilot_model_id()`. The secondary endpoint check then sees a non-None catalog and skips the redundant fetch.

For GPT-5 models, the fetch count stays at 1 (just moved earlier — the early return via `_should_use_copilot_responses_api` still works). For Claude/Gemini models, it goes from 2 → 1.

Surfaced during review of PR #10533.

### File changed

- `hermes_cli/models.py` — move catalog fetch to top of `copilot_model_api_mode()`

## Test Results

```
tests/hermes_cli/test_model_switch_copilot_api_mode.py     3 passed
tests/hermes_cli/test_model_validation.py                  63 passed
tests/hermes_cli/test_model_provider_persistence.py        10 passed
All copilot-related tests (pytest -k copilot)              80 passed
───────────────────────────────────────────────────────────────────────
Total                                                       0 new failures
```
