### PR TITLE
fix 10942: dont suppress final response after interim assistant message

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9365,7 +9365,6 @@ class GatewayRunner:
                         _sc
                         and (
                             getattr(_sc, "final_response_sent", False)
-                            or getattr(_sc, "already_sent", False)
                         )
                     )
                     first_response = result.get("final_response", "")
@@ -9473,7 +9472,6 @@ class GatewayRunner:
             _is_empty_sentinel = not _final or _final == "(empty)"
             if not _is_empty_sentinel and (
                 getattr(_sc, "final_response_sent", False)
-                or getattr(_sc, "already_sent", False)
             ):
                 response["already_sent"] = True
         


### PR DESCRIPTION
Fixes #10942

When display.interim_assistant_messages is true, the interim callback sends short pre-tool text and sets already_sent=True on the stream consumer. The gateway then checks already_sent and marks the full final response as already delivered - even though only the small interim fragment was sent.

Fix: Only use final_response_sent (not already_sent) to determine whether to suppress the final response delivery.