### PR TITLE
Avoid redacting plain AgentMail-like identifiers

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -44,7 +44,6 @@ _PREFIX_PATTERNS = [
     r"pypi-[A-Za-z0-9_-]{10,}",         # PyPI API token
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
-    r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -59,6 +59,31 @@ class TestKnownPrefixes:
         assert "***" in result
 
 
+class TestAgentMailRedaction:
+    def test_plain_agentmail_like_identifier_unchanged(self):
+        text = "am_example_identifier_123"
+        assert redact_sensitive_text(text) == text
+
+    def test_dotted_agentmail_like_identifier_unchanged(self):
+        text = "schema.am_example_identifier_123"
+        assert redact_sensitive_text(text) == text
+
+    def test_path_with_agentmail_like_identifier_unchanged(self):
+        text = "path/to/am_example_identifier_123.sql"
+        assert redact_sensitive_text(text) == text
+
+    def test_agentmail_api_key_env_value_redacted(self):
+        text = "AGENTMAIL_API_KEY=am_abcdefghijklmnopqrstuvwxyz123456"
+        result = redact_sensitive_text(text)
+        assert "AGENTMAIL_API_KEY=" in result
+        assert "abcdefghijklmnopqrstuvwxyz" not in result
+
+    def test_agentmail_json_secret_value_redacted(self):
+        text = '{"apiKey": "am_abcdefghijklmnopqrstuvwxyz123456"}'
+        result = redact_sensitive_text(text)
+        assert "abcdefghijklmnopqrstuvwxyz" not in result
+
+
 class TestEnvAssignments:
     def test_export_api_key(self):
         text = "export OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"


### PR DESCRIPTION
## Summary
- remove the bare am_ prefix from global token-prefix redaction
- keep AgentMail-looking values redacted when they appear in secret contexts like AGENTMAIL_API_KEY or JSON apiKey fields
- add regression coverage for plain identifiers, dotted names, and file paths from issue #10983

Fixes #10983

## Tests
- python3 -m pytest -o addopts='' tests/agent/test_redact.py
- python3 -m py_compile agent/redact.py tests/agent/test_redact.py
- git diff --check