### PR TITLE
fix(run_agent): send max_tokens default for self-hosted endpoints

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2014,6 +2014,38 @@ class AIAgent:
         """Return True when the base URL targets OpenRouter."""
         return "openrouter" in self._base_url_lower
 
+    def _is_custom_selfhosted_endpoint(self) -> bool:
+        """Return True when the base URL looks like a custom/self-hosted
+        OpenAI-compatible server (mlx_vlm.server, llama.cpp, vLLM, etc.)
+        rather than a known managed provider.
+
+        Used to apply conservative defaults (e.g. max_tokens) for endpoints
+        that historically ship with very small default output caps.  A URL
+        is considered "custom" when it is configured AND does not match any
+        recognised managed provider.
+        """
+        url = self._base_url_lower
+        if not url:
+            return False
+        KNOWN_HOSTS = (
+            "api.openai.com",
+            "openrouter.ai",
+            "api.anthropic.com",
+            "nousresearch.com",
+            "api.deepseek.com",
+            "api.mistral.ai",
+            "api.together.xyz",
+            "api.groq.com",
+            "api.fireworks.ai",
+            "api.cerebras.ai",
+            "api.x.ai",
+            "generativelanguage.googleapis.com",
+            "models.github.ai",
+            "api.githubcopilot.com",
+            "dashscope",  # Qwen Portal (dashscope-intl / dashscope.aliyuncs.com)
+        )
+        return not any(h in url for h in KNOWN_HOSTS)
+
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:
         """Return True for models that require the Responses API path.
@@ -6662,6 +6694,16 @@ class AIAgent:
                 api_kwargs["max_tokens"] = _model_output_limit
             except Exception:
                 pass  # fail open — let the proxy pick its default
+        elif self._is_custom_selfhosted_endpoint():
+            # Custom / self-hosted OpenAI-compatible endpoints (mlx_vlm.server,
+            # llama.cpp server, vLLM on a private IP, etc.) frequently ship
+            # very low default max_tokens values.  mlx_vlm.server in particular
+            # hardcodes DEFAULT_MAX_TOKENS=256, which truncates any non-trivial
+            # response (long diary entries, multi-file write_file tool calls,
+            # code review output) mid-sentence with finish_reason="stop".
+            # When the user hasn't set model.max_tokens explicitly, send a
+            # generous default so self-hosted servers don't silently cap output.
+            api_kwargs.update(self._max_tokens_param(16384))
 
         extra_body = {}
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -985,6 +985,68 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["max_tokens"] == 65536
 
+    def test_custom_selfhosted_default_max_tokens(self, agent):
+        """Custom/self-hosted endpoints (mlx_vlm.server, llama.cpp, vLLM etc.)
+        should receive a generous max_tokens default when the user hasn't
+        configured one.  mlx_vlm.server hardcodes DEFAULT_MAX_TOKENS=256,
+        which silently truncates long responses mid-sentence with
+        finish_reason='stop'.  16384 is the pragmatic sweet spot for
+        single-response output without triggering context-length errors
+        on smaller models."""
+        agent.provider = "custom"
+        agent.base_url = "https://my-mac-mini.example.net/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["max_tokens"] == 16384
+
+    def test_custom_selfhosted_respects_explicit_max_tokens(self, agent):
+        """When the user explicitly sets max_tokens, self-hosted endpoints
+        should honour that value rather than the 16384 fallback."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:8000/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.max_tokens = 2048
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["max_tokens"] == 2048
+
+    def test_openrouter_not_treated_as_selfhosted(self, agent):
+        """OpenRouter has its own max_tokens handling (per-model Anthropic
+        limits).  It must NOT fall through to the 16384 self-hosted default."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "openai/gpt-5.4"  # non-Claude, skips the Claude branch too
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "max_tokens" not in kwargs
+
+    def test_openai_not_treated_as_selfhosted(self, agent):
+        """api.openai.com is a known managed provider and must not trigger
+        the self-hosted max_tokens default."""
+        agent.base_url = "https://api.openai.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "gpt-4o-mini"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "max_tokens" not in kwargs
+
+    def test_empty_base_url_not_treated_as_selfhosted(self, agent):
+        """Empty base_url (provider default) must not be classified as
+        self-hosted, since there's no URL to distinguish it from the
+        provider's own API."""
+        agent.base_url = ""
+        agent._base_url_lower = ""
+        agent.provider = "openrouter"
+        agent.model = "openai/gpt-5.4"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "max_tokens" not in kwargs
+
     def test_ollama_think_false_on_effort_none(self, agent):
         """Custom (Ollama) provider with effort=none should inject think=false."""
         agent.provider = "custom"


### PR DESCRIPTION
## Summary

Self-hosted OpenAI-compatible servers like `mlx_vlm.server`, `llama.cpp` server, and some `vLLM` configs ship with very low default `max_tokens` values. `mlx_vlm.server` in particular hardcodes `DEFAULT_MAX_TOKENS=256` via a pydantic `Field` default on its `/v1/chat/completions` handler.

When a user points Hermes at a self-hosted endpoint and omits `model.max_tokens` in their config — the common case for a local-primary setup — the agent currently sends no `max_tokens` parameter at all. The server then applies its hardcoded default (256) and silently truncates responses mid-sentence with `finish_reason="stop"`. The agent interprets this as a clean stop and exits the loop, leaving the user wondering why long outputs keep getting cut off.

## Fix

Add a new `_is_custom_selfhosted_endpoint()` helper and a corresponding branch in `_build_api_kwargs` that fires when:

1. `self.max_tokens` is not explicitly configured, AND
2. The base URL does not match any recognised managed provider.

It sends `16384` as a conservative default — generous enough for a full long-form response or a multi-kilobyte tool call, small enough to not trip context-window errors on smaller local models.

Known-provider detection covers: OpenAI, OpenRouter, Anthropic, Nous, DeepSeek, Mistral, Together, Groq, Fireworks, Cerebras, xAI, Google Gemini, GitHub Models/Copilot, Qwen Portal (dashscope). Any other configured `base_url` is treated as self-hosted.

Order is preserved: the existing Qwen Portal (65536) and OpenRouter-Claude (per-model Anthropic limit) branches still win, so no managed-provider behaviour changes.

## Testing

Five new assertions in `tests/run_agent/test_run_agent.py`:
- `test_custom_selfhosted_default_max_tokens` — self-hosted endpoint with `max_tokens=None` receives `16384`
- `test_custom_selfhosted_respects_explicit_max_tokens` — explicit value always wins
- `test_openrouter_not_treated_as_selfhosted` — OpenRouter unchanged
- `test_openai_not_treated_as_selfhosted` — `api.openai.com` unchanged
- `test_empty_base_url_not_treated_as_selfhosted` — empty `base_url` safely short-circuits

All 11 tests in the related suite (existing `qwen_portal` / `max_tokens` tests + the new ones) pass:

```
tests/run_agent/test_run_agent.py ........... [100%]
11 passed in 7.09s
```

## Reproduction (before fix)

```bash
curl -s http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model": "some-local-mlx-model",
       "messages": [{"role": "user",
                     "content": "Write a detailed 800-word essay."}]}'
# Returns ~256 output tokens, finish_reason="stop", truncated mid-sentence.
```

With the fix, Hermes sends `max_tokens=16384` and the server produces the full response.