### PR TITLE
fix(cli): show provider in status bar (#11191)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1903,9 +1903,11 @@ class HermesCLI:
             model_short = f"{model_short[:23]}..."
 
         elapsed_seconds = max(0.0, (datetime.now() - self.session_start).total_seconds())
+        provider_name = (getattr(agent, "provider", None) or getattr(self, "provider", None) or "")
         snapshot = {
             "model_name": model_name,
             "model_short": model_short,
+            "provider": provider_name,
             "duration": format_duration_compact(elapsed_seconds),
             "context_tokens": 0,
             "context_length": None,
@@ -2067,10 +2069,13 @@ class HermesCLI:
             duration_label = snapshot["duration"]
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"⚕ {snapshot['model_short']} · {snapshot['duration']}"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"⚕ {snapshot['model_short']}"]
+                if snapshot.get("provider"):
+                    parts.append(snapshot["provider"])
+                parts.append(percent_label)
                 parts.append(duration_label)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
@@ -2081,8 +2086,10 @@ class HermesCLI:
             else:
                 context_label = "ctx --"
 
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
-            parts.append(duration_label)
+            parts = [f"⚕ {snapshot['model_short']}"]
+            if snapshot.get("provider"):
+                parts.append(snapshot["provider"])
+            parts.extend([context_label, percent_label, duration_label])
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -2099,6 +2106,7 @@ class HermesCLI:
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
+            provider_label = snapshot.get("provider")
 
             if width < 52:
                 frags = [
@@ -2115,12 +2123,23 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
-                        ("class:status-bar-dim", " · "),
-                        (self._status_bar_context_style(percent), percent_label),
-                        ("class:status-bar-dim", " · "),
-                        ("class:status-bar-dim", duration_label),
-                        ("class:status-bar", " "),
                     ]
+                    if provider_label:
+                        frags.extend(
+                            [
+                                ("class:status-bar-dim", " · "),
+                                ("class:status-bar-dim", provider_label),
+                            ]
+                        )
+                    frags.extend(
+                        [
+                            ("class:status-bar-dim", " · "),
+                            (self._status_bar_context_style(percent), percent_label),
+                            ("class:status-bar-dim", " · "),
+                            ("class:status-bar-dim", duration_label),
+                            ("class:status-bar", " "),
+                        ]
+                    )
                 else:
                     if snapshot["context_length"]:
                         ctx_total = _format_context_length(snapshot["context_length"])
@@ -2133,16 +2152,27 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
-                        ("class:status-bar-dim", " │ "),
-                        ("class:status-bar-dim", context_label),
-                        ("class:status-bar-dim", " │ "),
-                        (bar_style, self._build_context_bar(percent)),
-                        ("class:status-bar-dim", " "),
-                        (bar_style, percent_label),
-                        ("class:status-bar-dim", " │ "),
-                        ("class:status-bar-dim", duration_label),
-                        ("class:status-bar", " "),
                     ]
+                    if provider_label:
+                        frags.extend(
+                            [
+                                ("class:status-bar-dim", " │ "),
+                                ("class:status-bar-dim", provider_label),
+                            ]
+                        )
+                    frags.extend(
+                        [
+                            ("class:status-bar-dim", " │ "),
+                            ("class:status-bar-dim", context_label),
+                            ("class:status-bar-dim", " │ "),
+                            (bar_style, self._build_context_bar(percent)),
+                            ("class:status-bar-dim", " "),
+                            (bar_style, percent_label),
+                            ("class:status-bar-dim", " │ "),
+                            ("class:status-bar-dim", duration_label),
+                            ("class:status-bar", " "),
+                        ]
+                    )
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -75,6 +75,7 @@ class TestCLIStatusBar:
         text = cli_obj._build_status_bar_text(width=120)
 
         assert "claude-sonnet-4-20250514" in text
+        assert "anthropic" in text
         assert "12.4K/200K" in text
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default


### PR DESCRIPTION
## Summary
- Show the active provider in the CLI status bar when available
- Keep narrow layouts compact and preserve existing width trimming

## Verification
- /home/dell/.venv/bin/python3 -m pytest tests/cli/test_cli_status_bar.py -q