### PR TITLE
fix(model-switch): require OpenRouter key for openrouter.ai

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -21,6 +21,7 @@ OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
 from __future__ import annotations
 
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import List, NamedTuple, Optional
@@ -44,6 +45,37 @@ from agent.models_dev import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _openrouter_missing_key_error(*, target_provider: str, base_url: str, api_key: str) -> str:
+    """Detect the common OpenRouter auth misconfiguration during `/model`.
+
+    Users often have ``OPENAI_API_KEY`` in their shell and no
+    ``OPENROUTER_API_KEY``. Runtime resolution currently allows that
+    fallback, which means `/model --provider openrouter` appears to work,
+    but the first real request to ``openrouter.ai`` fails with HTTP 400.
+
+    Guard the model-switch path so provider selection fails early with a
+    precise setup message instead of persisting a broken OpenRouter config.
+    """
+    if target_provider != "openrouter":
+        return ""
+    if "openrouter.ai" not in (base_url or "").lower():
+        return ""
+
+    openrouter_key = str(os.getenv("OPENROUTER_API_KEY") or "").strip()
+    openai_key = str(os.getenv("OPENAI_API_KEY") or "").strip()
+    if openrouter_key or not openai_key:
+        return ""
+    if str(api_key or "").strip() != openai_key:
+        return ""
+
+    return (
+        "OpenRouter requires OPENROUTER_API_KEY. Hermes only found "
+        "OPENAI_API_KEY for this switch, which openrouter.ai will reject "
+        "and typically surfaces later as HTTP 400. Set OPENROUTER_API_KEY "
+        "or run `hermes setup` before switching to OpenRouter."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -671,6 +703,21 @@ def switch_model(
             api_mode = runtime.get("api_mode", "")
         except Exception:
             pass
+
+    openrouter_key_error = _openrouter_missing_key_error(
+        target_provider=target_provider,
+        base_url=base_url,
+        api_key=api_key,
+    )
+    if openrouter_key_error:
+        return ModelSwitchResult(
+            success=False,
+            new_model=new_model,
+            target_provider=target_provider,
+            provider_label=provider_label,
+            is_global=is_global,
+            error_message=openrouter_key_error,
+        )
 
     # --- Direct alias override: use exact base_url from the alias if set ---
     if resolved_alias:

--- a/tests/hermes_cli/test_model_switch_openrouter_auth.py
+++ b/tests/hermes_cli/test_model_switch_openrouter_auth.py
@@ -1,0 +1,79 @@
+"""Regression tests for OpenRouter auth validation during `/model` switching."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_explicit_openrouter_switch_requires_openrouter_api_key(monkeypatch):
+    """Refuse `/model --provider openrouter` when only OPENAI_API_KEY exists."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-fallback")
+
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "sk-openai-fallback",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="openai/gpt-5.4",
+            current_provider="nous",
+            current_model="hermes-3-llama-3.1-8b",
+            explicit_provider="openrouter",
+        )
+
+    assert result.success is False
+    assert "OPENROUTER_API_KEY" in result.error_message
+    assert "HTTP 400" in result.error_message
+
+
+def test_explicit_openrouter_switch_accepts_real_openrouter_key(monkeypatch):
+    """Allow the switch once OPENROUTER_API_KEY is actually configured."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-real")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-fallback")
+
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "sk-or-real",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="openai/gpt-5.4",
+            current_provider="nous",
+            current_model="hermes-3-llama-3.1-8b",
+            explicit_provider="openrouter",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "openrouter"
+    assert result.api_key == "sk-or-real"


### PR DESCRIPTION
## Summary
- refuse `/model` switches to `openrouter` when Hermes only found `OPENAI_API_KEY` for the real `openrouter.ai` endpoint
- surface a direct setup error that tells users to configure `OPENROUTER_API_KEY` before persisting the switch
- add regression coverage for both the failure path and the valid OpenRouter-key path

## Why
Users can currently switch to an OpenRouter model even when they only have `OPENAI_API_KEY` in their environment. That makes the switch look successful, but the first request to `openrouter.ai` fails later with a generic HTTP 400. Failing early in `/model` gives the user the actual fix instead of saving a broken provider selection.

Fixes #11057

## Testing
- `pytest -o addopts= tests/hermes_cli/test_model_switch_openrouter_auth.py tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/hermes_cli/test_model_switch_variant_tags.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_user_providers_model_switch.py`
