### PR TITLE
fix(run_agent): honor model.context_length override for sub-64K models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1351,10 +1351,12 @@ class AIAgent:
         self.compression_enabled = compression_enabled
 
         # Reject models whose context window is below the minimum required
-        # for reliable tool-calling workflows (64K tokens).
+        # for reliable tool-calling workflows (64K tokens). Honor an explicit
+        # operator override — the error message below documents this escape
+        # hatch (set model.context_length in config.yaml).
         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
         _ctx = getattr(self.context_compressor, "context_length", 0)
-        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and _config_context_length is None:
             raise ValueError(
                 f"Model {self.model} has a context window of {_ctx:,} tokens, "
                 f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "


### PR DESCRIPTION
## Summary

Commit c8aff7463 ("prevent agent from stopping mid-task") added a `MINIMUM_CONTEXT_LENGTH=64K` guard in `AIAgent.__init__` that rejects agent initialization for any model whose native context window is smaller than 64K. The raised `ValueError` explicitly documents an escape hatch:

> "or set `model.context_length` in config.yaml to override"

But the guard fires unconditionally — it never checks whether the operator actually set `model.context_length` in `config.yaml`. The promised escape hatch is cosmetic.

## Fix

Add `and _config_context_length is None` to the gate condition. `_config_context_length` is already a local variable in the same `__init__` method, populated from the config.yaml value, so no additional plumbing is needed.

## Behavior change

- **Default** (operator has not set `model.context_length`): unchanged — guard still fires, agent still refuses to start against sub-64K models.
- **Override** (operator explicitly sets `model.context_length` in config.yaml, accepting sub-64K risk): agent now starts, matching what the error message already promises.

## Repro

1. In `config.yaml`:
   ```yaml
   model:
     context_length: 32000
   ```
2. Run `hermes chat -q "hello" -Q` against a model with a 32K native context (e.g. Qwen 3.5 35B-A3B).
3. **Before:** `ValueError: Model ... has a context window of 32,000 tokens, which is below the minimum 65,536...`
4. **After:** Agent starts normally, runs to completion.

## Related

Addresses Bug 1 from #11096 (combined issue covering three v0.9.0 rough edges).
