### PR TITLE
fix: tighten AgentMail API key regex to avoid false positives

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -44,7 +44,7 @@ _PREFIX_PATTERNS = [
     r"pypi-[A-Za-z0-9_-]{10,}",         # PyPI API token
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
-    r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
+    r"am_[a-f0-9]{32,}",              # AgentMail API key (hex format, 32+ chars)
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key


### PR DESCRIPTION
## Summary
The secret redaction pattern for AgentMail API keys was too broad, causing ordinary identifiers like "am_example_identifier" to be falsely masked as secrets.

## Root Cause
The regex pattern  matched any 10+ alphanumeric characters after "am_", which is a common pattern for generic identifiers.

## Fix
Changed the pattern to  which:
- Requires lowercase hex characters only (real AgentMail keys use hex format)
- Requires 32+ characters after the prefix (reducing false positives)

## Test Plan
- [x] Verified safe identifiers like "am_example" are not redacted
- [x] Verified real AgentMail-like keys (32+ hex chars) are still redacted
- [x] All 56 existing redaction tests pass

Closes NousResearch/hermes-agent#10983