### PR TITLE
fix: stop /model picker from replaying trigger command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4494,9 +4494,26 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        user_provs=None,
+        custom_provs=None,
+        *,
+        preserve_draft: bool = True,
+    ) -> None:
         """Open prompt_toolkit-native /model picker modal."""
-        self._capture_modal_input_snapshot()
+        if preserve_draft:
+            self._capture_modal_input_snapshot()
+        else:
+            self._modal_input_snapshot = None
+            if getattr(self, "_app", None):
+                try:
+                    self._app.current_buffer.reset()
+                except Exception:
+                    pass
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
         self._model_picker_state = {
             "stage": "provider",
@@ -4716,6 +4733,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                preserve_draft=False,
             )
             return
 

--- a/tests/cli/test_cli_model_picker.py
+++ b/tests/cli/test_cli_model_picker.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text="", cursor_position=None):
+        self.text = text
+        self.cursor_position = len(text) if cursor_position is None else cursor_position
+
+    def reset(self, append_to_history=False):
+        self.text = ""
+        self.cursor_position = 0
+
+
+def _make_cli_stub(initial_text="/model"):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer(initial_text))
+    cli._invalidate = MagicMock()
+    cli._model_picker_state = None
+    cli._modal_input_snapshot = None
+    cli.model = "glm-5.1"
+    cli.provider = "zai"
+    cli.requested_provider = "zai"
+    cli.api_key = ""
+    cli.base_url = "https://api.z.ai/api/coding/paas/v4"
+    cli.api_mode = "chat_completions"
+    cli.agent = None
+    return cli
+
+
+def test_model_picker_does_not_restore_triggering_slash_command_after_selection():
+    cli = _make_cli_stub("/model")
+    providers = [{
+        "slug": "zai",
+        "name": "Z.AI",
+        "models": ["glm-5.1"],
+        "total_models": 1,
+        "is_current": True,
+    }]
+    switch_result = SimpleNamespace(
+        success=True,
+        new_model="glm-5.1",
+        target_provider="zai",
+        provider_changed=False,
+        api_key="",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        api_mode="chat_completions",
+        error_message="",
+        warning_message="",
+        provider_label="Z.AI",
+        model_info=None,
+    )
+
+    with patch("cli._cprint"), \
+         patch("hermes_cli.model_switch.list_authenticated_providers", return_value=providers), \
+         patch("hermes_cli.models.provider_model_ids", return_value=[]), \
+         patch("hermes_cli.model_switch.switch_model", return_value=switch_result):
+        cli._handle_model_switch("/model")
+        assert cli._model_picker_state is not None
+        assert cli._modal_input_snapshot is None
+        assert cli._app.current_buffer.text == ""
+
+        cli._handle_model_picker_selection()
+        assert cli._model_picker_state["stage"] == "model"
+
+        cli._handle_model_picker_selection()
+        assert cli._model_picker_state is None
+        assert cli._app.current_buffer.text == ""


### PR DESCRIPTION
## Summary
- fix the CLI `/model` picker so it does not restore the triggering slash command into the input buffer
- preserve draft-buffer restore behavior for true modal cases via an explicit `preserve_draft` flag
- add a regression test covering provider -> model selection and asserting the buffer stays empty before and after selection

## Problem
In terminal sessions, selecting a model from the interactive `/model` picker could successfully switch models and then immediately replay the original `/model` command from the restored draft buffer. That stale replay could surface misleading follow-on validation errors, including `Model names cannot contain spaces.`

## Test Plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o 'addopts=' tests/cli/test_cli_model_picker.py -q`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o 'addopts=' tests/cli/test_cli_approval_ui.py -q`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o 'addopts=' tests/hermes_cli/test_model_validation.py -q -k 'spaces or zai or glm'`
- [x] direct CLI-state-machine probe confirming the input buffer is empty after picker open and after selection
