### PR TITLE
fix(logging): preserve parent session audit tag across nested run_conversation

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -19,8 +19,11 @@ Component separation:
 
 Session context:
     Call ``set_session_context(session_id)`` at the start of a conversation
-    and ``clear_session_context()`` when done.  All log lines emitted on
-    that thread will include ``[session_id]`` for filtering/correlation.
+    and ``clear_session_context()`` when done.  Values are kept on a
+    per-thread **stack** so a nested ``run_conversation`` (e.g. delegate
+    subagent on the same thread) can restore the parent session tag after
+    the inner turn ends.  Log lines use the innermost active session for
+    ``[session_id]`` filtering/correlation.
 """
 
 import logging
@@ -28,7 +31,7 @@ import os
 import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 
 from hermes_constants import get_config_path, get_hermes_home
 
@@ -69,18 +72,36 @@ _NOISY_LOGGERS = (
 # Public session context API
 # ---------------------------------------------------------------------------
 
-def set_session_context(session_id: str) -> None:
-    """Set the session ID for the current thread.
+def _session_stack() -> List[str]:
+    stack = getattr(_session_context, "stack", None)
+    if stack is None:
+        stack = []
+        _session_context.stack = stack
+    return stack
 
-    All subsequent log records on this thread will include ``[session_id]``
-    in the formatted output.  Call at the start of ``run_conversation()``.
+
+def _effective_session_id() -> Optional[str]:
+    stack = getattr(_session_context, "stack", None)
+    if not stack:
+        return None
+    return stack[-1]
+
+
+def set_session_context(session_id: str) -> None:
+    """Push a session ID for the current thread.
+
+    Nested calls (subagent ``run_conversation`` on the same thread) push a
+    second ID; the log record factory always tags with the innermost ID.
+    Pair every ``set_session_context`` with ``clear_session_context``.
     """
-    _session_context.session_id = session_id
+    _session_stack().append(session_id)
 
 
 def clear_session_context() -> None:
-    """Clear the session ID for the current thread."""
-    _session_context.session_id = None
+    """Pop the innermost session ID for the current thread (no-op if empty)."""
+    stack = getattr(_session_context, "stack", None)
+    if stack:
+        stack.pop()
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +127,7 @@ def _install_session_record_factory() -> None:
 
     def _session_record_factory(*args, **kwargs):
         record = current_factory(*args, **kwargs)
-        sid = getattr(_session_context, "session_id", None)
+        sid = _effective_session_id()
         record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
         return record
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8203,8 +8203,33 @@ class AIAgent:
 
         # Tag all log records on this thread with the session ID so
         # ``hermes logs --session <id>`` can filter a single conversation.
-        from hermes_logging import set_session_context
+        # Always clear in ``finally`` so pooled / gateway worker threads cannot
+        # leak one session's tag into another turn (log correlation / audit).
+        from hermes_logging import clear_session_context, set_session_context
+
         set_session_context(self.session_id)
+        try:
+            return self._run_conversation_impl(
+                user_message,
+                system_message,
+                conversation_history,
+                task_id,
+                stream_callback,
+                persist_user_message,
+            )
+        finally:
+            clear_session_context()
+
+    def _run_conversation_impl(
+        self,
+        user_message: str,
+        system_message: str = None,
+        conversation_history: List[Dict[str, Any]] = None,
+        task_id: str = None,
+        stream_callback: Optional[callable] = None,
+        persist_user_message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Body for ``run_conversation`` (session context is owned by the wrapper)."""
 
         # If the previous turn activated fallback, restore the primary
         # runtime so this turn gets a fresh attempt with the preferred model.

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -44,7 +44,9 @@ def _reset_logging_state():
             root.removeHandler(h)
             h.close()
     hermes_logging._logging_initialized = False
-    hermes_logging.clear_session_context()
+    # Drain any stacked session IDs (tests may push more than once).
+    while getattr(hermes_logging._session_context, "stack", None):
+        hermes_logging.clear_session_context()
 
 
 @pytest.fixture
@@ -373,6 +375,23 @@ class TestSessionContext:
         agent_log = hermes_home / "logs" / "agent.log"
         content = agent_log.read_text()
         assert "[xyz789]" not in content
+
+    def test_nested_session_context_restores_parent(self, hermes_home):
+        """Inner conversation pops so outer session tag applies again."""
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        hermes_logging.set_session_context("parent_sess")
+
+        factory = logging.getLogRecordFactory()
+        assert factory("t", logging.INFO, "", 0, "outer", (), None).session_tag == " [parent_sess]"
+
+        hermes_logging.set_session_context("child_sess")
+        assert factory("t", logging.INFO, "", 0, "inner", (), None).session_tag == " [child_sess]"
+
+        hermes_logging.clear_session_context()
+        assert factory("t", logging.INFO, "", 0, "after_child", (), None).session_tag == " [parent_sess]"
+
+        hermes_logging.clear_session_context()
+        assert factory("t", logging.INFO, "", 0, "done", (), None).session_tag == ""
 
     def test_session_context_thread_isolated(self, hermes_home):
         """Session context is per-thread — one thread's context doesn't leak."""


### PR DESCRIPTION
## Problem
Hermes uses a per-thread session tag (`[session_id]`) to correlate logs for long-running turns and audit trails.
When delegation runs a subagent via a nested `run_conversation()` on the same thread, the inner call clears the
thread-local session context in `finally`, which accidentally wipes the parent session tag too.

This breaks long-task auditing: after the subagent finishes, the parent turn's subsequent log lines lose `[session_id]`,
making it hard to trace tool calls, budget/exit reasons, and post-turn hooks as a single causal chain.

## Fix
Switch session context storage from a single thread-local value to a per-thread stack:
- `set_session_context()` pushes
- `clear_session_context()` pops
- the LogRecord factory always uses the top-most (innermost) session id

This allows nested conversations to restore the parent session tag automatically when the inner turn ends.

## Tests
- Added regression coverage for nested push/pop restoration.
- python -m pytest tests/test_hermes_logging.py::TestSessionContext -o addopts=

## Files
- `hermes_logging.py`
- `run_agent.py`
- `tests/test_hermes_logging.py`