### PR TITLE
fix(anthropic_adapter): guard against trailing thinking block in assistant turns

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1181,6 +1181,25 @@ def convert_messages_to_anthropic(
             if isinstance(b, dict) and b.get("type") in _THINKING_TYPES:
                 b.pop("cache_control", None)
 
+    # Guard against assistant messages whose FINAL content block is a thinking
+    # block. The Anthropic API rejects these with HTTP 400:
+    #   "messages.N: The final block in an assistant message cannot be `thinking`."
+    # Context compression / session truncation can leave a message in this
+    # state by snipping the trailing text or tool_use block while leaving the
+    # thinking block intact. Once this happens, every subsequent API call in
+    # the session fails identically until the session state is purged.
+    #
+    # Append a minimal text sentinel so the turn ends on a valid block.
+    # Preserves reasoning content above; costs one extra token per affected
+    # message. Upstream of this point should ideally prevent the state from
+    # being created — this is a safety net.
+    for m in result:
+        if m.get("role") != "assistant" or not isinstance(m.get("content"), list) or not m["content"]:
+            continue
+        last_block = m["content"][-1]
+        if isinstance(last_block, dict) and last_block.get("type") in _THINKING_TYPES:
+            m["content"].append({"type": "text", "text": "(continuing)"})
+
     return system, result
 
 


### PR DESCRIPTION
## Summary

Anthropic's Messages API rejects any assistant message whose **final content block** is `thinking` or `redacted_thinking` with HTTP 400:

```
messages.N: The final block in an assistant message cannot be `thinking`.
```

Context compression / session truncation upstream of `convert_messages_to_anthropic()` can leave a session's final assistant turn in this state — the trailing `text` or `tool_use` block is snipped while the thinking block survives. Once the state is created, **every subsequent API call in the session fails identically** until the `.jsonl` is manually moved out of `sessions/`. The session is effectively poisoned.

## Fix

Guard at the end of `convert_messages_to_anthropic()`, after the existing thinking-block processing loop. If any assistant message's final content block is still `thinking` / `redacted_thinking`, append a minimal text sentinel (`"(continuing)"`) so the turn ends on a valid block. Reasoning content above is preserved; cost is one extra token per afflicted message.

```python
for m in result:
    if m.get("role") != "assistant" or not isinstance(m.get("content"), list) or not m["content"]:
        continue
    last_block = m["content"][-1]
    if isinstance(last_block, dict) and last_block.get("type") in _THINKING_TYPES:
        m["content"].append({"type": "text", "text": "(continuing)"})
```

## Safety-net, not root cause

This is a safety net — a proper fix would prevent the invalid state from being created upstream (likely in `agent/context_engine.py` or the compressor). The guard here ensures a poisoned session can still make forward progress while that deeper investigation happens.

## Validation

Replayed a captured 400-causing production request through the patched converter. Before the fix: API rejects with HTTP 400. After the fix: payload is valid, `messages[N]` now ends in the sentinel text block, the session resumes normally on the next call. An anonymized minimal repro skeleton is included inline in the linked issue.

## Detection

Any afflicted session `.jsonl` will have an assistant turn whose `content[-1].type` is `"thinking"` or `"redacted_thinking"`. Operators who suspect their session is poisoned can grep their `sessions/` directory and manually purge affected files — this PR prevents the rejection at runtime but doesn't heal already-saved state.

## Related

Addresses Bug 2 from #11096 (combined issue covering three v0.9.0 rough edges).
