### PR TITLE
fix(honcho): reject whitespace-only tool queries

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -959,7 +959,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": card})
 
             elif tool_name == "honcho_search":
-                query = args.get("query", "")
+                query = args.get("query", "").strip()
                 if not query:
                     return tool_error("Missing required parameter: query")
                 max_tokens = min(int(args.get("max_tokens", 800)), 2000)
@@ -972,7 +972,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": result})
 
             elif tool_name == "honcho_reasoning":
-                query = args.get("query", "")
+                query = args.get("query", "").strip()
                 if not query:
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -525,6 +525,34 @@ class TestConcludeToolDispatch:
         assert parsed == {"error": "Exactly one of conclusion or delete_id must be provided."}
         provider._manager.delete_conclusion.assert_not_called()
 
+    def test_honcho_search_rejects_whitespace_only_query(self):
+        """Whitespace-only query should be treated as missing in honcho_search."""
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call("honcho_search", {"query": "   "})
+
+        parsed = json.loads(result)
+        assert parsed == {"error": "Missing required parameter: query"}
+        provider._manager.search_context.assert_not_called()
+
+    def test_honcho_reasoning_rejects_whitespace_only_query(self):
+        """Whitespace-only query should be treated as missing in honcho_reasoning."""
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call("honcho_reasoning", {"query": "   "})
+
+        parsed = json.loads(result)
+        assert parsed == {"error": "Missing required parameter: query"}
+        provider._manager.dialectic_query.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Message chunking


### PR DESCRIPTION
## Summary
- normalize `honcho_search` and `honcho_reasoning` `query` inputs with `strip()` before validation
- reject whitespace-only `query` as missing required parameter to match existing `honcho_conclude` input hygiene
- add regression tests for whitespace-only `query` in both tool paths

## Test plan
- [x] `python -m pytest tests/honcho_plugin/test_session.py -q -o addopts=`