### PR TITLE
feat(gateway): track owner ingress work-state

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -359,6 +359,43 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "ignored", "event": event_type}
             )
 
+        delivery_id = request.headers.get(
+            "X-GitHub-Delivery",
+            request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+        )
+
+        if route_config.get("owner_ingress"):
+            if not self.gateway_runner or not hasattr(self.gateway_runner, "handle_owner_ingress_packet"):
+                return web.json_response(
+                    {"status": "reject", "verdict": "reject", "reason": "gateway_runner_unavailable"},
+                    status=503,
+                )
+            verdict = await self.gateway_runner.handle_owner_ingress_packet(
+                payload,
+                route_name=route_name,
+                delivery_id=delivery_id,
+            )
+            return web.json_response(
+                {k: v for k, v in verdict.items() if k != "http_status"},
+                status=int(verdict.get("http_status", 202)),
+            )
+
+        if route_config.get("delegated_ingress"):
+            if not self.gateway_runner or not hasattr(self.gateway_runner, "handle_delegated_ingress_packet"):
+                return web.json_response(
+                    {"status": "reject", "verdict": "reject", "reason": "gateway_runner_unavailable"},
+                    status=503,
+                )
+            verdict = await self.gateway_runner.handle_delegated_ingress_packet(
+                payload,
+                route_name=route_name,
+                delivery_id=delivery_id,
+            )
+            return web.json_response(
+                {k: v for k, v in verdict.items() if k != "http_status"},
+                status=int(verdict.get("http_status", 202)),
+            )
+
         # Format prompt from template
         prompt_template = route_config.get("prompt", "")
         prompt = self._render_prompt(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1946,6 +1946,46 @@ class GatewayRunner:
         )
         return work_id
 
+    def _begin_targeted_internal_work_record(
+        self,
+        *,
+        event: MessageEvent,
+        session_key: str,
+        message_text: str,
+    ) -> Optional[str]:
+        if not getattr(event, "internal", False):
+            return None
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return None
+        raw_message = getattr(event, "raw_message", None)
+        if not isinstance(raw_message, dict):
+            return None
+        work_id = str(raw_message.get("work_id", "")).strip()
+        if not work_id:
+            return None
+        existing_records = work_state_store.find_matching_records(
+            work_id,
+            owner_session_id=session_key,
+            live_only=False,
+        )
+        existing = existing_records[0] if existing_records else None
+        if existing is None:
+            return None
+        if existing.mode != "direct" or existing.executor != "hermes":
+            return None
+        preview = (message_text or "").strip().splitlines()[0] if (message_text or "").strip() else "Continue the targeted internal work"
+        preview = preview[:160]
+        now = datetime.now().astimezone()
+        work_state_store.update_record(
+            work_id,
+            session_key,
+            state="running",
+            last_progress_at=now,
+            next_action=preview or existing.next_action,
+        )
+        return work_id
+
     def _finish_direct_work_record(
         self,
         work_id: Optional[str],
@@ -4514,13 +4554,19 @@ class GatewayRunner:
         if message_text is None:
             return
 
-        direct_work_id = self._begin_direct_work_record(
-            session_id=session_entry.session_id,
+        direct_work_id = self._begin_targeted_internal_work_record(
+            event=event,
             session_key=session_key,
             message_text=message_text,
-            platform=_platform_name,
-            event_message_id=event.message_id,
         )
+        if direct_work_id is None and not getattr(event, "internal", False):
+            direct_work_id = self._begin_direct_work_record(
+                session_id=session_entry.session_id,
+                session_key=session_key,
+                message_text=message_text,
+                platform=_platform_name,
+                event_message_id=event.message_id,
+            )
 
         try:
             # Emit agent:start hook
@@ -6972,6 +7018,7 @@ class GatewayRunner:
                     session_id=session_id,
                     source=source.platform.value if source.platform else "unknown",
                     user_id=source.user_id,
+                    source_metadata=source.to_dict(),
                 )
             except Exception:
                 pass  # Session might already exist, ignore errors
@@ -7124,6 +7171,7 @@ class GatewayRunner:
                 session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
+                source_metadata=source.to_dict(),
                 parent_session_id=parent_session_id,
             )
         except Exception as e:
@@ -8820,10 +8868,16 @@ class GatewayRunner:
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )
+        iteration_report_every = resolve_display_setting(
+            user_config, platform_key, "iteration_report_every", 0
+        )
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
         tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        iteration_reports_enabled = (
+            source.platform != Platform.WEBHOOK and int(iteration_report_every or 0) > 0
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -8840,7 +8894,9 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
-        
+        max_iterations_holder = [90]
+        last_iteration_report = [0]
+
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
             if not progress_queue:
@@ -9062,17 +9118,36 @@ class GatewayRunner:
                         _names.append(_t.get("name") or "")
                     else:
                         _names.append(str(_t))
-                asyncio.run_coroutine_threadsafe(
-                    _hooks_ref.emit("agent:step", {
-                        "platform": source.platform.value if source.platform else "",
-                        "user_id": source.user_id,
-                        "session_id": session_id,
-                        "iteration": iteration,
-                        "tool_names": _names,
-                        "tools": prev_tools,
-                    }),
-                    _loop_for_step,
-                )
+                if _hooks_ref.loaded_hooks:
+                    asyncio.run_coroutine_threadsafe(
+                        _hooks_ref.emit("agent:step", {
+                            "platform": source.platform.value if source.platform else "",
+                            "user_id": source.user_id,
+                            "session_id": session_id,
+                            "iteration": iteration,
+                            "tool_names": _names,
+                            "tools": prev_tools,
+                        }),
+                        _loop_for_step,
+                    )
+
+                _interval = int(iteration_report_every or 0)
+                if (
+                    iteration_reports_enabled
+                    and _interval > 0
+                    and iteration >= _interval
+                    and iteration % _interval == 0
+                    and iteration != last_iteration_report[0]
+                ):
+                    last_iteration_report[0] = iteration
+                    _recent = ", ".join(name for name in _names if name) or "(no recent tools)"
+                    _status_callback_sync(
+                        "iteration_report",
+                        (
+                            f"🔄 Iteration report: starting iteration {iteration}/{max_iterations_holder[0]}"
+                            f" — recent tools: {_recent}"
+                        ),
+                    )
             except Exception as _e:
                 logger.debug("agent:step hook error: %s", _e)
 
@@ -9111,6 +9186,7 @@ class GatewayRunner:
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            max_iterations_holder[0] = max_iterations
             
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
@@ -9298,7 +9374,7 @@ class GatewayRunner:
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
-            agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
+            agent.step_callback = _step_callback_sync if (_hooks_ref.loaded_hooks or iteration_reports_enabled) else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -268,6 +268,7 @@ from gateway.session import (
     build_session_key,
 )
 from gateway.delivery import DeliveryRouter
+from gateway.work_state import WorkRecord, WorkStateStore
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -596,6 +597,7 @@ class GatewayRunner:
             self.config.sessions_dir, self.config,
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(key),
         )
+        self.work_state_store = WorkStateStore()
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._shutdown_event = asyncio.Event()
@@ -1368,6 +1370,611 @@ class GatewayRunner:
             if agent is not _AGENT_PENDING_SENTINEL
         }
 
+    def _running_sessions_checkpoint_path(self):
+        return _hermes_home / ".running_sessions.json"
+
+    def _persist_running_sessions_checkpoint(self) -> None:
+        """Persist the exact in-flight gateway session keys for crash recovery."""
+        path = self._running_sessions_checkpoint_path()
+        session_keys = sorted(str(key) for key in self._running_agents.keys() if key)
+        if not session_keys:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                logger.debug("Failed removing running-session checkpoint: %s", e)
+            return
+
+        payload = {"session_keys": session_keys}
+        try:
+            path.write_text(json.dumps(payload), encoding="utf-8")
+        except Exception as e:
+            logger.debug("Failed writing running-session checkpoint: %s", e)
+
+    def _set_running_agent_entry(
+        self,
+        session_key: str,
+        agent: Any,
+        *,
+        update_timestamp: bool = True,
+    ) -> None:
+        self._running_agents[session_key] = agent
+        if update_timestamp:
+            self._running_agents_ts[session_key] = time.time()
+        self._persist_running_sessions_checkpoint()
+
+    def _clear_running_agent_entry(
+        self,
+        session_key: str,
+        *,
+        clear_timestamp: bool = True,
+    ) -> None:
+        if session_key in self._running_agents:
+            del self._running_agents[session_key]
+        if clear_timestamp:
+            self._running_agents_ts.pop(session_key, None)
+        self._persist_running_sessions_checkpoint()
+
+    def _recover_interrupted_sessions_from_checkpoint(self) -> int:
+        """Recover exact interrupted session keys from the previous gateway run."""
+        path = self._running_sessions_checkpoint_path()
+        if not path.exists():
+            return 0
+
+        session_keys: list[str] = []
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                raw_keys = payload.get("session_keys", [])
+                if isinstance(raw_keys, list):
+                    session_keys = [str(key) for key in raw_keys if key]
+        except Exception as e:
+            logger.warning("Failed reading running-session checkpoint: %s", e)
+        finally:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                logger.debug("Failed removing running-session checkpoint: %s", e)
+
+        if not session_keys:
+            return 0
+        recovered = self.session_store.mark_interrupted_sessions(session_keys, reason="restart")
+        try:
+            work_state_store = getattr(self, "work_state_store", None)
+            if work_state_store is not None:
+                work_state_store.mark_owner_sessions_blocked(
+                    session_keys,
+                    next_action="Continue the interrupted turn",
+                    proof="gateway_restart_checkpoint",
+                )
+        except Exception:
+            logger.debug("Failed to mark blocked work-state records during restart recovery", exc_info=True)
+        return recovered
+
+    async def handle_owner_ingress_packet(
+        self,
+        payload: dict,
+        *,
+        route_name: str = "",
+        delivery_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Validate and inject a bounded owner-ingress wake packet."""
+        payload = payload or {}
+        work_id = str(payload.get("work_id", "")).strip()
+        owner = str(payload.get("owner", "")).strip()
+        owner_session_id = str(payload.get("owner_session_id", "")).strip() or None
+        state = str(payload.get("state", "")).strip()
+        next_action = str(payload.get("next_action", "")).strip()
+        proof = str(payload.get("proof", "")).strip()
+
+        if not work_id or owner != "hermes" or not next_action or not proof:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "invalid_owner_ingress_packet",
+                "resolution": "invalid",
+                "http_status": 400,
+            }
+
+        from gateway.work_state import WAKE_STATES
+
+        if state not in WAKE_STATES:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "invalid_owner_ingress_state",
+                "resolution": "invalid",
+                "http_status": 400,
+            }
+
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "work_state_unavailable",
+                "resolution": "invalid",
+                "http_status": 503,
+            }
+
+        resolution = work_state_store.resolve_owner_ingress_candidate(
+            work_id,
+            owner_session_id=owner_session_id,
+        )
+        status = resolution.get("status")
+        if status == "missing":
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": resolution.get("reason", "missing_or_closed_work_record"),
+                "resolution": "missing",
+                "http_status": 404,
+            }
+        if status == "ambiguous":
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": resolution.get("reason", "ambiguous_owner_resolution"),
+                "resolution": "ambiguous",
+                "http_status": 409,
+            }
+
+        record = resolution.get("record")
+        if record is None:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "missing_or_closed_work_record",
+                "resolution": "missing",
+                "http_status": 404,
+            }
+
+        session_entry = self.session_store.get_session_entry(record.owner_session_id)
+        if not session_entry or not getattr(session_entry, "origin", None):
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "missing_owner_session_source",
+                "resolution": "missing",
+                "http_status": 404,
+            }
+
+        target_source = session_entry.origin
+        if getattr(target_source, "chat_type", "") == "thread" and not getattr(target_source, "thread_id", None):
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "missing_owner_thread_source",
+                "resolution": "missing",
+                "http_status": 404,
+            }
+
+        adapter = self.adapters.get(target_source.platform)
+        if adapter is None or not hasattr(adapter, "handle_message"):
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "target_platform_unavailable",
+                "resolution": "missing",
+                "http_status": 503,
+            }
+
+        ingress_message = (
+            "[System note: Owner ingress signal accepted. "
+            f"route={route_name or 'owner-ingress'} "
+            f"work_id={work_id} state={state} "
+            f"next_action={next_action} "
+            f"proof={proof}. "
+            "Resume only this targeted owner work record and do not broad-wake any other session.]"
+        )
+        internal_event = MessageEvent(
+            text=ingress_message,
+            message_type=MessageType.TEXT,
+            source=target_source,
+            message_id=f"owner-ingress:{delivery_id or work_id}",
+            raw_message=payload,
+            internal=True,
+        )
+        await adapter.handle_message(internal_event)
+        return {
+            "status": "accepted",
+            "verdict": "accepted",
+            "reason": "eligible",
+            "resolution": "single_match",
+            "target_session_key": record.owner_session_id,
+            "work_id": work_id,
+            "http_status": 202,
+        }
+
+    async def handle_delegated_ingress_packet(
+        self,
+        payload: dict,
+        *,
+        route_name: str = "",
+        delivery_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Resolve an OMX/clawhip delegated signal back to one owner work record."""
+        payload = payload or {}
+        owner = str(payload.get("owner", "")).strip()
+        executor = str(payload.get("executor", "")).strip() or "omx"
+        work_id = str(payload.get("work_id", "")).strip() or None
+        owner_session_id = str(payload.get("owner_session_id", "")).strip() or None
+        executor_session_id = str(payload.get("executor_session_id", "")).strip() or None
+        tmux_session = str(payload.get("tmux_session", payload.get("tmuxSession", ""))).strip() or None
+        repo_path = str(payload.get("repo_path", "")).strip() or None
+        worktree_path = str(payload.get("worktree_path", "")).strip() or None
+        state = str(payload.get("state", "")).strip() or str(payload.get("normalized_event", "")).strip().replace("-", "_")
+        next_action = str(payload.get("next_action", "")).strip()
+        proof = str(payload.get("proof", "")).strip()
+
+        if owner != "hermes" or executor != "omx" or not next_action or not proof:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "invalid_delegated_ingress_packet",
+                "resolution": "invalid",
+                "http_status": 400,
+            }
+
+        from gateway.work_state import WAKE_STATES
+
+        if state not in WAKE_STATES:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "invalid_delegated_ingress_state",
+                "resolution": "invalid",
+                "http_status": 400,
+            }
+
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "work_state_unavailable",
+                "resolution": "invalid",
+                "http_status": 503,
+            }
+
+        resolution = work_state_store.resolve_delegated_signal_candidate(
+            work_id=work_id,
+            owner_session_id=owner_session_id,
+            executor_session_id=executor_session_id,
+            tmux_session=tmux_session,
+            repo_path=repo_path,
+            worktree_path=worktree_path,
+            live_only=True,
+        )
+        status = resolution.get("status")
+        if status == "missing":
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": resolution.get("reason", "missing_or_closed_delegated_work_record"),
+                "resolution": "missing",
+                "http_status": 404,
+            }
+        if status == "ambiguous":
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": resolution.get("reason", "ambiguous_delegated_work_resolution"),
+                "resolution": "ambiguous",
+                "http_status": 409,
+            }
+
+        record = resolution.get("record")
+        if record is None:
+            return {
+                "status": "reject",
+                "verdict": "reject",
+                "reason": "missing_or_closed_delegated_work_record",
+                "resolution": "missing",
+                "http_status": 404,
+            }
+
+        now = datetime.now().astimezone()
+        if state == "retry_needed":
+            dispatch_result = self._dispatch_delegated_retry_followup(
+                record,
+                next_action=next_action,
+                proof=proof,
+                route_name=route_name,
+            )
+            if dispatch_result.get("status") == "accepted":
+                dispatch_route = str(dispatch_result.get("route", "executor_surface") or "executor_surface")
+                target_executor_id = (
+                    dispatch_result.get("target")
+                    or executor_session_id
+                    or record.executor_session_id
+                    or tmux_session
+                    or record.tmux_session
+                )
+                work_state_store.update_record(
+                    record.work_id,
+                    record.owner_session_id,
+                    state="running",
+                    last_progress_at=now,
+                    next_action="Wait for delegated executor retry outcome",
+                    proof=f"retry_dispatch:{dispatch_route}|source={proof}",
+                    executor_session_id=executor_session_id or record.executor_session_id,
+                    tmux_session=tmux_session or record.tmux_session,
+                    repo_path=repo_path or record.repo_path,
+                    worktree_path=worktree_path or record.worktree_path,
+                )
+                return {
+                    "status": "accepted",
+                    "verdict": "accepted",
+                    "reason": "eligible",
+                    "resolution": "single_match",
+                    "reaction": "executor_first",
+                    "dispatch_route": dispatch_route,
+                    "target_executor_id": target_executor_id,
+                    "work_id": record.work_id,
+                    "http_status": 202,
+                }
+        else:
+            dispatch_result = None
+
+        work_state_store.update_record(
+            record.work_id,
+            record.owner_session_id,
+            state=state,
+            last_progress_at=now,
+            next_action=next_action,
+            proof=proof,
+            executor_session_id=executor_session_id or record.executor_session_id,
+            tmux_session=tmux_session or record.tmux_session,
+            repo_path=repo_path or record.repo_path,
+            worktree_path=worktree_path or record.worktree_path,
+        )
+
+        owner_result = await self.handle_owner_ingress_packet(
+            {
+                "work_id": record.work_id,
+                "owner": "hermes",
+                "owner_session_id": record.owner_session_id,
+                "state": state,
+                "next_action": next_action,
+                "proof": proof,
+            },
+            route_name=route_name,
+            delivery_id=delivery_id,
+        )
+        owner_result["work_id"] = record.work_id
+        if state == "retry_needed":
+            owner_result["reaction"] = "owner_fallback"
+            if dispatch_result:
+                owner_result["dispatch_reason"] = dispatch_result.get("reason")
+        else:
+            owner_result["reaction"] = "owner_second"
+        return owner_result
+
+    def _dispatch_delegated_retry_followup(
+        self,
+        record,
+        *,
+        next_action: str,
+        proof: str,
+        route_name: str = "",
+    ) -> Dict[str, Any]:
+        message = (
+            "[Hermes system note] retry-needed signal accepted. "
+            f"route={route_name or 'delegated-ingress'} "
+            f"work_id={record.work_id} proof={proof}. "
+            f"Execute exactly one bounded retry/follow-up on this OMX lane. Next action: {next_action}. "
+            "If the issue remains unresolved after this attempt, emit handoff-needed instead of asking the human directly."
+        )
+
+        executor_session_id = getattr(record, "executor_session_id", None)
+        if executor_session_id:
+            try:
+                from tools.process_registry import process_registry
+
+                session = process_registry.get(executor_session_id)
+                if session is not None and not getattr(session, "exited", False):
+                    result = process_registry.submit_stdin(executor_session_id, message)
+                    if result.get("status") == "ok":
+                        return {
+                            "status": "accepted",
+                            "route": "process_stdin",
+                            "target": executor_session_id,
+                        }
+            except Exception:
+                logger.debug(
+                    "Failed to dispatch retry-needed follow-up to executor process %s",
+                    executor_session_id,
+                    exc_info=True,
+                )
+
+        tmux_session = getattr(record, "tmux_session", None)
+        if tmux_session:
+            try:
+                import subprocess
+
+                has_session = subprocess.run(
+                    ["tmux", "has-session", "-t", tmux_session],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if has_session.returncode != 0:
+                    return {
+                        "status": "unavailable",
+                        "reason": "tmux_session_missing",
+                    }
+
+                send = subprocess.run(
+                    ["tmux", "send-keys", "-t", tmux_session, message, "C-m"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if send.returncode == 0:
+                    return {
+                        "status": "accepted",
+                        "route": "tmux_send_keys",
+                        "target": tmux_session,
+                    }
+                return {
+                    "status": "unavailable",
+                    "reason": "tmux_send_failed",
+                }
+            except FileNotFoundError:
+                return {
+                    "status": "unavailable",
+                    "reason": "tmux_unavailable",
+                }
+            except Exception:
+                logger.debug(
+                    "Failed to dispatch retry-needed follow-up to tmux session %s",
+                    tmux_session,
+                    exc_info=True,
+                )
+                return {
+                    "status": "unavailable",
+                    "reason": "tmux_send_failed",
+                }
+
+        return {
+            "status": "unavailable",
+            "reason": "no_live_executor_surface",
+        }
+
+    def _mark_work_record_delegated(
+        self,
+        work_id: Optional[str],
+        session_key: str,
+        *,
+        executor_session_id: Optional[str] = None,
+        tmux_session: Optional[str] = None,
+        repo_path: Optional[str] = None,
+        worktree_path: Optional[str] = None,
+        next_action: str = "Resume the delegated OMX work",
+        proof: str = "delegated_handoff",
+    ) -> bool:
+        if not work_id:
+            return False
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return False
+        now = datetime.now().astimezone()
+        return work_state_store.update_record(
+            work_id,
+            session_key,
+            executor="omx",
+            mode="delegated",
+            state="running",
+            last_progress_at=now,
+            executor_session_id=executor_session_id,
+            tmux_session=tmux_session,
+            repo_path=repo_path,
+            worktree_path=worktree_path,
+            next_action=next_action,
+            proof=proof,
+        )
+
+    def _update_delegated_work_for_process(
+        self,
+        *,
+        executor_session_id: str,
+        exit_code: Optional[int],
+    ) -> bool:
+        if not executor_session_id:
+            return False
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return False
+        resolution = work_state_store.resolve_delegated_signal_candidate(
+            executor_session_id=executor_session_id,
+            live_only=True,
+        )
+        if resolution.get("status") != "single_match":
+            return False
+        record = resolution.get("record")
+        if record is None:
+            return False
+        now = datetime.now().astimezone()
+        succeeded = exit_code == 0
+        return work_state_store.update_record(
+            record.work_id,
+            record.owner_session_id,
+            state="finished" if succeeded else "failed",
+            last_progress_at=now,
+            next_action="Inspect the completed OMX run" if succeeded else "Inspect the failed OMX run",
+            proof=f"background_process_exit:{exit_code}",
+        )
+
+    def _begin_direct_work_record(
+        self,
+        *,
+        session_id: str,
+        session_key: str,
+        message_text: str,
+        platform: str,
+        event_message_id: Optional[str] = None,
+    ) -> Optional[str]:
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return None
+        now = datetime.now().astimezone()
+        raw_token = str(event_message_id or int(now.timestamp() * 1000))
+        safe_token = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw_token).strip("-") or "turn"
+        work_id = f"wk-direct-{session_id}-{safe_token}"[:160]
+        preview = (message_text or "").strip().splitlines()[0] if (message_text or "").strip() else "Gateway direct work"
+        preview = preview[:160]
+        objective = (message_text or preview or "Gateway direct work")[:1000]
+        work_state_store.upsert(
+            WorkRecord(
+                work_id=work_id,
+                title=preview,
+                objective=objective,
+                owner="hermes",
+                executor="hermes",
+                mode="direct",
+                owner_session_id=session_key,
+                state="running",
+                started_at=now,
+                last_progress_at=now,
+                next_action=preview or "Continue the active direct work",
+                proof=f"message_ingress:{platform}",
+            )
+        )
+        return work_id
+
+    def _finish_direct_work_record(
+        self,
+        work_id: Optional[str],
+        session_key: str,
+        *,
+        failed: bool = False,
+    ) -> None:
+        if not work_id:
+            return
+        work_state_store = getattr(self, "work_state_store", None)
+        if work_state_store is None:
+            return
+        existing_records = work_state_store.find_matching_records(
+            work_id,
+            owner_session_id=session_key,
+            live_only=False,
+        )
+        existing = existing_records[0] if existing_records else None
+        if existing and (existing.mode != "direct" or existing.executor != "hermes"):
+            return
+        now = datetime.now().astimezone()
+        work_state_store.update_record(
+            work_id,
+            session_key,
+            state="failed" if failed else "finished",
+            last_progress_at=now,
+            proof="agent_failed" if failed else "agent_completed",
+        )
+
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
@@ -1819,29 +2426,24 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
 
-        # Suspend sessions that were active when the gateway last exited.
-        # This prevents stuck sessions from being blindly resumed on restart,
-        # which can create an unrecoverable loop (#7536).  Suspended sessions
-        # auto-reset on the next incoming message, giving the user a clean start.
-        #
-        # SKIP suspension after a clean (graceful) shutdown — the previous
-        # process already drained active agents, so sessions aren't stuck.
-        # This prevents unwanted auto-resets after `hermes update`,
-        # `hermes gateway restart`, or `/restart`.
+        # Recover exact in-flight gateway sessions from the runtime checkpoint.
+        # Unlike the old recently-active heuristic, this only touches sessions
+        # that were actually running when the previous process exited.
         _clean_marker = _hermes_home / ".clean_shutdown"
         if _clean_marker.exists():
-            logger.info("Previous gateway exited cleanly — skipping session suspension")
+            logger.info("Previous gateway exited cleanly — skipping interrupted-session recovery")
             try:
                 _clean_marker.unlink()
             except Exception:
                 pass
+            self._persist_running_sessions_checkpoint()
         else:
             try:
-                suspended = self.session_store.suspend_recently_active()
-                if suspended:
-                    logger.info("Suspended %d in-flight session(s) from previous run", suspended)
+                recovered_sessions = self._recover_interrupted_sessions_from_checkpoint()
+                if recovered_sessions:
+                    logger.info("Recovered %d interrupted session(s) from previous run", recovered_sessions)
             except Exception as e:
-                logger.warning("Session suspension on startup failed: %s", e)
+                logger.warning("Interrupted-session recovery on startup failed: %s", e)
 
         # Stuck-loop detection (#7536): if a session has been active across
         # 3+ consecutive restarts, it's probably stuck in a loop (the same
@@ -2310,6 +2912,7 @@ class GatewayRunner:
 
             timeout = self._restart_drain_timeout
             active_agents, timed_out = await self._drain_active_agents(timeout)
+            interrupted_session_keys = sorted(active_agents.keys()) if timed_out else []
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
@@ -2351,6 +2954,7 @@ class GatewayRunner:
 
             self.adapters.clear()
             self._running_agents.clear()
+            self._persist_running_sessions_checkpoint()
             self._pending_messages.clear()
             self._pending_approvals.clear()
             if hasattr(self, '_busy_ack_ts'):
@@ -2378,31 +2982,24 @@ class GatewayRunner:
             from gateway.status import remove_pid_file
             remove_pid_file()
 
-            # Write a clean-shutdown marker so the next startup knows this
-            # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits.  However, if the drain timed out and
-            # agents were force-interrupted, their sessions may be in an
-            # incomplete state (trailing tool response, no final assistant
-            # message).  Skip the marker in that case so the next startup
-            # suspends those sessions — giving users a clean slate instead
-            # of resuming a half-finished tool loop.
-            if not timed_out:
-                try:
+            # Mark a truly graceful exit so the next startup skips interrupted
+            # session recovery. If we timed out and interrupted live work, keep
+            # an exact checkpoint instead so only those sessions resume.
+            try:
+                if interrupted_session_keys:
+                    self._running_sessions_checkpoint_path().write_text(
+                        json.dumps({"session_keys": interrupted_session_keys}),
+                        encoding="utf-8",
+                    )
+                else:
                     (_hermes_home / ".clean_shutdown").touch()
-                except Exception:
-                    pass
-            else:
-                logger.info(
-                    "Skipping .clean_shutdown marker — drain timed out with "
-                    "interrupted agents; next startup will suspend recently "
-                    "active sessions."
-                )
+            except Exception:
+                pass
 
             # Track sessions that were active at shutdown for stuck-loop
-            # detection (#7536).  On each restart, the counter increments
-            # for sessions that were running.  If a session hits the
-            # threshold (3 consecutive restarts while active), the next
-            # startup auto-suspends it — breaking the loop.
+            # detection (#7536). On each restart, the counter increments for
+            # sessions that were running. If a session hits the threshold,
+            # the next startup auto-suspends it — breaking the loop.
             if active_agents:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
@@ -2837,8 +3434,7 @@ class GatewayRunner:
                     _quick_key[:30], _stale_age, _stale_idle,
                     _raw_stale_timeout, _stale_detail,
                 )
-                del self._running_agents[_quick_key]
-                self._running_agents_ts.pop(_quick_key, None)
+                self._clear_running_agent_entry(_quick_key)
                 self._busy_ack_ts.pop(_quick_key, None)
 
         if _quick_key in self._running_agents:
@@ -2868,7 +3464,7 @@ class GatewayRunner:
                     adapter.get_pending_message(_quick_key)  # consume and discard
                 self._pending_messages.pop(_quick_key, None)
                 if _quick_key in self._running_agents:
-                    del self._running_agents[_quick_key]
+                    self._clear_running_agent_entry(_quick_key)
                 logger.info("STOP for session %s — agent interrupted, session lock released", _quick_key[:20])
                 return "⚡ Stopped. You can continue this session."
 
@@ -2891,7 +3487,7 @@ class GatewayRunner:
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
                 if _quick_key in self._running_agents:
-                    del self._running_agents[_quick_key]
+                    self._clear_running_agent_entry(_quick_key)
                 return await self._handle_reset_command(event)
 
             # /queue <prompt> — queue without interrupting
@@ -2969,7 +3565,7 @@ class GatewayRunner:
                 if event.get_command() == "stop":
                     # Force-clean the sentinel so the session is unlocked.
                     if _quick_key in self._running_agents:
-                        del self._running_agents[_quick_key]
+                        self._clear_running_agent_entry(_quick_key)
                     logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key[:20])
                     return "⚡ Force-stopped. The agent was still starting — session unlocked."
                 # Queue the message so it will be picked up after the
@@ -3274,8 +3870,7 @@ class GatewayRunner:
         # message arriving during any of those yields would pass the
         # "already running" guard and spin up a duplicate agent for the
         # same session — corrupting the transcript.
-        self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
-        self._running_agents_ts[_quick_key] = time.time()
+        self._set_running_agent_entry(_quick_key, _AGENT_PENDING_SENTINEL)
 
         try:
             return await self._handle_message_with_agent(event, source, _quick_key)
@@ -3285,8 +3880,7 @@ class GatewayRunner:
             # (exception, command fallthrough, etc.) the sentinel must
             # not linger or the session would be permanently locked out.
             if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
-                del self._running_agents[_quick_key]
-            self._running_agents_ts.pop(_quick_key, None)
+                self._clear_running_agent_entry(_quick_key)
 
     async def _prepare_inbound_message_text(
         self,
@@ -3554,6 +4148,25 @@ class GatewayRunner:
 
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
+
+        if getattr(session_entry, 'was_interrupted', False):
+            interrupted_reason = getattr(session_entry, 'interrupted_reason', None) or 'restart'
+            if interrupted_reason == "restart":
+                context_note = (
+                    "[System note: The user's previous turn was interrupted by a gateway restart or shutdown. "
+                    "Resume the existing conversation context from the transcript and continue naturally. "
+                    "Acknowledge the interruption only if it is directly helpful.]"
+                )
+            else:
+                context_note = (
+                    f"[System note: The user's previous turn was interrupted ({interrupted_reason}). "
+                    "Resume the existing conversation context from the transcript and continue naturally. "
+                    "Acknowledge the interruption only if it is directly helpful.]"
+                )
+            context_prompt = context_note + "\n\n" + context_prompt
+            session_entry.was_interrupted = False
+            session_entry.interrupted_reason = None
+            self.session_store._save()
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.
@@ -3901,6 +4514,14 @@ class GatewayRunner:
         if message_text is None:
             return
 
+        direct_work_id = self._begin_direct_work_record(
+            session_id=session_entry.session_id,
+            session_key=session_key,
+            message_text=message_text,
+            platform=_platform_name,
+            event_message_id=event.message_id,
+        )
+
         try:
             # Emit agent:start hook
             hook_ctx = {
@@ -4183,12 +4804,24 @@ class GatewayRunner:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
+                self._finish_direct_work_record(direct_work_id, session_key, failed=False)
                 return None
 
+            if response and response.startswith("MEDIA:"):
+                _media_adapter = self.adapters.get(source.platform)
+                if _media_adapter:
+                    await self._deliver_media_from_response(
+                        response, event, _media_adapter,
+                    )
+                self._finish_direct_work_record(direct_work_id, session_key, failed=False)
+                return None
+
+            self._finish_direct_work_record(direct_work_id, session_key, failed=False)
             return response
             
         except Exception as e:
-            # Stop typing indicator on error too
+            self._finish_direct_work_record(direct_work_id, session_key, failed=True)
+
             try:
                 _err_adapter = self.adapters.get(source.platform)
                 if _err_adapter and hasattr(_err_adapter, "stop_typing"):
@@ -4503,7 +5136,7 @@ class GatewayRunner:
         if agent is _AGENT_PENDING_SENTINEL:
             # Force-clean the sentinel so the session is unlocked.
             if session_key in self._running_agents:
-                del self._running_agents[session_key]
+                self._clear_running_agent_entry(session_key)
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key[:20])
             return "⚡ Stopped. The agent hadn't started yet — you can continue this session."
         if agent:
@@ -4511,7 +5144,7 @@ class GatewayRunner:
             # Force-clean the session lock so a truly hung agent doesn't
             # keep it locked forever.
             if session_key in self._running_agents:
-                del self._running_agents[session_key]
+                self._clear_running_agent_entry(session_key)
             return "⚡ Stopped. You can continue this session."
         else:
             return "No active task to stop."
@@ -6428,7 +7061,7 @@ class GatewayRunner:
 
         # Clear any running agent for this session key
         if session_key in self._running_agents:
-            del self._running_agents[session_key]
+            self._clear_running_agent_entry(session_key)
 
         # Switch the session entry to point at the old session
         new_entry = self.session_store.switch_session(session_key, target_id)
@@ -7675,6 +8308,16 @@ class GatewayRunner:
             last_output_len = current_output_len
 
             if session.exited:
+                try:
+                    self._update_delegated_work_for_process(
+                        executor_session_id=session_id,
+                        exit_code=session.exit_code,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to update delegated work-state from process completion",
+                        exc_info=True,
+                    )
                 # --- Agent-triggered completion: inject synthetic message ---
                 # Skip if the agent already consumed the result via wait/poll/log
                 from tools.process_registry import process_registry as _pr_check
@@ -9040,7 +9683,11 @@ class GatewayRunner:
             while agent_holder[0] is None:
                 await asyncio.sleep(0.05)
             if session_key:
-                self._running_agents[session_key] = agent_holder[0]
+                self._set_running_agent_entry(
+                    session_key,
+                    agent_holder[0],
+                    update_timestamp=False,
+                )
                 if self._draining:
                     self._update_runtime_status("draining")
         
@@ -9519,8 +10166,8 @@ class GatewayRunner:
             # Clean up tracking
             tracking_task.cancel()
             if session_key and session_key in self._running_agents:
-                del self._running_agents[session_key]
-            if session_key:
+                self._clear_running_agent_entry(session_key)
+            elif session_key:
                 self._running_agents_ts.pop(session_key, None)
             if self._draining:
                 self._update_runtime_status("draining")

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -376,6 +376,15 @@ class SessionEntry:
     # this session (create a new session_id) so the user starts fresh.
     # Set by /stop to break stuck-resume loops (#7536).
     suspended: bool = False
+
+    # Persisted crash/restart recovery marker. Unlike ``suspended``, interrupted
+    # sessions keep the same session_id/transcript and resume on the next turn.
+    interrupted: bool = False
+    interrupted_reason: Optional[str] = None
+
+    # One-shot in-memory signal consumed by the message handler to inject a
+    # resume note into the next prompt. Not persisted.
+    was_interrupted: bool = False
     
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -396,6 +405,8 @@ class SessionEntry:
             "cost_status": self.cost_status,
             "memory_flushed": self.memory_flushed,
             "suspended": self.suspended,
+            "interrupted": self.interrupted,
+            "interrupted_reason": self.interrupted_reason,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -433,6 +444,8 @@ class SessionEntry:
             cost_status=data.get("cost_status", "unknown"),
             memory_flushed=data.get("memory_flushed", False),
             suspended=data.get("suspended", False),
+            interrupted=data.get("interrupted", False),
+            interrupted_reason=data.get("interrupted_reason"),
         )
 
 
@@ -715,6 +728,12 @@ class SessionStore:
                 else:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:
+                    if entry.interrupted:
+                        entry.updated_at = now
+                        entry.interrupted = False
+                        entry.was_interrupted = True
+                        self._save()
+                        return entry
                     entry.updated_at = now
                     self._save()
                     return entry
@@ -785,6 +804,45 @@ class SessionStore:
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 self._save()
+
+    def get_session_entry(self, session_key: str) -> Optional[SessionEntry]:
+        """Return a copy of the persisted session entry for *session_key*."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry:
+                return None
+            return SessionEntry.from_dict(entry.to_dict())
+
+    def mark_interrupted_sessions(
+        self,
+        session_keys: list[str],
+        reason: str = "restart",
+    ) -> int:
+        """Mark exact sessions as interrupted so the next turn resumes them.
+
+        Used for gateway restart/crash recovery. Interrupted sessions preserve
+        their session_id and transcript; the next access clears the persisted
+        flag and exposes a one-shot ``was_interrupted`` marker to the caller.
+        """
+        count = 0
+        keys = {key for key in session_keys if key}
+        if not keys:
+            return 0
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            for key in keys:
+                entry = self._entries.get(key)
+                if not entry:
+                    continue
+                entry.interrupted = True
+                entry.interrupted_reason = reason
+                entry.was_interrupted = False
+                count += 1
+            if count:
+                self._save()
+        return count
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/gateway/work_state.py
+++ b/gateway/work_state.py
@@ -1,0 +1,396 @@
+"""Gateway-scoped Hermes work-state tracking for targeted owner ingress.
+
+This module keeps a small persistent ledger of live Hermes work records so
+owner-ingress packets can be resolved against explicit work state rather than
+broad chat/session heuristics.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+
+LIVE_STATES = frozenset({
+    "created",
+    "running",
+    "blocked",
+    "stale",
+    "retry_needed",
+    "handoff_needed",
+    "failed",
+})
+
+WAKE_STATES = frozenset({
+    "blocked",
+    "stale",
+    "retry_needed",
+    "handoff_needed",
+    "failed",
+})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_path_value(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return str(Path(text).expanduser().resolve())
+    except Exception:
+        try:
+            return str(Path(text).expanduser())
+        except Exception:
+            return text
+
+
+@dataclass
+class WorkRecord:
+    work_id: str
+    title: str
+    objective: str
+    owner: str
+    executor: str
+    mode: str
+    owner_session_id: str
+    state: str
+    started_at: datetime
+    last_progress_at: datetime
+    next_action: str
+    executor_session_id: Optional[str] = None
+    tmux_session: Optional[str] = None
+    repo_path: Optional[str] = None
+    worktree_path: Optional[str] = None
+    escalation_target: Optional[str] = None
+    proof: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["started_at"] = self.started_at.isoformat()
+        data["last_progress_at"] = self.last_progress_at.isoformat()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WorkRecord":
+        return cls(
+            work_id=str(data["work_id"]),
+            title=str(data.get("title", "")),
+            objective=str(data.get("objective", "")),
+            owner=str(data.get("owner", "")),
+            executor=str(data.get("executor", "")),
+            mode=str(data.get("mode", "")),
+            owner_session_id=str(data.get("owner_session_id", "")),
+            state=str(data.get("state", "")),
+            started_at=datetime.fromisoformat(data["started_at"]),
+            last_progress_at=datetime.fromisoformat(data["last_progress_at"]),
+            next_action=str(data.get("next_action", "")),
+            executor_session_id=data.get("executor_session_id"),
+            tmux_session=data.get("tmux_session"),
+            repo_path=data.get("repo_path"),
+            worktree_path=data.get("worktree_path"),
+            escalation_target=data.get("escalation_target"),
+            proof=data.get("proof"),
+        )
+
+
+class WorkStateStore:
+    def __init__(self, path: Optional[Path] = None):
+        self.path = Path(path) if path is not None else get_hermes_home() / "gateway_work_state.json"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._records: List[WorkRecord] = []
+        self._loaded = False
+        self._last_mtime_ns: Optional[int] = None
+
+    def _current_mtime_ns(self) -> Optional[int]:
+        try:
+            return self.path.stat().st_mtime_ns
+        except FileNotFoundError:
+            return None
+
+    def _ensure_loaded(self) -> None:
+        current_mtime_ns = self._current_mtime_ns()
+        if self._loaded and current_mtime_ns == self._last_mtime_ns:
+            return
+        if current_mtime_ns is None:
+            self._records = []
+            self._loaded = True
+            self._last_mtime_ns = None
+            return
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception:
+            payload = []
+        if isinstance(payload, dict):
+            payload = payload.get("records", [])
+        self._records = [
+            WorkRecord.from_dict(item)
+            for item in payload
+            if isinstance(item, dict)
+        ]
+        self._loaded = True
+        self._last_mtime_ns = current_mtime_ns
+
+    def _save_locked(self) -> None:
+        self.path.write_text(
+            json.dumps([record.to_dict() for record in self._records], ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        self._last_mtime_ns = self._current_mtime_ns()
+
+    def list_records(self) -> List[WorkRecord]:
+        with self._lock:
+            self._ensure_loaded()
+            return [WorkRecord.from_dict(record.to_dict()) for record in self._records]
+
+    def upsert(self, record: WorkRecord) -> None:
+        with self._lock:
+            self._ensure_loaded()
+            for idx, existing in enumerate(self._records):
+                if (
+                    existing.work_id == record.work_id
+                    and existing.owner_session_id == record.owner_session_id
+                ):
+                    self._records[idx] = record
+                    self._save_locked()
+                    return
+            self._records.append(record)
+            self._save_locked()
+
+    def update_record(
+        self,
+        work_id: str,
+        owner_session_id: str,
+        **updates: Any,
+    ) -> bool:
+        with self._lock:
+            self._ensure_loaded()
+            for record in self._records:
+                if record.work_id == work_id and record.owner_session_id == owner_session_id:
+                    for key, value in updates.items():
+                        if hasattr(record, key):
+                            setattr(record, key, value)
+                    self._save_locked()
+                    return True
+        return False
+
+    def find_matching_records(
+        self,
+        work_id: str,
+        *,
+        owner_session_id: Optional[str] = None,
+        live_only: bool = True,
+    ) -> List[WorkRecord]:
+        with self._lock:
+            self._ensure_loaded()
+            matches = [record for record in self._records if record.work_id == work_id]
+            if owner_session_id:
+                matches = [record for record in matches if record.owner_session_id == owner_session_id]
+            if live_only:
+                matches = [record for record in matches if record.state in LIVE_STATES]
+            return [WorkRecord.from_dict(record.to_dict()) for record in matches]
+
+    def resolve_owner_ingress_candidate(
+        self,
+        work_id: str,
+        *,
+        owner_session_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        matches = self.find_matching_records(
+            work_id,
+            owner_session_id=owner_session_id,
+            live_only=True,
+        )
+        if not matches:
+            return {
+                "status": "missing",
+                "reason": "missing_or_closed_work_record",
+                "matches": [],
+            }
+        hermes_matches = [record for record in matches if record.owner == "hermes"]
+        if not hermes_matches:
+            return {
+                "status": "missing",
+                "reason": "missing_or_closed_work_record",
+                "matches": [],
+            }
+        wake_matches = [record for record in hermes_matches if record.state in WAKE_STATES]
+        if not wake_matches:
+            return {
+                "status": "missing",
+                "reason": "missing_or_closed_work_record",
+                "matches": [],
+            }
+        if len(wake_matches) > 1:
+            return {
+                "status": "ambiguous",
+                "reason": "ambiguous_owner_resolution",
+                "matches": [record.to_dict() for record in wake_matches],
+            }
+        return {
+            "status": "single_match",
+            "reason": "eligible",
+            "matches": [wake_matches[0].to_dict()],
+            "record": wake_matches[0],
+        }
+
+    def resolve_delegated_signal_candidate(
+        self,
+        *,
+        work_id: Optional[str] = None,
+        owner_session_id: Optional[str] = None,
+        executor_session_id: Optional[str] = None,
+        tmux_session: Optional[str] = None,
+        repo_path: Optional[str] = None,
+        worktree_path: Optional[str] = None,
+        live_only: bool = True,
+    ) -> Dict[str, Any]:
+        normalized_repo_path = _normalize_path_value(repo_path)
+        normalized_worktree_path = _normalize_path_value(worktree_path)
+
+        with self._lock:
+            self._ensure_loaded()
+            matches = [
+                record
+                for record in self._records
+                if record.owner == "hermes"
+                and record.executor == "omx"
+                and record.mode == "delegated"
+            ]
+            if live_only:
+                matches = [record for record in matches if record.state in LIVE_STATES]
+            if work_id:
+                matches = [record for record in matches if record.work_id == work_id]
+            if owner_session_id:
+                matches = [record for record in matches if record.owner_session_id == owner_session_id]
+            if executor_session_id:
+                matches = [
+                    record for record in matches if record.executor_session_id == executor_session_id
+                ]
+            if tmux_session:
+                matches = [record for record in matches if record.tmux_session == tmux_session]
+            if normalized_repo_path:
+                matches = [
+                    record
+                    for record in matches
+                    if _normalize_path_value(record.repo_path) == normalized_repo_path
+                ]
+            if normalized_worktree_path:
+                matches = [
+                    record
+                    for record in matches
+                    if _normalize_path_value(record.worktree_path) == normalized_worktree_path
+                ]
+            matches = [WorkRecord.from_dict(record.to_dict()) for record in matches]
+
+        if not matches:
+            return {
+                "status": "missing",
+                "reason": "missing_or_closed_delegated_work_record",
+                "matches": [],
+            }
+        if len(matches) > 1:
+            return {
+                "status": "ambiguous",
+                "reason": "ambiguous_delegated_work_resolution",
+                "matches": [record.to_dict() for record in matches],
+            }
+        return {
+            "status": "single_match",
+            "reason": "eligible",
+            "matches": [matches[0].to_dict()],
+            "record": matches[0],
+        }
+
+    def mark_owner_sessions_blocked(
+        self,
+        session_keys: List[str],
+        *,
+        next_action: str = "Resume the interrupted turn",
+        proof: str = "gateway_restart_checkpoint",
+    ) -> int:
+        keys = {key for key in session_keys if key}
+        if not keys:
+            return 0
+        updated = 0
+        with self._lock:
+            self._ensure_loaded()
+            for record in self._records:
+                if (
+                    record.owner == "hermes"
+                    and record.mode == "direct"
+                    and record.owner_session_id in keys
+                    and record.state in {"created", "running", "stale"}
+                ):
+                    record.state = "blocked"
+                    if next_action:
+                        record.next_action = next_action
+                    record.last_progress_at = _utcnow()
+                    record.proof = proof
+                    updated += 1
+            if updated:
+                self._save_locked()
+        return updated
+
+    def derive_direct_signal(
+        self,
+        work_id: str,
+        *,
+        now: Optional[datetime] = None,
+        stale_after_seconds: int = 0,
+    ) -> Optional[Dict[str, str]]:
+        now = now or _utcnow()
+        matches = self.find_matching_records(work_id, live_only=True)
+        if len(matches) != 1:
+            return None
+        record = matches[0]
+        if record.owner != "hermes" or record.mode != "direct":
+            return None
+        if not record.next_action:
+            return None
+        if record.state == "blocked":
+            return {
+                "work_id": record.work_id,
+                "owner": record.owner,
+                "owner_session_id": record.owner_session_id,
+                "state": "blocked",
+                "next_action": record.next_action,
+                "proof": record.proof or "work_state=blocked",
+            }
+        if record.state in WAKE_STATES:
+            return {
+                "work_id": record.work_id,
+                "owner": record.owner,
+                "owner_session_id": record.owner_session_id,
+                "state": record.state,
+                "next_action": record.next_action,
+                "proof": record.proof or f"work_state={record.state}",
+            }
+        if (
+            record.state == "running"
+            and stale_after_seconds > 0
+            and (now - record.last_progress_at).total_seconds() >= stale_after_seconds
+        ):
+            return {
+                "work_id": record.work_id,
+                "owner": record.owner,
+                "owner_session_id": record.owner_session_id,
+                "state": "stale",
+                "next_action": record.next_action,
+                "proof": (
+                    f"last_progress_at older than {int(stale_after_seconds)}s "
+                    f"({record.last_progress_at.isoformat()})"
+                ),
+            }
+        return None

--- a/tests/gateway/test_owner_ingress_work_state.py
+++ b/tests/gateway/test_owner_ingress_work_state.py
@@ -399,6 +399,135 @@ async def test_handle_message_with_agent_tracks_direct_work_record_failure(tmp_p
     assert records[0].proof == "agent_failed"
 
 
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_reuses_targeted_internal_direct_work_record(tmp_path):
+    runner, store, work_state_store = _make_message_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-direct-resume-1",
+            title="resume blocked direct work",
+            objective="resume the exact blocked direct work record rather than creating a duplicate",
+            owner="hermes",
+            executor="hermes",
+            mode="direct",
+            owner_session_id=session_entry.session_key,
+            state="blocked",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Resume the interrupted owner turn",
+            proof="gateway_restart_checkpoint",
+        )
+    )
+
+    async def fake_run_agent(**_kwargs):
+        records = work_state_store.list_records()
+        assert len(records) == 1
+        assert records[0].work_id == "wk-direct-resume-1"
+        assert records[0].state == "running"
+        return {
+            "final_response": "resumed",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+        }
+
+    runner._run_agent = fake_run_agent
+
+    event = gateway_run.MessageEvent(
+        text="[System note: resume only this targeted work record]",
+        message_type=gateway_run.MessageType.TEXT,
+        source=source,
+        message_id="owner-ingress:direct-resume",
+        raw_message={"work_id": "wk-direct-resume-1", "owner": "hermes"},
+        internal=True,
+    )
+
+    result = await GatewayRunner._handle_message_with_agent(
+        runner,
+        event,
+        source,
+        session_entry.session_key,
+    )
+
+    assert result == "resumed"
+    records = work_state_store.list_records()
+    assert len(records) == 1
+    assert records[0].work_id == "wk-direct-resume-1"
+    assert records[0].state == "finished"
+    assert records[0].proof == "agent_completed"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_does_not_create_duplicate_direct_record_for_internal_delegated_followup(tmp_path):
+    runner, store, work_state_store = _make_message_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-blocked-1",
+            title="delegated blocked work",
+            objective="keep delegated ledger state stable while the owner handles the follow-up",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="blocked",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Inspect the blocked delegated run",
+            executor_session_id="proc-delegated-1",
+            proof="clawhip:session.blocked",
+        )
+    )
+
+    async def fake_run_agent(**_kwargs):
+        records = work_state_store.list_records()
+        assert len(records) == 1
+        assert records[0].work_id == "wk-delegated-blocked-1"
+        assert records[0].mode == "delegated"
+        assert records[0].state == "blocked"
+        return {
+            "final_response": "owner handled",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+        }
+
+    runner._run_agent = fake_run_agent
+
+    event = gateway_run.MessageEvent(
+        text="[System note: delegated owner follow-up]",
+        message_type=gateway_run.MessageType.TEXT,
+        source=source,
+        message_id="owner-ingress:delegated-followup",
+        raw_message={"work_id": "wk-delegated-blocked-1", "owner": "hermes"},
+        internal=True,
+    )
+
+    result = await GatewayRunner._handle_message_with_agent(
+        runner,
+        event,
+        source,
+        session_entry.session_key,
+    )
+
+    assert result == "owner handled"
+    records = work_state_store.list_records()
+    assert len(records) == 1
+    assert records[0].work_id == "wk-delegated-blocked-1"
+    assert records[0].mode == "delegated"
+    assert records[0].state == "blocked"
+    assert records[0].proof == "clawhip:session.blocked"
+
+
 def test_mark_work_record_delegated_handoff_writes_executor_correlation_fields(tmp_path):
     runner, store, work_state_store = _make_runner(tmp_path)
     source = _make_source()

--- a/tests/gateway/test_owner_ingress_work_state.py
+++ b/tests/gateway/test_owner_ingress_work_state.py
@@ -1,0 +1,1120 @@
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+from gateway.work_state import WorkRecord, WorkStateStore
+
+
+class _CaptureAdapter:
+    def __init__(self):
+        self.events = []
+        self.sent = []
+
+    async def handle_message(self, event):
+        self.events.append(event)
+
+    async def send(self, chat_id, content, metadata=None):
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _make_source(chat_id: str = "chat-1", user_id: str = "user-1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        user_id=user_id,
+        user_name=user_id,
+        chat_type="dm",
+    )
+
+
+def _make_discord_thread_source(
+    thread_id: str = "1493539933749776415",
+    user_id: str = "user-1",
+    *,
+    chat_id: str | None = None,
+    include_thread_id: bool = True,
+) -> SessionSource:
+    resolved_chat_id = chat_id or thread_id
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=resolved_chat_id,
+        chat_name="guild / #ops / thread",
+        chat_type="thread",
+        user_id=user_id,
+        user_name=user_id,
+        thread_id=thread_id if include_thread_id else None,
+    )
+
+
+def _make_runner(tmp_path):
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="***"),
+            Platform.WEBHOOK: PlatformConfig(enabled=True, extra={}),
+        }
+    )
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    work_state_store = WorkStateStore(tmp_path / "work_state.json")
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = config
+    runner.session_store = store
+    runner.work_state_store = work_state_store
+    runner.adapters = {Platform.TELEGRAM: _CaptureAdapter()}
+    return runner, store, work_state_store
+
+
+@pytest.mark.asyncio
+async def test_owner_ingress_route_injects_internal_event_for_single_live_work(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-direct-1",
+            title="resume interrupted gateway turn",
+            objective="resume the blocked direct work after restart",
+            owner="hermes",
+            executor="hermes",
+            mode="direct",
+            owner_session_id=entry.session_key,
+            state="blocked",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Resume the interrupted owner turn",
+            proof="gateway_restart_checkpoint",
+        )
+    )
+
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "0.0.0.0",
+                "port": 0,
+                "routes": {
+                    "owner-ingress": {
+                        "secret": _INSECURE_NO_AUTH,
+                        "owner_ingress": True,
+                    }
+                },
+            },
+        )
+    )
+    adapter.gateway_runner = runner
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/webhooks/owner-ingress",
+            json={
+                "work_id": "wk-direct-1",
+                "owner": "hermes",
+                "owner_session_id": entry.session_key,
+                "state": "blocked",
+                "next_action": "Resume the interrupted owner turn",
+                "proof": "gateway_restart_checkpoint",
+            },
+            headers={"X-Request-ID": "owner-ingress-001"},
+        )
+        assert resp.status == 202
+        data = await resp.json()
+        assert data["status"] == "accepted"
+        assert data["verdict"] == "accepted"
+        assert data["resolution"] == "single_match"
+        assert data["target_session_key"] == entry.session_key
+
+    await asyncio.sleep(0.05)
+
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert len(capture_adapter.events) == 1
+    event = capture_adapter.events[0]
+    assert event.internal is True
+    assert event.source.platform == Platform.TELEGRAM
+    assert event.source.chat_id == source.chat_id
+    assert event.source.user_id == source.user_id
+    assert "wk-direct-1" in event.text
+    assert "Resume the interrupted owner turn" in event.text
+    assert "gateway_restart_checkpoint" in event.text
+
+
+@pytest.mark.asyncio
+async def test_owner_ingress_route_rejects_ambiguous_live_work_matches(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source_a = _make_source(chat_id="chat-a", user_id="user-a")
+    source_b = _make_source(chat_id="chat-b", user_id="user-b")
+    entry_a = store.get_or_create_session(source_a)
+    entry_b = store.get_or_create_session(source_b)
+
+    now = datetime.now(timezone.utc)
+    for entry in (entry_a, entry_b):
+        work_state_store.upsert(
+            WorkRecord(
+                work_id="wk-ambiguous",
+                title="ambiguous work",
+                objective="prove 2+ matches refuse wake",
+                owner="hermes",
+                executor="hermes",
+                mode="direct",
+                owner_session_id=entry.session_key,
+                state="blocked",
+                started_at=now,
+                last_progress_at=now,
+                next_action="Do not broad-wake",
+                proof="test-fixture",
+            )
+        )
+
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "0.0.0.0",
+                "port": 0,
+                "routes": {
+                    "owner-ingress": {
+                        "secret": _INSECURE_NO_AUTH,
+                        "owner_ingress": True,
+                    }
+                },
+            },
+        )
+    )
+    adapter.gateway_runner = runner
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/webhooks/owner-ingress",
+            json={
+                "work_id": "wk-ambiguous",
+                "owner": "hermes",
+                "state": "blocked",
+                "next_action": "Do not broad-wake",
+                "proof": "test-fixture",
+            },
+            headers={"X-Request-ID": "owner-ingress-ambiguous"},
+        )
+        assert resp.status == 409
+        data = await resp.json()
+        assert data["verdict"] == "reject"
+        assert data["reason"] == "ambiguous_owner_resolution"
+        assert data["resolution"] == "ambiguous"
+
+    await asyncio.sleep(0.05)
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert capture_adapter.events == []
+
+
+def test_recover_interrupted_sessions_marks_running_direct_work_blocked(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-restart-1",
+            title="restart interrupted work",
+            objective="derive blocked signal from gateway restart checkpoint",
+            owner="hermes",
+            executor="hermes",
+            mode="direct",
+            owner_session_id=entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Continue the interrupted turn",
+        )
+    )
+
+    checkpoint_path = tmp_path / ".running_sessions.json"
+    checkpoint_path.write_text(
+        json.dumps({"session_keys": [entry.session_key]}),
+        encoding="utf-8",
+    )
+
+    recovered = GatewayRunner._recover_interrupted_sessions_from_checkpoint(runner)
+    assert recovered == 1
+
+    signal = work_state_store.derive_direct_signal(
+        "wk-restart-1",
+        now=now + timedelta(minutes=1),
+        stale_after_seconds=3600,
+    )
+    assert signal is not None
+    assert signal["state"] == "blocked"
+    assert signal["owner_session_id"] == entry.session_key
+    assert signal["proof"] == "gateway_restart_checkpoint"
+    assert "Continue the interrupted turn" in signal["next_action"]
+
+
+def test_derive_direct_signal_promotes_stale_from_last_progress_age(tmp_path):
+    work_state_store = WorkStateStore(tmp_path / "work_state.json")
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-stale-1",
+            title="stale work",
+            objective="derive stale from work-state age",
+            owner="hermes",
+            executor="hermes",
+            mode="direct",
+            owner_session_id="agent:main:telegram:dm:chat-1",
+            state="running",
+            started_at=now - timedelta(minutes=20),
+            last_progress_at=now - timedelta(minutes=20),
+            next_action="Check the stuck direct work",
+        )
+    )
+
+    signal = work_state_store.derive_direct_signal(
+        "wk-stale-1",
+        now=now,
+        stale_after_seconds=300,
+    )
+
+    assert signal is not None
+    assert signal["state"] == "stale"
+    assert signal["work_id"] == "wk-stale-1"
+    assert signal["owner"] == "hermes"
+    assert signal["owner_session_id"] == "agent:main:telegram:dm:chat-1"
+    assert signal["next_action"] == "Check the stuck direct work"
+    assert "last_progress_at" in signal["proof"]
+
+
+def _make_message_runner(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    runner.hooks = type("Hooks", (), {"emit": AsyncMock()})()
+    runner._set_session_env = lambda _context: ()
+    runner._prepare_inbound_message_text = AsyncMock(return_value="investigate direct work")
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    return runner, store, work_state_store
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_tracks_direct_work_record_success(tmp_path):
+    runner, store, work_state_store = _make_message_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+
+    async def fake_run_agent(**_kwargs):
+        records = work_state_store.list_records()
+        assert len(records) == 1
+        assert records[0].state == "running"
+        return {
+            "final_response": "done",
+            "messages": [],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "api_calls": 1,
+        }
+
+    runner._run_agent = fake_run_agent
+
+    event = gateway_run.MessageEvent(
+        text="investigate direct work",
+        message_type=gateway_run.MessageType.TEXT,
+        source=source,
+        message_id="msg-success",
+    )
+
+    result = await GatewayRunner._handle_message_with_agent(
+        runner,
+        event,
+        source,
+        session_entry.session_key,
+    )
+
+    assert result == "done"
+    records = work_state_store.list_records()
+    assert len(records) == 1
+    assert records[0].owner_session_id == session_entry.session_key
+    assert records[0].state == "finished"
+    assert records[0].proof == "agent_completed"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_with_agent_tracks_direct_work_record_failure(tmp_path):
+    runner, store, work_state_store = _make_message_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+
+    async def fake_run_agent(**_kwargs):
+        records = work_state_store.list_records()
+        assert len(records) == 1
+        assert records[0].state == "running"
+        raise RuntimeError("boom")
+
+    runner._run_agent = fake_run_agent
+
+    event = gateway_run.MessageEvent(
+        text="investigate direct work",
+        message_type=gateway_run.MessageType.TEXT,
+        source=source,
+        message_id="msg-fail",
+    )
+
+    result = await GatewayRunner._handle_message_with_agent(
+        runner,
+        event,
+        source,
+        session_entry.session_key,
+    )
+
+    assert "encountered an error" in result.lower()
+    records = work_state_store.list_records()
+    assert len(records) == 1
+    assert records[0].owner_session_id == session_entry.session_key
+    assert records[0].state == "failed"
+    assert records[0].proof == "agent_failed"
+
+
+def test_mark_work_record_delegated_handoff_writes_executor_correlation_fields(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+
+    work_id = GatewayRunner._begin_direct_work_record(
+        runner,
+        session_id=session_entry.session_id,
+        session_key=session_entry.session_key,
+        message_text="delegate this task to OMX",
+        platform="telegram",
+        event_message_id="msg-delegated",
+    )
+
+    updated = GatewayRunner._mark_work_record_delegated(
+        runner,
+        work_id,
+        session_entry.session_key,
+        executor_session_id="omx-session-123",
+        tmux_session="omx-hermes-test",
+        repo_path="/repo/demo",
+        worktree_path="/repo/demo",
+        next_action="Resume the OMX-owned delegated run",
+        proof="delegated_handoff:test",
+    )
+
+    assert updated is True
+    records = work_state_store.list_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.work_id == work_id
+    assert record.owner == "hermes"
+    assert record.executor == "omx"
+    assert record.mode == "delegated"
+    assert record.owner_session_id == session_entry.session_key
+    assert record.executor_session_id == "omx-session-123"
+    assert record.tmux_session == "omx-hermes-test"
+    assert record.repo_path == "/repo/demo"
+    assert record.worktree_path == "/repo/demo"
+    assert record.next_action == "Resume the OMX-owned delegated run"
+    assert record.proof == "delegated_handoff:test"
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_resolves_single_match_and_injects_owner_followup(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-1",
+            title="delegated work",
+            objective="correlate OMX signal back to one owner session",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for delegated executor signal",
+            executor_session_id="omx-session-123",
+            tmux_session="omx-hermes-test",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "blocked",
+            "normalized_event": "blocked",
+            "executor": "omx",
+            "executor_session_id": "omx-session-123",
+            "tmux_session": "omx-hermes-test",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Wake the owner and inspect the blocked OMX run",
+            "proof": "clawhip:session.blocked",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-001",
+    )
+
+    assert result["status"] == "accepted"
+    assert result["verdict"] == "accepted"
+    assert result["resolution"] == "single_match"
+    assert result["work_id"] == "wk-delegated-1"
+    assert result["target_session_key"] == session_entry.session_key
+
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert len(capture_adapter.events) == 1
+    event = capture_adapter.events[0]
+    assert event.internal is True
+    assert "wk-delegated-1" in event.text
+    assert "Wake the owner and inspect the blocked OMX run" in event.text
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_preserves_discord_thread_source_for_owner_followup(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    runner.adapters[Platform.DISCORD] = _CaptureAdapter()
+    source = _make_discord_thread_source(thread_id="thread-42", user_id="discord-user")
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-discord-thread-1",
+            title="delegated discord thread work",
+            objective="relay actionable alert back into the owning Discord thread",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for delegated executor signal",
+            executor_session_id="omx-session-discord-1",
+            tmux_session="omx-discord-thread-test",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "blocked",
+            "normalized_event": "blocked",
+            "executor": "omx",
+            "executor_session_id": "omx-session-discord-1",
+            "tmux_session": "omx-discord-thread-test",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Relay the actionable alert into the owning Discord thread",
+            "proof": "clawhip:session.blocked",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-discord-thread-001",
+    )
+
+    assert result["status"] == "accepted"
+    assert result["resolution"] == "single_match"
+
+    capture_adapter = runner.adapters[Platform.DISCORD]
+    assert len(capture_adapter.events) == 1
+    event = capture_adapter.events[0]
+    assert event.internal is True
+    assert event.source.platform == Platform.DISCORD
+    assert event.source.chat_type == "thread"
+    assert event.source.chat_id == "thread-42"
+    assert event.source.thread_id == "thread-42"
+    assert "wk-delegated-discord-thread-1" in event.text
+    assert "Relay the actionable alert into the owning Discord thread" in event.text
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_rejects_missing_discord_thread_source(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    runner.adapters[Platform.DISCORD] = _CaptureAdapter()
+    source = _make_discord_thread_source(
+        thread_id="thread-missing",
+        user_id="discord-user",
+        chat_id="parent-channel-1",
+        include_thread_id=False,
+    )
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-discord-thread-missing",
+            title="delegated discord thread work missing thread id",
+            objective="refuse wrong-thread contamination when thread metadata cannot be restored",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for delegated executor signal",
+            executor_session_id="omx-session-discord-missing",
+            tmux_session="omx-discord-thread-missing",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "blocked",
+            "normalized_event": "blocked",
+            "executor": "omx",
+            "executor_session_id": "omx-session-discord-missing",
+            "tmux_session": "omx-discord-thread-missing",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Do not leak this alert into the parent channel",
+            "proof": "clawhip:session.blocked",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-discord-thread-missing",
+    )
+
+    assert result["status"] == "reject"
+    assert result["reason"] == "missing_owner_thread_source"
+    assert result["resolution"] == "missing"
+
+    capture_adapter = runner.adapters[Platform.DISCORD]
+    assert capture_adapter.events == []
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_retry_needed_prefers_executor_followup_without_owner_wake(
+    tmp_path,
+    monkeypatch,
+):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-retry-1",
+            title="delegated retry work",
+            objective="retry-needed should stay executor-first when a bounded executor target exists",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for delegated executor signal",
+            executor_session_id="proc-retry-1",
+            tmux_session="omx-retry-test",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    dispatched = {}
+
+    def _fake_dispatch(self, record, *, next_action, proof, route_name=""):
+        dispatched["work_id"] = record.work_id
+        dispatched["next_action"] = next_action
+        dispatched["proof"] = proof
+        dispatched["route_name"] = route_name
+        return {
+            "status": "accepted",
+            "route": "process_stdin",
+            "target": record.executor_session_id,
+        }
+
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_dispatch_delegated_retry_followup",
+        _fake_dispatch,
+        raising=False,
+    )
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "retry_needed",
+            "normalized_event": "retry-needed",
+            "executor": "omx",
+            "executor_session_id": "proc-retry-1",
+            "tmux_session": "omx-retry-test",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Retry the OMX lane exactly once using the current session context",
+            "proof": "clawhip:retry-needed",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-retry-001",
+    )
+
+    assert result["status"] == "accepted"
+    assert result["verdict"] == "accepted"
+    assert result["resolution"] == "single_match"
+    assert result["reaction"] == "executor_first"
+    assert result["work_id"] == "wk-delegated-retry-1"
+    assert result["dispatch_route"] == "process_stdin"
+    assert result["target_executor_id"] == "proc-retry-1"
+    assert dispatched == {
+        "work_id": "wk-delegated-retry-1",
+        "next_action": "Retry the OMX lane exactly once using the current session context",
+        "proof": "clawhip:retry-needed",
+        "route_name": "delegated-ingress",
+    }
+
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert capture_adapter.events == []
+
+    record = work_state_store.resolve_delegated_signal_candidate(
+        work_id="wk-delegated-retry-1",
+        live_only=False,
+    )["record"]
+    assert record.state == "running"
+    assert record.next_action == "Wait for delegated executor retry outcome"
+    assert record.proof == "retry_dispatch:process_stdin|source=clawhip:retry-needed"
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_retry_needed_falls_back_to_owner_wake_when_executor_followup_unavailable(
+    tmp_path,
+    monkeypatch,
+):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-retry-2",
+            title="delegated retry fallback work",
+            objective="owner wake should happen only after executor-first follow-up is unavailable",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for delegated executor signal",
+            executor_session_id="proc-retry-missing",
+            tmux_session="omx-retry-missing",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    def _fake_dispatch(self, record, *, next_action, proof, route_name=""):
+        return {
+            "status": "unavailable",
+            "reason": "no_live_executor_surface",
+        }
+
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_dispatch_delegated_retry_followup",
+        _fake_dispatch,
+        raising=False,
+    )
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "retry_needed",
+            "normalized_event": "retry-needed",
+            "executor": "omx",
+            "executor_session_id": "proc-retry-missing",
+            "tmux_session": "omx-retry-missing",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Retry the OMX lane exactly once using the current session context",
+            "proof": "clawhip:retry-needed",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-retry-002",
+    )
+
+    assert result["status"] == "accepted"
+    assert result["verdict"] == "accepted"
+    assert result["resolution"] == "single_match"
+    assert result["reaction"] == "owner_fallback"
+    assert result["work_id"] == "wk-delegated-retry-2"
+
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert len(capture_adapter.events) == 1
+    event = capture_adapter.events[0]
+    assert event.internal is True
+    assert "wk-delegated-retry-2" in event.text
+    assert "Retry the OMX lane exactly once using the current session context" in event.text
+
+    record = work_state_store.resolve_delegated_signal_candidate(
+        work_id="wk-delegated-retry-2",
+        live_only=False,
+    )["record"]
+    assert record.state == "retry_needed"
+    assert record.next_action == "Retry the OMX lane exactly once using the current session context"
+    assert record.proof == "clawhip:retry-needed"
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_rejects_missing_match(tmp_path):
+    runner, store, _work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    store.get_or_create_session(source)
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "blocked",
+            "normalized_event": "blocked",
+            "executor": "omx",
+            "executor_session_id": "omx-session-missing",
+            "tmux_session": "omx-missing",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Do not broad-wake anyone",
+            "proof": "clawhip:session.blocked",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-missing",
+    )
+
+    assert result["status"] == "reject"
+    assert result["verdict"] == "reject"
+    assert result["resolution"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_handle_delegated_ingress_packet_rejects_ambiguous_match(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source_a = _make_source(chat_id="chat-a", user_id="user-a")
+    source_b = _make_source(chat_id="chat-b", user_id="user-b")
+    entry_a = store.get_or_create_session(source_a)
+    entry_b = store.get_or_create_session(source_b)
+    now = datetime.now(timezone.utc)
+
+    for index, entry in enumerate((entry_a, entry_b), start=1):
+        work_state_store.upsert(
+            WorkRecord(
+                work_id=f"wk-delegated-{index}",
+                title="delegated work",
+                objective="prove delegated ambiguity rejects owner wake",
+                owner="hermes",
+                executor="omx",
+                mode="delegated",
+                owner_session_id=entry.session_key,
+                state="blocked",
+                started_at=now,
+                last_progress_at=now,
+                next_action="Do not broad-wake delegated work",
+                executor_session_id="omx-session-shared",
+                tmux_session="omx-shared",
+                repo_path="/repo/demo",
+                worktree_path="/repo/demo",
+                proof="delegated_handoff:test",
+            )
+        )
+
+    result = await GatewayRunner.handle_delegated_ingress_packet(
+        runner,
+        {
+            "owner": "hermes",
+            "state": "blocked",
+            "normalized_event": "blocked",
+            "executor": "omx",
+            "executor_session_id": "omx-session-shared",
+            "tmux_session": "omx-shared",
+            "repo_path": "/repo/demo",
+            "worktree_path": "/repo/demo",
+            "next_action": "Do not broad-wake delegated work",
+            "proof": "clawhip:session.blocked",
+        },
+        route_name="delegated-ingress",
+        delivery_id="delegated-ambiguous",
+    )
+
+    assert result["status"] == "reject"
+    assert result["verdict"] == "reject"
+    assert result["resolution"] == "ambiguous"
+
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert capture_adapter.events == []
+
+
+def test_resolve_delegated_signal_candidate_refreshes_external_store_updates(tmp_path):
+    path = tmp_path / "work_state.json"
+    reader = WorkStateStore(path)
+    assert reader.list_records() == []
+
+    writer = WorkStateStore(path)
+    now = datetime.now(timezone.utc)
+    writer.upsert(
+        WorkRecord(
+            work_id="wk-delegated-refresh-1",
+            title="delegated refresh",
+            objective="reader store should see delegated records written by another store instance",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id="agent:main:telegram:dm:chat-1",
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Resolve delegated record after external write",
+            executor_session_id="proc-refresh-1",
+            tmux_session=None,
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    resolution = reader.resolve_delegated_signal_candidate(
+        work_id="wk-delegated-refresh-1",
+        live_only=False,
+    )
+    assert resolution["status"] == "single_match"
+    assert resolution["record"].executor_session_id == "proc-refresh-1"
+
+
+def test_update_delegated_work_for_process_marks_finished_on_success(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-finish-1",
+            title="delegated finish",
+            objective="mark delegated work finished when OMX executor process exits cleanly",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for OMX completion",
+            executor_session_id="proc-finish-1",
+            tmux_session="omx-finish",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    updated = GatewayRunner._update_delegated_work_for_process(
+        runner,
+        executor_session_id="proc-finish-1",
+        exit_code=0,
+    )
+
+    assert updated is True
+    record = work_state_store.resolve_delegated_signal_candidate(
+        work_id="wk-delegated-finish-1",
+        live_only=False,
+    )["record"]
+    assert record.state == "finished"
+    assert record.proof == "background_process_exit:0"
+    assert record.next_action == "Inspect the completed OMX run"
+
+
+def test_update_delegated_work_for_process_marks_failed_on_nonzero_exit(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-finish-2",
+            title="delegated fail",
+            objective="mark delegated work failed when OMX executor process exits nonzero",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for OMX completion",
+            executor_session_id="proc-finish-2",
+            tmux_session="omx-fail",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    updated = GatewayRunner._update_delegated_work_for_process(
+        runner,
+        executor_session_id="proc-finish-2",
+        exit_code=23,
+    )
+
+    assert updated is True
+    record = work_state_store.resolve_delegated_signal_candidate(
+        work_id="wk-delegated-finish-2",
+        live_only=False,
+    )["record"]
+    assert record.state == "failed"
+    assert record.proof == "background_process_exit:23"
+    assert record.next_action == "Inspect the failed OMX run"
+
+
+def test_finish_direct_work_record_does_not_overwrite_delegated_record_state_or_proof(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-owner-followup-1",
+            title="delegated blocked work",
+            objective="owner follow-up turn should not overwrite delegated executor state",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="blocked",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Resume the delegated OMX work after blocked signal proof",
+            executor_session_id="proc-blocked-1",
+            repo_path="/repo/demo",
+            worktree_path="/repo/demo",
+            proof="clawhip:session.blocked",
+        )
+    )
+
+    GatewayRunner._finish_direct_work_record(
+        runner,
+        "wk-delegated-owner-followup-1",
+        session_entry.session_key,
+        failed=False,
+    )
+
+    record = work_state_store.resolve_delegated_signal_candidate(
+        work_id="wk-delegated-owner-followup-1",
+        live_only=False,
+    )["record"]
+    assert record.state == "blocked"
+    assert record.proof == "clawhip:session.blocked"
+    assert record.next_action == "Resume the delegated OMX work after blocked signal proof"
+
+
+@pytest.mark.asyncio
+async def test_delegated_ingress_webhook_route_calls_gateway_runner(tmp_path):
+    runner, store, work_state_store = _make_runner(tmp_path)
+    source = _make_source()
+    session_entry = store.get_or_create_session(source)
+    now = datetime.now(timezone.utc)
+    work_state_store.upsert(
+        WorkRecord(
+            work_id="wk-delegated-webhook-1",
+            title="delegated webhook work",
+            objective="verify delegated ingress webhook route uses gateway runner correlation",
+            owner="hermes",
+            executor="omx",
+            mode="delegated",
+            owner_session_id=session_entry.session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Wait for delegated webhook signal",
+            executor_session_id="omx-session-webhook",
+            tmux_session="omx-webhook",
+            repo_path="/repo/webhook",
+            worktree_path="/repo/webhook",
+            proof="delegated_handoff:test",
+        )
+    )
+
+    adapter = WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "0.0.0.0",
+                "port": 0,
+                "routes": {
+                    "delegated-ingress": {
+                        "secret": _INSECURE_NO_AUTH,
+                        "delegated_ingress": True,
+                    }
+                },
+            },
+        )
+    )
+    adapter.gateway_runner = runner
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/webhooks/delegated-ingress",
+            json={
+                "owner": "hermes",
+                "state": "blocked",
+                "normalized_event": "blocked",
+                "executor": "omx",
+                "executor_session_id": "omx-session-webhook",
+                "tmux_session": "omx-webhook",
+                "repo_path": "/repo/webhook",
+                "worktree_path": "/repo/webhook",
+                "next_action": "Wake the owner from delegated ingress webhook",
+                "proof": "clawhip:session.blocked",
+            },
+            headers={"X-Request-ID": "delegated-ingress-001"},
+        )
+        assert resp.status == 202
+        data = await resp.json()
+        assert data["status"] == "accepted"
+        assert data["verdict"] == "accepted"
+        assert data["resolution"] == "single_match"
+        assert data["work_id"] == "wk-delegated-webhook-1"
+
+    await asyncio.sleep(0.05)
+    capture_adapter = runner.adapters[Platform.TELEGRAM]
+    assert len(capture_adapter.events) == 1
+    assert "wk-delegated-webhook-1" in capture_adapter.events[0].text

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -12,10 +12,13 @@ import json
 import os
 import queue
 import time
-import pytest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from gateway.work_state import WorkRecord, WorkStateStore
 from tools.process_registry import (
     ProcessRegistry,
     ProcessSession,
@@ -328,6 +331,47 @@ class TestCompletionConsumed:
         result = registry.poll("proc_poll")
         assert result["status"] == "exited"
         assert registry.is_completion_consumed("proc_poll")
+
+    def test_poll_updates_matching_delegated_work_record_on_exit(self, registry, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        store = WorkStateStore(tmp_path / "gateway_work_state.json")
+        now = datetime.now(timezone.utc)
+        store.upsert(
+            WorkRecord(
+                work_id="wk-delegated-poll-1",
+                title="delegated poll finish",
+                objective="poll should close delegated work on exited process observation",
+                owner="hermes",
+                executor="omx",
+                mode="delegated",
+                owner_session_id="agent:discord:thread:test",
+                state="blocked",
+                started_at=now,
+                last_progress_at=now,
+                next_action="Resume delegated run",
+                executor_session_id="proc_poll_finish",
+                repo_path="/repo/demo",
+                worktree_path="/repo/demo",
+                proof="clawhip:session.blocked",
+            )
+        )
+
+        s = _make_session(sid="proc_poll_finish", notify_on_complete=True, output="done")
+        s.exited = True
+        s.exit_code = 0
+        registry._finished[s.id] = s
+
+        result = registry.poll("proc_poll_finish")
+        assert result["status"] == "exited"
+
+        refreshed = WorkStateStore(tmp_path / "gateway_work_state.json")
+        record = refreshed.resolve_delegated_signal_candidate(
+            work_id="wk-delegated-poll-1",
+            live_only=False,
+        )["record"]
+        assert record.state == "finished"
+        assert record.proof == "background_process_exit:0"
+        assert record.next_action == "Inspect the completed OMX run"
 
     def test_log_marks_completion_consumed(self, registry):
         """read_log() on exited session marks as consumed."""

--- a/tests/tools/test_terminal_tool_delegated_work_state.py
+++ b/tests/tools/test_terminal_tool_delegated_work_state.py
@@ -1,0 +1,136 @@
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from gateway.work_state import WorkRecord, WorkStateStore
+
+
+def _make_env_config():
+    return {
+        "env_type": "local",
+        "env_name": "default",
+        "cwd": "/repo/demo",
+        "timeout": 180,
+        "cleanup_timeout": 600,
+        "default_timeout": 180,
+    }
+
+
+def _seed_direct_record(tmp_path, session_key: str):
+    store = WorkStateStore(tmp_path / "gateway_work_state.json")
+    now = datetime.now(timezone.utc)
+    store.upsert(
+        WorkRecord(
+            work_id="wk-direct-live-1",
+            title="delegate current work to OMX",
+            objective="prove terminal background OMX handoff marks delegated work-state",
+            owner="hermes",
+            executor="hermes",
+            mode="direct",
+            owner_session_id=session_key,
+            state="running",
+            started_at=now,
+            last_progress_at=now,
+            next_action="Delegate to OMX",
+            proof="message_ingress:discord",
+        )
+    )
+    return store
+
+
+def test_background_omx_command_marks_current_gateway_work_record_delegated(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.terminal_tool import terminal_tool
+
+    session_key = "agent:discord:thread:test"
+    store = _seed_direct_record(tmp_path, session_key)
+
+    mock_env = MagicMock()
+    mock_env.env = {}
+
+    mock_proc_session = MagicMock()
+    mock_proc_session.id = "proc-omx-1"
+    mock_proc_session.pid = 4321
+
+    mock_registry = MagicMock()
+    mock_registry.spawn_local.return_value = mock_proc_session
+
+    command = "tmux new-session -d -s omx-ch36 'bash -lc \"cd /repo/demo && omx exec -C /repo/demo --json\"'"
+
+    with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+         patch("tools.terminal_tool._last_activity", {"default": 0}), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}), \
+         patch("tools.process_registry.process_registry", mock_registry), \
+         patch("tools.approval.get_current_session_key", return_value=session_key):
+        result = json.loads(
+            terminal_tool(
+                command=command,
+                background=True,
+                workdir="/repo/demo",
+            )
+        )
+
+    assert result["session_id"] == "proc-omx-1"
+    fresh_store = WorkStateStore(tmp_path / "gateway_work_state.json")
+    records = fresh_store.list_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.work_id == "wk-direct-live-1"
+    assert record.executor == "omx"
+    assert record.mode == "delegated"
+    assert record.executor_session_id is None
+    assert record.tmux_session == "omx-ch36"
+    assert record.repo_path == "/repo/demo"
+    assert record.worktree_path == "/repo/demo"
+    assert record.next_action == "Resume the delegated OMX work"
+    assert record.proof == "terminal_background:omx_exec"
+
+
+def test_background_non_omx_command_does_not_rewrite_work_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.terminal_tool import terminal_tool
+
+    session_key = "agent:discord:thread:test"
+    store = _seed_direct_record(tmp_path, session_key)
+
+    mock_env = MagicMock()
+    mock_env.env = {}
+
+    mock_proc_session = MagicMock()
+    mock_proc_session.id = "proc-shell-1"
+    mock_proc_session.pid = 9999
+
+    mock_registry = MagicMock()
+    mock_registry.spawn_local.return_value = mock_proc_session
+
+    with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+         patch("tools.terminal_tool._start_cleanup_thread"), \
+         patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+         patch("tools.terminal_tool._last_activity", {"default": 0}), \
+         patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}), \
+         patch("tools.process_registry.process_registry", mock_registry), \
+         patch("tools.approval.get_current_session_key", return_value=session_key):
+        result = json.loads(
+            terminal_tool(
+                command="python server.py",
+                background=True,
+                workdir="/repo/demo",
+            )
+        )
+
+    assert result["session_id"] == "proc-shell-1"
+    fresh_store = WorkStateStore(tmp_path / "gateway_work_state.json")
+    records = fresh_store.list_records()
+    assert len(records) == 1
+    record = records[0]
+    assert record.executor == "hermes"
+    assert record.mode == "direct"
+    assert record.executor_session_id is None
+    assert record.tmux_session is None
+    assert record.repo_path is None
+    assert record.worktree_path is None
+    assert record.proof == "message_ingress:discord"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -39,6 +39,7 @@ import subprocess
 import threading
 import time
 import uuid
+from datetime import datetime
 
 _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.local import _find_shell, _sanitize_subprocess_env
@@ -629,6 +630,40 @@ class ProcessRegistry:
 
     # ----- Query Methods -----
 
+    def _maybe_update_delegated_work_on_exit(self, session: Optional[ProcessSession]) -> None:
+        """Best-effort delegated work-state closeout when an exited process is observed.
+
+        This complements the gateway watcher path so that explicit process
+        observation via poll/wait/log can still propagate the same executor
+        session exit into the persisted delegated work ledger.
+        """
+        if session is None or not session.exited or not session.id:
+            return
+        try:
+            from gateway.work_state import WorkStateStore
+
+            store = WorkStateStore()
+            resolution = store.resolve_delegated_signal_candidate(
+                executor_session_id=session.id,
+                live_only=True,
+            )
+            if resolution.get("status") != "single_match":
+                return
+            record = resolution.get("record")
+            if record is None:
+                return
+            succeeded = session.exit_code == 0
+            store.update_record(
+                record.work_id,
+                record.owner_session_id,
+                state="finished" if succeeded else "failed",
+                last_progress_at=datetime.now().astimezone(),
+                next_action="Inspect the completed OMX run" if succeeded else "Inspect the failed OMX run",
+                proof=f"background_process_exit:{session.exit_code}",
+            )
+        except Exception:
+            logger.debug("Failed to propagate delegated work-state from process observation", exc_info=True)
+
     def is_completion_consumed(self, session_id: str) -> bool:
         """Check if a completion notification was already consumed via wait/poll/log."""
         return session_id in self._completion_consumed
@@ -659,6 +694,7 @@ class ProcessRegistry:
             "output_preview": output_preview,
         }
         if session.exited:
+            self._maybe_update_delegated_work_on_exit(session)
             result["exit_code"] = session.exit_code
             self._completion_consumed.add(session_id)
         if session.detached:
@@ -694,6 +730,7 @@ class ProcessRegistry:
             "showing": f"{len(selected)} lines",
         }
         if session.exited:
+            self._maybe_update_delegated_work_on_exit(session)
             self._completion_consumed.add(session_id)
         return result
 
@@ -738,6 +775,7 @@ class ProcessRegistry:
         while time.monotonic() < deadline:
             session = self._refresh_detached_session(session)
             if session.exited:
+                self._maybe_update_delegated_work_on_exit(session)
                 self._completion_consumed.add(session_id)
                 result = {
                     "status": "exited",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -36,11 +36,13 @@ import logging
 import os
 import platform
 import re
+import shlex
 import time
 import threading
 import atexit
 import shutil
 import subprocess
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -1103,6 +1105,73 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
+def _extract_tmux_session_name(command: str) -> Optional[str]:
+    try:
+        tokens = shlex.split(command)
+    except Exception:
+        return None
+    for idx, token in enumerate(tokens[:-1]):
+        if token == "-s" and idx + 1 < len(tokens):
+            value = str(tokens[idx + 1]).strip()
+            if value:
+                return value
+    return None
+
+
+def _looks_like_omx_delegation(command: str) -> bool:
+    normalized = " ".join((command or "").lower().split())
+    return "omx exec" in normalized or "omx team" in normalized
+
+
+def _maybe_mark_gateway_work_delegated(
+    *,
+    command: str,
+    session_key: str,
+    executor_session_id: Optional[str],
+    workdir: Optional[str],
+) -> bool:
+    if not session_key or not _looks_like_omx_delegation(command):
+        return False
+
+    from gateway.work_state import WorkStateStore
+
+    store = WorkStateStore()
+    candidates = [
+        record
+        for record in store.list_records()
+        if record.owner_session_id == session_key
+        and record.owner == "hermes"
+        and record.state in {"created", "running", "blocked", "stale"}
+    ]
+    if not candidates:
+        return False
+
+    direct_candidates = [record for record in candidates if record.mode == "direct"]
+    target = max(
+        direct_candidates or candidates,
+        key=lambda record: record.last_progress_at,
+    )
+    now = datetime.now().astimezone()
+    tmux_session = _extract_tmux_session_name(command)
+    repo_path = workdir or target.repo_path
+    worktree_path = workdir or target.worktree_path
+    delegated_executor_session_id = None if tmux_session else (executor_session_id or target.executor_session_id)
+    return store.update_record(
+        target.work_id,
+        target.owner_session_id,
+        executor="omx",
+        mode="delegated",
+        state="running",
+        last_progress_at=now,
+        executor_session_id=delegated_executor_session_id,
+        tmux_session=tmux_session or target.tmux_session,
+        repo_path=repo_path,
+        worktree_path=worktree_path,
+        next_action="Resume the delegated OMX work",
+        proof="terminal_background:omx_exec",
+    )
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -1380,6 +1449,14 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
+                delegated_marked = _maybe_mark_gateway_work_delegated(
+                    command=command,
+                    session_key=session_key,
+                    executor_session_id=proc_session.id,
+                    workdir=effective_cwd,
+                )
+                if delegated_marked:
+                    result_data["delegated_work_state"] = "marked"
                 if approval_note:
                     result_data["approval"] = approval_note
                 if pty_disabled_reason:


### PR DESCRIPTION
## Summary
- add a persistent gateway work-state ledger for direct and delegated owner work
- resolve owner/delegated ingress packets against explicit work records instead of broad chat heuristics
- reject thread-scoped owner follow-up when Discord thread metadata is missing
- reuse targeted internal direct work records instead of spawning duplicate ledger entries on owner-ingress resumes

## What changed
- add `gateway/work_state.py` with the persisted `WorkRecord` / `WorkStateStore` ledger
- add owner-ingress and delegated-ingress webhook handling and correlation in `gateway/run.py` and `gateway/platforms/webhook.py`
- track delegated OMX handoff / background-process completion in terminal and process-registry paths
- add targeted tests for Discord thread preservation/rejection, delegated work-state updates, and internal-owner resume behavior
- keep internal delegated owner follow-up from creating a duplicate direct work record

## Verification
- `source /home/ubuntu/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/gateway/test_owner_ingress_work_state.py tests/gateway/test_background_process_notifications.py tests/gateway/test_restart_notification.py tests/tools/test_notify_on_complete.py tests/tools/test_terminal_tool_delegated_work_state.py -q`
- result: 81 passed

## Notes
- branch is extracted onto a clean `upstream/main` base as `yuuka/gateway-owner-ingress-work-state-clean`
- this PR includes the follow-up fix commit that reuses targeted internal direct work records to avoid owner-ingress ledger drift
