### PR TITLE
fix(agent): downgrade xhigh→max on Anthropic pre-4.7 adaptive models

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -30,9 +30,11 @@ logger = logging.getLogger(__name__)
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
 # Anthropic exposes 5 levels on 4.7+: low, medium, high, xhigh, max.
-# We preserve xhigh as xhigh (the recommended default for coding/agentic on
-# 4.7) and expose max as a distinct ceiling. "minimal" is a legacy alias that
-# maps to low.  See:
+# Opus/Sonnet 4.6 only expose 4 levels: low, medium, high, max — no xhigh.
+# We preserve xhigh as xhigh on 4.7+ (the recommended default for coding/
+# agentic work) and downgrade it to max on pre-4.7 adaptive models (which
+# is the strongest level they accept).  "minimal" is a legacy alias that
+# maps to low on every model.  See:
 # https://platform.claude.com/docs/en/about-claude/models/migration-guide
 ADAPTIVE_EFFORT_MAP = {
     "max":     "max",
@@ -42,6 +44,12 @@ ADAPTIVE_EFFORT_MAP = {
     "low":     "low",
     "minimal": "low",
 }
+
+# Models that accept the "xhigh" output_config.effort level.  Opus 4.7 added
+# xhigh as a distinct level between high and max; older adaptive-thinking
+# models (4.6) reject it with a 400.  Keep this substring list in sync with
+# the Anthropic migration guide as new model families ship.
+_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7")
 
 # Models where extended thinking is deprecated/removed (4.6+ behavior: adaptive
 # is the only supported mode; 4.7 additionally forbids manual thinking entirely
@@ -111,6 +119,17 @@ def _get_anthropic_max_output(model: str) -> int:
 def _supports_adaptive_thinking(model: str) -> bool:
     """Return True for Claude 4.6+ models that support adaptive thinking."""
     return any(v in model for v in _ADAPTIVE_THINKING_SUBSTRINGS)
+
+
+def _supports_xhigh_effort(model: str) -> bool:
+    """Return True for models that accept the 'xhigh' adaptive effort level.
+
+    Opus 4.7 introduced xhigh as a distinct level between high and max.
+    Pre-4.7 adaptive models (Opus/Sonnet 4.6) only accept low/medium/high/max
+    and reject xhigh with an HTTP 400. Callers should downgrade xhigh→max
+    when this returns False.
+    """
+    return any(v in model for v in _XHIGH_EFFORT_SUBSTRINGS)
 
 
 def _forbids_sampling_params(model: str) -> bool:
@@ -1392,8 +1411,13 @@ def build_anthropic_kwargs(
                     "type": "adaptive",
                     "display": "summarized",
                 }
+                adaptive_effort = ADAPTIVE_EFFORT_MAP.get(effort, "medium")
+                # Downgrade xhigh→max on models that don't list xhigh as a
+                # supported level (Opus/Sonnet 4.6). Opus 4.7+ keeps xhigh.
+                if adaptive_effort == "xhigh" and not _supports_xhigh_effort(model):
+                    adaptive_effort = "max"
                 kwargs["output_config"] = {
-                    "effort": ADAPTIVE_EFFORT_MAP.get(effort, "medium"),
+                    "effort": adaptive_effort,
                 }
             else:
                 kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -959,13 +959,28 @@ class TestBuildAnthropicKwargs:
         assert "temperature" not in kwargs
         assert kwargs["max_tokens"] == 4096
 
-    def test_reasoning_config_maps_xhigh_to_xhigh_effort_for_4_6_models(self):
-        # Opus 4.7 added "xhigh" as a distinct effort level (the recommended
-        # default for coding/agentic work). Earlier mapping aliased xhigh→max,
-        # which silently over-efforted every request. 2026-04-16 migration
-        # guide: xhigh and max are distinct levels.
+    def test_reasoning_config_downgrades_xhigh_to_max_for_4_6_models(self):
+        # Opus 4.7 added "xhigh" as a distinct effort level (low/medium/high/
+        # xhigh/max). Opus 4.6 only supports low/medium/high/max — sending
+        # "xhigh" there returns an API 400. Preserve the pre-migration
+        # behavior of aliasing xhigh→max on pre-4.7 adaptive models so users
+        # who prefer xhigh as their default don't 400 every request when
+        # switching back to 4.6.
         kwargs = build_anthropic_kwargs(
             model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "think harder"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert kwargs["thinking"] == {"type": "adaptive", "display": "summarized"}
+        assert kwargs["output_config"] == {"effort": "max"}
+
+    def test_reasoning_config_preserves_xhigh_for_4_7_models(self):
+        # On 4.7+ xhigh is a real level and the recommended default for
+        # coding/agentic work — keep it distinct from max.
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
             messages=[{"role": "user", "content": "think harder"}],
             tools=None,
             max_tokens=4096,


### PR DESCRIPTION
## What does this PR do?

Fixes a regression from #11161 (Claude Opus 4.7 migration, merged as
[0517ac3e](https://github.com/NousResearch/hermes-agent/commit/0517ac3e)
earlier today): Hermes now 400s on every request when the user has
`reasoning_effort=xhigh` set and switches to a pre-4.7 Anthropic adaptive model
(Opus/Sonnet 4.6).

### Repro (before this fix)

```
hermes config set model anthropic/claude-opus-4-6
hermes config set agent.reasoning_effort xhigh
hermes chat -q "hi"
```

```
API call failed: BadRequestError [HTTP 400]
Provider: anthropic  Model: claude-opus-4-6
Error: HTTP 400: This model does not support effort level 'xhigh'.
       Supported levels: high, low, max, medium.
```

### Root cause

PR #11161 changed `ADAPTIVE_EFFORT_MAP["xhigh"]` from `"max"` (the pre-migration
alias) to `"xhigh"` to preserve the new 4.7 level as distinct from `max`. That
was correct for Opus 4.7. But per Anthropic's
[migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide),
Opus/Sonnet **4.6** only expose 4 effort levels (low/medium/high/max) — `xhigh`
was added on 4.7 as the recommended default for coding/agentic use:

| Level | 4.6 | 4.7 |
|-------|:---:|:---:|
| max   | ✅  | ✅  |
| xhigh | ❌  | ✅ (new) |
| high  | ✅  | ✅  |
| medium| ✅  | ✅  |
| low   | ✅  | ✅  |

The SDK typing agrees — `anthropic.types.OutputConfigParam.effort:
Literal["low","medium","high","max"]` in `anthropic==0.94.0`. TypedDict isn't
runtime-validated, so the API rejects `xhigh` on 4.6 directly with a 400.

Users who prefer `xhigh` as their default (per the migration guide
recommendation) get a hard 400 the moment they switch back to a 4.6 model —
common during A/B, cost comparison, or when 4.7 hits capacity.

### Fix

Make the adaptive-effort mapping model-aware. Add `_supports_xhigh_effort()`
predicate alongside the existing `_supports_adaptive_thinking()` and
`_forbids_sampling_params()` predicates — same substring-match pattern, matches
`4-7` / `4.7`. On pre-4.7 adaptive models, downgrade `xhigh → max` (the
strongest effort those models accept — restores pre-migration behavior). On
4.7+, keep `xhigh` as a distinct level.

## Related Issue

No open issue — self-reported during a live session right after #11161 shipped.
Regression source: [0517ac3e](https://github.com/NousResearch/hermes-agent/commit/0517ac3e).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`:
  - New `_XHIGH_EFFORT_SUBSTRINGS = ("4-7", "4.7")` module constant.
  - New `_supports_xhigh_effort(model)` predicate (mirrors
    `_supports_adaptive_thinking` / `_forbids_sampling_params`).
  - `build_anthropic_kwargs`: after `ADAPTIVE_EFFORT_MAP` lookup, downgrade
    `xhigh → max` when `_supports_xhigh_effort(model)` is False. 4.7+ path
    unchanged.
  - Updated `ADAPTIVE_EFFORT_MAP` docstring to document the split (4.6 has
    4 levels, 4.7 has 5).
- `tests/agent/test_anthropic_adapter.py`:
  - Replaced `test_reasoning_config_maps_xhigh_to_xhigh_effort_for_4_6_models`
    (which encoded the bugged post-#11161 behavior) with
    `test_reasoning_config_downgrades_xhigh_to_max_for_4_6_models` (asserts the
    API-correct downgrade).
  - Added `test_reasoning_config_preserves_xhigh_for_4_7_models` (asserts
    xhigh stays distinct on 4.7).

## How to Test

Live verification against the Anthropic API (`anthropic==0.94.0`):

```python
from agent.anthropic_adapter import build_anthropic_kwargs
import anthropic
client = anthropic.Anthropic()

for model in ["claude-opus-4-6", "claude-opus-4-7"]:
    kw = build_anthropic_kwargs(
        model=model,
        messages=[{"role": "user", "content": "reply with exactly: ok"}],
        tools=None, max_tokens=1024,
        reasoning_config={"enabled": True, "effort": "xhigh"},
    )
    resp = client.messages.create(**kw)
    print(f"{model} xhigh: OK (sent effort={kw['output_config']['effort']})")
```

Result:

```
claude-opus-4-6 xhigh: OK (sent effort=max)
claude-opus-4-7 xhigh: OK (sent effort=xhigh)
```

Unit tests:

```bash
pytest tests/agent/test_anthropic_adapter.py -q
# 120 passed in 1.05s
```

Broader sweep (agent + run_agent + CLI/gateway reasoning surfaces):

```bash
pytest tests/agent/ tests/run_agent/ tests/cli/test_reasoning_command.py \
       tests/gateway/test_reasoning_command.py -q
# 2140 passed, 7 skipped
# (2 failures are pre-existing on clean upstream/main @ 37913d91:
#  test_credential_pool and test_413_compression — unrelated to this change)
```

## Platforms

Tested on macOS 15.5 / Python 3.11.15 / `anthropic==0.94.0`. No platform-
specific code paths touched — pure Python string matching.

## Author note

This is the regression fix for my own PR #11157 (merged as #11161). Apologies
for the churn — I tested the 4.7 paths thoroughly but missed the 4.6
downgrade case in the review loop. The new model-aware mapping should be the
stable long-term shape: as new Anthropic tiers ship, adding them to
`_XHIGH_EFFORT_SUBSTRINGS` (or the broader model-gate pattern already in
`_ADAPTIVE_THINKING_SUBSTRINGS` / `_NO_SAMPLING_PARAMS_SUBSTRINGS`) is the
one-line update.
