### PR TITLE
fix(pairing): preserve directory ownership for root writes

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -60,6 +60,16 @@ def _secure_write(path: Path, data: str) -> None:
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, str(path))
+        # In Docker, bot owners often run `docker exec ... hermes pairing approve`
+        # as root while the gateway itself runs as the non-root `hermes` user.
+        # Preserve the pairing directory owner/group so root-authored approval
+        # files stay readable without loosening the 0600 permission model.
+        try:
+            if hasattr(os, "chown") and getattr(os, "geteuid", lambda: -1)() == 0:
+                parent_stat = path.parent.stat()
+                os.chown(path, parent_stat.st_uid, parent_stat.st_gid)
+        except OSError:
+            pass
         try:
             os.chmod(path, 0o600)
         except OSError:

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -55,21 +55,26 @@ def _secure_write(path: Path, data: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
     try:
+        parent_stat = None
+        if hasattr(os, "fchown") and getattr(os, "geteuid", lambda: -1)() == 0:
+            try:
+                parent_stat = path.parent.stat()
+            except OSError:
+                parent_stat = None
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(data)
             f.flush()
             os.fsync(f.fileno())
+            # In Docker, bot owners often run `docker exec ... hermes pairing approve`
+            # as root while the gateway itself runs as the non-root `hermes` user.
+            # Preserve the pairing directory owner/group on the temp file before
+            # the atomic replace so we avoid path-based chown races as root.
+            if parent_stat is not None:
+                try:
+                    os.fchown(f.fileno(), parent_stat.st_uid, parent_stat.st_gid)
+                except OSError:
+                    pass
         os.replace(tmp_path, str(path))
-        # In Docker, bot owners often run `docker exec ... hermes pairing approve`
-        # as root while the gateway itself runs as the non-root `hermes` user.
-        # Preserve the pairing directory owner/group so root-authored approval
-        # files stay readable without loosening the 0600 permission model.
-        try:
-            if hasattr(os, "chown") and getattr(os, "geteuid", lambda: -1)() == 0:
-                parent_stat = path.parent.stat()
-                os.chown(path, parent_stat.st_uid, parent_stat.st_gid)
-        except OSError:
-            pass
         try:
             os.chmod(path, 0o600)
         except OSError:

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -50,13 +50,17 @@ class TestSecureWrite:
 
         monkeypatch.setattr("gateway.pairing.os.geteuid", lambda: 0)
         monkeypatch.setattr(
-            "gateway.pairing.os.chown",
-            lambda path, uid, gid: chown_calls.append((path, uid, gid)),
+            "gateway.pairing.os.fchown",
+            lambda fd, uid, gid: chown_calls.append((fd, uid, gid)),
+            raising=False,
         )
 
         _secure_write(target, "data")
 
-        assert chown_calls == [(target, parent_stat.st_uid, parent_stat.st_gid)]
+        assert len(chown_calls) == 1
+        fd, uid, gid = chown_calls[0]
+        assert isinstance(fd, int)
+        assert (uid, gid) == (parent_stat.st_uid, parent_stat.st_gid)
 
     def test_non_root_write_skips_owner_fixup(self, tmp_path, monkeypatch):
         target = tmp_path / "secret.json"
@@ -64,8 +68,9 @@ class TestSecureWrite:
 
         monkeypatch.setattr("gateway.pairing.os.geteuid", lambda: 1000)
         monkeypatch.setattr(
-            "gateway.pairing.os.chown",
-            lambda path, uid, gid: chown_calls.append((path, uid, gid)),
+            "gateway.pairing.os.fchown",
+            lambda fd, uid, gid: chown_calls.append((fd, uid, gid)),
+            raising=False,
         )
 
         _secure_write(target, "data")

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -43,6 +43,35 @@ class TestSecureWrite:
         mode = oct(target.stat().st_mode & 0o777)
         assert mode == "0o600"
 
+    def test_root_write_preserves_parent_owner_group(self, tmp_path, monkeypatch):
+        target = tmp_path / "secret.json"
+        parent_stat = target.parent.stat()
+        chown_calls = []
+
+        monkeypatch.setattr("gateway.pairing.os.geteuid", lambda: 0)
+        monkeypatch.setattr(
+            "gateway.pairing.os.chown",
+            lambda path, uid, gid: chown_calls.append((path, uid, gid)),
+        )
+
+        _secure_write(target, "data")
+
+        assert chown_calls == [(target, parent_stat.st_uid, parent_stat.st_gid)]
+
+    def test_non_root_write_skips_owner_fixup(self, tmp_path, monkeypatch):
+        target = tmp_path / "secret.json"
+        chown_calls = []
+
+        monkeypatch.setattr("gateway.pairing.os.geteuid", lambda: 1000)
+        monkeypatch.setattr(
+            "gateway.pairing.os.chown",
+            lambda path, uid, gid: chown_calls.append((path, uid, gid)),
+        )
+
+        _secure_write(target, "data")
+
+        assert chown_calls == []
+
 
 # ---------------------------------------------------------------------------
 # Code generation


### PR DESCRIPTION
## What does this PR do?

Fixes a Docker pairing regression where `hermes pairing approve` is often executed as `root` via `docker exec`, but the gateway itself runs as the non-root `hermes` user after the entrypoint drops privileges. Pairing state files are written with `0600`, so a root-authored `{platform}-approved.json` becomes unreadable to the runtime gateway and the approval is silently ignored.

This change keeps the existing `0600` permission model but makes root-authored writes inherit the pairing directory's owner/group. In the official Docker image that means approvals written from a root shell stay readable to the `hermes` gateway process without weakening file privacy.

## Related Issue

Fixes #10270

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/pairing.py`
- Preserve the pairing directory owner/group when `_secure_write()` runs as `root`, then keep the existing `0600` chmod.
- `tests/gateway/test_pairing.py`
- Add regression coverage for root vs non-root writes so the Docker ownership case stays fixed.

## How to Test

1. Run `python -m pytest tests/gateway/test_pairing.py -q`
2. Run `python -m pytest tests/gateway/test_internal_event_bypass_pairing.py -q`
3. Confirm `_secure_write()` keeps `0600` permissions and, when run as root, calls `chown()` with the pairing directory's owner/group.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Root cause:
- `_secure_write()` always wrote pairing state as the current user with `0600` permissions.
- In Docker, `docker exec` defaults to `root`, so `hermes pairing approve` produced root-owned approval files that the non-root gateway process could not read.
- `PairingStore._load_json()` treats unreadable files like missing files, so approvals were silently ignored.

Why this is the smallest safe fix:
- It stays inside the pairing write helper used by the approval flow.
- It preserves the existing privacy model (`0600`) instead of broadening readability.
- It relies on the existing pairing directory ownership, which is already correct in the official image when the gateway creates the directory as `hermes`.

Backward compatibility:
- Non-root writes are unchanged.
- Windows remains unchanged because the new owner fix-up is gated on `os.chown` and `geteuid() == 0`.
- Existing pairing files and formats are unchanged.

Validation commands and outcomes:
- `python -m pytest tests/gateway/test_pairing.py -q` → `30 passed`
- `python -m pytest tests/gateway/test_internal_event_bypass_pairing.py -q` → `8 passed`
- `git diff --check` → passed
- `python -m py_compile gateway/pairing.py tests/gateway/test_pairing.py` → passed
- `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` → repo baseline is not fully clean in this environment; unrelated failures were:
  - `tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_wsl_with_systemd`
  - `tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_native_linux`
  - `tests/tools/test_file_staleness.py::TestStalenessCheck::test_warning_when_file_modified_externally`
  - `tests/tools/test_file_staleness.py::TestPatchStaleness::test_patch_warns_on_stale_file`
  - three additional failures from the xdist run passed when rerun serially:
    - `tests/gateway/test_internal_event_bypass_pairing.py::test_non_internal_event_without_user_triggers_pairing`
    - `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once`
    - `tests/test_plugin_skills.py::TestSkillViewPluginGuards::test_injection_logged_but_served`

No standalone lint command is defined in the repo docs, so I did not invent one.

Adjacent surfaces checked:
- `PairingStore.approve_code()` / `_save_json()` / `_load_json()` flow in `gateway/pairing.py`
- pairing-related authorization path via `tests/gateway/test_internal_event_bypass_pairing.py`
