### PR TITLE
fix(run_agent): strip reasoning_content for Groq to prevent HTTP 400 (#11089)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7159,12 +7159,17 @@ class AIAgent:
         try:
             # Build API messages for the flush call
             _needs_sanitize = self._should_sanitize_tool_calls()
+            # Skip ``reasoning_content`` entirely on Groq so the direct-
+            # client fallback (when auxiliary is unavailable) doesn't hit
+            # ``HTTP 400: property 'reasoning_content' is unsupported``.
+            # See issue #11089.
+            _reject_reasoning_content = self._provider_rejects_reasoning_content()
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
                 if msg.get("role") == "assistant":
                     reasoning = msg.get("reasoning")
-                    if reasoning:
+                    if reasoning and not _reject_reasoning_content:
                         api_msg["reasoning_content"] = reasoning
                 api_msg.pop("reasoning", None)
                 api_msg.pop("finish_reason", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -6667,10 +6667,18 @@ class AIAgent:
 
         sanitized_messages = api_messages
         needs_sanitization = False
+        _strip_reasoning_content = self._provider_rejects_reasoning_content()
         for msg in api_messages:
             if not isinstance(msg, dict):
                 continue
             if "codex_reasoning_items" in msg:
+                needs_sanitization = True
+                break
+            if (
+                _strip_reasoning_content
+                and msg.get("role") == "assistant"
+                and "reasoning_content" in msg
+            ):
                 needs_sanitization = True
                 break
 
@@ -6693,6 +6701,14 @@ class AIAgent:
 
                 # Codex-only replay state must not leak into strict chat-completions APIs.
                 msg.pop("codex_reasoning_items", None)
+
+                # Groq rejects ``reasoning_content`` on role:assistant with
+                # HTTP 400 ``property 'reasoning_content' is unsupported``.
+                # Strip it on the outgoing copy — ``reasoning`` is preserved
+                # in the internal history so a later switch back to a
+                # reasoning-aware provider still has the context.
+                if _strip_reasoning_content and msg.get("role") == "assistant":
+                    msg.pop("reasoning_content", None)
 
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
@@ -7083,6 +7099,26 @@ class AIAgent:
             bool: True if sanitization is needed (non-Codex API), False otherwise.
         """
         return self.api_mode != "codex_responses"
+
+    def _provider_rejects_reasoning_content(self) -> bool:
+        """Return True for OpenAI-compatible providers that strictly validate
+        assistant messages and reject the ``reasoning_content`` field.
+
+        Hermes copies a persisted ``reasoning`` field onto outbound assistant
+        messages as ``reasoning_content`` so reasoning-aware providers
+        (Moonshot AI, Novita, OpenRouter, etc.) can maintain multi-turn
+        reasoning context. Groq's OpenAI-compatible endpoint, in contrast,
+        rejects unknown assistant-message properties with HTTP 400
+        ``property 'reasoning_content' is unsupported`` — which trips users
+        who wire Groq through ``provider: custom`` + ``GROQ_API_KEY`` after
+        any prior turn populated ``reasoning`` (either from a thinking-capable
+        model earlier in the session or from a Groq response that surfaced a
+        provider-internal reasoning field).
+
+        Detecting by ``_base_url_lower`` avoids having to hand-roll a new
+        provider entry for every Groq deployment.  See issue #11089.
+        """
+        return "api.groq.com" in self._base_url_lower
 
     def flush_memories(self, messages: list = None, min_turns: int = None):
         """Give the model one turn to persist memories before context is lost.

--- a/tests/run_agent/test_flush_memories_codex.py
+++ b/tests/run_agent/test_flush_memories_codex.py
@@ -145,6 +145,70 @@ class TestFlushMemoriesRespectsConfigTimeout:
             f"Expected timeout={custom_timeout} from config, got {call_kwargs.kwargs.get('timeout')}"
         )
 
+    def test_groq_fallback_strips_reasoning_content(self, monkeypatch):
+        """When flush_memories falls back to the direct primary client and
+        the base_url targets Groq, the outgoing messages must not carry
+        ``reasoning_content`` — Groq rejects it with HTTP 400. Regression
+        for the Copilot review follow-up on #11089."""
+        agent = _make_agent(monkeypatch, api_mode="chat_completions", provider="custom")
+        agent.base_url = "https://api.groq.com/openai/v1"
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _chat_response_with_memory_call()
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("no provider")), \
+             patch("agent.auxiliary_client._get_task_timeout", return_value=60.0), \
+             patch("tools.memory_tool.memory_tool", return_value="Saved."):
+            messages = [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": "Hi there.",
+                    "reasoning": "greet the user",
+                },
+                {"role": "user", "content": "Note my preference."},
+            ]
+            agent.flush_memories(messages)
+
+        agent.client.chat.completions.create.assert_called_once()
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assistant_msgs = [m for m in sent_messages if m.get("role") == "assistant"]
+        assert assistant_msgs, "expected at least one assistant message"
+        for m in assistant_msgs:
+            assert "reasoning_content" not in m, (
+                f"reasoning_content leaked into Groq flush payload: {m}"
+            )
+        # Internal history intact — a later switch back to a reasoning-aware
+        # provider still carries the reasoning context.
+        assert messages[1].get("reasoning") == "greet the user"
+
+    def test_non_groq_fallback_keeps_reasoning_content(self, monkeypatch):
+        """On non-Groq providers the direct-client fallback still forwards
+        reasoning_content so Moonshot/Novita/etc. continue to receive
+        multi-turn reasoning context."""
+        agent = _make_agent(monkeypatch, api_mode="chat_completions", provider="openrouter")
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _chat_response_with_memory_call()
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=RuntimeError("no provider")), \
+             patch("agent.auxiliary_client._get_task_timeout", return_value=60.0), \
+             patch("tools.memory_tool.memory_tool", return_value="Saved."):
+            messages = [
+                {"role": "user", "content": "Hello"},
+                {
+                    "role": "assistant",
+                    "content": "Hi there.",
+                    "reasoning": "greet the user",
+                },
+                {"role": "user", "content": "Note my preference."},
+            ]
+            agent.flush_memories(messages)
+
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assistant_msgs = [m for m in sent_messages if m.get("role") == "assistant"]
+        # At least one assistant message carries the forwarded reasoning.
+        assert any(m.get("reasoning_content") == "greet the user" for m in assistant_msgs)
+
 
 class TestFlushMemoriesUsesAuxiliaryClient:
     """When an auxiliary client is available, flush_memories should use it

--- a/tests/run_agent/test_strict_api_validation.py
+++ b/tests/run_agent/test_strict_api_validation.py
@@ -142,3 +142,170 @@ class TestStrictApiValidation:
 
         # Should NOT sanitize for Codex
         assert agent._should_sanitize_tool_calls() is False
+
+
+class TestGroqReasoningContentStrip:
+    """Regression for #11089.
+
+    Groq's OpenAI-compatible endpoint rejects ``reasoning_content`` on
+    role:assistant with HTTP 400 ``property 'reasoning_content' is
+    unsupported``. Hermes unconditionally copies a persisted ``reasoning``
+    field onto outbound assistant messages as ``reasoning_content`` (needed
+    for Moonshot/Novita/OpenRouter multi-turn reasoning), which breaks users
+    who point ``provider: custom`` at Groq after any thinking-enabled turn.
+
+    ``_build_api_kwargs`` must strip ``reasoning_content`` from outbound
+    assistant messages when the base URL targets Groq, while leaving the
+    internal message history untouched so the reasoning context survives
+    a later switch back to a reasoning-aware provider.
+    """
+
+    def test_groq_rejects_reasoning_content_flag(self, monkeypatch):
+        groq_agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="chat_completions",
+            base_url="https://api.groq.com/openai/v1",
+        )
+        assert groq_agent._provider_rejects_reasoning_content() is True
+
+        or_agent = _make_agent(
+            monkeypatch,
+            "openrouter",
+            api_mode="chat_completions",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert or_agent._provider_rejects_reasoning_content() is False
+
+    def test_groq_strips_reasoning_content_from_outgoing_messages(self, monkeypatch):
+        """Outgoing Groq payload must not carry ``reasoning_content``."""
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="chat_completions",
+            base_url="https://api.groq.com/openai/v1",
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Hello!",
+                "reasoning_content": "User greeted me; respond warmly.",
+            },
+            {"role": "user", "content": "what's 2+2?"},
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assistant_msg = kwargs["messages"][1]
+        # Groq would 400 on this — must be stripped.
+        assert "reasoning_content" not in assistant_msg
+        # Regular content preserved.
+        assert assistant_msg["content"] == "Hello!"
+        assert assistant_msg["role"] == "assistant"
+
+    def test_groq_preserves_internal_history(self, monkeypatch):
+        """Stripping the outgoing copy must not mutate the caller's list."""
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="chat_completions",
+            base_url="https://api.groq.com/openai/v1",
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Hello!",
+                "reasoning_content": "internal thought",
+            },
+        ]
+
+        agent._build_api_kwargs(messages)
+
+        # Internal history untouched — a later switch back to a reasoning-
+        # aware provider still has the context.
+        assert messages[1]["reasoning_content"] == "internal thought"
+
+    def test_non_groq_preserves_reasoning_content(self, monkeypatch):
+        """OpenRouter (and other reasoning-aware providers) still receive
+        ``reasoning_content`` so multi-turn reasoning context is preserved."""
+        agent = _make_agent(
+            monkeypatch,
+            "openrouter",
+            api_mode="chat_completions",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Hello!",
+                "reasoning_content": "User greeted me.",
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+        assistant_msg = kwargs["messages"][1]
+
+        assert assistant_msg["reasoning_content"] == "User greeted me."
+
+    def test_groq_strips_alongside_codex_fields(self, monkeypatch):
+        """When both Codex fields and reasoning_content are present, both
+        are stripped in a single deepcopy pass."""
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="chat_completions",
+            base_url="https://api.groq.com/openai/v1",
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Checking.",
+                "reasoning_content": "think",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "call_id": "call_1",
+                        "response_item_id": "fc_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+        asst = kwargs["messages"][1]
+
+        assert "reasoning_content" not in asst
+        tc = asst["tool_calls"][0]
+        assert "call_id" not in tc
+        assert "response_item_id" not in tc
+        assert tc["id"] == "call_1"
+
+    def test_groq_no_reasoning_content_is_a_noop(self, monkeypatch):
+        """When there is no ``reasoning_content`` to strip, the outgoing
+        messages should be the exact same list (no unnecessary deepcopy)."""
+        agent = _make_agent(
+            monkeypatch,
+            "custom",
+            api_mode="chat_completions",
+            base_url="https://api.groq.com/openai/v1",
+        )
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        # No strip needed → outgoing list is the original reference.
+        assert kwargs["messages"] is messages


### PR DESCRIPTION
## What does this PR do?

Fixes #11089.

Groq's OpenAI-compatible endpoint strictly validates Chat Completions messages and rejects the `reasoning_content` field on assistant messages with:

> HTTP 400: `'messages.4' : for 'role:assistant' the following must be satisfied[('messages.4' : property 'reasoning_content' is unsupported)]`

Hermes unconditionally copies the persisted `reasoning` field onto outbound assistant messages as `reasoning_content` so reasoning-aware providers (Moonshot AI, Novita, OpenRouter) can maintain multi-turn reasoning context. Any user who points `provider: custom` at `https://api.groq.com/openai/v1` then hits this 400 the moment a prior turn populated `reasoning` — either from a thinking-capable model earlier in the session, or from Groq itself surfacing a provider-internal reasoning field in the response.

## Root cause

`run_agent.py:8624` adds `reasoning_content` to every outbound assistant message when a `reasoning` field is present, regardless of the current provider. `_build_api_kwargs` (`run_agent.py:6553-6587`) already sanitizes Codex-only `call_id` / `response_item_id` / `codex_reasoning_items` for strict providers, but has no awareness of `reasoning_content` rejection.

## Smallest safe fix

* Add `AIAgent._provider_rejects_reasoning_content()` — returns `True` when `_base_url_lower` contains `api.groq.com`. Base-URL detection (rather than a provider-name switch) covers users who wire Groq through `provider: custom` + `GROQ_API_KEY`, which is the reporter's exact setup.
* Extend the existing sanitization block in `_build_api_kwargs` so it also drops `reasoning_content` from assistant messages on Groq. Reuses the same `deepcopy` the Codex-sanitization path creates — no extra copy when the payload is already clean.

The internal message history is untouched, so a later switch back to a reasoning-aware provider still has the context. Other providers (OpenRouter, Moonshot, Novita, Nous, Anthropic, self-hosted) keep `reasoning_content` exactly as today.

## Precedence / compat truth table

| Provider (base_url) | assistant has `reasoning_content`? | Outgoing payload |
| --- | --- | --- |
| `api.groq.com` | yes | field stripped on outgoing copy only |
| `api.groq.com` | no | outgoing list is the original ref (no deepcopy) |
| `openrouter.ai`, `moonshot`, `novita`, etc. | yes | preserved (unchanged) |
| `openrouter.ai` etc. | no | preserved (unchanged) |
| Groq + Codex `call_id`/`response_item_id` + `reasoning_content` | yes | all three stripped in a single deepcopy |

Internal `messages` list is never mutated in any of these cases.

## Narrow scope — why only `_build_api_kwargs`

The reporter's bug is in the main agent loop, which routes through `_build_api_kwargs`. `flush_memories` has a direct-client fallback path that also sets `reasoning_content`, but it defaults to the auxiliary client (a separate OpenAI client), and the fallback only fires if auxiliary is unavailable. Fixing that path would require touching `flush_memories` and `auxiliary_client`, which is out of scope here. If Groq-as-auxiliary ever surfaces, that's a clean follow-up in a dedicated PR — I can open it on request.

I considered a general "strict providers" whitelist but decided against it: other strict providers (Cerebras, Groq variants) can be added as narrowly as this one when a real report surfaces, rather than guessing.

## How to test

1. Run the new regression suite:
   ```
   source venv/bin/activate
   python -m pytest tests/run_agent/test_strict_api_validation.py -v
   ```
   → 10 passed (4 existing + 6 new).

2. Confirm the new tests catch the bug on origin/main:
   ```
   git stash push run_agent.py
   python -m pytest tests/run_agent/test_strict_api_validation.py::TestGroqReasoningContentStrip -v
   ```
   → 3 fail (`test_groq_rejects_reasoning_content_flag`, `test_groq_strips_reasoning_content_from_outgoing_messages`, `test_groq_strips_alongside_codex_fields`). Restore with `git stash pop`.

3. CI-aligned broad suite:
   ```
   python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
   ```
   → 12088 passed + 37 skipped + 14 pre-existing baseline failures in `tests/agent/test_bedrock_integration.py`, `tests/hermes_cli/test_claw.py`, `tests/gateway/test_approve_deny_commands.py`, `tests/hermes_cli/test_ollama_cloud_provider.py`, `tests/agent/test_credential_pool.py`, `tests/hermes_cli/test_gateway_wsl.py`, `tests/tools/test_file_staleness.py`, `tests/hermes_cli/test_xiaomi_provider.py`, `tests/run_agent/test_413_compression.py`. Each reproduces on clean `origin/main` with the same assertion — none are in the touched code path. `tests/test_plugin_skills.py::TestSkillViewPluginGuards::test_injection_logged_but_served` passes in isolation; failure is a known ordering issue.

Tested on: macOS 15 (Darwin 25.5.0), Python 3.11.15.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: add `_provider_rejects_reasoning_content()` helper and extend `_build_api_kwargs` sanitization block to strip `reasoning_content` from assistant messages when the base URL targets Groq.
- `tests/run_agent/test_strict_api_validation.py`: add `TestGroqReasoningContentStrip` — 6 tests covering the full truth table (Groq strip, non-Groq preserve, history-not-mutated, combined with Codex strip, noop-when-absent, helper-flag).

## Adjacent surfaces checked

- `flush_memories` direct-client fallback (`run_agent.py:7076-7086`) — not in scope, deliberate; see "Narrow scope" above.
- `_supports_reasoning_extra_body` (`run_agent.py:6740`) — unrelated; that method gates outbound `extra_body.reasoning` for OpenRouter routing, not inbound `reasoning_content` on assistant messages.
- `auxiliary_client` — separate client; out of scope.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] Searched for existing PRs — no competing PR on #11089 at PR open
- [x] Only changes related to this fix
- [x] Ran the CI-aligned test command and classified failures baseline-vs-change
- [x] Added tests for my changes (6 new tests; 3 fail on `origin/main` without the fix)
- [x] Tested on macOS 15 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] No docs changes needed — internal sanitization detail, no public API surface
- [x] No config-key changes (N/A for `cli-config.yaml.example`)
- [x] No architecture/workflow changes (N/A for `CONTRIBUTING.md` / `AGENTS.md`)
- [x] Cross-platform impact: none — pure dict manipulation; no filesystem/process/encoding work
- [x] No tool descriptions/schemas touched

## Notes for reviewers

- No standalone lint command is defined; CI runs `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` (matches `.github/workflows/tests.yml`).
- No `hermes_cli/**` changes — the Nix workflow should not trigger.