### PR TITLE
fix(gateway): pre-wire voice callbacks on Discord adapters at startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1992,7 +1992,20 @@ class GatewayRunner:
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
-        
+
+        # Pre-wire voice callbacks on Discord adapters so persistent/auto-joined
+        # voice channels receive speech input immediately.  Without this, the
+        # callbacks are only set on the first manual join_voice_channel() call,
+        # so auto-joined channels silently drop all transcribed speech.
+        from gateway.platforms import discord as discord_mod
+        for platform_type, adapter in self.adapters.items():
+            if isinstance(adapter, discord_mod.DiscordAdapter):
+                if hasattr(adapter, "_voice_input_callback") and not adapter._voice_input_callback:
+                    adapter._voice_input_callback = self._handle_voice_channel_input
+                if hasattr(adapter, "_on_voice_disconnect") and not adapter._on_voice_disconnect:
+                    adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+                logger.info("Pre-wired voice callbacks for Discord adapter")
+
         # Build initial channel directory for send_message name resolution
         try:
             from gateway.channel_directory import build_channel_directory


### PR DESCRIPTION
## Summary

When the Discord adapter auto-joins a voice channel on startup (via persistent voice config), the voice input and disconnect callbacks (`_voice_input_callback`, `_on_voice_disconnect`) have not yet been set by `GatewayRunner`. The gateway wires these callbacks lazily — only after the first `join_voice_channel()` call triggered by a user command — so auto-joined channels receive voice audio with no handler attached, silently dropping all speech input.

This fix iterates over Discord adapters in `GatewayRunner.connect()` after all platforms have connected and pre-wires the callbacks if they are not already set.

## Changes

- Added callback pre-wiring block in `GatewayRunner.connect()` after the "Gateway running" log line
- Only sets callbacks when currently `None` — safe for non-auto-join deployments

## Test Scenario

1. Set `DISCORD_VOICE_CHANNEL_ID=<channel_id>` and `DISCORD_VOICE_TIMEOUT=0` in `.env`
2. Restart the gateway
3. Speak in the voice channel immediately after the bot joins
4. **Without fix:** audio is silently dropped (no transcript, no agent call)
5. **With fix:** speech is transcribed and routed to the agent normally

## Context

We've been running this fix in production for several days via a local patch. The callback wiring gap affects all deployments using persistent/auto-join voice channels, not just our setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)