### PR TITLE
fix: suppress stale heartbeats during gateway restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9111,6 +9111,9 @@ class GatewayRunner:
                 return
             while True:
                 await asyncio.sleep(_NOTIFY_INTERVAL)
+                # Skip notification if gateway is draining or restart requested
+                if self._draining or self._restart_requested:
+                    continue
                 _elapsed_mins = int((time.time() - _notify_start) // 60)
                 # Include agent activity context if available.
                 _agent_ref = agent_holder[0]


### PR DESCRIPTION
## Summary
The gateway's long-running notification task was sending "Still working..." messages even after a restart was requested, causing confusing UX where users received a restart warning followed by normal heartbeat messages.

## Root Cause
The _notify_long_running() task runs independently and doesn't check if the gateway is draining or restarting before sending notifications.

## Fix
Added a check in _notify_long_running() to skip notifications when:
- Gateway is draining (self._draining is True)
- Restart has been requested (self._restart_requested is True)

## Test Plan
- [x] Code review confirms the fix is in the right location
- [x] The fix is minimal and targeted

Closes NousResearch/hermes-agent#10990