### PR TITLE
fix(cli): export HERMES_PYTHON=sys.executable so skills use the agent's interpreter

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -123,6 +123,8 @@ def _apply_profile_override() -> None:
             print(f"Warning: profile override failed ({exc}), using default", file=sys.stderr)
             return
         os.environ["HERMES_HOME"] = hermes_home
+        # Export HERMES_PYTHON so skills use the agent's interpreter, not system python3.
+        os.environ.setdefault("HERMES_PYTHON", sys.executable)
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0:
             for i, arg in enumerate(argv):

--- a/tests/hermes_cli/test_hermes_python_env.py
+++ b/tests/hermes_cli/test_hermes_python_env.py
@@ -1,0 +1,38 @@
+"""Verify HERMES_PYTHON is exported when hermes applies a profile."""
+import os
+import sys
+from unittest.mock import patch
+
+# Import at module level so the module-level _apply_profile_override() call
+# happens with normal argv (not our test argv), avoiding side effects.
+import hermes_cli.main as _main_mod
+
+
+def test_hermes_python_set_to_sys_executable(monkeypatch, tmp_path):
+    """HERMES_PYTHON must be set to sys.executable so skills use the agent's interpreter."""
+    hermes_home = str(tmp_path / ".hermes")
+
+    monkeypatch.delenv("HERMES_PYTHON", raising=False)
+    monkeypatch.setattr(sys, "argv", ["hermes", "--profile", "myprofile"])
+
+    with patch("hermes_cli.profiles.resolve_profile_env", return_value=hermes_home):
+        _main_mod._apply_profile_override()
+
+    assert os.environ.get("HERMES_PYTHON") == sys.executable, (
+        f"Expected HERMES_PYTHON={sys.executable!r}, got {os.environ.get('HERMES_PYTHON')!r}"
+    )
+
+
+def test_hermes_python_not_overwritten_if_already_set(monkeypatch, tmp_path):
+    """A user-set HERMES_PYTHON must not be overwritten by the agent."""
+    hermes_home = str(tmp_path / ".hermes")
+
+    monkeypatch.setenv("HERMES_PYTHON", "/custom/python3")
+    monkeypatch.setattr(sys, "argv", ["hermes", "--profile", "myprofile"])
+
+    with patch("hermes_cli.profiles.resolve_profile_env", return_value=hermes_home):
+        _main_mod._apply_profile_override()
+
+    assert os.environ.get("HERMES_PYTHON") == "/custom/python3", (
+        "HERMES_PYTHON should not be overwritten when already set by user"
+    )


### PR DESCRIPTION
## Summary

- Skills use `${HERMES_PYTHON:-python3}` but hermes never exported `HERMES_PYTHON`
- They fell back to system `python3` — or worse, the legacy `hermes-agent/venv/bin/python` which has no pip
- One-liner fix: `os.environ.setdefault("HERMES_PYTHON", sys.executable)` in `main.py`
- `setdefault` preserves any user-set override while ensuring skills always run under the same interpreter as the agent (pipx, uv tool, etc.)

## How to Test

```
pytest tests/hermes_cli/test_hermes_python_env.py -v
```

Manual: start `hermes`, ask it to run any skill that calls `${HERMES_PYTHON}` — confirm it uses the correct interpreter.

## Platforms Tested

- Linux (WSL2, Arch)

Split from #10841 per reviewer request.