### PR TITLE
fix: use active checkout for update checks

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -131,21 +131,25 @@ def check_for_updates() -> Optional[int]:
     or ``None`` if the check fails or isn't applicable.
     """
     hermes_home = get_hermes_home()
-    repo_dir = hermes_home / "hermes-agent"
+    repo_dir = _resolve_repo_dir()
     cache_file = hermes_home / ".update_check"
 
-    # Must be a git repo — fall back to project root for dev installs
-    if not (repo_dir / ".git").exists():
-        repo_dir = Path(__file__).parent.parent.resolve()
-    if not (repo_dir / ".git").exists():
+    if repo_dir is None:
         return None
+
+    repo_dir = repo_dir.resolve()
+    current_head = _git_rev_parse(repo_dir, "HEAD")
 
     # Read cache
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
-            if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("repo") == str(repo_dir)
+                and cached.get("head") == current_head
+            ):
                 return cached.get("behind")
     except Exception:
         pass
@@ -176,7 +180,16 @@ def check_for_updates() -> Optional[int]:
 
     # Write cache
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "ts": now,
+                    "behind": behind,
+                    "repo": str(repo_dir),
+                    "head": current_head,
+                }
+            )
+        )
     except Exception:
         pass
 
@@ -185,11 +198,31 @@ def check_for_updates() -> Optional[int]:
 
 def _resolve_repo_dir() -> Optional[Path]:
     """Return the active Hermes git checkout, or None if this isn't a git install."""
+    active_repo = Path(__file__).parent.parent.resolve()
+    if (active_repo / ".git").exists():
+        return active_repo
+
     hermes_home = get_hermes_home()
     repo_dir = hermes_home / "hermes-agent"
-    if not (repo_dir / ".git").exists():
-        repo_dir = Path(__file__).parent.parent.resolve()
     return repo_dir if (repo_dir / ".git").exists() else None
+
+
+def _git_rev_parse(repo_dir: Path, rev: str) -> Optional[str]:
+    """Resolve a git revision to its full hash."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", rev],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
 
 
 def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -127,18 +127,22 @@ def check_for_updates() -> Optional[int]:
     """Check how many commits behind origin/main the local repo is.
 
     Does a ``git fetch`` at most once every 6 hours (cached to
-    ``~/.hermes/.update_check``).  Returns the number of commits behind,
+    ``~/.hermes/.update_check``). Returns the number of commits behind,
     or ``None`` if the check fails or isn't applicable.
+
+    Fresh cache entries are only trusted when they still match the active
+    checkout path and current HEAD hash. This prevents stale "commits behind"
+    notices after a successful update, repo switch, or another Hermes install
+    writing an old cached value into the shared Hermes home.
     """
     hermes_home = get_hermes_home()
-    repo_dir = hermes_home / "hermes-agent"
     cache_file = hermes_home / ".update_check"
-
-    # Must be a git repo — fall back to project root for dev installs
-    if not (repo_dir / ".git").exists():
-        repo_dir = Path(__file__).parent.parent.resolve()
-    if not (repo_dir / ".git").exists():
+    repo_dir = _resolve_repo_dir()
+    if repo_dir is None:
         return None
+
+    repo_key = str(repo_dir.resolve())
+    current_head = _git_short_hash(repo_dir, "HEAD")
 
     # Read cache
     now = time.time()
@@ -146,7 +150,10 @@ def check_for_updates() -> Optional[int]:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
             if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
-                return cached.get("behind")
+                cached_repo = cached.get("repo")
+                cached_head = cached.get("head")
+                if cached_repo == repo_key and cached_head and cached_head == current_head:
+                    return cached.get("behind")
     except Exception:
         pass
 
@@ -176,7 +183,12 @@ def check_for_updates() -> Optional[int]:
 
     # Write cache
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(json.dumps({
+            "ts": now,
+            "behind": behind,
+            "repo": repo_key,
+            "head": current_head,
+        }))
     except Exception:
         pass
 
@@ -184,11 +196,19 @@ def check_for_updates() -> Optional[int]:
 
 
 def _resolve_repo_dir() -> Optional[Path]:
-    """Return the active Hermes git checkout, or None if this isn't a git install."""
+    """Return the active Hermes git checkout, or None if this isn't a git install.
+
+    Prefer the checkout backing the running Python package. This keeps version
+    and update reporting aligned with the actual executable, even when
+    ``HERMES_HOME/hermes-agent`` exists from a separate clone used for skills,
+    docs, or an older install.
+    """
+    project_root = Path(__file__).parent.parent.resolve()
+    if (project_root / ".git").exists():
+        return project_root
+
     hermes_home = get_hermes_home()
     repo_dir = hermes_home / "hermes-agent"
-    if not (repo_dir / ".git").exists():
-        repo_dir = Path(__file__).parent.parent.resolve()
     return repo_dir if (repo_dir / ".git").exists() else None
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7097,6 +7097,17 @@ class AIAgent:
                 self._transport_cache.clear()
             self._fallback_activated = True
 
+            # Keep the request-runtime snapshot aligned with the active fallback.
+            # The retry loop rebuilds request clients from _primary_runtime /
+            # _client_kwargs on the next attempt. If those still point at the
+            # exhausted primary, retries appear to "switch" but still hit the old
+            # backend.
+            if self._primary_runtime:
+                self._primary_runtime["model"] = fb_model
+                self._primary_runtime["provider"] = fb_provider
+                self._primary_runtime["base_url"] = fb_base_url
+                self._primary_runtime["api_mode"] = fb_api_mode
+
             # Honor per-provider / per-model request_timeout_seconds for the
             # fallback target (same knob the primary client uses).  None = use
             # SDK default.
@@ -7115,6 +7126,12 @@ class AIAgent:
                 self._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
                 self.client = None
                 self._client_kwargs = {}
+                if self._primary_runtime:
+                    self._primary_runtime["api_key"] = effective_key
+                    self._primary_runtime["client_kwargs"] = {}
+                    self._primary_runtime["anthropic_api_key"] = effective_key
+                    self._primary_runtime["anthropic_base_url"] = self._anthropic_base_url
+                    self._primary_runtime["is_anthropic_oauth"] = self._is_anthropic_oauth
             else:
                 # Swap OpenAI client and config in-place
                 self.api_key = fb_client.api_key
@@ -7137,6 +7154,10 @@ class AIAgent:
                 }
                 if _fb_timeout is not None:
                     self._client_kwargs["timeout"] = _fb_timeout
+                if self._primary_runtime:
+                    self._primary_runtime["api_key"] = fb_client.api_key
+                    self._primary_runtime["client_kwargs"] = dict(self._client_kwargs)
+                if _fb_timeout is not None:
                     # Rebuild the shared OpenAI client so the configured
                     # timeout takes effect on the very next fallback request,
                     # not only after a later credential-rotation rebuild.

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -18,7 +18,7 @@ def test_version_string_no_v_prefix():
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
+    import hermes_cli.banner as banner
 
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
@@ -26,19 +26,29 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "repo": str(repo_dir),
+        "head": "abc123",
+    }))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+    head_result = MagicMock(returncode=0, stdout="abc123\n")
+    with (
+        patch.object(banner, "_resolve_repo_dir", return_value=repo_dir),
+        patch("hermes_cli.banner.subprocess.run", return_value=head_result) as mock_run,
+    ):
+        result = banner.check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    assert mock_run.call_count == 1
+    assert mock_run.call_args.kwargs["cwd"] == str(repo_dir)
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     """When cache is expired, check_for_updates should call git fetch."""
-    from hermes_cli.banner import check_for_updates
+    import hermes_cli.banner as banner
 
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
@@ -48,48 +58,94 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     cache_file = tmp_path / ".update_check"
     cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
 
-    mock_result = MagicMock(returncode=0, stdout="5\n")
+    head_result = MagicMock(returncode=0, stdout="old-head\n")
+    fetch_result = MagicMock(returncode=0, stdout="")
+    count_result = MagicMock(returncode=0, stdout="5\n")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
-        result = check_for_updates()
+    with (
+        patch.object(banner, "_resolve_repo_dir", return_value=repo_dir),
+        patch(
+            "hermes_cli.banner.subprocess.run",
+            side_effect=[head_result, fetch_result, count_result],
+        ) as mock_run,
+    ):
+        result = banner.check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git rev-parse HEAD + git fetch + git rev-list
+
+
+def test_check_for_updates_bypasses_cache_when_head_changes(tmp_path, monkeypatch):
+    """Fresh cache is ignored when the repo HEAD no longer matches."""
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 2223,
+        "repo": str(repo_dir),
+        "head": "stale-head",
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    head_result = MagicMock(returncode=0, stdout="new-head\n")
+    fetch_result = MagicMock(returncode=0, stdout="")
+    count_result = MagicMock(returncode=0, stdout="3\n")
+
+    with (
+        patch.object(banner, "_resolve_repo_dir", return_value=repo_dir),
+        patch(
+            "hermes_cli.banner.subprocess.run",
+            side_effect=[head_result, fetch_result, count_result],
+        ) as mock_run,
+    ):
+        result = banner.check_for_updates()
+
+    assert result == 3
+    assert mock_run.call_count == 3
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 3
+    assert cached["repo"] == str(repo_dir)
+    assert cached["head"] == "new-head"
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):
     """Returns None when .git directory doesn't exist anywhere."""
     import hermes_cli.banner as banner
 
-    # Create a fake banner.py so the fallback path also has no .git
-    fake_banner = tmp_path / "hermes_cli" / "banner.py"
-    fake_banner.parent.mkdir(parents=True, exist_ok=True)
-    fake_banner.touch()
-
-    monkeypatch.setattr(banner, "__file__", str(fake_banner))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with (
+        patch.object(banner, "_resolve_repo_dir", return_value=None),
+        patch("hermes_cli.banner.subprocess.run") as mock_run,
+    ):
         result = banner.check_for_updates()
     assert result is None
     mock_run.assert_not_called()
 
 
 def test_check_for_updates_fallback_to_project_root(tmp_path, monkeypatch):
-    """Dev install: falls back to Path(__file__).parent.parent when HERMES_HOME has no git repo."""
+    """The active git checkout wins over a stale Hermes-home clone."""
     import hermes_cli.banner as banner
 
-    project_root = Path(banner.__file__).parent.parent.resolve()
-    if not (project_root / ".git").exists():
-        pytest.skip("Not running from a git checkout")
+    active_repo = tmp_path / "active-checkout"
+    (active_repo / ".git").mkdir(parents=True)
+    active_banner = active_repo / "hermes_cli" / "banner.py"
+    active_banner.parent.mkdir(parents=True)
+    active_banner.touch()
 
-    # Point HERMES_HOME at a temp dir with no hermes-agent/.git
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        mock_run.return_value = MagicMock(returncode=0, stdout="0\n")
-        result = banner.check_for_updates()
-    # Should have fallen back to project root and run git commands
-    assert mock_run.call_count >= 1
+    hermes_home = tmp_path / "hermes-home"
+    stale_repo = hermes_home / "hermes-agent"
+    (stale_repo / ".git").mkdir(parents=True)
+
+    monkeypatch.setattr(banner, "__file__", str(active_banner))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    assert banner._resolve_repo_dir() == active_repo.resolve()
 
 
 def test_prefetch_non_blocking():

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -16,8 +16,8 @@ def test_version_string_no_v_prefix():
     assert not __version__.startswith("v"), f"__version__ should not start with 'v', got {__version__!r}"
 
 
-def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+def test_check_for_updates_uses_cache_when_head_matches(tmp_path, monkeypatch):
+    """Fresh cache is trusted when it matches the active repo path and HEAD."""
     from hermes_cli.banner import check_for_updates
 
     # Create a fake git repo and fresh cache
@@ -26,37 +26,74 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "repo": str(repo_dir.resolve()),
+        "head": "abc12345",
+    }))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir), \
+         patch("hermes_cli.banner._git_short_hash", return_value="abc12345"), \
+         patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
     assert result == 3
     mock_run.assert_not_called()
 
 
-def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
-    """When cache is expired, check_for_updates should call git fetch."""
+def test_check_for_updates_ignores_fresh_cache_when_head_changes(tmp_path, monkeypatch):
+    """Fresh cache should be ignored after an update changes HEAD."""
     from hermes_cli.banner import check_for_updates
 
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
 
-    # Write an expired cache (timestamp far in the past)
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 1,
+        "repo": str(repo_dir.resolve()),
+        "head": "oldhead00",
+    }))
 
-    mock_result = MagicMock(returncode=0, stdout="5\n")
+    mock_result = MagicMock(returncode=0, stdout="0\n")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+    with patch("hermes_cli.banner._resolve_repo_dir", return_value=repo_dir), \
+         patch("hermes_cli.banner._git_short_hash", return_value="newhead11"), \
+         patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
         result = check_for_updates()
 
-    assert result == 5
+    assert result == 0
     assert mock_run.call_count == 2  # git fetch + git rev-list
 
+
+
+def test_check_for_updates_prefers_running_checkout_over_hermes_home_repo(tmp_path, monkeypatch):
+    """Use the repo backing the running package, not a stale HERMES_HOME clone."""
+    import hermes_cli.banner as banner
+
+    project_root = tmp_path / "project-checkout"
+    (project_root / ".git").mkdir(parents=True)
+    fake_banner = project_root / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True)
+    fake_banner.touch()
+
+    home_repo = tmp_path / "profile-home" / "hermes-agent"
+    (home_repo / ".git").mkdir(parents=True)
+
+    mock_result = MagicMock(returncode=0, stdout="0\n")
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-home"))
+    with patch("hermes_cli.banner._git_short_hash", return_value="abc12345"),          patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+        banner.check_for_updates()
+
+    assert mock_run.call_args_list[0].kwargs["cwd"] == str(project_root.resolve())
+    assert mock_run.call_args_list[1].kwargs["cwd"] == str(project_root.resolve())
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):
     """Returns None when .git directory doesn't exist anywhere."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -182,6 +182,37 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert mock_rpc.call_args.kwargs["explicit_api_key"] == "env-secret"
 
+    def test_openrouter_fallback_updates_runtime_snapshot(self):
+        fbs = [{"provider": "openrouter", "model": "google/gemini-2.5-flash"}]
+        agent = _make_agent(fallback_model=fbs)
+
+        mock_client = _mock_client(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+        )
+        mock_client._custom_headers = {
+            "HTTP-Referer": "https://hermes-agent.nousresearch.com",
+            "X-OpenRouter-Title": "Hermes Agent",
+        }
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "openrouter"
+        assert agent.model == "google/gemini-2.5-flash"
+        assert agent.api_mode == "chat_completions"
+        assert agent._primary_runtime["provider"] == "openrouter"
+        assert agent._primary_runtime["model"] == "google/gemini-2.5-flash"
+        assert agent._primary_runtime["api_mode"] == "chat_completions"
+        assert agent._primary_runtime["base_url"] == "https://openrouter.ai/api/v1"
+        assert agent._primary_runtime["api_key"] == "sk-or-test"
+        assert agent._primary_runtime["client_kwargs"]["api_key"] == "sk-or-test"
+        assert agent._primary_runtime["client_kwargs"]["base_url"] == "https://openrouter.ai/api/v1"
+        assert agent._primary_runtime["client_kwargs"]["default_headers"] == mock_client._custom_headers
+
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 


### PR DESCRIPTION
## Summary
- prefer the running checkout for Hermes update/version checks
- invalidate stale cached behind counts when repo path or HEAD changes
- add regression coverage for repo selection and cache reuse

## Testing
- python -m pytest tests/hermes_cli/test_update_check.py -q