### PR TITLE
fix(bedrock): inherit modalities for inference profiles + detect AWS creds in /model picker

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -96,6 +96,7 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
 
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
+    "bedrock": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
     "gemini": "gemini-3-flash-preview",
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
@@ -484,10 +485,11 @@ class AsyncCodexAuxiliaryClient:
 class _AnthropicCompletionsAdapter:
     """OpenAI-client-compatible adapter for Anthropic Messages API."""
 
-    def __init__(self, real_client: Any, model: str, is_oauth: bool = False):
+    def __init__(self, real_client: Any, model: str, is_oauth: bool = False, preserve_dots: bool = False):
         self._client = real_client
         self._model = model
         self._is_oauth = is_oauth
+        self._preserve_dots = preserve_dots
 
     def create(self, **kwargs) -> Any:
         from agent.anthropic_adapter import build_anthropic_kwargs, normalize_anthropic_response
@@ -517,6 +519,7 @@ class _AnthropicCompletionsAdapter:
             reasoning_config=None,
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
+            preserve_dots=self._preserve_dots,
         )
         if temperature is not None:
             anthropic_kwargs["temperature"] = temperature
@@ -555,9 +558,9 @@ class _AnthropicChatShim:
 class AnthropicAuxiliaryClient:
     """OpenAI-client-compatible wrapper over a native Anthropic client."""
 
-    def __init__(self, real_client: Any, model: str, api_key: str, base_url: str, is_oauth: bool = False):
+    def __init__(self, real_client: Any, model: str, api_key: str, base_url: str, is_oauth: bool = False, preserve_dots: bool = False):
         self._real_client = real_client
-        adapter = _AnthropicCompletionsAdapter(real_client, model, is_oauth=is_oauth)
+        adapter = _AnthropicCompletionsAdapter(real_client, model, is_oauth=is_oauth, preserve_dots=preserve_dots)
         self.chat = _AnthropicChatShim(adapter)
         self.api_key = api_key
         self.base_url = base_url
@@ -1616,6 +1619,33 @@ def resolve_provider_client(
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
+
+    # ── AWS Bedrock (aws_sdk auth via AnthropicBedrock SDK) ──────────
+    if pconfig.auth_type == "aws_sdk":
+        try:
+            from agent.anthropic_adapter import build_anthropic_bedrock_client
+            from agent.bedrock_adapter import resolve_bedrock_region
+            from hermes_cli.config import load_config as _load_br_cfg
+
+            _br_cfg = _load_br_cfg()
+            _bedrock_cfg = _br_cfg.get("bedrock", {})
+            region = (_bedrock_cfg.get("region") or "").strip() or resolve_bedrock_region()
+            # Resolve auxiliary model: explicit arg > global auxiliary config > default
+            global_aux_model = str((_br_cfg.get("auxiliary") or {}).get("model") or "").strip()
+            aux_model = model or global_aux_model or _API_KEY_PROVIDER_AUX_MODELS.get(
+                "bedrock", "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+            )
+            real_client = build_anthropic_bedrock_client(region)
+            base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
+            client = AnthropicAuxiliaryClient(
+                real_client, aux_model, "aws-sdk", base_url, preserve_dots=True,
+            )
+            logger.debug("resolve_provider_client: bedrock auxiliary (%s) at %s", aux_model, base_url)
+            return (_to_async_client(client, aux_model) if async_mode
+                    else (client, aux_model))
+        except (ImportError, Exception) as exc:
+            logger.warning("resolve_provider_client: bedrock auxiliary failed: %s", exc)
+            return None, None
 
     if pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -909,6 +909,17 @@ def discover_bedrock_models(
     except Exception as e:
         logger.warning("Failed to list Bedrock foundation models: %s", e)
 
+    # Build a lookup map from foundation models so inference profiles can
+    # inherit modalities.  Without this, profiles default to TEXT-only and
+    # models like Claude (which support IMAGE input) lose that capability.
+    # Mirrors OpenClaw's resolveInferenceProfiles() pattern.
+    _foundation_modalities: Dict[str, Dict[str, List[str]]] = {}
+    for m in models:
+        _foundation_modalities[m["id"].lower()] = {
+            "input": m["input_modalities"],
+            "output": m["output_modalities"],
+        }
+
     # 2. Discover inference profiles (cross-region, better capacity)
     try:
         profiles = []
@@ -933,9 +944,31 @@ def discover_bedrock_models(
             if profile_id.lower() in seen_ids:
                 continue
 
+            # Inherit modalities from the underlying foundation model.
+            # Inference profiles wrap foundation models but the ListInferenceProfiles
+            # API doesn't expose modalities.  Look up the base model from the ARN.
+            profile_models = profile.get("models", [])
+            base_model_id = None
+            for pm in profile_models:
+                arn = pm.get("modelArn", "")
+                match = re.search(r"foundation-model/(.+)$", arn)
+                if match:
+                    base_model_id = match.group(1)
+                    break
+            # Also try stripping regional prefix: "us.anthropic.claude-v2" → "anthropic.claude-v2"
+            if base_model_id is None and "." in profile_id:
+                parts = profile_id.split(".", 1)
+                if len(parts) == 2 and parts[0] in ("us", "eu", "ap", "global", "jp"):
+                    base_model_id = parts[1]
+
+            base_mods = _foundation_modalities.get(
+                (base_model_id or "").lower(), {}
+            )
+            input_mods = base_mods.get("input", ["TEXT"])
+            output_mods = base_mods.get("output", ["TEXT"])
+
             # Apply provider filter to underlying models
             if filter_set:
-                profile_models = profile.get("models", [])
                 matches = any(
                     _extract_provider_from_arn(m.get("modelArn", "")).lower() in filter_set
                     for m in profile_models
@@ -947,8 +980,8 @@ def discover_bedrock_models(
                 "id": profile_id,
                 "name": (profile.get("inferenceProfileName") or profile_id).strip(),
                 "provider": "inference-profile",
-                "input_modalities": ["TEXT"],
-                "output_modalities": ["TEXT"],
+                "input_modalities": input_mods,
+                "output_modalities": output_mods,
                 "streaming": True,
             })
             seen_ids.add(profile_id.lower())

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -999,6 +999,16 @@ def list_authenticated_providers(
                     _cp_has_creds = True
             except Exception:
                 pass
+        # Bedrock uses the AWS SDK credential chain (IAM instance roles,
+        # SSO, env vars, etc.) — not API keys or auth stores.  Detect it
+        # via has_aws_credentials() which probes boto3's credential chain.
+        if not _cp_has_creds and _cp.slug == "bedrock":
+            try:
+                from agent.bedrock_adapter import has_aws_credentials
+                if has_aws_credentials():
+                    _cp_has_creds = True
+            except Exception:
+                pass
 
         if not _cp_has_creds:
             continue

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1292,3 +1292,30 @@ class TestInferenceProfileModalityInheritance:
 
         assert len(models) == 1
         assert models[0]["input_modalities"] == ["TEXT"]
+
+
+class TestBedrockModelPickerDetection:
+    """Test that /model (no args) detects Bedrock via AWS credential chain."""
+
+    def test_bedrock_detected_when_aws_credentials_available(self):
+        """Bedrock should appear in list_authenticated_providers when AWS creds exist."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None, "bedrock should appear when AWS credentials are available"
+
+    def test_bedrock_not_detected_without_aws_credentials(self):
+        """Bedrock should NOT appear when no AWS credentials exist."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=False), \
+             patch("agent.models_dev.fetch_models_dev", return_value={}), \
+             patch.dict(os.environ, {}, clear=True):
+            providers = list_authenticated_providers(current_provider="openrouter")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is None, "bedrock should not appear without AWS credentials"

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1230,3 +1230,65 @@ class TestEmptyTextBlockFix:
         from agent.bedrock_adapter import _convert_content_to_converse
         blocks = _convert_content_to_converse("Hello")
         assert blocks[0]["text"] == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# Inference profile modality inheritance
+# ---------------------------------------------------------------------------
+
+class TestInferenceProfileModalityInheritance:
+    """Test that inference profiles inherit modalities from foundation models."""
+
+    def test_profile_inherits_image_input_from_foundation(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-sonnet-4-6",
+                "modelName": "Claude Sonnet 4.6",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT", "IMAGE"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                "inferenceProfileName": "US Claude Sonnet 4.6",
+                "status": "ACTIVE",
+                "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"}],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profile = [m for m in models if m["id"] == "us.anthropic.claude-sonnet-4-6"]
+        assert len(profile) == 1
+        assert "IMAGE" in profile[0]["input_modalities"]
+        assert "TEXT" in profile[0]["input_modalities"]
+
+    def test_profile_defaults_to_text_when_no_foundation_match(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {"modelSummaries": []}
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.unknown.model-v1",
+                "inferenceProfileName": "Unknown Model",
+                "status": "ACTIVE",
+                "models": [],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 1
+        assert models[0]["input_modalities"] == ["TEXT"]

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1319,3 +1319,44 @@ class TestBedrockModelPickerDetection:
 
         bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
         assert bedrock is None, "bedrock should not appear without AWS credentials"
+
+
+class TestBedrockAuxiliaryClient:
+    """Test that Bedrock auxiliary client resolves correctly for context compression."""
+
+    def test_bedrock_auxiliary_client_resolves(self):
+        """resolve_provider_client('bedrock') should return an AnthropicAuxiliaryClient."""
+        from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+        mock_anthropic_client = MagicMock()
+        with patch("agent.anthropic_adapter.build_anthropic_bedrock_client", return_value=mock_anthropic_client), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"), \
+             patch("hermes_cli.config.load_config", return_value={"bedrock": {"region": "us-east-1"}}):
+            client, model = resolve_provider_client("bedrock")
+
+        assert client is not None, "bedrock auxiliary client should resolve"
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert "claude-haiku" in model
+
+    def test_bedrock_auxiliary_preserves_dots_in_model_id(self):
+        """Bedrock auxiliary adapter must pass preserve_dots=True to avoid mangling model IDs."""
+        from agent.auxiliary_client import _AnthropicCompletionsAdapter
+
+        adapter = _AnthropicCompletionsAdapter(
+            MagicMock(), "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+            preserve_dots=True,
+        )
+        assert adapter._preserve_dots is True
+
+    def test_bedrock_auxiliary_fails_gracefully_without_boto3(self):
+        """resolve_provider_client('bedrock') should return (None, None) when boto3 is missing."""
+        from agent.auxiliary_client import resolve_provider_client
+
+        with patch("agent.anthropic_adapter.build_anthropic_bedrock_client",
+                   side_effect=ImportError("No module named 'anthropic'")), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"), \
+             patch("hermes_cli.config.load_config", return_value={"bedrock": {}}):
+            client, model = resolve_provider_client("bedrock")
+
+        assert client is None
+        assert model is None


### PR DESCRIPTION
Three Bedrock fixes based on community and colleague feedback:

## 1. Inherit modalities from foundation models for inference profiles

Inference profiles (`us.*`, `global.*`) returned by `discover_bedrock_models()` were hardcoded to `["TEXT"]` input/output modalities. Claude inference profiles (which support IMAGE input) lose that capability in discovery results.

Fix: Build a foundation model lookup map after discovery, resolve the underlying model via ARN, and inherit its modalities.

Reported by @ptlally in PR #7920.

## 2. Detect AWS credentials in `/model` provider picker

`list_authenticated_providers()` only checked API keys and auth stores, missing Bedrock's `aws_sdk` auth type. Running `/model` (no args) would show "No authenticated providers found" even with valid IAM credentials.

Fix: Add `has_aws_credentials()` check in the `CANONICAL_PROVIDERS` loop.

## 3. Add Bedrock auxiliary client for context compression

`resolve_provider_client()` in `auxiliary_client.py` had no `aws_sdk` auth branch, so Bedrock users got "No auxiliary LLM provider configured" on startup. Context compression fell back to dropping middle turns without summaries.

Fix: Add `aws_sdk` auth branch using `AnthropicBedrock` SDK, register default aux model (`claude-haiku-4-5`), and thread `preserve_dots=True` through the adapter chain so Bedrock model IDs (which use dots as vendor separators) aren't mangled.

## Changes

- `agent/bedrock_adapter.py` — Build `_foundation_modalities` lookup map for inference profiles
- `hermes_cli/model_switch.py` — Add Bedrock AWS credential detection in `list_authenticated_providers()`
- `agent/auxiliary_client.py` — Add `aws_sdk` auth branch, `preserve_dots` param, Bedrock default aux model
- `tests/agent/test_bedrock_adapter.py` — 7 new tests (2 modality + 2 picker + 3 auxiliary)

## Testing

137 tests passing on EC2 (Python 3.11.14).

Ref: #7920, #10549