### PR TITLE
fix(weixin): correct send_image_file parameter name to match base class

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -520,3 +520,63 @@ class TestWeixinMediaBuilder:
         adapter = _make_adapter()
         media_type, builder = adapter._outbound_media_builder("recording.silk")
         assert media_type == weixin.MEDIA_VOICE
+
+
+class TestWeixinSendImageFileParameterName:
+    """Regression test for send_image_file parameter name mismatch.
+
+    The gateway calls send_image_file(chat_id=..., image_path=...) but the
+    WeixinAdapter previously used 'path' as the parameter name, causing
+    image sending to fail. This test ensures the interface stays correct.
+    """
+
+    @patch.object(WeixinAdapter, "send_document", new_callable=AsyncMock)
+    def test_send_image_file_uses_image_path_parameter(self, send_document_mock):
+        """Verify send_image_file accepts image_path and forwards to send_document."""
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+
+        send_document_mock.return_value = weixin.SendResult(success=True, message_id="test-id")
+
+        # This is the call pattern used by gateway/run.py extract_media
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                image_path="/tmp/test_image.png",
+                caption="Test caption",
+                metadata={"thread_id": "thread-123"},
+            )
+        )
+
+        assert result.success is True
+        send_document_mock.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/test_image.png",
+            caption="Test caption",
+            metadata={"thread_id": "thread-123"},
+        )
+
+    @patch.object(WeixinAdapter, "send_document", new_callable=AsyncMock)
+    def test_send_image_file_works_without_optional_params(self, send_document_mock):
+        """Verify send_image_file works with minimal required params."""
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+
+        send_document_mock.return_value = weixin.SendResult(success=True, message_id="test-id")
+
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                image_path="/tmp/test_image.jpg",
+            )
+        )
+
+        assert result.success is True
+        send_document_mock.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/test_image.jpg",
+            caption="",
+            metadata=None,
+        )


### PR DESCRIPTION
## Summary

Fixed a bug in the Weixin adapter where the `send_image_file` method used `path` as the parameter name, but `BasePlatformAdapter` and gateway callers use `image_path`.

## Problem

This mismatch caused image sending to fail on WeChat platform when called through the gateway's `extract_media` path. The gateway would call `send_image_file(chat_id=..., image_path=...)` but the Weixin adapter expected `path=...`, resulting in images not being delivered.

## Fix

Changed parameter name from `path` to `image_path` to match the interface defined in `base.py` and the calls in `gateway/run.py`.

## Testing

Verified by generating an image and sending it via WeChat - the image was successfully delivered after this fix.

---

Generated with help from user rucchi during a live debugging session 🍊