### PR TITLE
fix(feishu): route WebSocket group im.message.receive_v1 events to message handler

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -971,6 +971,44 @@ def _unique_lines(lines: List[str]) -> List[str]:
     return unique
 
 
+def _decode_feishu_ws_payload(raw_message: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(raw_message, bytes):
+        try:
+            raw_message = raw_message.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    if not isinstance(raw_message, str):
+        return None
+    payload_text = raw_message.strip()
+    if not payload_text:
+        return None
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+class _FeishuRawPayloadWebSocketProxy:
+    def __init__(self, websocket: Any, adapter: Any):
+        self._websocket = websocket
+        self._adapter = adapter
+
+    async def recv(self, *args: Any, **kwargs: Any) -> Any:
+        message = await self._websocket.recv(*args, **kwargs)
+        self._adapter._handle_websocket_raw_payload(message)
+        return message
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._websocket, name)
+
+    def __aiter__(self) -> Any:
+        return self
+
+    async def __anext__(self) -> Any:
+        return await self.recv()
+
+
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
@@ -997,7 +1035,8 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return await original_connect(*args, **kwargs)
+        websocket = await original_connect(*args, **kwargs)
+        return _FeishuRawPayloadWebSocketProxy(websocket, adapter)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:
@@ -2354,6 +2393,27 @@ class FeishuAdapter(BasePlatformAdapter):
         if isinstance(value, list):
             return [FeishuAdapter._namespace_from_mapping(item) for item in value]
         return value
+
+    def _handle_websocket_raw_payload(self, raw_message: Any) -> None:
+        payload = _decode_feishu_ws_payload(raw_message)
+        if not payload:
+            return
+        event_type = str((payload.get("header") or {}).get("event_type") or "")
+        if event_type != "im.message.receive_v1":
+            return
+        data = self._namespace_from_mapping(payload)
+        event = getattr(data, "event", None)
+        message = getattr(event, "message", None)
+        chat_type = str(getattr(message, "chat_type", "") or "").strip().lower()
+        if not message or chat_type in {"", "p2p"}:
+            return
+        message_id = str(getattr(message, "message_id", "") or "")
+        logger.info(
+            "[Feishu] Fallback captured %s message %s",
+            chat_type,
+            message_id or "unknown",
+        )
+        self._on_message_event(data)
 
     async def _handle_webhook_request(self, request: Any) -> Any:
         remote_ip = (getattr(request, "remote", None) or "unknown")

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -601,6 +601,71 @@ class TestAdapterModule(unittest.TestCase):
         self.assertEqual(fake_client._ping_interval, 4)
 
 
+    def test_runtime_ws_wrapper_forwards_raw_payloads_to_adapter_fallback(self):
+        import sys
+        from types import ModuleType
+
+        class _FakeWebSocket:
+            def __init__(self):
+                self.messages = [json.dumps({"header": {"event_type": "im.message.receive_v1"}})]
+
+            async def recv(self):
+                return self.messages.pop(0)
+
+        class _FakeWSClient:
+            def __init__(self):
+                self._reconnect_nonce = 30
+                self._reconnect_interval = 120
+                self._ping_interval = 120
+
+            def _configure(self, _conf):
+                return None
+
+            def start(self):
+                async def _consume_one():
+                    websocket = await fake_client_module.websockets.connect()
+                    await websocket.recv()
+                    raise RuntimeError("stop test client")
+
+                asyncio.get_event_loop().run_until_complete(_consume_one())
+
+        captured = []
+        fake_client = _FakeWSClient()
+        fake_adapter = SimpleNamespace(
+            _ws_thread_loop=None,
+            _ws_reconnect_nonce=2,
+            _ws_reconnect_interval=3,
+            _ws_ping_interval=4,
+            _ws_ping_timeout=5,
+            _handle_websocket_raw_payload=lambda payload: captured.append(payload),
+        )
+        fake_client_module = ModuleType("lark_oapi.ws.client")
+        fake_client_module.loop = None
+
+        async def _connect(*_args, **_kwargs):
+            return _FakeWebSocket()
+
+        fake_client_module.websockets = SimpleNamespace(connect=_connect)
+        fake_ws_module = ModuleType("lark_oapi.ws")
+        fake_ws_module.client = fake_client_module
+        fake_root_module = ModuleType("lark_oapi")
+        fake_root_module.ws = fake_ws_module
+
+        original_modules = sys.modules.copy()
+        sys.modules["lark_oapi"] = fake_root_module
+        sys.modules["lark_oapi.ws"] = fake_ws_module
+        sys.modules["lark_oapi.ws.client"] = fake_client_module
+        try:
+            from gateway.platforms.feishu import _run_official_feishu_ws_client
+
+            _run_official_feishu_ws_client(fake_client, fake_adapter)
+        finally:
+            sys.modules.clear()
+            sys.modules.update(original_modules)
+
+        self.assertEqual(captured, [json.dumps({"header": {"event_type": "im.message.receive_v1"}})])
+
+
 class TestAdapterBehavior(unittest.TestCase):
     @patch.dict(os.environ, {}, clear=True)
     def test_build_event_handler_registers_reaction_and_card_processors(self):
@@ -667,6 +732,43 @@ class TestAdapterBehavior(unittest.TestCase):
                 "build",
             ],
         )
+
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_websocket_raw_payload_fallback_routes_group_messages_only(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._on_message_event = Mock()
+
+        adapter._handle_websocket_raw_payload(
+            json.dumps(
+                {
+                    "header": {"event_type": "im.message.receive_v1"},
+                    "event": {
+                        "message": {"message_id": "om_group", "chat_type": "group"},
+                    },
+                }
+            )
+        )
+        adapter._handle_websocket_raw_payload(
+            json.dumps(
+                {
+                    "header": {"event_type": "im.message.receive_v1"},
+                    "event": {
+                        "message": {"message_id": "om_p2p", "chat_type": "p2p"},
+                    },
+                }
+            )
+        )
+        adapter._handle_websocket_raw_payload(json.dumps({"header": {"event_type": "im.message.reaction.created_v1"}}))
+        adapter._handle_websocket_raw_payload("not json")
+
+        adapter._on_message_event.assert_called_once()
+        forwarded = adapter._on_message_event.call_args.args[0]
+        self.assertEqual(forwarded.event.message.message_id, "om_group")
+        self.assertEqual(forwarded.event.message.chat_type, "group")
 
     @patch.dict(os.environ, {}, clear=True)
     @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")


### PR DESCRIPTION
## Summary

- Fix Feishu/Lark WebSocket long-connection mode dropping group chat messages with event type `im.message.receive_v1`. The lark-oapi SDK dispatcher only handles events with registered `p2_*` handlers; group messages fall through unhandled.
- Add a lightweight raw-payload interception layer (`_FeishuRawPayloadWebSocketProxy`) that captures WebSocket messages before the SDK dispatcher and routes group `im.message.receive_v1` events directly to `_on_message_event`.
- P2P messages are intentionally skipped to avoid double-processing by the SDK's own `register_p2_im_message_receive_v1` handler.

## Root Cause

The lark-oapi `EventDispatcherHandler` raises errors for event types without a registered processor. The SDK only exposes `register_p2_*` methods, so `im.message.receive_v1` group events (which don't map to any `p2_*` handler) are silently dropped in WebSocket mode. Webhook mode works correctly because it dispatches directly by event type string.

## Changes

- **`_decode_feishu_ws_payload()`**: Safely parses raw WebSocket bytes/strings into JSON dicts
- **`_FeishuRawPayloadWebSocketProxy`**: Wraps the SDK websocket to intercept every received message
- **`_handle_websocket_raw_payload()`**: Routes group `im.message.receive_v1` events to `_on_message_event`, skipping p2p to avoid double-dispatch

## Test plan

- [x] `test_websocket_raw_payload_fallback_routes_group_messages_only` — verifies group messages are forwarded, p2p/non-message/malformed payloads are skipped
- [x] `test_runtime_ws_wrapper_forwards_raw_payloads_to_adapter_fallback` — verifies the WebSocket proxy intercepts and forwards raw payloads
- [x] All 92 existing tests pass (16 skipped due to missing lark-oapi in CI)

Related: #6889

---

*Unrelated changes in the working tree (`uv.lock`, `scripts/whatsapp-bridge/package-lock.json`) are not included in this PR.*