### PR TITLE
feat(gateway): add model and provider info to /status command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4481,6 +4481,14 @@ class GatewayRunner:
             model_name = "unknown"
             provider = "auto"
 
+        # Check for session override (same logic as /model command)
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        override = self._session_model_overrides.get(session_key, {})
+        if override:
+            model_name = override.get("model", model_name)
+            provider = override.get("provider", provider)
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4493,7 +4493,6 @@ class GatewayRunner:
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Tokens:** {session_entry.total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
-            "",
             f"**Model:** {model_name}",
             f"**Provider:** {provider}",
             "",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4466,6 +4466,21 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        # Get model info from config
+        from hermes_cli.config import load_config
+        try:
+            config = load_config()
+            model_cfg = config.get("model", {})
+            if isinstance(model_cfg, dict):
+                model_name = model_cfg.get("default") or model_cfg.get("name") or "unknown"
+                provider = model_cfg.get("provider") or "auto"
+            else:
+                model_name = str(model_cfg) if model_cfg else "unknown"
+                provider = "auto"
+        except Exception:
+            model_name = "unknown"
+            provider = "auto"
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -4478,6 +4493,9 @@ class GatewayRunner:
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Tokens:** {session_entry.total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
+            "",
+            f"**Model:** {model_name}",
+            f"**Provider:** {provider}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ])


### PR DESCRIPTION
## What does this PR do?

Adds model name and provider information to the gateway `/status` command output, with real-time session override support.

**Key improvement:** When you switch models with `/model`, `/status` immediately shows the new model instead of the global config. This brings `/status` to parity with `/new` and `/reset` commands.

## Related Issue

N/A - Small UX enhancement to help gateway users quickly verify their active model configuration.

## Changes Made

- Read model config from `config.yaml` in `_handle_status_command()`
- Check session-specific model overrides (same logic as `/model` command)
- Display "Model: {name}" and "Provider: {provider}" in status output
- Graceful error handling with fallback to "unknown" / "auto"

## How to Test

1. Start gateway: `hermes gateway start`
2. Send `/status` → verify shows current model/provider
3. Switch model: `/model minimax/MiniMax-M2.7`
4. Send `/status` again → verify shows MiniMax-M2.7 (not global config)
5. Test error handling: rename `config.yaml` → verify shows "unknown"/"auto" without crash

## Checklist

### Code
- [x] Read Contributing Guide
- [x] Conventional Commits format
- [x] Searched existing PRs
- [x] Only related changes
- [x] Tested on macOS
- [x] Session override feature verified working

### Documentation
- [x] No README/docs changes needed (output-only change)
- [x] No new config keys
- [x] No architecture changes
- [x] Cross-platform compatible (pathlib, YAML)
- [x] No tool schema changes

## Screenshots

**Before:**
```
📊 Hermes Gateway Status

Session ID: 20260417_045547_94fbb370
Created: 2026-04-17 04:55
Last Activity: 2026-04-17 05:09
Tokens: 0
Agent Running: No

Connected Platforms: telegram, weixin
```

**After (global config):**
```
📊 Hermes Gateway Status

Session ID: 20260417_045547_94fbb370
Created: 2026-04-17 04:55
Last Activity: 2026-04-17 05:09
Tokens: 0
Agent Running: No
Model: claude-sonnet-4-6
Provider: anthropic

Connected Platforms: telegram, weixin
```

**After model switch (session override):**
```
📊 Hermes Gateway Status

Session ID: 20260417_045547_94fbb370
Created: 2026-04-17 04:55
Last Activity: 2026-04-17 05:09
Tokens: 0
Agent Running: No
Model: MiniMax-M2.7
Provider: minimaxi.com

Connected Platforms: telegram, weixin
```

