### PR TITLE
fix(honcho,cli): consolidate duplicate PRs — conclude validation + skin null config

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -708,7 +708,9 @@ def init_skin_from_config(config: dict) -> None:
 
     Call this once during CLI init with the loaded config dict.
     """
-    display = config.get("display", {})
+    display = config.get("display") or {}
+    if not isinstance(display, dict):
+        display = {}
     skin_name = display.get("skin", "default")
     if isinstance(skin_name, str) and skin_name.strip():
         set_active_skin(skin_name.strip())

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -160,11 +160,11 @@ CONCLUDE_SCHEMA = {
         "properties": {
             "conclusion": {
                 "type": "string",
-                "description": "A factual statement to persist. Required when not using delete_id.",
+                "description": "A factual statement to persist. Provide this when creating a conclusion. Do not send it together with delete_id.",
             },
             "delete_id": {
                 "type": "string",
-                "description": "Conclusion ID to delete (for PII removal). Required when not using conclusion.",
+                "description": "Conclusion ID to delete for PII removal. Provide this when deleting a conclusion. Do not send it together with conclusion.",
             },
             "peer": {
                 "type": "string",
@@ -1009,15 +1009,20 @@ class HonchoMemoryProvider(MemoryProvider):
 
             elif tool_name == "honcho_conclude":
                 delete_id = args.get("delete_id")
+                conclusion = args.get("conclusion", "")
                 peer = args.get("peer", "user")
-                if delete_id:
+
+                has_delete_id = bool(delete_id)
+                has_conclusion = bool(conclusion)
+                if has_delete_id == has_conclusion:
+                    return tool_error("Exactly one of conclusion or delete_id must be provided.")
+
+                if has_delete_id:
                     ok = self._manager.delete_conclusion(self._session_key, delete_id, peer=peer)
                     if ok:
                         return json.dumps({"result": f"Conclusion {delete_id} deleted."})
                     return tool_error(f"Failed to delete conclusion {delete_id}.")
-                conclusion = args.get("conclusion", "")
-                if not conclusion:
-                    return tool_error("Missing required parameter: conclusion or delete_id")
+
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -152,6 +152,24 @@ class TestSkinManagement:
         init_skin_from_config({})
         assert get_active_skin_name() == "default"
 
+    def test_init_skin_from_null_display(self):
+        """display: null should fall back to default, not crash."""
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        init_skin_from_config({"display": None})
+        assert get_active_skin_name() == "default"
+
+    def test_init_skin_from_non_dict_display(self):
+        """display: <non-dict> should fall back to default."""
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+        init_skin_from_config({"display": "invalid"})
+        assert get_active_skin_name() == "default"
+
+        init_skin_from_config({"display": 42})
+        assert get_active_skin_name() == "default"
+
+        init_skin_from_config({"display": []})
+        assert get_active_skin_name() == "default"
+
 
 class TestUserSkins:
     def test_load_user_skin_from_yaml(self, tmp_path, monkeypatch):

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -366,6 +366,18 @@ class TestPeerLookupHelpers:
 
 
 class TestConcludeToolDispatch:
+    def test_conclude_schema_has_no_anyof(self):
+        """anyOf/oneOf/allOf breaks Anthropic and Fireworks APIs — schema must be plain object."""
+        from plugins.memory.honcho import CONCLUDE_SCHEMA
+        params = CONCLUDE_SCHEMA["parameters"]
+
+        assert params["type"] == "object"
+        assert "conclusion" in params["properties"]
+        assert "delete_id" in params["properties"]
+        assert "anyOf" not in params
+        assert "oneOf" not in params
+        assert "allOf" not in params
+
     def test_honcho_conclude_defaults_to_user_peer(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
@@ -470,7 +482,25 @@ class TestConcludeToolDispatch:
         result = provider.handle_tool_call("honcho_conclude", {})
 
         parsed = json.loads(result)
-        assert "error" in parsed or "Missing required" in parsed.get("result", "")
+        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
+        provider._manager.create_conclusion.assert_not_called()
+        provider._manager.delete_conclusion.assert_not_called()
+
+    def test_honcho_conclude_rejects_both_params_at_once(self):
+        """Sending both conclusion and delete_id should be rejected."""
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "User prefers dark mode", "delete_id": "conc-123"},
+        )
+
+        parsed = json.loads(result)
+        assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
         provider._manager.create_conclusion.assert_not_called()
         provider._manager.delete_conclusion.assert_not_called()
 


### PR DESCRIPTION
## Summary

Consolidates 6 duplicate PRs into 2 focused commits with authorship preserved.

### Commit 1: fix(honcho) — conclude schema + runtime validation

Improves `honcho_conclude` tool descriptions to explicitly guide models away from sending both params. Adds runtime exactly-one validation (rejects both and neither). Adds schema regression test and both-params rejection test.

Consolidates: #10847 (@ygd58), #10864 (@cola-runner), #10870 (@vominh1919), #10952 (@ogzerber). The `anyOf` removal itself was already merged — this adds the runtime validation and tests that those PRs contributed.

| PR | What we took |
|----|-------------|
| #10847 @ygd58 | Issue linkage (the bug report) |
| #10864 @cola-runner | Schema regression test pattern |
| #10870 @vominh1919 | Test assertions |
| #10952 @ogzerber | Runtime exactly-one validation, improved descriptions, both-params test |

### Commit 2: fix(cli) — null/non-dict display config in skin init

`display: null` or `display: "invalid"` in config.yaml crashed `init_skin_from_config` with `AttributeError`. Now falls back to default skin gracefully.

Consolidates: #10867 (@Bartok9), #10876 (@cola-runner).

| PR | What we took |
|----|-------------|
| #10867 @Bartok9 | `or {}` guard + isinstance check + 4 test cases (None, string, int, list) |
| #10876 @cola-runner | isinstance check (subset of #10867) |

## Test Results

```
tests/honcho_plugin/test_session.py::TestConcludeToolDispatch  14 passed
tests/hermes_cli/test_skin_engine.py                           25 passed
──────────────────────────────────────────────────────────────────────
Total                                                          39 passed (0 failures)
```
