### PR TITLE
fix #11017: handle list-type models in providers dict format

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1776,6 +1776,9 @@ def _normalize_custom_provider_entry(
     models = entry.get("models")
     if isinstance(models, dict) and models:
         normalized["models"] = models
+    elif isinstance(models, list) and models:
+        # providers: dict format uses a plain list for models
+        normalized["models"] = {m: {} for m in models if isinstance(m, str)}
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:


### PR DESCRIPTION
Fixes #11017

_normalize_custom_provider_entry() only handled models when it was a dict, silently dropping the list format used by the providers: dict in config.yaml. This caused duplicate entries in the /model picker.

Fix: Also handle list-format models by converting to the expected dict format.