### PR TITLE
fix(agent): avoid reusing mutated http client kwargs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4353,6 +4353,11 @@ class AIAgent:
 
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+        # Never mutate the caller's kwargs in-place. Gateway sessions keep
+        # self._client_kwargs around for future request clients; if we stash a
+        # concrete http_client object into that dict, later "fresh" request
+        # clients will silently reuse the same stale transport pool.
+        client_kwargs = dict(client_kwargs)
         _validate_proxy_env_urls()
         _validate_base_url(client_kwargs.get("base_url"))
         if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
@@ -4375,6 +4380,10 @@ class AIAgent:
             try:
                 import httpx as _httpx
                 import socket as _socket
+                from openai._constants import (
+                    DEFAULT_CONNECTION_LIMITS as _OPENAI_DEFAULT_CONNECTION_LIMITS,
+                    DEFAULT_TIMEOUT as _OPENAI_DEFAULT_TIMEOUT,
+                )
                 _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
                 if hasattr(_socket, "TCP_KEEPIDLE"):
                     # Linux
@@ -4386,6 +4395,8 @@ class AIAgent:
                     _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
                 client_kwargs["http_client"] = _httpx.Client(
                     transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                    timeout=_OPENAI_DEFAULT_TIMEOUT,
+                    limits=_OPENAI_DEFAULT_CONNECTION_LIMITS,
                 )
             except Exception:
                 pass  # Fall through to default transport if socket opts fail

--- a/tests/run_agent/test_openai_client_lifecycle.py
+++ b/tests/run_agent/test_openai_client_lifecycle.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import httpx
 import pytest
 from openai import APIConnectionError
+from openai._constants import DEFAULT_TIMEOUT
 
 sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
 sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
@@ -152,6 +153,52 @@ def test_concurrent_requests_do_not_break_each_other_when_one_client_closes(monk
     assert sum(isinstance(value, APIConnectionError) for value in values) == 1
     assert values.count({"ok": "second"}) == 1
     assert len(factory.calls) == 2
+
+
+def test_keepalive_http_client_preserves_openai_default_timeout(monkeypatch):
+    factory = OpenAIFactory([FakeSharedClient(lambda **kwargs: {"ok": True})])
+    monkeypatch.setattr(run_agent, "OpenAI", factory)
+
+    agent = _build_agent()
+    _ = agent._create_openai_client(dict(agent._client_kwargs), reason="test_keepalive", shared=True)
+
+    assert len(factory.calls) == 1
+    http_client = factory.calls[0]["http_client"]
+    assert isinstance(http_client, httpx.Client)
+    assert http_client.timeout == DEFAULT_TIMEOUT
+    assert http_client.timeout != httpx.Timeout(5.0)
+    http_client.close()
+
+
+def test_keepalive_http_client_does_not_mutate_stored_client_kwargs(monkeypatch):
+    factory = OpenAIFactory([FakeSharedClient(lambda **kwargs: {"ok": True})])
+    monkeypatch.setattr(run_agent, "OpenAI", factory)
+
+    agent = _build_agent()
+    original = dict(agent._client_kwargs)
+    _ = agent._create_openai_client(agent._client_kwargs, reason="test_kwargs_immutability", shared=True)
+
+    assert agent._client_kwargs == original
+    assert "http_client" not in agent._client_kwargs
+    factory.calls[0]["http_client"].close()
+
+
+def test_request_client_gets_fresh_http_client_after_shared_client_creation(monkeypatch):
+    shared_client = FakeSharedClient(lambda **kwargs: {"shared": True})
+    request_client = FakeRequestClient(lambda **kwargs: {"ok": True})
+    factory = OpenAIFactory([shared_client, request_client])
+    monkeypatch.setattr(run_agent, "OpenAI", factory)
+
+    agent = _build_agent()
+    shared = agent._create_openai_client(agent._client_kwargs, reason="shared", shared=True)
+    agent.client = shared
+    req = agent._create_request_openai_client(reason="request")
+
+    assert len(factory.calls) == 2
+    assert factory.calls[0]["http_client"] is not factory.calls[1]["http_client"]
+    factory.calls[0]["http_client"].close()
+    factory.calls[1]["http_client"].close()
+    agent._close_request_openai_client(req, reason="test_cleanup")
 
 
 


### PR DESCRIPTION
## Summary
- avoid mutating caller-owned `client_kwargs` in `_create_openai_client()`
- preserve OpenAI SDK timeout/connection limits when injecting keepalive `http_client`
- add regression coverage for timeout preservation and per-request client isolation

## Root Cause
The keepalive change introduced a subtle gateway regression:

- `_create_openai_client()` inserted a concrete `http_client` into the passed `client_kwargs`
- gateway sessions retain `self._client_kwargs` across turns
- later request clients silently reused the same underlying `httpx.Client` / transport pool instead of getting a fresh one
- stale sockets then survived across retries/turns and produced repeated `APIConnectionError` / `APITimeoutError`

This was especially visible in long-running gateway processes, while fresh-shell `hermes chat -q ...` calls could still succeed.

## Fix
1. Copy `client_kwargs` on entry so the caller-owned dict is never mutated
2. Keep the TCP keepalive transport, but explicitly preserve OpenAI SDK default timeout / connection limits
3. Add regression tests to ensure:
   - `_client_kwargs` is not mutated
   - request clients do not reuse the shared client's `http_client`
   - keepalive clients do not fall back to `httpx`'s 5s default timeout

## How To Reproduce
Before this fix:
1. run Hermes through gateway with `openai-codex`
2. keep the gateway alive across multiple turns / retries
3. observe repeated `Connection error.` / `Request timed out.` even for tiny prompts
4. inspect the daemon with `lsof` and note lingering stale sockets / pool reuse behavior
5. compare with a fresh-shell `hermes chat -q ...`, which can still succeed

## Validation
Tests:
- `pytest tests/run_agent/test_openai_client_lifecycle.py -q`

Manual checks on macOS:
- `hermes chat -q` succeeds for both default and named profile
- threaded / gateway-like probes succeed
- default and ferriscluster gateway logs resumed normal responses after restart

## Platforms Tested
- macOS

Closes #11070