### PR TITLE
fix(agent): resolve bare `cd backend` targets in SubdirectoryHintTracker

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -145,6 +145,12 @@ class SubdirectoryHintTracker:
         except ValueError:
             tokens = cmd.split()
 
+        # First pass: extract targets of shell navigation commands so bare
+        # directory names like `backend` in `cd backend && ls` resolve
+        # relative to working_dir. The generic token filter below would
+        # otherwise drop them because they contain no `/` or `.`.
+        self._extract_nav_command_targets(tokens, candidates)
+
         for token in tokens:
             # Skip flags
             if token.startswith("-"):
@@ -156,6 +162,30 @@ class SubdirectoryHintTracker:
             if token.startswith(("http://", "https://", "git@")):
                 continue
             self._add_path_candidate(token, candidates)
+
+    _NAV_COMMANDS = frozenset({"cd", "pushd"})
+
+    def _extract_nav_command_targets(self, tokens: list, candidates: Set[Path]):
+        """Resolve targets of `cd`/`pushd` invocations anywhere in tokens.
+
+        Scans the token stream for a `cd` / `pushd` token and treats the
+        next non-flag token as the navigation target. This covers the
+        common chained forms -- `cd backend && ls`, `pushd backend`, and
+        even cases where `shlex.split` leaves an operator glued to a
+        previous token such as `echo starting; cd backend`.
+
+        `cd -` (previous dir) and a bare `cd` (home) are intentionally
+        ignored -- neither points at a project subdirectory we could
+        augment with hints.
+        """
+        for idx, token in enumerate(tokens):
+            if token not in self._NAV_COMMANDS:
+                continue
+            for arg in tokens[idx + 1 :]:
+                if arg.startswith("-"):
+                    continue
+                self._add_path_candidate(arg, candidates)
+                break
 
     def _is_valid_subdir(self, path: Path) -> bool:
         """Check if path is a valid directory to scan for hints."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -113,6 +113,39 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Backend-specific instructions" in result
 
+    def test_terminal_cd_relative_directory(self, project):
+        """`cd backend` resolves relative to working_dir (issue #11032).
+
+        Before the fix, the generic token filter in
+        `_extract_paths_from_command` dropped bare directory names because
+        they contain no `/` or `.`, so Hermes silently missed AGENTS.md
+        in the entered subdirectory.
+        """
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "cd backend && ls"}
+        )
+        assert result is not None
+        assert "Backend-specific instructions" in result
+
+    def test_terminal_pushd_relative_directory(self, project):
+        """`pushd backend` behaves the same as `cd backend`."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "pushd backend"}
+        )
+        assert result is not None
+        assert "Backend-specific instructions" in result
+
+    def test_terminal_cd_in_later_subcommand(self, project):
+        """A `cd` later in a pipeline/chain is still picked up."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "echo starting; cd backend && ls"}
+        )
+        assert result is not None
+        assert "Backend-specific instructions" in result
+
     def test_relative_path(self, project):
         """Relative paths resolved against working_dir."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))


### PR DESCRIPTION
## Summary

`SubdirectoryHintTracker` silently missed `AGENTS.md` / `CLAUDE.md` / `.cursorrules` whenever a user navigated with a plain relative directory name like `cd backend && ls`. The generic token filter in `_extract_paths_from_command` requires a `/` or `.` in the token, which `backend` has neither of, so the target directory was never added as a hint candidate.

## Fix

Add `_extract_nav_command_targets`: scans the token stream for `cd` / `pushd` and treats the next non-flag token as a path candidate resolved against `working_dir`. The generic token pass still runs so absolute paths, files with extensions, etc. keep working. `cd -` (previous dir) and bare `cd` (home) are intentionally skipped — neither points at a project subdirectory worth augmenting with hints.

## Tests

Added three cases to `tests/agent/test_subdirectory_hints.py`:

- `test_terminal_cd_relative_directory` — `cd backend && ls` (the issue's minimal reproduction).
- `test_terminal_pushd_relative_directory` — same behavior under `pushd`.
- `test_terminal_cd_in_later_subcommand` — `cd` appearing after an earlier sub-command (`shlex.split` glues `;` to the previous token, so this exercises that the scan still finds the nav command).

Verified locally:

```
python -m pytest tests/agent/test_subdirectory_hints.py -p no:xdist -o addopts=''
# 21 passed
```

## Out of scope

Multi-step chains like `cd backend && cd src` still resolve each hop against `working_dir` rather than simulating the shell's evolving cwd — so this PR discovers hints under `<root>/backend` and `<root>/src` but not `<root>/backend/src`. That's a bigger change (shell state tracking across separator boundaries) and is outside the scope of the reported bug; happy to follow up if you want full chain tracking.

Fixes #11032
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
