### PR TITLE
fix(gateway): write clean-shutdown marker before drain to preserve session context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2304,6 +2304,15 @@ class GatewayRunner:
             self._running = False
             self._draining = True
 
+            # Write clean-shutdown marker EARLY — before drain begins — so that
+            # even if systemd SIGKILLs us due to TimeoutStopSec (60s), the marker
+            # already exists. This prevents suspend_recently_active() from
+            # auto-resetting sessions on the next startup.
+            try:
+                (_hermes_home / ".clean_shutdown").touch()
+            except Exception:
+                pass
+
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.
             await self._notify_active_sessions_of_shutdown()
@@ -2378,14 +2387,10 @@ class GatewayRunner:
             from gateway.status import remove_pid_file
             remove_pid_file()
 
-            # Write a clean-shutdown marker so the next startup knows this
-            # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits.  However, if the drain timed out and
-            # agents were force-interrupted, their sessions may be in an
-            # incomplete state (trailing tool response, no final assistant
-            # message).  Skip the marker in that case so the next startup
-            # suspends those sessions — giving users a clean slate instead
-            # of resuming a half-finished tool loop.
+            # Clean-shutdown marker was already written at the top of _stop_impl()
+            # (before drain), so it exists even if systemd SIGKILLs us during a
+            # long drain.  Re-touch here as a no-op for completeness.
+            # (See the early write above for the real safeguard.)
             if not timed_out:
                 try:
                     (_hermes_home / ".clean_shutdown").touch()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -211,6 +211,7 @@ AUTHOR_MAP = {
     "zzn+pa@zzn.im": "xinbenlv",
     "zaynjarvis@gmail.com": "ZaynJarvis",
     "zhiheng.liu@bytedance.com": "ZaynJarvis",
+    "brantzh6@users.nore.github.com": "brantzh6",
 }
 
 


### PR DESCRIPTION
## Problem

When the gateway stops (`hermes update`, `hermes gateway restart`, `/restart`), it writes a `.clean_shutdown` marker **after** draining active agents. If the drain exceeds systemd's `TimeoutStopSec` (default 60s), systemd sends SIGKILL and the marker is never written.

On the next startup, `suspend_recently_active()` sees no marker, concludes it was a crash, and **resets all recently-active sessions** — wiping conversation context.

## Impact on messaging users

For users on Telegram, Discord, Feishu, WeChat etc., conversation continuity is critical. They expect the agent to remember what was just discussed. Losing context after a gateway restart is jarring and breaks trust:

- User is mid-discussion about a complex task
- Admin runs `hermes update` → gateway restarts
- Drain takes >60s (common with long-running tool calls, multiple active agents)
- systemd SIGKILLs the process
- User returns, sends a follow-up message → **blank slate, agent has no memory of the prior conversation**

## Evidence

In production over 3 days, we observed **6 SIGKILL events** from systemd due to drain timeout:

```
Apr 14 14:05:39 systemd: Killing process 263 (python) with signal SIGKILL.
Apr 14 22:11:21 systemd: Killing process 231 (python) with signal SIGKILL.
Apr 15 08:03:03 python: Gateway drain timed out after 60.0s with 2 active agent(s)
Apr 15 08:03:04 systemd: Killing process 1412 (python) with signal SIGKILL.
Apr 15 09:00:58 systemd: Killing process 6263 (python) with signal SIGKILL.
Apr 16 12:31:19 python: Gateway drain timed out after 60.0s with 1 active agent(s)
Apr 16 12:31:29 systemd: hermes-gateway.service: Failed with result exit-code.
```

Without this fix, each of these events would cause session context loss for active users.

## Solution

Move the `.clean_shutdown` marker write to **before** drain begins. Two-line change:

1. **Early write** (top of `_stop_impl()`): Write marker immediately when stop begins, before any drain logic
2. **Late re-touch** (after drain): Keep the existing write as a no-op for completeness

This guarantees the marker survives even if SIGKILL arrives during drain.

## Tradeoff

The old code intentionally skipped the marker when drain timed out, reasoning that force-interrupted sessions might be in an inconsistent state (trailing tool response, no final assistant message). That's a valid concern, but:

1. **Losing the entire conversation is worse** than resuming a slightly stale state
2. The agent can handle a trailing tool result gracefully — it just continues
3. The stuck-loop detector (`_suspend_stuck_loop_sessions`) already catches genuinely stuck sessions across 3+ restarts

## Testing

- Deployed in production with this patch for 3 days
- Gateway restarted multiple times (both planned and SIGKILL)
- All active sessions resumed seamlessly after restart
- No false-positive session resets observed