### PR TITLE
fix(gateway): make /fast command respect session scoped model overrides

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6089,7 +6089,12 @@ class GatewayRunner:
         self._service_tier = self._load_service_tier()
 
         user_config = _load_gateway_config()
-        model = _resolve_gateway_model(user_config)
+        session_key = self._session_key_for_source(event.source)
+        model, _ = self._apply_session_model_override(
+            session_key,
+            _resolve_gateway_model(user_config),
+            {},
+        )
         if not model_supports_fast_mode(model):
             return "⚡ /fast is only available for OpenAI models that support Priority Processing."
 

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -152,6 +152,43 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_handle_fast_command_uses_session_model_override(monkeypatch, tmp_path):
+    runner = _make_runner()
+    source = _make_source()
+    session_key = runner._session_key_for_source(source)
+    runner._session_model_overrides[session_key] = {"model": "gpt-5.4"}
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "claude-sonnet-4")
+
+    response = await runner._handle_fast_command(MessageEvent(text="/fast fast", source=source, message_id="m1"))
+
+    assert "FAST" in response
+    assert runner._service_tier == "priority"
+    saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+    assert saved["agent"]["service_tier"] == "fast"
+
+
+@pytest.mark.asyncio
+async def test_handle_fast_command_rejects_unsupported_session_override(monkeypatch, tmp_path):
+    runner = _make_runner()
+    source = _make_source()
+    session_key = runner._session_key_for_source(source)
+    runner._session_model_overrides[session_key] = {"model": "claude-sonnet-4"}
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+
+    response = await runner._handle_fast_command(MessageEvent(text="/fast fast", source=source, message_id="m1"))
+
+    assert "only available for OpenAI models" in response
+    assert runner._service_tier is None
+    assert not (tmp_path / "config.yaml").exists()
+
+
+@pytest.mark.asyncio
 async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch, tmp_path):
     _install_fake_agent(monkeypatch)
     runner = _make_runner()


### PR DESCRIPTION
## Summary

Fix gateway `/fast` so it evaluates fast-mode support against the session's effective model, including any session-scoped `/model` override.

Previously, `/fast` checked only the global config model. That caused incorrect behavior in both directions:
- `/model gpt-5.4` followed by `/fast fast` could be rejected if the global model was unsupported
- `/fast` could be allowed incorrectly if the global model supported fast mode but the session override did not

## Changes

- resolve the effective model for `/fast` via `_apply_session_model_override()`
- add regression tests covering:
  - supported session override with unsupported global model
  - unsupported session override with supported global model

## Testing

Passed:
- `uv run python -m pytest tests/gateway/test_fast_command.py -q`
- `uv run python -m pytest tests/gateway/test_fast_command.py tests/gateway/test_session_model_override_routing.py -q`


