### PR TITLE
fix: UnboundLocalError on 'entry' in parallel subagent polling loop

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -806,28 +806,28 @@ def delegate_task(
                     results.append(entry)
                     completed_count += 1
 
-                # Print per-task completion line above the spinner
-                idx = entry["task_index"]
-                label = task_labels[idx] if idx < len(task_labels) else f"Task {idx}"
-                dur = entry.get("duration_seconds", 0)
-                status = entry.get("status", "?")
-                icon = "✓" if status == "completed" else "✗"
-                remaining = n_tasks - completed_count
-                completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
-                if spinner_ref:
-                    try:
-                        spinner_ref.print_above(completion_line)
-                    except Exception:
+                    # Print per-task completion line above the spinner
+                    idx = entry["task_index"]
+                    label = task_labels[idx] if idx < len(task_labels) else f"Task {idx}"
+                    dur = entry.get("duration_seconds", 0)
+                    status = entry.get("status", "?")
+                    icon = "✓" if status == "completed" else "✗"
+                    remaining = n_tasks - completed_count
+                    completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
+                    if spinner_ref:
+                        try:
+                            spinner_ref.print_above(completion_line)
+                        except Exception:
+                            print(f"  {completion_line}")
+                    else:
                         print(f"  {completion_line}")
-                else:
-                    print(f"  {completion_line}")
 
-                # Update spinner text to show remaining count
-                if spinner_ref and remaining > 0:
-                    try:
-                        spinner_ref.update_text(f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining")
-                    except Exception as e:
-                        logger.debug("Spinner update_text failed: %s", e)
+                    # Update spinner text to show remaining count
+                    if spinner_ref and remaining > 0:
+                        try:
+                            spinner_ref.update_text(f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining")
+                        except Exception as e:
+                            logger.debug("Spinner update_text failed: %s", e)
 
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])


### PR DESCRIPTION
## Summary

`delegate_task()` crashes with `cannot access local variable 'entry'` when parallel subagents are running.

**Root cause:** PR #10940 replaced `as_completed()` with `wait(timeout=0.5)` for interrupt support, but the completion-line printing block was left outside the `for future in done:` loop. When the 0.5s timeout expires with no futures completed, `done` is empty, the loop body never executes, `entry` is never assigned, and line 810 hits `UnboundLocalError`.

**Fix:** Moved completion-line printing + spinner update inside the `for future in done:` loop. Pure indentation change (20 lines in, 20 lines out). Each completed future now gets its own status line, and empty poll cycles loop back without accessing `entry`.

## Test plan
- `python3 -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py` — 72/72 pass