### PR TITLE
Support claude-opus-4-7 with adaptive thinking

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -41,6 +41,8 @@ ADAPTIVE_EFFORT_MAP = {
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # Claude 4.7
+    "claude-opus-4-7":   128_000,
     # Claude 4.6
     "claude-opus-4-6":   128_000,
     "claude-sonnet-4-6":  64_000,
@@ -91,8 +93,8 @@ def _get_anthropic_max_output(model: str) -> int:
 
 
 def _supports_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude 4.6 models that support adaptive thinking."""
-    return any(v in model for v in ("4-6", "4.6"))
+    """Return True for Claude 4.6+ models that support adaptive thinking."""
+    return any(v in model for v in ("4-6", "4.6", "4-7", "4.7"))
 
 
 # Beta headers for enhanced features (sent with ALL auth types)


### PR DESCRIPTION
Fixes #11137

## Problem

`claude-opus-4-7` returns HTTP 400:
```
"thinking.type.enabled" is not supported for this model. Use
"thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

The adaptive-thinking code path (added in #1128) already handles this correctly, but `_supports_adaptive_thinking()` only matches `"4-6"` / `"4.6"`, so opus 4-7 falls through to the old `thinking.type="enabled"` path.

## Change

Two line-level additions, both gated by model name:

1. Add `"claude-opus-4-7": 128_000` to `_ANTHROPIC_OUTPUT_LIMITS`.
2. Match `"4-7"` / `"4.7"` in `_supports_adaptive_thinking()`.

No logic changes. Models that don't match these strings are not touched.

## Verification

Confirmed live against Anthropic API: after this patch, opus 4-7 requests succeed with `thinking: {type: "adaptive"}` + `output_config.effort`, which is the same path opus 4-6 already uses.

## Out of scope

Opus 4-7 also rejects `temperature`, `top_p`, `top_k` (returns 400). Those require separate parameter stripping and are left for a follow-up PR to keep this one minimal.