### PR TITLE
fix(wecom): fallback to proactive send when reply stream returns 600039

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1303,7 +1303,29 @@ class WeComAdapter(BasePlatformAdapter):
         try:
             reply_req_id = self._reply_req_id_for_message(reply_to)
             if reply_req_id:
-                response = await self._send_reply_stream(reply_req_id, content)
+                try:
+                    response = await self._send_reply_stream(reply_req_id, content)
+                except Exception as exc:
+                    err_str = str(exc).lower()
+                    if "600039" in err_str or "device type not support" in err_str:
+                        logger.warning(
+                            "[%s] Reply stream failed (%s), falling back to proactive send",
+                            self.name,
+                            exc,
+                        )
+                        # Remove stale reply_req_id so subsequent fallbacks
+                        # don't re-enter the broken reply path.
+                        self._reply_req_ids.pop(str(reply_to or "").strip(), None)
+                        response = await self._send_request(
+                            APP_CMD_SEND,
+                            {
+                                "chatid": chat_id,
+                                "msgtype": "markdown",
+                                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
+                            },
+                        )
+                    else:
+                        raise
             else:
                 response = await self._send_request(
                     APP_CMD_SEND,


### PR DESCRIPTION
## Problem

WeCom messages frequently fail to deliver with:



This happens when the adapter tries to send a response via the passive **reply stream** path () and the original  has become stale — typically after a WebSocket reconnect or when the reply window has closed.

The generic retry/fallback logic in  catches the failure and retries with  still present, which causes the WeCom adapter to **re-enter the same broken reply stream path** instead of falling back to a proactive .

## Change

Inside , catch  /  specifically when the reply stream fails:

1. Log the fallback.
2. Remove the stale  from .
3. Retry via the proactive  () path.

This ensures group-chat and DM responses are still delivered even when the passive reply channel is unavailable.

## Verification

-  passes (7/7).
- The pre-existing unrelated failure in  remains unchanged.