### PR TITLE
fix: always create fresh httpx.Client to prevent use-after-close (#10324 regression)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4371,24 +4371,47 @@ class AIAgent:
         # socket in CLOSE-WAIT and epoll_wait may never fire, causing the
         # agent to hang indefinitely.  Keepalive probes detect the dead
         # peer within ~60s (30s idle + 3×10s probes).
-        if "http_client" not in client_kwargs:
-            try:
-                import httpx as _httpx
-                import socket as _socket
-                _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
-                if hasattr(_socket, "TCP_KEEPIDLE"):
-                    # Linux
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
-                elif hasattr(_socket, "TCP_KEEPALIVE"):
-                    # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
-                client_kwargs["http_client"] = _httpx.Client(
-                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
-                )
-            except Exception:
-                pass  # Fall through to default transport if socket opts fail
+        #
+        # Always create a *fresh* httpx.Client here regardless of whether
+        # client_kwargs already carries one.  The former guard
+        # ``if "http_client" not in client_kwargs`` caused a use-after-close
+        # bug: _create_request_openai_client copies self._client_kwargs
+        # (shallow copy), so the per-request OpenAI client receives the same
+        # httpx.Client object as the shared/init client.  OpenAI.close() calls
+        # httpx.Client.close(), which marks that transport as closed.  Any
+        # subsequent OpenAI client built from the same self._client_kwargs
+        # inherits the already-closed transport and immediately raises
+        # APIConnectionError("Connection error.") on the first request —
+        # typically the second API call in a session (e.g. after a tool result).
+        try:
+            import httpx as _httpx
+            import socket as _socket
+            _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+            if hasattr(_socket, "TCP_KEEPIDLE"):
+                # Linux
+                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
+                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
+                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
+            elif hasattr(_socket, "TCP_KEEPALIVE"):
+                # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
+                _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+            # Also honour standard proxy environment variables.  httpx ignores
+            # HTTPS_PROXY / HTTP_PROXY when a custom transport is supplied, so
+            # we must forward them explicitly.
+            _proxy_url = (
+                os.environ.get("HTTPS_PROXY")
+                or os.environ.get("https_proxy")
+                or os.environ.get("HTTP_PROXY")
+                or os.environ.get("http_proxy")
+            )
+            _http_client_kwargs: dict = {
+                "transport": _httpx.HTTPTransport(socket_options=_sock_opts),
+            }
+            if _proxy_url:
+                _http_client_kwargs["proxy"] = _proxy_url
+            client_kwargs["http_client"] = _httpx.Client(**_http_client_kwargs)
+        except Exception:
+            pass  # Fall through to default transport if socket opts fail
         client = OpenAI(**client_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",


### PR DESCRIPTION
## Problem

The guard introduced in #10324 —

```python
if "http_client" not in client_kwargs:
    client_kwargs["http_client"] = httpx.Client(transport=HTTPTransport(...))
```

— caused a **use-after-close bug** that makes every multi-turn session fail with `APIConnectionError("Connection error.")` starting from the second API call.

## Root Cause

`_create_request_openai_client()` does a **shallow copy** of `self._client_kwargs`:

```python
request_kwargs = dict(self._client_kwargs)   # shallow copy
return self._create_openai_client(request_kwargs, reason=reason, shared=False)
```

Because the copy is shallow, every per-request `OpenAI` client receives the **same `httpx.Client` reference** as the shared/init client.

`OpenAI.close()` calls `httpx.Client.close()` internally, which marks the underlying transport as closed. After the first per-request client is closed (e.g. after a tool-call result is processed), the shared `httpx.Client` stored in `self._client_kwargs["http_client"]` is already closed. The next `OpenAI` client created from the same `_client_kwargs` inherits the closed transport and **immediately raises `APIConnectionError("Connection error.")`** without even attempting a network connection.

Observed symptom: session consistently works for the first LLM call (initial response / tool decision), then fails on every subsequent call (processing tool results, follow-up turns).

## Fix

Remove the `if "http_client" not in client_kwargs:` guard so that `_create_openai_client()` **always instantiates a fresh `httpx.Client`**. Per-request clients now own their own transport; closing one does not affect any other client.

As a bonus, also forward `HTTPS_PROXY` / `HTTP_PROXY` environment variables explicitly. httpx normally reads proxy env vars automatically, but that behaviour is **bypassed when a custom `transport=` is supplied** — so users behind proxies would silently get no proxy support despite setting the standard env vars.

## Verification

```python
# Two consecutive _run_codex_stream calls — both succeed with independent httpx clients
c1 = agent._create_request_openai_client(reason="test_req_1")
r1 = agent._run_codex_stream(api_kwargs, client=c1)   # SUCCESS
agent._close_request_openai_client(c1, ...)            # closes httpx_1

c2 = agent._create_request_openai_client(reason="test_req_2")
# c2._client is a NEW httpx.Client (not the closed httpx_1)
r2 = agent._run_codex_stream(api_kwargs, client=c2)   # SUCCESS ✓
```