### PR TITLE
feat(plugins): make pre_api_request hook mutable

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8819,7 +8819,7 @@ class AIAgent:
 
                     try:
                         from hermes_cli.plugins import invoke_hook as _invoke_hook
-                        _invoke_hook(
+                        _hook_results = _invoke_hook(
                             "pre_api_request",
                             task_id=effective_task_id,
                             session_id=self.session_id or "",
@@ -8834,7 +8834,12 @@ class AIAgent:
                             approx_input_tokens=approx_tokens,
                             request_char_count=total_chars,
                             max_tokens=self.max_tokens,
+                            api_kwargs=api_kwargs,
                         )
+                        # Let plugins mutate the request — last non-None dict wins
+                        for _hr in _hook_results:
+                            if isinstance(_hr, dict):
+                                api_kwargs = _hr
                     except Exception:
                         pass
 


### PR DESCRIPTION
## Summary

The `pre_api_request` hook is currently observe-only — plugins receive metadata (model name, token counts, etc.) but cannot modify the actual API request. The return value is discarded.

This PR passes `api_kwargs` into the hook and allows callbacks to return a modified dict that replaces the original `api_kwargs` for the API call.

## Changes

**`run_agent.py`** (~5 lines changed):
- Pass `api_kwargs=api_kwargs` as an additional kwarg to the `pre_api_request` hook
- Capture the hook's return list; iterate results — last non-`None` `dict` becomes the new `api_kwargs`

## Convention

Last non-`None` dict wins. If multiple plugins return modified kwargs, the last one in registration order takes precedence. Plugins that just observe can continue returning `None` — fully backward compatible.

## Use cases

- Set `tool_choice` to force tool calls during specific execution phases
- Inject or override request parameters based on plugin state
- Implement request-level middleware (rate shaping, payload transforms, etc.)

## Example

```python
def on_pre_api_request(**kwargs):
    api_kwargs = kwargs.get("api_kwargs", {})
    if should_force_tool_call():
        api_kwargs["tool_choice"] = {"type": "function", "function": {"name": "my_tool"}}
        return api_kwargs
    return None  # pass-through
```

## Testing

Existing tests pass — `test_tool_calls_then_stop` (exercises the hook path) and all 48 plugin tests.