### PR TITLE
fix(gateway): boot-md hook inherits model/provider/api_mode from config.yaml

### DIFF
--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -46,6 +46,25 @@ def _run_boot_agent(content: str) -> None:
     """Spawn a one-shot agent session to execute the boot instructions."""
     try:
         from run_agent import AIAgent
+        from hermes_cli.config import load_config
+
+        # Inherit model/provider/api_mode from config.yaml so the boot
+        # agent hits the user's configured endpoint. Without these,
+        # AIAgent falls back to defaults (model="", api_mode=None)
+        # and the init chain selects api_mode="chat_completions" — on
+        # an openai-codex setup that POSTs to
+        # chatgpt.com/backend-api/codex/chat/completions, a route the
+        # Codex backend doesn't expose (only /responses exists) → 404.
+        cfg = load_config()
+        model_cfg = cfg.get("model")
+        if isinstance(model_cfg, dict):
+            agent_kwargs = {
+                "model": model_cfg.get("default") or "",
+                "provider": model_cfg.get("provider") or None,
+                "api_mode": model_cfg.get("api_mode") or None,
+            }
+        else:
+            agent_kwargs = {"model": str(model_cfg or "")}
 
         prompt = _build_boot_prompt(content)
         agent = AIAgent(
@@ -53,6 +72,7 @@ def _run_boot_agent(content: str) -> None:
             skip_context_files=True,
             skip_memory=True,
             max_iterations=20,
+            **agent_kwargs,
         )
         result = agent.run_conversation(prompt)
         response = result.get("final_response", "")


### PR DESCRIPTION
## Summary

The built-in `boot-md` hook (`gateway/builtin_hooks/boot_md.py`) spawns a one-shot `AIAgent` on gateway startup without forwarding the user's model configuration. `AIAgent.__init__` then falls back to defaults (`model=""`, `provider=""`, `api_mode=None`), the api_mode resolution chain picks `chat_completions`, and on an `openai-codex` setup the boot agent POSTs to `chatgpt.com/backend-api/codex/chat/completions` — a route the Codex backend does not expose. The backend replies `HTTP 404 {"detail":"Not Found"}` and the boot checklist is aborted before anything runs.

This is the only `AIAgent` call in the codebase that skips the standard model-config plumbing — every other caller passes it in explicitly.

## Fix

Load `~/.hermes/config.yaml` via `hermes_cli.config.load_config()` inside `_run_boot_agent()` and forward `model` / `provider` / `api_mode` to `AIAgent`. Both the current dict shape (`model: {default, provider, api_mode}`) and the legacy string shape (`model: "..."`) are handled explicitly, matching how `runtime_provider.py` and `web_server.py` already read the config.

## Repro + verification

On a local install configured with:

```yaml
model:
  default: gpt-5.4
  provider: openai-codex
  api_mode: codex_responses
```

**Before fix** — session `20260416_220458_542285`:
- Request dump URL: `https://chatgpt.com/backend-api/codex/chat/completions`
- `body.model`: `""`
- Result: `HTTP 404 {"detail":"Not Found"}` — boot agent exits immediately, 0 messages exchanged

**After fix** — session `20260416_221913_84a6bb`:
- Session `model`: `"gpt-5.4"`
- Base URL resolves to `/responses`
- Result: 14 messages exchanged, boot checklist completes

## Test plan

- [ ] Existing tests still pass (no new tests added — change is a 15-line init site fix; covered indirectly by the standard `AIAgent` config path)
- [ ] Manual: restart a gateway configured with `openai-codex` + non-empty `BOOT.md` and confirm no `Non-retryable client error: 404` in `~/.hermes/logs/errors.log`