### PR TITLE
gateway: rewrite transcripts atomically to avoid mid-write corruption

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import json
+import tempfile
 import threading
 import uuid
 from pathlib import Path
@@ -1002,11 +1003,27 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
         
-        # JSONL: overwrite the file
+        # JSONL: rewrite atomically so interrupts never leave a truncated file.
         transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(transcript_path.parent),
+            suffix=".tmp",
+            prefix=f".{transcript_path.stem}_",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for msg in messages:
+                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, transcript_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError as e:
+                logger.debug("Could not remove temp transcript %s: %s", tmp_path, e)
+            raise
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -420,6 +420,37 @@ class TestSessionStoreRewriteTranscript:
         reloaded = store.load_transcript(session_id)
         assert reloaded == []
 
+    def test_rewrite_failure_preserves_existing_transcript(self, store, monkeypatch):
+        session_id = "test_session_atomicity"
+        original_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "keep this"},
+        ]
+        for msg in original_messages:
+            store.append_to_transcript(session_id, msg)
+
+        real_json_dumps = json.dumps
+        call_count = 0
+
+        def _crash_on_second_message(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise RuntimeError("simulated mid-write failure")
+            return real_json_dumps(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.session.json.dumps", _crash_on_second_message)
+
+        with pytest.raises(RuntimeError, match="simulated mid-write failure"):
+            store.rewrite_transcript(session_id, [
+                {"role": "user", "content": "new hello"},
+                {"role": "assistant", "content": "new hi"},
+            ])
+
+        reloaded = store.load_transcript(session_id)
+        assert reloaded == original_messages
+
 
 class TestLoadTranscriptCorruptLines:
     """Regression: corrupt JSONL lines (e.g. from mid-write crash) must be


### PR DESCRIPTION
## Summary

`SessionStore.rewrite_transcript()` was rewriting legacy JSONL transcripts in-place with `"w"` mode. If Hermes crashed or a serialization error happened mid-rewrite, the transcript file could be left truncated even though the previous version was still valid.

This patch makes transcript rewrites atomic by writing to a temporary sibling file, flushing and fsyncing it, and then swapping it into place with `os.replace()`.

## Why 

This is a small reliability fix, but it closes a real failure mode in a sensitive code path used by `/retry`, `/undo`, and `/compress`.

Before this change:
- a mid-write failure could partially overwrite the JSONL transcript
- legacy sessions that still rely on JSONL fallback could lose usable history
- subsequent `load_transcript()` calls could observe truncated state

After this change:
- the old transcript remains intact unless the replacement file is fully written
- interruptions and serialization failures no longer corrupt the existing JSONL transcript
- rewrite behavior is consistent with the repo’s other atomic-write patterns

## Changes

- update `gateway/session.py` so `rewrite_transcript()` uses:
  - temp file in the same directory
  - `flush()` + `os.fsync()`
  - atomic `os.replace()`
  - temp-file cleanup on failure
- add regression coverage in `tests/gateway/test_session.py` for a simulated mid-write serialization failure

## Test coverage

Ran:

```powershell
uv run --extra dev pytest tests\gateway\test_session.py -k "test_rewrite_failure_preserves_existing_transcript" -v

Result:
PASSED

Also verified the broader test_session.py gateway session tests completed successfully.
