### PR TITLE
feat: IBKR brokerage integration with Telegram approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ For the full command lists, see the [CLI guide](https://hermes-agent.nousresearc
 
 All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**:
 
+### Brokerage paper-trading subsystem
+
+An in-repo guide for the Telegram -> Hermes -> IBKR paper-trading workflow lives at:
+
+- [docs/brokerage/README.md](docs/brokerage/README.md)
+- [docs/brokerage/openapi.md](docs/brokerage/openapi.md)
+
+It covers local FastAPI service startup, Hermes configuration, IBKR paper setup, current v1 limitations, and safety notes.
+
+
 | Section | What's Covered |
 |---------|---------------|
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |

--- a/brokerage/__init__.py
+++ b/brokerage/__init__.py
@@ -1,0 +1,5 @@
+"""Brokerage subsystem for deterministic trade intent handling and broker execution."""
+
+from .config import BrokerageSettings
+
+__all__ = ["BrokerageSettings"]

--- a/brokerage/__init__.py
+++ b/brokerage/__init__.py
@@ -1,5 +1,12 @@
 """Brokerage subsystem for deterministic trade intent handling and broker execution."""
 
 from .config import BrokerageSettings
+from .models import BrokerSubmissionResult, TradeConfirmation, TradeEvent, TradeIntent
 
-__all__ = ["BrokerageSettings"]
+__all__ = [
+    "BrokerageSettings",
+    "TradeIntent",
+    "TradeConfirmation",
+    "BrokerSubmissionResult",
+    "TradeEvent",
+]

--- a/brokerage/app.py
+++ b/brokerage/app.py
@@ -116,6 +116,12 @@ def create_app(
         except ValueError as exc:
             raise _translate_error(exc) from exc
 
+    @app.get("/positions", dependencies=[Depends(require_auth)])
+    def get_positions(account_mode: str | None = None) -> dict:
+        """Return current broker account positions."""
+        positions = deps.service.get_positions(account_mode=account_mode)
+        return {"positions": positions, "count": len(positions)}
+
     return app
 
 

--- a/brokerage/app.py
+++ b/brokerage/app.py
@@ -83,8 +83,10 @@ def create_app(
         return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
 
     @app.get("/healthz")
-    def healthz() -> dict[str, bool]:
-        return {"ok": True}
+    def healthz() -> dict:
+        """Service health + broker connection status."""
+        broker_health = deps.service.broker.health_check()
+        return {"ok": True, **broker_health}
 
     @app.post("/trade-intents", status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_auth)])
     def create_trade_intent(payload: CreateTradeIntentRequest) -> dict:

--- a/brokerage/app.py
+++ b/brokerage/app.py
@@ -1,0 +1,130 @@
+"""FastAPI surface for the deterministic brokerage service."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from pydantic import BaseModel
+
+from brokerage.brokers.ibkr_tws import IBKRTwsBrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.policy import BrokeragePolicy
+from brokerage.service import BrokerageService
+from brokerage.storage import SQLiteBrokerageStore
+
+
+class CreateTradeIntentRequest(BaseModel):
+    account_mode: str
+    symbol: str
+    side: str
+    quantity: int
+    order_type: str
+    asset_class: str = "stock"
+    limit_price: float | None = None
+    raw_request_text: str | None = None
+    session_id: str | None = None
+    telegram_chat_id: str | None = None
+    market_snapshot: dict | None = None
+
+
+class ConfirmTradeIntentRequest(BaseModel):
+    confirmation_text: str
+
+
+class BrokerageAppDependencies(BaseModel):
+    service: BrokerageService
+    auth_token: str | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+def build_service(settings: BrokerageSettings | None = None) -> BrokerageService:
+    runtime_settings = settings or BrokerageSettings()
+    store = SQLiteBrokerageStore()
+    policy = BrokeragePolicy(runtime_settings)
+    broker = IBKRTwsBrokerAdapter(runtime_settings)
+    return BrokerageService(runtime_settings, store, policy, broker)
+
+
+def create_app(
+    *,
+    service: BrokerageService | None = None,
+    auth_token: str | None = None,
+) -> FastAPI:
+    deps = BrokerageAppDependencies(
+        service=service or build_service(),
+        auth_token=auth_token,
+    )
+    if deps.auth_token is None:
+        deps.auth_token = deps.service.settings.service_token
+
+    app = FastAPI(title="Hermes Brokerage Service", version="0.1.0")
+
+    def require_auth(authorization: str | None = Header(default=None)) -> None:
+        if not deps.auth_token:
+            return
+        if authorization is None or not authorization.startswith("Bearer "):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing or invalid authorization header",
+            )
+        expected = f"Bearer {deps.auth_token}"
+        if not hmac.compare_digest(authorization.encode(), expected.encode()):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Unauthorized",
+            )
+
+    def _translate_error(exc: ValueError) -> HTTPException:
+        detail = str(exc)
+        if detail.startswith("Unknown intent:"):
+            return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.post("/trade-intents", status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_auth)])
+    def create_trade_intent(payload: CreateTradeIntentRequest) -> dict:
+        try:
+            return deps.service.create_intent(**payload.model_dump())
+        except ValueError as exc:
+            raise _translate_error(exc) from exc
+
+    @app.post("/trade-intents/{intent_id}/confirm", dependencies=[Depends(require_auth)])
+    def confirm_trade_intent(intent_id: str, payload: ConfirmTradeIntentRequest) -> dict:
+        try:
+            return deps.service.confirm_intent(intent_id, payload.confirmation_text)
+        except ValueError as exc:
+            raise _translate_error(exc) from exc
+
+    @app.post("/trade-intents/{intent_id}/cancel", dependencies=[Depends(require_auth)])
+    def cancel_trade_intent(intent_id: str) -> dict:
+        try:
+            return deps.service.cancel_intent(intent_id)
+        except ValueError as exc:
+            raise _translate_error(exc) from exc
+
+    @app.get("/trade-intents/{intent_id}", dependencies=[Depends(require_auth)])
+    def get_trade_intent(intent_id: str) -> dict:
+        try:
+            return deps.service.get_intent(intent_id)
+        except ValueError as exc:
+            raise _translate_error(exc) from exc
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("brokerage.app:app", host="127.0.0.1", port=8787, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/brokerage/app.py
+++ b/brokerage/app.py
@@ -16,12 +16,14 @@ from brokerage.storage import SQLiteBrokerageStore
 
 class CreateTradeIntentRequest(BaseModel):
     account_mode: str
+    broker_account: str | None = None
     symbol: str
     side: str
     quantity: int
     order_type: str
     asset_class: str = "stock"
     limit_price: float | None = None
+    stop_price: float | None = None
     raw_request_text: str | None = None
     session_id: str | None = None
     telegram_chat_id: str | None = None
@@ -40,11 +42,25 @@ class BrokerageAppDependencies(BaseModel):
 
 
 def build_service(settings: BrokerageSettings | None = None) -> BrokerageService:
-    runtime_settings = settings or BrokerageSettings()
+    runtime_settings = settings or _load_brokerage_settings_from_config()
     store = SQLiteBrokerageStore()
     policy = BrokeragePolicy(runtime_settings)
     broker = IBKRTwsBrokerAdapter(runtime_settings)
     return BrokerageService(runtime_settings, store, policy, broker)
+
+
+def _load_brokerage_settings_from_config() -> BrokerageSettings:
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+    except Exception:
+        config = {}
+
+    brokerage_config = config.get("brokerage", {}) if isinstance(config, dict) else {}
+    if not isinstance(brokerage_config, dict):
+        brokerage_config = {}
+    return BrokerageSettings(**brokerage_config)
 
 
 def create_app(
@@ -117,9 +133,9 @@ def create_app(
             raise _translate_error(exc) from exc
 
     @app.get("/positions", dependencies=[Depends(require_auth)])
-    def get_positions(account_mode: str | None = None) -> dict:
+    def get_positions(account_mode: str | None = None, account: str | None = None) -> dict:
         """Return current broker account positions."""
-        positions = deps.service.get_positions(account_mode=account_mode)
+        positions = deps.service.get_positions(account_mode=account_mode, account=account)
         return {"positions": positions, "count": len(positions)}
 
     return app

--- a/brokerage/brokers/__init__.py
+++ b/brokerage/brokers/__init__.py
@@ -1,0 +1,6 @@
+"""Broker adapter interfaces for the brokerage subsystem."""
+
+from .base import BrokerAdapter
+from .ibkr_tws import IBKRTwsBrokerAdapter
+
+__all__ = ["BrokerAdapter", "IBKRTwsBrokerAdapter"]

--- a/brokerage/brokers/base.py
+++ b/brokerage/brokers/base.py
@@ -15,7 +15,13 @@ class BrokerAdapter(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_order_status(self, order_id: str):
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
         raise NotImplementedError
 
     @abstractmethod

--- a/brokerage/brokers/base.py
+++ b/brokerage/brokers/base.py
@@ -32,6 +32,14 @@ class BrokerAdapter(ABC):
         """Return broker connection health status. Override in subclasses."""
         return {"connected": False, "mode": None}
 
+    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+        """Return current account positions as a list of dicts.
+
+        Each dict has keys: symbol, position (float), avg_cost (float), account_mode.
+        Override in subclasses. Returns empty list by default.
+        """
+        return []
+
     def disconnect(self) -> None:
         """Graceful disconnect. Override in subclasses."""
         pass

--- a/brokerage/brokers/base.py
+++ b/brokerage/brokers/base.py
@@ -1,0 +1,23 @@
+"""Abstract broker adapter interface."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from brokerage.models import BrokerSubmissionResult, TradeIntent
+
+
+class BrokerAdapter(ABC):
+    """Abstract broker adapter interface."""
+
+    @abstractmethod
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_order_status(self, order_id: str):
+        raise NotImplementedError
+
+    @abstractmethod
+    def cancel_order(self, order_id: str):
+        raise NotImplementedError

--- a/brokerage/brokers/base.py
+++ b/brokerage/brokers/base.py
@@ -21,3 +21,11 @@ class BrokerAdapter(ABC):
     @abstractmethod
     def cancel_order(self, order_id: str):
         raise NotImplementedError
+
+    def health_check(self) -> dict:
+        """Return broker connection health status. Override in subclasses."""
+        return {"connected": False, "mode": None}
+
+    def disconnect(self) -> None:
+        """Graceful disconnect. Override in subclasses."""
+        pass

--- a/brokerage/brokers/base.py
+++ b/brokerage/brokers/base.py
@@ -32,10 +32,10 @@ class BrokerAdapter(ABC):
         """Return broker connection health status. Override in subclasses."""
         return {"connected": False, "mode": None}
 
-    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+    def get_positions(self, *, account_mode: str | None = None, account: str | None = None) -> list[dict]:
         """Return current account positions as a list of dicts.
 
-        Each dict has keys: symbol, position (float), avg_cost (float), account_mode.
+        Each dict has keys: account, symbol, position (float), avg_cost (float), account_mode.
         Override in subclasses. Returns empty list by default.
         """
         return []

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 
@@ -91,7 +92,22 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
 
     # --- Connection management ---
 
+    def _ensure_thread_event_loop(self):
+        """Ensure the current thread has a live asyncio event loop for ib_insync."""
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
+
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop
+
     def _ensure_ib(self):
+        self._ensure_thread_event_loop()
         if IB is None:
             raise RuntimeError("ib_insync is not installed")
         if self._ib is None:

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -212,8 +212,84 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
             broker_status=status,
         )
 
-    def get_order_status(self, order_id: str):
-        raise NotImplementedError("get_order_status not implemented yet")
+    def _find_open_trade(self, order_id: int):
+        ib = self._ensure_ib()
+        for trade in ib.openTrades():
+            trade_order = getattr(trade, "order", None)
+            if getattr(trade_order, "orderId", None) == order_id:
+                return trade
+        return None
+
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
+        try:
+            numeric_order_id = int(order_id)
+        except (TypeError, ValueError):
+            return None
+
+        if account_mode:
+            modes_to_try = [account_mode]
+        elif self.connected_mode:
+            modes_to_try = [self.connected_mode]
+        else:
+            modes_to_try = ["paper", "live"]
+
+        seen_modes: set[str] = set()
+        for mode in modes_to_try:
+            if not mode or mode in seen_modes:
+                continue
+            seen_modes.add(mode)
+            try:
+                self._ensure_connected(mode)
+            except Exception:
+                continue
+
+            trade = self._find_open_trade(numeric_order_id)
+            if trade is not None:
+                broker_status = getattr(getattr(trade, "orderStatus", None), "status", None)
+                return {"broker_status": broker_status}
+
+            try:
+                completed = self._ib.reqCompletedOrders(apiOnly=False)
+            except Exception:
+                completed = []
+            for trade in completed:
+                trade_order = getattr(trade, "order", None)
+                if getattr(trade_order, "orderId", None) == numeric_order_id:
+                    return {
+                        "broker_status": getattr(getattr(trade, "orderStatus", None), "status", None)
+                    }
+
+            try:
+                fills = self._ib.reqExecutions()
+            except Exception:
+                fills = []
+            matching_fills = [
+                fill for fill in fills
+                if getattr(getattr(fill, "execution", None), "orderId", None) == numeric_order_id
+            ]
+            if matching_fills:
+                total_shares = sum(
+                    float(getattr(getattr(fill, "execution", None), "shares", 0) or 0)
+                    for fill in matching_fills
+                )
+                latest_execution = getattr(matching_fills[-1], "execution", None)
+                if expected_quantity is not None and total_shares < expected_quantity:
+                    return {
+                        "broker_status": "PartiallyFilled",
+                        "detail": getattr(latest_execution, "execId", None),
+                    }
+                return {
+                    "broker_status": "Filled",
+                    "detail": getattr(latest_execution, "execId", None),
+                }
+
+        return None
 
     def cancel_order(self, order_id: str):
         raise NotImplementedError("cancel_order not implemented yet")

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -252,6 +252,37 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
             trade = self._find_open_trade(numeric_order_id)
             if trade is not None:
                 broker_status = getattr(getattr(trade, "orderStatus", None), "status", None)
+                # If the open-trade status is non-terminal, cross-check with
+                # execution records — ib_insync's orderStatus can be stale
+                # until the next event-loop tick processes the fill event.
+                non_terminal = {
+                    "PendingSubmit", "PreSubmitted", "Submitted", "ApiPending",
+                    "PendingCancel", "PendingReplace",
+                }
+                if broker_status in non_terminal:
+                    try:
+                        fills = self._ib.reqExecutions()
+                    except Exception:
+                        fills = []
+                    matching_fills = [
+                        fill for fill in fills
+                        if getattr(getattr(fill, "execution", None), "orderId", None) == numeric_order_id
+                    ]
+                    if matching_fills:
+                        total_shares = sum(
+                            float(getattr(getattr(fill, "execution", None), "shares", 0) or 0)
+                            for fill in matching_fills
+                        )
+                        latest_execution = getattr(matching_fills[-1], "execution", None)
+                        if expected_quantity is not None and total_shares < expected_quantity:
+                            return {
+                                "broker_status": "PartiallyFilled",
+                                "detail": getattr(latest_execution, "execId", None),
+                            }
+                        return {
+                            "broker_status": "Filled",
+                            "detail": getattr(latest_execution, "execId", None),
+                        }
                 return {"broker_status": broker_status}
 
             try:

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -324,3 +324,35 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
 
     def cancel_order(self, order_id: str):
         raise NotImplementedError("cancel_order not implemented yet")
+
+    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+        """Return current IBKR account positions.
+
+        Requires an active connection. If account_mode is given and differs
+        from the current connection, reconnects to the appropriate port.
+        """
+        mode = account_mode or self._connected_mode or "paper"
+        try:
+            self._ensure_connected(mode)
+        except Exception as exc:
+            logger.warning("Cannot connect to IBKR for positions query: %s", exc)
+            return []
+
+        if self._ib is None:
+            return []
+
+        try:
+            positions = self._ib.positions()
+        except Exception as exc:
+            logger.warning("Error fetching IBKR positions: %s", exc)
+            return []
+
+        result = []
+        for p in positions:
+            result.append({
+                "symbol": p.contract.symbol,
+                "position": float(p.position),
+                "avg_cost": float(p.avgCost),
+                "account_mode": mode,
+            })
+        return result

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -1,7 +1,8 @@
-"""IBKR TWS / IB Gateway broker adapter."""
+"""IBKR TWS / IB Gateway broker adapter with connection lifecycle management."""
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 from brokerage.brokers.base import BrokerAdapter
@@ -33,6 +34,9 @@ except Exception:  # pragma: no cover - exercised via mocked methods in tests
             self.currency = currency
 
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class _OrderContractBundle:
     contract: object
@@ -40,15 +44,52 @@ class _OrderContractBundle:
 
 
 class IBKRTwsBrokerAdapter(BrokerAdapter):
-    """Minimal IBKR adapter using ib_insync."""
+    """IBKR adapter using ib_insync with connection lifecycle management.
+
+    Features:
+    - Lazy connection: connects on first order submission
+    - Auto-reconnect: detects dropped connections and reconnects
+    - Mode-aware: reconnects when switching between paper/live
+    - Health check: reports connection status for monitoring
+    - Graceful disconnect: clean shutdown support
+    """
 
     def __init__(self, settings: BrokerageSettings, *, host: str = "127.0.0.1"):
         self.settings = settings
         self.host = host
-        self._ib = None
+        self._ib: IB | None = None
+        self._connected_mode: str | None = None
+
+    # --- Connection state properties ---
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if currently connected to TWS/Gateway."""
+        if self._ib is None:
+            return False
+        try:
+            return self._ib.isConnected()
+        except Exception:
+            return False
+
+    @property
+    def connected_mode(self) -> str | None:
+        """Return the account mode of the current connection, or None."""
+        if not self.is_connected:
+            return None
+        return self._connected_mode
+
+    # --- Port selection ---
 
     def _select_port(self, account_mode: str) -> int:
+        """Select the IB Gateway port based on account mode.
+
+        Paper: 4002 (Gateway) / 7497 (TWS)
+        Live:  4001 (Gateway) / 7496 (TWS)
+        """
         return 4002 if account_mode == "paper" else 4001
+
+    # --- Connection management ---
 
     def _ensure_ib(self):
         if IB is None:
@@ -57,10 +98,68 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
             self._ib = IB()
         return self._ib
 
-    def _connect(self, account_mode: str) -> None:
+    def _ensure_connected(self, account_mode: str) -> None:
+        """Ensure we have an active connection for the given account mode.
+
+        - If not connected at all, connect.
+        - If connected but to the wrong mode, reconnect.
+        - If already connected to the right mode, do nothing.
+        """
         ib = self._ensure_ib()
+
+        # Already connected to the correct mode
+        if self.is_connected and self._connected_mode == account_mode:
+            return
+
+        # If connected to a different mode or connection dropped, disconnect first
+        if self.is_connected:
+            logger.info("Disconnecting from %s mode to switch to %s", self._connected_mode, account_mode)
+            self._safe_disconnect()
+
+        # Connect to the requested mode
         port = self._select_port(account_mode)
+        logger.info("Connecting to IB Gateway at %s:%d (%s mode)", self.host, port, account_mode)
         ib.connect(self.host, port, clientId=0)
+        self._connected_mode = account_mode
+
+    def _connect(self, account_mode: str) -> None:
+        """Legacy connect method - delegates to _ensure_connected."""
+        self._ensure_connected(account_mode)
+
+    def _safe_disconnect(self) -> None:
+        """Disconnect without raising errors."""
+        if self._ib is not None:
+            try:
+                self._ib.disconnect()
+            except Exception as exc:
+                logger.warning("Error during disconnect: %s", exc)
+        self._connected_mode = None
+
+    def disconnect(self) -> None:
+        """Graceful disconnect - safe to call even if not connected."""
+        self._safe_disconnect()
+
+    # --- Health check ---
+
+    def health_check(self) -> dict:
+        """Return connection health status for monitoring.
+
+        Returns:
+            dict with 'connected' (bool) and 'mode' (str|None)
+        """
+        connected = self.is_connected
+
+        # If connection dropped, clear the mode
+        if not connected and self._connected_mode is not None:
+            logger.info("Detected dropped connection (was %s mode)", self._connected_mode)
+            self._connected_mode = None
+
+        return {
+            "connected": connected,
+            "mode": self._connected_mode,
+        }
+
+    # --- Order construction ---
 
     def _build_contract(self, intent: TradeIntent):
         if intent.asset_class != "stock":
@@ -79,11 +178,13 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
         qualified = ib.qualifyContracts(contract)
         return qualified[0] if qualified else contract
 
+    # --- Order submission ---
+
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         if intent.asset_class != "stock":
             raise ValueError(f"Unsupported asset class: {intent.asset_class}")
 
-        self._connect(intent.account_mode)
+        self._ensure_connected(intent.account_mode)
         contract = self._qualify_contract(self._build_contract(intent))
         order = self._build_order(intent)
         trade = self._ib.placeOrder(contract, order)

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -1,0 +1,102 @@
+"""IBKR TWS / IB Gateway broker adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from brokerage.brokers.base import BrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import BrokerSubmissionResult, TradeIntent
+
+try:
+    from ib_insync import IB, LimitOrder, MarketOrder, Stock
+except Exception:  # pragma: no cover - exercised via mocked methods in tests
+    IB = None
+
+    class MarketOrder:  # type: ignore[no-redef]
+        def __init__(self, action, totalQuantity):
+            self.action = action
+            self.totalQuantity = totalQuantity
+            self.orderType = "MKT"
+
+    class LimitOrder:  # type: ignore[no-redef]
+        def __init__(self, action, totalQuantity, lmtPrice):
+            self.action = action
+            self.totalQuantity = totalQuantity
+            self.orderType = "LMT"
+            self.lmtPrice = lmtPrice
+
+    class Stock:  # type: ignore[no-redef]
+        def __init__(self, symbol, exchange, currency):
+            self.symbol = symbol
+            self.exchange = exchange
+            self.currency = currency
+
+
+@dataclass
+class _OrderContractBundle:
+    contract: object
+    order: object
+
+
+class IBKRTwsBrokerAdapter(BrokerAdapter):
+    """Minimal IBKR adapter using ib_insync."""
+
+    def __init__(self, settings: BrokerageSettings, *, host: str = "127.0.0.1"):
+        self.settings = settings
+        self.host = host
+        self._ib = None
+
+    def _select_port(self, account_mode: str) -> int:
+        return 4002 if account_mode == "paper" else 4001
+
+    def _ensure_ib(self):
+        if IB is None:
+            raise RuntimeError("ib_insync is not installed")
+        if self._ib is None:
+            self._ib = IB()
+        return self._ib
+
+    def _connect(self, account_mode: str) -> None:
+        ib = self._ensure_ib()
+        port = self._select_port(account_mode)
+        ib.connect(self.host, port, clientId=0)
+
+    def _build_contract(self, intent: TradeIntent):
+        if intent.asset_class != "stock":
+            raise ValueError(f"Unsupported asset class: {intent.asset_class}")
+        return Stock(intent.symbol, "SMART", "USD")
+
+    def _build_order(self, intent: TradeIntent):
+        if intent.order_type == "MARKET":
+            return MarketOrder(intent.side, intent.quantity)
+        if intent.order_type == "LIMIT":
+            return LimitOrder(intent.side, intent.quantity, intent.limit_price)
+        raise ValueError(f"Unsupported order type: {intent.order_type}")
+
+    def _qualify_contract(self, contract):
+        ib = self._ensure_ib()
+        qualified = ib.qualifyContracts(contract)
+        return qualified[0] if qualified else contract
+
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        if intent.asset_class != "stock":
+            raise ValueError(f"Unsupported asset class: {intent.asset_class}")
+
+        self._connect(intent.account_mode)
+        contract = self._qualify_contract(self._build_contract(intent))
+        order = self._build_order(intent)
+        trade = self._ib.placeOrder(contract, order)
+        order_id = getattr(getattr(trade, "order", None), "orderId", None)
+        status = getattr(getattr(trade, "orderStatus", None), "status", None)
+        return BrokerSubmissionResult(
+            accepted=True,
+            broker_order_id=str(order_id) if order_id is not None else None,
+            broker_status=status,
+        )
+
+    def get_order_status(self, order_id: str):
+        raise NotImplementedError("get_order_status not implemented yet")
+
+    def cancel_order(self, order_id: str):
+        raise NotImplementedError("cancel_order not implemented yet")

--- a/brokerage/brokers/ibkr_tws.py
+++ b/brokerage/brokers/ibkr_tws.py
@@ -11,7 +11,7 @@ from brokerage.config import BrokerageSettings
 from brokerage.models import BrokerSubmissionResult, TradeIntent
 
 try:
-    from ib_insync import IB, LimitOrder, MarketOrder, Stock
+    from ib_insync import IB, LimitOrder, MarketOrder, StopOrder, Stock
 except Exception:  # pragma: no cover - exercised via mocked methods in tests
     IB = None
 
@@ -27,6 +27,13 @@ except Exception:  # pragma: no cover - exercised via mocked methods in tests
             self.totalQuantity = totalQuantity
             self.orderType = "LMT"
             self.lmtPrice = lmtPrice
+
+    class StopOrder:  # type: ignore[no-redef]
+        def __init__(self, action, totalQuantity, stopPrice):
+            self.action = action
+            self.totalQuantity = totalQuantity
+            self.orderType = "STP"
+            self.auxPrice = stopPrice
 
     class Stock:  # type: ignore[no-redef]
         def __init__(self, symbol, exchange, currency):
@@ -131,6 +138,7 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
         if self.is_connected:
             logger.info("Disconnecting from %s mode to switch to %s", self._connected_mode, account_mode)
             self._safe_disconnect()
+            ib = self._ensure_ib()
 
         # Connect to the requested mode
         port = self._select_port(account_mode)
@@ -149,6 +157,7 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
                 self._ib.disconnect()
             except Exception as exc:
                 logger.warning("Error during disconnect: %s", exc)
+        self._ib = None
         self._connected_mode = None
 
     def disconnect(self) -> None:
@@ -184,10 +193,17 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
 
     def _build_order(self, intent: TradeIntent):
         if intent.order_type == "MARKET":
-            return MarketOrder(intent.side, intent.quantity)
-        if intent.order_type == "LIMIT":
-            return LimitOrder(intent.side, intent.quantity, intent.limit_price)
-        raise ValueError(f"Unsupported order type: {intent.order_type}")
+            order = MarketOrder(intent.side, intent.quantity)
+        elif intent.order_type == "LIMIT":
+            order = LimitOrder(intent.side, intent.quantity, intent.limit_price)
+        elif intent.order_type == "STOP":
+            order = StopOrder(intent.side, intent.quantity, intent.stop_price)
+        else:
+            raise ValueError(f"Unsupported order type: {intent.order_type}")
+
+        if intent.broker_account:
+            order.account = intent.broker_account
+        return order
 
     def _qualify_contract(self, contract):
         ib = self._ensure_ib()
@@ -325,7 +341,7 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
     def cancel_order(self, order_id: str):
         raise NotImplementedError("cancel_order not implemented yet")
 
-    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+    def get_positions(self, *, account_mode: str | None = None, account: str | None = None) -> list[dict]:
         """Return current IBKR account positions.
 
         Requires an active connection. If account_mode is given and differs
@@ -349,7 +365,10 @@ class IBKRTwsBrokerAdapter(BrokerAdapter):
 
         result = []
         for p in positions:
+            if account is not None and getattr(p, "account", None) != account:
+                continue
             result.append({
+                "account": getattr(p, "account", None),
                 "symbol": p.contract.symbol,
                 "position": float(p.position),
                 "avg_cost": float(p.avgCost),

--- a/brokerage/config.py
+++ b/brokerage/config.py
@@ -14,3 +14,10 @@ class BrokerageSettings(BaseModel):
     default_account_mode: Literal["paper", "live"] = "paper"
     confirmation_ttl_seconds: int = Field(default=120, ge=1)
     allowed_asset_classes: tuple[str, ...] = ("stock",)
+    paper_max_shares: int = Field(default=25, ge=1)
+    paper_max_notional: float = Field(default=2000.0, gt=0)
+    live_enabled: bool = False
+    live_max_shares: int = Field(default=5, ge=1)
+    live_max_notional: float = Field(default=1000.0, gt=0)
+    allowed_symbols: tuple[str, ...] = ()
+    blocked_symbols: tuple[str, ...] = ()

--- a/brokerage/config.py
+++ b/brokerage/config.py
@@ -1,0 +1,16 @@
+"""Configuration models for the brokerage subsystem."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class BrokerageSettings(BaseModel):
+    """Runtime settings for the local brokerage service and Hermes integration."""
+
+    enabled: bool = False
+    service_url: str = "http://127.0.0.1:8787"
+    service_token: str | None = None
+    default_account_mode: Literal["paper", "live"] = "paper"
+    confirmation_ttl_seconds: int = Field(default=120, ge=1)
+    allowed_asset_classes: tuple[str, ...] = ("stock",)

--- a/brokerage/config.py
+++ b/brokerage/config.py
@@ -1,5 +1,6 @@
 """Configuration models for the brokerage subsystem."""
 
+import os
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -10,7 +11,7 @@ class BrokerageSettings(BaseModel):
 
     enabled: bool = False
     service_url: str = "http://127.0.0.1:8787"
-    service_token: str | None = None
+    service_token: str | None = Field(default_factory=lambda: os.getenv("BROKERAGE_SERVICE_TOKEN"))
     default_account_mode: Literal["paper", "live"] = "paper"
     confirmation_ttl_seconds: int = Field(default=120, ge=1)
     allowed_asset_classes: tuple[str, ...] = ("stock",)

--- a/brokerage/config.py
+++ b/brokerage/config.py
@@ -13,6 +13,7 @@ class BrokerageSettings(BaseModel):
     service_url: str = "http://127.0.0.1:8787"
     service_token: str | None = Field(default_factory=lambda: os.getenv("BROKERAGE_SERVICE_TOKEN"))
     default_account_mode: Literal["paper", "live"] = "paper"
+    default_live_account: str | None = Field(default=None)
     confirmation_ttl_seconds: int = Field(default=120, ge=1)
     allowed_asset_classes: tuple[str, ...] = ("stock",)
     paper_max_shares: int = Field(default=25, ge=1)

--- a/brokerage/models.py
+++ b/brokerage/models.py
@@ -21,6 +21,26 @@ TradeStatus = Literal[
     "expired",
 ]
 
+# Legal state transitions: from_status -> set of allowed to_statuses
+LEGAL_TRANSITIONS: dict[str, set[str]] = {
+    "pending_confirmation": {"confirmed", "cancelled", "expired"},
+    "confirmed": {"submitted", "submission_error", "rejected"},
+    "submitted": {"filled", "rejected", "cancelled"},
+    "submission_error": set(),  # dead-end for now; retry path can be added later
+    "filled": set(),            # terminal
+    "rejected": set(),          # terminal
+    "cancelled": set(),         # terminal
+    "expired": set(),           # terminal
+}
+
+
+def is_legal_transition(from_status: str, to_status: str) -> bool:
+    """Check whether a state transition is allowed by the transition graph."""
+    allowed = LEGAL_TRANSITIONS.get(from_status)
+    if allowed is None:
+        return False
+    return to_status in allowed
+
 
 class TradeIntent(BaseModel):
     """A normalized request to place a trade after user confirmation."""

--- a/brokerage/models.py
+++ b/brokerage/models.py
@@ -1,0 +1,85 @@
+"""Domain models for the brokerage subsystem."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+AccountMode = Literal["paper", "live"]
+TradeSide = Literal["BUY", "SELL"]
+OrderType = Literal["MARKET", "LIMIT"]
+AssetClass = Literal["stock"]
+TradeStatus = Literal[
+    "pending_confirmation",
+    "confirmed",
+    "submitted",
+    "filled",
+    "rejected",
+    "cancelled",
+    "expired",
+]
+
+
+class TradeIntent(BaseModel):
+    """A normalized request to place a trade after user confirmation."""
+
+    request_id: str
+    account_mode: AccountMode
+    symbol: str
+    side: TradeSide | str
+    quantity: int = Field(ge=1)
+    order_type: OrderType | str
+    asset_class: AssetClass = "stock"
+    limit_price: float | None = Field(default=None, gt=0)
+    status: TradeStatus = "pending_confirmation"
+
+    @field_validator("symbol")
+    @classmethod
+    def _normalize_symbol(cls, value: str) -> str:
+        value = value.strip().upper()
+        if not value:
+            raise ValueError("symbol cannot be empty")
+        return value
+
+    @field_validator("side", mode="before")
+    @classmethod
+    def _normalize_side(cls, value: str) -> str:
+        value = str(value).strip().upper()
+        if value not in {"BUY", "SELL"}:
+            raise ValueError("side must be BUY or SELL")
+        return value
+
+    @field_validator("order_type", mode="before")
+    @classmethod
+    def _normalize_order_type(cls, value: str) -> str:
+        value = str(value).strip().upper()
+        if value not in {"MARKET", "LIMIT"}:
+            raise ValueError("order_type must be MARKET or LIMIT")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_limit_price_rules(self) -> "TradeIntent":
+        if self.order_type == "LIMIT" and self.limit_price is None:
+            raise ValueError("limit_price is required for LIMIT orders")
+        if self.order_type == "MARKET" and self.limit_price is not None:
+            raise ValueError("limit_price is not allowed for MARKET orders")
+        return self
+
+
+class TradeConfirmation(BaseModel):
+    intent_id: str
+    confirmation_code: str
+
+
+class BrokerSubmissionResult(BaseModel):
+    accepted: bool
+    broker_order_id: str | None = None
+    broker_status: str | None = None
+    detail: str | None = None
+
+
+class TradeEvent(BaseModel):
+    intent_id: str
+    event_type: str
+    detail: str | None = None

--- a/brokerage/models.py
+++ b/brokerage/models.py
@@ -14,6 +14,7 @@ TradeStatus = Literal[
     "pending_confirmation",
     "confirmed",
     "submitted",
+    "submission_error",
     "filled",
     "rejected",
     "cancelled",

--- a/brokerage/models.py
+++ b/brokerage/models.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 AccountMode = Literal["paper", "live"]
 TradeSide = Literal["BUY", "SELL"]
-OrderType = Literal["MARKET", "LIMIT"]
+OrderType = Literal["MARKET", "LIMIT", "STOP"]
 AssetClass = Literal["stock"]
 TradeStatus = Literal[
     "pending_confirmation",
@@ -47,12 +47,14 @@ class TradeIntent(BaseModel):
 
     request_id: str
     account_mode: AccountMode
+    broker_account: str | None = None
     symbol: str
     side: TradeSide | str
     quantity: int = Field(ge=1)
     order_type: OrderType | str
     asset_class: AssetClass = "stock"
     limit_price: float | None = Field(default=None, gt=0)
+    stop_price: float | None = Field(default=None, gt=0)
     status: TradeStatus = "pending_confirmation"
 
     @field_validator("symbol")
@@ -62,6 +64,14 @@ class TradeIntent(BaseModel):
         if not value:
             raise ValueError("symbol cannot be empty")
         return value
+
+    @field_validator("broker_account")
+    @classmethod
+    def _normalize_broker_account(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip().upper()
+        return value or None
 
     @field_validator("side", mode="before")
     @classmethod
@@ -75,16 +85,20 @@ class TradeIntent(BaseModel):
     @classmethod
     def _normalize_order_type(cls, value: str) -> str:
         value = str(value).strip().upper()
-        if value not in {"MARKET", "LIMIT"}:
-            raise ValueError("order_type must be MARKET or LIMIT")
+        if value not in {"MARKET", "LIMIT", "STOP"}:
+            raise ValueError("order_type must be MARKET, LIMIT, or STOP")
         return value
 
     @model_validator(mode="after")
     def _validate_limit_price_rules(self) -> "TradeIntent":
         if self.order_type == "LIMIT" and self.limit_price is None:
             raise ValueError("limit_price is required for LIMIT orders")
-        if self.order_type == "MARKET" and self.limit_price is not None:
-            raise ValueError("limit_price is not allowed for MARKET orders")
+        if self.order_type != "LIMIT" and self.limit_price is not None:
+            raise ValueError("limit_price is only allowed for LIMIT orders")
+        if self.order_type == "STOP" and self.stop_price is None:
+            raise ValueError("stop_price is required for STOP orders")
+        if self.order_type != "STOP" and self.stop_price is not None:
+            raise ValueError("stop_price is only allowed for STOP orders")
         return self
 
 

--- a/brokerage/policy.py
+++ b/brokerage/policy.py
@@ -1,0 +1,92 @@
+"""Deterministic policy checks for brokerage intents and confirmations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from brokerage.config import BrokerageSettings
+from brokerage.models import TradeIntent
+
+
+@dataclass
+class PolicyDecision:
+    allowed: bool
+    reason: str | None = None
+
+
+class BrokeragePolicy:
+    """Policy/risk checks that must pass before any broker submission."""
+
+    def __init__(self, settings: BrokerageSettings):
+        self.settings = settings
+
+    def validate_new_intent(
+        self,
+        intent: TradeIntent,
+        market_snapshot: dict[str, Any] | None = None,
+    ) -> PolicyDecision:
+        if intent.asset_class not in self.settings.allowed_asset_classes:
+            return PolicyDecision(False, f"asset class '{intent.asset_class}' is not allowed")
+
+        if self.settings.allowed_symbols and intent.symbol not in set(self.settings.allowed_symbols):
+            return PolicyDecision(False, f"symbol '{intent.symbol}' is not in the allowed_symbols list")
+
+        if intent.symbol in set(self.settings.blocked_symbols):
+            return PolicyDecision(False, f"symbol '{intent.symbol}' is blocked")
+
+        if intent.account_mode == "live" and not self.settings.live_enabled:
+            return PolicyDecision(False, "live trading is disabled")
+
+        if intent.account_mode == "paper":
+            max_shares = self.settings.paper_max_shares
+            max_notional = self.settings.paper_max_notional
+        else:
+            max_shares = self.settings.live_max_shares
+            max_notional = self.settings.live_max_notional
+
+        if intent.quantity > max_shares:
+            label = "paper_max_shares" if intent.account_mode == "paper" else "live_max_shares"
+            return PolicyDecision(False, f"quantity exceeds {label}")
+
+        estimated_notional = self._estimate_notional(intent, market_snapshot)
+        if estimated_notional is not None and estimated_notional > max_notional:
+            label = "paper_max_notional" if intent.account_mode == "paper" else "live_max_notional"
+            return PolicyDecision(False, f"estimated notional exceeds {label}")
+
+        return PolicyDecision(True)
+
+    def validate_confirmation(
+        self,
+        intent: TradeIntent,
+        *,
+        confirmation_text: str,
+        confirmation_code: str,
+        expires_at: datetime | None = None,
+        now: datetime | None = None,
+    ) -> PolicyDecision:
+        current_time = now or datetime.now(timezone.utc)
+        if expires_at is not None and expires_at <= current_time:
+            return PolicyDecision(False, "confirmation token is expired")
+
+        normalized = " ".join(confirmation_text.strip().split())
+        if intent.account_mode == "live":
+            expected = f"CONFIRM LIVE {intent.side} {intent.quantity} {intent.symbol} {confirmation_code}"
+        else:
+            expected = f"CONFIRM {confirmation_code}"
+
+        if normalized != expected:
+            return PolicyDecision(False, "confirmation text does not match required format")
+
+        return PolicyDecision(True)
+
+    @staticmethod
+    def _estimate_notional(intent: TradeIntent, market_snapshot: dict[str, Any] | None = None) -> float | None:
+        if intent.order_type == "LIMIT" and intent.limit_price is not None:
+            return float(intent.quantity) * float(intent.limit_price)
+
+        if market_snapshot and market_snapshot.get("last_price") is not None:
+            return float(intent.quantity) * float(market_snapshot["last_price"])
+
+        return None

--- a/brokerage/policy.py
+++ b/brokerage/policy.py
@@ -86,6 +86,9 @@ class BrokeragePolicy:
         if intent.order_type == "LIMIT" and intent.limit_price is not None:
             return float(intent.quantity) * float(intent.limit_price)
 
+        if intent.order_type == "STOP" and intent.stop_price is not None:
+            return float(intent.quantity) * float(intent.stop_price)
+
         if market_snapshot and market_snapshot.get("last_price") is not None:
             return float(intent.quantity) * float(market_snapshot["last_price"])
 

--- a/brokerage/service.py
+++ b/brokerage/service.py
@@ -96,13 +96,18 @@ class BrokerageService:
         if not decision.allowed:
             raise ValueError(decision.reason or "confirmation rejected")
 
-        self.store.update_status(intent_id, "confirmed")
+        # CAS transition: pending_confirmation -> confirmed
+        # Prevents double-submission under concurrency — if another request
+        # already transitioned this intent, the CAS will fail.
+        if not self.store.transition_status(intent_id, "pending_confirmation", "confirmed"):
+            raise ValueError("Intent is no longer in pending_confirmation status (concurrent modification)")
+        self.store.consume_confirmation_code(intent_id)
         self.store.append_event(TradeEvent(intent_id=intent_id, event_type="confirmed", detail=confirmation_text))
 
         try:
             result = self.broker.submit_order(intent)
         except Exception as exc:
-            self.store.update_status(intent_id, "submission_error")
+            self.store.transition_status(intent_id, "confirmed", "submission_error")
             self.store.append_event(
                 TradeEvent(intent_id=intent_id, event_type="submission_error", detail=str(exc))
             )
@@ -115,7 +120,7 @@ class BrokerageService:
             }
 
         if result.accepted:
-            self.store.update_status(intent_id, "submitted", ibkr_order_id=result.broker_order_id)
+            self.store.transition_status(intent_id, "confirmed", "submitted", ibkr_order_id=result.broker_order_id)
             self.store.append_event(
                 TradeEvent(intent_id=intent_id, event_type="submitted", detail=result.broker_status)
             )
@@ -127,7 +132,7 @@ class BrokerageService:
                 "detail": result.detail,
             }
 
-        self.store.update_status(intent_id, "rejected")
+        self.store.transition_status(intent_id, "confirmed", "rejected")
         self.store.append_event(
             TradeEvent(intent_id=intent_id, event_type="rejected", detail=result.detail or result.broker_status)
         )

--- a/brokerage/service.py
+++ b/brokerage/service.py
@@ -150,7 +150,53 @@ class BrokerageService:
         return updated
 
     def get_intent(self, intent_id: str) -> dict:
-        return self._require_intent(intent_id)
+        row = self._require_intent(intent_id)
+        return self._refresh_broker_status(row)
+
+    def _refresh_broker_status(self, row: dict) -> dict:
+        if row.get("status") != "submitted" or not row.get("ibkr_order_id"):
+            return row
+
+        try:
+            broker_status = self.broker.get_order_status(
+                row["ibkr_order_id"],
+                account_mode=row.get("account_mode"),
+                expected_quantity=row.get("quantity"),
+            )
+        except Exception:
+            return row
+
+        if not broker_status:
+            return row
+
+        live_status = broker_status.get("broker_status") or broker_status.get("status")
+        row = dict(row)
+        row["broker_status"] = live_status
+        if broker_status.get("detail") is not None:
+            row["broker_detail"] = broker_status["detail"]
+
+        resolved_status = self._map_broker_status(live_status)
+        if resolved_status is None or resolved_status == row["status"]:
+            return row
+
+        transitioned = self.store.transition_status(
+            row["intent_id"],
+            row["status"],
+            resolved_status,
+        )
+        if transitioned:
+            self.store.append_event(
+                TradeEvent(
+                    intent_id=row["intent_id"],
+                    event_type=resolved_status,
+                    detail=broker_status.get("detail") or live_status,
+                )
+            )
+        refreshed = self._require_intent(row["intent_id"])
+        refreshed["broker_status"] = live_status
+        if broker_status.get("detail") is not None:
+            refreshed["broker_detail"] = broker_status["detail"]
+        return refreshed
 
     def expire_stale_intents(self, *, now: datetime | None = None) -> int:
         timestamp = now or datetime.now(timezone.utc)
@@ -174,6 +220,24 @@ class BrokerageService:
             limit_price=row["limit_price"],
             status=row["status"],
         )
+
+    @staticmethod
+    def _map_broker_status(status: str | None) -> str | None:
+        if not status:
+            return None
+
+        normalized = status.strip().upper()
+        if normalized == "FILLED":
+            return "filled"
+        if normalized in {"CANCELLED", "APICANCELLED"}:
+            return "cancelled"
+        if normalized == "PARTIALLYFILLED":
+            return "submitted"
+        if "REJECT" in normalized or normalized == "INACTIVE":
+            return "rejected"
+        if normalized in {"PENDINGSUBMIT", "PRESUBMITTED", "SUBMITTED", "APIPENDING"}:
+            return "submitted"
+        return None
 
     @staticmethod
     def _intent_preview(intent: TradeIntent) -> dict:

--- a/brokerage/service.py
+++ b/brokerage/service.py
@@ -158,6 +158,10 @@ class BrokerageService:
         row = self._require_intent(intent_id)
         return self._refresh_broker_status(row)
 
+    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+        """Return current broker account positions."""
+        return self.broker.get_positions(account_mode=account_mode)
+
     def _refresh_broker_status(self, row: dict) -> dict:
         if row.get("status") != "submitted" or not row.get("ibkr_order_id"):
             return row

--- a/brokerage/service.py
+++ b/brokerage/service.py
@@ -1,0 +1,190 @@
+"""Deterministic service layer for brokerage intent lifecycle management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from secrets import token_hex
+from uuid import uuid4
+
+from brokerage.brokers.base import BrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import TradeEvent, TradeIntent
+from brokerage.policy import BrokeragePolicy
+from brokerage.storage import SQLiteBrokerageStore
+
+
+class BrokerageService:
+    """Create, confirm, cancel, and inspect brokerage trade intents."""
+
+    def __init__(
+        self,
+        settings: BrokerageSettings,
+        store: SQLiteBrokerageStore,
+        policy: BrokeragePolicy,
+        broker: BrokerAdapter,
+    ):
+        self.settings = settings
+        self.store = store
+        self.policy = policy
+        self.broker = broker
+
+    def create_intent(
+        self,
+        *,
+        account_mode: str,
+        symbol: str,
+        side: str,
+        quantity: int,
+        order_type: str,
+        asset_class: str = "stock",
+        limit_price: float | None = None,
+        raw_request_text: str | None = None,
+        session_id: str | None = None,
+        telegram_chat_id: str | None = None,
+        market_snapshot: dict | None = None,
+    ) -> dict:
+        intent = TradeIntent(
+            request_id=self._generate_intent_id(),
+            account_mode=account_mode,
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            order_type=order_type,
+            asset_class=asset_class,
+            limit_price=limit_price,
+            status="pending_confirmation",
+        )
+
+        decision = self.policy.validate_new_intent(intent, market_snapshot=market_snapshot)
+        if not decision.allowed:
+            raise ValueError(decision.reason or "trade intent rejected by policy")
+
+        confirmation_code = self._generate_confirmation_code()
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=self.settings.confirmation_ttl_seconds)
+        self.store.create_intent(
+            intent,
+            confirmation_code=confirmation_code,
+            confirmation_expires_at=expires_at,
+            raw_request_text=raw_request_text,
+            session_id=session_id,
+            telegram_chat_id=telegram_chat_id,
+        )
+        self.store.append_event(TradeEvent(intent_id=intent.request_id, event_type="created", detail=raw_request_text))
+
+        return {
+            "intent_id": intent.request_id,
+            "status": intent.status,
+            "confirmation_code": confirmation_code,
+            "preview": self._intent_preview(intent),
+            "expires_at": expires_at.isoformat(),
+        }
+
+    def confirm_intent(self, intent_id: str, confirmation_text: str, *, now: datetime | None = None) -> dict:
+        row = self._require_intent(intent_id)
+        if row["status"] != "pending_confirmation":
+            raise ValueError("Intent is not in pending_confirmation status")
+
+        intent = self._intent_from_row(row)
+        expires_at = self._parse_optional_datetime(row.get("confirmation_expires_at"))
+        decision = self.policy.validate_confirmation(
+            intent,
+            confirmation_text=confirmation_text,
+            confirmation_code=row["confirmation_code"],
+            expires_at=expires_at,
+            now=now,
+        )
+        if not decision.allowed:
+            raise ValueError(decision.reason or "confirmation rejected")
+
+        self.store.update_status(intent_id, "confirmed")
+        self.store.append_event(TradeEvent(intent_id=intent_id, event_type="confirmed", detail=confirmation_text))
+
+        result = self.broker.submit_order(intent)
+        if result.accepted:
+            self.store.update_status(intent_id, "submitted", ibkr_order_id=result.broker_order_id)
+            self.store.append_event(
+                TradeEvent(intent_id=intent_id, event_type="submitted", detail=result.broker_status)
+            )
+            return {
+                "intent_id": intent_id,
+                "status": "submitted",
+                "broker_order_id": result.broker_order_id,
+                "broker_status": result.broker_status,
+                "detail": result.detail,
+            }
+
+        self.store.update_status(intent_id, "rejected")
+        self.store.append_event(
+            TradeEvent(intent_id=intent_id, event_type="rejected", detail=result.detail or result.broker_status)
+        )
+        return {
+            "intent_id": intent_id,
+            "status": "rejected",
+            "broker_order_id": result.broker_order_id,
+            "broker_status": result.broker_status,
+            "detail": result.detail,
+        }
+
+    def cancel_intent(self, intent_id: str) -> dict:
+        row = self._require_intent(intent_id)
+        if row["status"] != "pending_confirmation":
+            raise ValueError("Only pending_confirmation intents can be cancelled")
+
+        self.store.update_status(intent_id, "cancelled")
+        self.store.append_event(TradeEvent(intent_id=intent_id, event_type="cancelled", detail="cancelled by user"))
+        updated = self._require_intent(intent_id)
+        return updated
+
+    def get_intent(self, intent_id: str) -> dict:
+        return self._require_intent(intent_id)
+
+    def expire_stale_intents(self, *, now: datetime | None = None) -> int:
+        timestamp = now or datetime.now(timezone.utc)
+        return self.store.expire_pending_confirmations(timestamp)
+
+    def _require_intent(self, intent_id: str) -> dict:
+        row = self.store.get_intent(intent_id)
+        if row is None:
+            raise ValueError(f"Unknown intent: {intent_id}")
+        return row
+
+    def _intent_from_row(self, row: dict) -> TradeIntent:
+        return TradeIntent(
+            request_id=row["intent_id"],
+            account_mode=row["account_mode"],
+            symbol=row["symbol"],
+            side=row["side"],
+            quantity=row["quantity"],
+            order_type=row["order_type"],
+            asset_class=row["asset_class"],
+            limit_price=row["limit_price"],
+            status=row["status"],
+        )
+
+    @staticmethod
+    def _intent_preview(intent: TradeIntent) -> dict:
+        preview = {
+            "account_mode": intent.account_mode,
+            "side": intent.side,
+            "symbol": intent.symbol,
+            "quantity": intent.quantity,
+            "order_type": intent.order_type,
+            "asset_class": intent.asset_class,
+        }
+        if intent.limit_price is not None:
+            preview["limit_price"] = intent.limit_price
+        return preview
+
+    @staticmethod
+    def _parse_optional_datetime(value: str | None) -> datetime | None:
+        if not value:
+            return None
+        return datetime.fromisoformat(value)
+
+    @staticmethod
+    def _generate_intent_id() -> str:
+        return f"ti_{uuid4().hex[:12]}"
+
+    @staticmethod
+    def _generate_confirmation_code() -> str:
+        return f"T-{token_hex(2).upper()}"

--- a/brokerage/service.py
+++ b/brokerage/service.py
@@ -99,7 +99,21 @@ class BrokerageService:
         self.store.update_status(intent_id, "confirmed")
         self.store.append_event(TradeEvent(intent_id=intent_id, event_type="confirmed", detail=confirmation_text))
 
-        result = self.broker.submit_order(intent)
+        try:
+            result = self.broker.submit_order(intent)
+        except Exception as exc:
+            self.store.update_status(intent_id, "submission_error")
+            self.store.append_event(
+                TradeEvent(intent_id=intent_id, event_type="submission_error", detail=str(exc))
+            )
+            return {
+                "intent_id": intent_id,
+                "status": "submission_error",
+                "broker_order_id": None,
+                "broker_status": None,
+                "detail": f"broker submission failed: {exc}",
+            }
+
         if result.accepted:
             self.store.update_status(intent_id, "submitted", ibkr_order_id=result.broker_order_id)
             self.store.append_event(
@@ -128,7 +142,7 @@ class BrokerageService:
     def cancel_intent(self, intent_id: str) -> dict:
         row = self._require_intent(intent_id)
         if row["status"] != "pending_confirmation":
-            raise ValueError("Only pending_confirmation intents can be cancelled")
+            raise ValueError(f"Only pending_confirmation intents can be cancelled (current: {row['status']})")
 
         self.store.update_status(intent_id, "cancelled")
         self.store.append_event(TradeEvent(intent_id=intent_id, event_type="cancelled", detail="cancelled by user"))

--- a/brokerage/service.py
+++ b/brokerage/service.py
@@ -38,6 +38,8 @@ class BrokerageService:
         order_type: str,
         asset_class: str = "stock",
         limit_price: float | None = None,
+        stop_price: float | None = None,
+        broker_account: str | None = None,
         raw_request_text: str | None = None,
         session_id: str | None = None,
         telegram_chat_id: str | None = None,
@@ -46,12 +48,14 @@ class BrokerageService:
         intent = TradeIntent(
             request_id=self._generate_intent_id(),
             account_mode=account_mode,
+            broker_account=self._resolve_broker_account(account_mode=account_mode, broker_account=broker_account),
             symbol=symbol,
             side=side,
             quantity=quantity,
             order_type=order_type,
             asset_class=asset_class,
             limit_price=limit_price,
+            stop_price=stop_price,
             status="pending_confirmation",
         )
 
@@ -158,9 +162,9 @@ class BrokerageService:
         row = self._require_intent(intent_id)
         return self._refresh_broker_status(row)
 
-    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+    def get_positions(self, *, account_mode: str | None = None, account: str | None = None) -> list[dict]:
         """Return current broker account positions."""
-        return self.broker.get_positions(account_mode=account_mode)
+        return self.broker.get_positions(account_mode=account_mode, account=account)
 
     def _refresh_broker_status(self, row: dict) -> dict:
         if row.get("status") != "submitted" or not row.get("ibkr_order_id"):
@@ -221,12 +225,14 @@ class BrokerageService:
         return TradeIntent(
             request_id=row["intent_id"],
             account_mode=row["account_mode"],
+            broker_account=row.get("broker_account"),
             symbol=row["symbol"],
             side=row["side"],
             quantity=row["quantity"],
             order_type=row["order_type"],
             asset_class=row["asset_class"],
             limit_price=row["limit_price"],
+            stop_price=row.get("stop_price"),
             status=row["status"],
         )
 
@@ -258,9 +264,20 @@ class BrokerageService:
             "order_type": intent.order_type,
             "asset_class": intent.asset_class,
         }
+        if intent.broker_account is not None:
+            preview["broker_account"] = intent.broker_account
         if intent.limit_price is not None:
             preview["limit_price"] = intent.limit_price
+        if intent.stop_price is not None:
+            preview["stop_price"] = intent.stop_price
         return preview
+
+    def _resolve_broker_account(self, *, account_mode: str, broker_account: str | None) -> str | None:
+        if broker_account is not None:
+            return broker_account
+        if account_mode == "live":
+            return self.settings.default_live_account
+        return None
 
     @staticmethod
     def _parse_optional_datetime(value: str | None) -> datetime | None:

--- a/brokerage/storage.py
+++ b/brokerage/storage.py
@@ -119,6 +119,19 @@ class SQLiteBrokerageStore:
             )
             conn.commit()
 
+    def transition_status(self, intent_id: str, from_status: str, to_status: str, *, ibkr_order_id: str | None = None) -> bool:
+        with self._connect() as conn:
+            result = conn.execute(
+                """
+                UPDATE trade_intents
+                SET status = ?, ibkr_order_id = COALESCE(?, ibkr_order_id)
+                WHERE intent_id = ? AND status = ?
+                """,
+                (to_status, ibkr_order_id, intent_id, from_status),
+            )
+            conn.commit()
+            return result.rowcount > 0
+
     def append_event(self, event: TradeEvent) -> None:
         with self._connect() as conn:
             conn.execute(

--- a/brokerage/storage.py
+++ b/brokerage/storage.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from hermes_constants import get_hermes_home
 
-from brokerage.models import TradeEvent, TradeIntent
+from brokerage.models import TradeEvent, TradeIntent, is_legal_transition
 
 
 class SQLiteBrokerageStore:
@@ -112,6 +112,19 @@ class SQLiteBrokerageStore:
         return dict(row) if row else None
 
     def update_status(self, intent_id: str, status: str, *, ibkr_order_id: str | None = None) -> None:
+        """Update status with transition graph enforcement.
+
+        Raises ValueError if the transition is not legal.
+        For CAS (compare-and-swap) safety, prefer transition_status() instead.
+        """
+        current = self.get_intent(intent_id)
+        if current is None:
+            raise ValueError(f"Unknown intent: {intent_id}")
+        if not is_legal_transition(current["status"], status):
+            raise ValueError(
+                f"Illegal state transition: {current['status']} -> {status} "
+                f"for intent {intent_id}"
+            )
         with self._connect() as conn:
             conn.execute(
                 "UPDATE trade_intents SET status = ?, ibkr_order_id = COALESCE(?, ibkr_order_id) WHERE intent_id = ?",
@@ -120,6 +133,15 @@ class SQLiteBrokerageStore:
             conn.commit()
 
     def transition_status(self, intent_id: str, from_status: str, to_status: str, *, ibkr_order_id: str | None = None) -> bool:
+        """CAS status transition with transition graph enforcement.
+
+        Returns True if the transition succeeded (row matched from_status).
+        Raises ValueError if the transition is not legal regardless of current state.
+        """
+        if not is_legal_transition(from_status, to_status):
+            raise ValueError(
+                f"Illegal state transition: {from_status} -> {to_status}"
+            )
         with self._connect() as conn:
             result = conn.execute(
                 """
@@ -128,6 +150,23 @@ class SQLiteBrokerageStore:
                 WHERE intent_id = ? AND status = ?
                 """,
                 (to_status, ibkr_order_id, intent_id, from_status),
+            )
+            conn.commit()
+            return result.rowcount > 0
+
+    def consume_confirmation_code(self, intent_id: str) -> bool:
+        """Null out the confirmation code after successful use.
+
+        Returns True if the code was consumed (was non-null before).
+        """
+        with self._connect() as conn:
+            result = conn.execute(
+                """
+                UPDATE trade_intents
+                SET confirmation_code = NULL
+                WHERE intent_id = ? AND confirmation_code IS NOT NULL
+                """,
+                (intent_id,),
             )
             conn.commit()
             return result.rowcount > 0

--- a/brokerage/storage.py
+++ b/brokerage/storage.py
@@ -1,0 +1,151 @@
+"""SQLite persistence for brokerage intents and audit events."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+from brokerage.models import TradeEvent, TradeIntent
+
+
+class SQLiteBrokerageStore:
+    """Persist brokerage intents and audit events in SQLite."""
+
+    def __init__(self, db_path: str | Path | None = None):
+        self.db_path = Path(db_path) if db_path is not None else get_hermes_home() / "brokerage" / "brokerage.db"
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialize_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trade_intents (
+                    intent_id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    account_mode TEXT NOT NULL,
+                    symbol TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    quantity INTEGER NOT NULL,
+                    order_type TEXT NOT NULL,
+                    limit_price REAL,
+                    asset_class TEXT NOT NULL,
+                    confirmation_code TEXT,
+                    confirmation_expires_at TEXT,
+                    session_id TEXT,
+                    telegram_chat_id TEXT,
+                    ibkr_order_id TEXT,
+                    raw_request_text TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trade_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    intent_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    detail TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
+
+    def create_intent(
+        self,
+        intent: TradeIntent,
+        *,
+        confirmation_code: str,
+        confirmation_expires_at: datetime | None = None,
+        raw_request_text: str | None = None,
+        session_id: str | None = None,
+        telegram_chat_id: str | None = None,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO trade_intents (
+                    intent_id, created_at, status, account_mode, symbol, side,
+                    quantity, order_type, limit_price, asset_class,
+                    confirmation_code, confirmation_expires_at,
+                    session_id, telegram_chat_id, ibkr_order_id, raw_request_text
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    intent.request_id,
+                    datetime.now(timezone.utc).isoformat(),
+                    intent.status,
+                    intent.account_mode,
+                    intent.symbol,
+                    intent.side,
+                    intent.quantity,
+                    intent.order_type,
+                    intent.limit_price,
+                    intent.asset_class,
+                    confirmation_code,
+                    confirmation_expires_at.isoformat() if confirmation_expires_at else None,
+                    session_id,
+                    telegram_chat_id,
+                    None,
+                    raw_request_text,
+                ),
+            )
+            conn.commit()
+
+    def get_intent(self, intent_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM trade_intents WHERE intent_id = ?",
+                (intent_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def update_status(self, intent_id: str, status: str, *, ibkr_order_id: str | None = None) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE trade_intents SET status = ?, ibkr_order_id = COALESCE(?, ibkr_order_id) WHERE intent_id = ?",
+                (status, ibkr_order_id, intent_id),
+            )
+            conn.commit()
+
+    def append_event(self, event: TradeEvent) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO trade_events (intent_id, event_type, detail, created_at) VALUES (?, ?, ?, ?)",
+                (event.intent_id, event.event_type, event.detail, datetime.now(timezone.utc).isoformat()),
+            )
+            conn.commit()
+
+    def list_events(self, intent_id: str) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT intent_id, event_type, detail, created_at FROM trade_events WHERE intent_id = ? ORDER BY id ASC",
+                (intent_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def expire_pending_confirmations(self, now: datetime) -> int:
+        with self._connect() as conn:
+            result = conn.execute(
+                """
+                UPDATE trade_intents
+                SET status = 'expired'
+                WHERE status = 'pending_confirmation'
+                  AND confirmation_expires_at IS NOT NULL
+                  AND confirmation_expires_at < ?
+                """,
+                (now.isoformat(),),
+            )
+            conn.commit()
+            return result.rowcount

--- a/brokerage/storage.py
+++ b/brokerage/storage.py
@@ -34,11 +34,13 @@ class SQLiteBrokerageStore:
                     created_at TEXT NOT NULL,
                     status TEXT NOT NULL,
                     account_mode TEXT NOT NULL,
+                    broker_account TEXT,
                     symbol TEXT NOT NULL,
                     side TEXT NOT NULL,
                     quantity INTEGER NOT NULL,
                     order_type TEXT NOT NULL,
                     limit_price REAL,
+                    stop_price REAL,
                     asset_class TEXT NOT NULL,
                     confirmation_code TEXT,
                     confirmation_expires_at TEXT,
@@ -49,6 +51,11 @@ class SQLiteBrokerageStore:
                 )
                 """
             )
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(trade_intents)")}
+            if "broker_account" not in columns:
+                conn.execute("ALTER TABLE trade_intents ADD COLUMN broker_account TEXT")
+            if "stop_price" not in columns:
+                conn.execute("ALTER TABLE trade_intents ADD COLUMN stop_price REAL")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS trade_events (
@@ -76,22 +83,24 @@ class SQLiteBrokerageStore:
             conn.execute(
                 """
                 INSERT INTO trade_intents (
-                    intent_id, created_at, status, account_mode, symbol, side,
-                    quantity, order_type, limit_price, asset_class,
+                    intent_id, created_at, status, account_mode, broker_account, symbol, side,
+                    quantity, order_type, limit_price, stop_price, asset_class,
                     confirmation_code, confirmation_expires_at,
                     session_id, telegram_chat_id, ibkr_order_id, raw_request_text
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     intent.request_id,
                     datetime.now(timezone.utc).isoformat(),
                     intent.status,
                     intent.account_mode,
+                    intent.broker_account,
                     intent.symbol,
                     intent.side,
                     intent.quantity,
                     intent.order_type,
                     intent.limit_price,
+                    intent.stop_price,
                     intent.asset_class,
                     confirmation_code,
                     confirmation_expires_at.isoformat() if confirmation_expires_at else None,

--- a/brokerage_server.py
+++ b/brokerage_server.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Standalone runner for the Hermes Brokerage FastAPI service.
+
+Usage:
+    python brokerage_server.py [--host HOST] [--port PORT] [--token TOKEN] [--reload]
+
+Defaults:
+    Host: 127.0.0.1
+    Port: 8787
+    Token: BROKERAGE_SERVICE_TOKEN env var, or "dev-token" in dev mode
+
+This script starts the FastAPI app defined in brokerage/app.py using uvicorn.
+It is intended for local development and as the entry point for `hermes brokerage start`.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path so `brokerage` package is importable
+PROJECT_ROOT = Path(__file__).parent.resolve()
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Start the Hermes Brokerage FastAPI service")
+    parser.add_argument("--host", default=os.environ.get("BROKERAGE_HOST", "127.0.0.1"),
+                        help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("BROKERAGE_PORT", "8787")),
+                        help="Bind port (default: 8787)")
+    parser.add_argument("--token", default=os.environ.get("BROKERAGE_SERVICE_TOKEN", ""),
+                        help="Bearer auth token (default: BROKERAGE_SERVICE_TOKEN env var)")
+    parser.add_argument("--reload", action="store_true",
+                        help="Enable auto-reload for development")
+    parser.add_argument("--no-auth", action="store_true",
+                        help="Disable bearer token authentication (dev only)")
+
+    args = parser.parse_args()
+
+    # Set env vars that the FastAPI app reads at startup
+    if args.token:
+        os.environ["BROKERAGE_SERVICE_TOKEN"] = args.token
+    elif args.no_auth:
+        os.environ["BROKERAGE_SERVICE_TOKEN"] = ""
+    elif not os.environ.get("BROKERAGE_SERVICE_TOKEN"):
+        # Dev mode: generate a random token and print it
+        import secrets
+        dev_token = f"dev-{secrets.token_hex(8)}"
+        os.environ["BROKERAGE_SERVICE_TOKEN"] = dev_token
+        print(f"⚠  No token set. Using generated dev token: {dev_token}")
+        print(f"   Add to ~/.hermes/.env: BROKERAGE_SERVICE_TOKEN={dev_token}")
+
+    try:
+        import uvicorn
+    except ImportError:
+        print("Error: uvicorn is not installed. Install with: pip install uvicorn", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Starting Hermes Brokerage Service on {args.host}:{args.port}")
+    print(f"  Auth: {'disabled' if args.no_auth else 'bearer token required'}")
+    print(f"  Health: http://{args.host}:{args.port}/healthz")
+
+    uvicorn.run(
+        "brokerage.app:create_app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        factory=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/brokerage/README.md
+++ b/docs/brokerage/README.md
@@ -1,0 +1,233 @@
+# Brokerage Paper-Trading Guide
+
+This subsystem lets Hermes turn a chat request into a deterministic brokerage workflow:
+
+1. The user asks for a trade in natural language.
+2. Hermes creates a pending structured trade intent.
+3. The local brokerage service returns a confirmation code.
+4. The user explicitly confirms with the exact code.
+5. Deterministic Python code validates, persists, risk-checks, and submits the order.
+
+The LLM is intentionally not allowed to submit trades directly from raw natural language.
+
+## What v1 does
+
+- Telegram + Hermes driven trading workflow
+- Local FastAPI brokerage service
+- SQLite persistence for intents and audit events
+- IBKR TWS / IB Gateway adapter via `ib_insync`
+- Paper trading first
+- US stocks only
+- Market and limit orders only
+- Explicit text confirmation before submission
+
+## Current v1 limitations
+
+- Paper mode is the intended operating mode today
+- Live mode is still gated and should be treated as not ready for normal use
+- No options, futures, forex, crypto, or short selling
+- No autonomous trading or strategy execution
+- No Telegram inline button confirmations yet
+- No quote-fetching dependency for previews; keep sizing limits conservative
+- Real broker connectivity still requires a logged-in local TWS / IB Gateway session
+
+## Required dependencies
+
+The project includes a trading extra:
+
+```bash
+uv pip install -e ".[trading,dev]"
+```
+
+That extra currently installs:
+
+- `fastapi>=0.104.0,<1`
+- `uvicorn[standard]>=0.24.0,<1`
+- `ib_insync>=0.9.86,<1`
+
+If you are working inside the Hermes virtualenv and `python -m pip` is unavailable, use:
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python 'fastapi>=0.104.0,<1' 'uvicorn[standard]>=0.24.0,<1' 'ib_insync>=0.9.86,<1'
+```
+
+## IBKR local setup
+
+For phase 1, use IB Gateway Paper or TWS Paper running on the same machine as Hermes.
+
+### Default IBKR ports
+
+- TWS live: `7496`
+- TWS paper: `7497`
+- IB Gateway live: `4001`
+- IB Gateway paper: `4002`
+
+### Recommended phase-1 choice
+
+Use IB Gateway Paper.
+
+The current adapter defaults to IB Gateway ports:
+
+- paper -> `4002`
+- live -> `4001`
+
+### TWS / IB Gateway API settings
+
+In TWS or IB Gateway, enable the API/socket connection settings needed for local clients.
+
+Typical local setup checklist:
+
+- Log in to your paper account
+- Enable API connections in TWS / IB Gateway settings
+- Allow localhost connections
+- Confirm the expected socket port
+- Keep the app running while testing Hermes brokerage flows
+
+Important IBKR constraint: this is not a fully headless cloud-native flow. A logged-in local IBKR app session is still required.
+
+## Running the local brokerage service
+
+Start the FastAPI service locally:
+
+```bash
+uvicorn brokerage.app:app --host 127.0.0.1 --port 8787
+```
+
+Or:
+
+```bash
+python -m brokerage.app
+```
+
+The default local service URL is:
+
+```text
+http://127.0.0.1:8787
+```
+
+## Hermes configuration
+
+Hermes reads brokerage settings from the `brokerage` section in `~/.hermes/config.yaml`.
+
+Current default config shape:
+
+```yaml
+brokerage:
+  enabled: false
+  service_url: http://127.0.0.1:8787
+  default_account_mode: paper
+  confirmation_ttl_seconds: 120
+```
+
+The deterministic backend also supports policy settings such as:
+
+- `paper_max_shares`
+- `paper_max_notional`
+- `live_enabled`
+- `live_max_shares`
+- `live_max_notional`
+- `allowed_symbols`
+- `blocked_symbols`
+
+A practical local config looks like this:
+
+```yaml
+brokerage:
+  enabled: true
+  service_url: http://127.0.0.1:8787
+  default_account_mode: paper
+  confirmation_ttl_seconds: 120
+```
+
+The shared bearer token is intended to come from environment-backed config:
+
+```text
+BROKERAGE_SERVICE_TOKEN=replace-me-with-a-long-random-secret
+```
+
+Example env file: `examples/brokerage.env.example`
+
+## Enabling the Hermes brokerage tools
+
+The brokerage wrappers live in a dedicated `brokerage` toolset and are not enabled globally by default.
+
+Enable them in Hermes, then start a fresh session:
+
+```bash
+hermes tools enable brokerage
+```
+
+After changing toolsets, start a new session or use `/reset` so the updated toolset is available to the agent.
+
+## HTTP API summary
+
+The local service exposes:
+
+- `GET /healthz`
+- `POST /trade-intents`
+- `POST /trade-intents/{intent_id}/confirm`
+- `POST /trade-intents/{intent_id}/cancel`
+- `GET /trade-intents/{intent_id}`
+
+See also: `docs/brokerage/openapi.md`
+
+## Example paper-trading flow
+
+User request:
+
+```text
+Buy 1 share of AAPL at market in paper
+```
+
+Expected behavior:
+
+1. Hermes calls `create_trade_intent`
+2. The service stores a `pending_confirmation` intent
+3. Hermes shows a preview and confirmation code such as `T-82K4`
+4. User replies with exact text:
+
+```text
+CONFIRM T-82K4
+```
+
+5. Hermes calls `confirm_trade_intent`
+6. The service validates policy, submits through the broker adapter, and persists final status
+7. Hermes can call `get_trade_intent_status` to report the result
+
+## Local development checklist
+
+1. Install trading dependencies
+2. Run IB Gateway Paper locally and log in
+3. Start the brokerage FastAPI service on `127.0.0.1:8787`
+4. Set `brokerage.enabled: true` in Hermes config
+5. Set `BROKERAGE_SERVICE_TOKEN`
+6. Enable the `brokerage` toolset in Hermes
+7. Start a fresh Hermes session and run a paper trade request
+
+## Security notes
+
+This project is intentionally designed to separate natural-language interpretation from actual execution.
+
+Key safeguards already in place:
+
+- Trade requests become pending intents first
+- Confirmation requires an explicit second message
+- State transitions are persisted in SQLite
+- Policy checks run before broker submission
+- Paper and live are configured separately
+- Live trading is disabled by default
+
+## Live-trading warning
+
+Do not treat this branch as production-ready for live money.
+
+Before enabling live trading in any serious way, you should add at minimum:
+
+- stronger operational auth and host hardening
+- stricter risk limits and symbol allowlists
+- order-status reconciliation and retry design
+- better cancellation and fill handling
+- stronger audit/reporting workflows
+- manual operational runbooks and smoke tests
+
+For now, use IBKR paper trading only.

--- a/docs/brokerage/openapi.md
+++ b/docs/brokerage/openapi.md
@@ -1,0 +1,150 @@
+# Brokerage FastAPI Service
+
+Local-only HTTP API for the deterministic brokerage engine.
+
+## Run
+
+```bash
+uvicorn brokerage.app:app --host 127.0.0.1 --port 8787
+```
+
+Or:
+
+```bash
+python -m brokerage.app
+```
+
+## Authentication
+
+When `brokerage.service_token` is configured, all trade-intent endpoints require:
+
+```text
+Authorization: Bearer <TOKEN>
+```
+
+`GET /healthz` is intentionally unauthenticated.
+
+## Endpoints
+
+### `GET /healthz`
+
+Response:
+
+```json
+{
+  "ok": true
+}
+```
+
+### `POST /trade-intents`
+
+Create a pending trade intent.
+
+Request body:
+
+```json
+{
+  "account_mode": "paper",
+  "symbol": "AAPL",
+  "side": "BUY",
+  "quantity": 10,
+  "order_type": "MARKET",
+  "asset_class": "stock",
+  "raw_request_text": "buy 10 shares of AAPL at market in paper"
+}
+```
+
+Response:
+
+```json
+{
+  "intent_id": "ti_123456789abc",
+  "status": "pending_confirmation",
+  "confirmation_code": "T-82K4",
+  "preview": {
+    "account_mode": "paper",
+    "side": "BUY",
+    "symbol": "AAPL",
+    "quantity": 10,
+    "order_type": "MARKET",
+    "asset_class": "stock"
+  },
+  "expires_at": "2026-04-14T22:30:00+00:00"
+}
+```
+
+### `POST /trade-intents/{intent_id}/confirm`
+
+Submit a confirmation phrase for a pending intent.
+
+Request body:
+
+```json
+{
+  "confirmation_text": "CONFIRM T-82K4"
+}
+```
+
+Response on accepted broker submission:
+
+```json
+{
+  "intent_id": "ti_123456789abc",
+  "status": "submitted",
+  "broker_order_id": "ib-123",
+  "broker_status": "Submitted",
+  "detail": null
+}
+```
+
+Response on broker rejection:
+
+```json
+{
+  "intent_id": "ti_123456789abc",
+  "status": "rejected",
+  "broker_order_id": null,
+  "broker_status": "Rejected",
+  "detail": "insufficient buying power"
+}
+```
+
+### `POST /trade-intents/{intent_id}/cancel`
+
+Cancel a pending confirmation before broker submission.
+
+Response:
+
+```json
+{
+  "intent_id": "ti_123456789abc",
+  "status": "cancelled",
+  "account_mode": "paper",
+  "symbol": "AAPL",
+  "side": "BUY",
+  "quantity": 10,
+  "order_type": "MARKET",
+  "asset_class": "stock",
+  "confirmation_code": "T-82K4",
+  "confirmation_expires_at": "2026-04-14T22:30:00+00:00",
+  "created_at": "2026-04-14T22:28:00+00:00"
+}
+```
+
+### `GET /trade-intents/{intent_id}`
+
+Fetch the current stored state for an intent.
+
+Response shape matches the persisted SQLite trade-intent row, including current `status`, `confirmation_code`, `confirmation_expires_at`, and `ibkr_order_id` when present.
+
+## Error behavior
+
+- `401 Unauthorized`
+  - Missing bearer header when auth is enabled
+  - Wrong bearer token
+- `400 Bad Request`
+  - Invalid order payload
+  - Confirmation phrase mismatch
+  - Cancel/confirm attempted from an invalid state
+- `404 Not Found`
+  - Unknown `intent_id`

--- a/docs/plans/2026-04-14-telegram-hermes-ibkr-brokerage-system.md
+++ b/docs/plans/2026-04-14-telegram-hermes-ibkr-brokerage-system.md
@@ -1,0 +1,968 @@
+# Telegram → Hermes → IBKR Brokerage System Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build an open-source, extensible brokerage workflow where a user sends a natural-language trade request to Hermes over Telegram, Hermes creates a pending structured trade intent, the user explicitly confirms it in chat, and deterministic code submits the order to IBKR paper trading first and live trading later.
+
+**Architecture:** Keep the LLM in the UI/intent-formation role only. Actual validation, confirmation state, risk checks, persistence, and broker submission must live in deterministic Python code behind a local FastAPI service. Hermes should integrate with that service via a custom tool so the execution layer stays testable, auditable, and reusable across Telegram and other Hermes gateways.
+
+**Tech Stack:** Python 3.11, FastAPI, Pydantic, SQLite (stdlib `sqlite3`), `ib_insync`, `httpx`, Hermes tool registry, pytest, pytest-asyncio.
+
+---
+
+## Non-Goals for v1
+
+- No options, futures, forex, crypto, or short selling
+- No autonomous trading or strategy execution
+- No direct LLM-to-broker order placement without confirmation
+- No broker abstraction beyond IBKR in the first release, though the code should be broker-extensible
+- No Telegram-specific inline-button UX in v1; use confirmation messages with deterministic tokens first
+
+## Core Safety Rules
+
+1. The assistant never directly places a trade from raw natural language.
+2. Every request becomes a `pending` trade intent first.
+3. The user must explicitly confirm with an exact confirmation token before submission.
+4. Paper and live must be separate modes with distinct confirmations and config.
+5. The deterministic service enforces all policy checks before broker submission.
+6. Every state transition is durably logged.
+
+## Recommended Repository Layout
+
+```text
+brokerage/
+├── __init__.py
+├── config.py
+├── models.py
+├── storage.py
+├── policy.py
+├── service.py
+├── app.py
+└── brokers/
+    ├── __init__.py
+    ├── base.py
+    └── ibkr_tws.py
+
+tools/
+└── brokerage_tool.py
+
+tests/
+├── brokerage/
+│   ├── test_models.py
+│   ├── test_storage.py
+│   ├── test_policy.py
+│   ├── test_service.py
+│   ├── test_app.py
+│   └── test_ibkr_tws.py
+└── tools/
+    └── test_brokerage_tool.py
+
+docs/
+├── plans/
+│   └── 2026-04-14-telegram-hermes-ibkr-brokerage-system.md
+└── brokerage/
+    ├── README.md
+    └── openapi.md
+```
+
+---
+
+## Task 0: Prepare git workspace safely
+
+**Objective:** Start from a clean, reviewable workspace before implementation.
+
+**Files:**
+- No code changes required
+
+**Step 1: Inspect git status**
+
+Run:
+```bash
+git status --short --branch
+```
+Expected: See current branch and any unrelated modified/untracked files.
+
+**Step 2: Avoid mixing unrelated work**
+
+If unrelated files are present, either commit/stash them first or create a fresh worktree.
+
+Preferred:
+```bash
+git fetch origin
+git worktree add ../hermes-brokerage-worktree -b feat/brokerage-telegram-ibkr origin/main
+```
+
+Fallback in the current tree only after cleaning unrelated files:
+```bash
+git checkout -b feat/brokerage-telegram-ibkr
+```
+
+**Step 3: Verify clean workspace**
+
+Run:
+```bash
+git status --short
+```
+Expected: no unrelated changes.
+
+**Step 4: Commit**
+
+No commit for this task.
+
+---
+
+## Task 1: Add packaging and config scaffolding for the brokerage subsystem
+
+**Objective:** Make the repo capable of shipping a brokerage subsystem and optional trading dependencies.
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `hermes_cli/config.py`
+- Create: `brokerage/__init__.py`
+- Create: `brokerage/config.py`
+- Test: `tests/brokerage/test_models.py`
+
+**Step 1: Write failing test for config defaults**
+
+Create `tests/brokerage/test_models.py` with a first test like:
+```python
+from brokerage.config import BrokerageSettings
+
+
+def test_brokerage_settings_defaults_to_paper_mode_and_local_service():
+    settings = BrokerageSettings()
+    assert settings.service_url == "http://127.0.0.1:8787"
+    assert settings.default_account_mode == "paper"
+    assert settings.confirmation_ttl_seconds == 120
+```
+
+**Step 2: Run test to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_models.py::test_brokerage_settings_defaults_to_paper_mode_and_local_service -v
+```
+Expected: FAIL because `brokerage.config` does not exist yet.
+
+**Step 3: Add minimal implementation**
+
+Create:
+- `brokerage/__init__.py`
+- `brokerage/config.py`
+
+Implement a `BrokerageSettings` Pydantic model with at least:
+- `service_url: str = "http://127.0.0.1:8787"`
+- `service_token: str | None = None`
+- `default_account_mode: Literal["paper", "live"] = "paper"`
+- `confirmation_ttl_seconds: int = 120`
+- `allowed_asset_classes: tuple[str, ...] = ("stock",)`
+
+Modify `pyproject.toml`:
+- add `"brokerage", "brokerage.*"` to `[tool.setuptools.packages.find].include`
+- add optional extra:
+```toml
+trading = [
+  "fastapi>=0.104.0,<1",
+  "uvicorn[standard]>=0.24.0,<1",
+  "ib_insync>=0.9.86,<1",
+]
+```
+
+Modify `hermes_cli/config.py`:
+- add a `brokerage` section to `DEFAULT_CONFIG`
+- add `BROKERAGE_SERVICE_TOKEN` to optional env vars if appropriate
+
+**Step 4: Run test to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_models.py::test_brokerage_settings_defaults_to_paper_mode_and_local_service -v
+```
+Expected: PASS.
+
+**Step 5: Run targeted regression checks**
+
+Run:
+```bash
+pytest tests/brokerage/test_models.py -v
+```
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add pyproject.toml hermes_cli/config.py brokerage/__init__.py brokerage/config.py tests/brokerage/test_models.py
+git commit -m "feat: add brokerage config scaffolding"
+```
+
+---
+
+## Task 2: Define domain models for trade intents and state transitions
+
+**Objective:** Create explicit typed models for pending confirmations, broker submissions, and audit events.
+
+**Files:**
+- Create: `brokerage/models.py`
+- Modify: `tests/brokerage/test_models.py`
+
+**Step 1: Write failing tests for domain models**
+
+Add tests for:
+- valid paper trade intent
+- invalid live mode without stricter confirmation requirements
+- allowed order types (`market`, `limit`)
+- status transitions (`pending_confirmation`, `confirmed`, `submitted`, `filled`, `rejected`, `cancelled`, `expired`)
+
+Example:
+```python
+from brokerage.models import TradeIntent
+
+
+def test_trade_intent_normalizes_symbol_to_uppercase():
+    intent = TradeIntent(
+        request_id="r1",
+        account_mode="paper",
+        symbol="aapl",
+        side="buy",
+        quantity=10,
+        order_type="market",
+        asset_class="stock",
+    )
+    assert intent.symbol == "AAPL"
+    assert intent.side == "BUY"
+```
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_models.py -v
+```
+Expected: FAIL because `TradeIntent` does not exist.
+
+**Step 3: Write minimal implementation**
+
+In `brokerage/models.py`, define:
+- `TradeIntent`
+- `TradeConfirmation`
+- `BrokerSubmissionResult`
+- `TradeEvent`
+- enums/literals for account mode, side, order type, status
+
+Rules:
+- normalize `symbol` uppercase
+- normalize `side` uppercase (`BUY`/`SELL`)
+- support only `asset_class="stock"` in v1
+- `limit_price` required for limit orders, forbidden for market orders
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_models.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add brokerage/models.py tests/brokerage/test_models.py
+git commit -m "feat: add brokerage domain models"
+```
+
+---
+
+## Task 3: Build SQLite persistence for intents and audit events
+
+**Objective:** Persist intents and every state transition durably for traceability and recovery.
+
+**Files:**
+- Create: `brokerage/storage.py`
+- Create: `tests/brokerage/test_storage.py`
+
+**Step 1: Write failing tests**
+
+Add tests covering:
+- schema initialization
+- insert trade intent
+- update status
+- fetch by `intent_id`
+- append audit event
+- expire stale pending intents
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_storage.py -v
+```
+Expected: FAIL because storage module does not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement a `SQLiteBrokerageStore` using stdlib `sqlite3`.
+
+Database location:
+- `get_hermes_home() / "brokerage" / "brokerage.db"`
+
+Create tables:
+- `trade_intents`
+- `trade_events`
+
+Minimum columns on `trade_intents`:
+- `intent_id`
+- `created_at`
+- `status`
+- `account_mode`
+- `symbol`
+- `side`
+- `quantity`
+- `order_type`
+- `limit_price`
+- `asset_class`
+- `confirmation_code`
+- `confirmation_expires_at`
+- `telegram_chat_id` (optional metadata only; keep generic naming if preferred)
+- `session_id`
+- `ibkr_order_id`
+- `raw_request_text`
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_storage.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add brokerage/storage.py tests/brokerage/test_storage.py
+git commit -m "feat: add brokerage sqlite persistence"
+```
+
+---
+
+## Task 4: Implement deterministic policy and risk checks
+
+**Objective:** Enforce guardrails before any broker submission.
+
+**Files:**
+- Create: `brokerage/policy.py`
+- Create: `tests/brokerage/test_policy.py`
+
+**Step 1: Write failing tests**
+
+Cover these rules:
+- paper and live are explicit only
+- only stocks allowed in v1
+- only market and limit orders allowed in v1
+- quantity must be positive integer
+- block notional above configured cap
+- block expired confirmation tokens
+- require stronger confirmation phrase for live mode
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_policy.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- `PolicyDecision`
+- `BrokeragePolicy`
+- `validate_new_intent(intent, market_snapshot=None)`
+- `validate_confirmation(intent, confirmation_text)`
+
+Configuration knobs:
+- `paper_max_shares`
+- `paper_max_notional`
+- `live_enabled`
+- `live_max_shares`
+- `live_max_notional`
+- `allowed_symbols` / `blocked_symbols` (optional simple lists)
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_policy.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add brokerage/policy.py tests/brokerage/test_policy.py
+git commit -m "feat: add brokerage policy engine"
+```
+
+---
+
+## Task 5: Add broker adapter interface and IBKR TWS implementation
+
+**Objective:** Isolate IBKR-specific behavior behind a stable broker interface.
+
+**Files:**
+- Create: `brokerage/brokers/__init__.py`
+- Create: `brokerage/brokers/base.py`
+- Create: `brokerage/brokers/ibkr_tws.py`
+- Create: `tests/brokerage/test_ibkr_tws.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- paper mode chooses paper port
+- live mode chooses live port
+- adapter maps `BUY/SELL` + `market/limit` into IB order objects
+- adapter rejects unsupported asset classes/order types
+- submission response captures broker order id/status
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_ibkr_tws.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+In `brokerage/brokers/base.py` define:
+- `BrokerAdapter` protocol / abstract base class
+- `submit_order(intent) -> BrokerSubmissionResult`
+- `get_order_status(order_id)`
+- `cancel_order(order_id)`
+
+In `brokerage/brokers/ibkr_tws.py` implement `IBKRTwsBrokerAdapter` using `ib_insync`.
+
+Defaults from IBKR docs:
+- TWS live: `7496`
+- TWS paper: `7497`
+- IB Gateway live: `4001`
+- IB Gateway paper: `4002`
+
+Prefer IB Gateway defaults in examples, but keep ports configurable.
+
+Do not require a real TWS/IB Gateway session in tests. Mock `ib_insync.IB`.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_ibkr_tws.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add brokerage/brokers/__init__.py brokerage/brokers/base.py brokerage/brokers/ibkr_tws.py tests/brokerage/test_ibkr_tws.py
+git commit -m "feat: add ibkr tws broker adapter"
+```
+
+---
+
+## Task 6: Build the brokerage service state machine
+
+**Objective:** Centralize create/confirm/cancel/submit logic in deterministic code.
+
+**Files:**
+- Create: `brokerage/service.py`
+- Create: `tests/brokerage/test_service.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- creating a new intent returns a confirmation code and `pending_confirmation`
+- confirming with wrong token fails
+- confirming after expiry fails
+- confirming with valid token moves to `submitted` when broker accepts
+- broker rejection moves to `rejected`
+- cancelling pending intent moves to `cancelled`
+- intent IDs and confirmation codes are one-time use
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_service.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Implement a `BrokerageService` that composes:
+- `BrokerageSettings`
+- `SQLiteBrokerageStore`
+- `BrokeragePolicy`
+- `BrokerAdapter`
+
+Public methods:
+- `create_intent(...)`
+- `confirm_intent(intent_id, confirmation_text)`
+- `cancel_intent(intent_id)`
+- `get_intent(intent_id)`
+- `expire_stale_intents()`
+
+Generate confirmation codes like `T-82K4` or longer. Keep them short enough for Telegram, but unguessable enough for safe single-user use.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_service.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add brokerage/service.py tests/brokerage/test_service.py
+git commit -m "feat: add brokerage service state machine"
+```
+
+---
+
+## Task 7: Expose the service over FastAPI
+
+**Objective:** Make the deterministic brokerage engine available to Hermes through a local HTTP API.
+
+**Files:**
+- Create: `brokerage/app.py`
+- Create: `tests/brokerage/test_app.py`
+- Create: `docs/brokerage/openapi.md`
+
+**Step 1: Write failing API tests**
+
+Cover these endpoints:
+- `GET /healthz`
+- `POST /trade-intents`
+- `POST /trade-intents/{intent_id}/confirm`
+- `POST /trade-intents/{intent_id}/cancel`
+- `GET /trade-intents/{intent_id}`
+
+Use `fastapi.testclient.TestClient`.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_app.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Implement a FastAPI app bound locally only.
+
+Use a bearer token header for Hermes → service requests, for example:
+- `Authorization: Bearer <BROKERAGE_SERVICE_TOKEN>`
+
+Suggested response shape for create:
+```json
+{
+  "intent_id": "ti_123",
+  "status": "pending_confirmation",
+  "confirmation_code": "T-82K4",
+  "preview": {
+    "account_mode": "paper",
+    "side": "BUY",
+    "symbol": "AAPL",
+    "quantity": 10,
+    "order_type": "MARKET"
+  }
+}
+```
+
+Add a small `main()` so users can run:
+```bash
+uvicorn brokerage.app:app --host 127.0.0.1 --port 8787
+```
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_app.py -v
+```
+Expected: PASS.
+
+**Step 5: Document the API**
+
+Write `docs/brokerage/openapi.md` summarizing endpoints, auth header, and sample payloads.
+
+**Step 6: Commit**
+
+```bash
+git add brokerage/app.py tests/brokerage/test_app.py docs/brokerage/openapi.md
+git commit -m "feat: add brokerage fastapi service"
+```
+
+---
+
+## Task 8: Add Hermes brokerage tools that call the local service
+
+**Objective:** Let Hermes convert chat messages into structured intents and confirmations without embedding broker logic in the LLM loop.
+
+**Files:**
+- Create: `tools/brokerage_tool.py`
+- Modify: `model_tools.py`
+- Modify: `toolsets.py`
+- Create: `tests/tools/test_brokerage_tool.py`
+
+**Step 1: Write failing tool tests**
+
+Cover:
+- tool registration succeeds
+- create-intent tool sends expected payload to local service
+- confirm-intent tool forwards confirmation text and intent id
+- cancel-intent tool works
+- service errors become JSON errors
+- tool availability is gated by config/token presence
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/tools/test_brokerage_tool.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Create `tools/brokerage_tool.py` with these initial tools:
+- `create_trade_intent`
+- `confirm_trade_intent`
+- `cancel_trade_intent`
+- `get_trade_intent_status`
+
+Recommended schema for `create_trade_intent`:
+- `account_mode`
+- `symbol`
+- `side`
+- `quantity`
+- `order_type`
+- `limit_price` (optional)
+- `asset_class` (default `stock`)
+- `time_in_force` (optional, default `DAY`)
+- `raw_user_text` (optional; persisted for audit)
+
+Tool description must instruct the model:
+- create pending intent first
+- never submit a trade without confirmation
+- if the user has not confirmed, do not call confirm tool
+
+Modify `model_tools.py` to import `tools.brokerage_tool` in `_discover_tools()`.
+
+Modify `toolsets.py`:
+- add toolset `brokerage`
+- do not include it in `_HERMES_CORE_TOOLS` yet unless you explicitly want this enabled everywhere
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/tools/test_brokerage_tool.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tools/brokerage_tool.py model_tools.py toolsets.py tests/tools/test_brokerage_tool.py
+git commit -m "feat: add hermes brokerage tools"
+```
+
+---
+
+## Task 9: Write end-to-end paper-trading tests with a fake broker
+
+**Objective:** Prove the full intent → confirm → submit flow without requiring a live IBKR session.
+
+**Files:**
+- Modify: `tests/brokerage/test_service.py`
+- Modify: `tests/tools/test_brokerage_tool.py`
+- Optionally create: `tests/brokerage/test_end_to_end.py`
+
+**Step 1: Write failing tests**
+
+Add an end-to-end case:
+1. create AAPL paper market intent
+2. receive confirmation code
+3. confirm exact code
+4. fake broker returns accepted order id
+5. final status is `submitted`
+
+Add a rejection case too.
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_end_to_end.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Use a fake broker implementation in tests only. Do not modify production logic beyond what is needed for dependency injection.
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_end_to_end.py -v
+pytest tests/brokerage/ tests/tools/test_brokerage_tool.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/brokerage tests/tools/test_brokerage_tool.py
+git commit -m "test: add end-to-end brokerage flow coverage"
+```
+
+---
+
+## Task 10: Document local development and paper-trading operation
+
+**Objective:** Make the feature understandable and open-source-ready for contributors and users.
+
+**Files:**
+- Create: `docs/brokerage/README.md`
+- Modify: `README.md`
+- Optionally create: `examples/brokerage.env.example`
+
+**Step 1: Write docs-first checklist**
+
+Document:
+- what the subsystem does
+- current v1 limitations
+- required dependencies
+- how to run IB Gateway paper locally
+- API/TWS settings from IBKR docs
+- default ports:
+  - TWS live 7496
+  - TWS paper 7497
+  - IB Gateway live 4001
+  - IB Gateway paper 4002
+- how to run the local FastAPI service
+- how Hermes is configured to talk to it
+- security warnings for live mode
+
+**Step 2: Add README section**
+
+Update the top-level `README.md` with a short section linking to `docs/brokerage/README.md`.
+
+**Step 3: Verify docs paths**
+
+Run:
+```bash
+python -m pytest tests/brokerage/ tests/tools/test_brokerage_tool.py -q
+```
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add docs/brokerage/README.md README.md examples/brokerage.env.example
+git commit -m "docs: add brokerage setup and usage guide"
+```
+
+---
+
+## Task 11: Add a live-mode feature gate without enabling it by default
+
+**Objective:** Prepare for live trading safely while keeping v1 paper-only in practice.
+
+**Files:**
+- Modify: `brokerage/config.py`
+- Modify: `brokerage/policy.py`
+- Modify: `tests/brokerage/test_policy.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- live mode blocked when `live_enabled=False`
+- live mode requires explicit stronger confirmation phrase
+- live mode has stricter size/notional caps than paper
+
+**Step 2: Run tests to verify failure**
+
+Run:
+```bash
+pytest tests/brokerage/test_policy.py -v
+```
+Expected: FAIL.
+
+**Step 3: Write minimal implementation**
+
+Add config:
+- `live_enabled: bool = False`
+- `live_max_shares`
+- `live_max_notional`
+
+Add confirmation rule like:
+```text
+CONFIRM LIVE BUY 10 AAPL T-82K4
+```
+
+**Step 4: Run tests to verify pass**
+
+Run:
+```bash
+pytest tests/brokerage/test_policy.py -v
+```
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add brokerage/config.py brokerage/policy.py tests/brokerage/test_policy.py
+git commit -m "feat: add gated live trading safeguards"
+```
+
+---
+
+## Task 12: Run final verification and integration review
+
+**Objective:** Confirm the subsystem is ready for paper-trading trials and open-source iteration.
+
+**Files:**
+- No new files required
+
+**Step 1: Run focused suite**
+
+Run:
+```bash
+pytest tests/brokerage/ tests/tools/test_brokerage_tool.py -v
+```
+Expected: PASS.
+
+**Step 2: Run broader regression suite**
+
+Run:
+```bash
+python -m pytest tests/ -o 'addopts=' -q
+```
+Expected: PASS.
+
+**Step 3: Review diff**
+
+Run:
+```bash
+git diff --stat origin/main...
+```
+Expected: only brokerage-related files and intentional config/package changes.
+
+**Step 4: Manual paper smoke test**
+
+With IB Gateway Paper running and API enabled:
+```bash
+uvicorn brokerage.app:app --host 127.0.0.1 --port 8787
+```
+Then in Hermes over Telegram, try:
+```text
+Buy 1 share of AAPL at market in paper
+```
+Expected:
+- Hermes produces a pending confirmation preview
+- Hermes does not submit immediately
+- confirming with exact code submits through paper mode
+- status response includes broker order id or simulated broker response
+
+**Step 5: Final commit if needed**
+
+```bash
+git add -A
+git commit -m "feat: complete telegram hermes ibkr brokerage paper trading flow"
+```
+
+---
+
+## Design Notes
+
+### Why a local FastAPI service instead of putting everything in the Hermes tool?
+
+- Keeps broker logic deterministic and independently testable
+- Makes future non-Hermes clients possible
+- Keeps the Hermes tool thin and auditable
+- Makes eventual open-sourcing cleaner
+
+### Why SQLite first?
+
+- Zero extra infra
+- Easy local development
+- Good fit for audit logs and pending intents
+- Easy to swap later behind a repository interface
+
+### Why `ib_insync`?
+
+- Much simpler ergonomics than raw IB API
+- Well-documented connect pattern
+- Easy to mock in tests
+
+### Why no Telegram inline buttons in v1?
+
+- Text confirmation is messaging-platform-agnostic
+- Much less gateway coupling
+- Easier to open source and test
+- Hermes already supports Telegram chat input, so no extra gateway work is required to get the first version working
+
+### Telegram-specific future enhancement
+
+After paper-mode stability, add optional Telegram inline confirmation buttons by reusing patterns already covered by:
+- `gateway/platforms/telegram.py`
+- `tests/gateway/test_telegram_approval_buttons.py`
+
+That should be a separate feature branch after v1 is stable.
+
+---
+
+## Suggested Execution Order
+
+1. Task 0
+2. Task 1
+3. Task 2
+4. Task 3
+5. Task 4
+6. Task 5
+7. Task 6
+8. Task 7
+9. Task 8
+10. Task 9
+11. Task 10
+12. Task 11
+13. Task 12
+
+This order ensures the core deterministic engine exists before Hermes integration.
+
+---
+
+## Open Questions to resolve during implementation
+
+1. Should the default broker connection assume IB Gateway or TWS? Recommendation: IB Gateway.
+2. Should confirmation codes be short human tokens only, or full exact phrases from v1? Recommendation: short token for paper, exact full phrase for live.
+3. Should market quotes be fetched before preview to estimate notional? Recommendation: no for initial implementation unless quote access is already available; keep quantity/notional caps conservative first.
+4. Should the initial Hermes tool be hidden behind an explicit `brokerage` toolset? Recommendation: yes.
+
+---
+
+## Definition of Done
+
+- User can send a Telegram message to Hermes describing a paper stock trade
+- Hermes creates a structured pending intent via the brokerage tool
+- Hermes returns a confirmation preview and token
+- User confirms with exact required text
+- Deterministic service validates and submits to IBKR paper through `ib_insync`
+- Order status is stored and returned
+- Every step is tested and logged
+- Live mode remains disabled by default
+- Setup and contributor docs exist for open-source users

--- a/examples/brokerage.env.example
+++ b/examples/brokerage.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for the Hermes brokerage paper-trading flow.
+# Copy relevant values into ~/.hermes/.env or your shell environment.
+
+# Shared bearer token used by Hermes brokerage tools when calling the local
+# brokerage FastAPI service.
+BROKERAGE_SERVICE_TOKEN=replace-me-with-a-long-random-secret

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -595,6 +595,14 @@ DEFAULT_CONFIG = {
         "provider": "",
     },
 
+    # Local brokerage integration settings for deterministic trading workflows.
+    "brokerage": {
+        "enabled": False,
+        "service_url": "http://127.0.0.1:8787",
+        "default_account_mode": "paper",
+        "confirmation_ttl_seconds": 120,
+    },
+
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
@@ -703,7 +711,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 17,
+    "_config_version": 18,
 }
 
 # =============================================================================
@@ -719,6 +727,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    18: ["BROKERAGE_SERVICE_TOKEN"],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1047,6 +1056,14 @@ OPTIONAL_ENV_VARS = {
         "tools": ["web_search", "web_extract", "web_crawl"],
         "password": True,
         "category": "tool",
+    },
+    "BROKERAGE_SERVICE_TOKEN": {
+        "description": "Shared bearer token used by Hermes brokerage tools to authenticate to the local brokerage service",
+        "prompt": "Brokerage service token",
+        "url": None,
+        "password": True,
+        "category": "tool",
+        "advanced": True,
     },
     "BROWSERBASE_API_KEY": {
         "description": "Browserbase API key for cloud browser (optional — local browser works without this)",
@@ -1787,6 +1804,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
+    "brokerage",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/model_tools.py
+++ b/model_tools.py
@@ -156,6 +156,7 @@ def _discover_tools():
         "tools.delegate_tool",
         "tools.process_registry",
         "tools.send_message_tool",
+        "tools.brokerage_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,11 @@ honcho = ["honcho-ai>=2.0.1,<3"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
+trading = [
+  "fastapi>=0.104.0,<1",
+  "uvicorn[standard]>=0.24.0,<1",
+  "ib_insync>=0.9.86,<1",
+]
 acp = ["agent-client-protocol>=0.9.0,<1.0"]
 mistral = ["mistralai>=2.3.0,<3"]
 termux = [
@@ -123,7 +128,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "brokerage", "brokerage.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/brokerage/test_app.py
+++ b/tests/brokerage/test_app.py
@@ -16,12 +16,13 @@ from brokerage.storage import SQLiteBrokerageStore
 
 
 class FakeBroker(BrokerAdapter):
-    def __init__(self, result: BrokerSubmissionResult | None = None):
+    def __init__(self, result: BrokerSubmissionResult | None = None, positions: list[dict] | None = None):
         self.result = result or BrokerSubmissionResult(
             accepted=True,
             broker_order_id="ib-123",
             broker_status="Submitted",
         )
+        self._positions = positions or []
 
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         return self.result
@@ -38,12 +39,15 @@ class FakeBroker(BrokerAdapter):
     def cancel_order(self, order_id: str):
         return None
 
+    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+        return self._positions
 
-def _make_client(tmp_path: Path, *, token: str = "test-token") -> TestClient:
+
+def _make_client(tmp_path: Path, *, token: str = "test-token", positions: list[dict] | None = None) -> TestClient:
     settings = BrokerageSettings(service_token=token)
     store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
     policy = BrokeragePolicy(settings)
-    service = BrokerageService(settings, store, policy, FakeBroker())
+    service = BrokerageService(settings, store, policy, FakeBroker(positions=positions))
     app = create_app(service=service, auth_token=token)
     return TestClient(app)
 
@@ -196,3 +200,50 @@ def test_get_trade_intent_returns_current_status(tmp_path):
     assert body["intent_id"] == created["intent_id"]
     assert body["status"] == "pending_confirmation"
     assert body["confirmation_code"] == created["confirmation_code"]
+
+
+def test_get_positions_returns_empty_when_no_positions(tmp_path):
+    client = _make_client(tmp_path)
+
+    response = client.get("/positions", headers=_auth_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["positions"] == []
+    assert body["count"] == 0
+
+
+def test_get_positions_returns_broker_positions(tmp_path):
+    positions = [
+        {"symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+        {"symbol": "MSFT", "position": 3.0, "avg_cost": 420.50, "account_mode": "paper"},
+    ]
+    client = _make_client(tmp_path, positions=positions)
+
+    response = client.get("/positions", headers=_auth_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 2
+    assert body["positions"] == positions
+
+
+def test_get_positions_passes_account_mode_query_param(tmp_path):
+    positions = [
+        {"symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+    ]
+    client = _make_client(tmp_path, positions=positions)
+
+    response = client.get("/positions?account_mode=paper", headers=_auth_headers())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["count"] == 1
+
+
+def test_get_positions_requires_auth(tmp_path):
+    client = _make_client(tmp_path)
+
+    response = client.get("/positions")
+
+    assert response.status_code == 401

--- a/tests/brokerage/test_app.py
+++ b/tests/brokerage/test_app.py
@@ -26,7 +26,13 @@ class FakeBroker(BrokerAdapter):
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         return self.result
 
-    def get_order_status(self, order_id: str):
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
         return None
 
     def cancel_order(self, order_id: str):

--- a/tests/brokerage/test_app.py
+++ b/tests/brokerage/test_app.py
@@ -52,7 +52,10 @@ def test_healthz_returns_ok(tmp_path):
     response = client.get("/healthz")
 
     assert response.status_code == 200
-    assert response.json() == {"ok": True}
+    data = response.json()
+    assert data["ok"] is True
+    assert "connected" in data
+    assert "mode" in data
 
 
 def test_create_trade_intent_requires_bearer_auth(tmp_path):

--- a/tests/brokerage/test_app.py
+++ b/tests/brokerage/test_app.py
@@ -1,0 +1,189 @@
+"""Tests for the FastAPI brokerage service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from brokerage.app import create_app
+from brokerage.brokers.base import BrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import BrokerSubmissionResult, TradeIntent
+from brokerage.policy import BrokeragePolicy
+from brokerage.service import BrokerageService
+from brokerage.storage import SQLiteBrokerageStore
+
+
+class FakeBroker(BrokerAdapter):
+    def __init__(self, result: BrokerSubmissionResult | None = None):
+        self.result = result or BrokerSubmissionResult(
+            accepted=True,
+            broker_order_id="ib-123",
+            broker_status="Submitted",
+        )
+
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        return self.result
+
+    def get_order_status(self, order_id: str):
+        return None
+
+    def cancel_order(self, order_id: str):
+        return None
+
+
+def _make_client(tmp_path: Path, *, token: str = "test-token") -> TestClient:
+    settings = BrokerageSettings(service_token=token)
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    service = BrokerageService(settings, store, policy, FakeBroker())
+    app = create_app(service=service, auth_token=token)
+    return TestClient(app)
+
+
+def _auth_headers(token: str = "test-token") -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_healthz_returns_ok(tmp_path):
+    client = _make_client(tmp_path)
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_create_trade_intent_requires_bearer_auth(tmp_path):
+    client = _make_client(tmp_path)
+
+    response = client.post(
+        "/trade-intents",
+        json={
+            "account_mode": "paper",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+            "asset_class": "stock",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing or invalid authorization header"
+
+
+def test_create_trade_intent_returns_pending_preview_and_confirmation_code(tmp_path):
+    client = _make_client(tmp_path)
+
+    response = client.post(
+        "/trade-intents",
+        headers=_auth_headers(),
+        json={
+            "account_mode": "paper",
+            "symbol": "aapl",
+            "side": "buy",
+            "quantity": 10,
+            "order_type": "market",
+            "asset_class": "stock",
+            "raw_request_text": "buy 10 shares of aapl at market in paper",
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["intent_id"].startswith("ti_")
+    assert body["status"] == "pending_confirmation"
+    assert body["confirmation_code"].startswith("T-")
+    assert body["preview"] == {
+        "account_mode": "paper",
+        "side": "BUY",
+        "symbol": "AAPL",
+        "quantity": 10,
+        "order_type": "MARKET",
+        "asset_class": "stock",
+    }
+
+
+def test_confirm_trade_intent_submits_order(tmp_path):
+    client = _make_client(tmp_path)
+    created = client.post(
+        "/trade-intents",
+        headers=_auth_headers(),
+        json={
+            "account_mode": "paper",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+            "asset_class": "stock",
+        },
+    ).json()
+
+    response = client.post(
+        f"/trade-intents/{created['intent_id']}/confirm",
+        headers=_auth_headers(),
+        json={"confirmation_text": f"CONFIRM {created['confirmation_code']}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "intent_id": created["intent_id"],
+        "status": "submitted",
+        "broker_order_id": "ib-123",
+        "broker_status": "Submitted",
+        "detail": None,
+    }
+
+
+def test_cancel_trade_intent_returns_cancelled_status(tmp_path):
+    client = _make_client(tmp_path)
+    created = client.post(
+        "/trade-intents",
+        headers=_auth_headers(),
+        json={
+            "account_mode": "paper",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+            "asset_class": "stock",
+        },
+    ).json()
+
+    response = client.post(
+        f"/trade-intents/{created['intent_id']}/cancel",
+        headers=_auth_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["intent_id"] == created["intent_id"]
+    assert response.json()["status"] == "cancelled"
+
+
+def test_get_trade_intent_returns_current_status(tmp_path):
+    client = _make_client(tmp_path)
+    created = client.post(
+        "/trade-intents",
+        headers=_auth_headers(),
+        json={
+            "account_mode": "paper",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "quantity": 10,
+            "order_type": "MARKET",
+            "asset_class": "stock",
+        },
+    ).json()
+
+    response = client.get(
+        f"/trade-intents/{created['intent_id']}",
+        headers=_auth_headers(),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["intent_id"] == created["intent_id"]
+    assert body["status"] == "pending_confirmation"
+    assert body["confirmation_code"] == created["confirmation_code"]

--- a/tests/brokerage/test_app.py
+++ b/tests/brokerage/test_app.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from brokerage.app import create_app
+from brokerage.app import build_service, create_app
 from brokerage.brokers.base import BrokerAdapter
 from brokerage.config import BrokerageSettings
 from brokerage.models import BrokerSubmissionResult, TradeIntent
@@ -23,6 +23,7 @@ class FakeBroker(BrokerAdapter):
             broker_status="Submitted",
         )
         self._positions = positions or []
+        self.last_positions_query: dict[str, str | None] | None = None
 
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         return self.result
@@ -39,8 +40,11 @@ class FakeBroker(BrokerAdapter):
     def cancel_order(self, order_id: str):
         return None
 
-    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
-        return self._positions
+    def get_positions(self, *, account_mode: str | None = None, account: str | None = None) -> list[dict]:
+        self.last_positions_query = {"account_mode": account_mode, "account": account}
+        if account is None:
+            return self._positions
+        return [p for p in self._positions if p.get("account") == account]
 
 
 def _make_client(tmp_path: Path, *, token: str = "test-token", positions: list[dict] | None = None) -> TestClient:
@@ -66,6 +70,23 @@ def test_healthz_returns_ok(tmp_path):
     assert data["ok"] is True
     assert "connected" in data
     assert "mode" in data
+
+
+def test_build_service_loads_brokerage_settings_from_hermes_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "brokerage:\n"
+        "  live_enabled: true\n"
+        "  default_live_account: U3510752\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    service = build_service()
+
+    assert service.settings.live_enabled is True
+    assert service.settings.default_live_account == "U3510752"
 
 
 def test_create_trade_intent_requires_bearer_auth(tmp_path):
@@ -119,6 +140,35 @@ def test_create_trade_intent_returns_pending_preview_and_confirmation_code(tmp_p
     }
 
 
+def test_create_trade_intent_accepts_paper_stop_market_order(tmp_path):
+    client = _make_client(tmp_path)
+
+    response = client.post(
+        "/trade-intents",
+        headers=_auth_headers(),
+        json={
+            "account_mode": "paper",
+            "symbol": "AAPL",
+            "side": "SELL",
+            "quantity": 5,
+            "order_type": "STOP",
+            "stop_price": 180.25,
+            "asset_class": "stock",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["preview"] == {
+        "account_mode": "paper",
+        "side": "SELL",
+        "symbol": "AAPL",
+        "quantity": 5,
+        "order_type": "STOP",
+        "asset_class": "stock",
+        "stop_price": 180.25,
+    }
+
+
 def test_confirm_trade_intent_submits_order(tmp_path):
     client = _make_client(tmp_path)
     created = client.post(
@@ -148,6 +198,32 @@ def test_confirm_trade_intent_submits_order(tmp_path):
         "broker_status": "Submitted",
         "detail": None,
     }
+
+
+def test_create_trade_intent_accepts_explicit_broker_account(tmp_path):
+    settings = BrokerageSettings(service_token="test-token", live_enabled=True)
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    service = BrokerageService(settings, store, policy, FakeBroker())
+    app = create_app(service=service, auth_token="test-token")
+    client = TestClient(app)
+
+    response = client.post(
+        "/trade-intents",
+        headers=_auth_headers(),
+        json={
+            "account_mode": "live",
+            "symbol": "AAPL",
+            "side": "BUY",
+            "quantity": 1,
+            "order_type": "MARKET",
+            "asset_class": "stock",
+            "broker_account": "u3510752",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["preview"]["broker_account"] == "U3510752"
 
 
 def test_cancel_trade_intent_returns_cancelled_status(tmp_path):
@@ -215,8 +291,8 @@ def test_get_positions_returns_empty_when_no_positions(tmp_path):
 
 def test_get_positions_returns_broker_positions(tmp_path):
     positions = [
-        {"symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
-        {"symbol": "MSFT", "position": 3.0, "avg_cost": 420.50, "account_mode": "paper"},
+        {"account": "DUQ218494", "symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+        {"account": "DUQ218494", "symbol": "MSFT", "position": 3.0, "avg_cost": 420.50, "account_mode": "paper"},
     ]
     client = _make_client(tmp_path, positions=positions)
 
@@ -228,17 +304,26 @@ def test_get_positions_returns_broker_positions(tmp_path):
     assert body["positions"] == positions
 
 
-def test_get_positions_passes_account_mode_query_param(tmp_path):
+def test_get_positions_passes_account_mode_and_account_query_params(tmp_path):
     positions = [
-        {"symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+        {"account": "DUQ218494", "symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+        {"account": "U3510752", "symbol": "NFLX", "position": 10.0, "avg_cost": 900.5, "account_mode": "live"},
     ]
-    client = _make_client(tmp_path, positions=positions)
+    settings = BrokerageSettings(service_token="test-token")
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    broker = FakeBroker(positions=positions)
+    service = BrokerageService(settings, store, policy, broker)
+    app = create_app(service=service, auth_token="test-token")
+    client = TestClient(app)
 
-    response = client.get("/positions?account_mode=paper", headers=_auth_headers())
+    response = client.get("/positions?account_mode=live&account=U3510752", headers=_auth_headers())
 
     assert response.status_code == 200
     body = response.json()
     assert body["count"] == 1
+    assert body["positions"] == [positions[1]]
+    assert broker.last_positions_query == {"account_mode": "live", "account": "U3510752"}
 
 
 def test_get_positions_requires_auth(tmp_path):

--- a/tests/brokerage/test_end_to_end.py
+++ b/tests/brokerage/test_end_to_end.py
@@ -19,26 +19,38 @@ import tools.brokerage_tool as brokerage_tool
 
 
 class FakeBroker(BrokerAdapter):
-    def __init__(self, result: BrokerSubmissionResult):
+    def __init__(self, result: BrokerSubmissionResult, *, order_statuses: dict[str, dict] | None = None):
         self.result = result
+        self.order_statuses = order_statuses or {}
         self.submitted: list[TradeIntent] = []
 
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         self.submitted.append(intent)
         return self.result
 
-    def get_order_status(self, order_id: str):
-        return None
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
+        return self.order_statuses.get(order_id)
 
     def cancel_order(self, order_id: str):
         return None
 
 
-def _build_stack(tmp_path: Path, broker_result: BrokerSubmissionResult) -> tuple[TestClient, FakeBroker]:
+def _build_stack(
+    tmp_path: Path,
+    broker_result: BrokerSubmissionResult,
+    *,
+    order_statuses: dict[str, dict] | None = None,
+) -> tuple[TestClient, FakeBroker]:
     settings = BrokerageSettings(enabled=True, service_token="test-token")
     store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
     policy = BrokeragePolicy(settings)
-    broker = FakeBroker(broker_result)
+    broker = FakeBroker(broker_result, order_statuses=order_statuses)
     service = BrokerageService(settings, store, policy, broker)
     app = create_app(service=service, auth_token="test-token")
     return TestClient(app), broker
@@ -123,6 +135,46 @@ def test_end_to_end_tool_driven_paper_trade_reaches_submitted_status(tmp_path, m
     assert status["status"] == "submitted"
     assert status["ibkr_order_id"] == "ib-accepted-1"
     assert [intent.symbol for intent in broker.submitted] == ["AAPL"]
+
+
+def test_end_to_end_tool_status_check_reconciles_filled_trade(tmp_path, monkeypatch):
+    client, broker = _build_stack(
+        tmp_path,
+        BrokerSubmissionResult(
+            accepted=True,
+            broker_order_id="ib-accepted-1",
+            broker_status="Submitted",
+        ),
+        order_statuses={"ib-accepted-1": {"broker_status": "Filled"}},
+    )
+    _patch_tool_client(monkeypatch, client)
+
+    created = json.loads(
+        brokerage_tool.create_trade_intent_tool(
+            {
+                "account_mode": "paper",
+                "symbol": "AAPL",
+                "side": "BUY",
+                "quantity": 10,
+                "order_type": "MARKET",
+                "asset_class": "stock",
+            }
+        )
+    )
+    brokerage_tool.confirm_trade_intent_tool(
+        {
+            "intent_id": created["intent_id"],
+            "confirmation_text": f"CONFIRM {created['confirmation_code']}",
+        }
+    )
+
+    status = json.loads(
+        brokerage_tool.get_trade_intent_status_tool({"intent_id": created["intent_id"]})
+    )
+
+    assert status["status"] == "filled"
+    assert status["broker_status"] == "Filled"
+    assert [intent.request_id for intent in broker.submitted] == [created["intent_id"]]
 
 
 def test_end_to_end_tool_driven_paper_trade_records_broker_rejection(tmp_path, monkeypatch):

--- a/tests/brokerage/test_end_to_end.py
+++ b/tests/brokerage/test_end_to_end.py
@@ -1,0 +1,173 @@
+"""End-to-end coverage for the paper-trading confirmation flow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+from fastapi.testclient import TestClient
+
+from brokerage.app import create_app
+from brokerage.brokers.base import BrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import BrokerSubmissionResult, TradeIntent
+from brokerage.policy import BrokeragePolicy
+from brokerage.service import BrokerageService
+from brokerage.storage import SQLiteBrokerageStore
+import tools.brokerage_tool as brokerage_tool
+
+
+class FakeBroker(BrokerAdapter):
+    def __init__(self, result: BrokerSubmissionResult):
+        self.result = result
+        self.submitted: list[TradeIntent] = []
+
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        self.submitted.append(intent)
+        return self.result
+
+    def get_order_status(self, order_id: str):
+        return None
+
+    def cancel_order(self, order_id: str):
+        return None
+
+
+def _build_stack(tmp_path: Path, broker_result: BrokerSubmissionResult) -> tuple[TestClient, FakeBroker]:
+    settings = BrokerageSettings(enabled=True, service_token="test-token")
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    broker = FakeBroker(broker_result)
+    service = BrokerageService(settings, store, policy, broker)
+    app = create_app(service=service, auth_token="test-token")
+    return TestClient(app), broker
+
+
+def _patch_tool_client(monkeypatch, client: TestClient) -> None:
+    class _BridgeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def request(self, method, url, *, json=None, headers=None):
+            response = client.request(method, url, json=json, headers=headers)
+            request = httpx.Request(method, url)
+            return httpx.Response(
+                status_code=response.status_code,
+                json=response.json(),
+                request=request,
+            )
+
+    monkeypatch.setattr(brokerage_tool.httpx, "Client", _BridgeClient)
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {
+            "enabled": True,
+            "service_url": "http://testserver",
+            "service_token": "test-token",
+        },
+    )
+
+
+def test_end_to_end_tool_driven_paper_trade_reaches_submitted_status(tmp_path, monkeypatch):
+    client, broker = _build_stack(
+        tmp_path,
+        BrokerSubmissionResult(
+            accepted=True,
+            broker_order_id="ib-accepted-1",
+            broker_status="Submitted",
+        ),
+    )
+    _patch_tool_client(monkeypatch, client)
+
+    created = json.loads(
+        brokerage_tool.create_trade_intent_tool(
+            {
+                "account_mode": "paper",
+                "symbol": "AAPL",
+                "side": "BUY",
+                "quantity": 10,
+                "order_type": "MARKET",
+                "asset_class": "stock",
+                "raw_user_text": "buy 10 shares of aapl at market in paper",
+            }
+        )
+    )
+    confirmed = json.loads(
+        brokerage_tool.confirm_trade_intent_tool(
+            {
+                "intent_id": created["intent_id"],
+                "confirmation_text": f"CONFIRM {created['confirmation_code']}",
+            }
+        )
+    )
+    status = json.loads(
+        brokerage_tool.get_trade_intent_status_tool({"intent_id": created["intent_id"]})
+    )
+
+    assert created["status"] == "pending_confirmation"
+    assert confirmed == {
+        "intent_id": created["intent_id"],
+        "status": "submitted",
+        "broker_order_id": "ib-accepted-1",
+        "broker_status": "Submitted",
+        "detail": None,
+    }
+    assert status["status"] == "submitted"
+    assert status["ibkr_order_id"] == "ib-accepted-1"
+    assert [intent.symbol for intent in broker.submitted] == ["AAPL"]
+
+
+def test_end_to_end_tool_driven_paper_trade_records_broker_rejection(tmp_path, monkeypatch):
+    client, broker = _build_stack(
+        tmp_path,
+        BrokerSubmissionResult(
+            accepted=False,
+            broker_order_id=None,
+            broker_status="Rejected",
+            detail="insufficient buying power",
+        ),
+    )
+    _patch_tool_client(monkeypatch, client)
+
+    created = json.loads(
+        brokerage_tool.create_trade_intent_tool(
+            {
+                "account_mode": "paper",
+                "symbol": "AAPL",
+                "side": "BUY",
+                "quantity": 10,
+                "order_type": "MARKET",
+                "asset_class": "stock",
+            }
+        )
+    )
+    confirmed = json.loads(
+        brokerage_tool.confirm_trade_intent_tool(
+            {
+                "intent_id": created["intent_id"],
+                "confirmation_text": f"CONFIRM {created['confirmation_code']}",
+            }
+        )
+    )
+    status = json.loads(
+        brokerage_tool.get_trade_intent_status_tool({"intent_id": created["intent_id"]})
+    )
+
+    assert confirmed == {
+        "intent_id": created["intent_id"],
+        "status": "rejected",
+        "broker_order_id": None,
+        "broker_status": "Rejected",
+        "detail": "insufficient buying power",
+    }
+    assert status["status"] == "rejected"
+    assert status["ibkr_order_id"] is None
+    assert [intent.request_id for intent in broker.submitted] == [created["intent_id"]]

--- a/tests/brokerage/test_ibkr_lifecycle.py
+++ b/tests/brokerage/test_ibkr_lifecycle.py
@@ -1,0 +1,197 @@
+"""Tests for IBKR TWS adapter connection lifecycle management."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brokerage.brokers.ibkr_tws import IBKRTwsBrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import TradeIntent
+
+
+def _make_intent(**overrides) -> TradeIntent:
+    data = {
+        "request_id": "test-1",
+        "account_mode": "paper",
+        "symbol": "AAPL",
+        "side": "BUY",
+        "quantity": 1,
+        "order_type": "MARKET",
+        "asset_class": "stock",
+    }
+    data.update(overrides)
+    return TradeIntent(**data)
+
+
+@pytest.fixture
+def settings():
+    return BrokerageSettings()
+
+
+@pytest.fixture
+def adapter(settings):
+    return IBKRTwsBrokerAdapter(settings)
+
+
+def _make_connected_ib(adapter, mode="paper", connected=True):
+    """Set up a mock IB instance on the adapter."""
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    mock_ib.isConnected.return_value = connected
+    adapter._connected_mode = mode if connected else None
+    return mock_ib
+
+
+def _setup_ib_for_submit(mock_ib, order_id=1, status="Submitted"):
+    """Configure a mock IB to handle a full submit_order call."""
+    mock_ib.qualifyContracts.return_value = [MagicMock()]
+    mock_trade = MagicMock()
+    mock_trade.order = MagicMock(orderId=order_id)
+    mock_trade.orderStatus = MagicMock(status=status)
+    mock_ib.placeOrder.return_value = mock_trade
+    return mock_ib
+
+
+# --- Connection state ---
+
+def test_adapter_starts_disconnected(adapter):
+    assert adapter.is_connected is False
+
+
+def test_adapter_tracks_account_mode_on_connect(adapter):
+    _make_connected_ib(adapter, mode="paper", connected=True)
+    assert adapter.connected_mode == "paper"
+
+
+def test_adapter_connected_mode_is_none_when_not_connected(adapter):
+    assert adapter.connected_mode is None
+
+
+# --- Reconnection logic ---
+
+def test_submit_order_reconnects_if_disconnected():
+    """If the IB connection drops between orders, submit_order should reconnect."""
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    mock_ib = _make_connected_ib(adapter, mode="paper", connected=False)
+    _setup_ib_for_submit(mock_ib)
+
+    # Patch _ensure_ib to return our mock
+    with patch.object(adapter, "_ensure_ib", return_value=mock_ib):
+        result = adapter.submit_order(_make_intent())
+
+    mock_ib.connect.assert_called_once()
+    assert result.accepted is True
+
+
+def test_submit_order_skips_reconnect_if_already_connected():
+    """If already connected, no reconnection needed."""
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    mock_ib = _make_connected_ib(adapter, mode="paper", connected=True)
+    _setup_ib_for_submit(mock_ib)
+
+    with patch.object(adapter, "_ensure_ib", return_value=mock_ib):
+        adapter.submit_order(_make_intent())
+
+    # Should NOT have called connect since already connected
+    mock_ib.connect.assert_not_called()
+
+
+# --- Disconnect ---
+
+def test_disconnect_closes_connection(adapter):
+    mock_ib = _make_connected_ib(adapter, mode="paper", connected=True)
+
+    adapter.disconnect()
+
+    mock_ib.disconnect.assert_called_once()
+    assert adapter._connected_mode is None
+
+
+def test_disconnect_is_safe_when_not_connected(adapter):
+    # Should not raise
+    adapter.disconnect()
+
+
+# --- Port selection ---
+
+def test_paper_mode_uses_paper_gateway_port():
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    assert adapter._select_port("paper") == 4002
+
+
+def test_live_mode_uses_live_gateway_port():
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    assert adapter._select_port("live") == 4001
+
+
+# --- Health check ---
+
+def test_health_check_returns_disconnected_when_no_ib(adapter):
+    health = adapter.health_check()
+    assert health["connected"] is False
+    assert health["mode"] is None
+
+
+def test_health_check_returns_connected_when_ib_connected():
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    _make_connected_ib(adapter, mode="paper", connected=True)
+
+    health = adapter.health_check()
+
+    assert health["connected"] is True
+    assert health["mode"] == "paper"
+
+
+def test_health_check_detects_dropped_connection():
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    # Was connected to paper, but now disconnected
+    _make_connected_ib(adapter, mode="paper", connected=False)
+
+    health = adapter.health_check()
+
+    assert health["connected"] is False
+    assert health["mode"] is None  # mode cleared because connection dropped
+
+
+# --- Account mode switching ---
+
+def test_switching_account_mode_reconnects():
+    """Switching from paper to live should reconnect on the live port."""
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    mock_ib = _make_connected_ib(adapter, mode="paper", connected=True)
+    _setup_ib_for_submit(mock_ib)
+
+    # When we switch modes, _ensure_connected will disconnect and reconnect
+    # First call to isConnected during _ensure_connected check returns True (paper mode)
+    # But since mode != "live", it should disconnect and reconnect
+
+    with patch.object(adapter, "_ensure_ib", return_value=mock_ib):
+        adapter.submit_order(_make_intent(account_mode="live"))
+
+    # Should have disconnected from paper and connected to live
+    mock_ib.disconnect.assert_called_once()
+    mock_ib.connect.assert_called_once_with("127.0.0.1", 4001, clientId=0)
+
+
+def test_same_mode_does_not_reconnect():
+    """Submitting to the same mode should not trigger reconnection."""
+    settings = BrokerageSettings()
+    adapter = IBKRTwsBrokerAdapter(settings)
+    mock_ib = _make_connected_ib(adapter, mode="paper", connected=True)
+    _setup_ib_for_submit(mock_ib)
+
+    with patch.object(adapter, "_ensure_ib", return_value=mock_ib):
+        adapter.submit_order(_make_intent(account_mode="paper"))
+
+    # No disconnect or connect should have been called
+    mock_ib.disconnect.assert_not_called()
+    mock_ib.connect.assert_not_called()

--- a/tests/brokerage/test_ibkr_lifecycle.py
+++ b/tests/brokerage/test_ibkr_lifecycle.py
@@ -174,7 +174,11 @@ def test_switching_account_mode_reconnects():
     # First call to isConnected during _ensure_connected check returns True (paper mode)
     # But since mode != "live", it should disconnect and reconnect
 
-    with patch.object(adapter, "_ensure_ib", return_value=mock_ib):
+    def fake_ensure_ib():
+        adapter._ib = mock_ib
+        return mock_ib
+
+    with patch.object(adapter, "_ensure_ib", side_effect=fake_ensure_ib):
         adapter.submit_order(_make_intent(account_mode="live"))
 
     # Should have disconnected from paper and connected to live

--- a/tests/brokerage/test_ibkr_tws.py
+++ b/tests/brokerage/test_ibkr_tws.py
@@ -1,5 +1,6 @@
 """Tests for the IBKR TWS/IB Gateway broker adapter."""
-
+import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -89,3 +90,51 @@ def test_submit_order_rejects_non_stock_assets_defensively():
 
     with pytest.raises(ValueError):
         adapter.submit_order(bad_intent)
+
+
+def test_submit_order_creates_event_loop_when_called_from_worker_thread():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+
+    class EventLoopCheckingIB:
+        def __init__(self):
+            self.connected = False
+
+        def isConnected(self):
+            return self.connected
+
+        def connect(self, host, port, clientId=0):
+            asyncio.get_event_loop()
+            self.connected = True
+            return True
+
+        def disconnect(self):
+            self.connected = False
+
+        def qualifyContracts(self, contract):
+            asyncio.get_event_loop()
+            return [contract]
+
+        def placeOrder(self, contract, order):
+            asyncio.get_event_loop()
+            return SimpleNamespace(
+                orderStatus=SimpleNamespace(status="Submitted"),
+                order=SimpleNamespace(orderId=1234),
+            )
+
+    result: list = []
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            result.append(adapter.submit_order(_make_intent()))
+        except Exception as exc:  # pragma: no cover - exercised in the red phase
+            errors.append(exc)
+
+    with patch("brokerage.brokers.ibkr_tws.IB", EventLoopCheckingIB):
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+    assert errors == []
+    assert result[0].accepted is True
+    assert result[0].broker_order_id == "1234"

--- a/tests/brokerage/test_ibkr_tws.py
+++ b/tests/brokerage/test_ibkr_tws.py
@@ -138,3 +138,76 @@ def test_submit_order_creates_event_loop_when_called_from_worker_thread():
     assert errors == []
     assert result[0].accepted is True
     assert result[0].broker_order_id == "1234"
+
+
+def test_get_order_status_returns_filled_when_execution_matches_order_id():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    mock_ib.isConnected.return_value = True
+    adapter._connected_mode = "paper"
+    mock_ib.openTrades.return_value = []
+    mock_ib.reqExecutions.return_value = [
+        SimpleNamespace(execution=SimpleNamespace(orderId=1234, execId="abc"))
+    ]
+
+    result = adapter.get_order_status("1234")
+
+    assert result == {"broker_status": "Filled", "detail": "abc"}
+
+
+def test_get_order_status_respects_requested_account_mode_when_disconnected():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    adapter._connected_mode = None
+    adapter._ib = MagicMock()
+    adapter._ib.reqExecutions.return_value = []
+    adapter._ib.reqCompletedOrders.return_value = []
+
+    attempted_modes: list[str] = []
+
+    def fake_ensure_connected(mode: str) -> None:
+        attempted_modes.append(mode)
+
+    with patch.object(adapter, "_ensure_connected", side_effect=fake_ensure_connected), \
+         patch.object(adapter, "_find_open_trade", return_value=None):
+        adapter.get_order_status("1234", account_mode="live")
+
+    assert attempted_modes == ["live"]
+
+
+def test_get_order_status_returns_partially_filled_when_execution_shares_are_below_expected_quantity():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    mock_ib.isConnected.return_value = True
+    adapter._connected_mode = "paper"
+    mock_ib.openTrades.return_value = []
+    mock_ib.reqCompletedOrders.return_value = []
+    mock_ib.reqExecutions.return_value = [
+        SimpleNamespace(execution=SimpleNamespace(orderId=1234, execId="abc", shares=3))
+    ]
+
+    result = adapter.get_order_status("1234", expected_quantity=10)
+
+    assert result == {"broker_status": "PartiallyFilled", "detail": "abc"}
+
+
+def test_get_order_status_prefers_completed_terminal_state_over_execution_history():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    mock_ib.isConnected.return_value = True
+    adapter._connected_mode = "paper"
+    mock_ib.openTrades.return_value = []
+    completed_trade = SimpleNamespace(
+        order=SimpleNamespace(orderId=1234),
+        orderStatus=SimpleNamespace(status="Cancelled"),
+    )
+    mock_ib.reqCompletedOrders.return_value = [completed_trade]
+    mock_ib.reqExecutions.return_value = [
+        SimpleNamespace(execution=SimpleNamespace(orderId=1234, execId="abc", shares=3))
+    ]
+
+    result = adapter.get_order_status("1234", expected_quantity=10)
+
+    assert result == {"broker_status": "Cancelled"}

--- a/tests/brokerage/test_ibkr_tws.py
+++ b/tests/brokerage/test_ibkr_tws.py
@@ -59,7 +59,7 @@ def test_submit_order_returns_submission_result_from_mocked_ib():
     adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
     trade = SimpleNamespace(orderStatus=SimpleNamespace(status="Submitted"), order=SimpleNamespace(orderId=1234))
 
-    with patch.object(adapter, "_connect") as mock_connect, patch.object(adapter, "_qualify_contract") as mock_contract:
+    with patch.object(adapter, "_ensure_connected") as mock_connect, patch.object(adapter, "_qualify_contract") as mock_contract:
         adapter._ib = MagicMock()
         mock_connect.return_value = None
         mock_contract.return_value = SimpleNamespace(conId=1)

--- a/tests/brokerage/test_ibkr_tws.py
+++ b/tests/brokerage/test_ibkr_tws.py
@@ -1,0 +1,91 @@
+"""Tests for the IBKR TWS/IB Gateway broker adapter."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brokerage.brokers.ibkr_tws import IBKRTwsBrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import TradeIntent
+
+
+def _make_intent(**overrides) -> TradeIntent:
+    data = {
+        "request_id": "req-1",
+        "account_mode": "paper",
+        "symbol": "AAPL",
+        "side": "BUY",
+        "quantity": 10,
+        "order_type": "MARKET",
+        "asset_class": "stock",
+    }
+    data.update(overrides)
+    return TradeIntent(**data)
+
+
+def test_paper_mode_uses_ib_gateway_paper_port_by_default():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+
+    assert adapter._select_port("paper") == 4002
+
+
+def test_live_mode_uses_ib_gateway_live_port_by_default():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+
+    assert adapter._select_port("live") == 4001
+
+
+def test_build_order_maps_market_order_correctly():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    order = adapter._build_order(_make_intent())
+
+    assert order.action == "BUY"
+    assert order.totalQuantity == 10
+    assert order.orderType == "MKT"
+
+
+def test_build_order_maps_limit_order_correctly():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    order = adapter._build_order(_make_intent(order_type="LIMIT", limit_price=123.45))
+
+    assert order.action == "BUY"
+    assert order.totalQuantity == 10
+    assert order.orderType == "LMT"
+    assert order.lmtPrice == 123.45
+
+
+def test_submit_order_returns_submission_result_from_mocked_ib():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    trade = SimpleNamespace(orderStatus=SimpleNamespace(status="Submitted"), order=SimpleNamespace(orderId=1234))
+
+    with patch.object(adapter, "_connect") as mock_connect, patch.object(adapter, "_qualify_contract") as mock_contract:
+        adapter._ib = MagicMock()
+        mock_connect.return_value = None
+        mock_contract.return_value = SimpleNamespace(conId=1)
+        adapter._ib.placeOrder.return_value = trade
+
+        result = adapter.submit_order(_make_intent())
+
+    assert result.accepted is True
+    assert result.broker_order_id == "1234"
+    assert result.broker_status == "Submitted"
+
+
+def test_submit_order_rejects_non_stock_assets_defensively():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+
+    bad_intent = TradeIntent.model_construct(
+        request_id="req-2",
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=1,
+        order_type="MARKET",
+        asset_class="option",
+        limit_price=None,
+        status="pending_confirmation",
+    )
+
+    with pytest.raises(ValueError):
+        adapter.submit_order(bad_intent)

--- a/tests/brokerage/test_ibkr_tws.py
+++ b/tests/brokerage/test_ibkr_tws.py
@@ -56,6 +56,16 @@ def test_build_order_maps_limit_order_correctly():
     assert order.lmtPrice == 123.45
 
 
+def test_build_order_maps_stop_market_order_correctly():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    order = adapter._build_order(_make_intent(side="SELL", order_type="STOP", stop_price=180.25))
+
+    assert order.action == "SELL"
+    assert order.totalQuantity == 10
+    assert order.orderType == "STP"
+    assert order.auxPrice == 180.25
+
+
 def test_submit_order_returns_submission_result_from_mocked_ib():
     adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
     trade = SimpleNamespace(orderStatus=SimpleNamespace(status="Submitted"), order=SimpleNamespace(orderId=1234))
@@ -71,6 +81,32 @@ def test_submit_order_returns_submission_result_from_mocked_ib():
     assert result.accepted is True
     assert result.broker_order_id == "1234"
     assert result.broker_status == "Submitted"
+
+
+def test_submit_order_sets_target_ib_account_when_present_on_intent():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    trade = SimpleNamespace(orderStatus=SimpleNamespace(status="Submitted"), order=SimpleNamespace(orderId=1234))
+    intent = SimpleNamespace(
+        asset_class="stock",
+        account_mode="live",
+        symbol="AAPL",
+        side="BUY",
+        quantity=1,
+        order_type="MARKET",
+        limit_price=None,
+        broker_account="U3510752",
+    )
+
+    with patch.object(adapter, "_ensure_connected") as mock_connect, patch.object(adapter, "_qualify_contract") as mock_contract:
+        adapter._ib = MagicMock()
+        mock_connect.return_value = None
+        mock_contract.return_value = SimpleNamespace(conId=1)
+        adapter._ib.placeOrder.return_value = trade
+
+        adapter.submit_order(intent)
+
+    submitted_order = adapter._ib.placeOrder.call_args.args[1]
+    assert submitted_order.account == "U3510752"
 
 
 def test_submit_order_rejects_non_stock_assets_defensively():
@@ -211,3 +247,53 @@ def test_get_order_status_prefers_completed_terminal_state_over_execution_histor
     result = adapter.get_order_status("1234", expected_quantity=10)
 
     assert result == {"broker_status": "Cancelled"}
+
+
+def test_get_positions_returns_account_labels_from_ib_positions():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    mock_ib.isConnected.return_value = True
+    adapter._connected_mode = "live"
+    mock_ib.positions.return_value = [
+        SimpleNamespace(account="U123", contract=SimpleNamespace(symbol="NFLX"), position=10, avgCost=900.5),
+        SimpleNamespace(account="U456", contract=SimpleNamespace(symbol="SPY"), position=5.25, avgCost=500.0),
+    ]
+
+    result = adapter.get_positions(account_mode="live")
+
+    assert result == [
+        {"account": "U123", "symbol": "NFLX", "position": 10.0, "avg_cost": 900.5, "account_mode": "live"},
+        {"account": "U456", "symbol": "SPY", "position": 5.25, "avg_cost": 500.0, "account_mode": "live"},
+    ]
+
+
+def test_get_positions_filters_to_requested_account():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    mock_ib.isConnected.return_value = True
+    adapter._connected_mode = "live"
+    mock_ib.positions.return_value = [
+        SimpleNamespace(account="U123", contract=SimpleNamespace(symbol="NFLX"), position=10, avgCost=900.5),
+        SimpleNamespace(account="U456", contract=SimpleNamespace(symbol="SPY"), position=5.25, avgCost=500.0),
+    ]
+
+    result = adapter.get_positions(account_mode="live", account="U456")
+
+    assert result == [
+        {"account": "U456", "symbol": "SPY", "position": 5.25, "avg_cost": 500.0, "account_mode": "live"},
+    ]
+
+
+def test_safe_disconnect_clears_ib_instance_to_prevent_cross_mode_position_leaks():
+    adapter = IBKRTwsBrokerAdapter(BrokerageSettings())
+    mock_ib = MagicMock()
+    adapter._ib = mock_ib
+    adapter._connected_mode = "paper"
+
+    adapter._safe_disconnect()
+
+    mock_ib.disconnect.assert_called_once()
+    assert adapter._ib is None
+    assert adapter._connected_mode is None

--- a/tests/brokerage/test_models.py
+++ b/tests/brokerage/test_models.py
@@ -1,0 +1,10 @@
+"""Tests for brokerage configuration and domain models."""
+
+from brokerage.config import BrokerageSettings
+
+
+def test_brokerage_settings_defaults_to_paper_mode_and_local_service():
+    settings = BrokerageSettings()
+    assert settings.service_url == "http://127.0.0.1:8787"
+    assert settings.default_account_mode == "paper"
+    assert settings.confirmation_ttl_seconds == 120

--- a/tests/brokerage/test_models.py
+++ b/tests/brokerage/test_models.py
@@ -1,6 +1,10 @@
 """Tests for brokerage configuration and domain models."""
 
+import pytest
+from pydantic import ValidationError
+
 from brokerage.config import BrokerageSettings
+from brokerage.models import TradeIntent
 
 
 def test_brokerage_settings_defaults_to_paper_mode_and_local_service():
@@ -8,3 +12,59 @@ def test_brokerage_settings_defaults_to_paper_mode_and_local_service():
     assert settings.service_url == "http://127.0.0.1:8787"
     assert settings.default_account_mode == "paper"
     assert settings.confirmation_ttl_seconds == 120
+
+
+def test_trade_intent_normalizes_symbol_and_side():
+    intent = TradeIntent(
+        request_id="r1",
+        account_mode="paper",
+        symbol="aapl",
+        side="buy",
+        quantity=10,
+        order_type="market",
+        asset_class="stock",
+    )
+    assert intent.symbol == "AAPL"
+    assert intent.side == "BUY"
+    assert intent.order_type == "MARKET"
+
+
+def test_trade_intent_requires_limit_price_for_limit_orders():
+    with pytest.raises(ValidationError):
+        TradeIntent(
+            request_id="r1",
+            account_mode="paper",
+            symbol="AAPL",
+            side="BUY",
+            quantity=10,
+            order_type="LIMIT",
+            asset_class="stock",
+        )
+
+
+def test_trade_intent_rejects_limit_price_for_market_orders():
+    with pytest.raises(ValidationError):
+        TradeIntent(
+            request_id="r1",
+            account_mode="paper",
+            symbol="AAPL",
+            side="BUY",
+            quantity=10,
+            order_type="MARKET",
+            asset_class="stock",
+            limit_price=200.0,
+        )
+
+
+def test_trade_intent_supports_allowed_status_values():
+    intent = TradeIntent(
+        request_id="r1",
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+        status="pending_confirmation",
+    )
+    assert intent.status == "pending_confirmation"

--- a/tests/brokerage/test_models.py
+++ b/tests/brokerage/test_models.py
@@ -11,6 +11,7 @@ def test_brokerage_settings_defaults_to_paper_mode_and_local_service():
     settings = BrokerageSettings()
     assert settings.service_url == "http://127.0.0.1:8787"
     assert settings.default_account_mode == "paper"
+    assert settings.default_live_account is None
     assert settings.confirmation_ttl_seconds == 120
 
 
@@ -53,6 +54,33 @@ def test_trade_intent_rejects_limit_price_for_market_orders():
             order_type="MARKET",
             asset_class="stock",
             limit_price=200.0,
+        )
+
+
+def test_trade_intent_requires_stop_price_for_stop_orders():
+    with pytest.raises(ValidationError):
+        TradeIntent(
+            request_id="r1",
+            account_mode="paper",
+            symbol="AAPL",
+            side="SELL",
+            quantity=10,
+            order_type="STOP",
+            asset_class="stock",
+        )
+
+
+def test_trade_intent_rejects_stop_price_for_non_stop_orders():
+    with pytest.raises(ValidationError):
+        TradeIntent(
+            request_id="r1",
+            account_mode="paper",
+            symbol="AAPL",
+            side="SELL",
+            quantity=10,
+            order_type="MARKET",
+            asset_class="stock",
+            stop_price=180.0,
         )
 
 

--- a/tests/brokerage/test_policy.py
+++ b/tests/brokerage/test_policy.py
@@ -1,0 +1,103 @@
+"""Tests for deterministic brokerage policy checks."""
+
+from datetime import datetime, timedelta, timezone
+
+from brokerage.config import BrokerageSettings
+from brokerage.models import TradeIntent
+from brokerage.policy import BrokeragePolicy
+
+
+def _make_intent(**overrides) -> TradeIntent:
+    data = {
+        "request_id": "req-1",
+        "account_mode": "paper",
+        "symbol": "AAPL",
+        "side": "BUY",
+        "quantity": 10,
+        "order_type": "MARKET",
+        "asset_class": "stock",
+    }
+    data.update(overrides)
+    return TradeIntent(**data)
+
+
+def test_validate_new_intent_allows_valid_paper_trade():
+    settings = BrokerageSettings()
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(_make_intent(), market_snapshot={"last_price": 100.0})
+
+    assert decision.allowed is True
+    assert decision.reason is None
+
+
+def test_validate_new_intent_rejects_trade_over_paper_share_cap():
+    settings = BrokerageSettings(paper_max_shares=5)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(_make_intent(quantity=10), market_snapshot={"last_price": 100.0})
+
+    assert decision.allowed is False
+    assert "paper_max_shares" in decision.reason
+
+
+def test_validate_new_intent_rejects_trade_over_paper_notional_cap():
+    settings = BrokerageSettings(paper_max_notional=500.0)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(_make_intent(quantity=10), market_snapshot={"last_price": 100.0})
+
+    assert decision.allowed is False
+    assert "paper_max_notional" in decision.reason
+
+
+def test_validate_new_intent_blocks_live_when_live_disabled():
+    settings = BrokerageSettings(live_enabled=False)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(
+        _make_intent(account_mode="live", quantity=1),
+        market_snapshot={"last_price": 100.0},
+    )
+
+    assert decision.allowed is False
+    assert "live trading is disabled" in decision.reason.lower()
+
+
+def test_validate_confirmation_accepts_exact_paper_confirmation_token():
+    policy = BrokeragePolicy(BrokerageSettings())
+    decision = policy.validate_confirmation(
+        _make_intent(),
+        confirmation_text="CONFIRM T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is True
+    assert decision.reason is None
+
+
+def test_validate_confirmation_rejects_expired_token():
+    policy = BrokeragePolicy(BrokerageSettings())
+    decision = policy.validate_confirmation(
+        _make_intent(),
+        confirmation_text="CONFIRM T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+
+    assert decision.allowed is False
+    assert "expired" in decision.reason.lower()
+
+
+def test_validate_confirmation_requires_stronger_live_phrase():
+    policy = BrokeragePolicy(BrokerageSettings(live_enabled=True))
+    decision = policy.validate_confirmation(
+        _make_intent(account_mode="live", quantity=10),
+        confirmation_text="CONFIRM LIVE BUY 10 AAPL T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is True
+    assert decision.reason is None

--- a/tests/brokerage/test_policy.py
+++ b/tests/brokerage/test_policy.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from brokerage.config import BrokerageSettings
 from brokerage.models import TradeIntent
 from brokerage.policy import BrokeragePolicy
@@ -20,6 +22,8 @@ def _make_intent(**overrides) -> TradeIntent:
     data.update(overrides)
     return TradeIntent(**data)
 
+
+# --- Paper mode validation ---
 
 def test_validate_new_intent_allows_valid_paper_trade():
     settings = BrokerageSettings()
@@ -51,6 +55,8 @@ def test_validate_new_intent_rejects_trade_over_paper_notional_cap():
     assert "paper_max_notional" in decision.reason
 
 
+# --- Live mode validation ---
+
 def test_validate_new_intent_blocks_live_when_live_disabled():
     settings = BrokerageSettings(live_enabled=False)
     policy = BrokeragePolicy(settings)
@@ -63,6 +69,100 @@ def test_validate_new_intent_blocks_live_when_live_disabled():
     assert decision.allowed is False
     assert "live trading is disabled" in decision.reason.lower()
 
+
+def test_validate_new_intent_allows_live_when_live_enabled():
+    settings = BrokerageSettings(live_enabled=True)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(
+        _make_intent(account_mode="live", quantity=1),
+        market_snapshot={"last_price": 100.0},
+    )
+
+    assert decision.allowed is True
+
+
+def test_validate_new_intent_rejects_live_trade_over_live_share_cap():
+    settings = BrokerageSettings(live_enabled=True, live_max_shares=3)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(
+        _make_intent(account_mode="live", quantity=5),
+        market_snapshot={"last_price": 100.0},
+    )
+
+    assert decision.allowed is False
+    assert "live_max_shares" in decision.reason
+
+
+def test_validate_new_intent_rejects_live_trade_over_live_notional_cap():
+    settings = BrokerageSettings(live_enabled=True, live_max_shares=100, live_max_notional=500.0)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(
+        _make_intent(account_mode="live", quantity=10),
+        market_snapshot={"last_price": 100.0},
+    )
+
+    assert decision.allowed is False
+    assert "live_max_notional" in decision.reason
+
+
+def test_live_caps_are_independent_of_paper_caps():
+    """Paper allows 25 shares; live allows 5 -- each enforced independently."""
+    settings = BrokerageSettings(live_enabled=True, paper_max_shares=25, live_max_shares=5)
+    policy = BrokeragePolicy(settings)
+
+    # 10 shares OK for paper
+    assert policy.validate_new_intent(
+        _make_intent(quantity=10), market_snapshot={"last_price": 50.0}
+    ).allowed is True
+
+    # 10 shares TOO MANY for live
+    assert policy.validate_new_intent(
+        _make_intent(account_mode="live", quantity=10),
+        market_snapshot={"last_price": 50.0},
+    ).allowed is False
+
+
+def test_validate_new_intent_blocks_disallowed_asset_class():
+    """When asset_class is expanded beyond 'stock', the policy gate must reject
+    classes not in the allowed_asset_classes config. We test this by creating a
+    valid stock intent and then modifying its asset_class post-construction,
+    simulating a future expansion of the model."""
+    settings = BrokerageSettings(allowed_asset_classes=("stock",))
+    policy = BrokeragePolicy(settings)
+
+    intent = _make_intent()
+    intent.asset_class = "option"  # bypass Pydantic validation for policy test
+
+    decision = policy.validate_new_intent(intent)
+
+    assert decision.allowed is False
+    assert "asset class" in decision.reason.lower()
+
+
+def test_validate_new_intent_blocks_blocked_symbol():
+    settings = BrokerageSettings(blocked_symbols=("SPCE",))
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(_make_intent(symbol="SPCE"))
+
+    assert decision.allowed is False
+    assert "blocked" in decision.reason.lower()
+
+
+def test_validate_new_intent_blocks_symbol_not_in_allowed_list():
+    settings = BrokerageSettings(allowed_symbols=("AAPL", "MSFT"))
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(_make_intent(symbol="TSLA"))
+
+    assert decision.allowed is False
+    assert "not in the allowed_symbols" in decision.reason
+
+
+# --- Paper confirmation validation ---
 
 def test_validate_confirmation_accepts_exact_paper_confirmation_token():
     policy = BrokeragePolicy(BrokerageSettings())
@@ -90,6 +190,34 @@ def test_validate_confirmation_rejects_expired_token():
     assert "expired" in decision.reason.lower()
 
 
+def test_validate_confirmation_rejects_wrong_code_for_paper():
+    policy = BrokeragePolicy(BrokerageSettings())
+    decision = policy.validate_confirmation(
+        _make_intent(),
+        confirmation_text="CONFIRM T-WRONG",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is False
+    assert "does not match" in decision.reason.lower()
+
+
+def test_validate_confirmation_rejects_bare_code_without_confirm_prefix():
+    policy = BrokeragePolicy(BrokerageSettings())
+    decision = policy.validate_confirmation(
+        _make_intent(),
+        confirmation_text="T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is False
+    assert "does not match" in decision.reason.lower()
+
+
+# --- Live confirmation validation ---
+
 def test_validate_confirmation_requires_stronger_live_phrase():
     policy = BrokeragePolicy(BrokerageSettings(live_enabled=True))
     decision = policy.validate_confirmation(
@@ -101,3 +229,65 @@ def test_validate_confirmation_requires_stronger_live_phrase():
 
     assert decision.allowed is True
     assert decision.reason is None
+
+
+def test_validate_confirmation_rejects_paper_phrase_for_live():
+    policy = BrokeragePolicy(BrokerageSettings(live_enabled=True))
+    decision = policy.validate_confirmation(
+        _make_intent(account_mode="live", quantity=10),
+        confirmation_text="CONFIRM T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is False
+    assert "does not match" in decision.reason.lower()
+
+
+def test_validate_confirmation_rejects_live_phrase_with_wrong_side():
+    policy = BrokeragePolicy(BrokerageSettings(live_enabled=True))
+    decision = policy.validate_confirmation(
+        _make_intent(account_mode="live", side="BUY", quantity=10, symbol="AAPL"),
+        confirmation_text="CONFIRM LIVE SELL 10 AAPL T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is False
+
+
+def test_validate_confirmation_rejects_live_phrase_with_wrong_quantity():
+    policy = BrokeragePolicy(BrokerageSettings(live_enabled=True))
+    decision = policy.validate_confirmation(
+        _make_intent(account_mode="live", side="BUY", quantity=10, symbol="AAPL"),
+        confirmation_text="CONFIRM LIVE BUY 5 AAPL T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is False
+
+
+def test_validate_confirmation_rejects_live_phrase_with_wrong_symbol():
+    policy = BrokeragePolicy(BrokerageSettings(live_enabled=True))
+    decision = policy.validate_confirmation(
+        _make_intent(account_mode="live", side="BUY", quantity=10, symbol="AAPL"),
+        confirmation_text="CONFIRM LIVE BUY 10 MSFT T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=1),
+    )
+
+    assert decision.allowed is False
+
+
+def test_validate_confirmation_with_no_expiry_always_allowed():
+    """If expires_at is None, the confirmation never expires."""
+    policy = BrokeragePolicy(BrokerageSettings())
+    decision = policy.validate_confirmation(
+        _make_intent(),
+        confirmation_text="CONFIRM T-82K4",
+        confirmation_code="T-82K4",
+        expires_at=None,
+    )
+
+    assert decision.allowed is True

--- a/tests/brokerage/test_policy.py
+++ b/tests/brokerage/test_policy.py
@@ -55,6 +55,19 @@ def test_validate_new_intent_rejects_trade_over_paper_notional_cap():
     assert "paper_max_notional" in decision.reason
 
 
+def test_validate_new_intent_uses_stop_price_for_paper_stop_notional_estimate():
+    settings = BrokerageSettings(paper_max_notional=500.0)
+    policy = BrokeragePolicy(settings)
+
+    decision = policy.validate_new_intent(
+        _make_intent(side="SELL", quantity=5, order_type="STOP", stop_price=150.0),
+        market_snapshot={"last_price": 50.0},
+    )
+
+    assert decision.allowed is False
+    assert "paper_max_notional" in decision.reason
+
+
 # --- Live mode validation ---
 
 def test_validate_new_intent_blocks_live_when_live_disabled():

--- a/tests/brokerage/test_service.py
+++ b/tests/brokerage/test_service.py
@@ -15,7 +15,7 @@ from brokerage.storage import SQLiteBrokerageStore
 
 
 class FakeBroker(BrokerAdapter):
-    def __init__(self, result: BrokerSubmissionResult | None = None, *, order_statuses: dict[str, dict] | None = None):
+    def __init__(self, result: BrokerSubmissionResult | None = None, *, order_statuses: dict[str, dict] | None = None, positions: list[dict] | None = None):
         self.result = result or BrokerSubmissionResult(
             accepted=True,
             broker_order_id="ib-123",
@@ -23,6 +23,7 @@ class FakeBroker(BrokerAdapter):
         )
         self.order_statuses = order_statuses or {}
         self.submitted: list[TradeIntent] = []
+        self._positions = positions or []
 
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         self.submitted.append(intent)
@@ -39,6 +40,9 @@ class FakeBroker(BrokerAdapter):
 
     def cancel_order(self, order_id: str):
         return None
+
+    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
+        return self._positions
 
 
 def _make_service(tmp_path, broker: BrokerAdapter | None = None) -> BrokerageService:
@@ -452,3 +456,23 @@ def test_cancel_cancelled_intent_fails(tmp_path):
 
     with pytest.raises(ValueError, match="pending_confirmation"):
         service.cancel_intent(created["intent_id"])
+
+
+def test_get_positions_delegates_to_broker(tmp_path):
+    positions = [
+        {"symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+    ]
+    broker = FakeBroker(positions=positions)
+    service = _make_service(tmp_path, broker=broker)
+
+    result = service.get_positions(account_mode="paper")
+
+    assert result == positions
+
+
+def test_get_positions_returns_empty_list_when_no_positions(tmp_path):
+    service = _make_service(tmp_path)
+
+    result = service.get_positions()
+
+    assert result == []

--- a/tests/brokerage/test_service.py
+++ b/tests/brokerage/test_service.py
@@ -15,20 +15,27 @@ from brokerage.storage import SQLiteBrokerageStore
 
 
 class FakeBroker(BrokerAdapter):
-    def __init__(self, result: BrokerSubmissionResult | None = None):
+    def __init__(self, result: BrokerSubmissionResult | None = None, *, order_statuses: dict[str, dict] | None = None):
         self.result = result or BrokerSubmissionResult(
             accepted=True,
             broker_order_id="ib-123",
             broker_status="Submitted",
         )
+        self.order_statuses = order_statuses or {}
         self.submitted: list[TradeIntent] = []
 
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         self.submitted.append(intent)
         return self.result
 
-    def get_order_status(self, order_id: str):
-        return None
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
+        return self.order_statuses.get(order_id)
 
     def cancel_order(self, order_id: str):
         return None
@@ -114,6 +121,70 @@ def test_confirm_intent_with_valid_token_submits_order(tmp_path):
     assert len(broker.submitted) == 1
 
 
+def test_get_intent_reconciles_submitted_trade_to_filled_status(tmp_path):
+    broker = FakeBroker(order_statuses={"ib-123": {"broker_status": "Filled"}})
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+    result = service.get_intent(created["intent_id"])
+
+    assert result["status"] == "filled"
+    assert result["broker_status"] == "Filled"
+    events = service.store.list_events(created["intent_id"])
+    assert events[-1]["event_type"] == "filled"
+
+
+def test_get_intent_reconciliation_is_idempotent_for_terminal_status(tmp_path):
+    broker = FakeBroker(order_statuses={"ib-123": {"broker_status": "Filled"}})
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+    first = service.get_intent(created["intent_id"])
+    second = service.get_intent(created["intent_id"])
+
+    assert first["status"] == "filled"
+    assert second["status"] == "filled"
+    events = service.store.list_events(created["intent_id"])
+    assert [event["event_type"] for event in events].count("filled") == 1
+
+
+def test_get_intent_keeps_submitted_status_for_pending_cancel_broker_state(tmp_path):
+    broker = FakeBroker(order_statuses={"ib-123": {"broker_status": "PendingCancel"}})
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+    result = service.get_intent(created["intent_id"])
+
+    assert result["status"] == "submitted"
+    assert result["broker_status"] == "PendingCancel"
+    events = service.store.list_events(created["intent_id"])
+    assert [event["event_type"] for event in events].count("cancelled") == 0
+
+
 def test_broker_rejection_moves_intent_to_rejected(tmp_path):
     broker = FakeBroker(
         BrokerSubmissionResult(
@@ -184,7 +255,13 @@ class CrashingBroker(BrokerAdapter):
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         raise ConnectionError("TWS connection refused")
 
-    def get_order_status(self, order_id: str):
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
         return None
 
     def cancel_order(self, order_id: str):

--- a/tests/brokerage/test_service.py
+++ b/tests/brokerage/test_service.py
@@ -1,0 +1,175 @@
+"""Tests for the brokerage service state machine."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from brokerage.brokers.base import BrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import BrokerSubmissionResult, TradeIntent
+from brokerage.policy import BrokeragePolicy
+from brokerage.service import BrokerageService
+from brokerage.storage import SQLiteBrokerageStore
+
+
+class FakeBroker(BrokerAdapter):
+    def __init__(self, result: BrokerSubmissionResult | None = None):
+        self.result = result or BrokerSubmissionResult(
+            accepted=True,
+            broker_order_id="ib-123",
+            broker_status="Submitted",
+        )
+        self.submitted: list[TradeIntent] = []
+
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        self.submitted.append(intent)
+        return self.result
+
+    def get_order_status(self, order_id: str):
+        return None
+
+    def cancel_order(self, order_id: str):
+        return None
+
+
+def _make_service(tmp_path, broker: BrokerAdapter | None = None) -> BrokerageService:
+    settings = BrokerageSettings()
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    return BrokerageService(settings, store, policy, broker or FakeBroker())
+
+
+def test_create_intent_returns_confirmation_code_and_pending_status(tmp_path):
+    service = _make_service(tmp_path)
+
+    result = service.create_intent(
+        account_mode="paper",
+        symbol="aapl",
+        side="buy",
+        quantity=10,
+        order_type="market",
+        asset_class="stock",
+        raw_request_text="buy 10 aapl market paper",
+        session_id="session-1",
+    )
+
+    assert result["status"] == "pending_confirmation"
+    assert result["intent_id"].startswith("ti_")
+    assert result["confirmation_code"].startswith("T-")
+    assert result["preview"]["symbol"] == "AAPL"
+
+
+def test_confirm_intent_with_wrong_token_fails(tmp_path):
+    service = _make_service(tmp_path)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    with pytest.raises(ValueError, match="confirmation"):
+        service.confirm_intent(created["intent_id"], "CONFIRM T-WRONG")
+
+
+def test_confirm_intent_after_expiry_fails(tmp_path):
+    service = _make_service(tmp_path)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        service.confirm_intent(
+            created["intent_id"],
+            f"CONFIRM {created['confirmation_code']}",
+            now=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+
+
+def test_confirm_intent_with_valid_token_submits_order(tmp_path):
+    broker = FakeBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    result = service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    assert result["status"] == "submitted"
+    assert result["broker_order_id"] == "ib-123"
+    assert len(broker.submitted) == 1
+
+
+def test_broker_rejection_moves_intent_to_rejected(tmp_path):
+    broker = FakeBroker(
+        BrokerSubmissionResult(
+            accepted=False,
+            broker_order_id=None,
+            broker_status="Rejected",
+            detail="insufficient buying power",
+        )
+    )
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    result = service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    assert result["status"] == "rejected"
+    assert result["detail"] == "insufficient buying power"
+
+
+def test_cancel_pending_intent_moves_to_cancelled(tmp_path):
+    service = _make_service(tmp_path)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    result = service.cancel_intent(created["intent_id"])
+
+    assert result["status"] == "cancelled"
+
+
+def test_confirmation_code_is_one_time_use(tmp_path):
+    broker = FakeBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+    confirmation = f"CONFIRM {created['confirmation_code']}"
+
+    first = service.confirm_intent(created["intent_id"], confirmation)
+    assert first["status"] == "submitted"
+
+    with pytest.raises(ValueError, match="pending_confirmation"):
+        service.confirm_intent(created["intent_id"], confirmation)

--- a/tests/brokerage/test_service.py
+++ b/tests/brokerage/test_service.py
@@ -246,6 +246,90 @@ def test_confirmation_code_is_one_time_use(tmp_path):
         service.confirm_intent(created["intent_id"], confirmation)
 
 
+def test_confirm_intent_consumes_confirmation_code(tmp_path):
+    broker = FakeBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+    code = created["confirmation_code"]
+    assert service.store.get_intent(created["intent_id"])["confirmation_code"] == code
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {code}")
+
+    # Code should be nullified after use
+    assert service.store.get_intent(created["intent_id"])["confirmation_code"] is None
+
+
+def test_transition_graph_prevents_backward_transition(tmp_path):
+    """Terminal states cannot transition to any other state."""
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = TradeIntent(
+        request_id="req-t1",
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=1,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+    store.create_intent(intent, confirmation_code="T-AAAA")
+    store.update_status("req-t1", "confirmed")
+    store.update_status("req-t1", "submitted")
+    store.transition_status("req-t1", "submitted", "filled")
+
+    with pytest.raises(ValueError, match="Illegal state transition"):
+        store.update_status("req-t1", "pending_confirmation")
+
+    with pytest.raises(ValueError, match="Illegal state transition"):
+        store.transition_status("req-t1", "filled", "submitted")
+
+
+def test_transition_graph_prevents_skip(tmp_path):
+    """Cannot skip the confirmed state."""
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = TradeIntent(
+        request_id="req-t2",
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=1,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+    store.create_intent(intent, confirmation_code="T-BBBB")
+
+    with pytest.raises(ValueError, match="Illegal state transition"):
+        store.transition_status("req-t2", "pending_confirmation", "submitted")
+
+
+def test_cas_prevents_double_confirm(tmp_path):
+    """Two concurrent confirm calls cannot both succeed — CAS wins."""
+    broker = FakeBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+    code = created["confirmation_code"]
+
+    # First confirm succeeds
+    service.confirm_intent(created["intent_id"], f"CONFIRM {code}")
+
+    # Second confirm fails — status is no longer pending_confirmation
+    with pytest.raises(ValueError, match="pending_confirmation"):
+        service.confirm_intent(created["intent_id"], f"CONFIRM {code}")
+
+
 # --- Broker error handling ---
 
 

--- a/tests/brokerage/test_service.py
+++ b/tests/brokerage/test_service.py
@@ -173,3 +173,121 @@ def test_confirmation_code_is_one_time_use(tmp_path):
 
     with pytest.raises(ValueError, match="pending_confirmation"):
         service.confirm_intent(created["intent_id"], confirmation)
+
+
+# --- Broker error handling ---
+
+
+class CrashingBroker(BrokerAdapter):
+    """A broker that always raises an exception on submit."""
+
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        raise ConnectionError("TWS connection refused")
+
+    def get_order_status(self, order_id: str):
+        return None
+
+    def cancel_order(self, order_id: str):
+        return None
+
+
+def test_confirm_intent_handles_broker_exception_gracefully(tmp_path):
+    broker = CrashingBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    result = service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    assert result["status"] == "submission_error"
+    assert "TWS connection refused" in result["detail"]
+    assert result["broker_order_id"] is None
+
+    # Verify persisted status
+    stored = service.get_intent(created["intent_id"])
+    assert stored["status"] == "submission_error"
+
+
+def test_confirm_intent_logs_submission_error_event(tmp_path):
+    broker = CrashingBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    events = service.store.list_events(created["intent_id"])
+    event_types = [e["event_type"] for e in events]
+    assert "submission_error" in event_types
+
+
+def test_cancel_rejected_intent_fails(tmp_path):
+    broker = FakeBroker(
+        BrokerSubmissionResult(
+            accepted=False,
+            broker_order_id=None,
+            broker_status="Rejected",
+            detail="insufficient buying power",
+        )
+    )
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    with pytest.raises(ValueError, match="pending_confirmation"):
+        service.cancel_intent(created["intent_id"])
+
+
+def test_cancel_submission_error_intent_fails(tmp_path):
+    broker = CrashingBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    with pytest.raises(ValueError, match="pending_confirmation"):
+        service.cancel_intent(created["intent_id"])
+
+
+def test_cancel_cancelled_intent_fails(tmp_path):
+    service = _make_service(tmp_path)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    service.cancel_intent(created["intent_id"])
+
+    with pytest.raises(ValueError, match="pending_confirmation"):
+        service.cancel_intent(created["intent_id"])

--- a/tests/brokerage/test_service.py
+++ b/tests/brokerage/test_service.py
@@ -24,6 +24,7 @@ class FakeBroker(BrokerAdapter):
         self.order_statuses = order_statuses or {}
         self.submitted: list[TradeIntent] = []
         self._positions = positions or []
+        self.last_positions_query: dict[str, str | None] | None = None
 
     def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
         self.submitted.append(intent)
@@ -41,8 +42,11 @@ class FakeBroker(BrokerAdapter):
     def cancel_order(self, order_id: str):
         return None
 
-    def get_positions(self, *, account_mode: str | None = None) -> list[dict]:
-        return self._positions
+    def get_positions(self, *, account_mode: str | None = None, account: str | None = None) -> list[dict]:
+        self.last_positions_query = {"account_mode": account_mode, "account": account}
+        if account is None:
+            return self._positions
+        return [p for p in self._positions if p.get("account") == account]
 
 
 def _make_service(tmp_path, broker: BrokerAdapter | None = None) -> BrokerageService:
@@ -123,6 +127,112 @@ def test_confirm_intent_with_valid_token_submits_order(tmp_path):
     assert result["status"] == "submitted"
     assert result["broker_order_id"] == "ib-123"
     assert len(broker.submitted) == 1
+
+
+def test_paper_stop_market_order_survives_create_and_confirm(tmp_path):
+    broker = FakeBroker()
+    service = _make_service(tmp_path, broker=broker)
+    created = service.create_intent(
+        account_mode="paper",
+        symbol="AAPL",
+        side="SELL",
+        quantity=5,
+        order_type="STOP",
+        stop_price=180.25,
+        asset_class="stock",
+    )
+
+    assert created["preview"]["stop_price"] == 180.25
+
+    result = service.confirm_intent(created["intent_id"], f"CONFIRM {created['confirmation_code']}")
+
+    assert result["status"] == "submitted"
+    assert broker.submitted[0].order_type == "STOP"
+    assert broker.submitted[0].stop_price == 180.25
+
+
+def test_live_trade_defaults_to_configured_live_account_and_freezes_it_in_preview(tmp_path):
+    settings = BrokerageSettings(live_enabled=True, default_live_account="U3510752")
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    broker = FakeBroker()
+    service = BrokerageService(settings, store, policy, broker)
+
+    created = service.create_intent(
+        account_mode="live",
+        symbol="AAPL",
+        side="BUY",
+        quantity=1,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+    assert created["preview"]["broker_account"] == "U3510752"
+
+    result = service.confirm_intent(
+        created["intent_id"],
+        f"CONFIRM LIVE BUY 1 AAPL {created['confirmation_code']}",
+    )
+
+    assert result["status"] == "submitted"
+    assert broker.submitted[0].broker_account == "U3510752"
+
+
+def test_explicit_live_account_overrides_default_live_account(tmp_path):
+    settings = BrokerageSettings(live_enabled=True, default_live_account="U3510752")
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    broker = FakeBroker()
+    service = BrokerageService(settings, store, policy, broker)
+
+    created = service.create_intent(
+        account_mode="live",
+        symbol="AAPL",
+        side="BUY",
+        quantity=1,
+        order_type="MARKET",
+        asset_class="stock",
+        broker_account="U3053904",
+    )
+
+    assert created["preview"]["broker_account"] == "U3053904"
+
+    service.confirm_intent(
+        created["intent_id"],
+        f"CONFIRM LIVE BUY 1 AAPL {created['confirmation_code']}",
+    )
+
+    assert broker.submitted[0].broker_account == "U3053904"
+
+
+def test_live_stop_market_order_uses_default_live_account(tmp_path):
+    settings = BrokerageSettings(live_enabled=True, default_live_account="U3510752")
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    broker = FakeBroker()
+    service = BrokerageService(settings, store, policy, broker)
+
+    created = service.create_intent(
+        account_mode="live",
+        symbol="AAPL",
+        side="SELL",
+        quantity=1,
+        order_type="STOP",
+        stop_price=180.25,
+        asset_class="stock",
+    )
+
+    assert created["preview"]["broker_account"] == "U3510752"
+    assert created["preview"]["stop_price"] == 180.25
+
+    service.confirm_intent(
+        created["intent_id"],
+        f"CONFIRM LIVE SELL 1 AAPL {created['confirmation_code']}",
+    )
+
+    assert broker.submitted[0].broker_account == "U3510752"
+    assert broker.submitted[0].order_type == "STOP"
+    assert broker.submitted[0].stop_price == 180.25
 
 
 def test_get_intent_reconciles_submitted_trade_to_filled_status(tmp_path):
@@ -460,7 +570,7 @@ def test_cancel_cancelled_intent_fails(tmp_path):
 
 def test_get_positions_delegates_to_broker(tmp_path):
     positions = [
-        {"symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+        {"account": "DUQ218494", "symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
     ]
     broker = FakeBroker(positions=positions)
     service = _make_service(tmp_path, broker=broker)
@@ -468,6 +578,21 @@ def test_get_positions_delegates_to_broker(tmp_path):
     result = service.get_positions(account_mode="paper")
 
     assert result == positions
+    assert broker.last_positions_query == {"account_mode": "paper", "account": None}
+
+
+def test_get_positions_delegates_account_filter_to_broker(tmp_path):
+    positions = [
+        {"account": "DUQ218494", "symbol": "AAPL", "position": 5.0, "avg_cost": 264.98, "account_mode": "paper"},
+        {"account": "U3510752", "symbol": "NFLX", "position": 10.0, "avg_cost": 900.5, "account_mode": "live"},
+    ]
+    broker = FakeBroker(positions=positions)
+    service = _make_service(tmp_path, broker=broker)
+
+    result = service.get_positions(account_mode="live", account="U3510752")
+
+    assert result == [positions[1]]
+    assert broker.last_positions_query == {"account_mode": "live", "account": "U3510752"}
 
 
 def test_get_positions_returns_empty_list_when_no_positions(tmp_path):

--- a/tests/brokerage/test_storage.py
+++ b/tests/brokerage/test_storage.py
@@ -43,12 +43,36 @@ def test_store_updates_status_and_order_id(tmp_path):
     intent = _make_intent()
     store.create_intent(intent, confirmation_code="T-82K4")
 
+    # Must follow legal transition graph: pending_confirmation -> confirmed -> submitted
+    store.update_status("req-1", "confirmed")
     store.update_status("req-1", "submitted", ibkr_order_id="ib-123")
 
     loaded = store.get_intent("req-1")
     assert loaded is not None
     assert loaded["status"] == "submitted"
     assert loaded["ibkr_order_id"] == "ib-123"
+
+
+def test_store_rejects_illegal_transition(tmp_path):
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = _make_intent()
+    store.create_intent(intent, confirmation_code="T-82K4")
+
+    import pytest
+    with pytest.raises(ValueError, match="Illegal state transition"):
+        store.update_status("req-1", "submitted")  # can't skip confirmed
+
+
+def test_store_consume_confirmation_code(tmp_path):
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = _make_intent()
+    store.create_intent(intent, confirmation_code="T-82K4")
+
+    assert store.get_intent("req-1")["confirmation_code"] == "T-82K4"
+    assert store.consume_confirmation_code("req-1") is True
+    assert store.get_intent("req-1")["confirmation_code"] is None
+    # Second consume is a no-op
+    assert store.consume_confirmation_code("req-1") is False
 
 
 def test_store_appends_audit_events(tmp_path):

--- a/tests/brokerage/test_storage.py
+++ b/tests/brokerage/test_storage.py
@@ -1,0 +1,78 @@
+"""Tests for brokerage SQLite storage."""
+
+from datetime import datetime, timedelta, timezone
+
+from brokerage.models import TradeEvent, TradeIntent
+from brokerage.storage import SQLiteBrokerageStore
+
+
+def _make_intent() -> TradeIntent:
+    return TradeIntent(
+        request_id="req-1",
+        account_mode="paper",
+        symbol="AAPL",
+        side="BUY",
+        quantity=10,
+        order_type="MARKET",
+        asset_class="stock",
+    )
+
+
+def test_store_initializes_schema_and_round_trips_intent(tmp_path):
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = _make_intent()
+
+    store.create_intent(
+        intent,
+        confirmation_code="T-82K4",
+        confirmation_expires_at=datetime.now(timezone.utc) + timedelta(minutes=2),
+        raw_request_text="buy 10 aapl market paper",
+        session_id="session-1",
+    )
+
+    loaded = store.get_intent(intent.request_id)
+    assert loaded is not None
+    assert loaded["intent_id"] == "req-1"
+    assert loaded["symbol"] == "AAPL"
+    assert loaded["confirmation_code"] == "T-82K4"
+    assert loaded["status"] == "pending_confirmation"
+
+
+def test_store_updates_status_and_order_id(tmp_path):
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = _make_intent()
+    store.create_intent(intent, confirmation_code="T-82K4")
+
+    store.update_status("req-1", "submitted", ibkr_order_id="ib-123")
+
+    loaded = store.get_intent("req-1")
+    assert loaded is not None
+    assert loaded["status"] == "submitted"
+    assert loaded["ibkr_order_id"] == "ib-123"
+
+
+def test_store_appends_audit_events(tmp_path):
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    store.append_event(TradeEvent(intent_id="req-1", event_type="created", detail="created by test"))
+
+    events = store.list_events("req-1")
+    assert len(events) == 1
+    assert events[0]["event_type"] == "created"
+    assert events[0]["detail"] == "created by test"
+
+
+def test_store_expires_stale_pending_confirmations(tmp_path):
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    intent = _make_intent()
+    store.create_intent(
+        intent,
+        confirmation_code="T-82K4",
+        confirmation_expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+
+    expired = store.expire_pending_confirmations(datetime.now(timezone.utc))
+
+    assert expired == 1
+    loaded = store.get_intent("req-1")
+    assert loaded is not None
+    assert loaded["status"] == "expired"

--- a/tests/tools/test_brokerage_tool.py
+++ b/tests/tools/test_brokerage_tool.py
@@ -65,7 +65,13 @@ class _IntegrationFakeBroker(BrokerAdapter):
         self.submitted.append(intent)
         return self.result
 
-    def get_order_status(self, order_id: str):
+    def get_order_status(
+        self,
+        order_id: str,
+        *,
+        account_mode: str | None = None,
+        expected_quantity: int | None = None,
+    ):
         return None
 
     def cancel_order(self, order_id: str):

--- a/tests/tools/test_brokerage_tool.py
+++ b/tests/tools/test_brokerage_tool.py
@@ -1,0 +1,210 @@
+"""Tests for Hermes brokerage tool wrappers."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from model_tools import get_tool_definitions
+
+import tools.brokerage_tool as brokerage_tool
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+        self.request = httpx.Request("POST", "http://127.0.0.1:8787")
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("request failed", request=self.request, response=self)
+
+
+class _FakeClient:
+    def __init__(self, calls: list[dict], response: _FakeResponse):
+        self._calls = calls
+        self._response = response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def request(self, method, url, *, json=None, headers=None):
+        self._calls.append({
+            "method": method,
+            "url": url,
+            "json": json,
+            "headers": headers,
+        })
+        return self._response
+
+
+def test_brokerage_tools_register_under_brokerage_toolset(monkeypatch):
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": True, "service_url": "http://127.0.0.1:8787", "service_token": "secret"},
+    )
+
+    tools = get_tool_definitions(enabled_toolsets=["brokerage"], quiet_mode=True)
+    names = {tool["function"]["name"] for tool in tools}
+
+    assert names == {
+        "create_trade_intent",
+        "confirm_trade_intent",
+        "cancel_trade_intent",
+        "get_trade_intent_status",
+    }
+
+
+def test_create_trade_intent_sends_expected_payload_and_auth_header(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": True, "service_url": "http://127.0.0.1:8787", "service_token": "secret"},
+    )
+    monkeypatch.setattr(
+        brokerage_tool.httpx,
+        "Client",
+        lambda timeout: _FakeClient(
+            calls,
+            _FakeResponse(
+                201,
+                {
+                    "intent_id": "ti_123",
+                    "status": "pending_confirmation",
+                    "confirmation_code": "T-82K4",
+                },
+            ),
+        ),
+    )
+
+    result = json.loads(
+        brokerage_tool.create_trade_intent_tool(
+            {
+                "account_mode": "paper",
+                "symbol": "aapl",
+                "side": "buy",
+                "quantity": 10,
+                "order_type": "market",
+                "asset_class": "stock",
+                "raw_user_text": "buy 10 shares of aapl at market in paper",
+            }
+        )
+    )
+
+    assert result["intent_id"] == "ti_123"
+    assert calls == [
+        {
+            "method": "POST",
+            "url": "http://127.0.0.1:8787/trade-intents",
+            "json": {
+                "account_mode": "paper",
+                "symbol": "aapl",
+                "side": "buy",
+                "quantity": 10,
+                "order_type": "market",
+                "asset_class": "stock",
+                "raw_request_text": "buy 10 shares of aapl at market in paper",
+            },
+            "headers": {"Authorization": "Bearer secret"},
+        }
+    ]
+
+
+def test_confirm_trade_intent_forwards_intent_id_and_confirmation_text(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": True, "service_url": "http://127.0.0.1:8787", "service_token": None},
+    )
+    monkeypatch.setattr(
+        brokerage_tool.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, _FakeResponse(200, {"status": "submitted"})),
+    )
+
+    result = json.loads(
+        brokerage_tool.confirm_trade_intent_tool(
+            {"intent_id": "ti_123", "confirmation_text": "CONFIRM T-82K4"}
+        )
+    )
+
+    assert result == {"status": "submitted"}
+    assert calls == [
+        {
+            "method": "POST",
+            "url": "http://127.0.0.1:8787/trade-intents/ti_123/confirm",
+            "json": {"confirmation_text": "CONFIRM T-82K4"},
+            "headers": {},
+        }
+    ]
+
+
+def test_cancel_trade_intent_calls_cancel_endpoint(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": True, "service_url": "http://127.0.0.1:8787", "service_token": None},
+    )
+    monkeypatch.setattr(
+        brokerage_tool.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, _FakeResponse(200, {"status": "cancelled"})),
+    )
+
+    result = json.loads(brokerage_tool.cancel_trade_intent_tool({"intent_id": "ti_123"}))
+
+    assert result == {"status": "cancelled"}
+    assert calls == [
+        {
+            "method": "POST",
+            "url": "http://127.0.0.1:8787/trade-intents/ti_123/cancel",
+            "json": None,
+            "headers": {},
+        }
+    ]
+
+
+def test_service_http_errors_become_json_errors(monkeypatch):
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": True, "service_url": "http://127.0.0.1:8787", "service_token": "secret"},
+    )
+    monkeypatch.setattr(
+        brokerage_tool.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls=[], response=_FakeResponse(400, {"detail": "bad confirmation"})),
+    )
+
+    result = json.loads(
+        brokerage_tool.confirm_trade_intent_tool(
+            {"intent_id": "ti_123", "confirmation_text": "CONFIRM T-WRONG"}
+        )
+    )
+
+    assert result == {"error": "Brokerage service error (400): bad confirmation"}
+
+
+def test_brokerage_toolset_is_unavailable_when_disabled(monkeypatch):
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": False, "service_url": "http://127.0.0.1:8787", "service_token": "secret"},
+    )
+
+    tools = get_tool_definitions(enabled_toolsets=["brokerage"], quiet_mode=True)
+
+    assert tools == []

--- a/tests/tools/test_brokerage_tool.py
+++ b/tests/tools/test_brokerage_tool.py
@@ -134,6 +134,7 @@ def test_brokerage_tools_register_under_brokerage_toolset(monkeypatch):
         "confirm_trade_intent",
         "cancel_trade_intent",
         "get_trade_intent_status",
+        "brokerage_health",
     }
 
 

--- a/tests/tools/test_brokerage_tool.py
+++ b/tests/tools/test_brokerage_tool.py
@@ -3,9 +3,18 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import httpx
+from fastapi.testclient import TestClient
 
+from brokerage.app import create_app
+from brokerage.brokers.base import BrokerAdapter
+from brokerage.config import BrokerageSettings
+from brokerage.models import BrokerSubmissionResult, TradeIntent
+from brokerage.policy import BrokeragePolicy
+from brokerage.service import BrokerageService
+from brokerage.storage import SQLiteBrokerageStore
 from model_tools import get_tool_definitions
 
 import tools.brokerage_tool as brokerage_tool
@@ -45,6 +54,69 @@ class _FakeClient:
             "headers": headers,
         })
         return self._response
+
+
+class _IntegrationFakeBroker(BrokerAdapter):
+    def __init__(self, result: BrokerSubmissionResult):
+        self.result = result
+        self.submitted: list[TradeIntent] = []
+
+    def submit_order(self, intent: TradeIntent) -> BrokerSubmissionResult:
+        self.submitted.append(intent)
+        return self.result
+
+    def get_order_status(self, order_id: str):
+        return None
+
+    def cancel_order(self, order_id: str):
+        return None
+
+
+def _make_integration_client(tmp_path: Path) -> tuple[TestClient, _IntegrationFakeBroker]:
+    settings = BrokerageSettings(enabled=True, service_token="test-token")
+    store = SQLiteBrokerageStore(tmp_path / "brokerage.db")
+    policy = BrokeragePolicy(settings)
+    broker = _IntegrationFakeBroker(
+        BrokerSubmissionResult(
+            accepted=True,
+            broker_order_id="ib-int-123",
+            broker_status="Submitted",
+        )
+    )
+    service = BrokerageService(settings, store, policy, broker)
+    app = create_app(service=service, auth_token="test-token")
+    return TestClient(app), broker
+
+
+def _patch_integration_transport(monkeypatch, client: TestClient) -> None:
+    class _BridgeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def request(self, method, url, *, json=None, headers=None):
+            response = client.request(method, url, json=json, headers=headers)
+            return httpx.Response(
+                status_code=response.status_code,
+                json=response.json(),
+                request=httpx.Request(method, url),
+            )
+
+    monkeypatch.setattr(brokerage_tool.httpx, "Client", _BridgeClient)
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {
+            "enabled": True,
+            "service_url": "http://testserver",
+            "service_token": "test-token",
+        },
+    )
 
 
 def test_brokerage_tools_register_under_brokerage_toolset(monkeypatch):
@@ -208,3 +280,38 @@ def test_brokerage_toolset_is_unavailable_when_disabled(monkeypatch):
     tools = get_tool_definitions(enabled_toolsets=["brokerage"], quiet_mode=True)
 
     assert tools == []
+
+
+def test_tool_flow_can_reach_real_service_and_submit_trade(tmp_path, monkeypatch):
+    client, broker = _make_integration_client(tmp_path)
+    _patch_integration_transport(monkeypatch, client)
+
+    created = json.loads(
+        brokerage_tool.create_trade_intent_tool(
+            {
+                "account_mode": "paper",
+                "symbol": "AAPL",
+                "side": "BUY",
+                "quantity": 10,
+                "order_type": "MARKET",
+                "asset_class": "stock",
+            }
+        )
+    )
+    confirmed = json.loads(
+        brokerage_tool.confirm_trade_intent_tool(
+            {
+                "intent_id": created["intent_id"],
+                "confirmation_text": f"CONFIRM {created['confirmation_code']}",
+            }
+        )
+    )
+    status = json.loads(
+        brokerage_tool.get_trade_intent_status_tool({"intent_id": created["intent_id"]})
+    )
+
+    assert created["status"] == "pending_confirmation"
+    assert confirmed["status"] == "submitted"
+    assert confirmed["broker_order_id"] == "ib-int-123"
+    assert status["status"] == "submitted"
+    assert [intent.symbol for intent in broker.submitted] == ["AAPL"]

--- a/tests/tools/test_brokerage_tool.py
+++ b/tests/tools/test_brokerage_tool.py
@@ -200,6 +200,37 @@ def test_create_trade_intent_sends_expected_payload_and_auth_header(monkeypatch)
     ]
 
 
+def test_create_trade_intent_forwards_stop_price(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        brokerage_tool,
+        "_load_brokerage_config",
+        lambda: {"enabled": True, "service_url": "http://127.0.0.1:8787", "service_token": "secret"},
+    )
+    monkeypatch.setattr(
+        brokerage_tool.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, _FakeResponse(201, {"intent_id": "ti_stop", "status": "pending_confirmation"})),
+    )
+
+    json.loads(
+        brokerage_tool.create_trade_intent_tool(
+            {
+                "account_mode": "paper",
+                "symbol": "aapl",
+                "side": "sell",
+                "quantity": 5,
+                "order_type": "stop",
+                "stop_price": 180.25,
+                "asset_class": "stock",
+            }
+        )
+    )
+
+    assert calls[0]["json"]["order_type"] == "stop"
+    assert calls[0]["json"]["stop_price"] == 180.25
+
+
 def test_confirm_trade_intent_forwards_intent_id_and_confirmation_text(monkeypatch):
     calls = []
     monkeypatch.setattr(
@@ -278,6 +309,9 @@ def test_service_http_errors_become_json_errors(monkeypatch):
 
 
 def test_brokerage_toolset_is_unavailable_when_disabled(monkeypatch):
+    monkeypatch.delenv("BROKERAGE_ENABLED", raising=False)
+    monkeypatch.delenv("BROKERAGE_SERVICE_URL", raising=False)
+    monkeypatch.delenv("BROKERAGE_SERVICE_TOKEN", raising=False)
     monkeypatch.setattr(
         brokerage_tool,
         "_load_brokerage_config",

--- a/tools/brokerage_tool.py
+++ b/tools/brokerage_tool.py
@@ -1,0 +1,220 @@
+"""Hermes tool wrappers for the local brokerage FastAPI service."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+
+from tools.registry import registry, tool_error, tool_result
+
+
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+BROKERAGE_TOOL_DESCRIPTION = (
+    "Create and manage deterministic brokerage trade intents through the local brokerage service. "
+    "Always create a pending trade intent first. Never submit a trade directly from natural language. "
+    "Do not call confirm_trade_intent unless the user has explicitly confirmed the trade."
+)
+
+
+CREATE_TRADE_INTENT_SCHEMA = {
+    "name": "create_trade_intent",
+    "description": (
+        BROKERAGE_TOOL_DESCRIPTION
+        + " Use this to turn a requested trade into a pending intent with a confirmation code."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "account_mode": {"type": "string", "enum": ["paper", "live"]},
+            "symbol": {"type": "string"},
+            "side": {"type": "string", "enum": ["buy", "sell", "BUY", "SELL"]},
+            "quantity": {"type": "integer", "minimum": 1},
+            "order_type": {"type": "string", "enum": ["market", "limit", "MARKET", "LIMIT"]},
+            "limit_price": {"type": "number", "exclusiveMinimum": 0},
+            "asset_class": {"type": "string", "default": "stock"},
+            "time_in_force": {"type": "string", "default": "DAY"},
+            "raw_user_text": {
+                "type": "string",
+                "description": "Optional original user message for audit logging.",
+            },
+        },
+        "required": ["account_mode", "symbol", "side", "quantity", "order_type"],
+    },
+}
+
+
+CONFIRM_TRADE_INTENT_SCHEMA = {
+    "name": "confirm_trade_intent",
+    "description": (
+        BROKERAGE_TOOL_DESCRIPTION
+        + " Only call this after the user explicitly provides the confirmation text."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "intent_id": {"type": "string"},
+            "confirmation_text": {"type": "string"},
+        },
+        "required": ["intent_id", "confirmation_text"],
+    },
+}
+
+
+CANCEL_TRADE_INTENT_SCHEMA = {
+    "name": "cancel_trade_intent",
+    "description": "Cancel a pending trade intent before broker submission.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "intent_id": {"type": "string"},
+        },
+        "required": ["intent_id"],
+    },
+}
+
+
+GET_TRADE_INTENT_STATUS_SCHEMA = {
+    "name": "get_trade_intent_status",
+    "description": "Fetch the current stored status for a trade intent.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "intent_id": {"type": "string"},
+        },
+        "required": ["intent_id"],
+    },
+}
+
+
+def _load_brokerage_config() -> dict[str, Any]:
+    """Load the brokerage section from Hermes config, returning an empty dict on failure."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        brokerage = config.get("brokerage", {}) if isinstance(config, dict) else {}
+        return brokerage if isinstance(brokerage, dict) else {}
+    except Exception:
+        return {}
+
+
+def check_brokerage_requirements() -> bool:
+    config = _load_brokerage_config()
+    return bool(config.get("enabled") and str(config.get("service_url", "")).strip())
+
+
+def _build_headers(config: dict[str, Any]) -> dict[str, str]:
+    token = config.get("service_token")
+    if token and str(token).strip():
+        return {"Authorization": f"Bearer {str(token).strip()}"}
+    return {}
+
+
+def _service_request(method: str, path: str, *, payload: dict[str, Any] | None = None) -> str:
+    config = _load_brokerage_config()
+    base_url = str(config.get("service_url", "")).rstrip("/")
+    if not base_url:
+        return tool_error("Brokerage service_url is not configured")
+
+    url = f"{base_url}{path}"
+    headers = _build_headers(config)
+
+    try:
+        with httpx.Client(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
+            response = client.request(method, url, json=payload, headers=headers)
+            response.raise_for_status()
+            return tool_result(response.json())
+    except httpx.HTTPStatusError as exc:
+        detail = None
+        try:
+            body = exc.response.json()
+            if isinstance(body, dict):
+                detail = body.get("detail") or body.get("error")
+        except Exception:
+            detail = None
+        detail = detail or exc.response.text or str(exc)
+        return tool_error(f"Brokerage service error ({exc.response.status_code}): {detail}")
+    except Exception as exc:
+        return tool_error(f"Brokerage service request failed: {exc}")
+
+
+def create_trade_intent_tool(args: dict[str, Any], **kwargs) -> str:
+    payload = {
+        "account_mode": args.get("account_mode"),
+        "symbol": args.get("symbol"),
+        "side": args.get("side"),
+        "quantity": args.get("quantity"),
+        "order_type": args.get("order_type"),
+        "asset_class": args.get("asset_class", "stock"),
+    }
+    if args.get("limit_price") is not None:
+        payload["limit_price"] = args.get("limit_price")
+    if args.get("raw_user_text"):
+        payload["raw_request_text"] = args.get("raw_user_text")
+    return _service_request("POST", "/trade-intents", payload=payload)
+
+
+def confirm_trade_intent_tool(args: dict[str, Any], **kwargs) -> str:
+    intent_id = args.get("intent_id")
+    if not intent_id:
+        return tool_error("intent_id is required")
+    return _service_request(
+        "POST",
+        f"/trade-intents/{intent_id}/confirm",
+        payload={"confirmation_text": args.get("confirmation_text")},
+    )
+
+
+def cancel_trade_intent_tool(args: dict[str, Any], **kwargs) -> str:
+    intent_id = args.get("intent_id")
+    if not intent_id:
+        return tool_error("intent_id is required")
+    return _service_request("POST", f"/trade-intents/{intent_id}/cancel")
+
+
+def get_trade_intent_status_tool(args: dict[str, Any], **kwargs) -> str:
+    intent_id = args.get("intent_id")
+    if not intent_id:
+        return tool_error("intent_id is required")
+    return _service_request("GET", f"/trade-intents/{intent_id}")
+
+
+registry.register(
+    name="create_trade_intent",
+    toolset="brokerage",
+    schema=CREATE_TRADE_INTENT_SCHEMA,
+    handler=create_trade_intent_tool,
+    check_fn=check_brokerage_requirements,
+    emoji="💸",
+)
+
+registry.register(
+    name="confirm_trade_intent",
+    toolset="brokerage",
+    schema=CONFIRM_TRADE_INTENT_SCHEMA,
+    handler=confirm_trade_intent_tool,
+    check_fn=check_brokerage_requirements,
+    emoji="✅",
+)
+
+registry.register(
+    name="cancel_trade_intent",
+    toolset="brokerage",
+    schema=CANCEL_TRADE_INTENT_SCHEMA,
+    handler=cancel_trade_intent_tool,
+    check_fn=check_brokerage_requirements,
+    emoji="🛑",
+)
+
+registry.register(
+    name="get_trade_intent_status",
+    toolset="brokerage",
+    schema=GET_TRADE_INTENT_STATUS_SCHEMA,
+    handler=get_trade_intent_status_tool,
+    check_fn=check_brokerage_requirements,
+    emoji="📈",
+)

--- a/tools/brokerage_tool.py
+++ b/tools/brokerage_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 import httpx
@@ -104,11 +105,16 @@ def _load_brokerage_config() -> dict[str, Any]:
 
 def check_brokerage_requirements() -> bool:
     config = _load_brokerage_config()
-    return bool(config.get("enabled") and str(config.get("service_url", "")).strip())
+    enabled = config.get("enabled")
+    # Also accept BROKERAGE_ENABLED env var as a fallback
+    if not enabled:
+        enabled = os.environ.get("BROKERAGE_ENABLED", "").lower() in ("1", "true", "yes")
+    return bool(enabled and (str(config.get("service_url", "")).strip() or os.environ.get("BROKERAGE_SERVICE_URL", "").strip()))
 
 
 def _build_headers(config: dict[str, Any]) -> dict[str, str]:
-    token = config.get("service_token")
+    # Token can come from config YAML (brokerage.service_token) or .env (BROKERAGE_SERVICE_TOKEN)
+    token = config.get("service_token") or os.environ.get("BROKERAGE_SERVICE_TOKEN", "")
     if token and str(token).strip():
         return {"Authorization": f"Bearer {str(token).strip()}"}
     return {}
@@ -116,10 +122,7 @@ def _build_headers(config: dict[str, Any]) -> dict[str, str]:
 
 def _service_request(method: str, path: str, *, payload: dict[str, Any] | None = None) -> str:
     config = _load_brokerage_config()
-    base_url = str(config.get("service_url", "")).rstrip("/")
-    if not base_url:
-        return tool_error("Brokerage service_url is not configured")
-
+    base_url = str(config.get("service_url", "")).rstrip("/") or os.environ.get("BROKERAGE_SERVICE_URL", "http://127.0.0.1:8787").rstrip("/")
     url = f"{base_url}{path}"
     headers = _build_headers(config)
 
@@ -183,6 +186,20 @@ def get_trade_intent_status_tool(args: dict[str, Any], **kwargs) -> str:
     return _service_request("GET", f"/trade-intents/{intent_id}")
 
 
+BROKERAGE_HEALTH_SCHEMA = {
+    "name": "brokerage_health",
+    "description": "Check if the brokerage service is running and the broker connection is healthy. Returns service status and IBKR connection state.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+    },
+}
+
+
+def brokerage_health_tool(args: dict[str, Any], **kwargs) -> str:
+    return _service_request("GET", "/healthz")
+
+
 registry.register(
     name="create_trade_intent",
     toolset="brokerage",
@@ -217,4 +234,13 @@ registry.register(
     handler=get_trade_intent_status_tool,
     check_fn=check_brokerage_requirements,
     emoji="📈",
+)
+
+registry.register(
+    name="brokerage_health",
+    toolset="brokerage",
+    schema=BROKERAGE_HEALTH_SCHEMA,
+    handler=brokerage_health_tool,
+    check_fn=check_brokerage_requirements,
+    emoji="🩺",
 )

--- a/tools/brokerage_tool.py
+++ b/tools/brokerage_tool.py
@@ -34,8 +34,9 @@ CREATE_TRADE_INTENT_SCHEMA = {
             "symbol": {"type": "string"},
             "side": {"type": "string", "enum": ["buy", "sell", "BUY", "SELL"]},
             "quantity": {"type": "integer", "minimum": 1},
-            "order_type": {"type": "string", "enum": ["market", "limit", "MARKET", "LIMIT"]},
+            "order_type": {"type": "string", "enum": ["market", "limit", "stop", "MARKET", "LIMIT", "STOP"]},
             "limit_price": {"type": "number", "exclusiveMinimum": 0},
+            "stop_price": {"type": "number", "exclusiveMinimum": 0},
             "asset_class": {"type": "string", "default": "stock"},
             "time_in_force": {"type": "string", "default": "DAY"},
             "raw_user_text": {
@@ -156,6 +157,8 @@ def create_trade_intent_tool(args: dict[str, Any], **kwargs) -> str:
     }
     if args.get("limit_price") is not None:
         payload["limit_price"] = args.get("limit_price")
+    if args.get("stop_price") is not None:
+        payload["stop_price"] = args.get("stop_price")
     if args.get("raw_user_text"):
         payload["raw_request_text"] = args.get("raw_user_text")
     return _service_request("POST", "/trade-intents", payload=payload)

--- a/toolsets.py
+++ b/toolsets.py
@@ -201,6 +201,17 @@ TOOLSETS = {
         "includes": []
     },
 
+    "brokerage": {
+        "description": "Deterministic brokerage intent tools that call the local FastAPI trading service",
+        "tools": [
+            "create_trade_intent",
+            "confirm_trade_intent",
+            "cancel_trade_intent",
+            "get_trade_intent_status",
+        ],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -208,6 +208,7 @@ TOOLSETS = {
             "confirm_trade_intent",
             "cancel_trade_intent",
             "get_trade_intent_status",
+            "brokerage_health",
         ],
         "includes": []
     },


### PR DESCRIPTION
## Summary

Production-ready Interactive Brokers integration for the Hermes brokerage subsystem, enabling trade execution via a Telegram-based approval flow.

### Commits

1. **fix: ensure ibkr worker threads have an event loop** (`68662029`)
   - FastAPI worker threads (AnyIO) lacked an asyncio event loop required by `ib_insync`
   - Added `_ensure_thread_event_loop()` to create/restore loops on demand

2. **feat: reconcile brokerage intents with broker status** (`b241dc1a`)
   - On-demand reconciliation during `GET /trade-intents/{id}` calls
   - Maps IBKR states (Filled, Cancelled, ApiCancelled, Inactive) to local states
   - Uses `reqExecutions()` and `reqCompletedOrders()` as safety lookups

3. **fix: cross-check executions when openTrade status is stale** (`f84821d2`)
   - `ib_insync`'s `orderStatus` can be stale (showing `PendingSubmit`) after a fill
   - When open-trade status is non-terminal, now cross-checks `reqExecutions()` before returning
   - Verified end-to-end: AAPL market order confirmed, filled, and reconciled in a single poll

### Key Design Decisions
- **Lazy connection**: Broker adapter connects on first order submission, not at startup
- **On-demand reconciliation**: Triggered per GET request rather than background polling
- **Confirmation flow**: Trades require explicit `CONFIRM T-XXXX` code before submission
- **State machine**: pending_confirmation → confirmed → submitted → filled/cancelled/rejected

### Testing
- 79 tests passing in `tests/brokerage/`
- End-to-end verified with IBKR Paper Trading (AAPL market orders)
- Reconciliation confirmed working for both instant fills and stale-status scenarios