### PR TITLE
fix: empty response nudge crash + placeholder leak to cron targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -837,6 +837,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
 
         final_response = result.get("final_response", "") or ""
+        # Strip leaked placeholder text that upstream may inject on empty completions.
+        if final_response.strip() == "(No response generated)":
+            final_response = ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8886,7 +8886,7 @@ class GatewayRunner:
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
-                error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
+                error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
                     "final_response": error_msg,
                     "messages": result.get("messages", []),

--- a/run_agent.py
+++ b/run_agent.py
@@ -10945,8 +10945,9 @@ class AIAgent:
                             #   tool(result) → assistant("(empty)") → user(nudge)
                             # Without this, we'd have tool → user which most
                             # APIs reject as an invalid sequence.
-                            assistant_msg["content"] = "(empty)"
-                            messages.append(assistant_msg)
+                            _nudge_msg = self._build_assistant_message(assistant_message, finish_reason)
+                            _nudge_msg["content"] = "(empty)"
+                            messages.append(_nudge_msg)
                             messages.append({
                                 "role": "user",
                                 "content": (

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -179,6 +179,7 @@ AUTHOR_MAP = {
     "limars874@gmail.com": "limars874",
     "lisicheng168@gmail.com": "lesterli",
     "mingjwan@microsoft.com": "MagicRay1217",
+    "orangeko@gmail.com": "GenKoKo",
     "niyant@spicefi.xyz": "spniyant",
     "olafthiele@gmail.com": "olafthiele",
     "oncuevtv@gmail.com": "sprmn24",


### PR DESCRIPTION
## Summary

Salvage of two independent contributor fixes for empty response handling bugs.

### Fix 1: UnboundLocalError in post-tool nudge path (from PR #10435 by @GenKoKo)

**The bug:** When a model returns empty after tool calls, the nudge recovery path at line ~10948 references `assistant_msg` — but that variable is only assigned inside the `if tool_calls:` branch. When the first API call in a `run_conversation()` returns empty and conversation history already contains tool messages (session replay), `assistant_msg` is unbound → crash → all retries fail → no response.

**The fix:** Build a fresh message via `_build_assistant_message()` instead of reusing the potentially unbound variable. Consistent with the exhausted-retries path which already does this.

**Reproducer:** GLM-5 / GLM-4.5-Air on Z.AI coding plan — these models frequently return empty after tool calls.

### Fix 2: "(No response generated)" placeholder leaks to cron targets (from PR #9292 by @Magicray1217)

**The bug:** When `final_response` is empty and there's no error, `gateway/run.py` line ~8889 injects the literal string `"(No response generated)"`. This string is truthy, defeating `cron/scheduler.py`'s `bool(deliver_content)` guard — the placeholder gets delivered to home channels as if it were a real response.

**The fix:** Return empty string instead of placeholder for the return-to-caller path (the user-facing DM sends at lines 5773/5954 intentionally keep the placeholder as UI feedback). Belt-and-suspenders: `cron/scheduler.py` also strips the placeholder defensively.

### Follow-up
- Added GenKoKo to AUTHOR_MAP

## Files changed
- `run_agent.py` — 3-line fix in nudge path (+3/-2)
- `gateway/run.py` — return empty string instead of placeholder (+1/-1)
- `cron/scheduler.py` — defensive placeholder strip (+3/-0)
- `scripts/release.py` — AUTHOR_MAP entry (+1/-0)

## Test results
- `tests/run_agent/test_run_agent.py`: 175 passed (86 errors pre-existing, unrelated to changes)
- `tests/gateway/test_duplicate_reply_suppression.py`: 22 passed
- `tests/cron/`: 170 passed, 4 skipped
- E2E verification: both fixes confirmed working
- py_compile: all 3 modified files pass

Closes #10435. Closes #9292. Fixes #9270.