### PR TITLE
fix(email): support SMTP-only outbound delivery

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -927,19 +927,25 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
 
     # Email
+    # SMTP is sufficient for outbound delivery; IMAP is optional and only
+    # needed when the email adapter should also ingest inbound mail.
     email_addr = os.getenv("EMAIL_ADDRESS")
     email_pwd = os.getenv("EMAIL_PASSWORD")
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    email_smtp_username = os.getenv("EMAIL_SMTP_USERNAME")
+    if all([email_addr, email_pwd, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True
         config.platforms[Platform.EMAIL].extra.update({
             "address": email_addr,
-            "imap_host": email_imap,
             "smtp_host": email_smtp,
         })
+        if email_smtp_username:
+            config.platforms[Platform.EMAIL].extra["smtp_username"] = email_smtp_username
+        if email_imap:
+            config.platforms[Platform.EMAIL].extra["imap_host"] = email_imap
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -79,9 +79,8 @@ def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
     addr = os.getenv("EMAIL_ADDRESS")
     pwd = os.getenv("EMAIL_PASSWORD")
-    imap = os.getenv("EMAIL_IMAP_HOST")
     smtp = os.getenv("EMAIL_SMTP_HOST")
-    if not all([addr, pwd, imap, smtp]):
+    if not all([addr, pwd, smtp]):
         return False
     return True
 
@@ -219,7 +218,7 @@ def _extract_attachments(
 
 
 class EmailAdapter(BasePlatformAdapter):
-    """Email gateway adapter using IMAP (receive) and SMTP (send)."""
+    """Email gateway adapter using optional IMAP receive and SMTP send."""
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
@@ -230,6 +229,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+        self._smtp_username = os.getenv("EMAIL_SMTP_USERNAME") or self._address
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
 
         # Skip attachments — configured via config.yaml:
@@ -270,21 +270,32 @@ class EmailAdapter(BasePlatformAdapter):
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
     async def connect(self) -> bool:
-        """Connect to the IMAP server and start polling for new messages."""
+        """Connect the SMTP sender and, if configured, start IMAP polling."""
         try:
-            # Test IMAP connection
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
-            # Mark all existing messages as seen so we only process new ones
-            imap.select("INBOX")
-            status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-            # Keep only the most recent UIDs to prevent unbounded growth
-            self._trim_seen_uids()
-            imap.logout()
-            logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
+            if self._imap_host:
+                # Test IMAP connection when inbound mail ingestion is enabled
+                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+                try:
+                    imap.login(self._address, self._password)
+                    # Mark all existing messages as seen so we only process new ones
+                    imap.select("INBOX")
+                    status, data = imap.uid("search", None, "ALL")
+                    if status == "OK" and data and data[0]:
+                        for uid in data[0].split():
+                            self._seen_uids.add(uid)
+                    # Keep only the most recent UIDs to prevent unbounded growth
+                    self._trim_seen_uids()
+                    logger.info(
+                        "[Email] IMAP connection test passed. %d existing messages skipped.",
+                        len(self._seen_uids),
+                    )
+                finally:
+                    try:
+                        imap.logout()
+                    except Exception:
+                        pass
+            else:
+                logger.info("[Email] IMAP disabled; running in SMTP-only mode.")
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
             return False
@@ -293,7 +304,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._smtp_username, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
@@ -301,7 +312,8 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         self._running = True
-        self._poll_task = asyncio.create_task(self._poll_loop())
+        if self._imap_host:
+            self._poll_task = asyncio.create_task(self._poll_loop())
         print(f"[Email] Connected as {self._address}")
         return True
 
@@ -512,7 +524,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._smtp_username, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -604,7 +616,7 @@ class EmailAdapter(BasePlatformAdapter):
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
             smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._smtp_username, self._password)
             smtp.send_message(msg)
         finally:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2482,7 +2482,7 @@ class GatewayRunner:
         elif platform == Platform.EMAIL:
             from gateway.platforms.email import EmailAdapter, check_email_requirements
             if not check_email_requirements():
-                logger.warning("Email: EMAIL_ADDRESS, EMAIL_PASSWORD, EMAIL_IMAP_HOST, or EMAIL_SMTP_HOST not set")
+                logger.warning("Email: EMAIL_ADDRESS, EMAIL_PASSWORD, or EMAIL_SMTP_HOST not set")
                 return None
             return EmailAdapter(config)
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -53,6 +53,21 @@ class TestConfigEnvOverrides(unittest.TestCase):
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",
         "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }, clear=False)
+    def test_email_config_loaded_smtp_only(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        self.assertIn(Platform.EMAIL, config.platforms)
+        self.assertTrue(config.platforms[Platform.EMAIL].enabled)
+        self.assertEqual(config.platforms[Platform.EMAIL].extra["address"], "hermes@test.com")
+        self.assertEqual(config.platforms[Platform.EMAIL].extra["smtp_host"], "smtp.test.com")
+        self.assertNotIn("imap_host", config.platforms[Platform.EMAIL].extra)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
         "EMAIL_IMAP_HOST": "imap.test.com",
         "EMAIL_SMTP_HOST": "smtp.test.com",
         "EMAIL_HOME_ADDRESS": "user@test.com",
@@ -85,6 +100,18 @@ class TestConfigEnvOverrides(unittest.TestCase):
         connected = config.get_connected_platforms()
         self.assertIn(Platform.EMAIL, connected)
 
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }, clear=False)
+    def test_email_in_connected_platforms_smtp_only(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        connected = config.get_connected_platforms()
+        self.assertIn(Platform.EMAIL, connected)
+
 
 class TestCheckRequirements(unittest.TestCase):
     """Verify check_email_requirements function."""
@@ -96,6 +123,15 @@ class TestCheckRequirements(unittest.TestCase):
         "EMAIL_SMTP_HOST": "smtp.b.com",
     }, clear=False)
     def test_requirements_met(self):
+        from gateway.platforms.email import check_email_requirements
+        self.assertTrue(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_PASSWORD": "pw",
+        "EMAIL_SMTP_HOST": "smtp.b.com",
+    }, clear=False)
+    def test_requirements_met_smtp_only(self):
         from gateway.platforms.email import check_email_requirements
         self.assertTrue(check_email_requirements())
 
@@ -688,7 +724,33 @@ class TestSendMethods(unittest.TestCase):
 
             self.assertTrue(result.success)
             mock_server.starttls.assert_called_once()
-            mock_server.login.assert_called_once_with("hermes@test.com", "secret")
+            mock_server.login.assert_called_once_with(adapter._smtp_username, "secret")
+            mock_server.send_message.assert_called_once()
+            mock_server.quit.assert_called_once()
+
+    def test_send_uses_custom_smtp_username(self):
+        """send() should use EMAIL_SMTP_USERNAME when provided."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_USERNAME": "smtp-login@test.com",
+        }, clear=False):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                adapter.send("user@test.com", "Hello from Hermes!")
+            )
+
+            self.assertTrue(result.success)
+            mock_server.login.assert_called_once_with("smtp-login@test.com", "secret")
             mock_server.send_message.assert_called_once()
             mock_server.quit.assert_called_once()
 
@@ -793,6 +855,17 @@ class TestConnectDisconnect(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def _make_smtp_only_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }, clear=False):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
     def test_connect_success(self):
         """Successful IMAP + SMTP connection returns True."""
         import asyncio
@@ -839,6 +912,26 @@ class TestConnectDisconnect(unittest.TestCase):
              patch("smtplib.SMTP", side_effect=Exception("SMTP down")):
             result = asyncio.run(adapter.connect())
             self.assertFalse(result)
+
+    def test_connect_smtp_only_success(self):
+        """SMTP-only configuration should connect without IMAP polling."""
+        import asyncio
+        adapter = self._make_smtp_only_adapter()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            self.assertTrue(adapter._running)
+            self.assertIsNone(adapter._poll_task)
+            mock_server.starttls.assert_called_once()
+            mock_server.login.assert_called_once_with(adapter._smtp_username, "secret")
+            mock_server.quit.assert_called_once()
+
+            adapter._running = False
 
     def test_disconnect_cancels_poll(self):
         """disconnect() should cancel the polling task."""
@@ -1026,6 +1119,29 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertEqual(result["platform"], "email")
             _, kwargs = mock_server.starttls.call_args
             self.assertIsInstance(kwargs["context"], ssl.SSLContext)
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_USERNAME": "smtp-login@test.com",
+        "EMAIL_SMTP_PORT": "587",
+    })
+    def test_send_email_tool_uses_custom_smtp_username(self):
+        """_send_email should prefer EMAIL_SMTP_USERNAME when provided."""
+        import asyncio
+        from tools.send_message_tool import _send_email
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                _send_email({"address": "hermes@test.com", "smtp_host": "smtp.test.com"}, "user@test.com", "Hello")
+            )
+
+            self.assertTrue(result["success"])
+            mock_server.login.assert_called_once_with("smtp-login@test.com", "secret")
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -830,6 +830,11 @@ async def _send_email(extra, chat_id, message):
     from email.mime.text import MIMEText
 
     address = extra.get("address") or os.getenv("EMAIL_ADDRESS", "")
+    smtp_username = (
+        extra.get("smtp_username")
+        or os.getenv("EMAIL_SMTP_USERNAME", "")
+        or address
+    )
     password = os.getenv("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or os.getenv("EMAIL_SMTP_HOST", "")
     try:
@@ -848,7 +853,7 @@ async def _send_email(extra, chat_id, message):
 
         server = smtplib.SMTP(smtp_host, smtp_port)
         server.starttls(context=ssl.create_default_context())
-        server.login(address, password)
+        server.login(smtp_username, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}


### PR DESCRIPTION
## Summary
- allow the email gateway to start in SMTP-only mode when IMAP is intentionally omitted
- treat `EMAIL_IMAP_HOST` as optional in gateway email config/requirements
- prefer `EMAIL_SMTP_USERNAME` for SMTP authentication while keeping `EMAIL_ADDRESS` as the visible sender
- add regression coverage for SMTP-only config and custom SMTP usernames

## Why
Some outbound-only setups intentionally do not grant IMAP access. Requiring `EMAIL_IMAP_HOST` prevents Hermes from enabling email delivery even when SMTP is fully configured and sufficient for the use case.

This keeps inbound email behavior unchanged when IMAP is configured, but stops treating IMAP as mandatory for outbound delivery.

## Test Plan
- `source /home/hermes/.hermes/hermes-agent/venv/bin/activate && pytest tests/gateway/test_email.py -q`
- `source /home/hermes/.hermes/hermes-agent/venv/bin/activate && pytest tests/gateway/test_config.py -q`
