### PR TITLE
fix(run_agent): prevent _create_openai_client from mutating caller's kwargs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4340,6 +4340,15 @@ class AIAgent:
 
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+        # Treat client_kwargs as read-only. Callers pass self._client_kwargs (or shallow
+        # copies of it) in; any in-place mutation leaks back into the stored dict and is
+        # reused on subsequent requests. #10933 hit this by injecting an httpx.Client
+        # transport that was torn down after the first request, so the next request
+        # wrapped a closed transport and raised "Cannot send a request, as the client
+        # has been closed" on every retry. The revert resolved that specific path; this
+        # copy locks the contract so future transport/keepalive work can't reintroduce
+        # the same class of bug.
+        client_kwargs = dict(client_kwargs)
         _validate_proxy_env_urls()
         _validate_base_url(client_kwargs.get("base_url"))
         if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -1,0 +1,35 @@
+"""Guardrail: _create_openai_client must not mutate its input kwargs.
+
+#10933 injected an httpx.Client directly into the caller's ``client_kwargs``.
+When the dict was ``self._client_kwargs``, the shared transport was torn down
+after the first request_complete close and subsequent request-scoped clients
+wrapped a closed transport, raising ``APIConnectionError('Connection error.')``
+with cause ``RuntimeError: Cannot send a request, as the client has been closed``
+on every retry. That PR has since been reverted, but the underlying issue
+(#10324, connections hanging in CLOSE-WAIT) is still open, so another transport
+tweak inside this function is likely. This test pins the contract that the
+function must treat its input dict as read-only.
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = {"api_key": "test-key", "base_url": "https://api.example.com/v1"}
+    snapshot = dict(kwargs)
+
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    assert kwargs == snapshot, (
+        f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
+    )


### PR DESCRIPTION
Cherry-picked from #10978 by @taeuk178.

Shallow-copy `client_kwargs` at the top of `_create_openai_client()` to prevent in-place mutation from leaking back into `self._client_kwargs`. Defensive fix that locks the contract for future httpx/transport work.

## Test Results
```
tests/run_agent/test_create_openai_client_kwargs_isolation.py: 1 passed
```