### PR TITLE
fix(agent): complete Claude Opus 4.7 API migration

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -28,19 +28,37 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
+# Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
+# Anthropic exposes 5 levels on 4.7+: low, medium, high, xhigh, max.
+# We preserve xhigh as xhigh (the recommended default for coding/agentic on
+# 4.7) and expose max as a distinct ceiling. "minimal" is a legacy alias that
+# maps to low.  See:
+# https://platform.claude.com/docs/en/about-claude/models/migration-guide
 ADAPTIVE_EFFORT_MAP = {
-    "xhigh": "max",
-    "high": "high",
-    "medium": "medium",
-    "low": "low",
+    "max":     "max",
+    "xhigh":   "xhigh",
+    "high":    "high",
+    "medium":  "medium",
+    "low":     "low",
     "minimal": "low",
 }
+
+# Models where extended thinking is deprecated/removed (4.6+ behavior: adaptive
+# is the only supported mode; 4.7 additionally forbids manual thinking entirely
+# and drops temperature/top_p/top_k).
+_ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7")
+
+# Models where temperature/top_p/top_k return 400 if set to non-default values.
+# This is the Opus 4.7 contract; future 4.x+ models are expected to follow it.
+_NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7")
 
 # ── Max output token limits per Anthropic model ───────────────────────
 # Source: Anthropic docs + Cline model catalog.  Anthropic's API requires
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
+    # Claude 4.7
+    "claude-opus-4-7":   128_000,
     # Claude 4.6
     "claude-opus-4-6":   128_000,
     "claude-sonnet-4-6":  64_000,
@@ -91,11 +109,26 @@ def _get_anthropic_max_output(model: str) -> int:
 
 
 def _supports_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude 4.6 models that support adaptive thinking."""
-    return any(v in model for v in ("4-6", "4.6"))
+    """Return True for Claude 4.6+ models that support adaptive thinking."""
+    return any(v in model for v in _ADAPTIVE_THINKING_SUBSTRINGS)
 
 
-# Beta headers for enhanced features (sent with ALL auth types)
+def _forbids_sampling_params(model: str) -> bool:
+    """Return True for models that 400 on any non-default temperature/top_p/top_k.
+
+    Opus 4.7 explicitly rejects sampling parameters; later Claude releases are
+    expected to follow suit.  Callers should omit these fields entirely rather
+    than passing zero/default values (the API rejects anything non-null).
+    """
+    return any(v in model for v in _NO_SAMPLING_PARAMS_SUBSTRINGS)
+
+
+# Beta headers for enhanced features (sent with ALL auth types).
+# As of Opus 4.7 (2026-04-16), both of these are GA on Claude 4.6+ — the
+# beta headers are still accepted (harmless no-op) but not required. Kept
+# here so older Claude (4.5, 4.1) + third-party Anthropic-compat endpoints
+# that still gate on the headers continue to get the enhanced features.
+# Migration guide: remove these if you no longer support ≤4.5 models.
 _COMMON_BETAS = [
     "interleaved-thinking-2025-05-14",
     "fine-grained-tool-streaming-2025-05-14",
@@ -1341,24 +1374,41 @@ def build_anthropic_kwargs(
             kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
 
     # Map reasoning_config to Anthropic's thinking parameter.
-    # Claude 4.6 models use adaptive thinking + output_config.effort.
+    # Claude 4.6+ models use adaptive thinking + output_config.effort.
     # Older models use manual thinking with budget_tokens.
     # MiniMax Anthropic-compat endpoints support thinking (manual mode only,
     # not adaptive).  Haiku does NOT support extended thinking — skip entirely.
+    #
+    # On 4.7+ the `thinking.display` field defaults to "omitted", which
+    # silently hides reasoning text that Hermes surfaces in its CLI. We
+    # request "summarized" so the reasoning blocks stay populated — matching
+    # 4.6 behavior and preserving the activity-feed UX during long tool runs.
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
             if _supports_adaptive_thinking(model):
-                kwargs["thinking"] = {"type": "adaptive"}
+                kwargs["thinking"] = {
+                    "type": "adaptive",
+                    "display": "summarized",
+                }
                 kwargs["output_config"] = {
-                    "effort": ADAPTIVE_EFFORT_MAP.get(effort, "medium")
+                    "effort": ADAPTIVE_EFFORT_MAP.get(effort, "medium"),
                 }
             else:
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
                 # Anthropic requires temperature=1 when thinking is enabled on older models
                 kwargs["temperature"] = 1
                 kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+
+    # ── Strip sampling params on 4.7+ ─────────────────────────────────
+    # Opus 4.7 rejects any non-default temperature/top_p/top_k with a 400.
+    # Callers (auxiliary_client, flush_memories, etc.) may set these for
+    # older models; drop them here as a safety net so upstream 4.6 → 4.7
+    # migrations don't require coordinated edits everywhere.
+    if _forbids_sampling_params(model):
+        for _sampling_key in ("temperature", "top_p", "top_k"):
+            kwargs.pop(_sampling_key, None)
 
     # ── Fast mode (Opus 4.6 only) ────────────────────────────────────
     # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
@@ -1417,12 +1467,20 @@ def normalize_anthropic_response(
                 )
             )
 
-    # Map Anthropic stop_reason to OpenAI finish_reason
+    # Map Anthropic stop_reason to OpenAI finish_reason.
+    # Newer stop reasons added in Claude 4.5+ / 4.7:
+    #   - refusal: the model declined to answer (cyber safeguards, CSAM, etc.)
+    #   - model_context_window_exceeded: hit context limit (not max_tokens)
+    # Both need distinct handling upstream — a refusal should surface to the
+    # user with a clear message, and a context-window overflow should trigger
+    # compression/truncation rather than be treated as normal end-of-turn.
     stop_reason_map = {
         "end_turn": "stop",
         "tool_use": "tool_calls",
         "max_tokens": "length",
         "stop_sequence": "stop",
+        "refusal": "content_filter",
+        "model_context_window_exceeded": "length",
     }
     finish_reason = stop_reason_map.get(response.stop_reason, "stop")
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -518,8 +518,13 @@ class _AnthropicCompletionsAdapter:
             tool_choice=normalized_tool_choice,
             is_oauth=self._is_oauth,
         )
+        # Opus 4.7+ rejects any non-default temperature/top_p/top_k; only set
+        # temperature for models that still accept it. build_anthropic_kwargs
+        # additionally strips these keys as a safety net — keep both layers.
         if temperature is not None:
-            anthropic_kwargs["temperature"] = temperature
+            from agent.anthropic_adapter import _forbids_sampling_params
+            if not _forbids_sampling_params(model):
+                anthropic_kwargs["temperature"] = temperature
 
         response = self._client.messages.create(**anthropic_kwargs)
         assistant_message, finish_reason = normalize_anthropic_response(response)
@@ -2287,6 +2292,15 @@ def _build_call_kwargs(
         "messages": messages,
         "timeout": timeout,
     }
+
+    # Opus 4.7+ rejects any non-default temperature/top_p/top_k — silently
+    # drop here so auxiliary callers that hardcode temperature (e.g. 0.3 on
+    # flush_memories, 0 on structured-JSON extraction) don't 400 the moment
+    # the aux model is flipped to 4.7.
+    if temperature is not None:
+        from agent.anthropic_adapter import _forbids_sampling_params
+        if _forbids_sampling_params(model):
+            temperature = None
 
     if temperature is not None:
         kwargs["temperature"] = temperature

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -102,6 +102,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # fuzzy-match collisions (e.g. "anthropic/claude-sonnet-4" is a
     # substring of "anthropic/claude-sonnet-4.6").
     # OpenRouter-prefixed models resolve via OpenRouter live API or models.dev.
+    "claude-opus-4-7": 1000000,
+    "claude-opus-4.7": 1000000,
     "claude-opus-4-6": 1000000,
     "claude-sonnet-4-6": 1000000,
     "claude-opus-4.6": 1000000,

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -561,7 +561,10 @@ class BatchRunner:
             provider_sort (str): Sort providers by price/throughput/latency (optional)
             max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
             reasoning_config (Dict): OpenRouter reasoning config override (e.g. {"effort": "none"} to disable thinking)
-            prefill_messages (List[Dict]): Messages to prepend as prefilled conversation context (few-shot priming)
+            prefill_messages (List[Dict]): Messages to prepend as prefilled conversation context (few-shot priming).
+                NOTE: Anthropic Sonnet 4.6+ and Opus 4.6+ reject a trailing assistant-role prefill
+                (400 error).  For those models use output_config.format or structured-output
+                schemas instead.  Safe here for user-role priming and for older Claude / non-Claude models.
             max_samples (int): Only process the first N samples from the dataset (optional, processes all if not set)
         """
         self.dataset_file = Path(dataset_file)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -26,7 +26,8 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # Fallback OpenRouter snapshot used when the live catalog is unavailable.
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
-    ("anthropic/claude-opus-4.6",       "recommended"),
+    ("anthropic/claude-opus-4.7",       "recommended"),
+    ("anthropic/claude-opus-4.6",       ""),
     ("anthropic/claude-sonnet-4.6",     ""),
     ("qwen/qwen3.6-plus",               ""),
     ("anthropic/claude-sonnet-4.5",     ""),
@@ -181,6 +182,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2",
     ],
     "anthropic": [
+        "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-sonnet-4-6",
         "claude-opus-4-5-20251101",

--- a/run_agent.py
+++ b/run_agent.py
@@ -641,6 +641,9 @@ class AIAgent:
             prefill_messages (List[Dict]): Messages to prepend to conversation history as prefilled context.
                 Useful for injecting a few-shot example or priming the model's response style.
                 Example: [{"role": "user", "content": "Hi!"}, {"role": "assistant", "content": "Hello!"}]
+                NOTE: Anthropic Sonnet 4.6+ and Opus 4.6+ reject a conversation that ends on an
+                assistant-role message (400 error).  For those models use structured outputs or
+                output_config.format instead of a trailing-assistant prefill.
             platform (str): The interface platform the user is on (e.g. "cli", "telegram", "discord", "whatsapp").
                 Used to inject platform-specific formatting hints into the system prompt.
             skip_context_files (bool): If True, skip auto-injection of SOUL.md, AGENTS.md, and .cursorrules

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -951,13 +951,19 @@ class TestBuildAnthropicKwargs:
             max_tokens=4096,
             reasoning_config={"enabled": True, "effort": "high"},
         )
-        assert kwargs["thinking"] == {"type": "adaptive"}
+        # Adaptive thinking + display="summarized" keeps reasoning text
+        # populated in the response stream (Opus 4.7 default is "omitted").
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
         assert kwargs["output_config"] == {"effort": "high"}
         assert "budget_tokens" not in kwargs["thinking"]
         assert "temperature" not in kwargs
         assert kwargs["max_tokens"] == 4096
 
-    def test_reasoning_config_maps_xhigh_to_max_effort_for_4_6_models(self):
+    def test_reasoning_config_maps_xhigh_to_xhigh_effort_for_4_6_models(self):
+        # Opus 4.7 added "xhigh" as a distinct effort level (the recommended
+        # default for coding/agentic work). Earlier mapping aliased xhigh→max,
+        # which silently over-efforted every request. 2026-04-16 migration
+        # guide: xhigh and max are distinct levels.
         kwargs = build_anthropic_kwargs(
             model="claude-sonnet-4-6",
             messages=[{"role": "user", "content": "think harder"}],
@@ -965,8 +971,39 @@ class TestBuildAnthropicKwargs:
             max_tokens=4096,
             reasoning_config={"enabled": True, "effort": "xhigh"},
         )
-        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kwargs["output_config"] == {"effort": "xhigh"}
+
+    def test_reasoning_config_maps_max_effort_for_4_7_models(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "maximum reasoning please"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
         assert kwargs["output_config"] == {"effort": "max"}
+
+    def test_opus_4_7_strips_sampling_params(self):
+        # Opus 4.7 returns 400 on non-default temperature/top_p/top_k.
+        # build_anthropic_kwargs must strip them as a safety net even if an
+        # upstream caller injects them for older-model compatibility.
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+        )
+        # Manually inject sampling params then re-run through the guard.
+        # Because build_anthropic_kwargs doesn't currently accept sampling
+        # params through its signature, we exercise the strip behavior by
+        # calling the internal predicate directly.
+        from agent.anthropic_adapter import _forbids_sampling_params
+        assert _forbids_sampling_params("claude-opus-4-7") is True
+        assert _forbids_sampling_params("claude-opus-4-6") is False
+        assert _forbids_sampling_params("claude-sonnet-4-5") is False
 
     def test_reasoning_disabled(self):
         kwargs = build_anthropic_kwargs(
@@ -1247,6 +1284,21 @@ class TestNormalizeResponse:
         assert r1 == "stop"
         assert r2 == "tool_calls"
         assert r3 == "length"
+
+    def test_stop_reason_refusal_and_context_exceeded(self):
+        # Claude 4.5+ introduced two new stop_reason values the Messages API
+        # returns.  We map both to OpenAI-style finish_reasons upstream
+        # handlers already understand, instead of silently collapsing to
+        # "stop" (old behavior).
+        block = SimpleNamespace(type="text", text="")
+        _, refusal_reason = normalize_anthropic_response(
+            self._make_response([block], "refusal")
+        )
+        _, overflow_reason = normalize_anthropic_response(
+            self._make_response([block], "model_context_window_exceeded")
+        )
+        assert refusal_reason == "content_filter"
+        assert overflow_reason == "length"
 
     def test_no_text_content(self):
         block = SimpleNamespace(

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -113,8 +113,10 @@ class TestDefaultContextLengths:
         for key, value in DEFAULT_CONTEXT_LENGTHS.items():
             if "claude" not in key:
                 continue
-            # Claude 4.6 models have 1M context
-            if "4.6" in key or "4-6" in key:
+            # Claude 4.6+ models (4.6 and 4.7) have 1M context at standard
+            # API pricing (no long-context premium).  Older Claude 4.x and
+            # 3.x models cap at 200k.
+            if any(tag in key for tag in ("4.6", "4-6", "4.7", "4-7")):
                 assert value == 1000000, f"{key} should be 1000000"
             else:
                 assert value == 200000, f"{key} should be 200000"


### PR DESCRIPTION
## What does this PR do?

Completes the Claude Opus 4.7 API migration. The existing adapter already handled the
minimal case (adaptive-thinking gate + output limit, from #1128 and working-tree edits
in response to #11137), but several related 4.7 breaking changes from Anthropic's
[official migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide)
still surface as silent regressions or hard 400s on common code paths:

1. Any request that hits `temperature` / `top_p` / `top_k` still 400s — flush_memories
   hardcodes `temperature=0.3` and the auxiliary OpenAI-protocol client forwards
   temperature for structured-JSON extraction. Both now strip for 4.7+.
2. `thinking.display` defaults to `"omitted"` on 4.7, which silently hides reasoning
   text from Hermes's CLI activity feed. Now set to `"summarized"` (restores 4.6 UX).
3. `ADAPTIVE_EFFORT_MAP["xhigh"] = "max"` silently upgraded every xhigh request to max.
   Anthropic's 5-level effort model treats xhigh and max as distinct (xhigh is the
   recommended coding/agentic default; max is a ceiling). Now passes through literally.
4. New stop_reason values `refusal` and `model_context_window_exceeded` were collapsed
   to `"stop"` by the adapter's stop_reason_map. Now mapped to `content_filter` and
   `length` respectively, matching the convention bedrock_adapter already uses.
5. Model catalog entries + docstring warnings about 4.6+/4.7 assistant-prefill 400s.

Discovered during a full audit of the codebase against Anthropic's migration guide.
Each item is small; collectively they prevent silent 400s and quality regressions on
real code paths (flush_memories, auxiliary clients, the kawaii CLI reasoning feed,
agentic coding runs).

## Related Issue

Fixes #11137

Related / overlapping:
- #11152 (OPEN): fixes item 0 (adaptive-thinking gate + output limit) only. This PR
  is a superset; if #11152 lands first, the overlapping 4 lines rebase cleanly.
- #11145 (CLOSED) and #11107 (CLOSED): tried the minimal fix; both explicitly flagged
  temperature / top_p / top_k stripping as out of scope. This PR addresses it.
- #6645 (OPEN): strips temperature for OAuth adaptive-thinking models. This PR's
  `_forbids_sampling_params()` guard is narrower (model-gated, not OAuth-gated) and
  complementary; they can both land.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`:
  - `ADAPTIVE_EFFORT_MAP`: `xhigh → xhigh` (was `xhigh → max`), explicit `max → max`.
  - `_supports_adaptive_thinking()`: matches 4.6+ (adds 4-7 / 4.7) via
    `_ADAPTIVE_THINKING_SUBSTRINGS`.
  - `_forbids_sampling_params()`: new predicate for 4.7+ models; drops
    `temperature` / `top_p` / `top_k` from kwargs.
  - `build_anthropic_kwargs`: emits `thinking={"type": "adaptive", "display": "summarized"}`
    on 4.6+; invokes `_forbids_sampling_params()` as a safety net.
  - `_ANTHROPIC_OUTPUT_LIMITS["claude-opus-4-7"] = 128_000`.
  - `normalize_anthropic_response.stop_reason_map`: `refusal → content_filter`,
    `model_context_window_exceeded → length`.
  - Updated beta-header comment to note `interleaved-thinking-2025-05-14` and
    `fine-grained-tool-streaming-2025-05-14` are now GA on 4.6+ (still sent for
    ≤4.5 / third-party Anthropic-compat endpoints).
- `agent/auxiliary_client.py`:
  - `AnthropicCompletionsAdapter.create()`: only passes temperature when
    `_forbids_sampling_params(model)` is False.
  - `_build_call_kwargs()`: drops temperature for 4.7+ models on the OpenAI-protocol
    path (covers OpenRouter / Anthropic-compat endpoints).
- `agent/model_metadata.py`: `DEFAULT_CONTEXT_LENGTHS` adds `claude-opus-4-7` and
  `claude-opus-4.7` at 1,000,000 (matching 4.6 per migration guide — 1M context at
  standard API pricing, no long-context premium).
- `hermes_cli/models.py`: `claude-opus-4-7` first in `_PROVIDER_MODELS["anthropic"]`;
  `anthropic/claude-opus-4.7` first in `OPENROUTER_MODELS` with "recommended" tag.
- `run_agent.py`, `batch_runner.py`: `prefill_messages` docstrings warn that
  Anthropic Sonnet/Opus 4.6+ reject a trailing assistant-role prefill (400).
- `tests/agent/test_anthropic_adapter.py`: 4 new tests:
  - `test_reasoning_config_maps_xhigh_to_xhigh_effort_for_4_6_models` (xhigh preservation)
  - `test_reasoning_config_maps_max_effort_for_4_7_models`
  - `test_opus_4_7_strips_sampling_params` (predicate contract)
  - `test_stop_reason_refusal_and_context_exceeded`
  - plus updated 2 existing assertions for the new `display: summarized` shape.
- `tests/agent/test_model_metadata.py`: `test_claude_models_context_lengths` accepts
  4.7 tags as 1M context.

## How to Test

```bash
# Repro the original 400 (before this fix)
hermes config set model anthropic/claude-opus-4-7
hermes chat -q "Summarize this repo"
# => BadRequestError 400: "thinking.type.enabled" is not supported for this model
# => or "temperature is not supported for this model"
# => or "top_p" / "top_k" ...

# After this fix: succeeds with adaptive thinking + output_config.effort
hermes chat -q "Summarize this repo"

# Verify reasoning text is still visible during tool runs
hermes chat -q "Look at 3 files in parallel and tell me what they do"
# => expect reasoning text in the CLI activity feed (not a long silent pause)

# Run the test suite
pytest tests/agent/test_anthropic_adapter.py tests/agent/test_model_metadata.py -q
# => 119+ passing (includes 4 new tests for this change)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — noted overlap with #11152, #6645 above
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/agent -q` — 1321 passed, 1 skipped
- [x] I've added tests for my changes (4 new tests for adapter, 1 updated for model_metadata)
- [x] I've tested on my platform: macOS 15.5 (darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in run_agent.py, batch_runner.py, anthropic_adapter.py) — or N/A
- [x] N/A — no config key changes
- [x] N/A — no architecture changes
- [x] N/A — pure string-matching + dict changes, no platform-specific code
- [x] N/A — no tool schema changes
