### PR TITLE
fix(security): normalize path casing for Windows write-safety checks

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -3,12 +3,22 @@
 Based on PR #1085 by ismoilh (salvaged).
 """
 
+import importlib
 import os
 from pathlib import Path
 
 import pytest
 
+import tools.file_operations as file_operations
 from tools.file_operations import _is_write_denied
+
+
+@pytest.fixture
+def windows_casefolded_file_operations():
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(os.path, "normcase", lambda value: str(value).lower())
+        yield importlib.reload(file_operations)
+    importlib.reload(file_operations)
 
 
 class TestStaticDenyList:
@@ -77,6 +87,33 @@ class TestSafeWriteRoot:
         # Point safe root at home to include ~/.ssh
         monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", os.path.expanduser("~"))
         assert _is_write_denied(os.path.expanduser("~/.ssh/id_rsa")) is True
+
+    def test_safe_root_comparison_is_case_insensitive_on_windows(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        windows_casefolded_file_operations,
+    ):
+        safe_root = tmp_path / "Workspace"
+        child = safe_root / "subdir" / "file.txt"
+        os.makedirs(child.parent, exist_ok=True)
+
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root).upper())
+        assert windows_casefolded_file_operations._is_write_denied(str(child)) is False
+
+
+class TestWindowsCaseInsensitiveComparisons:
+    def test_static_deny_list_matches_case_insensitively_on_windows(
+        self,
+        windows_casefolded_file_operations,
+    ):
+        mixed_case_key = os.path.join(
+            windows_casefolded_file_operations._HOME.upper(),
+            ".SSH",
+            "ID_RSA",
+        )
+
+        assert windows_casefolded_file_operations._is_write_denied(mixed_case_key) is True
 
 
 class TestCheckSensitivePathMacOSBypass:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -42,8 +42,14 @@ from tools.binary_extensions import BINARY_EXTENSIONS
 
 _HOME = str(Path.home())
 
+
+def _normalize_write_path(path: str) -> str:
+    """Normalize a path for deny-list and safe-root comparisons."""
+    return os.path.normcase(os.path.realpath(os.path.expanduser(str(path))))
+
+
 WRITE_DENIED_PATHS = {
-    os.path.realpath(p) for p in [
+    _normalize_write_path(p) for p in [
         os.path.join(_HOME, ".ssh", "authorized_keys"),
         os.path.join(_HOME, ".ssh", "id_rsa"),
         os.path.join(_HOME, ".ssh", "id_ed25519"),
@@ -65,7 +71,7 @@ WRITE_DENIED_PATHS = {
 }
 
 WRITE_DENIED_PREFIXES = [
-    os.path.realpath(p) + os.sep for p in [
+    _normalize_write_path(p) + os.sep for p in [
         os.path.join(_HOME, ".ssh"),
         os.path.join(_HOME, ".aws"),
         os.path.join(_HOME, ".gnupg"),
@@ -91,14 +97,14 @@ def _get_safe_write_root() -> Optional[str]:
     if not root:
         return None
     try:
-        return os.path.realpath(os.path.expanduser(root))
+        return _normalize_write_path(root)
     except Exception:
         return None
 
 
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
-    resolved = os.path.realpath(os.path.expanduser(str(path)))
+    resolved = _normalize_write_path(path)
 
     # 1) Static deny list
     if resolved in WRITE_DENIED_PATHS:


### PR DESCRIPTION
## Summary
This fixes a Windows-specific write-safety bypass in tools.file_operations.

The write deny-list, deny-prefix checks, and HERMES_WRITE_SAFE_ROOT sandboxing were comparing resolved paths with case-sensitive string checks. On Windows, that can produce incorrect security decisions because the filesystem is case-insensitive even when the strings are not.

This patch normalizes all write-safety path comparisons through a shared helper before checking:

static denied paths
denied path prefixes
HERMES_WRITE_SAFE_ROOT

## Root Cause
_is_write_denied() and _get_safe_write_root() used realpath()/expanduser() but did not normalize case before comparing paths.

That meant paths like the following could behave incorrectly on Windows:

C:\Users\name\.SSH\ID_RSA
C:\USERS\NAME\workspace\file.txt when HERMES_WRITE_SAFE_ROOT was configured with different casing

## Changes

Added _normalize_write_path() in tools/file_operations.py
Applied that normalization to:
WRITE_DENIED_PATHS
WRITE_DENIED_PREFIXES
_get_safe_write_root()
_is_write_denied()
Added regression coverage for Windows-style case-insensitive behavior in tests/tools/test_file_write_safety.py


## Tests
Ran targeted write-safety tests:

uv run --extra dev python -m pytest -n 0 \
  tests/tools/test_file_write_safety.py::TestStaticDenyList \
  tests/tools/test_file_write_safety.py::TestSafeWriteRoot \
  tests/tools/test_file_write_safety.py::TestWindowsCaseInsensitiveComparisons -q
  
## Result:
12 passed