### PR TITLE
chore: release v0.10.0 (2026.4.16)

### DIFF
--- a/RELEASE_v0.10.0.md
+++ b/RELEASE_v0.10.0.md
@@ -1,0 +1,27 @@
+# Hermes Agent v0.10.0 (v2026.4.16)
+
+**Release Date:** April 16, 2026
+
+> The Tool Gateway release — paid Nous Portal subscribers can now use web search, image generation, text-to-speech, and browser automation through their existing subscription with zero additional API keys.
+
+---
+
+## ✨ Highlights
+
+- **Nous Tool Gateway** — Paid [Nous Portal](https://portal.nousresearch.com) subscribers now get automatic access to **web search** (Firecrawl), **image generation** (FAL / FLUX 2 Pro), **text-to-speech** (OpenAI TTS), and **browser automation** (Browser Use) through their existing subscription. No separate API keys needed — just run `hermes model`, select Nous Portal, and pick which tools to enable. Per-tool opt-in via `use_gateway` config, full integration with `hermes tools` and `hermes status`, and the runtime correctly prefers the gateway even when direct API keys exist. Replaces the old hidden `HERMES_ENABLE_NOUS_MANAGED_TOOLS` env var with clean subscription-based detection. ([#11206](https://github.com/NousResearch/hermes-agent/pull/11206), based on work by @jquesnelle; docs: [#11208](https://github.com/NousResearch/hermes-agent/pull/11208))
+
+---
+
+## 🐛 Bug Fixes & Improvements
+
+This release includes 180+ commits with numerous bug fixes, platform improvements, and reliability enhancements across the agent core, gateway, CLI, and tool system. Full details will be published in the v0.11.0 changelog.
+
+---
+
+## 👥 Contributors
+
+- **@jquesnelle** (emozilla) — Original Tool Gateway implementation ([#10799](https://github.com/NousResearch/hermes-agent/pull/10799)), salvaged and shipped in this release
+
+---
+
+**Full Changelog**: [v2026.4.13...v2026.4.16](https://github.com/NousResearch/hermes-agent/compare/v2026.4.13...v2026.4.16)

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -11,5 +11,5 @@ Provides subcommands for:
 - hermes cron          - Manage cron jobs
 """
 
-__version__ = "0.9.0"
-__release_date__ = "2026.4.13"
+__version__ = "0.10.0"
+__release_date__ = "2026.4.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.9.0"
+version = "0.10.0"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release v0.10.0 — Tool Gateway

**Version bump:** 0.9.0 → 0.10.0
**CalVer tag:** v2026.4.16

### What's in this PR
- Version bump in `hermes_cli/__init__.py` and `pyproject.toml`
- `RELEASE_v0.10.0.md` changelog focused on the Nous Tool Gateway (#11206)

### Release theme
Focused release highlighting the Tool Gateway — paid Nous Portal subscribers get web search, image generation, TTS, and browser automation through their existing subscription. All other changes since v0.9.0 will be detailed in the v0.11.0 changelog.

### After merge
```bash
git tag -a v2026.4.16 origin/main -m 'Hermes Agent v0.10.0 (2026.4.16)'
git push origin v2026.4.16
gh release create v2026.4.16 --title 'Hermes Agent v0.10.0 (2026.4.16)' --notes-file RELEASE_v0.10.0.md
```