### PR TITLE
fix: use UTF-16 length for Telegram stream consumer message splitting

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -884,6 +884,15 @@ class BasePlatformAdapter(ABC):
         self._typing_paused: set = set()
 
     @property
+    def message_len_fn(self) -> Callable[[str], int]:
+        """Return the length function for measuring message size on this platform.
+
+        Override in adapters whose platform counts characters differently from
+        Python ``len`` (e.g. Telegram counts UTF-16 code units).
+        """
+        return len
+
+    @property
     def has_fatal_error(self) -> bool:
         return self._fatal_error_message is not None
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -136,7 +136,12 @@ class TelegramAdapter(BasePlatformAdapter):
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
-    
+
+    @property
+    def message_len_fn(self):
+        """Telegram measures message length in UTF-16 code units."""
+        return utf16_len
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
         self._app: Optional[Application] = None

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -21,7 +21,9 @@ import queue
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
+
+from gateway.platforms.base import _custom_unit_to_cp
 
 logger = logging.getLogger("gateway.stream_consumer")
 
@@ -256,9 +258,17 @@ class GatewayStreamConsumer:
 
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""
-        # Platform message length limit — leave room for cursor + formatting
+        # Platform message length limit — leave room for cursor + formatting.
+        # Use the adapter's length function (e.g. utf16_len for Telegram) so
+        # overflow detection matches what the platform actually enforces.
+        # Fall back to len for adapters that don't override it.
+        try:
+            from gateway.platforms.base import BasePlatformAdapter as _BPA
+            _len_fn = self.adapter.message_len_fn if isinstance(self.adapter, _BPA) else len
+        except Exception:
+            _len_fn = len
         _raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
-        _safe_limit = max(500, _raw_limit - len(self.cfg.cursor) - 100)
+        _safe_limit = max(500, _raw_limit - _len_fn(self.cfg.cursor) - 100)
 
         try:
             while True:
@@ -305,7 +315,7 @@ class GatewayStreamConsumer:
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (
-                        len(self._accumulated) > _safe_limit
+                        _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is None
                     ):
                         # No existing message to edit (first message or after a
@@ -314,7 +324,7 @@ class GatewayStreamConsumer:
                         # proper word/code-fence boundaries and chunk
                         # indicators like "(1/2)".
                         chunks = self.adapter.truncate_message(
-                            self._accumulated, _safe_limit
+                            self._accumulated, _safe_limit, len_fn=_len_fn,
                         )
                         for chunk in chunks:
                             await self._send_new_chunk(chunk, self._message_id)
@@ -333,11 +343,14 @@ class GatewayStreamConsumer:
                     # Existing message: edit it with the first chunk, then
                     # start a new message for the overflow remainder.
                     while (
-                        len(self._accumulated) > _safe_limit
+                        _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is not None
                         and self._edit_supported
                     ):
-                        split_at = self._accumulated.rfind("\n", 0, _safe_limit)
+                        _cp_budget = _custom_unit_to_cp(
+                            self._accumulated, _safe_limit, _len_fn,
+                        ) if _len_fn is not len else _safe_limit
+                        split_at = self._accumulated.rfind("\n", 0, _cp_budget)
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
@@ -489,14 +502,21 @@ class GatewayStreamConsumer:
         return final_text
 
     @staticmethod
-    def _split_text_chunks(text: str, limit: int) -> list[str]:
+    def _split_text_chunks(
+        text: str, limit: int,
+        len_fn: "Callable[[str], int]" = len,
+    ) -> list[str]:
         """Split text into reasonably sized chunks for fallback sends."""
-        if len(text) <= limit:
+        if len_fn(text) <= limit:
             return [text]
         chunks: list[str] = []
         remaining = text
-        while len(remaining) > limit:
-            split_at = remaining.rfind("\n", 0, limit)
+        while len_fn(remaining) > limit:
+            _cp_budget = (
+                _custom_unit_to_cp(remaining, limit, len_fn)
+                if len_fn is not len else limit
+            )
+            split_at = remaining.rfind("\n", 0, _cp_budget)
             if split_at < limit // 2:
                 split_at = limit
             chunks.append(remaining[:split_at])
@@ -528,8 +548,13 @@ class GatewayStreamConsumer:
                 return
 
         raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+        try:
+            from gateway.platforms.base import BasePlatformAdapter as _BPA
+            _len_fn = self.adapter.message_len_fn if isinstance(self.adapter, _BPA) else len
+        except Exception:
+            _len_fn = len
         safe_limit = max(500, raw_limit - 100)
-        chunks = self._split_text_chunks(continuation, safe_limit)
+        chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
 
         last_message_id: Optional[str] = None
         last_successful_chunk = ""


### PR DESCRIPTION
## Problem

The stream consumer measured message length using Python's `len()` (Unicode code points), but Telegram's actual limit is in UTF-16 code units. This caused messages with supplementary characters (emoji, CJK text, etc.) to exceed Telegram's 4096-character limit, resulting in:

- Truncated messages cut off mid-sentence
- Black square (\x00) rendering artifacts from incomplete MarkdownV2 placeholder processing
- Failed `editMessageText` calls that silently fell back to plain text

The `send()` method in `TelegramAdapter` already correctly used `utf16_len` for `truncate_message`, but the streaming path in `GatewayStreamConsumer` did not.

## Solution

Three changes designed for easy adoption by any platform adapter:

1. **`BasePlatformAdapter.message_len_fn`** — new property that returns `len` by default. Platforms that measure differently (like Telegram) override this.

2. **`TelegramAdapter.message_len_fn`** — returns `utf16_len` so all downstream consumers get correct lengths automatically.

3. **`GatewayStreamConsumer`** — uses `adapter.message_len_fn` instead of bare `len` for:
   - `_safe_limit` calculation
   - overflow detection
   - `truncate_message` calls (passes `len_fn`)
   - split point calculation (via `_custom_unit_to_cp`)
   - fallback final send chunking

## Testing

- All 58 stream consumer tests pass
- All 3009 gateway tests pass (7 pre-existing flaky failures unrelated to this change)
- Backwards compatible: adapters that don't override `message_len_fn` get `len` behavior