### PR TITLE
feat: add Codex account usage summary to /usage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6430,6 +6430,25 @@ class HermesCLI:
             print(format_rate_limit_display(rl_state))
             print()
 
+        # ── Codex account usage (live provider quota windows) ──────
+        try:
+            from hermes_cli.codex_usage import (
+                format_codex_usage_report_lines,
+                get_current_codex_usage_snapshot,
+                is_codex_provider,
+            )
+
+            if is_codex_provider(getattr(agent, "provider", None), getattr(agent, "base_url", None)):
+                codex_usage = get_current_codex_usage_snapshot(timeout=5.0)
+                codex_usage_lines = format_codex_usage_report_lines(codex_usage)
+                if codex_usage_lines:
+                    print()
+                    for line in codex_usage_lines:
+                        print(f"  {line}" if not line.startswith("  ") else line)
+                    print()
+        except Exception:
+            pass
+
         # ── Session token usage ─────────────────────────────────────
         input_tokens = getattr(agent, "session_input_tokens", 0) or 0
         output_tokens = getattr(agent, "session_output_tokens", 0) or 0

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6566,6 +6566,29 @@ class GatewayRunner:
                 lines.append(f"⏱️ **Rate Limits:** {format_rate_limit_compact(rl_state)}")
                 lines.append("")
 
+            # Codex account usage (live provider quota windows)
+            try:
+                from hermes_cli.codex_usage import (
+                    format_codex_usage_report_lines,
+                    get_current_codex_usage_snapshot,
+                    is_codex_provider,
+                )
+
+                if is_codex_provider(getattr(agent, "provider", None), getattr(agent, "base_url", None)):
+                    codex_usage = get_current_codex_usage_snapshot(timeout=5.0)
+                    codex_lines = format_codex_usage_report_lines(codex_usage)
+                    if codex_lines:
+                        lines.append("🧾 **Codex Account Usage**")
+                        for line in (
+                            codex_lines[1:]
+                            if codex_lines and codex_lines[0] == "Codex Account Usage:"
+                            else codex_lines
+                        ):
+                            lines.append(line.strip())
+                        lines.append("")
+            except Exception:
+                pass
+
             # Session token usage — detailed breakdown matching CLI
             input_tokens = getattr(agent, "session_input_tokens", 0) or 0
             output_tokens = getattr(agent, "session_output_tokens", 0) or 0

--- a/hermes_cli/codex_usage.py
+++ b/hermes_cli/codex_usage.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+import httpx
+
+CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+WEEKLY_RESET_GAP_SECONDS = 3 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class CodexUsageWindow:
+    label: str
+    used_percent: float
+    reset_at_ms: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CodexUsageSnapshot:
+    available: bool = False
+    plan: Optional[str] = None
+    windows: list[CodexUsageWindow] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+GetFn = Callable[..., Any]
+
+
+def _clamp_percent(value: Any) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(100.0, numeric))
+
+
+def _coerce_reset_at_ms(window: dict[str, Any], now_ms: int) -> Optional[int]:
+    reset_at = window.get("reset_at")
+    if isinstance(reset_at, (int, float)) and reset_at > 0:
+        return int(float(reset_at) * 1000)
+    reset_after = window.get("reset_after_seconds")
+    if isinstance(reset_after, (int, float)) and reset_after > 0:
+        return int(now_ms + float(reset_after) * 1000)
+    return None
+
+
+def _resolve_secondary_window_label(*, window_hours: int, secondary_reset_at: Any, primary_reset_at: Any) -> str:
+    if window_hours >= 168:
+        return "Week"
+    if window_hours < 24:
+        return f"{window_hours}h"
+    if isinstance(secondary_reset_at, (int, float)) and isinstance(primary_reset_at, (int, float)):
+        if float(secondary_reset_at) - float(primary_reset_at) >= WEEKLY_RESET_GAP_SECONDS:
+            return "Week"
+    return "Day"
+
+
+def _format_reset_remaining(target_ms: Optional[int], *, now_ms: Optional[int] = None) -> Optional[str]:
+    if not target_ms:
+        return None
+    base = now_ms if now_ms is not None else int(datetime.now(timezone.utc).timestamp() * 1000)
+    diff_ms = int(target_ms) - int(base)
+    if diff_ms <= 0:
+        return "now"
+
+    diff_mins = diff_ms // 60000
+    if diff_mins < 60:
+        return f"{diff_mins}m"
+
+    hours = diff_mins // 60
+    mins = diff_mins % 60
+    if hours < 24:
+        return f"{hours}h {mins}m" if mins > 0 else f"{hours}h"
+
+    days = hours // 24
+    if days < 7:
+        return f"{days}d {hours % 24}h"
+
+    formatted = datetime.fromtimestamp(target_ms / 1000, tz=timezone.utc).strftime("%b %d")
+    return formatted.replace(" 0", " ")
+
+
+def _format_plan(data: dict[str, Any]) -> Optional[str]:
+    plan = data.get("plan_type")
+    credits = data.get("credits")
+    if isinstance(credits, dict) and credits.get("balance") is not None:
+        try:
+            balance = float(credits.get("balance"))
+        except (TypeError, ValueError):
+            balance = 0.0
+        if isinstance(plan, str) and plan.strip():
+            return f"{plan.strip()} (${balance:.2f})"
+        return f"${balance:.2f}"
+    if isinstance(plan, str) and plan.strip():
+        return plan.strip()
+    return None
+
+
+def fetch_codex_usage_snapshot(
+    access_token: str,
+    *,
+    account_id: Optional[str] = None,
+    timeout: float = 10.0,
+    get: Optional[GetFn] = None,
+    now_ms: Optional[int] = None,
+) -> CodexUsageSnapshot:
+    if not isinstance(access_token, str) or not access_token.strip():
+        return CodexUsageSnapshot(available=False, error="Missing access token")
+
+    headers = {
+        "Authorization": f"Bearer {access_token.strip()}",
+        "User-Agent": "CodexBar",
+        "Accept": "application/json",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+
+    getter = get or httpx.get
+    current_now_ms = now_ms if now_ms is not None else int(datetime.now(timezone.utc).timestamp() * 1000)
+
+    try:
+        response = getter(CODEX_USAGE_URL, headers=headers, timeout=timeout)
+    except Exception as exc:  # pragma: no cover - exercised by tests with custom exception types
+        return CodexUsageSnapshot(available=False, error=str(exc))
+
+    status_code = getattr(response, "status_code", None)
+    if status_code != 200:
+        return CodexUsageSnapshot(available=False, error=f"HTTP {status_code}")
+
+    try:
+        data = response.json()
+    except Exception:
+        return CodexUsageSnapshot(available=False, error="Invalid JSON")
+
+    if not isinstance(data, dict):
+        return CodexUsageSnapshot(available=False, error="Invalid response")
+
+    rate_limit = data.get("rate_limit") if isinstance(data.get("rate_limit"), dict) else {}
+    windows: list[CodexUsageWindow] = []
+
+    primary_window = rate_limit.get("primary_window") if isinstance(rate_limit.get("primary_window"), dict) else None
+    if primary_window:
+        try:
+            window_hours = round(float(primary_window.get("limit_window_seconds") or 10_800) / 3600)
+        except (TypeError, ValueError):
+            window_hours = 3
+        windows.append(
+            CodexUsageWindow(
+                label=f"{window_hours}h",
+                used_percent=_clamp_percent(primary_window.get("used_percent")),
+                reset_at_ms=_coerce_reset_at_ms(primary_window, current_now_ms),
+            )
+        )
+
+    secondary_window = rate_limit.get("secondary_window") if isinstance(rate_limit.get("secondary_window"), dict) else None
+    if secondary_window:
+        try:
+            window_hours = round(float(secondary_window.get("limit_window_seconds") or 86_400) / 3600)
+        except (TypeError, ValueError):
+            window_hours = 24
+        windows.append(
+            CodexUsageWindow(
+                label=_resolve_secondary_window_label(
+                    window_hours=window_hours,
+                    secondary_reset_at=secondary_window.get("reset_at"),
+                    primary_reset_at=primary_window.get("reset_at") if primary_window else None,
+                ),
+                used_percent=_clamp_percent(secondary_window.get("used_percent")),
+                reset_at_ms=_coerce_reset_at_ms(secondary_window, current_now_ms),
+            )
+        )
+
+    plan = _format_plan(data)
+    return CodexUsageSnapshot(available=bool(windows or plan), plan=plan, windows=windows)
+
+
+def get_current_codex_usage_snapshot(*, timeout: float = 10.0) -> CodexUsageSnapshot:
+    try:
+        from hermes_cli.auth import get_codex_auth_status
+
+        status = get_codex_auth_status()
+        api_key = status.get("api_key") if isinstance(status, dict) else None
+        if not status or not status.get("logged_in") or not isinstance(api_key, str) or not api_key.strip():
+            return CodexUsageSnapshot(available=False, error="Not logged in")
+        account_id = status.get("account_id") if isinstance(status, dict) else None
+        account_id = account_id.strip() if isinstance(account_id, str) and account_id.strip() else None
+        return fetch_codex_usage_snapshot(api_key, account_id=account_id, timeout=timeout)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return CodexUsageSnapshot(available=False, error=str(exc))
+
+
+def format_codex_usage_summary(
+    snapshot: CodexUsageSnapshot,
+    *,
+    now_ms: Optional[int] = None,
+    max_windows: Optional[int] = 2,
+    include_resets: bool = True,
+) -> Optional[str]:
+    if not snapshot.available or not snapshot.windows:
+        return None
+
+    windows = snapshot.windows if not max_windows or max_windows <= 0 else snapshot.windows[:max_windows]
+    parts: list[str] = []
+    for window in windows:
+        remaining = _clamp_percent(100.0 - window.used_percent)
+        reset = _format_reset_remaining(window.reset_at_ms, now_ms=now_ms) if include_resets else None
+        reset_suffix = f" ⏱{reset}" if reset else ""
+        parts.append(f"{window.label} {remaining:.0f}% left{reset_suffix}")
+    return " · ".join(parts)
+
+
+def format_codex_usage_report_lines(
+    snapshot: CodexUsageSnapshot,
+    *,
+    now_ms: Optional[int] = None,
+) -> list[str]:
+    if not snapshot.available or not snapshot.windows:
+        return []
+
+    lines = ["Codex Account Usage:"]
+    if snapshot.plan:
+        lines.append(f"  Plan: {snapshot.plan}")
+    for window in snapshot.windows:
+        remaining = _clamp_percent(100.0 - window.used_percent)
+        reset = _format_reset_remaining(window.reset_at_ms, now_ms=now_ms)
+        suffix = f" · resets {reset}" if reset else ""
+        lines.append(f"  {window.label}: {remaining:.0f}% left{suffix}")
+    return lines
+
+
+def is_codex_provider(provider: Optional[str], base_url: Optional[str] = None) -> bool:
+    if isinstance(provider, str) and provider.strip().lower() == "openai-codex":
+        return True
+    return isinstance(base_url, str) and "chatgpt.com/backend-api/codex" in base_url.lower()

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -28,11 +28,13 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    provider: str | None = None,
+    base_url: str = "",
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
-        provider="anthropic" if cli_obj.model.startswith("anthropic/") else None,
-        base_url="",
+        provider=provider if provider is not None else ("anthropic" if cli_obj.model.startswith("anthropic/") else None),
+        base_url=base_url,
         session_input_tokens=input_tokens if input_tokens is not None else prompt_tokens,
         session_output_tokens=output_tokens if output_tokens is not None else completion_tokens,
         session_cache_read_tokens=cache_read_tokens,
@@ -323,6 +325,68 @@ class TestCLIUsageReport:
         assert "Total cost:" in output
         assert "n/a" in output
         assert "Pricing unknown for glm-5" in output
+
+
+    def test_show_usage_includes_codex_account_usage_block(self, capsys):
+        from hermes_cli.codex_usage import CodexUsageSnapshot, CodexUsageWindow
+
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        cli_obj.verbose = False
+
+        snapshot = CodexUsageSnapshot(
+            available=True,
+            plan="Plus ($12.50)",
+            windows=[
+                CodexUsageWindow(label="3h", used_percent=35.5, reset_at_ms=10_000_000),
+                CodexUsageWindow(label="Week", used_percent=75.0, reset_at_ms=100_000_000),
+            ],
+        )
+
+        with patch("hermes_cli.codex_usage.get_current_codex_usage_snapshot", return_value=snapshot):
+            cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Codex Account Usage" in output
+        assert "Plan:" in output
+        assert "3h: 64% left" in output
+        assert "Week: 25% left" in output
+        assert "Session Token Usage" in output
+
+    def test_show_usage_skips_codex_account_usage_when_probe_unavailable(self, capsys):
+        from hermes_cli.codex_usage import CodexUsageSnapshot
+
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        cli_obj.verbose = False
+
+        with patch(
+            "hermes_cli.codex_usage.get_current_codex_usage_snapshot",
+            return_value=CodexUsageSnapshot(available=False, error="HTTP 401"),
+        ):
+            cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Codex Account Usage" not in output
+        assert "Session Token Usage" in output
 
 
 class TestStatusBarWidthSource:

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -163,14 +163,68 @@ class TestUsageCachedAgent:
         assert "Cache write" not in result
 
     @pytest.mark.asyncio
+    async def test_codex_account_usage_block_added_for_codex_provider(self):
+        from hermes_cli.codex_usage import CodexUsageSnapshot, CodexUsageWindow
+
+        agent = _make_mock_agent(provider="openai-codex", model="gpt-5.4")
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+        snapshot = CodexUsageSnapshot(
+            available=True,
+            plan="Plus ($12.50)",
+            windows=[
+                CodexUsageWindow(label="3h", used_percent=35.5, reset_at_ms=10_000_000),
+                CodexUsageWindow(label="Week", used_percent=75.0, reset_at_ms=100_000_000),
+            ],
+        )
+
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost, \
+             patch("hermes_cli.codex_usage.get_current_codex_usage_snapshot", return_value=snapshot):
+            mock_cost.return_value = MagicMock(amount_usd=None, status="included")
+            result = await runner._handle_usage_command(event)
+
+        assert "Codex Account Usage" in result
+        assert "Plan: Plus ($12.50)" in result
+        assert "3h: 64% left" in result
+        assert "Week: 25% left" in result
+        assert "Session Token Usage" in result
+
+    @pytest.mark.asyncio
+    async def test_codex_account_usage_probe_failure_is_silent(self):
+        from hermes_cli.codex_usage import CodexUsageSnapshot
+
+        agent = _make_mock_agent(provider="openai-codex", model="gpt-5.4")
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost, \
+             patch(
+                 "hermes_cli.codex_usage.get_current_codex_usage_snapshot",
+                 return_value=CodexUsageSnapshot(available=False, error="HTTP 401"),
+             ):
+            mock_cost.return_value = MagicMock(amount_usd=None, status="included")
+            result = await runner._handle_usage_command(event)
+
+        assert "Codex Account Usage" not in result
+        assert "Session Token Usage" in result
+
+    @pytest.mark.asyncio
     async def test_cost_included_status(self):
         """Subscription-included providers show 'included' instead of dollar amount."""
+        from hermes_cli.codex_usage import CodexUsageSnapshot
+
         agent = _make_mock_agent(provider="openai-codex")
         runner = _make_runner(SK, cached_agent=agent)
         event = MagicMock()
 
         with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
-             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost:
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost, \
+             patch(
+                 "hermes_cli.codex_usage.get_current_codex_usage_snapshot",
+                 return_value=CodexUsageSnapshot(available=False, error="HTTP 401"),
+             ):
             mock_cost.return_value = MagicMock(amount_usd=None, status="included")
             result = await runner._handle_usage_command(event)
 

--- a/tests/hermes_cli/test_codex_usage.py
+++ b/tests/hermes_cli/test_codex_usage.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import httpx
+
+from hermes_cli.codex_usage import (
+    CodexUsageSnapshot,
+    CodexUsageWindow,
+    fetch_codex_usage_snapshot,
+    format_codex_usage_report_lines,
+    format_codex_usage_summary,
+)
+
+
+class _Response:
+    def __init__(self, status_code: int, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_codex_usage_snapshot_parses_windows_and_plan():
+    def _get(_url, *, headers, timeout):
+        assert headers["Authorization"] == "Bearer token"
+        assert headers["User-Agent"] == "CodexBar"
+        assert timeout == 5.0
+        return _Response(
+            200,
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "limit_window_seconds": 10_800,
+                        "used_percent": 35.5,
+                        "reset_at": 1_700_000_000,
+                    },
+                    "secondary_window": {
+                        "limit_window_seconds": 604_800,
+                        "used_percent": 75,
+                        "reset_at": 1_700_500_000,
+                    },
+                },
+                "plan_type": "Plus",
+                "credits": {"balance": "12.5"},
+            },
+        )
+
+    snapshot = fetch_codex_usage_snapshot("token", timeout=5.0, get=_get)
+
+    assert snapshot.available is True
+    assert snapshot.plan == "Plus ($12.50)"
+    assert snapshot.windows == [
+        CodexUsageWindow(label="3h", used_percent=35.5, reset_at_ms=1_700_000_000_000),
+        CodexUsageWindow(label="Week", used_percent=75.0, reset_at_ms=1_700_500_000_000),
+    ]
+
+
+def test_fetch_codex_usage_snapshot_prefers_weekly_cadence_over_day_label():
+    snapshot = fetch_codex_usage_snapshot(
+        "token",
+        get=lambda *_args, **_kwargs: _Response(
+            200,
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "limit_window_seconds": 10_800,
+                        "used_percent": 14,
+                        "reset_at": 1_700_000_000,
+                    },
+                    "secondary_window": {
+                        "limit_window_seconds": 86_400,
+                        "used_percent": 20,
+                        "reset_at": 1_700_000_000 + 5 * 24 * 60 * 60,
+                    },
+                }
+            },
+        ),
+    )
+
+    assert [window.label for window in snapshot.windows] == ["3h", "Week"]
+
+
+def test_fetch_codex_usage_snapshot_returns_unavailable_on_http_error():
+    snapshot = fetch_codex_usage_snapshot(
+        "token",
+        get=lambda *_args, **_kwargs: _Response(401, {"error": "unauthorized"}),
+    )
+
+    assert snapshot.available is False
+    assert snapshot.error == "HTTP 401"
+    assert snapshot.windows == []
+
+
+def test_fetch_codex_usage_snapshot_returns_unavailable_on_network_error():
+    def _get(*_args, **_kwargs):
+        raise httpx.ConnectError("boom")
+
+    snapshot = fetch_codex_usage_snapshot("token", get=_get)
+
+    assert snapshot.available is False
+    assert snapshot.windows == []
+    assert snapshot.error == "boom"
+
+
+def test_format_codex_usage_summary_includes_remaining_and_resets():
+    snapshot = CodexUsageSnapshot(
+        available=True,
+        plan="Plus ($12.50)",
+        windows=[
+            CodexUsageWindow(label="3h", used_percent=35.5, reset_at_ms=10_000_000),
+            CodexUsageWindow(label="Week", used_percent=75.0, reset_at_ms=100_000_000),
+        ],
+    )
+
+    summary = format_codex_usage_summary(snapshot, now_ms=1_000_000, include_resets=True)
+
+    assert summary == "3h 64% left ⏱2h 30m · Week 25% left ⏱1d 3h"
+
+
+def test_format_codex_usage_report_lines_renders_plan_and_windows():
+    snapshot = CodexUsageSnapshot(
+        available=True,
+        plan="Plus ($12.50)",
+        windows=[
+            CodexUsageWindow(label="3h", used_percent=35.5, reset_at_ms=10_000_000),
+            CodexUsageWindow(label="Week", used_percent=75.0, reset_at_ms=100_000_000),
+        ],
+    )
+
+    lines = format_codex_usage_report_lines(snapshot, now_ms=1_000_000)
+
+    assert lines == [
+        "Codex Account Usage:",
+        "  Plan: Plus ($12.50)",
+        "  3h: 64% left · resets 2h 30m",
+        "  Week: 25% left · resets 1d 3h",
+    ]


### PR DESCRIPTION
## Summary

- Adds a new `hermes_cli/codex_usage.py` module that fetches live quota usage
  from the OpenAI Codex API (`chatgpt.com/backend-api/wham/usage`) using the
  user's stored auth token
- Surfaces `primary_window` (e.g. `3h`) and `secondary_window` (e.g. `Day`/`Week`)
  quota percentages with countdown-to-reset timers in the `/usage` command
- Integrates into both the CLI (`cli.py`) and Gateway (`gateway/run.py`) usage
  displays, gated behind `is_codex_provider()` so it only activates when the
  agent is configured for the Codex provider

## Details

- `CodexUsageSnapshot` / `CodexUsageWindow` — frozen dataclasses representing
  the parsed API response
- `fetch_codex_usage_snapshot()` — injectable `get` callable for testability,
  handles both `reset_at` (epoch) and `reset_after_seconds` offset fields
- `format_codex_usage_summary()` — compact one-liner for status bars
- `format_codex_usage_report_lines()` — verbose multi-line output with plan
  info for `/usage`
- All integration points wrapped in `try/except Exception: pass` — silently
  skipped if Codex is not configured or auth is unavailable
  
 
 ## Screenshots 

<img width="1530" height="809" alt="image" src="https://github.com/user-attachments/assets/76f0aa52-7de7-4088-833a-4c37afaa53e4" />
 
<img width="475" height="449" alt="image" src="https://github.com/user-attachments/assets/482dffb6-9321-4655-a952-c5b1ab9f5c17" />