### PR TITLE
fix(matrix): strip only explicit @mentions in _strip_mention

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1816,13 +1816,33 @@ class MatrixAdapter(BasePlatformAdapter):
         return False
 
     def _strip_mention(self, body: str) -> str:
-        """Remove bot mention from message body."""
+        """Remove explicit bot mentions from message body.
+
+        Important: only strip explicit mention tokens (``@user:server`` or
+        ``@localpart``). Do NOT strip bare words matching the bot localpart,
+        otherwise normal phrases like "Hermes Agent" become "Agent".
+        """
+        if not body:
+            return ""
+
+        # Strip explicit full MXID mentions.
         if self._user_id:
             body = body.replace(self._user_id, "")
+
+        # Strip explicit @localpart mentions only (not bare localpart words).
         if self._user_id and ":" in self._user_id:
             localpart = self._user_id.split(":")[0].lstrip("@")
             if localpart:
-                body = re.sub(r'\b' + re.escape(localpart) + r'\b', '', body, flags=re.IGNORECASE)
+                body = re.sub(
+                    r'(?<![\w])@' + re.escape(localpart) + r'\b',
+                    '',
+                    body,
+                    flags=re.IGNORECASE,
+                )
+
+        # Normalize spacing after mention removal.
+        body = re.sub(r'[ \t]{2,}', ' ', body)
+        body = re.sub(r'\s+([,.;:!?])', r'\1', body)
         return body.strip()
 
     async def _get_display_name(self, room_id: str, user_id: str) -> str:

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -159,9 +159,14 @@ class TestStripMention:
         result = self.adapter._strip_mention("@hermes:example.org help me")
         assert result == "help me"
 
-    def test_strip_localpart(self):
-        result = self.adapter._strip_mention("hermes help me")
+    def test_strip_localpart_when_explicit_at_mention(self):
+        result = self.adapter._strip_mention("@hermes help me")
         assert result == "help me"
+
+    def test_does_not_strip_bare_localpart_word(self):
+        # Regression: plain words like "Hermes Agent" should not be mutated.
+        result = self.adapter._strip_mention("Hermes Agent")
+        assert result == "Hermes Agent"
 
     def test_strip_returns_empty_for_mention_only(self):
         result = self.adapter._strip_mention("@hermes:example.org")


### PR DESCRIPTION
## Summary
- Fix Matrix mention stripping to remove only explicit mentions (`@user:server` and `@localpart`).
- Prevent accidental mutation of normal text containing the bot name localpart (e.g. "Hermes Agent" -> "Agent").
- Keep whitespace/punctuation normalization after mention removal.

## Tests
- `python -m pytest tests/gateway/test_matrix_mention.py -q`
- `python -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_voice.py -q`

All targeted Matrix gateway tests pass locally.

## Why
Previously `_strip_mention` removed bare localpart words with a `\b<localpart>\b` regex. That caused false positives in ordinary messages that were not explicit mention tokens.
