### PR TITLE
fix: wire Ollama Cloud into /model TUI picker (0 models regression)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -807,6 +807,10 @@ def list_authenticated_providers(
     # "nous" shares OpenRouter's curated list if not separately defined
     if "nous" not in curated:
         curated["nous"] = curated["openrouter"]
+    # Ollama Cloud uses dynamic discovery (no static curated list)
+    if "ollama-cloud" not in curated:
+        from hermes_cli.models import fetch_ollama_cloud_models
+        curated["ollama-cloud"] = fetch_ollama_cloud_models()
 
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1286,6 +1286,10 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         live = _fetch_ai_gateway_models()
         if live:
             return live
+    if normalized == "ollama-cloud":
+        live = fetch_ollama_cloud_models(force_refresh=force_refresh)
+        if live:
+            return live
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -114,6 +114,65 @@ class TestOllamaCloudModelCatalog:
         assert "ollama-cloud" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["ollama-cloud"] == "Ollama Cloud"
 
+    def test_provider_model_ids_returns_dynamic_models(self, tmp_path, monkeypatch):
+        """provider_model_ids('ollama-cloud') should call fetch_ollama_cloud_models()."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "qwen3.5:397b": {"tool_call": True},
+                    "glm-5": {"tool_call": True},
+                }
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            result = provider_model_ids("ollama-cloud", force_refresh=True)
+
+        assert len(result) > 0
+        assert "qwen3.5:397b" in result
+
+
+# ── Model Picker (list_authenticated_providers) ──
+
+class TestOllamaCloudModelPicker:
+    def test_ollama_cloud_shows_model_count(self, tmp_path, monkeypatch):
+        """Ollama Cloud should show non-zero model count in provider picker."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+
+        mock_mdev = {
+            "ollama-cloud": {
+                "models": {
+                    "qwen3.5:397b": {"tool_call": True},
+                    "glm-5": {"tool_call": True},
+                }
+            }
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.5:397b"]), \
+             patch("agent.models_dev.fetch_models_dev", return_value=mock_mdev):
+            providers = list_authenticated_providers(current_provider="ollama-cloud")
+
+        ollama = next((p for p in providers if p["slug"] == "ollama-cloud"), None)
+        assert ollama is not None, "ollama-cloud should appear when OLLAMA_API_KEY is set"
+        assert ollama["total_models"] > 0, "ollama-cloud should show non-zero model count"
+
+    def test_ollama_cloud_not_shown_without_creds(self, monkeypatch):
+        """Ollama Cloud should not appear without credentials."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        providers = list_authenticated_providers(current_provider="openrouter")
+        ollama = next((p for p in providers if p["slug"] == "ollama-cloud"), None)
+        assert ollama is None, "ollama-cloud should not appear without OLLAMA_API_KEY"
+
 
 # ── Merged Model Discovery ──
 


### PR DESCRIPTION
## Summary

Salvage of PR #10964 by @jvcl. Fixes #10977 — `/model` TUI picker shows "Ollama Cloud (0 models)" because `provider_model_ids()` and `list_authenticated_providers()` had no case for `"ollama-cloud"`.

Based on #10964 by @jvcl — cherry-picked with authorship preserved.

### Root cause

`fetch_ollama_cloud_models()` was implemented (PR #10782) but not wired into the two functions the `/model` TUI picker depends on:
- `provider_model_ids()` in `hermes_cli/models.py`
- `list_authenticated_providers()` in `hermes_cli/model_switch.py`

The `hermes model` CLI subcommand worked fine because it calls `fetch_ollama_cloud_models()` directly.

### Changes

- `hermes_cli/models.py`: Add `ollama-cloud` case to `provider_model_ids()` — follows the same pattern as anthropic, copilot, nous, ai-gateway
- `hermes_cli/model_switch.py`: Populate `curated` dict for `ollama-cloud` in `list_authenticated_providers()` — follows the existing nous pattern
- `tests/hermes_cli/test_ollama_cloud_provider.py`: Add 3 tests covering `provider_model_ids()`, `list_authenticated_providers()` model count, and negative (no creds) case

### Test plan
- 40 ollama-cloud tests pass
- 2153 broader CLI tests pass (11 pre-existing platform-specific failures)
- E2E verified: `provider_model_ids("ollama-cloud")` returns models via models.dev fallback
- Provider coverage audit confirmed ollama-cloud is fully wired across all 10+ enumeration sites
