### PR TITLE
chore: salvage 3 easy wins from helix4u (#9832, #10654, #8524)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6220,13 +6220,21 @@ class HermesCLI:
     def _toggle_yolo(self):
         """Toggle YOLO mode — skip all dangerous command approval prompts."""
         import os
+        from hermes_cli.colors import Colors as _Colors
+
         current = bool(os.environ.get("HERMES_YOLO_MODE"))
         if current:
             os.environ.pop("HERMES_YOLO_MODE", None)
-            self.console.print("  ⚠ YOLO mode [bold red]OFF[/] — dangerous commands will require approval.")
+            _cprint(
+                f"  ⚠ YOLO mode {_Colors.BOLD}{_Colors.RED}OFF{_Colors.RESET}"
+                " — dangerous commands will require approval."
+            )
         else:
             os.environ["HERMES_YOLO_MODE"] = "1"
-            self.console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
+            _cprint(
+                f"  ⚡ YOLO mode {_Colors.BOLD}{_Colors.GREEN}ON{_Colors.RESET}"
+                " — all commands auto-approved. Use with caution."
+            )
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -267,7 +267,6 @@ Run `nix build .#configKeys && cat result` to see every leaf config key extracte
 
     # ── Documents ──────────────────────────────────────────────────────
     documents = {
-      "SOUL.md" = builtins.readFile /home/user/.hermes/SOUL.md;
       "USER.md" = ./documents/USER.md;
     };
 
@@ -316,7 +315,7 @@ Quick reference for the most common things Nix users want to customize:
 | Change the LLM model | `settings.model.default` | `"anthropic/claude-sonnet-4"` |
 | Use a different provider endpoint | `settings.model.base_url` | `"https://openrouter.ai/api/v1"` |
 | Add API keys | `environmentFiles` | `[ config.sops.secrets."hermes-env".path ]` |
-| Give the agent a personality | `documents."SOUL.md"` | `builtins.readFile ./my-soul.md` |
+| Give the agent a personality | `${services.hermes-agent.stateDir}/.hermes/SOUL.md` | manage the file directly |
 | Add MCP tool servers | `mcpServers.<name>` | See [MCP Servers](#mcp-servers) |
 | Mount host directories into container | `container.extraVolumes` | `[ "/data:/data:rw" ]` |
 | Pass GPU access to container | `container.extraOptions` | `[ "--gpus" "all" ]` |
@@ -397,17 +396,14 @@ The file is only copied if `auth.json` doesn't already exist (unless `authFileFo
 
 The `documents` option installs files into the agent's working directory (the `workingDirectory`, which the agent reads as its workspace). Hermes looks for specific filenames by convention:
 
-- **`SOUL.md`** — the agent's system prompt / personality. Hermes reads this on startup and uses it as persistent instructions that shape its behavior across all conversations.
 - **`USER.md`** — context about the user the agent is interacting with.
 - Any other files you place here are visible to the agent as workspace files.
+
+The agent identity file is separate: Hermes loads its primary `SOUL.md` from `$HERMES_HOME/SOUL.md`, which in the NixOS module is `${services.hermes-agent.stateDir}/.hermes/SOUL.md`. Putting `SOUL.md` in `documents` only creates a workspace file and will not replace the main persona file.
 
 ```nix
 {
   services.hermes-agent.documents = {
-    "SOUL.md" = ''
-      You are a helpful research assistant specializing in NixOS packaging.
-      Always cite sources and prefer reproducible solutions.
-    '';
     "USER.md" = ./documents/USER.md;  # path reference, copied from Nix store
   };
 }

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -65,11 +65,7 @@ If `git status --short` shows unexpected changes after `hermes update`, stop and
 hermes version
 ```
 
-Compare against the latest release at the [GitHub releases page](https://github.com/NousResearch/hermes-agent/releases) or check for available updates:
-
-```bash
-hermes update --check
-```
+Compare against the latest release at the [GitHub releases page](https://github.com/NousResearch/hermes-agent/releases).
 
 ### Updating from Messaging Platforms
 


### PR DESCRIPTION
## Summary

Salvage of 3 small fixes from @helix4u — cherry-picked onto current main with authorship preserved.

### Changes

1. **docs(update): remove unsupported `--check` command** (PR #9832)
   - `hermes update --check` doesn't exist — the update argparser only has `--gateway`
   - Removes the misleading docs reference

2. **docs(nix): clarify SOUL.md location** (PR #10654)
   - NixOS docs incorrectly told users to put SOUL.md in the `documents` block
   - Hermes loads SOUL.md from `$HERMES_HOME/SOUL.md`, not workspace documents
   - Fixes the quick-ref table, examples, and adds a clarifying paragraph

3. **fix(cli): route /yolo toggle through TUI-safe renderer** (PR #8524)
   - `_toggle_yolo()` used `self.console.print()` with Rich markup
   - Every other toggle in the codebase uses `_cprint()` + ANSI codes
   - Aligns with the established pattern (218 `_cprint` calls on main)
