### PR TITLE
fix(copilot-acp): coerce httpx.Timeout to seconds (#11129)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -53,10 +53,12 @@ def _coerce_timeout_seconds(value: Any, default: float) -> float:
     # to ``.connect`` when ``.read`` is ``None`` (``httpx.Timeout(None)``
     # means no read timeout — keep default instead of passing ``inf``).
     for attr in ("read", "connect"):
-        if hasattr(value, attr):
+        try:
             inner = getattr(value, attr)
-            if isinstance(inner, (int, float)):
-                return float(inner)
+        except AttributeError:
+            continue
+        if isinstance(inner, (int, float)):
+            return float(inner)
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -341,7 +343,7 @@ class CopilotACPClient:
         *,
         model: str | None = None,
         messages: list[dict[str, Any]] | None = None,
-        timeout: float | None = None,
+        timeout: Any = None,
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
         **_: Any,

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -24,6 +24,45 @@ from typing import Any
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
+
+def _coerce_timeout_seconds(value: Any, default: float) -> float:
+    """Return a plain float-seconds timeout from any OpenAI-client timeout shape.
+
+    Hermes' chat-completions call path passes ``timeout=httpx.Timeout(...)``
+    for streaming requests (see ``run_agent.py``), but the Copilot ACP shim
+    only understands a single seconds value because it just guards a local
+    ``copilot --acp --stdio`` subprocess.  Bare ``float(httpx.Timeout(...))``
+    raises ``TypeError: float() argument must be a string or a real number,
+    not 'Timeout'``, which surfaces as a non-retryable error for every
+    user pointing Hermes at ``provider: copilot-acp``.
+
+    Accepted shapes: ``None`` (use ``default``), ``int``/``float``, any
+    object exposing a numeric ``.read`` attribute (``httpx.Timeout``), and
+    bare-string numeric timeouts.  Anything else falls back to ``default``
+    rather than aborting the request.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        # ``bool`` is a subclass of ``int`` but makes no sense as a timeout.
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    # ``httpx.Timeout`` exposes ``.read`` as ``float | None``; prefer it
+    # because read is what bounds the streaming response here.  Fall through
+    # to ``.connect`` when ``.read`` is ``None`` (``httpx.Timeout(None)``
+    # means no read timeout — keep default instead of passing ``inf``).
+    for attr in ("read", "connect"):
+        if hasattr(value, attr):
+            inner = getattr(value, attr)
+            if isinstance(inner, (int, float)):
+                return float(inner)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
 
@@ -315,7 +354,7 @@ class CopilotACPClient:
         )
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
-            timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
+            timeout_seconds=_coerce_timeout_seconds(timeout, _DEFAULT_TIMEOUT_SECONDS),
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -1,0 +1,149 @@
+"""Regression tests for agent.copilot_acp_client._coerce_timeout_seconds.
+
+Covers #11129: the Copilot ACP shim blew up with
+``TypeError: float() argument must be a string or a real number, not
+'Timeout'`` whenever Hermes' streaming path passed
+``timeout=httpx.Timeout(...)`` through to ``create(...)``.  The ACP shim
+has to convert *any* OpenAI-client timeout shape into a single float
+number of seconds for its ``copilot --acp --stdio`` subprocess guard.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from agent.copilot_acp_client import (
+    _DEFAULT_TIMEOUT_SECONDS,
+    CopilotACPClient,
+    _coerce_timeout_seconds,
+)
+
+
+class TestCoerceTimeoutSeconds:
+    """Every shape Hermes or an OpenAI-client caller might hand us."""
+
+    def test_none_returns_default(self):
+        assert _coerce_timeout_seconds(None, 123.0) == 123.0
+
+    def test_int_passes_through(self):
+        assert _coerce_timeout_seconds(42, 1.0) == 42.0
+
+    def test_float_passes_through(self):
+        assert _coerce_timeout_seconds(12.5, 1.0) == 12.5
+
+    def test_bool_falls_back_to_default(self):
+        """``bool`` is an ``int`` subclass but ``True``/``False`` are not
+        meaningful timeouts — fall back rather than silently use 1.0s."""
+        assert _coerce_timeout_seconds(True, 60.0) == 60.0
+        assert _coerce_timeout_seconds(False, 60.0) == 60.0
+
+    def test_httpx_timeout_uses_read(self):
+        """#11129 root-cause case. ``httpx.Timeout`` is what Hermes'
+        streaming path passes; read is what bounds the response."""
+        value = httpx.Timeout(connect=30.0, read=1800.0, write=1800.0, pool=30.0)
+        assert _coerce_timeout_seconds(value, 1.0) == 1800.0
+
+    def test_httpx_timeout_bare_number_is_applied_to_all(self):
+        """``httpx.Timeout(120)`` applies 120s to every phase including
+        read; we must resolve to 120.0, not fall back to default."""
+        assert _coerce_timeout_seconds(httpx.Timeout(120), 1.0) == 120.0
+
+    def test_httpx_timeout_none_falls_back_to_default(self):
+        """``httpx.Timeout(None)`` means *no* timeout. Keeping the default
+        bound is safer than passing ``inf`` to the subprocess guard."""
+        assert _coerce_timeout_seconds(httpx.Timeout(None), 600.0) == 600.0
+
+    def test_simplenamespace_with_read_attr(self):
+        """Any duck-typed object with ``.read`` as a number is accepted —
+        useful for test doubles and other OpenAI-client variants."""
+        assert _coerce_timeout_seconds(SimpleNamespace(read=77.0), 1.0) == 77.0
+
+    def test_string_numeric(self):
+        assert _coerce_timeout_seconds("30", 1.0) == 30.0
+
+    def test_unparseable_string_falls_back(self):
+        assert _coerce_timeout_seconds("thirty", 7.0) == 7.0
+
+    def test_arbitrary_object_falls_back(self):
+        class Weird:
+            pass
+
+        assert _coerce_timeout_seconds(Weird(), 99.0) == 99.0
+
+    def test_zero_is_preserved(self):
+        """A caller passing ``0`` opts into an immediate timeout; don't
+        clobber that with the default."""
+        assert _coerce_timeout_seconds(0, 99.0) == 0.0
+
+
+class TestCreateChatCompletionWithHttpxTimeout:
+    """End-to-end: the shim's ``.chat.completions.create(...)`` must not
+    raise when Hermes' real streaming path hands it an ``httpx.Timeout``.
+    """
+
+    def _make_client(self) -> CopilotACPClient:
+        return CopilotACPClient(base_url="acp://copilot", acp_cwd="/tmp")
+
+    def test_httpx_timeout_does_not_raise_typeerror(self):
+        """Before the fix: TypeError from ``float(httpx.Timeout(...))``
+        inside ``_create_chat_completion``.  After: the shim forwards a
+        plain float to ``_run_prompt``."""
+        client = self._make_client()
+
+        with patch.object(
+            CopilotACPClient, "_run_prompt", return_value=("ok", "")
+        ) as run_prompt:
+            client.chat.completions.create(
+                model="claude-sonnet-4.6",
+                messages=[{"role": "user", "content": "hi"}],
+                timeout=httpx.Timeout(connect=30.0, read=1800.0, write=1800.0, pool=30.0),
+            )
+
+        run_prompt.assert_called_once()
+        kwargs = run_prompt.call_args.kwargs
+        assert "timeout_seconds" in kwargs
+        assert kwargs["timeout_seconds"] == 1800.0
+        assert isinstance(kwargs["timeout_seconds"], float)
+
+    def test_float_timeout_still_passes_through(self):
+        """Non-regression: numeric timeouts still reach ``_run_prompt`` unchanged."""
+        client = self._make_client()
+
+        with patch.object(
+            CopilotACPClient, "_run_prompt", return_value=("ok", "")
+        ) as run_prompt:
+            client.chat.completions.create(
+                model="claude-sonnet-4.6",
+                messages=[{"role": "user", "content": "hi"}],
+                timeout=42.0,
+            )
+
+        assert run_prompt.call_args.kwargs["timeout_seconds"] == 42.0
+
+    def test_no_timeout_uses_default(self):
+        client = self._make_client()
+
+        with patch.object(
+            CopilotACPClient, "_run_prompt", return_value=("ok", "")
+        ) as run_prompt:
+            client.chat.completions.create(
+                model="claude-sonnet-4.6",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert run_prompt.call_args.kwargs["timeout_seconds"] == _DEFAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize("bogus", [httpx.Timeout(None), object(), "not-a-number"])
+def test_bogus_timeouts_never_raise(bogus):
+    """Safety net — if a future caller hands a new shape, we fall back
+    to the default rather than aborting the whole request."""
+    result = _coerce_timeout_seconds(bogus, 555.5)
+    assert isinstance(result, float)
+    assert not math.isinf(result)
+    assert not math.isnan(result)

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -86,14 +86,14 @@ class TestCreateChatCompletionWithHttpxTimeout:
     raise when Hermes' real streaming path hands it an ``httpx.Timeout``.
     """
 
-    def _make_client(self) -> CopilotACPClient:
-        return CopilotACPClient(base_url="acp://copilot", acp_cwd="/tmp")
+    def _make_client(self, tmp_path) -> CopilotACPClient:
+        return CopilotACPClient(base_url="acp://copilot", acp_cwd=str(tmp_path))
 
-    def test_httpx_timeout_does_not_raise_typeerror(self):
+    def test_httpx_timeout_does_not_raise_typeerror(self, tmp_path):
         """Before the fix: TypeError from ``float(httpx.Timeout(...))``
         inside ``_create_chat_completion``.  After: the shim forwards a
         plain float to ``_run_prompt``."""
-        client = self._make_client()
+        client = self._make_client(tmp_path)
 
         with patch.object(
             CopilotACPClient, "_run_prompt", return_value=("ok", "")
@@ -110,9 +110,9 @@ class TestCreateChatCompletionWithHttpxTimeout:
         assert kwargs["timeout_seconds"] == 1800.0
         assert isinstance(kwargs["timeout_seconds"], float)
 
-    def test_float_timeout_still_passes_through(self):
+    def test_float_timeout_still_passes_through(self, tmp_path):
         """Non-regression: numeric timeouts still reach ``_run_prompt`` unchanged."""
-        client = self._make_client()
+        client = self._make_client(tmp_path)
 
         with patch.object(
             CopilotACPClient, "_run_prompt", return_value=("ok", "")
@@ -125,8 +125,8 @@ class TestCreateChatCompletionWithHttpxTimeout:
 
         assert run_prompt.call_args.kwargs["timeout_seconds"] == 42.0
 
-    def test_no_timeout_uses_default(self):
-        client = self._make_client()
+    def test_no_timeout_uses_default(self, tmp_path):
+        client = self._make_client(tmp_path)
 
         with patch.object(
             CopilotACPClient, "_run_prompt", return_value=("ok", "")


### PR DESCRIPTION
## What does this PR do?

Fixes #11129.

This fixes the Copilot ACP provider path when Hermes passes an `httpx.Timeout(...)` object into `chat.completions.create(...)`. Before this change, the ACP shim tried to do `float(timeout or _DEFAULT_TIMEOUT_SECONDS)` inside `agent/copilot_acp_client.py`, which raises `TypeError: float() argument must be a string or a real number, not 'Timeout'` for the exact timeout shape Hermes uses in its streaming call path. The result is that `provider: copilot-acp` fails before the ACP subprocess even starts.

## Related Issue

Fixes #11129

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Root Cause

`CopilotACPClient._create_chat_completion()` converted the incoming timeout with a bare `float(...)` call at `agent/copilot_acp_client.py` (the `_run_prompt(... timeout_seconds=...)` call site now at lines 355-357 in this branch). Hermes' real streaming path passes `timeout=httpx.Timeout(...)`, and `httpx.Timeout` is not directly coercible to `float`, so every ACP request aborted with a non-retryable `TypeError` before tool execution or normal response handling.

## Smallest Safe Fix

This PR adds a tiny `_coerce_timeout_seconds()` helper in `agent/copilot_acp_client.py` and changes exactly one call site to use it.

The helper accepts the timeout shapes Hermes or OpenAI-compatible callers realistically send here:
- `None` -> default `_DEFAULT_TIMEOUT_SECONDS`
- `int` / `float` -> pass through
- `httpx.Timeout` / duck-typed objects with numeric `.read` or `.connect` -> use that numeric phase timeout
- numeric strings -> coerce
- anything else -> fall back to the default instead of aborting the whole request

This keeps the ACP shim's existing single-float subprocess timeout model intact. It does not change prompt formatting, ACP wire format, tool-call extraction, or retry behavior.

## Backward Compatibility

There is no config or precedence change in this PR.

Compatibility expectations:
- `timeout=None` -> still uses `_DEFAULT_TIMEOUT_SECONDS` (unchanged)
- `timeout=<float|int>` -> still passes through exactly (unchanged)
- `timeout=httpx.Timeout(...)` -> now resolves to a real seconds value instead of raising `TypeError` (bug fix)
- `timeout=httpx.Timeout(None)` / unsupported objects -> now fall back to `_DEFAULT_TIMEOUT_SECONDS` instead of aborting the request

## Changes Made

- `agent/copilot_acp_client.py`
  - add `_coerce_timeout_seconds()`
  - use it at the `_run_prompt(... timeout_seconds=...)` call site
- `tests/agent/test_copilot_acp_client.py`
  - add regression coverage for `httpx.Timeout`, numeric values, `None`, duck-typed timeout objects, bogus values, and end-to-end `CopilotACPClient.chat.completions.create(...)`

## Narrow Scope

This PR fixes only the timeout coercion bug reported in #11129.

I did not widen scope into other Copilot ACP behaviors or provider-specific parameter normalization. If maintainers want broader ACP hardening later, that can be a follow-up without mixing unrelated behavior changes into this regression fix.

## How to Test

1. Reproduce the old failure path on `origin/main` with the exact `httpx.Timeout(...)` shape Hermes passes.
2. Run the new ACP regression tests.
3. Run an adjacent agent slice.
4. Run the CI-aligned pytest command and classify unrelated baseline failures separately.

## Validation

Exact commands run locally:

```bash
source venv/bin/activate && python - <<'PY'
import subprocess
from unittest.mock import patch
import httpx

src = subprocess.check_output(['git', 'show', 'origin/main:agent/copilot_acp_client.py'], text=True)
ns = {'__name__': 'copilot_acp_main_repro'}
exec(src, ns)
CopilotACPClient = ns['CopilotACPClient']
client = CopilotACPClient(base_url='acp://copilot', acp_cwd='/tmp')
try:
    with patch.object(CopilotACPClient, '_run_prompt', return_value=('ok', '')):
        client.chat.completions.create(
            model='claude-sonnet-4.6',
            messages=[{'role': 'user', 'content': 'hi'}],
            timeout=httpx.Timeout(connect=30.0, read=1800.0, write=1800.0, pool=30.0),
        )
except Exception as exc:
    print(type(exc).__name__ + ':', exc)
PY
# -> TypeError: float() argument must be a string or a real number, not 'Timeout'

source venv/bin/activate && python -m pytest tests/agent/test_copilot_acp_client.py -q
# -> 18 passed

source venv/bin/activate && python -m pytest tests/agent/ -q -k copilot
# -> 26 passed

git diff --check
# -> passed

source venv/bin/activate && python -m py_compile agent/copilot_acp_client.py tests/agent/test_copilot_acp_client.py
# -> passed

source venv/bin/activate && python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
# -> 7 failures, all outside Copilot ACP
```

Baseline vs change classification for the CI-aligned broad suite:
- Reproduced on clean `origin/main` worktree:
  - `tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_wsl_with_systemd`
  - `tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_native_linux`
  - `tests/tools/test_file_staleness.py::TestStalenessCheck::test_warning_when_file_modified_externally`
  - `tests/tools/test_file_staleness.py::TestPatchStaleness::test_patch_warns_on_stale_file`
  - `tests/run_agent/test_413_compression.py::TestPreflightCompression::test_preflight_compresses_oversized_history`
- Failed in the broad suite but passed in isolated reruns on both this branch and a clean `origin/main` worktree, so they appear order-dependent / flaky rather than caused by this patch:
  - `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once`
  - `tests/test_plugin_skills.py::TestSkillViewPluginGuards::test_injection_logged_but_served`

## Tested Platform(s)

- Local development environment: macOS (repo venv)
- Bug report environment: Ubuntu 24 (from issue #11129)

## Adjacent Surfaces Checked

- `CopilotACPClient.chat.completions.create(...)` still preserves numeric timeout behavior
- bogus timeout shapes now fall back safely instead of aborting the request
- no changes to ACP prompt construction, tool-call parsing, or subprocess lifecycle

## Notes

- No standalone lint command is defined; CI runs `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — unit / regression fix.