### PR TITLE
fix 10878: strip UTF-8 BOM from memory files on read

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -417,6 +417,9 @@ class MemoryStore:
             return []
         try:
             raw = path.read_text(encoding="utf-8")
+            # Strip UTF-8 BOM if present (common when files are edited on Windows)
+            if raw.startswith("\ufeff"):
+                raw = raw[1:]
         except (OSError, IOError):
             return []
 


### PR DESCRIPTION
Fixes #10878

MemoryStore._read_file() reads with encoding=utf-8 which does not auto-strip BOM. If MEMORY.md starts with BOM (common on Windows Notepad), the invisible character enters the system prompt.

Now strips BOM after reading if present.