### PR TITLE
fix #11096: respect model.context_length override for minimum check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1504,7 +1504,7 @@ class AIAgent:
         # for reliable tool-calling workflows (64K tokens).
         from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
         _ctx = getattr(self.context_compressor, "context_length", 0)
-        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+        if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and _config_context_length is None:
             raise ValueError(
                 f"Model {self.model} has a context window of {_ctx:,} tokens, "
                 f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "


### PR DESCRIPTION
Fixes #11096 (Bug 1)

The MINIMUM_CONTEXT_LENGTH guard (64K) fired unconditionally, ignoring the documented model.context_length config override. This broke all models with <64K native context even when the user explicitly set an override.

The error message says "set model.context_length in config.yaml to override" but the guard never checked whether the override was set.

Fix: Added `and _config_context_length is None` to the guard condition so the documented escape hatch actually works.