### PR TITLE
fix(run-agent): fail over on provider overload

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9862,23 +9862,37 @@ class AIAgent:
                         # Fall through to normal error handling if compression
                         # is exhausted or didn't help.
 
-                    # Eager fallback for rate-limit errors (429 or quota exhaustion).
-                    # When a fallback model is configured, switch immediately instead
-                    # of burning through retries with exponential backoff -- the
-                    # primary provider won't recover within the retry window.
+                    # Eager fallback for availability failures when a fallback
+                    # model is configured. For rate limits and billing, avoid
+                    # short-circuiting credential pool rotation because another
+                    # key may still recover on the same provider. Overload
+                    # errors (503/529) do not benefit from pool rotation, so a
+                    # configured fallback provider should take over immediately.
                     is_rate_limited = classified.reason in (
                         FailoverReason.rate_limit,
                         FailoverReason.billing,
                     )
-                    if is_rate_limited and self._fallback_index < len(self._fallback_chain):
-                        # Don't eagerly fallback if credential pool rotation may
-                        # still recover.  The pool's retry-then-rotate cycle needs
-                        # at least one more attempt to fire — jumping to a fallback
-                        # provider here short-circuits it.
-                        pool = self._credential_pool
-                        pool_may_recover = pool is not None and pool.has_available()
-                        if not pool_may_recover:
-                            self._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                    is_overloaded = classified.reason == FailoverReason.overloaded
+                    if self._fallback_index < len(self._fallback_chain):
+                        eager_fallback_status = None
+                        if is_rate_limited:
+                            # Don't eagerly fallback if credential pool
+                            # rotation may still recover. The pool's
+                            # retry-then-rotate cycle needs at least one more
+                            # attempt to fire.
+                            pool = self._credential_pool
+                            pool_may_recover = pool is not None and pool.has_available()
+                            if not pool_may_recover:
+                                eager_fallback_status = (
+                                    "⚠️ Rate limited — switching to fallback provider..."
+                                )
+                        elif is_overloaded:
+                            eager_fallback_status = (
+                                "⚠️ Provider overloaded — switching to fallback provider..."
+                            )
+
+                        if eager_fallback_status:
+                            self._emit_status(eager_fallback_status)
                             if self._try_activate_fallback():
                                 retry_count = 0
                                 compression_attempts = 0

--- a/tests/run_agent/test_anthropic_error_handling.py
+++ b/tests/run_agent/test_anthropic_error_handling.py
@@ -229,6 +229,101 @@ def test_529_overloaded_is_retried_and_recovers(monkeypatch):
     assert result["final_response"] == "Recovered"
 
 
+def test_529_overloaded_switches_to_fallback_when_configured(monkeypatch):
+    """529 should switch to a configured fallback provider before exhausting retries."""
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.build_anthropic_client", _fake_build_anthropic_client
+    )
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS", "false")
+
+    calls = {"n": 0}
+
+    class _FallbackOnOverloadAgent(run_agent.AIAgent):
+        def __init__(self, *args, **kwargs):
+            kwargs.setdefault("skip_context_files", True)
+            kwargs.setdefault("skip_memory", True)
+            kwargs.setdefault("max_iterations", 4)
+            super().__init__(*args, **kwargs)
+            self._cleanup_task_resources = lambda task_id: None
+            self._persist_session = lambda messages, history=None: None
+            self._save_trajectory = lambda messages, user_message, completed: None
+            self._save_session_log = lambda messages: None
+
+        def _try_activate_fallback(self):
+            if self._fallback_index >= len(self._fallback_chain):
+                return False
+            self._fallback_index += 1
+            self._fallback_activated = True
+            self.provider = "openrouter"
+            self.model = "anthropic/claude-sonnet-4"
+            self.base_url = "https://openrouter.ai/api/v1"
+            return True
+
+        def run_conversation(self, user_message, conversation_history=None, task_id=None):
+            def _fake_api_call(api_kwargs, **kw):
+                calls["n"] += 1
+                if self._fallback_activated:
+                    return _anthropic_response("Fallback recovered")
+                raise _OverloadedError()
+
+            self._interruptible_api_call = _fake_api_call
+            self._interruptible_streaming_api_call = _fake_api_call
+            return super().run_conversation(
+                user_message, conversation_history=conversation_history, task_id=task_id
+            )
+
+    monkeypatch.setattr(run_agent, "AIAgent", _FallbackOnOverloadAgent)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.minimax.io/anthropic",
+            "api_key": "minimax-test-key",
+        },
+    )
+
+    runner = gateway_run.GatewayRunner.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = {
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4",
+    }
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_name="CLI",
+        chat_type="dm",
+        user_id="test-user-1",
+    )
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="hello",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="test-session",
+            session_key="agent:main:local:dm",
+        )
+    )
+
+    assert result["final_response"] == "Fallback recovered"
+    assert calls["n"] == 2
+
+
 def test_429_exhausts_all_retries_before_raising(monkeypatch):
     """429 must retry max_retries times, then return a failed result.
 


### PR DESCRIPTION
## Summary
- switch to a configured fallback provider immediately when the current provider is classified as overloaded (503/529)
- keep the credential-pool safeguard for rate-limit and billing errors only
- add a regression test that covers the MiniMax-style 529 path with fallback enabled

## Why
- provider overload does not benefit from credential-pool rotation, so retrying the same overloaded endpoint just burns the retry window
- users who already configured fallback providers expect Hermes to recover availability issues by moving to the backup provider

Fixes #10210

## Testing
- pytest -o addopts='' tests/run_agent/test_anthropic_error_handling.py