### PR TITLE
fix: pass resolved args to resolve_vision_provider_client()

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2391,10 +2391,10 @@ def call_llm(
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
-            provider=provider,
-            model=model,
-            base_url=base_url,
-            api_key=api_key,
+            provider=resolved_provider if resolved_provider != "auto" else provider,
+            model=resolved_model or model,
+            base_url=resolved_base_url or base_url,
+            api_key=resolved_api_key or api_key,
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -2599,10 +2599,10 @@ async def async_call_llm(
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
-            provider=provider,
-            model=model,
-            base_url=base_url,
-            api_key=api_key,
+            provider=resolved_provider if resolved_provider != "auto" else provider,
+            model=resolved_model or model,
+            base_url=resolved_base_url or base_url,
+            api_key=resolved_api_key or api_key,
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -1,0 +1,40 @@
+"""Test that call_llm vision path passes resolved provider args, not raw ones."""
+
+from unittest.mock import patch, MagicMock
+
+
+def test_vision_call_uses_resolved_provider_args():
+    """Resolved provider/model/key/url from config must reach resolve_vision_provider_client."""
+    from agent.auxiliary_client import call_llm
+
+    fake_client = MagicMock()
+    fake_client.chat.completions.create.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="description"))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("my-resolved-provider", "my-resolved-model", "http://resolved", "resolved-key", "chat_completions"),
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_vision_provider_client",
+            return_value=("my-resolved-provider", fake_client, "my-resolved-model"),
+        ) as mock_vision,
+    ):
+        call_llm(
+            "vision",
+            provider="raw-provider",
+            model="raw-model",
+            base_url="http://raw",
+            api_key="raw-key",
+            messages=[{"role": "user", "content": "describe this"}],
+        )
+
+    # The resolved values must be passed, not the raw call_llm arguments
+    call_args = mock_vision.call_args
+    assert call_args.kwargs["provider"] == "my-resolved-provider"
+    assert call_args.kwargs["model"] == "my-resolved-model"
+    assert call_args.kwargs["base_url"] == "http://resolved"
+    assert call_args.kwargs["api_key"] == "resolved-key"


### PR DESCRIPTION
Cherry-picked from #10901 by @lrawnsley.

`resolve_vision_provider_client()` was receiving the raw `call_llm` parameters instead of the resolved provider/model/key/url from `_resolve_task_provider_model()`. This caused config overrides (`auxiliary.vision.provider`, etc.) to be silently discarded.

## Test Results

```
tests/agent/test_auxiliary_client.py:          98 passed
tests/agent/test_vision_resolved_args.py:       1 passed (new)
```
