### PR TITLE
fix: support adaptive thinking for Claude Opus 4.7

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -86,8 +86,8 @@ def _get_anthropic_max_output(model: str) -> int:
 
 
 def _supports_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude 4.6 models that support adaptive thinking."""
-    return any(v in model for v in ("4-6", "4.6"))
+    """Return True for Claude 4.6+ models that support adaptive thinking."""
+    return any(v in model for v in ("4-6", "4.6", "4-7", "4.7"))
 
 
 # Beta headers for enhanced features (sent with ALL auth types)


### PR DESCRIPTION
## What does this PR do?

`_supports_adaptive_thinking()` only matches Claude 4.6 models (`4-6`, `4.6`). Claude Opus 4.7 was released with adaptive thinking support (not extended thinking), but the function does not recognize it.

Without this fix, Opus 4.7 falls through to the extended thinking codepath (`type: enabled` + `budget_tokens` + `temperature: 1`), which Opus 4.7 does not support per the [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`: Added `"4-7"` and `"4.7"` to the version match list in `_supports_adaptive_thinking()` so Opus 4.7 correctly uses adaptive thinking instead of falling through to extended thinking.

## How to Test

1. Set `model.default: claude-opus-4-7` in `~/.hermes/config.yaml`
2. Set `agent.reasoning_effort: medium`
3. Start a conversation — the agent should use adaptive thinking (not extended thinking with budget_tokens)

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [ ] I have added tests for my changes
- [x] I have tested on my platform: macOS

### Documentation & Housekeeping

- [x] I have updated relevant documentation — or N/A (docstring updated)
- [x] N/A — no config key changes
- [x] N/A — no architecture changes
- [x] N/A — cross-platform not affected (string matching only)
- [x] N/A — no tool schema changes

## Reference

https://docs.anthropic.com/en/docs/about-claude/models/overview — Opus 4.7 supports adaptive thinking, not extended thinking.