### PR TITLE
docs: add portal subscription links to tool-gateway page

### DIFF
--- a/website/docs/user-guide/features/tool-gateway.md
+++ b/website/docs/user-guide/features/tool-gateway.md
@@ -7,6 +7,10 @@ sidebar_position: 2
 
 # Nous Tool Gateway
 
+:::tip Get Started
+The Tool Gateway is included with paid Nous Portal subscriptions. **[Manage your subscription →](https://portal.nousresearch.com/manage-subscription)**
+:::
+
 The **Tool Gateway** lets paid [Nous Portal](https://portal.nousresearch.com) subscribers use web search, image generation, text-to-speech, and browser automation through their existing subscription — no need to sign up for separate API keys from Firecrawl, FAL, OpenAI, or Browser Use.
 
 ## What's Included
@@ -22,7 +26,7 @@ All four tools bill to your Nous subscription. You can enable any combination �
 
 ## Eligibility
 
-The Tool Gateway is available to **paid** Nous Portal subscribers. Free-tier accounts do not have access.
+The Tool Gateway is available to **paid** [Nous Portal](https://portal.nousresearch.com/manage-subscription) subscribers. Free-tier accounts do not have access — [upgrade your subscription](https://portal.nousresearch.com/manage-subscription) to unlock it.
 
 To check your status:
 
@@ -172,7 +176,7 @@ Yes. The `use_gateway` flag is per-tool. You can mix and match — for example, 
 
 ### What if my subscription expires?
 
-Tools that were routed through the gateway will stop working until you renew or switch to direct API keys via `hermes tools`.
+Tools that were routed through the gateway will stop working until you [renew your subscription](https://portal.nousresearch.com/manage-subscription) or switch to direct API keys via `hermes tools`.
 
 ### Does the gateway work with the messaging gateway?
 


### PR DESCRIPTION
Adds direct links to https://portal.nousresearch.com/manage-subscription in two spots on the Tool Gateway docs:

- **Eligibility section** — links 'Nous Portal' and adds 'upgrade your subscription' link for free-tier users
- **FAQ: What if my subscription expires?** — links 'renew your subscription'

Follow-up to PR #11206.