### PR TITLE
fix: handle httpx.Timeout object in CopilotACPClient

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -313,9 +313,25 @@ class CopilotACPClient:
             tools=tools,
             tool_choice=tool_choice,
         )
+        # Normalise timeout: run_agent.py may pass an httpx.Timeout object
+        # (used natively by the OpenAI SDK) rather than a plain float.
+        if timeout is None:
+            _effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            _effective_timeout = float(timeout)
+        else:
+            # httpx.Timeout or similar — pick the largest component so the
+            # subprocess has enough wall-clock time for the full response.
+            _candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
+            _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
+
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
-            timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
+            timeout_seconds=_effective_timeout,
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)


### PR DESCRIPTION
## Summary

`run_agent.py` passes `httpx.Timeout(connect=30, read=120, write=1800, pool=30)` as the `timeout` kwarg on the streaming code path. The OpenAI SDK handles this natively, but `CopilotACPClient._create_chat_completion()` called `float(timeout or default)`, which raises:

```
TypeError: float() argument must be a string or a real number, not 'Timeout'
```

This caused copilot-acp to fail on the first streaming attempt with "Streaming failed before delivery" followed by "Non-retryable client error".

## Fix

Normalize the timeout value before passing to `_run_prompt()`:
- `None` → default 900s
- Plain `float`/`int` → pass through
- `httpx.Timeout` (or similar) → extract largest component (write=1800s is the appropriate wall-clock budget for the ACP subprocess)

## Test plan
- Existing test `test_aiagent_uses_copilot_acp_client` passes
- E2E verified: httpx.Timeout object correctly yields 1800.0, plain floats pass through, None uses default
- Confirmed the old code reproduces the exact TypeError from the bug report