### PR TITLE
fix 10764: handle multiple atexit calls in browser cleanup

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -634,10 +634,14 @@ def _start_browser_cleanup_thread():
 
 def _stop_browser_cleanup_thread():
     """Stop the background cleanup thread."""
-    global _cleanup_running
+    global _cleanup_running, _cleanup_thread
     _cleanup_running = False
     if _cleanup_thread is not None:
-        _cleanup_thread.join(timeout=5)
+        try:
+            _cleanup_thread.join(timeout=5)
+        except Exception:
+            pass
+        _cleanup_thread = None
 
 
 def _update_session_activity(task_id: str):


### PR DESCRIPTION
Fixes #10764

_stop_browser_cleanup_thread() was registered with atexit but could be called multiple times during shutdown (e.g. Ctrl+C pressed rapidly). The _cleanup_thread.join() would fail on second call.

Now wraps join() in try/except and sets _cleanup_thread=None after cleanup to prevent repeated calls.