### PR TITLE
fix(status): detect launchd label for external Hermes homes

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -380,26 +380,35 @@ SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 def _profile_suffix() -> str:
     """Derive a service-name suffix from the current HERMES_HOME.
 
-    Returns ``""`` for the default root, the profile name for
+    Returns ``""`` for the native default root, the profile name for
     ``<root>/profiles/<name>``, or a short hash for any other path.
-    Works correctly in Docker (HERMES_HOME=/opt/data) and standard deployments.
+    Works correctly for external custom roots (for example Rocky's
+    ``/Users/.../Rocky/.hermes-home``) and for Docker deployments.
     """
     import hashlib
     import re
-    from hermes_constants import get_default_hermes_root
+
     home = get_hermes_home().resolve()
-    default = get_default_hermes_root().resolve()
-    if home == default:
+    native_default = (Path.home() / ".hermes").resolve()
+    if home == native_default:
         return ""
-    # Detect <root>/profiles/<name> pattern → use the profile name
-    profiles_root = (default / "profiles").resolve()
+
+    profile_name = None
+    native_profiles_root = native_default / "profiles"
     try:
-        rel = home.relative_to(profiles_root)
+        rel = home.relative_to(native_profiles_root)
         parts = rel.parts
-        if len(parts) == 1 and re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", parts[0]):
-            return parts[0]
+        if len(parts) == 1:
+            profile_name = parts[0]
     except ValueError:
         pass
+
+    if profile_name is None and home.parent.name == "profiles":
+        profile_name = home.name
+
+    if profile_name and re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", profile_name):
+        return profile_name
+
     # Fallback: short hash for arbitrary HERMES_HOME paths
     return hashlib.sha256(str(home).encode()).hexdigest()[:8]
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -83,6 +83,13 @@ class TestSystemdServiceRefresh:
         ]
 
 
+class TestProfileScopedServiceNames:
+    def test_custom_external_home_uses_hashed_launchd_label(self, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", "/Users/jakubkrcmar/Dev/Rocky/.hermes-home")
+
+        assert gateway_cli.get_launchd_label() == "ai.hermes.gateway-2fe7f184"
+
+
 class TestGeneratedSystemdUnits:
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=False)


### PR DESCRIPTION
## Summary
- fix launchd label derivation for custom external `HERMES_HOME` paths
- keep default `~/.hermes` behavior unchanged
- keep named profile behavior unchanged
- add regression coverage for a Rocky-style external home path

## Problem
On macOS, Hermes status/update logic uses `get_launchd_label()` to find and restart the installed gateway service.

For a custom external home like:
- `/Users/jakubkrcmar/Dev/Rocky/.hermes-home`

clean `origin/main` derives the plain default label:
- `ai.hermes.gateway`

But the actual installed launchd service for that external home is hash-scoped:
- `ai.hermes.gateway-2fe7f184`

That mismatch means status/restart logic can look for the wrong service label.

## Root cause
`_profile_suffix()` was using `get_default_hermes_root()` as the comparison root for deciding whether the current home was the default home.

In setups where `HERMES_HOME` itself is a custom external root, that could make the external root look like the default root and suppress the hash suffix.

## Fix
Use the native default root (`Path.home() / ".hermes"`) when deciding whether the current home is truly the default installation root.

Behavior after this patch:
- native default `~/.hermes` -> no suffix
- native named profile `~/.hermes/profiles/<name>` -> profile-name suffix
- arbitrary external custom home -> short hash suffix

## Verification
Verified locally on macOS with `HERMES_HOME=/Users/jakubkrcmar/Dev/Rocky/.hermes-home`:

- patched `get_launchd_label()` -> `ai.hermes.gateway-2fe7f184`
- `launchctl list ai.hermes.gateway-2fe7f184` -> success
- `launchctl list ai.hermes.gateway` -> service not found

## Test Plan
- added regression test for a custom external home path
- confirmed default/profile naming logic remains intact by inspection
