### PR TITLE
fix(tools): redirect bare filenames to HERMES_HOME in _expand_path

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1,6 +1,7 @@
 """Tests for tools/file_operations.py — deny list, result dataclasses, helpers."""
 
 import os
+import unittest.mock
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -211,9 +212,72 @@ class TestShellFileOpsHelpers:
         # High ratio of non-printable chars -> binary
         binary_content = "\x00\x01\x02\x03" * 250
         assert file_ops._is_likely_binary("unknown", binary_content) is True
-
         # Normal text -> not binary
         assert file_ops._is_likely_binary("unknown", "Hello world\nLine 2\n") is False
+
+
+@pytest.fixture()
+def local_file_ops():
+    """ShellFileOperations backed by a real LocalEnvironment stub."""
+    from tools.environments.local import LocalEnvironment
+    env = MagicMock(spec=LocalEnvironment)
+    env.cwd = "/tmp/test"
+    env.execute.return_value = {"output": "", "returncode": 0}
+    return ShellFileOperations(env)
+
+
+class TestExpandPathBareFilename:
+    """_expand_path redirects bare filenames to HERMES_HOME when the file exists there."""
+
+    def test_bare_filename_existing_in_hermes_home_is_redirected(self, local_file_ops, tmp_path):
+        soul = tmp_path / "SOUL.md"
+        soul.write_text("persona")
+        with unittest.mock.patch("tools.file_operations.get_hermes_home", return_value=tmp_path):
+            result = local_file_ops._expand_path("SOUL.md")
+        assert result == str(soul)
+
+    def test_bare_filename_absent_from_hermes_home_is_unchanged(self, local_file_ops, tmp_path):
+        # File does NOT exist in HERMES_HOME → path returned as-is for cwd resolution
+        with unittest.mock.patch("tools.file_operations.get_hermes_home", return_value=tmp_path):
+            result = local_file_ops._expand_path("output.txt")
+        assert result == "output.txt"
+
+    def test_non_local_env_is_not_redirected(self, file_ops, tmp_path):
+        # Docker/SSH envs must not redirect — the write runs on the remote side
+        soul = tmp_path / "SOUL.md"
+        soul.write_text("persona")
+        with unittest.mock.patch("tools.file_operations.get_hermes_home", return_value=tmp_path):
+            result = file_ops._expand_path("SOUL.md")
+        assert result == "SOUL.md"
+
+    def test_path_with_separator_is_not_redirected(self, local_file_ops, tmp_path):
+        # Relative paths with directory components are left alone
+        soul = tmp_path / "SOUL.md"
+        soul.write_text("persona")
+        with unittest.mock.patch("tools.file_operations.get_hermes_home", return_value=tmp_path):
+            result = local_file_ops._expand_path("./SOUL.md")
+        assert result == "./SOUL.md"
+
+    def test_dotfile_is_not_redirected(self, local_file_ops, tmp_path):
+        # Leading-dot names (e.g. .env) are excluded from bare-filename redirect
+        dotenv = tmp_path / ".env"
+        dotenv.write_text("KEY=val")
+        with unittest.mock.patch("tools.file_operations.get_hermes_home", return_value=tmp_path):
+            result = local_file_ops._expand_path(".env")
+        assert result == ".env"
+
+    def test_tilde_path_is_not_redirected(self, tmp_path, monkeypatch):
+        # ~ paths are handled by existing ~ expansion, not bare-filename redirect
+        soul = tmp_path / "SOUL.md"
+        soul.write_text("persona")
+        from tools.environments.local import LocalEnvironment
+        env = MagicMock(spec=LocalEnvironment)
+        env.cwd = str(tmp_path)
+        env.execute.return_value = {"output": str(tmp_path), "returncode": 0}
+        ops = ShellFileOperations(env)
+        with unittest.mock.patch("tools.file_operations.get_hermes_home", return_value=tmp_path):
+            result = ops._expand_path("~/SOUL.md")
+        assert result == str(tmp_path / "SOUL.md")
 
     def test_is_image(self, file_ops):
         assert file_ops._is_image("photo.png") is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -415,11 +415,7 @@ class ShellFileOperations(FileOperations):
         """
         Expand shell-style paths like ~ and ~user to absolute paths.
 
-        Also redirects bare filenames (no path separator, no leading dot or ~)
-        to HERMES_HOME when a matching file already exists there.  This
-        prevents write_file("SOUL.md") from silently landing in $HOME/SOUL.md
-        when the process cwd happens to be $HOME and ~/.hermes/SOUL.md is the
-        intended target.
+        Also redirects bare filenames (no path separator, no leading . or ~) to HERMES_HOME if a match exists there.
 
         This must be done BEFORE shell escaping, since ~ doesn't expand
         inside single quotes.
@@ -427,23 +423,19 @@ class ShellFileOperations(FileOperations):
         if not path:
             return path
 
-        # Redirect bare filenames to HERMES_HOME when a matching file exists
-        # there.  A "bare filename" has no path separator and no special prefix
-        # (~ or .), so it would otherwise silently resolve against self.cwd.
-        # Scoped to local environments only: in Docker/SSH/remote backends the
-        # write command executes on the remote side where the host HERMES_HOME
-        # path is not necessarily accessible at the same path.
-        # Use Path(path).name == path instead of checking for '/' so that
-        # Windows paths with backslash separators are also caught correctly.
+        # Redirect bare filenames to HERMES_HOME when a match exists there (LocalEnvironment only).
         if Path(path).name == path and not path.startswith(('.', '~')):
             try:
                 from tools.environments.local import LocalEnvironment
                 if isinstance(self.env, LocalEnvironment):
                     candidate = get_hermes_home() / path
                     if candidate.exists():
-                        return str(candidate)
+                        resolved = candidate.resolve()
+                        hermes_home_resolved = get_hermes_home().resolve()
+                        if str(resolved).startswith(str(hermes_home_resolved)):
+                            return str(resolved)
             except (OSError, ImportError) as e:
-                logger.debug("bare-filename HERMES_HOME lookup failed for %r: %s", path, e)
+                logger.debug("bare-filename HERMES_HOME lookup failed for %r", path, exc_info=True)
 
         # Handle ~ and ~user
         if path.startswith('~'):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -28,12 +28,15 @@ Usage:
 import os
 import re
 import difflib
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from tools.binary_extensions import BINARY_EXTENSIONS
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -411,13 +414,37 @@ class ShellFileOperations(FileOperations):
     def _expand_path(self, path: str) -> str:
         """
         Expand shell-style paths like ~ and ~user to absolute paths.
-        
+
+        Also redirects bare filenames (no path separator, no leading dot or ~)
+        to HERMES_HOME when a matching file already exists there.  This
+        prevents write_file("SOUL.md") from silently landing in $HOME/SOUL.md
+        when the process cwd happens to be $HOME and ~/.hermes/SOUL.md is the
+        intended target.
+
         This must be done BEFORE shell escaping, since ~ doesn't expand
         inside single quotes.
         """
         if not path:
             return path
-        
+
+        # Redirect bare filenames to HERMES_HOME when a matching file exists
+        # there.  A "bare filename" has no path separator and no special prefix
+        # (~ or .), so it would otherwise silently resolve against self.cwd.
+        # Scoped to local environments only: in Docker/SSH/remote backends the
+        # write command executes on the remote side where the host HERMES_HOME
+        # path is not necessarily accessible at the same path.
+        # Use Path(path).name == path instead of checking for '/' so that
+        # Windows paths with backslash separators are also caught correctly.
+        if Path(path).name == path and not path.startswith(('.', '~')):
+            try:
+                from tools.environments.local import LocalEnvironment
+                if isinstance(self.env, LocalEnvironment):
+                    candidate = get_hermes_home() / path
+                    if candidate.exists():
+                        return str(candidate)
+            except (OSError, ImportError) as e:
+                logger.debug("bare-filename HERMES_HOME lookup failed for %r: %s", path, e)
+
         # Handle ~ and ~user
         if path.startswith('~'):
             # Get home directory via the terminal environment


### PR DESCRIPTION
## Summary

- `write_file("SOUL.md")` silently wrote to `$HOME/SOUL.md` instead of `~/.hermes/SOUL.md` when the process cwd was `$HOME`
- No error or traceback — agent reported success; only symptom was a stray file in the home directory
- Root cause: `_expand_path` only handled `~` expansion; bare filenames fell through and were resolved against `self.cwd`

## What Changed

In `tools/file_operations.py`, `_expand_path` now checks whether a bare filename (no path separator, no leading `.` or `~`) exists in `HERMES_HOME`. If it does **and** the active environment is a `LocalEnvironment`, it returns the absolute `HERMES_HOME`-anchored path instead.

**Scope**: `LocalEnvironment` only — in Docker/SSH/remote backends the write executes on the remote side where host `HERMES_HOME` may not be accessible at the same location.

Any `OSError`/`ImportError` during the lookup is logged at `DEBUG` and the original path is returned unchanged — no new failure modes introduced.

## How to Test

1. Ensure `~/.hermes/SOUL.md` exists (default install creates it)
2. Start a Hermes CLI session from `$HOME`
3. Ask the agent: *"Update my SOUL.md — make me action-oriented"*
4. Verify `~/.hermes/SOUL.md` is updated and **no** `~/SOUL.md` is created

Unit tests:
```
pytest tests/tools/test_file_operations.py::TestExpandPathBareFilename -v
```

## Platforms Tested

- Linux (WSL2, Arch)

Closes #10981
Related: #6203, #6206

Re-submission of #10998 — scoped to `_expand_path` only, unrelated changes removed.