### PR TITLE
fix(matrix): prevent self-message echo loops

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -214,8 +214,10 @@ class MatrixAdapter(BasePlatformAdapter):
         self._user_id: str = config.extra.get("user_id", "") or os.getenv(
             "MATRIX_USER_ID", ""
         )
-        self._password: str = config.extra.get("password", "") or os.getenv(
-            "MATRIX_PASSWORD", ""
+        self._user_id_normalized: str = self._user_id.lower()
+        self._password: str = (
+            config.extra.get("password", "")
+            or os.getenv("MATRIX_PASSWORD", "")
         )
         self._encryption: bool = config.extra.get(
             "encryption",
@@ -449,6 +451,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 resolved_device_id = getattr(resp, "device_id", "")
                 if resolved_user_id:
                     self._user_id = str(resolved_user_id)
+                    self._user_id_normalized = self._user_id.lower()
                     client.mxid = UserID(self._user_id)
 
                 # Prefer user-configured device_id for stable E2EE identity.
@@ -1170,7 +1173,7 @@ class MatrixAdapter(BasePlatformAdapter):
         sender = str(getattr(event, "sender", ""))
 
         # Ignore own messages.
-        if sender == self._user_id:
+        if sender.lower() == self._user_id_normalized:
             return
 
         # Deduplicate by event ID.
@@ -1640,7 +1643,7 @@ class MatrixAdapter(BasePlatformAdapter):
     async def _on_reaction(self, event: Any) -> None:
         """Handle incoming reaction events."""
         sender = str(getattr(event, "sender", ""))
-        if sender == self._user_id:
+        if sender.lower() == self._user_id_normalized:
             return
         event_id = str(getattr(event, "event_id", ""))
         if self._is_duplicate_event(event_id):

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -209,6 +209,24 @@ async def test_ignores_own_messages_case_insensitively(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ignores_own_reactions_case_insensitively():
+    """Own reactions should not be deduplicated or logged as inbound work."""
+    adapter = _make_adapter()
+    adapter._user_id = "@Hermes:example.org"
+    adapter._user_id_normalized = adapter._user_id.lower()
+    reaction = SimpleNamespace(
+        sender="@hermes:example.org",
+        event_id="$reaction1",
+        room_id="!room1:example.org",
+        content={"m.relates_to": {"event_id": "$evt1", "key": "👍"}},
+    )
+
+    await adapter._on_reaction(reaction)
+
+    assert "$reaction1" not in adapter._processed_events_set
+
+
+@pytest.mark.asyncio
 async def test_require_mention_default_processes_mentioned(monkeypatch):
     """Default: messages with mention are processed, mention stripped."""
     monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -193,6 +193,22 @@ async def test_require_mention_default_ignores_unmentioned(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ignores_own_messages_case_insensitively(monkeypatch):
+    """Own messages should be dropped even if Matrix normalizes sender case."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
+
+    adapter = _make_adapter()
+    adapter._user_id = "@Hermes:example.org"
+    adapter._user_id_normalized = adapter._user_id.lower()
+    event = _make_event("Acknowledged. I’m idle and ready when you are.", sender="@hermes:example.org")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_require_mention_default_processes_mentioned(monkeypatch):
     """Default: messages with mention are processed, mention stripped."""
     monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)


### PR DESCRIPTION
## What does this PR do?

Fixes a Matrix gateway bug where Hermes can fail to recognize its own outbound events when the configured Matrix user ID casing differs from the casing used in inbound event sender IDs. In that case, Hermes can process its own outbound event as a new inbound user event, creating echo loops and unnecessary model turns.

This PR normalizes the adapter's own Matrix user ID for self-event checks and compares inbound sender IDs case-insensitively for both room messages and reactions.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Normalize `MatrixAdapter._user_id` into a lowercase `self._user_id_normalized` for self-event filtering.
- Refresh the normalized value after `whoami()` resolves the effective Matrix user ID.
- Ignore inbound room messages when `sender.lower()` matches the bot's normalized Matrix user ID.
- Ignore inbound reactions when `sender.lower()` matches the bot's normalized Matrix user ID.
- Add a regression test covering a mixed-case configured bot MXID with a lowercase inbound sender MXID.
- Add a regression test covering lowercase self-reaction events against a mixed-case configured bot MXID.

## How to Test

1. Configure the Matrix adapter with a mixed-case bot user ID (for example `@Hermes:example.org`).
2. Deliver an inbound room message event whose sender is the same MXID but lowercased (for example `@hermes:example.org`).
3. Verify the adapter drops the event instead of routing it into `handle_message()`.
4. Deliver an inbound reaction event from that same lowercased MXID.
5. Verify the adapter drops the reaction as well.
6. Run:
   - `source venv/bin/activate && python -m pytest tests/gateway/test_matrix_mention.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Tests Run

Targeted Matrix tests passed locally:

- `source venv/bin/activate && python -m pytest tests/gateway/test_matrix_mention.py -q`
  - `48 passed`
- `source venv/bin/activate && python -m pytest tests/gateway/test_matrix.py -k 'not upload_encrypted_room_uses_file_payload' -q`
  - `113 passed`

Note: the excluded encrypted-upload test depends on local `olm` availability and was unrelated to this self-echo fix.
