### PR TITLE
fix(cron): treat empty agent response as error in last_status

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -979,6 +979,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)
 
+                # Treat empty final_response as a soft failure so last_status
+                # is not "ok" — the agent ran but produced nothing useful.
+                # (issue #8585)
+                if success and not final_response:
+                    success = False
+                    error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
                 executed += 1
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -180,6 +180,7 @@ AUTHOR_MAP = {
     "lisicheng168@gmail.com": "lesterli",
     "mingjwan@microsoft.com": "MagicRay1217",
     "orangeko@gmail.com": "GenKoKo",
+    "82095453+iacker@users.noreply.github.com": "iacker",
     "niyant@spicefi.xyz": "spniyant",
     "olafthiele@gmail.com": "olafthiele",
     "oncuevtv@gmail.com": "sprmn24",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -675,7 +675,7 @@ class TestRunJobSessionPersistence:
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).
-        
+
         The placeholder '(No response generated)' should only appear in the
         output log, not in the returned final_response that's used for delivery.
         """
@@ -693,7 +693,7 @@ class TestRunJobSessionPersistence:
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
                  return_value={
-                     "api_key": "test-key",
+                     "api_key": "***",
                      "base_url": "https://example.invalid/v1",
                      "provider": "openrouter",
                      "api_mode": "chat_completions",
@@ -713,6 +713,43 @@ class TestRunJobSessionPersistence:
         assert final_response == ""
         # But the output log should show the placeholder
         assert "(No response generated)" in output
+
+    def test_tick_marks_empty_response_as_error(self, tmp_path):
+        """When run_job returns success=True but final_response is empty,
+        tick() should mark the job as error so last_status != 'ok'.
+        (issue #8585)
+        """
+        from cron.scheduler import tick
+        from cron.jobs import load_jobs, save_jobs
+
+        job = {
+            "id": "empty-job",
+            "name": "empty-test",
+            "prompt": "do something",
+            "schedule": "every 1h",
+            "enabled": True,
+            "next_run_at": "2020-01-01T00:00:00",
+            "deliver": "local",
+            "last_status": None,
+        }
+
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler.get_due_jobs", return_value=[job]), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.mark_job_run") as mock_mark, \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
+            tick(verbose=False)
+
+        # Should be called with success=False because final_response is empty
+        mock_mark.assert_called_once()
+        call_args = mock_mark.call_args
+        assert call_args[0][0] == "empty-job"
+        assert call_args[0][1] is False  # success should be False
+        assert "empty" in call_args[0][2].lower()  # error should mention empty
 
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {


### PR DESCRIPTION
## Summary

Salvage of PR #8634 by @iacker.

**The bug:** When a cron job completes but the agent produces no output (e.g. silent API 404 from invalid model name), `run_job()` returns `success=True` with empty `final_response`. `tick()` then calls `mark_job_run(success=True)`, so `last_status` is stored as `"ok"` — the failure is completely invisible in `/cron list`. Users can go days without realizing their jobs are silently producing nothing.

**The fix:** In `tick()`, after `run_job()` returns, check if `success=True` but `final_response` is empty. If so, flip `success=False` with a descriptive error message before calling `mark_job_run()`. Uses existing error status — no new states, no API changes.

### Live test results (4 scenarios against real tick/jobs pipeline):

| Scenario | last_status | Result |
|----------|-------------|--------|
| success + empty response | `"error"` + diagnostic message | ✓ Fixed |
| success + real content | `"ok"` | ✓ No regression |
| success=False + real error | `"error"` + original message | ✓ No regression |
| mark_job_run arg interception | receives `success=False` | ✓ Fix fires correctly |

### Follow-up
- Added iacker to AUTHOR_MAP

## Files changed
- `cron/scheduler.py` — 7-line check in tick() (+7/-0)
- `tests/cron/test_scheduler.py` — regression test (+39/-2)
- `scripts/release.py` — AUTHOR_MAP entry (+1/-0)

## Test results
- `tests/cron/`: 171 passed, 4 skipped
- E2E: 4 scenarios against real job files on disk

Closes #8634. Fixes #8585.