### PR TITLE
feat: add configurable fuzzy matching for file edits

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -438,6 +438,17 @@ DEFAULT_CONFIG = {
     # exceed this are rejected with guidance to use offset+limit.
     # 100K chars ≈ 25–35K tokens across typical tokenisers.
     "file_read_max_chars": 100_000,
+
+    # File edit fuzzy matching configuration
+    "file_edit": {
+        "fuzzy_matching": {
+            # Matching strategy for deletion operations (old_string found, new_string is empty)
+            # "inherit"      - Use Hermes default behavior (fuzzy matching enabled)
+            # "exact"        - Force exact match only (safest, prevents accidental deletions)
+            # "conservative" - Use only safe strategies: exact, line_trimmed, whitespace_normalized
+            "deletion_mode": "inherit",
+        },
+    },
     
     "compression": {
         "enabled": True,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -753,8 +753,11 @@ class ShellFileOperations(FileOperations):
         # Import and use fuzzy matching
         from tools.fuzzy_match import fuzzy_find_and_replace
         
+        # Get config for fuzzy matching settings
+        config = getattr(self.env, 'config', None)
+        
         new_content, match_count, _strategy, error = fuzzy_find_and_replace(
-            content, old_string, new_string, replace_all
+            content, old_string, new_string, replace_all, config=config
         )
         
         if error:
@@ -807,8 +810,11 @@ class ShellFileOperations(FileOperations):
         if parse_error:
             return PatchResult(error=f"Failed to parse patch: {parse_error}")
         
+        # Get config for fuzzy matching settings
+        config = getattr(self.env, 'config', None)
+        
         # Apply operations
-        result = apply_v4a_operations(operations, self)
+        result = apply_v4a_operations(operations, self, config=config)
         return result
     
     def _check_lint(self, path: str) -> LintResult:

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -69,6 +69,20 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     if old_string == new_string:
         return content, 0, None, "old_string and new_string are identical"
 
+    # Deletion operations require exact match to prevent accidental data loss.
+    # When new_string is empty, we're deleting - use exact match only.
+    if new_string == "":
+        matches = _strategy_exact(content, old_string)
+        if not matches:
+            return content, 0, None, "Could not find exact match for deletion. Deletion requires precise matching to prevent accidental data loss."
+        if len(matches) > 1 and not replace_all:
+            return content, 0, None, (
+                f"Found {len(matches)} exact matches for deletion. "
+                f"Provide more context to make it unique, or use replace_all=True."
+            )
+        new_content = _apply_replacements(content, matches, new_string)
+        return new_content, len(matches), "exact_for_deletion", None
+
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
         ("exact", _strategy_exact),

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -30,7 +30,7 @@ Usage:
 """
 
 import re
-from typing import Tuple, Optional, List, Callable
+from typing import Tuple, Optional, List, Callable, Dict, Any
 from difflib import SequenceMatcher
 
 UNICODE_MAP = {
@@ -48,7 +48,8 @@ def _unicode_normalize(text: str) -> str:
 
 
 def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
-                            replace_all: bool = False) -> Tuple[str, int, Optional[str], Optional[str]]:
+                            replace_all: bool = False,
+                            config: Optional[Dict[str, Any]] = None) -> Tuple[str, int, Optional[str], Optional[str]]:
     """
     Find and replace text using a chain of increasingly fuzzy matching strategies.
 
@@ -57,6 +58,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         old_string: The text to find
         new_string: The replacement text
         replace_all: If True, replace all occurrences; if False, require uniqueness
+        config: Optional config dict with file_edit.fuzzy_matching settings
 
     Returns:
         Tuple of (new_content, match_count, strategy_name, error_message)
@@ -69,20 +71,54 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     if old_string == new_string:
         return content, 0, None, "old_string and new_string are identical"
 
-    # Deletion operations require exact match to prevent accidental data loss.
-    # When new_string is empty, we're deleting - use exact match only.
-    if new_string == "":
-        matches = _strategy_exact(content, old_string)
-        if not matches:
-            return content, 0, None, "Could not find exact match for deletion. Deletion requires precise matching to prevent accidental data loss."
-        if len(matches) > 1 and not replace_all:
-            return content, 0, None, (
-                f"Found {len(matches)} exact matches for deletion. "
-                f"Provide more context to make it unique, or use replace_all=True."
-            )
-        new_content = _apply_replacements(content, matches, new_string)
-        return new_content, len(matches), "exact_for_deletion", None
+    # Read fuzzy matching configuration
+    cfg = config or {}
+    fm_cfg = cfg.get("file_edit", {}).get("fuzzy_matching", {})
+    deletion_mode = fm_cfg.get("deletion_mode", "inherit")
 
+    # Deletion operations can use stricter matching to prevent accidental data loss.
+    # When new_string is empty, we're deleting - check deletion_mode setting.
+    if new_string == "":
+        if deletion_mode == "exact":
+            # Strategy level 1: exact only (safest)
+            matches = _strategy_exact(content, old_string)
+            if not matches:
+                return content, 0, None, "Could not find exact match for deletion. Deletion requires precise matching to prevent accidental data loss."
+            if len(matches) > 1 and not replace_all:
+                return content, 0, None, (
+                    f"Found {len(matches)} exact matches for deletion. "
+                    f"Provide more context to make it unique, or use replace_all=True."
+                )
+            new_content = _apply_replacements(content, matches, new_string)
+            return new_content, len(matches), "exact_for_deletion", None
+
+        elif deletion_mode == "conservative":
+            # Strategy levels 1-3: exact, line_trimmed, whitespace_normalized
+            conservative_strategies: List[Tuple[str, Callable]] = [
+                ("exact", _strategy_exact),
+                ("line_trimmed", _strategy_line_trimmed),
+                ("whitespace_normalized", _strategy_whitespace_normalized),
+            ]
+            for strategy_name, strategy_fn in conservative_strategies:
+                matches = strategy_fn(content, old_string)
+                if matches:
+                    if len(matches) > 1 and not replace_all:
+                        return content, 0, None, (
+                            f"Found {len(matches)} matches for deletion using {strategy_name}. "
+                            f"Provide more context to make it unique, or use replace_all=True."
+                        )
+                    new_content = _apply_replacements(content, matches, new_string)
+                    return new_content, len(matches), f"{strategy_name}_for_deletion", None
+            return content, 0, None, "Could not find a match for deletion using conservative strategies (exact, line_trimmed, whitespace_normalized)."
+
+        elif deletion_mode == "full":
+            # Strategy levels 1-9: all strategies (least safe, most permissive)
+            # Fall through to normal matching logic below
+            pass
+
+        # deletion_mode == "inherit" or "full" - fall through to normal matching logic below
+
+    # Non-deletion operations, or deletion_mode == "inherit"
     # Try each matching strategy in order
     strategies: List[Tuple[str, Callable]] = [
         ("exact", _strategy_exact),

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -240,6 +240,7 @@ def _count_occurrences(text: str, pattern: str) -> int:
 def _validate_operations(
     operations: List[PatchOperation],
     file_ops: Any,
+    config: Optional[Any] = None,
 ) -> List[str]:
     """Validate all operations without writing any files.
 
@@ -286,7 +287,7 @@ def _validate_operations(
                 replacement = '\n'.join(replace_lines)
 
                 new_simulated, count, _strategy, match_error = fuzzy_find_and_replace(
-                    simulated, search_pattern, replacement, replace_all=False
+                    simulated, search_pattern, replacement, replace_all=False, config=config
                 )
                 if count == 0:
                     label = f"'{hunk.context_hint}'" if hunk.context_hint else "(no hint)"
@@ -323,7 +324,8 @@ def _validate_operations(
 
 
 def apply_v4a_operations(operations: List[PatchOperation],
-                          file_ops: Any) -> 'PatchResult':
+                          file_ops: Any,
+                          config: Optional[Any] = None) -> 'PatchResult':
     """Apply V4A patch operations using a file operations interface.
 
     Uses a two-phase validate-then-apply approach:
@@ -336,6 +338,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
     Args:
         operations: List of PatchOperation from parse_v4a_patch
         file_ops: Object with read_file_raw, write_file methods
+        config: Optional config dict for fuzzy matching settings
 
     Returns:
         PatchResult with results of all operations
@@ -344,7 +347,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
     from tools.file_operations import PatchResult
 
     # ---- Phase 1: validate ----
-    validation_errors = _validate_operations(operations, file_ops)
+    validation_errors = _validate_operations(operations, file_ops, config=config)
     if validation_errors:
         return PatchResult(
             success=False,
@@ -386,7 +389,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
                     errors.append(f"Failed to move {op.file_path}: {result[1]}")
 
             elif op.operation == OperationType.UPDATE:
-                result = _apply_update(op, file_ops)
+                result = _apply_update(op, file_ops, config=config)
                 if result[0]:
                     files_modified.append(op.file_path)
                     all_diffs.append(result[1])
@@ -479,7 +482,7 @@ def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff
 
 
-def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
+def _apply_update(op: PatchOperation, file_ops: Any, config: Optional[Any] = None) -> Tuple[bool, str]:
     """Apply an update file operation."""
     # Deferred import: breaks the patch_parser ↔ fuzzy_match circular dependency
     from tools.fuzzy_match import fuzzy_find_and_replace
@@ -514,7 +517,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
             replacement = '\n'.join(replace_lines)
 
             new_content, count, _strategy, error = fuzzy_find_and_replace(
-                new_content, search_pattern, replacement, replace_all=False
+                new_content, search_pattern, replacement, replace_all=False, config=config
             )
 
             if error and count == 0:
@@ -529,7 +532,7 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
                         window = new_content[window_start:window_end]
 
                         window_new, count, _strategy, error = fuzzy_find_and_replace(
-                            window, search_pattern, replacement, replace_all=False
+                            window, search_pattern, replacement, replace_all=False, config=config
                         )
                         
                         if count > 0:


### PR DESCRIPTION
## Problem

Hermes uses fuzzy matching for file edits. When modifying a file, the match scope can expand beyond user intent, causing **silent data loss**.

## Example

**Original file:**
```markdown
## Character Profile
Yi is a novel writing assistant specializing in sci-fi and mystery.

## Current Status
Working on Chapter 3 of "Stellar Journey", 60% complete
Completed: Chapter 1, Chapter 2

## Writing Style
Prefers first-person narrative...
```

**User says:** "Update the character profile to emphasize she's professional"

**Model generates:**
```
old_string: "## Character Profile\nYi is a novel writing assistant"
new_string: "## Character Profile\nYi is a professional novel writing assistant"
```

**Fuzzy matching matches:**
```markdown
## Character Profile
Yi is a novel writing assistant specializing in sci-fi and mystery.

## Current Status
Working on Chapter 3 of "Stellar Journey", 60% complete
Completed: Chapter 1, Chapter 2
```

**Result:**
```markdown
## Character Profile
Yi is a professional novel writing assistant

## Writing Style
Prefers first-person narrative...
```

**"Current Status" section is gone.** User asked to modify, but got an unintended deletion.

## Root Cause

1. User specifies vaguely in conversation
2. Model infers target text (may be imprecise)
3. Fuzzy matching further expands match scope
4. Result exceeds user's actual intent

## Solution

Add `deletion_mode` config to control matching strictness:

```python
"file_edit": {
    "fuzzy_matching": {
        "deletion_mode": "inherit"  # "exact" | "conservative" | "full" | "inherit"
    }
}
```

| Mode | Strategies Used | Safety |
|------|----------------|--------|
| `"exact"` | Level 1 only | Safest |
| `"conservative"` | Levels 1-3 | Safer |
| `"full"` | All 9 levels | Least safe |
| `"inherit"` | Default behavior | Default |

## Backward Compatible

✅ Default is `"inherit"` — no behavior change unless user configures it.