### PR TITLE
fix(cli): use env-aware cursor to avoid macOS input occlusion

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -51,7 +51,22 @@ from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 try:
     from prompt_toolkit.cursor_shapes import CursorShape
-    _STEADY_CURSOR = CursorShape.BLOCK  # Non-blinking block cursor
+
+    def _preferred_cursor_shape():
+        """Pick a cursor shape that avoids input glyph occlusion on macOS terminals.
+
+        A steady block cursor fixed border flashing in ghostty+tmux, but on
+        iTerm/Terminal.app it can visually cover the current glyph in the input
+        area and make typed text look blacked out/invisible. Keep the block
+        cursor only for tmux/ghostty-style environments that needed the original
+        workaround; otherwise use a beam cursor for normal text entry.
+        """
+        term_program = os.environ.get("TERM_PROGRAM", "").strip().lower()
+        if os.environ.get("TMUX") or term_program in {"ghostty", "wezterm"}:
+            return CursorShape.BLOCK
+        return CursorShape.BEAM
+
+    _STEADY_CURSOR = _preferred_cursor_shape()
 except (ImportError, AttributeError):
     _STEADY_CURSOR = None
 import threading


### PR DESCRIPTION
## Summary
- switch the Hermes CLI cursor from an unconditional steady block to an environment-aware choice
- keep block cursor behavior for tmux/ghostty/wezterm where it helps border stability
- use a beam cursor for iTerm.app and Terminal.app so typed input is not visually occluded

## Test Plan
- ran `python3 -m py_compile cli.py`
- verified local Hermes repo stays clean enough for `hermes update` to run without auto-stashing
- verified the live iTerm environment uses the new cursor logic

## Why
On macOS iTerm.app, the steady block cursor can cover the current glyph in the input area and make user text look blacked out or invisible while typing.