### PR TITLE
fix: quiet mode (-Q) outputs only raw response text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10039,6 +10039,11 @@ def main(
                 ):
                     cli.agent.quiet_mode = True
                     cli.agent.suppress_status_output = True
+                    # Suppress streaming display callbacks so stdout stays
+                    # machine-readable (no styled "Hermes" box, no tool-gen
+                    # status lines).  The response is printed once below.
+                    cli.agent.stream_delta_callback = None
+                    cli.agent.tool_gen_callback = None
                     result = cli.agent.run_conversation(
                         user_message=effective_query,
                         conversation_history=cli.conversation_history,
@@ -10046,7 +10051,8 @@ def main(
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
                     if response:
                         print(response)
-                    print(f"\nsession_id: {cli.session_id}")
+                    # Session ID goes to stderr so piped stdout is clean.
+                    print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
                     
                     # Ensure proper exit code for automation wrappers
                     sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)


### PR DESCRIPTION
## Summary

Fixes two issues with `hermes chat -Q -q "prompt"` that made it unusable for scripting/piping:

**1. Streaming box leaked into stdout**
When `display.streaming` is enabled (default), `_init_agent()` wires `stream_delta_callback=self._stream_delta` before quiet mode flags are set. This caused the styled "Hermes" response box to render to stdout, producing double output — once from streaming, once from the final `print(response)`.

**Fix:** Null out `stream_delta_callback` and `tool_gen_callback` after agent init in the quiet-mode path.

**2. `session_id` printed to stdout**
The `session_id: ...` line was printed to stdout, making piped output unusable (`hermes chat -Q -q "prompt" | jq` etc.).

**Fix:** Redirect to stderr. Scripts that need the session ID can capture stderr; scripts that pipe stdout get clean output.

### Before
```
$ hermes chat -Q -q "Write a limerick"
╭─⚕ Hermes────────────────────────╮
│ There once was a coder named... │
╰──────────────────────────────────╯
There once was a coder named Bree
Who argued with AI over tea...

session_id: 20260416_122045_f58303
```

### After
```
$ hermes chat -Q -q "Write a limerick"
There once was a coder named Bree
Who argued with AI over tea...
```
(`session_id` goes to stderr)

### Test plan
- `python3 -m pytest tests/cli/ -o 'addopts=' -q` — 445 passed (2 pre-existing failures unrelated)
- `py_compile` OK

Reported by @nixpiper on X.