### PR TITLE
chore: add bare noreply email for kshitijk4poor to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ AUTHOR_MAP = {
     # contributors (from noreply pattern)
     "35742124+0xbyt4@users.noreply.github.com": "0xbyt4",
     "82637225+kshitijk4poor@users.noreply.github.com": "kshitijk4poor",
+    "kshitijk4poor@users.noreply.github.com": "kshitijk4poor",
     "16443023+stablegenius49@users.noreply.github.com": "stablegenius49",
     "185121704+stablegenius49@users.noreply.github.com": "stablegenius49",
     "101283333+batuhankocyigit@users.noreply.github.com": "batuhankocyigit",


### PR DESCRIPTION
The numbered form (`82637225+kshitijk4poor@`) was already mapped but the bare form (`kshitijk4poor@users.noreply.github.com`) used by cherry-pick commits was missing, causing check-attribution CI to fail on salvage PRs.