### PR TITLE
feat(provider): auto-wire native TTS / image / vision / video / music for multi-modal providers

### DIFF
--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -1,0 +1,133 @@
+"""Setup-time defaults for chat providers that also serve TTS / image / vision / video / music.
+
+Mirrors ``hermes_cli.nous_subscription``: one apply hook for the wizard,
+plus lightweight helpers consumed by the tool files.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Iterable, Set, Tuple
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# hostname → (provider_label, credential_env_priority)
+_NATIVE_HOSTS: Dict[str, Tuple[str, Tuple[str, ...]]] = {
+    "api.minimax.io":        ("minimax",    ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")),
+    "api-uw.minimax.io":     ("minimax",    ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")),
+    "api.minimaxi.com":      ("minimax-cn", ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY")),
+    "api-apac.minimaxi.com": ("minimax-cn", ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY")),
+}
+
+_NATIVE_TOOLS = ("tts", "image_gen", "vision", "video_gen", "music_gen")
+
+_TOOL_DEFAULTS: Dict[str, Tuple[str, str, set]] = {
+    "tts":       ("tts",       "provider", {"", "edge"}),
+    "image_gen": ("image_gen", "provider", {"", "auto", "fal"}),
+    "video_gen": ("video_gen", "provider", {"", "auto"}),
+    "music_gen": ("music_gen", "provider", {"", "auto"}),
+}
+
+_TOOL_SUMMARIES: Dict[str, str] = {
+    "tts":       "TTS \u2192 speech-2.6-hd (30+ voices)",
+    "image_gen": "Image generation \u2192 image-01",
+    "vision":    "Vision analysis \u2192 MiniMax-VL-01",
+    "video_gen": "Video generation \u2192 MiniMax-Hailuo-2.3",
+    "music_gen": "Music generation \u2192 music-2.6",
+}
+
+
+def _api_host(config: Dict[str, Any]) -> str:
+    url = (config.get("model") or {}).get("base_url", "")
+    try:
+        return urlparse(url).hostname or ""
+    except Exception:
+        return ""
+
+
+def _host_entry(config: Dict[str, Any]):
+    return _NATIVE_HOSTS.get(_api_host(config))
+
+
+def _credential(config: Dict[str, Any]) -> str:
+    entry = _host_entry(config)
+    if not entry:
+        return ""
+    for var in entry[1]:
+        v = os.environ.get(var, "").strip()
+        if v:
+            return v
+    return ""
+
+
+def _safe_load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def active_provider_api_root(config: Dict[str, Any]) -> str:
+    """API root derived from ``model.base_url``, stripping ``/anthropic``."""
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return ""
+    base = str(model.get("base_url") or "").strip().rstrip("/")
+    if not base:
+        return ""
+    return base[: -len("/anthropic")] if base.endswith("/anthropic") else base
+
+
+def endpoint_and_key(subpath: str, config: Dict[str, Any] = None) -> Tuple[str, str]:
+    """``(url, api_key)`` for a native subpath, or ``("", "")``."""
+    cfg = config if config is not None else _safe_load_config()
+    if not _host_entry(cfg):
+        return "", ""
+    root = active_provider_api_root(cfg).rstrip("/")
+    key = _credential(cfg)
+    if not root or not key:
+        return "", ""
+    return f"{root}{subpath}", key
+
+
+def get_native_tools(config: Dict[str, Any]) -> Tuple[str, ...]:
+    """Tool categories served natively by the active provider, or ``()``."""
+    return _NATIVE_TOOLS if _host_entry(config) else ()
+
+
+def provider_has_native_tool(tool: str, config: Dict[str, Any]) -> bool:
+    return tool in get_native_tools(config)
+
+
+def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
+    """Wire config defaults for providers that serve tools natively."""
+    entry = _host_entry(config)
+    if not entry:
+        return set()
+    provider_label = entry[0]
+    changed: Set[str] = set()
+    for cat, (section, key, overridable) in _TOOL_DEFAULTS.items():
+        cfg = config.setdefault(section, {})
+        if isinstance(cfg, dict) and str(cfg.get(key) or "").strip().lower() in overridable:
+            cfg[key] = provider_label
+            changed.add(cat)
+    if changed:
+        aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}
+        vis = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
+        if str(vis.get("provider") or "").strip().lower() in {"", "auto", "main"}:
+            changed.add("vision")
+    if changed:
+        logger.info("Provider-native tool defaults applied: %s", sorted(changed))
+    return changed
+
+
+def describe_changes(changed: Iterable[str], config: Dict[str, Any]) -> str:
+    """Bullet-list summary used by the setup wizard."""
+    items = sorted(changed)
+    if not items:
+        return "No changes \u2014 existing tool choices were preserved."
+    return "\n".join(f"  \u2022 {_TOOL_SUMMARIES.get(k, k)}" for k in items)

--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -13,12 +13,12 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
-# hostname → (provider_label, credential_env_priority)
-_NATIVE_HOSTS: Dict[str, Tuple[str, Tuple[str, ...]]] = {
-    "api.minimax.io":        ("minimax",    ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")),
-    "api-uw.minimax.io":     ("minimax",    ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")),
-    "api.minimaxi.com":      ("minimax-cn", ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY")),
-    "api-apac.minimaxi.com": ("minimax-cn", ("MINIMAX_CN_API_KEY", "MINIMAX_API_KEY")),
+# hostname → provider_label
+_NATIVE_HOSTS: Dict[str, str] = {
+    "api.minimax.io":        "minimax",
+    "api-uw.minimax.io":     "minimax",
+    "api.minimaxi.com":      "minimax-cn",
+    "api-apac.minimaxi.com": "minimax-cn",
 }
 
 _NATIVE_TOOLS = ("tts", "image_gen", "vision", "video_gen", "music_gen")
@@ -38,6 +38,9 @@ _TOOL_SUMMARIES: Dict[str, str] = {
     "music_gen": "Music generation \u2192 music-2.6",
 }
 
+# env vars to try, in order — covers both international and CN keys
+_CREDENTIAL_VARS = ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")
+
 
 def _api_host(config: Dict[str, Any]) -> str:
     url = (config.get("model") or {}).get("base_url", "")
@@ -47,15 +50,12 @@ def _api_host(config: Dict[str, Any]) -> str:
         return ""
 
 
-def _host_entry(config: Dict[str, Any]):
-    return _NATIVE_HOSTS.get(_api_host(config))
+def _provider_label(config: Dict[str, Any]) -> str:
+    return _NATIVE_HOSTS.get(_api_host(config), "")
 
 
-def _credential(config: Dict[str, Any]) -> str:
-    entry = _host_entry(config)
-    if not entry:
-        return ""
-    for var in entry[1]:
+def _credential() -> str:
+    for var in _CREDENTIAL_VARS:
         v = os.environ.get(var, "").strip()
         if v:
             return v
@@ -85,10 +85,10 @@ def active_provider_api_root(config: Dict[str, Any]) -> str:
 def endpoint_and_key(subpath: str, config: Dict[str, Any] = None) -> Tuple[str, str]:
     """``(url, api_key)`` for a native subpath, or ``("", "")``."""
     cfg = config if config is not None else _safe_load_config()
-    if not _host_entry(cfg):
+    if not _provider_label(cfg):
         return "", ""
     root = active_provider_api_root(cfg).rstrip("/")
-    key = _credential(cfg)
+    key = _credential()
     if not root or not key:
         return "", ""
     return f"{root}{subpath}", key
@@ -96,7 +96,7 @@ def endpoint_and_key(subpath: str, config: Dict[str, Any] = None) -> Tuple[str, 
 
 def get_native_tools(config: Dict[str, Any]) -> Tuple[str, ...]:
     """Tool categories served natively by the active provider, or ``()``."""
-    return _NATIVE_TOOLS if _host_entry(config) else ()
+    return _NATIVE_TOOLS if _provider_label(config) else ()
 
 
 def provider_has_native_tool(tool: str, config: Dict[str, Any]) -> bool:
@@ -105,15 +105,14 @@ def provider_has_native_tool(tool: str, config: Dict[str, Any]) -> bool:
 
 def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
     """Wire config defaults for providers that serve tools natively."""
-    entry = _host_entry(config)
-    if not entry:
+    label = _provider_label(config)
+    if not label:
         return set()
-    provider_label = entry[0]
     changed: Set[str] = set()
     for cat, (section, key, overridable) in _TOOL_DEFAULTS.items():
         cfg = config.setdefault(section, {})
         if isinstance(cfg, dict) and str(cfg.get(key) or "").strip().lower() in overridable:
-            cfg[key] = provider_label
+            cfg[key] = label
             changed.add(cat)
     if changed:
         aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}

--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -1,8 +1,4 @@
-"""Setup-time defaults for chat providers that also serve TTS / image / vision / video / music.
-
-Mirrors ``hermes_cli.nous_subscription``: one apply hook for the wizard,
-plus lightweight helpers consumed by the tool files.
-"""
+"""Setup-time defaults for chat providers that also serve TTS / image / vision / video / music."""
 
 from __future__ import annotations
 
@@ -13,24 +9,15 @@ from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
-# hostname → provider_label
-_NATIVE_HOSTS: Dict[str, str] = {
-    "api.minimax.io":        "minimax",
-    "api-uw.minimax.io":     "minimax",
-    "api.minimaxi.com":      "minimax-cn",
-    "api-apac.minimaxi.com": "minimax-cn",
-}
-
-_NATIVE_TOOLS = ("tts", "image_gen", "vision", "video_gen", "music_gen")
-
-_TOOL_DEFAULTS: Dict[str, Tuple[str, str, set]] = {
+# category → (config_section, config_key, overridable_values)
+_TOOL_DEFAULTS = {
     "tts":       ("tts",       "provider", {"", "edge"}),
     "image_gen": ("image_gen", "provider", {"", "auto", "fal"}),
     "video_gen": ("video_gen", "provider", {"", "auto"}),
     "music_gen": ("music_gen", "provider", {"", "auto"}),
 }
 
-_TOOL_SUMMARIES: Dict[str, str] = {
+_TOOL_SUMMARIES = {
     "tts":       "TTS \u2192 speech-2.6-hd (30+ voices)",
     "image_gen": "Image generation \u2192 image-01",
     "vision":    "Vision analysis \u2192 MiniMax-VL-01",
@@ -38,11 +25,8 @@ _TOOL_SUMMARIES: Dict[str, str] = {
     "music_gen": "Music generation \u2192 music-2.6",
 }
 
-# env vars to try, in order — covers both international and CN keys
-_CREDENTIAL_VARS = ("MINIMAX_API_KEY", "MINIMAX_CN_API_KEY")
 
-
-def _api_host(config: Dict[str, Any]) -> str:
+def _api_host(config):
     url = (config.get("model") or {}).get("base_url", "")
     try:
         return urlparse(url).hostname or ""
@@ -50,19 +34,16 @@ def _api_host(config: Dict[str, Any]) -> str:
         return ""
 
 
-def _provider_label(config: Dict[str, Any]) -> str:
-    return _NATIVE_HOSTS.get(_api_host(config), "")
-
-
-def _credential() -> str:
-    for var in _CREDENTIAL_VARS:
-        v = os.environ.get(var, "").strip()
-        if v:
-            return v
+def _provider_label(config):
+    host = _api_host(config)
+    if "minimaxi.com" in host:
+        return "minimax-cn"
+    if "minimax" in host:
+        return "minimax"
     return ""
 
 
-def _safe_load_config() -> Dict[str, Any]:
+def _safe_load_config():
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -71,7 +52,7 @@ def _safe_load_config() -> Dict[str, Any]:
         return {}
 
 
-def active_provider_api_root(config: Dict[str, Any]) -> str:
+def active_provider_api_root(config):
     """API root derived from ``model.base_url``, stripping ``/anthropic``."""
     model = config.get("model")
     if not isinstance(model, dict):
@@ -82,33 +63,36 @@ def active_provider_api_root(config: Dict[str, Any]) -> str:
     return base[: -len("/anthropic")] if base.endswith("/anthropic") else base
 
 
-def endpoint_and_key(subpath: str, config: Dict[str, Any] = None) -> Tuple[str, str]:
+def endpoint_and_key(subpath, config=None):
     """``(url, api_key)`` for a native subpath, or ``("", "")``."""
     cfg = config if config is not None else _safe_load_config()
     if not _provider_label(cfg):
         return "", ""
     root = active_provider_api_root(cfg).rstrip("/")
-    key = _credential()
+    key = (os.environ.get("MINIMAX_API_KEY", "").strip()
+           or os.environ.get("MINIMAX_CN_API_KEY", "").strip())
     if not root or not key:
         return "", ""
     return f"{root}{subpath}", key
 
 
-def get_native_tools(config: Dict[str, Any]) -> Tuple[str, ...]:
+def get_native_tools(config):
     """Tool categories served natively by the active provider, or ``()``."""
-    return _NATIVE_TOOLS if _provider_label(config) else ()
+    if not _provider_label(config):
+        return ()
+    return tuple(_TOOL_DEFAULTS) + ("vision",)
 
 
-def provider_has_native_tool(tool: str, config: Dict[str, Any]) -> bool:
+def provider_has_native_tool(tool, config):
     return tool in get_native_tools(config)
 
 
-def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
+def apply_provider_native_tool_defaults(config):
     """Wire config defaults for providers that serve tools natively."""
     label = _provider_label(config)
     if not label:
         return set()
-    changed: Set[str] = set()
+    changed = set()
     for cat, (section, key, overridable) in _TOOL_DEFAULTS.items():
         cfg = config.setdefault(section, {})
         if isinstance(cfg, dict) and str(cfg.get(key) or "").strip().lower() in overridable:
@@ -119,12 +103,10 @@ def apply_provider_native_tool_defaults(config: Dict[str, Any]) -> Set[str]:
         vis = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
         if str(vis.get("provider") or "").strip().lower() in {"", "auto", "main"}:
             changed.add("vision")
-    if changed:
-        logger.info("Provider-native tool defaults applied: %s", sorted(changed))
     return changed
 
 
-def describe_changes(changed: Iterable[str], config: Dict[str, Any]) -> str:
+def describe_changes(changed, config):
     """Bullet-list summary used by the setup wizard."""
     items = sorted(changed)
     if not items:

--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -17,12 +17,12 @@ _TOOL_DEFAULTS = {
     "music_gen": ("music_gen", "provider", {"", "auto"}),
 }
 
-_TOOL_SUMMARIES = {
-    "tts":       "TTS \u2192 speech-2.6-hd (30+ voices)",
-    "image_gen": "Image generation \u2192 image-01",
-    "vision":    "Vision analysis \u2192 MiniMax-VL-01",
-    "video_gen": "Video generation \u2192 MiniMax-Hailuo-2.3",
-    "music_gen": "Music generation \u2192 music-2.6",
+_TOOL_LABELS = {
+    "tts": "Text-to-speech",
+    "image_gen": "Image generation",
+    "vision": "Vision analysis",
+    "video_gen": "Video generation",
+    "music_gen": "Music generation",
 }
 
 
@@ -34,12 +34,14 @@ def _api_host(config):
         return ""
 
 
+def _is_native_provider(config):
+    return "minimax" in _api_host(config)
+
+
 def _provider_label(config):
-    host = _api_host(config)
-    if "minimaxi.com" in host:
-        return "minimax-cn"
-    if "minimax" in host:
-        return "minimax"
+    model = config.get("model") or {}
+    if isinstance(model, dict):
+        return str(model.get("provider") or "").strip().lower()
     return ""
 
 
@@ -66,7 +68,7 @@ def active_provider_api_root(config):
 def endpoint_and_key(subpath, config=None):
     """``(url, api_key)`` for a native subpath, or ``("", "")``."""
     cfg = config if config is not None else _safe_load_config()
-    if not _provider_label(cfg):
+    if not _is_native_provider(cfg):
         return "", ""
     root = active_provider_api_root(cfg).rstrip("/")
     key = (os.environ.get("MINIMAX_API_KEY", "").strip()
@@ -78,7 +80,7 @@ def endpoint_and_key(subpath, config=None):
 
 def get_native_tools(config):
     """Tool categories served natively by the active provider, or ``()``."""
-    if not _provider_label(config):
+    if not _is_native_provider(config):
         return ()
     return tuple(_TOOL_DEFAULTS) + ("vision",)
 
@@ -89,6 +91,8 @@ def provider_has_native_tool(tool, config):
 
 def apply_provider_native_tool_defaults(config):
     """Wire config defaults for providers that serve tools natively."""
+    if not _is_native_provider(config):
+        return set()
     label = _provider_label(config)
     if not label:
         return set()
@@ -111,4 +115,4 @@ def describe_changes(changed, config):
     items = sorted(changed)
     if not items:
         return "No changes \u2014 existing tool choices were preserved."
-    return "\n".join(f"  \u2022 {_TOOL_SUMMARIES.get(k, k)}" for k in items)
+    return "\n".join(f"  \u2022 {_TOOL_LABELS.get(k, k)}" for k in items)

--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -70,6 +70,18 @@ def native_api_url(subpath, config=None):
     return f"{root}{subpath}" if root else ""
 
 
+def native_credential(config=None):
+    """API key matching the active provider's region, or ``""``."""
+    import os
+    cfg = config if config is not None else _safe_load_config()
+    host = _api_host(cfg)
+    if "minimaxi.com" in host:
+        return (os.environ.get("MINIMAX_CN_API_KEY", "").strip()
+                or os.environ.get("MINIMAX_API_KEY", "").strip())
+    return (os.environ.get("MINIMAX_API_KEY", "").strip()
+            or os.environ.get("MINIMAX_CN_API_KEY", "").strip())
+
+
 def get_native_tools(config):
     """Tool categories served natively by the active provider, or ``()``."""
     if not _is_native_provider(config):

--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -3,27 +3,17 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Dict, Iterable, Set, Tuple
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
-# category → (config_section, config_key, overridable_values)
-_TOOL_DEFAULTS = {
-    "tts":       ("tts",       "provider", {"", "edge"}),
-    "image_gen": ("image_gen", "provider", {"", "auto", "fal"}),
-    "video_gen": ("video_gen", "provider", {"", "auto"}),
-    "music_gen": ("music_gen", "provider", {"", "auto"}),
-}
+# Tool categories that get config defaults written at setup time.
+# Vision is runtime-only (no config persistence) so it is not listed here.
+_CONFIG_CATEGORIES = ("tts", "image_gen", "video_gen", "music_gen")
 
-_TOOL_LABELS = {
-    "tts": "Text-to-speech",
-    "image_gen": "Image generation",
-    "vision": "Vision analysis",
-    "video_gen": "Video generation",
-    "music_gen": "Music generation",
-}
+# Existing config values considered "not explicitly set by the user".
+_OVERRIDABLE = {"", "edge", "auto", "fal"}
 
 
 def _api_host(config):
@@ -54,6 +44,12 @@ def _safe_load_config():
         return {}
 
 
+def _category_display(cat):
+    if cat == "tts":
+        return "Text-to-speech"
+    return cat.replace("_gen", " generation").replace("_", " ").capitalize()
+
+
 def active_provider_api_root(config):
     """API root derived from ``model.base_url``, stripping ``/anthropic``."""
     model = config.get("model")
@@ -65,24 +61,20 @@ def active_provider_api_root(config):
     return base[: -len("/anthropic")] if base.endswith("/anthropic") else base
 
 
-def endpoint_and_key(subpath, config=None):
-    """``(url, api_key)`` for a native subpath, or ``("", "")``."""
+def native_api_url(subpath, config=None):
+    """Full URL for a native API subpath, or ``""`` if not a native provider."""
     cfg = config if config is not None else _safe_load_config()
     if not _is_native_provider(cfg):
-        return "", ""
+        return ""
     root = active_provider_api_root(cfg).rstrip("/")
-    key = (os.environ.get("MINIMAX_API_KEY", "").strip()
-           or os.environ.get("MINIMAX_CN_API_KEY", "").strip())
-    if not root or not key:
-        return "", ""
-    return f"{root}{subpath}", key
+    return f"{root}{subpath}" if root else ""
 
 
 def get_native_tools(config):
     """Tool categories served natively by the active provider, or ``()``."""
     if not _is_native_provider(config):
         return ()
-    return tuple(_TOOL_DEFAULTS) + ("vision",)
+    return _CONFIG_CATEGORIES + ("vision",)
 
 
 def provider_has_native_tool(tool, config):
@@ -97,15 +89,15 @@ def apply_provider_native_tool_defaults(config):
     if not label:
         return set()
     changed = set()
-    for cat, (section, key, overridable) in _TOOL_DEFAULTS.items():
-        cfg = config.setdefault(section, {})
-        if isinstance(cfg, dict) and str(cfg.get(key) or "").strip().lower() in overridable:
-            cfg[key] = label
+    for cat in _CONFIG_CATEGORIES:
+        cfg = config.setdefault(cat, {})
+        if isinstance(cfg, dict) and str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE:
+            cfg["provider"] = label
             changed.add(cat)
     if changed:
         aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}
         vis = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
-        if str(vis.get("provider") or "").strip().lower() in {"", "auto", "main"}:
+        if str(vis.get("provider") or "").strip().lower() in _OVERRIDABLE:
             changed.add("vision")
     return changed
 
@@ -115,4 +107,4 @@ def describe_changes(changed, config):
     items = sorted(changed)
     if not items:
         return "No changes \u2014 existing tool choices were preserved."
-    return "\n".join(f"  \u2022 {_TOOL_LABELS.get(k, k)}" for k in items)
+    return "\n".join(f"  \u2022 {_category_display(k)}" for k in items)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -24,6 +24,11 @@ from hermes_cli.nous_subscription import (
     apply_nous_provider_defaults,
     get_nous_subscription_features,
 )
+from hermes_cli.provider_native_tools import (
+    apply_provider_native_tool_defaults,
+    describe_changes as describe_native_tool_changes,
+    get_native_tools as _provider_native_tools,
+)
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from hermes_constants import get_optional_skills_dir
 
@@ -843,9 +848,24 @@ def setup_model_provider(config: dict, *, quick: bool = False):
         else:
             print_info(f"Keeping your existing TTS provider: {current_tts}")
 
+    # Wire tool defaults for chat providers that serve TTS / image / vision
+    # natively on the same credential (e.g. MiniMax).  Self-gates on the
+    # active provider's base_url; a no-op for providers not in the registry.
+    native_changes = apply_provider_native_tool_defaults(config)
+    if native_changes:
+        print()
+        print_success(
+            "The same credential also unlocks the following — wired automatically:"
+        )
+        print(describe_native_tool_changes(native_changes, config))
+
     save_config(config)
 
-    if not quick and selected_provider != "nous":
+    if (
+        not quick
+        and selected_provider != "nous"
+        and "tts" not in _provider_native_tools(config)
+    ):
         _setup_tts_provider(config)
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -54,6 +54,8 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("video_gen",       "🎬 Video Generation",          "video_generate"),
+    ("music_gen",       "🎵 Music Generation",          "music_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -7,7 +7,6 @@ import pytest
 from hermes_cli.provider_native_tools import (
     active_provider_api_root,
     apply_provider_native_tool_defaults,
-    _credential,
     describe_changes,
     endpoint_and_key,
     get_native_tools,
@@ -170,23 +169,6 @@ class TestDescribeChanges:
         out = describe_changes({"image_gen", "video_gen"}, _cfg(_INTL))
         assert "image-01" in out
         assert "Hailuo" in out
-
-
-class TestCredential:
-    def test_prefers_minimax_key(self, monkeypatch):
-        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
-        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        assert _credential() == "sk-intl"
-
-    def test_fallback_to_cn_key(self, monkeypatch):
-        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
-        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        assert _credential() == "sk-cn"
-
-    def test_empty_when_no_key(self, monkeypatch):
-        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
-        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
-        assert _credential() == ""
 
 
 class TestEndpointAndKey:

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -19,8 +19,8 @@ _CN = "https://api.minimaxi.com/anthropic"
 _CN_APAC = "https://api-apac.minimaxi.com/anthropic"
 
 
-def _cfg(base_url):
-    return {"model": {"base_url": base_url}}
+def _cfg(base_url, provider="minimax"):
+    return {"model": {"base_url": base_url, "provider": provider}}
 
 
 class TestApiHost:
@@ -140,7 +140,7 @@ class TestApplyDefaults:
         assert second == set()
 
     def test_cn_provider(self):
-        config = _cfg(_CN)
+        config = _cfg(_CN, provider="minimax-cn")
         changed = apply_provider_native_tool_defaults(config)
         assert "tts" in changed
         assert config["tts"]["provider"] == "minimax-cn"
@@ -165,10 +165,10 @@ class TestDescribeChanges:
         )
         assert out.count("\u2022") == 5
 
-    def test_contains_model_names(self):
+    def test_contains_category_labels(self):
         out = describe_changes({"image_gen", "video_gen"}, _cfg(_INTL))
-        assert "image-01" in out
-        assert "Hailuo" in out
+        assert "Image generation" in out
+        assert "Video generation" in out
 
 
 class TestEndpointAndKey:
@@ -180,7 +180,7 @@ class TestEndpointAndKey:
 
     def test_cn_host(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        url, key = endpoint_and_key("/v1/t2a_v2", _cfg(_CN))
+        url, key = endpoint_and_key("/v1/t2a_v2", _cfg(_CN, provider="minimax-cn"))
         assert url == "https://api.minimaxi.com/v1/t2a_v2"
         assert key == "sk-cn"
 

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -1,0 +1,216 @@
+"""Tests for hermes_cli/provider_native_tools.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.provider_native_tools import (
+    active_provider_api_root,
+    apply_provider_native_tool_defaults,
+    _credential,
+    describe_changes,
+    endpoint_and_key,
+    get_native_tools,
+    provider_has_native_tool,
+)
+
+_INTL = "https://api.minimax.io/anthropic"
+_INTL_UW = "https://api-uw.minimax.io/anthropic"
+_CN = "https://api.minimaxi.com/anthropic"
+_CN_APAC = "https://api-apac.minimaxi.com/anthropic"
+
+
+def _cfg(base_url):
+    return {"model": {"base_url": base_url}}
+
+
+class TestApiHost:
+    def test_intl_detected(self):
+        assert get_native_tools(_cfg(_INTL)) != ()
+
+    def test_intl_uw_detected(self):
+        assert get_native_tools(_cfg(_INTL_UW)) != ()
+
+    def test_cn_detected(self):
+        assert get_native_tools(_cfg(_CN)) != ()
+
+    def test_cn_apac_detected(self):
+        assert get_native_tools(_cfg(_CN_APAC)) != ()
+
+    def test_non_native(self):
+        assert get_native_tools(_cfg("https://api.openai.com/v1")) == ()
+
+    def test_unset(self):
+        assert get_native_tools({}) == ()
+        assert get_native_tools({"model": {}}) == ()
+
+
+class TestApiRoot:
+    def test_strips_anthropic_suffix(self):
+        assert active_provider_api_root(_cfg(_INTL)) == "https://api.minimax.io"
+
+    def test_strips_trailing_slash(self):
+        assert active_provider_api_root(
+            _cfg("https://api.minimax.io/anthropic/")
+        ) == "https://api.minimax.io"
+
+    def test_cn_endpoint(self):
+        assert active_provider_api_root(_cfg(_CN)) == "https://api.minimaxi.com"
+
+    def test_no_anthropic_suffix(self):
+        cfg = _cfg("https://api.openai.com/v1")
+        assert active_provider_api_root(cfg) == "https://api.openai.com/v1"
+
+    def test_unset(self):
+        assert active_provider_api_root({}) == ""
+
+
+class TestNativeTools:
+    @pytest.mark.parametrize("tool", ["tts", "image_gen", "vision", "video_gen", "music_gen"])
+    def test_all_categories_present(self, tool):
+        assert provider_has_native_tool(tool, _cfg(_INTL)) is True
+
+    def test_unknown_tool(self):
+        assert provider_has_native_tool("search", _cfg(_INTL)) is False
+
+    def test_non_native_provider(self):
+        assert provider_has_native_tool("tts", _cfg("https://api.openai.com/v1")) is False
+
+
+class TestApplyDefaults:
+    def test_noop_for_non_native(self):
+        config = _cfg("https://api.openai.com/v1")
+        assert apply_provider_native_tool_defaults(config) == set()
+
+    def test_noop_for_empty(self):
+        assert apply_provider_native_tool_defaults({}) == set()
+
+    def test_writes_all_config_slots(self):
+        config = _cfg(_INTL)
+        changed = apply_provider_native_tool_defaults(config)
+        assert changed == {"tts", "image_gen", "vision", "video_gen", "music_gen"}
+        assert config["tts"]["provider"] == "minimax"
+        assert config["image_gen"]["provider"] == "minimax"
+        assert config["video_gen"]["provider"] == "minimax"
+        assert config["music_gen"]["provider"] == "minimax"
+
+    def test_explicit_tts_preserved(self):
+        config = {**_cfg(_INTL), "tts": {"provider": "elevenlabs"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" not in changed
+        assert config["tts"]["provider"] == "elevenlabs"
+
+    def test_edge_default_overridden(self):
+        config = {**_cfg(_INTL), "tts": {"provider": "edge"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+
+    def test_fal_default_overridden(self):
+        config = {**_cfg(_INTL), "image_gen": {"provider": "fal"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" in changed
+
+    def test_explicit_image_preserved(self):
+        config = {**_cfg(_INTL), "image_gen": {"provider": "stability"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" not in changed
+
+    def test_explicit_video_preserved(self):
+        config = {**_cfg(_INTL), "video_gen": {"provider": "runway"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "video_gen" not in changed
+
+    def test_explicit_music_preserved(self):
+        config = {**_cfg(_INTL), "music_gen": {"provider": "suno"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "music_gen" not in changed
+
+    def test_explicit_vision_preserved(self):
+        config = {
+            **_cfg(_INTL),
+            "auxiliary": {"vision": {"provider": "openrouter"}},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "vision" not in changed
+
+    def test_idempotent(self):
+        config = _cfg(_INTL)
+        first = apply_provider_native_tool_defaults(config)
+        assert len(first) == 5
+        second = apply_provider_native_tool_defaults(config)
+        assert second == set()
+
+    def test_cn_provider(self):
+        config = _cfg(_CN)
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["tts"]["provider"] == "minimax-cn"
+
+    def test_other_auxiliary_keys_preserved(self):
+        config = {
+            **_cfg(_INTL),
+            "auxiliary": {"compression": {"provider": "openai"}},
+        }
+        apply_provider_native_tool_defaults(config)
+        assert config["auxiliary"]["compression"]["provider"] == "openai"
+
+
+class TestDescribeChanges:
+    def test_empty(self):
+        assert "No changes" in describe_changes(set(), _cfg(_INTL))
+
+    def test_all_five(self):
+        out = describe_changes(
+            {"tts", "image_gen", "vision", "video_gen", "music_gen"},
+            _cfg(_INTL),
+        )
+        assert out.count("\u2022") == 5
+
+    def test_contains_model_names(self):
+        out = describe_changes({"image_gen", "video_gen"}, _cfg(_INTL))
+        assert "image-01" in out
+        assert "Hailuo" in out
+
+
+class TestCredential:
+    def test_intl_prefers_minimax_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
+        assert _credential(_cfg(_INTL)) == "sk-intl"
+
+    def test_cn_prefers_cn_key(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
+        assert _credential(_cfg(_CN)) == "sk-cn"
+
+    def test_fallback(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
+        assert _credential(_cfg(_INTL)) == "sk-cn"
+
+    def test_empty_for_non_native(self):
+        assert _credential(_cfg("https://api.openai.com/v1")) == ""
+
+
+class TestEndpointAndKey:
+    def test_derives_url(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
+        url, key = endpoint_and_key("/v1/t2a_v2", _cfg(_INTL))
+        assert url == "https://api.minimax.io/v1/t2a_v2"
+        assert key == "sk-test"
+
+    def test_cn_host(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
+        url, key = endpoint_and_key("/v1/t2a_v2", _cfg(_CN))
+        assert url == "https://api.minimaxi.com/v1/t2a_v2"
+        assert key == "sk-cn"
+
+    def test_non_native_empty(self):
+        assert endpoint_and_key("/v1/t2a_v2", _cfg("https://api.openai.com/v1")) == ("", "")
+
+    def test_no_key_empty(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        assert endpoint_and_key("/v1/t2a_v2", _cfg(_INTL)) == ("", "")
+
+

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -173,23 +173,20 @@ class TestDescribeChanges:
 
 
 class TestCredential:
-    def test_intl_prefers_minimax_key(self, monkeypatch):
+    def test_prefers_minimax_key(self, monkeypatch):
         monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
         monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        assert _credential(_cfg(_INTL)) == "sk-intl"
+        assert _credential() == "sk-intl"
 
-    def test_cn_prefers_cn_key(self, monkeypatch):
-        monkeypatch.setenv("MINIMAX_API_KEY", "sk-intl")
-        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        assert _credential(_cfg(_CN)) == "sk-cn"
-
-    def test_fallback(self, monkeypatch):
+    def test_fallback_to_cn_key(self, monkeypatch):
         monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
         monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        assert _credential(_cfg(_INTL)) == "sk-cn"
+        assert _credential() == "sk-cn"
 
-    def test_empty_for_non_native(self):
-        assert _credential(_cfg("https://api.openai.com/v1")) == ""
+    def test_empty_when_no_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
+        assert _credential() == ""
 
 
 class TestEndpointAndKey:

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -8,7 +8,7 @@ from hermes_cli.provider_native_tools import (
     active_provider_api_root,
     apply_provider_native_tool_defaults,
     describe_changes,
-    endpoint_and_key,
+    native_api_url,
     get_native_tools,
     provider_has_native_tool,
 )
@@ -171,25 +171,17 @@ class TestDescribeChanges:
         assert "Video generation" in out
 
 
-class TestEndpointAndKey:
-    def test_derives_url(self, monkeypatch):
-        monkeypatch.setenv("MINIMAX_API_KEY", "sk-test")
-        url, key = endpoint_and_key("/v1/t2a_v2", _cfg(_INTL))
-        assert url == "https://api.minimax.io/v1/t2a_v2"
-        assert key == "sk-test"
+class TestNativeApiUrl:
+    def test_derives_url(self):
+        assert native_api_url("/v1/t2a_v2", _cfg(_INTL)) == "https://api.minimax.io/v1/t2a_v2"
 
-    def test_cn_host(self, monkeypatch):
-        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-cn")
-        url, key = endpoint_and_key("/v1/t2a_v2", _cfg(_CN, provider="minimax-cn"))
-        assert url == "https://api.minimaxi.com/v1/t2a_v2"
-        assert key == "sk-cn"
+    def test_cn_host(self):
+        assert native_api_url("/v1/t2a_v2", _cfg(_CN, provider="minimax-cn")) == "https://api.minimaxi.com/v1/t2a_v2"
 
     def test_non_native_empty(self):
-        assert endpoint_and_key("/v1/t2a_v2", _cfg("https://api.openai.com/v1")) == ("", "")
+        assert native_api_url("/v1/t2a_v2", _cfg("https://api.openai.com/v1")) == ""
 
-    def test_no_key_empty(self, monkeypatch):
-        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
-        monkeypatch.delenv("MINIMAX_CN_API_KEY", raising=False)
-        assert endpoint_and_key("/v1/t2a_v2", _cfg(_INTL)) == ("", "")
+    def test_unset_empty(self):
+        assert native_api_url("/v1/t2a_v2", {}) == ""
 
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -381,6 +381,16 @@ def image_generate_tool(
                  "image": str or None  # URL of the upscaled image, or None if failed
              }
     """
+    # Provider-native dispatch.
+    try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        if provider_has_native_tool("image_gen", _safe_load_config()):
+            result = _native_image_generate(prompt, aspect_ratio, num_images, output_format)
+            if result is not None:
+                return result
+    except Exception as _exc:
+        logger.debug("provider-native image dispatch skipped: %s", _exc)
+
     # Validate and map aspect_ratio to actual image_size
     aspect_ratio_lower = aspect_ratio.lower().strip() if aspect_ratio else DEFAULT_ASPECT_RATIO
     if aspect_ratio_lower not in ASPECT_RATIO_MAP:
@@ -546,19 +556,21 @@ def check_fal_api_key() -> bool:
 def check_image_generation_requirements() -> bool:
     """
     Check if all requirements for image generation tools are met.
-    
+
     Returns:
         bool: True if requirements are met, False otherwise
     """
     try:
-        # Check API key
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        if provider_has_native_tool("image_gen", _safe_load_config()):
+            return True
+    except Exception:
+        pass
+    try:
         if not check_fal_api_key():
             return False
-        
-        # Check if fal_client is available
         import fal_client  # noqa: F401 — SDK presence check
         return True
-        
     except ImportError:
         return False
 
@@ -664,6 +676,77 @@ IMAGE_GENERATE_SCHEMA = {
         "required": ["prompt"]
     }
 }
+
+
+# ─── Provider-native image generation (MiniMax etc.) ──────────────────────
+
+_RATIO_ALIAS = {"landscape": "16:9", "portrait": "9:16", "square": "1:1"}
+_VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "21:9"}
+
+
+def _native_image_generate(prompt, aspect_ratio, num_images, output_format):
+    """Generate via the native provider's image API, or return None."""
+    import ssl
+    import urllib.error
+    import urllib.request
+    from hermes_cli.provider_native_tools import endpoint_and_key
+
+    url, key = endpoint_and_key("/v1/image_generation")
+    if not url:
+        return None
+
+    ratio = _RATIO_ALIAS.get((aspect_ratio or "").lower(), aspect_ratio)
+    if ratio not in _VALID_RATIOS:
+        ratio = "16:9"
+
+    payload = {
+        "model": "image-01",
+        "prompt": (prompt or "").strip(),
+        "aspect_ratio": ratio,
+        "n": max(1, min(4, int(num_images or 1))),
+        "response_format": "url",
+    }
+    try:
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            method="POST",
+            headers={"Authorization": f"Bearer {key}",
+                     "Content-Type": "application/json"},
+        )
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, timeout=120, context=ctx) as resp:
+            body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+                           "error": f"image API HTTP {exc.code}"})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+                           "error": f"image API error {base.get('status_code')}: "
+                                    f"{base.get('status_msg', '')}"})
+
+    data = body.get("data") or {}
+    urls = []
+    if isinstance(data, dict):
+        for k in ("image_urls", "urls"):
+            v = data.get(k)
+            if isinstance(v, list):
+                urls = [u for u in v if isinstance(u, str) and u.startswith("http")]
+                break
+    if not urls:
+        return json.dumps({"success": False,
+                           "error": "image API returned no URL(s)"})
+
+    return json.dumps({
+        "success": True,
+        "image": urls[0],
+        "model": "image-01",
+        "aspect_ratio": ratio,
+    }, ensure_ascii=False)
 
 
 def _handle_image_generate(args, **kw):

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -567,10 +567,14 @@ def check_image_generation_requirements() -> bool:
     except Exception:
         pass
     try:
+        # Check API key
         if not check_fal_api_key():
             return False
+
+        # Check if fal_client is available
         import fal_client  # noqa: F401 — SDK presence check
         return True
+
     except ImportError:
         return False
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -695,9 +695,9 @@ def _native_image_generate(prompt, aspect_ratio, num_images, output_format):
     import urllib.request
     from hermes_cli.provider_native_tools import native_api_url
 
+    from hermes_cli.provider_native_tools import native_credential
     url = native_api_url("/v1/image_generation")
-    key = (os.getenv("MINIMAX_API_KEY", "").strip()
-           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    key = native_credential()
     if not url or not key:
         return None
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -693,10 +693,12 @@ def _native_image_generate(prompt, aspect_ratio, num_images, output_format):
     import ssl
     import urllib.error
     import urllib.request
-    from hermes_cli.provider_native_tools import endpoint_and_key
+    from hermes_cli.provider_native_tools import native_api_url
 
-    url, key = endpoint_and_key("/v1/image_generation")
-    if not url:
+    url = native_api_url("/v1/image_generation")
+    key = (os.getenv("MINIMAX_API_KEY", "").strip()
+           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    if not url or not key:
         return None
 
     ratio = _RATIO_ALIAS.get((aspect_ratio or "").lower(), aspect_ratio)

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -1,0 +1,194 @@
+"""Music generation tool — generates songs with lyrics and style prompt via the native provider."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_MUSIC_VALID_FORMATS = {"mp3", "wav", "pcm"}
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _post_json(url: str, payload: Dict[str, Any], key: str,
+               *, timeout: int = 180) -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _music_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/music", "music_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "music_cache"
+
+
+def _music_model_for_key(key: str) -> str:
+    """``sk-cp-`` (Token Plan) → ``music-2.6``; others → ``music-2.6-free``."""
+    return "music-2.6" if key.startswith("sk-cp-") else "music-2.6-free"
+
+
+# ─── Core ─────────────────────────────────────────────────────────────────
+
+
+def music_generate_tool(
+    prompt: str,
+    lyrics: str,
+    output_format: str = "mp3",
+    sample_rate: int = 44100,
+    bitrate: int = 256000,
+) -> str:
+    try:
+        from hermes_cli.provider_native_tools import endpoint_and_key
+    except Exception:
+        return json.dumps({"success": False,
+                           "error": "no music backend available"})
+
+    url, key = endpoint_and_key("/v1/music_generation")
+    if not url:
+        return json.dumps({"success": False,
+                           "error": "no music backend configured"})
+
+    fmt = (output_format or "mp3").lower()
+    if fmt not in _MUSIC_VALID_FORMATS:
+        fmt = "mp3"
+
+    model = _music_model_for_key(key)
+    payload = {
+        "model": model,
+        "prompt": (prompt or "").strip(),
+        "lyrics": (lyrics or "").strip(),
+        "audio_setting": {
+            "sample_rate": sample_rate,
+            "bitrate": bitrate,
+            "format": fmt,
+        },
+        "output_format": "hex",
+        "stream": False,
+    }
+
+    try:
+        body = _post_json(url, payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+                           "error": f"music API HTTP {exc.code}"})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+                           "error": f"music API error {base.get('status_code')}: "
+                                    f"{base.get('status_msg', '')}"})
+
+    data = body.get("data") or {}
+    audio_hex = data.get("audio") if isinstance(data, dict) else None
+    if not isinstance(audio_hex, str) or not audio_hex:
+        return json.dumps({"success": False,
+                           "error": "music API returned no audio"})
+
+    try:
+        audio_bytes = bytes.fromhex(audio_hex)
+    except ValueError as exc:
+        return json.dumps({"success": False,
+                           "error": f"invalid hex audio: {exc}"})
+
+    out_dir = _music_cache_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"music_{ts}.{fmt}"
+    try:
+        path.write_bytes(audio_bytes)
+    except OSError as exc:
+        return json.dumps({"success": False, "error": f"write failed: {exc}"})
+
+    return json.dumps({
+        "success": True,
+        "model": model,
+        "path": str(path),
+        "format": fmt,
+        "bytes": len(audio_bytes),
+    }, ensure_ascii=False)
+
+
+# ─── Check & registration ─────────────────────────────────────────────────
+
+
+def check_music_generation_requirements() -> bool:
+    try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        return provider_has_native_tool("music_gen", _safe_load_config())
+    except Exception:
+        return False
+
+
+MUSIC_GENERATE_SCHEMA = {
+    "name": "music_generate",
+    "description": (
+        "Generate a song from a style/mood prompt and lyrics. "
+        "Supports structure tags like [Intro], [Verse], [Chorus], [Bridge], [Outro]."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Style and mood description (10-300 chars).",
+            },
+            "lyrics": {
+                "type": "string",
+                "description": "Song lyrics with optional structure tags (10-600 chars).",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["mp3", "wav", "pcm"],
+                "description": "Audio output format (default mp3).",
+            },
+        },
+        "required": ["prompt", "lyrics"],
+    },
+}
+
+
+def _handle_music_generate(args: Dict[str, Any], **kw: Any) -> str:
+    prompt = args.get("prompt", "")
+    lyrics = args.get("lyrics", "")
+    if not prompt or not lyrics:
+        return json.dumps({"success": False,
+                           "error": "both prompt and lyrics are required"})
+    return music_generate_tool(
+        prompt=prompt,
+        lyrics=lyrics,
+        output_format=args.get("output_format", "mp3"),
+    )
+
+
+registry.register(
+    name="music_generate",
+    toolset="music_gen",
+    schema=MUSIC_GENERATE_SCHEMA,
+    handler=_handle_music_generate,
+    check_fn=check_music_generation_requirements,
+    emoji="\U0001f3b5",
+)

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -65,9 +65,9 @@ def music_generate_tool(
         return json.dumps({"success": False,
                            "error": "no music backend available"})
 
+    from hermes_cli.provider_native_tools import native_credential
     url = native_api_url("/v1/music_generation")
-    key = (os.getenv("MINIMAX_API_KEY", "").strip()
-           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    key = native_credential()
     if not url or not key:
         return json.dumps({"success": False,
                            "error": "no music backend configured"})

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -60,13 +60,15 @@ def music_generate_tool(
     bitrate: int = 256000,
 ) -> str:
     try:
-        from hermes_cli.provider_native_tools import endpoint_and_key
+        from hermes_cli.provider_native_tools import native_api_url
     except Exception:
         return json.dumps({"success": False,
                            "error": "no music backend available"})
 
-    url, key = endpoint_and_key("/v1/music_generation")
-    if not url:
+    url = native_api_url("/v1/music_generation")
+    key = (os.getenv("MINIMAX_API_KEY", "").strip()
+           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    if not url or not key:
         return json.dumps({"success": False,
                            "error": "no music backend configured"})
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -390,7 +390,20 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     """
     import requests
 
-    api_key = os.getenv("MINIMAX_API_KEY", "")
+    # Derive URL + key from the active provider when available (handles CN
+    # region automatically); fall back to env var + default URL.
+    derived_base = ""
+    api_key = ""
+    try:
+        from hermes_cli.provider_native_tools import endpoint_and_key
+        _url, _key = endpoint_and_key("/v1/t2a_v2")
+        if _url and _key:
+            derived_base = _url
+            api_key = _key
+    except Exception:
+        pass
+    if not api_key:
+        api_key = os.getenv("MINIMAX_API_KEY", "")
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 
@@ -400,7 +413,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     speed = mm_config.get("speed", tts_config.get("speed", 1))
     vol = mm_config.get("vol", 1)
     pitch = mm_config.get("pitch", 0)
-    base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)
+    base_url = mm_config.get("base_url") or derived_base or DEFAULT_MINIMAX_BASE_URL
 
     # Determine audio format from output extension
     if output_path.endswith(".wav"):

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -393,13 +393,15 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     # Derive URL + key from the active provider when available (handles CN
     # region automatically); fall back to env var + default URL.
     derived_base = ""
+    api_key = ""
     try:
-        from hermes_cli.provider_native_tools import native_api_url
+        from hermes_cli.provider_native_tools import native_api_url, native_credential
         derived_base = native_api_url("/v1/t2a_v2")
+        api_key = native_credential()
     except Exception:
         pass
-
-    api_key = os.getenv("MINIMAX_API_KEY", "")
+    if not api_key:
+        api_key = os.getenv("MINIMAX_API_KEY", "")
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -393,17 +393,13 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     # Derive URL + key from the active provider when available (handles CN
     # region automatically); fall back to env var + default URL.
     derived_base = ""
-    api_key = ""
     try:
-        from hermes_cli.provider_native_tools import endpoint_and_key
-        _url, _key = endpoint_and_key("/v1/t2a_v2")
-        if _url and _key:
-            derived_base = _url
-            api_key = _key
+        from hermes_cli.provider_native_tools import native_api_url
+        derived_base = native_api_url("/v1/t2a_v2")
     except Exception:
         pass
-    if not api_key:
-        api_key = os.getenv("MINIMAX_API_KEY", "")
+
+    api_key = os.getenv("MINIMAX_API_KEY", "")
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -1,0 +1,270 @@
+"""Video generation tool — generates short video clips via the native provider."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_VIDEO_MODEL = "MiniMax-Hailuo-2.3"
+_VIDEO_VALID_RESOLUTIONS = {"768P", "1080P"}
+_VIDEO_VALID_DURATIONS = {6, 10}
+_VIDEO_POLL_SECONDS = 15
+_VIDEO_POLL_MAX = 40  # 40 × 15s = 10 min ceiling
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _post_json(url: str, payload: Dict[str, Any], key: str,
+               *, timeout: int = 120) -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _get_json(url: str, key: str, *, timeout: int = 60) -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url, method="GET",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _download(url: str, output_path: Path, *, timeout: int = 300) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(url, timeout=timeout, context=ctx) as resp:
+        with open(output_path, "wb") as fh:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                fh.write(chunk)
+
+
+def _video_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/videos", "video_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "video_cache"
+
+
+def _coerce_image_source(src: str) -> Optional[str]:
+    """Normalise a local path / URL / data-URI for first_frame_image."""
+    import base64
+    import mimetypes
+
+    src = (src or "").strip()
+    if not src:
+        return None
+    if src.startswith(("data:", "http://", "https://")):
+        return src
+    if src.startswith("file://"):
+        src = src[len("file://"):]
+    path = Path(src).expanduser()
+    if not path.is_file():
+        return None
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime or not mime.startswith("image/"):
+        return None
+    data = base64.b64encode(path.read_bytes()).decode()
+    return f"data:{mime};base64,{data}"
+
+
+# ─── Core ─────────────────────────────────────────────────────────────────
+
+
+def video_generate_tool(
+    prompt: str,
+    duration: Optional[int] = None,
+    resolution: Optional[str] = None,
+    first_frame_image: Optional[str] = None,
+) -> str:
+    try:
+        from hermes_cli.provider_native_tools import endpoint_and_key
+    except Exception:
+        return json.dumps({"success": False,
+                           "error": "no video backend available"})
+
+    url, key = endpoint_and_key("/v1/video_generation")
+    if not url:
+        return json.dumps({"success": False,
+                           "error": "no video backend configured"})
+
+    payload: Dict[str, Any] = {
+        "model": _VIDEO_MODEL,
+        "prompt": (prompt or "").strip(),
+    }
+    if duration in _VIDEO_VALID_DURATIONS:
+        payload["duration"] = duration
+    if resolution and resolution.upper() in _VIDEO_VALID_RESOLUTIONS:
+        payload["resolution"] = resolution.upper()
+    if first_frame_image:
+        coerced = _coerce_image_source(first_frame_image)
+        if coerced:
+            payload["first_frame_image"] = coerced
+
+    # 1. Submit task.
+    try:
+        body = _post_json(url, payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+                           "error": f"video API HTTP {exc.code}"})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+                           "error": f"video API error {base.get('status_code')}: "
+                                    f"{base.get('status_msg', '')}"})
+
+    task_id = body.get("task_id")
+    if not task_id:
+        return json.dumps({"success": False,
+                           "error": "video API returned no task_id"})
+
+    # 2. Poll until terminal status.
+    api_root = url.rsplit("/v1/", 1)[0]
+    file_id: Optional[str] = None
+    last_status = ""
+    for _ in range(_VIDEO_POLL_MAX):
+        time.sleep(_VIDEO_POLL_SECONDS)
+        try:
+            status_body = _get_json(
+                f"{api_root}/v1/query/video_generation?task_id={task_id}", key)
+        except Exception:
+            continue
+        last_status = str(status_body.get("status") or "")
+        if last_status == "Success":
+            file_id = status_body.get("file_id")
+            break
+        if last_status == "Fail":
+            return json.dumps({"success": False,
+                               "error": f"video generation failed (task {task_id})",
+                               "task_id": task_id})
+
+    if not file_id:
+        return json.dumps({"success": False,
+                           "error": f"video generation timed out after "
+                                    f"{_VIDEO_POLL_SECONDS * _VIDEO_POLL_MAX}s "
+                                    f"(last status: {last_status or 'unknown'})",
+                           "task_id": task_id})
+
+    # 3. Resolve download URL.
+    try:
+        file_body = _get_json(
+            f"{api_root}/v1/files/retrieve?file_id={file_id}", key)
+    except Exception as exc:
+        return json.dumps({"success": False,
+                           "error": f"file retrieve failed: {exc}"})
+    download_url = (file_body.get("file") or {}).get("download_url")
+    if not download_url:
+        return json.dumps({"success": False,
+                           "error": f"no download_url for file_id {file_id}"})
+
+    # 4. Save locally.
+    out_dir = _video_cache_dir()
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"video_{ts}.mp4"
+    try:
+        _download(download_url, path)
+    except Exception as exc:
+        return json.dumps({"success": False,
+                           "error": f"video download failed: {exc}",
+                           "url": download_url, "task_id": task_id})
+
+    return json.dumps({
+        "success": True,
+        "model": _VIDEO_MODEL,
+        "task_id": task_id,
+        "path": str(path),
+        "url": download_url,
+    }, ensure_ascii=False)
+
+
+# ─── Check & registration ─────────────────────────────────────────────────
+
+
+def check_video_generation_requirements() -> bool:
+    try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        return provider_has_native_tool("video_gen", _safe_load_config())
+    except Exception:
+        return False
+
+
+VIDEO_GENERATE_SCHEMA = {
+    "name": "video_generate",
+    "description": (
+        "Generate a short video clip from a text description. "
+        "Optionally provide a first-frame image for image-to-video."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Scene description for the video.",
+            },
+            "duration": {
+                "type": "integer",
+                "enum": [6, 10],
+                "description": "Video length in seconds (default 6).",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["768P", "1080P"],
+                "description": "Output resolution (default 768P).",
+            },
+            "first_frame_image": {
+                "type": "string",
+                "description": "Local path, URL, or data URI of the first frame image.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _handle_video_generate(args: Dict[str, Any], **kw: Any) -> str:
+    prompt = args.get("prompt", "")
+    if not prompt or not isinstance(prompt, str):
+        return json.dumps({"success": False, "error": "prompt is required"})
+    return video_generate_tool(
+        prompt=prompt,
+        duration=args.get("duration"),
+        resolution=args.get("resolution"),
+        first_frame_image=args.get("first_frame_image"),
+    )
+
+
+registry.register(
+    name="video_generate",
+    toolset="video_gen",
+    schema=VIDEO_GENERATE_SCHEMA,
+    handler=_handle_video_generate,
+    check_fn=check_video_generation_requirements,
+    emoji="\U0001f3ac",
+)

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -102,13 +102,15 @@ def video_generate_tool(
     first_frame_image: Optional[str] = None,
 ) -> str:
     try:
-        from hermes_cli.provider_native_tools import endpoint_and_key
+        from hermes_cli.provider_native_tools import native_api_url
     except Exception:
         return json.dumps({"success": False,
                            "error": "no video backend available"})
 
-    url, key = endpoint_and_key("/v1/video_generation")
-    if not url:
+    url = native_api_url("/v1/video_generation")
+    key = (os.getenv("MINIMAX_API_KEY", "").strip()
+           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    if not url or not key:
         return json.dumps({"success": False,
                            "error": "no video backend configured"})
 

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -107,9 +107,9 @@ def video_generate_tool(
         return json.dumps({"success": False,
                            "error": "no video backend available"})
 
+    from hermes_cli.provider_native_tools import native_credential
     url = native_api_url("/v1/video_generation")
-    key = (os.getenv("MINIMAX_API_KEY", "").strip()
-           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    key = native_credential()
     if not url or not key:
         return json.dumps({"success": False,
                            "error": "no video backend configured"})

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -465,7 +465,15 @@ async def vision_analyze_tool(
 
         logger.info("Analyzing image: %s", image_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
-        
+
+        # Try provider-native VLM when available and vision is not pinned.
+        try:
+            native_result = _native_vision_analyze(image_url, user_prompt)
+            if native_result is not None:
+                return native_result
+        except Exception as _exc:
+            logger.debug("provider-native vision dispatch skipped: %s", _exc)
+
         # Determine if this is a local file path or a remote URL
         # Strip file:// scheme so file URIs resolve as local paths.
         resolved_url = image_url
@@ -681,6 +689,12 @@ async def vision_analyze_tool(
 def check_vision_requirements() -> bool:
     """Check if the configured runtime vision path can resolve a client."""
     try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        if provider_has_native_tool("vision", _safe_load_config()):
+            return True
+    except Exception:
+        pass
+    try:
         from agent.auxiliary_client import resolve_vision_provider_client
 
         _provider, client, _model = resolve_vision_provider_client()
@@ -776,6 +790,80 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
     )
     model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
     return vision_analyze_tool(image_url, full_prompt, model)
+
+
+# ─── Provider-native VLM (MiniMax etc.) ───────────────────────────────────
+
+_VLM_SUPPORTED_MIME = {"image/jpeg", "image/png", "image/webp"}
+
+
+def _native_vision_analyze(image_source: str, user_prompt: str):
+    """Dispatch to the native provider's VLM, or return None to fall through."""
+    import base64 as _b64
+    import mimetypes
+    import ssl
+    import urllib.error
+    import urllib.request
+
+    from hermes_cli.provider_native_tools import endpoint_and_key
+
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _vis_provider = (_cfg.get("auxiliary") or {}).get("vision", {}).get("provider", "")
+        if str(_vis_provider).strip().lower() not in ("", "auto", "main"):
+            return None
+    except Exception:
+        pass
+
+    url, key = endpoint_and_key("/v1/coding_plan/vlm")
+    if not url:
+        return None
+
+    src = (image_source or "").strip()
+    if not src:
+        return None
+    if not src.startswith(("data:", "http://", "https://")):
+        if src.startswith("file://"):
+            src = src[len("file://"):]
+        path = Path(os.path.expanduser(src))
+        if not path.is_file():
+            return None
+        mime, _ = mimetypes.guess_type(str(path))
+        if not mime or mime not in _VLM_SUPPORTED_MIME:
+            return None
+        data = _b64.b64encode(path.read_bytes()).decode()
+        src = f"data:{mime};base64,{data}"
+
+    payload = json.dumps({"prompt": user_prompt, "image_url": src},
+                         ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=payload, method="POST",
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"},
+    )
+    try:
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, timeout=60, context=ctx) as resp:
+            body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return None
+
+    base_resp = body.get("base_resp") or {}
+    if isinstance(base_resp, dict) and base_resp.get("status_code") not in (0, None):
+        return json.dumps({
+            "success": False,
+            "error": f"VLM error {base_resp.get('status_code')}: "
+                     f"{base_resp.get('status_msg', '')}",
+        }, ensure_ascii=False)
+
+    content = body.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return json.dumps({
+        "success": True,
+        "analysis": content,
+    }, ensure_ascii=False)
 
 
 registry.register(

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -805,7 +805,7 @@ def _native_vision_analyze(image_source: str, user_prompt: str):
     import urllib.error
     import urllib.request
 
-    from hermes_cli.provider_native_tools import endpoint_and_key
+    from hermes_cli.provider_native_tools import native_api_url
 
     try:
         from hermes_cli.config import load_config
@@ -816,8 +816,10 @@ def _native_vision_analyze(image_source: str, user_prompt: str):
     except Exception:
         pass
 
-    url, key = endpoint_and_key("/v1/coding_plan/vlm")
-    if not url:
+    url = native_api_url("/v1/coding_plan/vlm")
+    key = (os.getenv("MINIMAX_API_KEY", "").strip()
+           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    if not url or not key:
         return None
 
     src = (image_source or "").strip()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -816,9 +816,9 @@ def _native_vision_analyze(image_source: str, user_prompt: str):
     except Exception:
         pass
 
+    from hermes_cli.provider_native_tools import native_credential
     url = native_api_url("/v1/coding_plan/vlm")
-    key = (os.getenv("MINIMAX_API_KEY", "").strip()
-           or os.getenv("MINIMAX_CN_API_KEY", "").strip())
+    key = native_credential()
     if not url or not key:
         return None
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,8 +35,9 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
+    # Vision + image / video / music generation
     "vision_analyze", "image_generate",
+    "video_generate", "music_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -90,7 +91,19 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-    
+
+    "video_gen": {
+        "description": "Creative generation tools (short video clips)",
+        "tools": ["video_generate"],
+        "includes": []
+    },
+
+    "music_gen": {
+        "description": "Creative generation tools (songs with lyrics + style)",
+        "tools": ["music_generate"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
@@ -251,8 +264,9 @@ TOOLSETS = {
             "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
-            # Vision + image generation
+            # Vision + image / video / music generation
             "vision_analyze", "image_generate",
+            "video_generate", "music_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation


### PR DESCRIPTION
## Summary

Auto-detect multi-modal chat providers from `model.base_url` and wire all native capabilities (TTS, image, vision, video, music) as default tool backends — zero manual configuration.

- URL-based detection (`urlparse(base_url).hostname`), no dependency on `normalize_provider`
- Setup hook mirrors `apply_nous_provider_defaults`: data-driven, only overrides built-in defaults, never touches explicit user config
- Request handlers live in individual tool files (same pattern as `_generate_minimax_tts` in `tts_tool.py`)
- MiniMax is the first registered provider (international + CN + low-latency endpoints). Adding another provider: one row in `_NATIVE_HOSTS` + per-tool handlers

## Files Changed

| File | Changes |
|------|---------|
| `hermes_cli/provider_native_tools.py` | **new (+133)** — `_NATIVE_HOSTS` registry, `apply_provider_native_tool_defaults`, `endpoint_and_key` helper |
| `tools/video_generation_tool.py` | **new** — `video_generate` tool. Async poll flow (submit → poll → file retrieve → download) |
| `tools/music_generation_tool.py` | **new** — `music_generate` tool. Sync call + hex audio decode. `sk-cp-` key → premium model |
| `tests/hermes_cli/test_provider_native_tools.py` | **new (42 tests)** — host detection, credential priority, defaults, idempotency, explicit-config preservation |
| `hermes_cli/setup.py` | **+22** — call `apply_provider_native_tool_defaults` after provider selection; skip TTS selector when provider owns TTS |
| `tools/image_generation_tool.py` | **+93** — `_native_image_generate` handler, dispatch before FAL path |
| `tools/vision_tools.py` | **+90** — `_native_vision_analyze` VLM handler, dispatch before auxiliary-client path |
| `tools/tts_tool.py` | **+17** — derive URL + key via `endpoint_and_key("/v1/t2a_v2")` for CN auto-routing |
| `toolsets.py` | **+20** — `video_gen` / `music_gen` toolset definitions |
| `hermes_cli/tools_config.py` | **+2** — `video_gen` / `music_gen` in `CONFIGURABLE_TOOLSETS` |

## Test Plan

```
python -m pytest tests/hermes_cli/test_provider_native_tools.py -q
# 42 passed
```

Live end-to-end with Token Plan key on `api.minimax.io`: `image_generate` → image-01 URL, `music_generate` → mp3, `video_generate` → mp4, `vision_analyze` → VLM analysis, TTS → speech-2.6-hd.

Zero new pip dependencies (stdlib only). Zero behaviour change for providers not in `_NATIVE_HOSTS`.