### PR TITLE
fix(tools): add Slack channel ID parsing to send_message target resolution

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -910,6 +910,77 @@ class TestParseTargetRefMatrix:
         assert is_explicit is False
 
 
+class TestParseTargetRefSlack:
+    """_parse_target_ref correctly handles Slack channel, DM, and group IDs."""
+
+    def test_slack_channel_id_is_explicit(self):
+        """Slack channel IDs (C prefix) are recognized as explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "C0ANYSL2GBE")
+        assert chat_id == "C0ANYSL2GBE"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_slack_dm_id_is_explicit(self):
+        """Slack DM IDs (D prefix) are recognized as explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "D0ATJM3B9UH")
+        assert chat_id == "D0ATJM3B9UH"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_slack_group_id_is_explicit(self):
+        """Slack group IDs (G prefix) are recognized as explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "G0ABCDE5F")
+        assert chat_id == "G0ABCDE5F"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_slack_id_with_thread_timestamp(self):
+        """Slack IDs with thread timestamp (colon-separated) parse both parts."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "C0ANYSL2GBE:1776351448.347679")
+        assert chat_id == "C0ANYSL2GBE"
+        assert thread_id == "1776351448.347679"
+        assert is_explicit is True
+
+    def test_slack_bot_id_is_explicit(self):
+        """Slack bot IDs (B prefix) are recognized as explicit targets."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "B0XYZ123ABC")
+        assert chat_id == "B0XYZ123ABC"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_slack_usergroup_id_is_explicit(self):
+        """Slack usergroup/app IDs (U, F, V, W prefixes) are recognized."""
+        for prefix in ["U", "F", "V", "W"]:
+            uid = f"{prefix}0ABC123DEF"
+            chat_id, thread_id, is_explicit = _parse_target_ref("slack", uid)
+            assert chat_id == uid, f"Failed for prefix {prefix}"
+            assert thread_id is None
+            assert is_explicit is True
+
+    def test_slack_id_only_matches_slack_platform(self):
+        """Slack-style IDs on non-slack platforms are not treated as explicit."""
+        chat_id, _, is_explicit = _parse_target_ref("telegram", "C0ANYSL2GBE")
+        assert is_explicit is False
+
+        chat_id, _, is_explicit = _parse_target_ref("discord", "C0ANYSL2GBE")
+        assert is_explicit is False
+
+    def test_slack_lowercase_id_not_matched(self):
+        """Lowercase Slack-style IDs are not matched (real IDs use uppercase)."""
+        chat_id, _, is_explicit = _parse_target_ref("slack", "c0anysl2gbe")
+        assert is_explicit is False
+
+    def test_slack_invalid_prefix_not_matched(self):
+        """IDs starting with non-Slack prefixes (e.g. X, Z) are not matched."""
+        chat_id, _, is_explicit = _parse_target_ref("slack", "X0ANYSL2GBE")
+        assert is_explicit is False
+
+    def test_slack_id_with_invalid_thread_not_matched(self):
+        """Slack IDs with non-numeric thread parts are not matched."""
+        chat_id, _, is_explicit = _parse_target_ref("slack", "C0ANYSL2GBE:abc")
+        assert is_explicit is False
+
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -949,13 +949,20 @@ class TestParseTargetRefSlack:
         assert is_explicit is True
 
     def test_slack_usergroup_id_is_explicit(self):
-        """Slack usergroup/app IDs (U, F, V, W prefixes) are recognized."""
+        """Slack user (U), file (F), app (V), and workspace (W) IDs are recognized."""
         for prefix in ["U", "F", "V", "W"]:
             uid = f"{prefix}0ABC123DEF"
             chat_id, thread_id, is_explicit = _parse_target_ref("slack", uid)
             assert chat_id == uid, f"Failed for prefix {prefix}"
             assert thread_id is None
             assert is_explicit is True
+
+    def test_slack_id_with_whitespace_is_trimmed(self):
+        """Whitespace-padded Slack IDs are trimmed and recognized."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("slack", "  C0ANYSL2GBE  ")
+        assert chat_id == "C0ANYSL2GBE"
+        assert thread_id is None
+        assert is_explicit is True
 
     def test_slack_id_only_matches_slack_platform(self):
         """Slack-style IDs on non-slack platforms are not treated as explicit."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
+# Slack IDs: B (bot), C (channel), D (DM), F (file), G (group), U (user), V (app), W (workspace).
+# May include a thread timestamp after a colon (e.g. C0ANYSL2GBE:1776351448.347679).
+_SLACK_ID_RE = re.compile(r"^\s*([BCDFGUVW][A-Z0-9]+)(?::(\d+\.\d+))?\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
@@ -290,10 +293,7 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
-    # Slack IDs: C (channel), D (DM), G (group), B (bot) followed by alphanumeric.
-    # May include a thread timestamp after a colon (e.g. C0ANYSL2GBE:1776351448.347679).
     if platform_name == "slack":
-        _SLACK_ID_RE = re.compile(r"^([BCDFGUVW][A-Z0-9]+)(?::(\d+\.\d+))?$")
         match = _SLACK_ID_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -290,6 +290,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    # Slack IDs: C (channel), D (DM), G (group), B (bot) followed by alphanumeric.
+    # May include a thread timestamp after a colon (e.g. C0ANYSL2GBE:1776351448.347679).
+    if platform_name == "slack":
+        _SLACK_ID_RE = re.compile(r"^([BCDFGUVW][A-Z0-9]+)(?::(\d+\.\d+))?$")
+        match = _SLACK_ID_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
## What Changed

Added Slack channel ID parsing to `_parse_target_ref()` in `tools/send_message_tool.py`.

## Why

`_parse_target_ref` had handlers for Telegram, Discord, Feishu, WeChat, and Matrix — but **not Slack**. When `send_message` was called with a Slack channel ID target (e.g. `slack:C0ANYSL2GBE`), the ID was not recognized as explicit, causing the message to fall through to the home channel instead of being sent to the specified channel.

Slack channel IDs start with uppercase letters indicating their type:
- **C** = channel
- **D** = DM
- **G** = group (private channel)
- **B** = bot
- **U/F/V/W** = user/app identifiers

They may also include a thread timestamp after a colon (e.g. `C0ANYSL2GBE:1776351448.347679`).

## Changes

### `tools/send_message_tool.py`
- Added Slack ID regex `^([BCDFGUVW][A-Z0-9]+)(?::(\d+\.\d+))?$` to `_parse_target_ref`
- Returns `(channel_id, thread_ts, True)` for recognized Slack IDs
- Positioned before the generic numeric fallback to prevent false matches

### `tests/tools/test_send_message_tool.py`
- Added `TestParseTargetRefSlack` class with **10 new tests**:
  - Valid IDs for all prefixes (C, D, G, B, U, F, V, W)
  - Thread timestamp extraction
  - Platform specificity (Slack IDs not matched on Telegram/Discord)
  - Negative cases (lowercase, invalid prefix, malformed thread)

## How to Test

```bash
source venv/bin/activate
pytest tests/tools/test_send_message_tool.py::TestParseTargetRefSlack -v
```

All 19 parse_target tests pass:
```bash
pytest tests/tools/test_send_message_tool.py -v -k "parse_target" -o "addopts="
```

## Platforms Tested

- Linux (Python 3.11.15)
- All existing send_message tests continue to pass
- 10 new Slack ID parsing tests pass