### PR TITLE
fix(gateway): honor platforms.signal.enabled=false over SIGNAL_* env vars

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1167,14 +1167,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     signal_account = os.getenv("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
         if Platform.SIGNAL not in config.platforms:
-            # Not declared in config.yaml — env vars alone enable Signal.
+            # Not declared in any existing config source — env vars alone
+            # enable Signal.
             config.platforms[Platform.SIGNAL] = PlatformConfig(enabled=True)
-        # When platforms.signal is already declared in config.yaml, preserve
+        # When ``platforms.signal`` is already present in ``config.platforms``
+        # — from either ``config.yaml`` or legacy ``gateway.json`` — preserve
         # its ``enabled`` value (including an explicit ``enabled: false``) so
-        # env vars only supply connection defaults, not override the YAML
-        # opt-out. Env vars still update ``extra`` so a re-enable in YAML
-        # picks up the current env-supplied url/account without another
-        # restart cycle. See issue #11096 (Bug 3).
+        # env vars only supply connection defaults and do not override a
+        # persisted opt-out. Env vars still update ``extra`` so a later
+        # re-enable picks up the current env-supplied url/account without
+        # another restart cycle. See issue #11096 (Bug 3).
         config.platforms[Platform.SIGNAL].extra.update({
             "http_url": signal_url,
             "account": signal_account,

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1167,8 +1167,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     signal_account = os.getenv("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
         if Platform.SIGNAL not in config.platforms:
-            config.platforms[Platform.SIGNAL] = PlatformConfig()
-        config.platforms[Platform.SIGNAL].enabled = True
+            # Not declared in config.yaml — env vars alone enable Signal.
+            config.platforms[Platform.SIGNAL] = PlatformConfig(enabled=True)
+        # When platforms.signal is already declared in config.yaml, preserve
+        # its ``enabled`` value (including an explicit ``enabled: false``) so
+        # env vars only supply connection defaults, not override the YAML
+        # opt-out. Env vars still update ``extra`` so a re-enable in YAML
+        # picks up the current env-supplied url/account without another
+        # restart cycle. See issue #11096 (Bug 3).
         config.platforms[Platform.SIGNAL].extra.update({
             "http_url": signal_url,
             "account": signal_account,

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -850,8 +850,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     signal_account = os.getenv("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
         if Platform.SIGNAL not in config.platforms:
-            config.platforms[Platform.SIGNAL] = PlatformConfig()
-        config.platforms[Platform.SIGNAL].enabled = True
+            # Not declared in config.yaml — env vars alone enable Signal.
+            config.platforms[Platform.SIGNAL] = PlatformConfig(enabled=True)
+        # When platforms.signal is already declared in config.yaml, preserve
+        # its ``enabled`` value (including an explicit ``enabled: false``) so
+        # env vars only supply connection defaults, not override the YAML
+        # opt-out. Env vars still update ``extra`` so a re-enable in YAML
+        # picks up the current env-supplied url/account without another
+        # restart cycle. See issue #11096 (Bug 3).
         config.platforms[Platform.SIGNAL].extra.update({
             "http_url": signal_url,
             "account": signal_account,

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -850,14 +850,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     signal_account = os.getenv("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
         if Platform.SIGNAL not in config.platforms:
-            # Not declared in config.yaml — env vars alone enable Signal.
+            # Not declared in any existing config source — env vars alone
+            # enable Signal.
             config.platforms[Platform.SIGNAL] = PlatformConfig(enabled=True)
-        # When platforms.signal is already declared in config.yaml, preserve
+        # When ``platforms.signal`` is already present in ``config.platforms``
+        # — from either ``config.yaml`` or legacy ``gateway.json`` — preserve
         # its ``enabled`` value (including an explicit ``enabled: false``) so
-        # env vars only supply connection defaults, not override the YAML
-        # opt-out. Env vars still update ``extra`` so a re-enable in YAML
-        # picks up the current env-supplied url/account without another
-        # restart cycle. See issue #11096 (Bug 3).
+        # env vars only supply connection defaults and do not override a
+        # persisted opt-out. Env vars still update ``extra`` so a later
+        # re-enable picks up the current env-supplied url/account without
+        # another restart cycle. See issue #11096 (Bug 3).
         config.platforms[Platform.SIGNAL].extra.update({
             "http_url": signal_url,
             "account": signal_account,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -583,6 +583,38 @@ class TestLoadGatewayConfig:
         assert signal_cfg.extra["http_url"] == "http://localhost:9090"
         assert signal_cfg.extra["account"] == "+15551234567"
 
+    def test_signal_gateway_json_disabled_beats_env_vars(self, tmp_path, monkeypatch):
+        """Legacy ``gateway.json`` ``platforms.signal.enabled: false`` must also
+        survive SIGNAL_* env vars.
+
+        ``_apply_env_overrides`` treats *any* entry already present in
+        ``config.platforms`` as a persisted opt-out — not just config.yaml
+        entries — so a user who migrated from the legacy JSON persistence
+        and kept Signal disabled there keeps the opt-out without having
+        to re-declare it in config.yaml first.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        gateway_json = hermes_home / "gateway.json"
+        gateway_json.write_text(
+            '{"platforms": {"signal": {"enabled": false}}}',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = load_gateway_config()
+
+        assert Platform.SIGNAL in config.platforms
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        # Legacy JSON opt-out is preserved.
+        assert signal_cfg.enabled is False
+        # Env-supplied connection details still populated.
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
     def test_signal_env_vars_alone_enable_platform(self, monkeypatch):
         """When Signal is absent from config.yaml, env vars alone enable it.
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -529,6 +529,78 @@ class TestLoadGatewayConfig:
         import os
         assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
 
+    def test_signal_yaml_disabled_beats_env_vars(self, tmp_path, monkeypatch):
+        """YAML ``platforms.signal.enabled: false`` must not be clobbered by
+        SIGNAL_HTTP_URL/SIGNAL_ACCOUNT env vars.  Regression for #11096 (Bug 3).
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  signal:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = load_gateway_config()
+
+        assert Platform.SIGNAL in config.platforms
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        # YAML explicitly opted out — env vars must not flip it back on.
+        assert signal_cfg.enabled is False
+        # Connection details from env are still populated so a later
+        # ``enabled: true`` flip works without re-exporting.
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
+    def test_signal_yaml_enabled_preserved_with_env_vars(self, tmp_path, monkeypatch):
+        """YAML ``platforms.signal.enabled: true`` combined with env vars
+        keeps Signal enabled and lets env vars supply connection details.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  signal:\n"
+            "    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = load_gateway_config()
+
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        assert signal_cfg.enabled is True
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
+    def test_signal_env_vars_alone_enable_platform(self, monkeypatch):
+        """When Signal is absent from config.yaml, env vars alone enable it.
+
+        Preserves the documented behavior for users who configure Signal
+        purely via .env / SIGNAL_* variables with no YAML section.
+        """
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.SIGNAL in config.platforms
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        assert signal_cfg.enabled is True
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -390,6 +390,38 @@ class TestLoadGatewayConfig:
         assert signal_cfg.extra["http_url"] == "http://localhost:9090"
         assert signal_cfg.extra["account"] == "+15551234567"
 
+    def test_signal_gateway_json_disabled_beats_env_vars(self, tmp_path, monkeypatch):
+        """Legacy ``gateway.json`` ``platforms.signal.enabled: false`` must also
+        survive SIGNAL_* env vars.
+
+        ``_apply_env_overrides`` treats *any* entry already present in
+        ``config.platforms`` as a persisted opt-out — not just config.yaml
+        entries — so a user who migrated from the legacy JSON persistence
+        and kept Signal disabled there keeps the opt-out without having
+        to re-declare it in config.yaml first.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        gateway_json = hermes_home / "gateway.json"
+        gateway_json.write_text(
+            '{"platforms": {"signal": {"enabled": false}}}',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = load_gateway_config()
+
+        assert Platform.SIGNAL in config.platforms
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        # Legacy JSON opt-out is preserved.
+        assert signal_cfg.enabled is False
+        # Env-supplied connection details still populated.
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
     def test_signal_env_vars_alone_enable_platform(self, monkeypatch):
         """When Signal is absent from config.yaml, env vars alone enable it.
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -336,6 +336,78 @@ class TestLoadGatewayConfig:
         import os
         assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
 
+    def test_signal_yaml_disabled_beats_env_vars(self, tmp_path, monkeypatch):
+        """YAML ``platforms.signal.enabled: false`` must not be clobbered by
+        SIGNAL_HTTP_URL/SIGNAL_ACCOUNT env vars.  Regression for #11096 (Bug 3).
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  signal:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = load_gateway_config()
+
+        assert Platform.SIGNAL in config.platforms
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        # YAML explicitly opted out — env vars must not flip it back on.
+        assert signal_cfg.enabled is False
+        # Connection details from env are still populated so a later
+        # ``enabled: true`` flip works without re-exporting.
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
+    def test_signal_yaml_enabled_preserved_with_env_vars(self, tmp_path, monkeypatch):
+        """YAML ``platforms.signal.enabled: true`` combined with env vars
+        keeps Signal enabled and lets env vars supply connection details.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  signal:\n"
+            "    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = load_gateway_config()
+
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        assert signal_cfg.enabled is True
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
+    def test_signal_env_vars_alone_enable_platform(self, monkeypatch):
+        """When Signal is absent from config.yaml, env vars alone enable it.
+
+        Preserves the documented behavior for users who configure Signal
+        purely via .env / SIGNAL_* variables with no YAML section.
+        """
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.SIGNAL in config.platforms
+        signal_cfg = config.platforms[Platform.SIGNAL]
+        assert signal_cfg.enabled is True
+        assert signal_cfg.extra["http_url"] == "http://localhost:9090"
+        assert signal_cfg.extra["account"] == "+15551234567"
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already


### PR DESCRIPTION
## What does this PR do?

Fixes the [issue #11096](https://github.com/NousResearch/hermes-agent/issues/11096) Bug 3 precedence bug where setting `platforms.signal.enabled: false` in `config.yaml` was silently overwritten by `SIGNAL_HTTP_URL` + `SIGNAL_ACCOUNT` env vars. The operator who filed the bug spent ~30 min diagnosing — the YAML flag was never honored, and the only workaround was to comment out the env vars.

**Root cause.** `_apply_env_overrides` in [`gateway/config.py`](gateway/config.py) unconditionally assigned `config.platforms[Platform.SIGNAL].enabled = True` whenever both env vars were set, regardless of what `config.yaml` had already loaded into `config.platforms[Platform.SIGNAL].enabled` via `GatewayConfig.from_dict()`.

**Smallest safe fix.** `enabled=True` is now only applied when Signal is **not** already declared in `config.platforms` (fresh `PlatformConfig`). When `platforms.signal` is in `config.yaml` — including with `enabled: false` — the YAML-declared flag is preserved. Env vars continue to populate `extra.http_url`, `extra.account`, and `extra.ignore_stories`, so a later YAML flip back to `enabled: true` picks up current env-supplied connection details without another export cycle.

## Related Issue

Fixes part of #11096 (Bug 3 — `config.yaml` `signal.enabled: false` is silently ignored when `SIGNAL_*` env vars are set).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- [`gateway/config.py`](gateway/config.py) — Signal block in `_apply_env_overrides`: only force `enabled=True` on fresh `PlatformConfig` creation; preserve YAML-declared `.enabled` when the platform already exists. Still updates `extra` so env-supplied connection details are retained.
- [`tests/gateway/test_config.py`](tests/gateway/test_config.py) — three regression tests covering YAML-disabled + env vars (the bug), YAML-enabled + env vars (mixed), and env vars alone (preserve documented behavior for purely env-driven Signal configuration).

## Backward compatibility / precedence

- **YAML absent**: `SIGNAL_HTTP_URL` + `SIGNAL_ACCOUNT` still enable Signal end-to-end. Documented `.env`-only configuration path is unchanged.
- **YAML `enabled: true`** + env vars: Signal stays enabled; env vars continue to fill in `extra.http_url` / `extra.account`. Unchanged.
- **YAML `enabled: false`** + env vars (the bug): Signal now stays disabled as the operator intended. `extra` is still populated so a later YAML flip doesn't require re-exporting env vars.
- **YAML `platforms.signal: {}`** (empty block) + env vars: Signal remains at its YAML-derived default (`enabled=False`). Users who declare a platform block in YAML opt into YAML-authoritative behavior; set `enabled: true` explicitly to combine with env-supplied details. This is the same precedence principle #11096 recommends.

## Narrow scope — why only Signal

The same `enabled = True` pattern exists across other blocks in `_apply_env_overrides` (Discord, Mattermost, Matrix, etc. — 19 total). I deliberately kept this PR narrow to the platform the issue flagged so the fix is small, easy to review, and easy to revert if the precedence semantics need tuning. Once the precedence model is agreed, the same treatment can extend to the rest in follow-up PRs.

## How to Test

Repro on `main` (fails before this PR):

```bash
# ~/.hermes/config.yaml
platforms:
  signal:
    enabled: false
```

```bash
export SIGNAL_HTTP_URL=http://localhost:9090
export SIGNAL_ACCOUNT=+15551234567
python -c 'from gateway.config import load_gateway_config, Platform; c=load_gateway_config(); print(c.platforms[Platform.SIGNAL].enabled)'
# main: True  (bug — YAML opt-out ignored)
# this PR: False
```

Regression suite:

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_config.py -q -k signal
# 3 passed
```

## Validation

All commands run with `source venv/bin/activate`:

- `python -m pytest tests/gateway/test_config.py -q -k signal` — 3 passed (new regression tests)
- `python -m pytest tests/gateway/test_config.py tests/gateway/test_signal.py -q` — 87 passed
- `python -m pytest tests/gateway/ -q --tb=short` — 3016 passed, 1 skipped. The 2 residual failures (`test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once` and `::test_blocking_approval_deny`) also fail on clean `origin/main` — they are pre-existing and unrelated. A third flaky failure (`test_non_internal_event_without_user_triggers_pairing`) passes in isolation on this branch; it is a test-ordering issue unrelated to this change.
- `git diff --check` — clean
- `python -m py_compile gateway/config.py tests/gateway/test_config.py` — OK

Tested on macOS (Darwin 25.5.0), Python 3.11.15.

No standalone lint/typecheck command is defined in the contributor docs; the Tests workflow (`.github/workflows/tests.yml`) runs `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`, matching what CI will execute.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs — no duplicate for #11096 Bug 3 (Bugs 1 and 2 from that issue are covered by #11097 and #11098)
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant pytest slices and the baseline failures are pre-existing
- [x] I've added regression tests covering the bug and the adjacent preserved behaviors
- [x] Tested on macOS (Darwin 25.5.0), Python 3.11.15