### PR TITLE
[Bug] Add open.bigmodel.cn to _URL_TO_PROVIDER — zai China endpoint context length falls back to 128K

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -221,6 +221,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
     "api.z.ai": "zai",
+    "open.bigmodel.cn": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.moonshot.cn": "kimi-coding-cn",
     "api.kimi.com": "kimi-coding",


### PR DESCRIPTION
## Problem

`_URL_TO_PROVIDER` in `agent/model_metadata.py` maps `api.z.ai` to `"zai"`, but does not include `open.bigmodel.cn`, which is Z.AI (zhipu)'s China domain.

This is despite `hermes_cli/auth.py` already defining both domains as Z.AI endpoints in `detect_zai_endpoint()` (lines 392-395):

```python
("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1"], "Global (Coding Plan)"),
("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1"], "China (Coding Plan)"),
```

## Impact

When `_resolve_zai_base_url()` detects the China endpoint (open.bigmodel.cn) and returns it as the base URL, `get_model_context_length()` calls `_infer_provider_from_url()`, which only checks `_URL_TO_PROVIDER`. Since `open.bigmodel.cn` is not in that dict:

1. `_is_known_provider_base_url()` returns `False`
2. The URL is treated as a custom/unknown endpoint
3. Endpoint metadata probing fails (the server may not support `/models`)
4. Context length falls back to 128K (the default)
5. Step 8's hardcoded `"glm": 202752` is never reached

**Result**: GLM-5 models on China endpoints get 128K context instead of 202752, triggering premature compression and degraded performance.

## Fix

Add one entry to `_URL_TO_PROVIDER`:

```python
"open.bigmodel.cn": "zai",
```

This lets `_infer_provider_from_url()` correctly identify the provider, allowing the existing resolution chain to reach either `models.dev` lookup or the hardcoded `"glm": 202752` default.

## Verification

```python
# Before fix:
_infer_provider_from_url("https://open.bigmodel.cn/api/coding/paas/v4")  # → None (custom endpoint)

# After fix:
_infer_provider_from_url("https://open.bigmodel.cn/api/coding/paas/v4")  # → "zai" ✅
```

Confirmed locally: context length correctly resolves to 202752 after this change.