### PR TITLE
fix(gateway): key email thread context by root Message-ID instead of sender address

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -86,6 +86,23 @@ def check_email_requirements() -> bool:
     return True
 
 
+def _extract_thread_id(message_id: str, in_reply_to: str, references: str) -> str:
+    """Determine the canonical thread ID for an email.
+
+    The thread root is the *first* Message-ID in the References chain.
+    Falls back to In-Reply-To, then to the email's own Message-ID, so that
+    every email — new or reply — always belongs to exactly one thread.
+    Generates a local UUID for malformed emails with no usable identifier.
+    """
+    ids = references.split()
+    return (
+        ids[0] if ids
+        else in_reply_to.strip()
+        or message_id.strip()
+        or f"<local-{uuid.uuid4().hex}@hermes>"
+    )
+
+
 def _decode_header_value(raw: str) -> str:
     """Decode an RFC 2047 encoded email header into a plain string."""
     parts = decode_header(raw)
@@ -244,7 +261,8 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
+        # Map thread_id (root Message-ID) -> {subject, message_id, references}
+        # Each email reply-chain gets its own entry, enabling per-thread sessions.
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
@@ -372,8 +390,10 @@ class EmailAdapter(BasePlatformAdapter):
                         sender_name = sender_name.split("<")[0].strip().strip('"')
 
                     subject = _decode_header_value(msg.get("Subject", "(no subject)"))
-                    message_id = msg.get("Message-ID", "")
-                    in_reply_to = msg.get("In-Reply-To", "")
+                    message_id = msg.get("Message-ID", "").strip()
+                    in_reply_to = msg.get("In-Reply-To", "").strip()
+                    references = msg.get("References", "").strip()
+                    thread_id = _extract_thread_id(message_id, in_reply_to, references)
                     # Skip automated/noreply senders before any processing
                     msg_headers = dict(msg.items())
                     if _is_automated_sender(sender_addr, msg_headers):
@@ -389,6 +409,8 @@ class EmailAdapter(BasePlatformAdapter):
                         "subject": subject,
                         "message_id": message_id,
                         "in_reply_to": in_reply_to,
+                        "references": references,
+                        "thread_id": thread_id,
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
@@ -418,6 +440,7 @@ class EmailAdapter(BasePlatformAdapter):
         subject = msg_data["subject"]
         body = msg_data["body"].strip()
         attachments = msg_data["attachments"]
+        thread_id = msg_data["thread_id"]
 
         # Build message text: include subject as context
         text = body
@@ -436,9 +459,13 @@ class EmailAdapter(BasePlatformAdapter):
                 msg_type = MessageType.PHOTO
 
         # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
+        refs = msg_data["references"]
+        msg_id = msg_data["message_id"]
+        updated_refs = " ".join(filter(None, [refs, msg_id]))
+        self._thread_context[thread_id] = {
             "subject": subject,
-            "message_id": msg_data["message_id"],
+            "message_id": msg_id,
+            "references": updated_refs,
         }
 
         source = self.build_source(
@@ -447,6 +474,7 @@ class EmailAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(
@@ -471,9 +499,10 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
+            thread_id = (metadata or {}).get("thread_id")
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, thread_id
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -485,6 +514,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
@@ -492,7 +522,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(thread_id, {})
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -502,7 +532,7 @@ class EmailAdapter(BasePlatformAdapter):
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+            msg["References"] = ctx.get("references", original_msg_id)
 
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
@@ -532,11 +562,12 @@ class EmailAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image URL as part of an email body."""
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata)
 
     async def send_document(
         self,
@@ -545,9 +576,11 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:
+            thread_id = (metadata or {}).get("thread_id")
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None,
@@ -556,6 +589,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                thread_id,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -568,13 +602,14 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        thread_id: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_context.get(thread_id, {})
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -583,7 +618,7 @@ class EmailAdapter(BasePlatformAdapter):
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+            msg["References"] = ctx.get("references", original_msg_id)
 
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
@@ -616,10 +651,9 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""
-        ctx = self._thread_context.get(chat_id, {})
         return {
             "name": chat_id,
             "type": "dm",
             "chat_id": chat_id,
-            "subject": ctx.get("subject", ""),
+            "subject": "",
         }

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -170,6 +170,40 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertIn("a & b", result)
 
 
+class TestExtractThreadId(unittest.TestCase):
+    """Tests for the _extract_thread_id helper."""
+
+    def setUp(self):
+        from gateway.platforms.email import _extract_thread_id
+        self._fn = _extract_thread_id
+
+    def test_uses_first_references_entry(self):
+        """First Message-ID in References is the thread root."""
+        result = self._fn("<msg3@x>", "<msg2@x>", "<msg1@x> <msg2@x> <msg3@x>")
+        self.assertEqual(result, "<msg1@x>")
+
+    def test_falls_back_to_in_reply_to(self):
+        """With no References, In-Reply-To is the thread root."""
+        result = self._fn("<msg2@x>", "<msg1@x>", "")
+        self.assertEqual(result, "<msg1@x>")
+
+    def test_falls_back_to_message_id(self):
+        """New email with no References or In-Reply-To uses its own Message-ID."""
+        result = self._fn("<msg1@x>", "", "")
+        self.assertEqual(result, "<msg1@x>")
+
+    def test_generates_uuid_when_all_empty(self):
+        """Malformed email with no headers gets a local UUID fallback."""
+        result = self._fn("", "", "")
+        self.assertTrue(result.startswith("<local-"))
+        self.assertIn("@hermes>", result)
+
+    def test_references_single_entry(self):
+        """References with a single entry returns that entry."""
+        result = self._fn("<msg2@x>", "<msg1@x>", "<msg1@x>")
+        self.assertEqual(result, "<msg1@x>")
+
+
 class TestExtractTextBody(unittest.TestCase):
     """Test email body extraction from different message formats."""
 
@@ -404,6 +438,8 @@ class TestDispatchMessage(unittest.TestCase):
             "subject": "Test",
             "message_id": "<msg1@test.com>",
             "in_reply_to": "",
+            "references": "",
+            "thread_id": "<msg1@test.com>",
             "body": "Self message",
             "attachments": [],
             "date": "",
@@ -438,6 +474,8 @@ class TestDispatchMessage(unittest.TestCase):
             "subject": "Help with Python",
             "message_id": "<msg2@test.com>",
             "in_reply_to": "",
+            "references": "",
+            "thread_id": "<msg2@test.com>",
             "body": "How do I use lists?",
             "attachments": [],
             "date": "",
@@ -466,6 +504,8 @@ class TestDispatchMessage(unittest.TestCase):
             "subject": "Re: Help with Python",
             "message_id": "<msg3@test.com>",
             "in_reply_to": "<msg2@test.com>",
+            "references": "<msg2@test.com>",
+            "thread_id": "<msg2@test.com>",
             "body": "Thanks for the help!",
             "attachments": [],
             "date": "",
@@ -494,6 +534,8 @@ class TestDispatchMessage(unittest.TestCase):
             "subject": "Re: test",
             "message_id": "<msg4@test.com>",
             "in_reply_to": "",
+            "references": "",
+            "thread_id": "<msg4@test.com>",
             "body": "",
             "attachments": [],
             "date": "",
@@ -522,6 +564,8 @@ class TestDispatchMessage(unittest.TestCase):
             "subject": "Re: photo",
             "message_id": "<msg5@test.com>",
             "in_reply_to": "",
+            "references": "",
+            "thread_id": "<msg5@test.com>",
             "body": "Check this photo",
             "attachments": [{"path": "/tmp/img.jpg", "filename": "img.jpg", "type": "image", "media_type": "image/jpeg"}],
             "date": "",
@@ -550,6 +594,8 @@ class TestDispatchMessage(unittest.TestCase):
             "subject": "Re: hi",
             "message_id": "<msg6@test.com>",
             "in_reply_to": "",
+            "references": "",
+            "thread_id": "<msg6@test.com>",
             "body": "Hello",
             "attachments": [],
             "date": "",
@@ -561,6 +607,7 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(event.source.user_id, "john@example.com")
         self.assertEqual(event.source.user_name, "John Doe")
         self.assertEqual(event.source.chat_type, "dm")
+        self.assertEqual(event.source.thread_id, "<msg6@test.com>")
 
 
 class TestThreadContext(unittest.TestCase):
@@ -579,7 +626,7 @@ class TestThreadContext(unittest.TestCase):
         return adapter
 
     def test_thread_context_stored_after_dispatch(self):
-        """After dispatching a message, thread context should be stored."""
+        """After dispatching a message, thread context should be keyed by thread_id."""
         import asyncio
         adapter = self._make_adapter()
 
@@ -595,30 +642,33 @@ class TestThreadContext(unittest.TestCase):
             "subject": "Project question",
             "message_id": "<original@test.com>",
             "in_reply_to": "",
+            "references": "",
+            "thread_id": "<original@test.com>",
             "body": "Hello",
             "attachments": [],
             "date": "",
         }
 
         asyncio.run(adapter._dispatch_message(msg_data))
-        ctx = adapter._thread_context.get("user@test.com")
+        ctx = adapter._thread_context.get("<original@test.com>")
         self.assertIsNotNone(ctx)
         self.assertEqual(ctx["subject"], "Project question")
         self.assertEqual(ctx["message_id"], "<original@test.com>")
 
     def test_reply_uses_re_prefix(self):
-        """Reply subject should have Re: prefix."""
+        """Reply subject should have Re: prefix, threading headers set correctly."""
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
+        adapter._thread_context["<original@test.com>"] = {
             "subject": "Project question",
             "message_id": "<original@test.com>",
+            "references": "<original@test.com>",
         }
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Here is the answer.", None)
+            adapter._send_email("user@test.com", "Here is the answer.", None, "<original@test.com>")
 
             # Check the sent message
             send_call = mock_server.send_message.call_args[0][0]
@@ -629,16 +679,17 @@ class TestThreadContext(unittest.TestCase):
     def test_reply_does_not_double_re(self):
         """If subject already has Re:, don't add another."""
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
+        adapter._thread_context["<reply@test.com>"] = {
             "subject": "Re: Project question",
             "message_id": "<reply@test.com>",
+            "references": "<original@test.com> <reply@test.com>",
         }
 
         with patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Follow up.", None)
+            adapter._send_email("user@test.com", "Follow up.", None, "<reply@test.com>")
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Project question")
@@ -656,6 +707,105 @@ class TestThreadContext(unittest.TestCase):
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
+
+
+class TestThreadIdPropagation(unittest.TestCase):
+    """Test that thread_id flows correctly through dispatch → context → send."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def _dispatch(self, adapter, msg_data):
+        import asyncio
+        adapter.handle_message = AsyncMock()
+        asyncio.run(adapter._dispatch_message(msg_data))
+
+    def test_new_email_keyed_by_own_message_id(self):
+        """Email with no References or In-Reply-To is its own thread root."""
+        adapter = self._make_adapter()
+        self._dispatch(adapter, {
+            "uid": b"1", "sender_addr": "a@b.com", "sender_name": "A",
+            "subject": "Hello", "message_id": "<root@x>",
+            "in_reply_to": "", "references": "", "thread_id": "<root@x>",
+            "body": "Hi", "attachments": [], "date": "",
+        })
+        self.assertIn("<root@x>", adapter._thread_context)
+        self.assertNotIn("a@b.com", adapter._thread_context)
+
+    def test_reply_keyed_by_references_root(self):
+        """Reply email's thread_id is the first entry in References."""
+        adapter = self._make_adapter()
+        self._dispatch(adapter, {
+            "uid": b"2", "sender_addr": "a@b.com", "sender_name": "A",
+            "subject": "Re: Hello", "message_id": "<reply@x>",
+            "in_reply_to": "<root@x>", "references": "<root@x>",
+            "thread_id": "<root@x>",
+            "body": "Reply", "attachments": [], "date": "",
+        })
+        self.assertIn("<root@x>", adapter._thread_context)
+        self.assertNotIn("<reply@x>", adapter._thread_context)
+
+    def test_references_accumulated_in_context(self):
+        """thread_context references should include incoming refs + current message_id."""
+        adapter = self._make_adapter()
+        self._dispatch(adapter, {
+            "uid": b"3", "sender_addr": "a@b.com", "sender_name": "A",
+            "subject": "Re: Hello", "message_id": "<r2@x>",
+            "in_reply_to": "<r1@x>", "references": "<root@x> <r1@x>",
+            "thread_id": "<root@x>",
+            "body": "Reply 2", "attachments": [], "date": "",
+        })
+        refs = adapter._thread_context["<root@x>"]["references"]
+        self.assertIn("<root@x>", refs)
+        self.assertIn("<r1@x>", refs)
+        self.assertIn("<r2@x>", refs)
+
+    def test_send_uses_thread_id_from_metadata(self):
+        """send() with metadata thread_id looks up the right thread context."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._thread_context["<root@x>"] = {
+            "subject": "Hello",
+            "message_id": "<root@x>",
+            "references": "<root@x>",
+        }
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            asyncio.run(adapter.send(
+                "a@b.com", "Reply body",
+                metadata={"thread_id": "<root@x>"}
+            ))
+
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent["Subject"], "Re: Hello")
+            self.assertEqual(sent["In-Reply-To"], "<root@x>")
+
+    def test_send_without_thread_id_uses_default_subject(self):
+        """send() with no thread_id in metadata falls back to default subject."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            asyncio.run(adapter.send("a@b.com", "Hello"))
+
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent["Subject"], "Re: Hermes Agent")
+            self.assertIsNone(sent["In-Reply-To"])
 
 
 class TestSendMethods(unittest.TestCase):
@@ -764,18 +914,16 @@ class TestSendMethods(unittest.TestCase):
         asyncio.run(adapter.send_typing("user@test.com"))
 
     def test_get_chat_info(self):
-        """get_chat_info should return email address as chat info."""
+        """get_chat_info should return basic dm info for the email address."""
         import asyncio
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {"subject": "Test", "message_id": "<m@t>"}
 
-        info = asyncio.run(
-            adapter.get_chat_info("user@test.com")
-        )
+        info = asyncio.run(adapter.get_chat_info("user@test.com"))
 
         self.assertEqual(info["name"], "user@test.com")
         self.assertEqual(info["type"], "dm")
-        self.assertEqual(info["subject"], "Test")
+        self.assertEqual(info["chat_id"], "user@test.com")
+        self.assertEqual(info["subject"], "")
 
 
 class TestConnectDisconnect(unittest.TestCase):


### PR DESCRIPTION
## What changed and why

`_thread_context` was keyed by `sender_addr`, so all emails from the same
person shared a single thread entry. If Alice sent two unrelated emails,
the second would clobber the first's context — replies would use the wrong
subject, `In-Reply-To`, and `References` headers, breaking email threading
in most clients.

Introduce `_extract_thread_id()` to derive the canonical thread root per
RFC 2822:
1. First Message-ID in the `References` chain
2. `In-Reply-To` if no References
3. The email's own `Message-ID` for new threads
4. A local UUID fallback for malformed emails with no headers

`_thread_context` is now keyed by this thread root. The full `References`
chain is accumulated on each inbound message so outbound replies carry the
complete header. `thread_id` is propagated through `send()`,
`send_document()`, and `send_image()` via `metadata`.

`get_chat_info()` no longer performs a context lookup — the
`chat_id → thread_id` mapping is one-to-many and `get_chat_info` has no
external callers, so it now returns a static response with `subject: ""`.

## How to test

1. Configure an email adapter and send two unrelated emails from the same address
2. Reply to each — verify each reply has the correct `Subject`, `In-Reply-To`,
   and `References` headers matching its own thread (not the other)
3. Send a reply chain 3+ deep — verify `References` accumulates all
   Message-IDs in order

Unit tests: `pytest tests/gateway/test_email.py -v` (79 tests, all passing)

## Platforms tested

Linux