### PR TITLE
fix #11030: create branch session before ending original session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4263,13 +4263,8 @@ class HermesCLI:
         # Save the current session's state before branching
         parent_session_id = self.session_id
 
-        # End the old session
-        try:
-            self._session_db.end_session(self.session_id, "branched")
-        except Exception:
-            pass
-
-        # Create the new session with parent link
+        # Create the new session with parent link BEFORE ending the old one
+        # (so if creation fails, the original session remains active)
         try:
             self._session_db.create_session(
                 session_id=new_session_id,
@@ -4284,6 +4279,12 @@ class HermesCLI:
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")
             return
+
+        # Only end the old session after the new one is successfully created
+        try:
+            self._session_db.end_session(self.session_id, "branched")
+        except Exception:
+            pass
 
         # Copy conversation history to the new session
         for msg in self.conversation_history:


### PR DESCRIPTION
Fixes #11030

`/branch` marked the original session as ended with `end_reason="branched"` BEFORE creating the new session. If `create_session()` failed, the original session was left in an inconsistent state (ended but still active).

Changes:
- Moved `create_session()` call BEFORE `end_session()`
- If `create_session()` fails, the original session remains active
- Only ends the original session after the new one is successfully created