### PR TITLE
 fix(agent, cli) : fix NameError in summary model fallback and guard max_iterations parse

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -741,7 +741,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic)  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60

--- a/cli.py
+++ b/cli.py
@@ -1719,7 +1719,11 @@ class HermesCLI:
         elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
             self.max_turns = CLI_CONFIG["max_turns"]
         elif os.getenv("HERMES_MAX_ITERATIONS"):
-            self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
+            try:
+                self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
+            except ValueError:
+                logger.warning("HERMES_MAX_ITERATIONS has non-numeric value %r, using default 90", os.getenv("HERMES_MAX_ITERATIONS"))
+                self.max_turns = 90
         else:
             self.max_turns = 90
         


### PR DESCRIPTION

## What does this PR do?

Fixes two bugs: a NameError in the context compressor's summary model fallback path that prevented automatic recovery when the summary model is unavailable, and an unguarded int() parse of the HERMES_MAX_ITERATIONS env var that could crash CLI startup

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

1. agent/context_compressor.py: Fix _generate_summary retry call — was passing undefined messages and mistyped summary_budget, now correctly passes turns_to_summarize and focus_topic

2. cli.py: Wrap HERMES_MAX_ITERATIONS env var parsing in try/except ValueError, log a warning and fall back to default (90) instead of crashing

## How to Test

1. Set summary_model to a non-existent model name (e.g. "fake/nonexistent-model") in config, start a conversation long enough to trigger context compression, and verify the agent falls back to the main model without a NameError traceback
2. Set HERMES_MAX_ITERATIONS=abc in your environment and start hermes — verify the CLI starts normally with a warning logged instead of crashing with ValueError
3. Run python -m pytest tests/ -q to confirm no regressions

## Checklist

<!-- Complete these before requesting review. -->

### Code

Check all that apply — for this PR:
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs
- [x] PR contains only changes related to this fix
- [x] Considered cross-platform impact — N/A (pure Python logic, no platform-specific behavior)
- [x] Updated relevant documentation — N/A (no new config keys or architecture changes)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

