### PR TITLE
fix(webUI): render object lists in config editor (#11190)

### DIFF
--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectOption } from "@/components/ui/select";
@@ -26,6 +27,17 @@ export function AutoField({
   const rawLabel = schemaKey.split(".").pop() ?? schemaKey;
   const label = rawLabel.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 
+  const isObjectList =
+    schema.type === "list" && Array.isArray(value) && value.some((item) => typeof item === "object" && item !== null && !Array.isArray(item));
+  const [objectListText, setObjectListText] = useState(() =>
+    isObjectList ? JSON.stringify(value, null, 2) : "",
+  );
+
+  useEffect(() => {
+    if (isObjectList) {
+      setObjectListText(JSON.stringify(value ?? [], null, 2));
+    }
+  }, [isObjectList, value]);
   if (schema.type === "boolean") {
     return (
       <div className="flex items-center justify-between gap-4">
@@ -94,6 +106,32 @@ export function AutoField({
   }
 
   if (schema.type === "list") {
+    if (isObjectList) {
+      return (
+        <div className="grid gap-1.5">
+          <Label className="text-sm">{label}</Label>
+          <FieldHint schema={schema} schemaKey={schemaKey} />
+          <textarea
+            className="flex min-h-[120px] w-full border border-input bg-transparent px-3 py-2 font-mono text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            value={objectListText}
+            onChange={(e) => {
+              const next = e.target.value;
+              setObjectListText(next);
+              try {
+                const parsed = JSON.parse(next);
+                if (Array.isArray(parsed)) {
+                  onChange(parsed);
+                }
+              } catch {
+                // Keep the local JSON editor responsive while the user is typing.
+              }
+            }}
+            placeholder='[{"provider":"openai","model":"gpt-5-mini"}]'
+          />
+        </div>
+      );
+    }
+
     return (
       <div className="grid gap-1.5">
         <Label className="text-sm">{label}</Label>

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectOption } from "@/components/ui/select";
@@ -33,11 +33,6 @@ export function AutoField({
     isObjectList ? JSON.stringify(value, null, 2) : "",
   );
 
-  useEffect(() => {
-    if (isObjectList) {
-      setObjectListText(JSON.stringify(value ?? [], null, 2));
-    }
-  }, [isObjectList, value]);
   if (schema.type === "boolean") {
     return (
       <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary
- Render object arrays like fallback_providers as editable JSON instead of [object Object]
- Keep primitive lists on the existing comma-separated input path

## Verification
- npm run build (web)