### PR TITLE
fix #11031: pass task_count to child progress callback in batch mode

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -251,6 +251,8 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Batch context for progress display
+    task_count: int = 1,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -298,7 +300,7 @@ def _build_child_agent(
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
     # Build progress callback to relay tool calls to parent display
-    child_progress_cb = _build_child_progress_callback(task_index, parent_agent)
+    child_progress_cb = _build_child_progress_callback(task_index, parent_agent, task_count=task_count)
 
     # Each subagent gets its own iteration budget capped at max_iterations
     # (configurable via delegation.max_iterations, default 50).  This means
@@ -720,6 +722,7 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
+                task_count=len(task_list),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names


### PR DESCRIPTION
Fixes #11031

`_build_child_agent()` was called without `task_count` in batch mode, so `_build_child_progress_callback` defaulted to `task_count=1` and never showed the `[n]` task index prefix.

Changes:
- Added `task_count` parameter to `_build_child_agent()` (default 1)
- Passes `task_count` through to `_build_child_progress_callback()`
- Batch call site now passes `task_count=len(task_list)`