### PR TITLE
fix 11137: add Claude 4.7 support for adaptive thinking

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -41,6 +41,9 @@ ADAPTIVE_EFFORT_MAP = {
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # Claude 4.7
+    "claude-opus-4-7":   128_000,
+    "claude-sonnet-4-7":  64_000,
     # Claude 4.6
     "claude-opus-4-6":   128_000,
     "claude-sonnet-4-6":  64_000,
@@ -91,8 +94,8 @@ def _get_anthropic_max_output(model: str) -> int:
 
 
 def _supports_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude 4.6 models that support adaptive thinking."""
-    return any(v in model for v in ("4-6", "4.6"))
+    """Return True for Claude 4.6+ models that support adaptive thinking."""
+    return any(v in model for v in ("4-6", "4.6", "4-7", "4.7"))
 
 
 # Beta headers for enhanced features (sent with ALL auth types)


### PR DESCRIPTION
Fixes #11137

claude-opus-4-7 requires thinking.type.adaptive instead of thinking.type.enabled.

Changes:
1. Added 4-7/4.7 to _supports_adaptive_thinking()
2. Added claude-opus-4-7 and claude-sonnet-4-7 to _ANTHROPIC_OUTPUT_LIMITS