### PR TITLE
fix(backup): strip Hermes home zip prefix with case-insensitive match

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -284,7 +284,7 @@ def _detect_prefix(zf: zipfile.ZipFile) -> str:
     if len(first_parts) == 1:
         prefix = first_parts.pop()
         # Only strip if it looks like a hermes dir name
-        if prefix in (".hermes", "hermes"):
+        if prefix.lower() in (".hermes", "hermes"):
             return prefix + "/"
 
     return ""

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -573,6 +573,19 @@ class TestValidation:
         with zipfile.ZipFile(buf, "r") as zf:
             assert _detect_prefix(zf) == ".hermes/"
 
+    def test_detect_prefix_hermes_case_insensitive(self):
+        """Detects Hermes/ prefix regardless of case."""
+        import io
+        from hermes_cli.backup import _detect_prefix
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("Hermes/config.yaml", "test")
+            zf.writestr("Hermes/skills/a/SKILL.md", "skill")
+        buf.seek(0)
+        with zipfile.ZipFile(buf, "r") as zf:
+            assert _detect_prefix(zf) == "Hermes/"
+
     def test_detect_prefix_none(self):
         """No prefix when entries are at root."""
         import io


### PR DESCRIPTION
## Summary

`hermes import` uses `_detect_prefix()` to strip a common top-level directory when a backup zip wraps all entries under `.hermes/`, `hermes/`, etc. The previous check only matched exact lowercase `"hermes"`, so archives using mixed-case roots (e.g. `Hermes/`) were not stripped and could restore into the wrong layout.

## Changes

- `hermes_cli/backup.py`: treat the first path segment as a Hermes wrapper when it matches `.hermes` or `hermes` **case-insensitively**, preserving the original segment casing in the returned prefix string.
- `tests/hermes_cli/test_backup.py`: add `test_detect_prefix_hermes_case_insensitive` regression.

## Test plan

- `python -m pytest tests/hermes_cli/test_backup.py -k "detect_prefix_hermes or detect_prefix_hermes_case_insensitive" -q -o addopts=`