### PR TITLE
fix: restore vision provider/env resolution after upgrade regression

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1754,9 +1754,12 @@ def get_available_vision_backends() -> List[str]:
             if _strict_vision_backend_available(main_provider):
                 available.append(main_provider)
         else:
-            client, _ = resolve_provider_client(main_provider, _read_main_model())
-            if client is not None:
-                available.append(main_provider)
+            if main_provider in _PROVIDER_VISION_MODELS:
+                client, _ = resolve_provider_client(
+                    main_provider, _PROVIDER_VISION_MODELS.get(main_provider) or _read_main_model()
+                )
+                if client is not None:
+                    available.append(main_provider)
     # 2. OpenRouter, 3. Nous — skip if already covered by main provider.
     for p in _VISION_AUTO_PROVIDER_ORDER:
         if p not in available and _strict_vision_backend_available(p):
@@ -1823,17 +1826,18 @@ def resolve_vision_provider_client(
             else:
                 # Exotic provider (DeepSeek, Alibaba, Xiaomi, named custom, etc.)
                 # Use provider-specific vision model if available, otherwise main model.
-                vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
-                rpc_client, rpc_model = resolve_provider_client(
-                    main_provider, vision_model,
-                    api_mode=resolved_api_mode)
-                if rpc_client is not None:
-                    logger.info(
-                        "Vision auto-detect: using active provider %s (%s)",
-                        main_provider, rpc_model or vision_model,
-                    )
-                    return _finalize(
-                        main_provider, rpc_client, rpc_model or vision_model)
+                vision_model = _PROVIDER_VISION_MODELS.get(main_provider)
+                if vision_model:
+                    rpc_client, rpc_model = resolve_provider_client(
+                        main_provider, vision_model,
+                        api_mode=resolved_api_mode)
+                    if rpc_client is not None:
+                        logger.info(
+                            "Vision auto-detect: using active provider %s (%s)",
+                            main_provider, rpc_model or vision_model,
+                        )
+                        return _finalize(
+                            main_provider, rpc_client, rpc_model or vision_model)
 
         # Fall back through aggregators.
         for candidate in _VISION_AUTO_PROVIDER_ORDER:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1250,8 +1250,18 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
 def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
+    env_file_vars = {}
+    try:
+        from hermes_cli.config import load_env as _load_env_file
+        env_file_vars = _load_env_file() or {}
+    except Exception:
+        env_file_vars = {}
+
+    def _get_env(name: str) -> str:
+        return (os.getenv(name, "") or env_file_vars.get(name, "") or "").strip()
+
     if provider == "openrouter":
-        token = os.getenv("OPENROUTER_API_KEY", "").strip()
+        token = _get_env("OPENROUTER_API_KEY")
         if token:
             source = "env:OPENROUTER_API_KEY"
             active_sources.add(source)
@@ -1275,7 +1285,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+        env_url = _get_env(pconfig.base_url_env_var).rstrip("/")
 
     env_vars = list(pconfig.api_key_env_vars)
     if provider == "anthropic":
@@ -1286,7 +1296,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         ]
 
     for env_var in env_vars:
-        token = os.getenv(env_var, "").strip()
+        token = _get_env(env_var)
         if not token:
             continue
         source = f"env:{env_var}"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -381,6 +381,24 @@ def _resolve_api_key_provider_secret(
         if has_usable_secret(val):
             return val, env_var
 
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(provider_id)
+        if pool and pool.has_credentials():
+            entry = pool.select()
+            if entry is not None:
+                token = (
+                    getattr(entry, "runtime_api_key", None)
+                    or getattr(entry, "access_token", "")
+                )
+                token = str(token or "").strip()
+                if has_usable_secret(token):
+                    label = getattr(entry, "label", None) or getattr(entry, "id", None) or "unknown"
+                    return token, f"pool:{label}"
+    except Exception:
+        pass
+
     return "", ""
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -323,8 +323,18 @@ def get_provider(name: str) -> Optional[ProviderDef]:
         base_url_env = overlay.base_url_env_var if overlay else ""
         base_url_override = overlay.base_url_override if overlay else ""
 
-        # Combine env vars: models.dev env + hermes extra
-        env_vars = list(mdev_info.env)
+        env_vars: List[str]
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY
+
+            pconfig = PROVIDER_REGISTRY.get(canonical)
+            if pconfig and getattr(pconfig, "api_key_env_vars", None):
+                env_vars = list(pconfig.api_key_env_vars)
+            else:
+                env_vars = list(mdev_info.env)
+        except Exception:
+            env_vars = list(mdev_info.env)
+
         if overlay and overlay.extra_env_vars:
             for ev in overlay.extra_env_vars:
                 if ev not in env_vars:

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -39,6 +39,9 @@ from dotenv import load_dotenv
 env_path = PROJECT_DIR / '.env'
 if env_path.exists():
     load_dotenv(dotenv_path=env_path)
+home_env_path = Path.home() / ".hermes" / ".env"
+if home_env_path.exists():
+    load_dotenv(dotenv_path=home_env_path)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- load  in  so gateway run mode sees user credentials
- seed credential pool from  (not only process env) to avoid dropping API-key entries in non-shell contexts
- let API-key provider secret resolution fall back to credential pool entries
- prefer  env var mappings over  env metadata when available
- tighten vision auto backend detection so non-vision providers are not treated as vision-capable by default

## Repro before
-  returned runtime error: 
-  returned no key when only  had credentials

## Validation
-  passes for touched files
- credential resolution now reports  and 
- gateway service restarts successfully with updated loader
