### PR TITLE
fix(delegation): handle Google function_call_filter and validate toolsets

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9114,6 +9114,26 @@ class AIAgent:
                     else:
                         finish_reason = response.choices[0].finish_reason
                         assistant_message = response.choices[0].message
+
+                        # ── Google-specific tool call filters ──────────
+                        # Google's OpenAI-compatible endpoint returns this finish_reason
+                        # when it blocks a tool call (e.g. malformed or safety filter).
+                        # Treat it as an error to prevent the loop from retrying blindly
+                        # and returning "(empty)".
+                        if isinstance(finish_reason, str) and finish_reason.startswith("function_call_filter:"):
+                            _filter_error = f"Model generated a tool call that was blocked by the API: {finish_reason}"
+                            self._vprint(f"{self.log_prefix}⚠️  {_filter_error}", force=True)
+                            self._cleanup_task_resources(effective_task_id)
+                            self._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": None,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "partial": True,
+                                "error": _filter_error
+                            }
+
                         if self._should_treat_stop_as_truncated(
                             finish_reason,
                             assistant_message,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -282,6 +282,9 @@ def _build_child_agent(
 
     if toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks
+        missing_toolsets = [t for t in toolsets if t not in parent_toolsets]
+        if missing_toolsets:
+            raise ValueError(f"Requested toolsets {missing_toolsets} are not available in the parent agent. Use available toolsets or check your configuration.")
         child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)


### PR DESCRIPTION
## Summary
Fixes an infinite retry loop that occurs when a subagent is delegated a task with missing toolsets on Google models.

## Changes
- **`run_agent.py`**: Explicitly handle `function_call_filter:` finish_reason from Google's API. This prevents the agent from treating blocked tool calls as "empty responses" and retrying them blindly.
- **`tools/delegate_tool.py`**: Added validation to `_build_child_agent` to ensure requested toolsets are available in the parent agent. This provides a clear error message instead of spawning a toolless subagent that will inevitably hallucinate.

Resolves #11171