### PR TITLE
burndown: reliability: fix undefined names and lint hygiene

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -730,7 +730,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(
+                    turns_to_summarize,
+                    focus_topic=focus_topic,
+                )  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -28,7 +28,6 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from typing import Any, Dict, List, Optional

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -20,6 +20,7 @@ rather than parsing the raw JSON themselves.
 
 import json
 import logging
+import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -425,7 +426,6 @@ def list_provider_models(provider: str) -> List[str]:
 
 # Patterns that indicate non-agentic or noise models (TTS, embedding,
 # dated preview snapshots, live/streaming-only, image-only).
-import re
 _NOISE_PATTERNS: re.Pattern = re.compile(
     r"-tts\b|embedding|live-|-(preview|exp)-\d{2,4}[-_]|"
     r"-image\b|-image-preview\b|-customtools\b",
@@ -582,5 +582,4 @@ def get_model_info(
             return _parse_model_info(mid, mdata, mdev_id)
 
     return None
-
 

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -75,7 +75,8 @@ class CostResult:
     notes: tuple[str, ...] = ()
 
 
-_UTC_NOW = lambda: datetime.now(timezone.utc)
+def _UTC_NOW() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 # Official docs snapshot entries. Models whose published pricing and cache

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -15,14 +15,16 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-import os
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 from model_tools import handle_function_call
 from tools.terminal_tool import get_active_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
+
+if TYPE_CHECKING:
+    from tools.budget_config import BudgetConfig
 
 # Thread pool for running sync tool calls that internally use asyncio.run()
 # (e.g., the Modal/Docker/Daytona terminal backends). Running them in a separate
@@ -377,7 +379,6 @@ class HermesAgentLoop:
                         if args is not None:
                             try:
                                 if tool_name == "terminal":
-                                    backend = os.getenv("TERMINAL_ENV", "local")
                                     cmd_preview = args.get("command", "")[:80]
                                     logger.info(
                                         "[%s] $ %s", self.task_id[:8], cmd_preview,

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -25,7 +25,7 @@ import hmac
 import logging
 import os
 import urllib.parse
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -37,6 +37,9 @@ from gateway.platforms.base import (
 from gateway.platforms.helpers import redact_phone, strip_markdown
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import aiohttp
 
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
 MAX_SMS_LENGTH = 1600  # ~10 SMS segments

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -25,11 +25,14 @@ import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import aiohttp
 
 
 def _kill_port_process(port: int) -> None:

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -23,7 +23,10 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from agent.context_engine import ContextEngine
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -26,7 +26,10 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from agent.memory_provider import MemoryProvider
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import numpy as np
     from .store import MemoryStore
 
 try:

--- a/rl_cli.py
+++ b/rl_cli.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 import fire
 import yaml
+from hermes_constants import OPENROUTER_BASE_URL, get_hermes_home
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
@@ -59,8 +60,6 @@ from tools.rl_training_tool import get_missing_keys
 # ============================================================================
 # Config Loading
 # ============================================================================
-
-from hermes_constants import get_hermes_home, OPENROUTER_BASE_URL
 
 DEFAULT_MODEL = "anthropic/claude-opus-4.5"
 DEFAULT_BASE_URL = OPENROUTER_BASE_URL
@@ -412,7 +411,7 @@ def main(
                 
                 # Run the agent
                 print("\n" + "=" * 60)
-                response = agent.run_conversation(user_input)
+                agent.run_conversation(user_input)
                 print("\n" + "=" * 60)
                 
             except KeyboardInterrupt:
@@ -429,7 +428,7 @@ def main(
         print("-" * 40)
         
         try:
-            response = agent.run_conversation(task)
+            agent.run_conversation(task)
             print("\n" + "=" * 60)
             print("✅ Task completed")
         except KeyboardInterrupt:

--- a/run_agent.py
+++ b/run_agent.py
@@ -37,11 +37,14 @@ import time
 import threading
 from types import SimpleNamespace
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import TYPE_CHECKING, List, Dict, Any, Optional
 from openai import OpenAI
 import fire
 from datetime import datetime
 from pathlib import Path
+
+if TYPE_CHECKING:
+    from agent.rate_limit_tracker import RateLimitState
 
 from hermes_constants import get_hermes_home
 
@@ -70,9 +73,6 @@ from tools.terminal_tool import cleanup_vm, get_active_env, is_persistent_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
-
-
-from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block, sanitize_context
@@ -9013,7 +9013,7 @@ class AIAgent:
                         elif _resp_error_code == 504:
                             _failure_hint = f"upstream gateway timeout (504, {api_duration:.0f}s)"
                         elif _resp_error_code == 429:
-                            _failure_hint = f"rate limited by upstream provider (429)"
+                            _failure_hint = "rate limited by upstream provider (429)"
                         elif _resp_error_code in (500, 502):
                             _failure_hint = f"upstream server error ({_resp_error_code}, {api_duration:.0f}s)"
                         elif _resp_error_code in (503, 529):

--- a/skills/red-teaming/godmode/scripts/auto_jailbreak.py
+++ b/skills/red-teaming/godmode/scripts/auto_jailbreak.py
@@ -19,6 +19,7 @@ import os
 import json
 import time
 import yaml
+import inspect as _inspect
 from pathlib import Path
 
 try:
@@ -45,13 +46,15 @@ _parseltongue_path = _SCRIPTS_DIR / "parseltongue.py"
 _race_path = _SCRIPTS_DIR / "godmode_race.py"
 
 # Use the calling frame's globals so functions are accessible everywhere
-import inspect as _inspect
 _caller_globals = _inspect.stack()[0][0].f_globals if len(_inspect.stack()) > 0 else globals()
 
 if _parseltongue_path.exists():
     exec(compile(open(_parseltongue_path).read(), str(_parseltongue_path), 'exec'), _caller_globals)
 if _race_path.exists():
     exec(compile(open(_race_path).read(), str(_race_path), 'exec'), _caller_globals)
+
+escalate_encoding = _caller_globals.get("escalate_encoding")
+score_response = _caller_globals.get("score_response")
 
 # ═══════════════════════════════════════════════════════════════════
 # Hermes config paths
@@ -440,6 +443,11 @@ def auto_jailbreak(model=None, base_url=None, api_key=None,
     """
     if OpenAI is None:
         return {"success": False, "error": "openai package not installed"}
+    if not callable(score_response) or not callable(escalate_encoding):
+        return {
+            "success": False,
+            "error": "Required jailbreak helpers failed to load",
+        }
 
     # 1. Detect model
     if not model:
@@ -609,7 +617,7 @@ def auto_jailbreak(model=None, base_url=None, api_key=None,
 
         # Try with system prompt + prefill combined
         if verbose:
-            print(f"  [RETRY] Adding prefill messages...")
+            print("  [RETRY] Adding prefill messages...")
         msgs = _build_messages(
             system_prompt=system_prompt,
             prefill=STANDARD_PREFILL,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,6 +14,7 @@ import sys
 import uuid
 from datetime import datetime
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +22,9 @@ import pytest
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionEntry, SessionSource, build_session_key
+
+if TYPE_CHECKING:
+    from gateway.run import GatewayRunner
 
 
 # Platform library mocks

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -6,15 +6,16 @@ import os
 import tempfile
 import time
 import unittest
+import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
-try:
-    import lark_oapi
-    _HAS_LARK_OAPI = True
-except ImportError:
-    _HAS_LARK_OAPI = False
+if TYPE_CHECKING:
+    from gateway.platforms.feishu import FeishuAdapter
+
+_HAS_LARK_OAPI = importlib.util.find_spec("lark_oapi") is not None
 
 
 def _mock_event_dispatcher_builder(mock_handler_class):
@@ -2549,8 +2550,6 @@ class TestWebhookSecurity(unittest.TestCase):
 
     def test_signature_valid_passes(self):
         import hashlib
-        from gateway.platforms.feishu import FeishuAdapter
-        from gateway.config import PlatformConfig
 
         encrypt_key = "test_secret"
         adapter = self._make_adapter(encrypt_key)

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -31,8 +31,11 @@ Usage:
 import difflib
 import re
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Any
 from enum import Enum
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from tools.file_operations import PatchResult
 
 
 class OperationType(Enum):
@@ -263,7 +266,9 @@ def _validate_operations(
 
             simulated = read_result.content
             for hunk in op.hunks:
-                search_lines = [l.content for l in hunk.lines if l.prefix in (' ', '-')]
+                search_lines = [
+                    line.content for line in hunk.lines if line.prefix in (' ', '-')
+                ]
                 if not search_lines:
                     # Addition-only hunk: validate context hint uniqueness
                     if hunk.context_hint:
@@ -282,7 +287,9 @@ def _validate_operations(
                     continue
 
                 search_pattern = '\n'.join(search_lines)
-                replace_lines = [l.content for l in hunk.lines if l.prefix in (' ', '+')]
+                replace_lines = [
+                    line.content for line in hunk.lines if line.prefix in (' ', '+')
+                ]
                 replacement = '\n'.join(replace_lines)
 
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -37,7 +37,7 @@ import yaml
 import logging
 import asyncio
 from pathlib import Path
-from typing import List, Dict, Any, Optional, Tuple, Callable
+from typing import Any, Dict, List, Tuple
 from dataclasses import dataclass, field
 from datetime import datetime
 import fire
@@ -1153,7 +1153,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         skipped_pct = (skipped / max(total, 1)) * 100
         over_limit_pct = (over_limit / max(total, 1)) * 100
         
-        print(f"\n")
+        print("\n")
         print(f"╔{'═'*70}╗")
         print(f"║{'TRAJECTORY COMPRESSION REPORT':^70}║")
         print(f"╠{'═'*70}╣")
@@ -1236,7 +1236,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             ratios = self.aggregate_metrics.compression_ratios
             tokens_saved_list = self.aggregate_metrics.tokens_saved_list
             
-            print(f"\n📊 Distribution Summary:")
+            print("\n📊 Distribution Summary:")
             print(f"   Compression ratios: min={min(ratios):.2%}, max={max(ratios):.2%}, median={sorted(ratios)[len(ratios)//2]:.2%}")
             print(f"   Tokens saved:       min={min(tokens_saved_list):,}, max={max(tokens_saved_list):,}, median={sorted(tokens_saved_list)[len(tokens_saved_list)//2]:,}")
 
@@ -1319,7 +1319,7 @@ def main(
     is_file_input = input_path.is_file()
     
     if is_file_input:
-        print(f"📄 Input mode: Single JSONL file")
+        print("📄 Input mode: Single JSONL file")
         
         # For file input, default output is file with _compressed suffix
         if output:
@@ -1349,7 +1349,7 @@ def main(
             print(f"   Sampled {len(entries):,} trajectories ({sample_percent}% of {total_entries:,})")
         
         if dry_run:
-            print(f"\n🔍 DRY RUN MODE - analyzing without writing")
+            print("\n🔍 DRY RUN MODE - analyzing without writing")
             print(f"📄 Would process: {len(entries):,} trajectories")
             print(f"📄 Would output to: {output_path}")
             return
@@ -1385,12 +1385,12 @@ def main(
                 shutil.copy(metrics_file, metrics_output)
                 print(f"💾 Metrics saved to {metrics_output}")
         
-        print(f"\n✅ Compression complete!")
+        print("\n✅ Compression complete!")
         print(f"📄 Output: {output_path}")
         
     else:
         # Directory input - original behavior
-        print(f"📁 Input mode: Directory of JSONL files")
+        print("📁 Input mode: Directory of JSONL files")
         
         if output:
             output_path = Path(output)
@@ -1436,7 +1436,7 @@ def main(
                 print(f"   Sampled {total_sampled:,} from {total_original:,} total trajectories")
                 
                 if dry_run:
-                    print(f"\n🔍 DRY RUN MODE - analyzing without writing")
+                    print("\n🔍 DRY RUN MODE - analyzing without writing")
                     print(f"📁 Would process: {temp_input_dir}")
                     print(f"📁 Would output to: {output_path}")
                     return
@@ -1446,7 +1446,7 @@ def main(
                 compressor.process_directory(temp_input_dir, output_path)
         else:
             if dry_run:
-                print(f"\n🔍 DRY RUN MODE - analyzing without writing")
+                print("\n🔍 DRY RUN MODE - analyzing without writing")
                 print(f"📁 Would process: {input_path}")
                 print(f"📁 Would output to: {output_path}")
                 return


### PR DESCRIPTION
## Summary
- fix high-signal undefined-name failures across context compression, plugin loaders, gateway adapters, tests, and tooling
- harden auto_jailbreak helper loading and clean small reliability/lint issues in touched files
- remove a few no-op imports/variables and small string/comprehension hygiene issues uncovered during the slice

## Validation
- `ruff check . --select F821 --statistics`
- `ruff check agent/context_compressor.py rl_cli.py environments/agent_loop.py gateway/platforms/sms.py gateway/platforms/whatsapp.py plugins/context_engine/__init__.py plugins/memory/__init__.py plugins/memory/holographic/retrieval.py run_agent.py tests/e2e/conftest.py tests/gateway/test_feishu.py tools/patch_parser.py agent/memory_manager.py agent/models_dev.py agent/usage_pricing.py trajectory_compressor.py skills/red-teaming/godmode/scripts/auto_jailbreak.py --select F821,F401,E731,F541,F841,E741`
- `python -m pytest tests/agent/test_context_compressor.py tests/e2e tests/gateway/test_feishu.py tests/tools/test_file_operations.py -q`

## Notes
- this is an initial high-signal burndown slice, not a full repo-wide lint cleanup
- existing broader E402 debt in large files like `run_agent.py`, `gateway/platforms/whatsapp.py`, and `rl_cli.py` remains for later passes