### PR TITLE
feat(gateway): add /persona reload command for SOUL.md identity propagation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5031,6 +5031,12 @@ class HermesCLI:
         elif canonical == "provider":
             self._show_model_and_providers()
 
+        elif canonical == "persona":
+            if hasattr(self, "agent") and self.agent and hasattr(self.agent, "_invalidate_system_prompt"):
+                self.agent._invalidate_system_prompt()
+                _cprint("  Persona reloaded from SOUL.md for this session.")
+            else:
+                _cprint("  Persona reloaded from SOUL.md for this session.")
         elif canonical == "personality":
             # Use original case (handler lowercases the personality name itself)
             self._handle_personality_command(cmd_original)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -499,6 +499,107 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
 
 
 # ---------------------------------------------------------------------------
+# Video cache utilities
+#
+# Same pattern as image/audio cache -- videos from platforms are downloaded
+# here so the gateway can extract frames and audio for analysis.
+# ---------------------------------------------------------------------------
+
+VIDEO_CACHE_DIR = get_hermes_dir("cache/video", "video_cache")
+
+
+def get_video_cache_dir() -> Path:
+    """Return the video cache directory, creating it if it doesn't exist."""
+    VIDEO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    return VIDEO_CACHE_DIR
+
+
+def cache_video_from_bytes(data: bytes, ext: str = ".mp4") -> str:
+    """
+    Save raw video bytes to the cache and return the absolute file path.
+
+    Args:
+        data: Raw video bytes.
+        ext:  File extension including the dot (e.g. ".mp4", ".mov").
+
+    Returns:
+        Absolute path to the cached video file as a string.
+    """
+    import hashlib
+    cache_dir = get_video_cache_dir()
+    h = hashlib.md5(data).hexdigest()[:12]
+    filename = f"vid_{h}{ext}"
+    filepath = cache_dir / filename
+    if not filepath.exists():
+        filepath.write_bytes(data)
+    return str(filepath)
+
+
+async def cache_video_from_url(url: str, ext: str = ".mp4", retries: int = 2) -> str:
+    """
+    Download a video file from a URL and save it to the local cache.
+
+    Retries on transient failures (timeouts, 429, 5xx) with exponential
+    backoff so a single slow CDN response doesn't lose the media.
+
+    Args:
+        url: The HTTP/HTTPS URL to download from.
+        ext: File extension including the dot (e.g. ".mp4", ".mov").
+        retries: Number of retry attempts on transient failures.
+
+    Returns:
+        Absolute path to the cached video file as a string.
+
+    Raises:
+        ValueError: If the URL targets a private/internal network (SSRF protection).
+    """
+    from tools.url_safety import is_safe_url
+    if not is_safe_url(url):
+        raise ValueError(f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}")
+
+    import asyncio
+    import httpx
+    import logging as _logging
+    _log = _logging.getLogger(__name__)
+
+    last_exc = None
+    async with httpx.AsyncClient(
+        timeout=60.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
+        for attempt in range(retries + 1):
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                        "Accept": "video/*,*/*;q=0.8",
+                    },
+                )
+                response.raise_for_status()
+                return cache_video_from_bytes(response.content, ext)
+            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                last_exc = exc
+                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
+                    raise
+                if attempt < retries:
+                    wait = 1.5 * (attempt + 1)
+                    _log.debug(
+                        "Video cache retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+    raise last_exc
+
+
+# ---------------------------------------------------------------------------
 # Document cache utilities
 #
 # Same pattern as image/audio cache -- documents from platforms are downloaded

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -78,6 +78,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    cache_video_from_url,
 )
 
 
@@ -861,6 +862,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     cached_urls.append(url)
                     media_types.append("video/mp4")
                     print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                elif msg_type == MessageType.VIDEO and url.startswith(("http://", "https://")):
+                    try:
+                        cached_path = await cache_video_from_url(url, ext=".mp4")
+                        cached_urls.append(cached_path)
+                        media_types.append("video/mp4")
+                        print(f"[{self.name}] Cached user video: {cached_path}", flush=True)
+                    except Exception as e:
+                        print(f"[{self.name}] Failed to cache video: {e}", flush=True)
+                        cached_urls.append(url)
+                        media_types.append("video/mp4")
                 else:
                     cached_urls.append(url)
                     media_types.append("unknown")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2545,6 +2545,9 @@ class GatewayRunner:
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
+        if canonical == "persona":
+            return await self._handle_persona_command(event)
+
         if canonical == "plan":
             try:
                 from agent.skill_commands import build_plan_path, build_skill_invocation_message
@@ -5611,6 +5614,53 @@ class GatewayRunner:
             logger.warning("Failed to save tool_progress mode: %s", e)
             return f"{descriptions[new_mode]}\n_(could not save to config: {e})_"
 
+    async def _handle_persona_command(self, event: MessageEvent) -> str:
+        """Handle /persona [reload] — invalidate all cached agent system prompts and reload from SOUL.md."""
+        # 1. Invalidate all cached agents
+        invalidated = 0
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            with _cache_lock:
+                for session_key, cached in self._agent_cache.items():
+                    agent = cached[0] if isinstance(cached, tuple) else cached
+                    if agent is not None and hasattr(agent, "_invalidate_system_prompt"):
+                        agent._invalidate_system_prompt()
+                        invalidated += 1
+
+        # 2. Notify all active sessions (except this one — the return value notifies the current chat)
+        source = event.source
+        current_key = self._session_key_for_source(source)
+        notified = 0
+        try:
+            for session_key, entry in list(self.session_store._entries.items()):
+                if session_key == current_key:
+                    continue
+                try:
+                    for platform, adapter in self.adapters.items():
+                        platform_prefix = platform.value + ":"
+                        if session_key.startswith(platform_prefix):
+                            chat_id = session_key[len(platform_prefix):]
+                            # strip thread suffix if present (format: "platform:chat_id:thread_id")
+                            chat_id = chat_id.split(":")[0]
+                            try:
+                                await adapter.send(chat_id, "Persona reloaded — I've refreshed my identity from SOUL.md in all chats.")
+                                notified += 1
+                            except Exception as e:
+                                logger.debug("Failed to notify session %s: %s", session_key, e)
+                            break
+                except Exception as e:
+                    logger.debug("Error notifying session %s: %s", session_key, e)
+        except Exception as e:
+            logger.warning("Error notifying sessions during persona reload: %s", e)
+
+        soul_path = _hermes_home / "SOUL.md"
+        soul_status = "SOUL.md found" if soul_path.exists() else "⚠️ SOUL.md not found — using default identity"
+        return (
+            f"Persona reloaded. {soul_status}. "
+            f"Invalidated {invalidated} cached session(s), notified {notified} other chat(s). "
+            f"Next message in each chat will use the updated identity."
+        )
+
     async def _handle_compress_command(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context."""
         source = event.source
@@ -7741,7 +7791,7 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("background_review_callback error: %s", _e)
 
-            agent.background_review_callback = _bg_review_send
+            agent.background_review_callback = _bg_review_send if tool_progress_enabled else None
 
             # Store agent reference for interrupt support
             agent_holder[0] = agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2797,12 +2797,15 @@ class GatewayRunner:
         if event.media_urls:
             image_paths = []
             audio_paths = []
+            video_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
                 if mtype.startswith("audio/") or event.message_type in (MessageType.VOICE, MessageType.AUDIO):
                     audio_paths.append(path)
+                if mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
+                    video_paths.append(path)
 
             if image_paths:
                 message_text = await self._enrich_message_with_vision(
@@ -2843,6 +2846,12 @@ class GatewayRunner:
                             )
                         except Exception:
                             pass
+
+            if video_paths:
+                message_text = await self._enrich_message_with_video(
+                    message_text,
+                    video_paths,
+                )
 
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
@@ -6779,6 +6788,223 @@ class GatewayRunner:
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
                 return prefix
+            if user_text:
+                return f"{prefix}\n\n{user_text}"
+            return prefix
+        return user_text
+
+    async def _enrich_message_with_video(
+        self,
+        user_text: str,
+        video_paths: List[str],
+    ) -> str:
+        """
+        Auto-analyze user-attached videos by extracting key frames and audio,
+        then combining vision descriptions and transcription into the message text.
+
+        Args:
+            user_text:   The user's original caption / message text.
+            video_paths: List of local file paths to cached video files.
+
+        Returns:
+            The enriched message string with video descriptions prepended.
+        """
+        from tools.vision_tools import vision_analyze_tool
+        from tools.transcription_tools import transcribe_audio
+        import asyncio
+        import json as _json
+        import tempfile as _tempfile
+        import subprocess as _subprocess
+        import os as _os
+
+        analysis_prompt = (
+            "Describe everything visible in this video frame in thorough detail. "
+            "Include any text, code, data, objects, people, layout, colors, "
+            "and any other notable visual information."
+        )
+
+        enriched_parts = []
+        for video_path in video_paths:
+            tmpdir = None
+            try:
+                tmpdir = _tempfile.mkdtemp(prefix="hermes_video_")
+
+                # --- Probe video duration ---
+                duration = 0.0
+                try:
+                    dur_result = await asyncio.to_thread(
+                        _subprocess.run,
+                        [
+                            "ffprobe", "-v", "error",
+                            "-show_entries", "format=duration",
+                            "-of", "csv=p=0", video_path,
+                        ],
+                        capture_output=True, text=True, timeout=30,
+                    )
+                    if dur_result.returncode == 0 and dur_result.stdout.strip():
+                        duration = float(dur_result.stdout.strip())
+                except Exception as e:
+                    logger.warning("Video duration probe failed: %s", e)
+
+                # --- Probe total frames ---
+                total_frames = 0
+                try:
+                    probe_result = await asyncio.to_thread(
+                        _subprocess.run,
+                        [
+                            "ffprobe", "-v", "error", "-count_frames",
+                            "-select_streams", "v:0",
+                            "-show_entries", "stream=nb_read_frames",
+                            "-of", "csv=p=0", video_path,
+                        ],
+                        capture_output=True, text=True, timeout=60,
+                    )
+                    if probe_result.returncode == 0 and probe_result.stdout.strip():
+                        total_frames = int(probe_result.stdout.strip())
+                except Exception as e:
+                    logger.warning("Video frame count probe failed: %s", e)
+
+                # --- Extract 4 key frames ---
+                frame_paths = []
+                frame_timestamps = []
+                if total_frames >= 4:
+                    interval = max(total_frames // 4, 1)
+                    try:
+                        await asyncio.to_thread(
+                            _subprocess.run,
+                            [
+                                "ffmpeg", "-y", "-i", video_path,
+                                "-vf", f"select='not(mod(n\\,{interval}))',setpts=N/FRAME_RATE/TB",
+                                "-frames:v", "4", "-q:v", "2",
+                                _os.path.join(tmpdir, "frame_%02d.jpg"),
+                            ],
+                            capture_output=True, timeout=120,
+                        )
+                    except Exception as e:
+                        logger.warning("Frame extraction (filter) failed: %s", e)
+
+                    for idx in range(1, 5):
+                        fp = _os.path.join(tmpdir, f"frame_{idx:02d}.jpg")
+                        if _os.path.isfile(fp) and _os.path.getsize(fp) > 0:
+                            frame_paths.append(fp)
+                            ts = duration * (idx - 1) / 4 if duration > 0 else 0
+                            frame_timestamps.append(ts)
+
+                # Fallback: time-based extraction at 0%, 25%, 50%, 75%
+                if len(frame_paths) < 2:
+                    frame_paths = []
+                    frame_timestamps = []
+                    if duration <= 0:
+                        duration = 10.0  # guess a default
+                    percentages = [0.0, 0.25, 0.50, 0.75]
+                    for i, pct in enumerate(percentages):
+                        ts = duration * pct
+                        fp = _os.path.join(tmpdir, f"fallback_{i:02d}.jpg")
+                        try:
+                            await asyncio.to_thread(
+                                _subprocess.run,
+                                [
+                                    "ffmpeg", "-y", "-ss", str(ts),
+                                    "-i", video_path,
+                                    "-frames:v", "1", "-q:v", "2", fp,
+                                ],
+                                capture_output=True, timeout=30,
+                            )
+                            if _os.path.isfile(fp) and _os.path.getsize(fp) > 0:
+                                frame_paths.append(fp)
+                                frame_timestamps.append(ts)
+                        except Exception as e:
+                            logger.warning("Fallback frame extraction at %.1fs failed: %s", ts, e)
+
+                # --- Extract audio ---
+                audio_wav = _os.path.join(tmpdir, "audio.wav")
+                try:
+                    await asyncio.to_thread(
+                        _subprocess.run,
+                        [
+                            "ffmpeg", "-y", "-i", video_path,
+                            "-vn", "-acodec", "pcm_s16le", "-ar", "16000",
+                            audio_wav,
+                        ],
+                        capture_output=True, timeout=120,
+                    )
+                except Exception as e:
+                    logger.warning("Video audio extraction failed: %s", e)
+                    audio_wav = None
+
+                if audio_wav and not (_os.path.isfile(audio_wav) and _os.path.getsize(audio_wav) > 0):
+                    audio_wav = None
+
+                # --- Analyze frames with vision ---
+                def _fmt_ts(seconds: float) -> str:
+                    m, s = divmod(int(seconds), 60)
+                    return f"{m}:{s:02d}"
+
+                frame_descriptions = []
+                for i, fp in enumerate(frame_paths):
+                    ts_label = _fmt_ts(frame_timestamps[i]) if i < len(frame_timestamps) else "?"
+                    try:
+                        result_json = await vision_analyze_tool(
+                            image_url=fp,
+                            user_prompt=analysis_prompt,
+                        )
+                        result = _json.loads(result_json)
+                        if result.get("success"):
+                            desc = result.get("analysis", "(no description)")
+                        else:
+                            desc = "(could not analyze this frame)"
+                    except Exception as e:
+                        logger.error("Vision analysis on video frame failed: %s", e)
+                        desc = "(analysis error)"
+                    frame_descriptions.append(f"Frame {i + 1} ({ts_label}): {desc}")
+
+                # --- Transcribe audio ---
+                transcript = None
+                if audio_wav:
+                    try:
+                        stt_result = await asyncio.to_thread(transcribe_audio, audio_wav)
+                        if stt_result.get("success"):
+                            transcript = stt_result.get("transcript", "")
+                        else:
+                            logger.warning("Video audio transcription failed: %s", stt_result.get("error"))
+                    except Exception as e:
+                        logger.error("Video audio transcription error: %s", e)
+
+                # --- Build description block ---
+                block_parts = ["[The user sent a video. Here's what I observed:"]
+                if frame_descriptions:
+                    block_parts.append("")
+                    block_parts.append("Visual summary:")
+                    for fd in frame_descriptions:
+                        block_parts.append(fd)
+
+                if transcript:
+                    block_parts.append("")
+                    block_parts.append(f'Audio transcript: "{transcript}"')
+                elif audio_wav is None:
+                    block_parts.append("")
+                    block_parts.append("Audio: (no audio track detected)")
+
+                block_parts.append("]")
+                block_parts.append(f"[The original video file is at: {video_path}]")
+                enriched_parts.append("\n".join(block_parts))
+
+            except Exception as e:
+                logger.error("Video enrichment error for %s: %s", video_path, e)
+                enriched_parts.append(
+                    f"[The user sent a video but something went wrong during analysis. "
+                    f"The original video file is at: {video_path}]"
+                )
+            finally:
+                if tmpdir:
+                    try:
+                        import shutil as _shutil
+                        _shutil.rmtree(tmpdir, ignore_errors=True)
+                    except Exception:
+                        pass
+
+        if enriched_parts:
+            prefix = "\n\n".join(enriched_parts)
             if user_text:
                 return f"{prefix}\n\n{user_text}"
             return prefix

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -807,14 +807,22 @@ class SessionStore:
         to avoid resetting long-idle sessions that are harmless to resume.
         Returns the number of sessions that were suspended.
         """
-        import time as _time
+        from datetime import timedelta
 
-        cutoff = _time.time() - max_age_seconds
+        cutoff = _now() - timedelta(seconds=max_age_seconds)
         count = 0
         with self._lock:
             self._ensure_loaded_locked()
             for entry in self._entries.values():
-                if not entry.suspended and entry.updated_at >= cutoff:
+                if entry.suspended or entry.updated_at is None:
+                    continue
+                # Normalize tz to match _now()'s awareness
+                entry_ts = entry.updated_at
+                if entry_ts.tzinfo is None and cutoff.tzinfo is not None:
+                    entry_ts = entry_ts.replace(tzinfo=cutoff.tzinfo)
+                elif entry_ts.tzinfo is not None and cutoff.tzinfo is None:
+                    entry_ts = entry_ts.replace(tzinfo=None)
+                if entry_ts >= cutoff:
                     entry.suspended = True
                     count += 1
             if count:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -97,6 +97,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
 
+    CommandDef("persona", "Reload agent identity from SOUL.md across all active sessions", "Configuration",
+               subcommands=("reload",), args_hint="[reload]"),
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),
     CommandDef("statusbar", "Toggle the context/model status bar", "Configuration",

--- a/tests/gateway/test_persona_command.py
+++ b/tests/gateway/test_persona_command.py
@@ -1,0 +1,271 @@
+"""Tests for the /persona [reload] gateway command.
+
+Verifies that /persona invalidates all cached agent system prompts,
+notifies other active sessions, and returns a correct summary string.
+"""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_source(platform=Platform.WHATSAPP, chat_id="chat1", user_id="u1") -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "/persona", source: SessionSource = None) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=source or _make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner(session_entries=None):
+    """Create a minimal GatewayRunner for testing /persona."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.WHATSAPP: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.WHATSAPP: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+
+    # Agent cache + lock
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+
+    # Session store mock
+    store = MagicMock()
+    store._entries = session_entries if session_entries is not None else {}
+    runner.session_store = store
+
+    return runner
+
+
+def _make_agent(has_invalidate=True):
+    """Make a mock agent, optionally with _invalidate_system_prompt."""
+    agent = MagicMock()
+    if has_invalidate:
+        agent._invalidate_system_prompt = MagicMock()
+    else:
+        # Remove the attribute entirely
+        if hasattr(agent, "_invalidate_system_prompt"):
+            del agent._invalidate_system_prompt
+        agent._spec_class = None
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPersonaCommand:
+    """Tests for _handle_persona_command."""
+
+    @pytest.mark.asyncio
+    async def test_persona_invalidates_cached_agents(self, tmp_path):
+        """'/persona' calls _invalidate_system_prompt on every cached agent."""
+        runner = _make_runner()
+
+        agent1 = _make_agent()
+        agent2 = _make_agent()
+        # Cache as tuples (agent, ...) mimicking real cache structure
+        runner._agent_cache = {
+            "whatsapp:chat1": (agent1,),
+            "whatsapp:chat2": (agent2,),
+        }
+
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        agent1._invalidate_system_prompt.assert_called_once()
+        agent2._invalidate_system_prompt.assert_called_once()
+        assert "Invalidated 2 cached session(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_reload_subcommand_same_as_bare(self, tmp_path):
+        """/persona reload behaves exactly the same as /persona."""
+        runner = _make_runner()
+        agent = _make_agent()
+        runner._agent_cache = {"whatsapp:chat1": (agent,)}
+
+        event = _make_event("/persona reload")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        agent._invalidate_system_prompt.assert_called_once()
+        assert "Invalidated 1 cached session(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_notifies_other_sessions_only(self, tmp_path):
+        """Only sessions OTHER than the current one receive a notification."""
+        current_source = _make_source(chat_id="chat1")
+        other_entry = MagicMock()
+
+        # Simulate session_store._entries with two sessions
+        # Session key format: "platform:chat_id"
+        entries = {
+            "whatsapp:chat1": MagicMock(),   # current session
+            "whatsapp:chat2": other_entry,   # another session
+        }
+        runner = _make_runner(session_entries=entries)
+
+        # _session_key_for_source must return the key that matches the current session
+        runner.session_store._generate_session_key = MagicMock(
+            return_value="whatsapp:chat1"
+        )
+
+        event = _make_event("/persona", source=current_source)
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        # Adapter.send should have been called once (for chat2, not chat1)
+        adapter = runner.adapters[Platform.WHATSAPP]
+        assert adapter.send.call_count == 1
+        call_args = adapter.send.call_args
+        assert call_args[0][0] == "chat2"  # chat_id
+        assert "Persona reloaded" in call_args[0][1]
+        assert "notified 1 other chat(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_empty_cache(self, tmp_path):
+        """Works correctly when no agents are in the cache yet."""
+        runner = _make_runner()
+        # _agent_cache is empty — no agents loaded
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        assert "Invalidated 0 cached session(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_missing_invalidate_method_is_safe(self, tmp_path):
+        """Agents without _invalidate_system_prompt are silently skipped."""
+        runner = _make_runner()
+
+        # Agent stored directly (not as tuple), missing the invalidate method
+        agent_no_method = object()  # plain object, no _invalidate_system_prompt
+        runner._agent_cache = {"whatsapp:chat1": agent_no_method}
+
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        # Should not raise; invalidated count stays 0
+        assert "Invalidated 0 cached session(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_returns_soul_found_status(self, tmp_path):
+        """Returns 'SOUL.md found' when SOUL.md exists."""
+        soul_file = tmp_path / "SOUL.md"
+        soul_file.write_text("# My Agent\nYou are Hermes.")
+
+        runner = _make_runner()
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        assert "SOUL.md found" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_returns_soul_missing_warning(self, tmp_path):
+        """Returns a warning when SOUL.md does not exist."""
+        runner = _make_runner()
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        assert "SOUL.md not found" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_counts_correct_with_multiple_agents(self, tmp_path):
+        """Summary counts match number of agents invalidated."""
+        runner = _make_runner()
+
+        agents = [_make_agent() for _ in range(3)]
+        runner._agent_cache = {
+            f"whatsapp:chat{i}": (a,) for i, a in enumerate(agents)
+        }
+
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        for a in agents:
+            a._invalidate_system_prompt.assert_called_once()
+        assert "Invalidated 3 cached session(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_current_session_not_notified_via_send(self, tmp_path):
+        """The current chat is NOT notified via adapter.send (its response is the return value)."""
+        current_source = _make_source(chat_id="chat1")
+        entries = {
+            "whatsapp:chat1": MagicMock(),
+        }
+        runner = _make_runner(session_entries=entries)
+        runner.session_store._generate_session_key = MagicMock(
+            return_value="whatsapp:chat1"
+        )
+
+        event = _make_event("/persona", source=current_source)
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        adapter = runner.adapters[Platform.WHATSAPP]
+        adapter.send.assert_not_called()
+        assert "notified 0 other chat(s)" in result
+
+    @pytest.mark.asyncio
+    async def test_persona_no_cache_lock_skips_gracefully(self, tmp_path):
+        """When _agent_cache_lock is missing, command still completes without error."""
+        runner = _make_runner()
+        del runner._agent_cache_lock  # simulate missing lock
+
+        event = _make_event("/persona")
+
+        with patch("gateway.run._hermes_home", tmp_path):
+            result = await runner._handle_persona_command(event)
+
+        assert "Invalidated 0 cached session(s)" in result


### PR DESCRIPTION
## Problem

When a user renames the AI agent by editing SOUL.md, active sessions in other chats continue using the stale cached identity. There are two caching layers that prevent the change from propagating:

1. **Per-session system prompt cache** — `_build_system_prompt()` runs once per session and caches on `self._cached_system_prompt`. Existing sessions never re-read SOUL.md until the agent object is evicted.
2. **Gateway agent object cache** — The gateway caches `AIAgent` objects per session key in `_agent_cache`. These objects hold the stale cached system prompt.

The workaround was to manually `/reset` every active chat — painful with multiple active sessions.

## Solution

Adds a `/persona [reload]` command that:
1. Calls `_invalidate_system_prompt()` on every agent object in the gateway's `_agent_cache`, forcing a fresh SOUL.md read on the next turn in each chat
2. Sends a brief notification to all other active sessions so users know the identity was refreshed
3. Returns a summary of how many sessions were invalidated

Available in both the gateway (messaging platforms) and CLI.

## Files changed
- `hermes_cli/commands.py` — register the command
- `gateway/run.py` — `_handle_persona_command` + dispatch
- `cli.py` — CLI handler
- `tests/gateway/test_persona_command.py` — test coverage

## Testing
```
python -m pytest tests/gateway/test_persona_command.py -v
```