### PR TITLE
feat: add /routing smart model override command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1768,6 +1768,7 @@ class HermesCLI:
 
         # Optional cheap-vs-strong routing for simple turns
         self._smart_model_routing = CLI_CONFIG.get("smart_model_routing", {}) or {}
+        self._smart_model_routing_override_enabled: Optional[bool] = None
         self._active_agent_route_signature = None
 
         # Agent will be initialized on first use
@@ -2771,9 +2772,13 @@ class HermesCLI:
         from agent.smart_model_routing import resolve_turn_route
         from hermes_cli.models import resolve_fast_mode_overrides
 
+        routing_cfg = dict(self._smart_model_routing or {})
+        if self._smart_model_routing_override_enabled is not None:
+            routing_cfg["enabled"] = self._smart_model_routing_override_enabled
+
         route = resolve_turn_route(
             user_message,
-            self._smart_model_routing,
+            routing_cfg,
             {
                 "model": self.model,
                 "api_key": self.api_key,
@@ -4112,6 +4117,7 @@ class HermesCLI:
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        self._smart_model_routing_override_enabled = None
 
         if self.agent:
             self.agent.session_id = self.session_id
@@ -4801,6 +4807,82 @@ class HermesCLI:
         else:
             _cprint("    (session only — add --global to persist)")
 
+    def _handle_routing_command(self, cmd: str):
+        """Handle /routing — manage smart model routing for this session or globally."""
+        import shlex
+
+        raw_args = cmd.strip().split(maxsplit=1)
+        arg_text = raw_args[1] if len(raw_args) > 1 else ""
+        try:
+            tokens = shlex.split(arg_text)
+        except ValueError as exc:
+            _cprint(f"  {_DIM}(._.) Could not parse /routing arguments: {exc}{_RST}")
+            return
+
+        persist_global = False
+        normalized: list[str] = []
+        for token in tokens:
+            if token == "--global":
+                persist_global = True
+            else:
+                normalized.append(token.lower())
+
+        action = normalized[0] if normalized else "status"
+        if len(normalized) > 1:
+            _cprint(f"  {_DIM}(._.) Usage: /routing [on|off|status|default] [--global]{_RST}")
+            return
+
+        if action == "status":
+            global_enabled = bool((self._smart_model_routing or {}).get("enabled", False))
+            override = self._smart_model_routing_override_enabled
+            effective = override if override is not None else global_enabled
+            cheap_model = (self._smart_model_routing or {}).get("cheap_model") or {}
+            cheap_provider = cheap_model.get("provider") or "unconfigured"
+            cheap_model_name = cheap_model.get("model") or "unconfigured"
+            override_label = "inherit global" if override is None else ("on" if override else "off")
+            _cprint(f"  {_ACCENT}Smart routing (global): {('ON' if global_enabled else 'OFF')}{_RST}")
+            _cprint(f"  {_ACCENT}Smart routing (session):{_RST} {override_label}")
+            _cprint(f"  {_ACCENT}Effective for this session:{_RST} {('ON' if effective else 'OFF')}")
+            _cprint(f"  {_ACCENT}Cheap model:{_RST} {cheap_model_name} via {cheap_provider}")
+            _cprint(
+                f"  {_ACCENT}Thresholds:{_RST} "
+                f"{(self._smart_model_routing or {}).get('max_simple_chars', 160)} chars, "
+                f"{(self._smart_model_routing or {}).get('max_simple_words', 28)} words"
+            )
+            _cprint(f"  {_DIM}Usage: /routing [on|off|status|default] [--global]{_RST}")
+            return
+
+        if action not in {"on", "off", "default", "reset"}:
+            _cprint(f"  {_DIM}(._.) Unknown argument: {action}{_RST}")
+            _cprint(f"  {_DIM}Usage: /routing [on|off|status|default] [--global]{_RST}")
+            return
+
+        if action in {"default", "reset"}:
+            self._smart_model_routing_override_enabled = None
+            if persist_global:
+                _cprint(f"  {_DIM}(._.) /routing default ignores --global and just clears the session override.{_RST}")
+            effective = bool((self._smart_model_routing or {}).get("enabled", False))
+            _cprint(f"  {_ACCENT}✓ Smart routing session override cleared{_RST}")
+            _cprint(f"  {_DIM}  Effective state now follows global config: {('ON' if effective else 'OFF')}{_RST}")
+            return
+
+        enabled = action == "on"
+        if persist_global:
+            if save_config_value("smart_model_routing.enabled", enabled):
+                self._smart_model_routing["enabled"] = enabled
+                self._smart_model_routing_override_enabled = None
+                _cprint(f"  {_ACCENT}✓ Smart routing set to {('ON' if enabled else 'OFF')} (saved to config){_RST}")
+                _cprint(f"  {_DIM}  This session now follows the updated global setting.{_RST}")
+            else:
+                self._smart_model_routing_override_enabled = enabled
+                _cprint(f"  {_ACCENT}✓ Smart routing {('enabled' if enabled else 'disabled')} for this session{_RST}")
+                _cprint(f"  {_DIM}  Saving to config failed, so this change is session-only.{_RST}")
+            return
+
+        self._smart_model_routing_override_enabled = enabled
+        _cprint(f"  {_ACCENT}✓ Smart routing {('enabled' if enabled else 'disabled')} for this session{_RST}")
+        _cprint(f"  {_DIM}  Use /routing default to return to the global setting.{_RST}")
+
     def _should_handle_model_command_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when /model should be handled immediately on the UI thread."""
         if not text or has_images or not _looks_like_slash_command(text):
@@ -5408,6 +5490,8 @@ class HermesCLI:
             self._handle_resume_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
+        elif canonical == "routing":
+            self._handle_routing_command(cmd_original)
         elif canonical == "provider":
             self._show_model_and_providers()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -556,6 +556,7 @@ class GatewayRunner:
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    _session_smart_routing_overrides: Dict[str, bool] = {}
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -613,6 +614,9 @@ class GatewayRunner:
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
         self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        # Per-session smart-routing overrides from /routing command.
+        # Key: session_key, Value: bool enabled/disabled for this session.
+        self._session_smart_routing_overrides: Dict[str, bool] = {}
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
@@ -948,7 +952,16 @@ class GatewayRunner:
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _effective_smart_model_routing(self, session_key: Optional[str] = None) -> dict:
+        """Return smart-routing config with any session override applied."""
+        cfg = dict(getattr(self, "_smart_model_routing", {}) or {})
+        if session_key is not None:
+            override = getattr(self, "_session_smart_routing_overrides", {}).get(session_key)
+            if override is not None:
+                cfg["enabled"] = bool(override)
+        return cfg
+
+    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict, session_key: Optional[str] = None) -> dict:
         from agent.smart_model_routing import resolve_turn_route
         from hermes_cli.models import resolve_fast_mode_overrides
 
@@ -962,7 +975,11 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
-        route = resolve_turn_route(user_message, getattr(self, "_smart_model_routing", {}), primary)
+        route = resolve_turn_route(
+            user_message,
+            self._effective_smart_model_routing(session_key),
+            primary,
+        )
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
@@ -3007,6 +3024,9 @@ class GatewayRunner:
         if canonical == "model":
             return await self._handle_model_command(event)
 
+        if canonical == "routing":
+            return await self._handle_routing_command(event)
+
         if canonical == "provider":
             return await self._handle_provider_command(event)
         
@@ -4334,6 +4354,7 @@ class GatewayRunner:
         # Clear any session-scoped model override so the next agent picks up
         # the configured default instead of the previously switched model.
         self._session_model_overrides.pop(session_key, None)
+        self._session_smart_routing_overrides.pop(session_key, None)
 
         # Fire plugin on_session_finalize hook (session boundary)
         try:
@@ -4914,6 +4935,97 @@ class GatewayRunner:
             lines.append("_(session only -- add `--global` to persist)_")
 
         return "\n".join(lines)
+
+    async def _handle_routing_command(self, event: MessageEvent) -> str:
+        """Handle /routing — manage smart routing for this session or globally."""
+        import shlex
+        import yaml
+
+        raw_args = event.get_command_args().strip()
+        try:
+            tokens = shlex.split(raw_args)
+        except ValueError as exc:
+            return f"⚠️ Could not parse `/routing` arguments: {exc}"
+
+        persist_global = False
+        normalized: list[str] = []
+        for token in tokens:
+            if token == "--global":
+                persist_global = True
+            else:
+                normalized.append(token.lower())
+
+        action = normalized[0] if normalized else "status"
+        if len(normalized) > 1:
+            return "⚠️ Usage: `/routing [on|off|status|default] [--global]`"
+
+        config_path = _hermes_home / "config.yaml"
+        self._smart_model_routing = self._load_smart_model_routing()
+        session_key = self._session_key_for_source(event.source)
+
+        if action == "status":
+            cfg = self._effective_smart_model_routing(session_key)
+            global_enabled = bool((self._smart_model_routing or {}).get("enabled", False))
+            override = self._session_smart_routing_overrides.get(session_key)
+            override_label = "inherit global" if override is None else ("on" if override else "off")
+            cheap_model = cfg.get("cheap_model") or {}
+            lines = ["🧭 **Smart Routing**", ""]
+            lines.append(f"**Global:** `{'on' if global_enabled else 'off'}`")
+            lines.append(f"**This session:** `{override_label}`")
+            lines.append(f"**Effective:** `{'on' if cfg.get('enabled') else 'off'}`")
+            lines.append(
+                f"**Cheap model:** `{cheap_model.get('model') or 'unconfigured'}` via `{cheap_model.get('provider') or 'unconfigured'}`"
+            )
+            lines.append(
+                f"**Thresholds:** `{cfg.get('max_simple_chars', 160)}` chars, `{cfg.get('max_simple_words', 28)}` words"
+            )
+            lines.append("")
+            lines.append("_Usage:_ `/routing <on|off|status|default> [--global]`")
+            return "\n".join(lines)
+
+        if action not in {"on", "off", "default", "reset"}:
+            return "⚠️ Usage: `/routing [on|off|status|default] [--global]`"
+
+        if action in {"default", "reset"}:
+            self._session_smart_routing_overrides.pop(session_key, None)
+            effective = bool((self._smart_model_routing or {}).get("enabled", False))
+            return (
+                "🧭 ✓ Smart routing override cleared for this session\n"
+                f"Effective state now follows global config: `{'on' if effective else 'off'}`"
+            )
+
+        enabled = action == "on"
+        if persist_global:
+            try:
+                user_config = {}
+                if config_path.exists():
+                    with open(config_path, encoding="utf-8") as f:
+                        user_config = yaml.safe_load(f) or {}
+                smart_cfg = user_config.get("smart_model_routing")
+                if not isinstance(smart_cfg, dict):
+                    smart_cfg = {}
+                    user_config["smart_model_routing"] = smart_cfg
+                smart_cfg["enabled"] = enabled
+                atomic_yaml_write(config_path, user_config)
+                self._smart_model_routing["enabled"] = enabled
+                self._session_smart_routing_overrides.pop(session_key, None)
+                return (
+                    f"🧭 ✓ Smart routing set to **{'ON' if enabled else 'OFF'}** and saved to config\n"
+                    "This session now follows the updated global setting."
+                )
+            except Exception as exc:
+                logger.error("Failed to persist smart routing setting: %s", exc)
+                self._session_smart_routing_overrides[session_key] = enabled
+                return (
+                    f"🧭 ✓ Smart routing {'enabled' if enabled else 'disabled'} for this session\n"
+                    "⚠️ Saving to config failed, so this change is session-only."
+                )
+
+        self._session_smart_routing_overrides[session_key] = enabled
+        return (
+            f"🧭 ✓ Smart routing {'enabled' if enabled else 'disabled'} for this session\n"
+            "Use `/routing default` to return to the global setting."
+        )
 
     async def _handle_provider_command(self, event: MessageEvent) -> str:
         """Handle /provider command - show available providers."""
@@ -5683,7 +5795,7 @@ class GatewayRunner:
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs, session_key)
 
             def run_sync():
                 agent = AIAgent(
@@ -5849,7 +5961,7 @@ class GatewayRunner:
             platform_key = _platform_config_key(source.platform)
             reasoning_config = self._load_reasoning_config()
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs, session_key)
             pr = self._provider_routing
 
             # Snapshot history from running agent or stored transcript
@@ -8538,7 +8650,7 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs, session_key)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -100,6 +100,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration", args_hint="[model] [--global]"),
+    CommandDef("routing", "Manage smart model routing for this session", "Configuration",
+               args_hint="[on|off|status|default] [--global]",
+               subcommands=("on", "off", "status", "default", "reset")),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
 

--- a/tests/cli/test_routing_command.py
+++ b/tests/cli/test_routing_command.py
@@ -1,0 +1,80 @@
+"""Tests for the CLI /routing command."""
+
+from unittest.mock import patch
+
+import cli as cli_mod
+
+
+def _make_cli(enabled=True):
+    obj = object.__new__(cli_mod.HermesCLI)
+    obj._smart_model_routing = {
+        "enabled": enabled,
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+        "cheap_model": {
+            "provider": "nous",
+            "model": "google/gemini-3-flash-preview",
+        },
+    }
+    obj._smart_model_routing_override_enabled = None
+    return obj
+
+
+def _printed_text(mock_cprint):
+    return "\n".join(str(call.args[0]) for call in mock_cprint.call_args_list if call.args)
+
+
+def test_routing_status_shows_global_and_session_state():
+    cli_obj = _make_cli(enabled=True)
+
+    with patch("cli._cprint") as mock_cprint:
+        cli_obj._handle_routing_command("/routing")
+
+    printed = _printed_text(mock_cprint)
+    assert "Smart routing (global): ON" in printed
+    assert "Smart routing (session):" in printed
+    assert "inherit global" in printed
+    assert "google/gemini-3-flash-preview via nous" in printed
+
+
+def test_routing_off_sets_session_override_only():
+    cli_obj = _make_cli(enabled=True)
+
+    with patch("cli._cprint"):
+        cli_obj._handle_routing_command("/routing off")
+
+    assert cli_obj._smart_model_routing_override_enabled is False
+    assert cli_obj._smart_model_routing["enabled"] is True
+
+
+def test_routing_default_clears_session_override():
+    cli_obj = _make_cli(enabled=True)
+    cli_obj._smart_model_routing_override_enabled = False
+
+    with patch("cli._cprint"):
+        cli_obj._handle_routing_command("/routing default")
+
+    assert cli_obj._smart_model_routing_override_enabled is None
+
+
+def test_routing_global_updates_config_and_clears_override():
+    cli_obj = _make_cli(enabled=True)
+    cli_obj._smart_model_routing_override_enabled = False
+
+    with patch("cli._cprint"), patch("cli.save_config_value", return_value=True) as mock_save:
+        cli_obj._handle_routing_command("/routing off --global")
+
+    assert cli_obj._smart_model_routing_override_enabled is None
+    assert cli_obj._smart_model_routing["enabled"] is False
+    mock_save.assert_called_once_with("smart_model_routing.enabled", False)
+
+
+def test_routing_global_save_failure_falls_back_to_session_override():
+    cli_obj = _make_cli(enabled=True)
+
+    with patch("cli._cprint"), patch("cli.save_config_value", return_value=False) as mock_save:
+        cli_obj._handle_routing_command("/routing off --global")
+
+    assert cli_obj._smart_model_routing["enabled"] is True
+    assert cli_obj._smart_model_routing_override_enabled is False
+    mock_save.assert_called_once_with("smart_model_routing.enabled", False)

--- a/tests/gateway/test_routing_command.py
+++ b/tests/gateway/test_routing_command.py
@@ -1,0 +1,161 @@
+"""Tests for gateway /routing command and per-session overrides."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._session_smart_routing_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._smart_model_routing = {
+        "enabled": True,
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+        "cheap_model": {
+            "provider": "nous",
+            "model": "google/gemini-3-flash-preview",
+        },
+    }
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.reset_session.return_value = session_entry
+    runner.session_store._entries = {session_key: session_entry}
+    runner.session_store._generate_session_key.return_value = session_key
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_routing_off_sets_session_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    result = await runner._handle_routing_command(_make_event("/routing off"))
+
+    assert runner._session_smart_routing_overrides[session_key] is False
+    assert "disabled" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_routing_default_clears_session_override():
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_smart_routing_overrides[session_key] = False
+
+    result = await runner._handle_routing_command(_make_event("/routing default"))
+
+    assert session_key not in runner._session_smart_routing_overrides
+    assert "override cleared" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_routing_status_reports_effective_state(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({
+            "smart_model_routing": {
+                "enabled": True,
+                "max_simple_chars": 160,
+                "max_simple_words": 28,
+                "cheap_model": {
+                    "provider": "nous",
+                    "model": "google/gemini-3-flash-preview",
+                },
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_smart_routing_overrides[session_key] = False
+
+    result = await runner._handle_routing_command(_make_event("/routing status"))
+
+    assert "**Global:** `on`" in result
+    assert "**This session:** `off`" in result
+    assert "**Effective:** `off`" in result
+
+
+@pytest.mark.asyncio
+async def test_routing_global_persists_to_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump({
+            "smart_model_routing": {
+                "enabled": True,
+                "max_simple_chars": 160,
+                "max_simple_words": 28,
+                "cheap_model": {
+                    "provider": "nous",
+                    "model": "google/gemini-3-flash-preview",
+                },
+            }
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner._session_smart_routing_overrides[session_key] = False
+
+    result = await runner._handle_routing_command(_make_event("/routing on --global"))
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert saved["smart_model_routing"]["enabled"] is True
+    assert session_key not in runner._session_smart_routing_overrides
+    assert "saved to config" in result.lower()

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -37,6 +37,7 @@ def _make_runner():
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner._session_model_overrides = {}
+    runner._session_smart_routing_overrides = {}
     runner._pending_model_notes = {}
     runner._background_tasks = set()
 
@@ -75,14 +76,16 @@ async def test_new_command_clears_session_model_override():
     runner._session_model_overrides[session_key] = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
+    runner._session_smart_routing_overrides[session_key] = False
 
     await runner._handle_reset_command(_make_event("/new"))
 
     assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_smart_routing_overrides
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds a new `/routing` command for both the CLI and gateway so smart model routing can be inspected and overridden per session without changing the global config.

### What changed
- add `/routing [on|off|status|default] [--global]` to the slash command registry
- add CLI handling for per-session smart-routing overrides
- add gateway handling for per-session smart-routing overrides
- apply session-aware smart-routing state when resolving the model for a turn
- clear session-scoped smart-routing overrides on `/new`
- add regression tests for CLI and gateway routing behavior
- fix CLI `--global` save-failure behavior so it falls back to a session-only override instead of mutating the in-memory global setting

### Why
The current smart routing config is global-only. That makes it awkward to temporarily force routing on or off for one conversation/thread while keeping the default behavior everywhere else. This change adds an explicit session-level control path and keeps the implementation conservative by default.

## How to test
### Automated
```bash
source venv/bin/activate
python3 -m pytest tests/gateway/test_routing_command.py tests/gateway/test_session_model_reset.py tests/cli/test_routing_command.py
```

### Manual smoke checks run in dev env
- exercised CLI `/routing off` handler and verified the session override flips to `False`
- exercised gateway `/routing off` handler and verified the returned status message reflects that routing is disabled for the session

## Platforms tested
- macOS (local dev environment)

## Notes
- I also attempted the broader suite with `python3 -m pytest tests/ -q`, but the repository had many unrelated pre-existing failures/timeouts in this environment, so the reliable signal for this PR is the targeted routing/session-reset test set above.
- No security-sensitive surfaces were added; this is command/state-management logic only.

## Related
- no linked issue
