### PR TITLE
fix: count spinner widget height using display width

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2028,14 +2028,25 @@ class HermesCLI:
             return 0
         if self._use_minimal_tui_chrome(width=width):
             return 0
-        # Compute how many lines the spinner text needs when wrapped.
-        # The rendered text is "  {emoji} {label}  ({elapsed})" — about
-        # len(_spinner_text) + 16 chars for indent + timer suffix.
+        # Mirror the actual rendered spinner text and count display-cell width
+        # so wrapped CJK text does not under-report its visible height.
         width = width or self._get_tui_terminal_width()
         if width and width > 10:
             import math
-            text_len = len(self._spinner_text) + 16  # indent + timer
-            return max(1, math.ceil(text_len / width))
+            import time as _time
+
+            rendered = f"  {self._spinner_text}"
+            t0 = getattr(self, "_tool_start_time", 0.0)
+            if t0 > 0:
+                elapsed = _time.monotonic() - t0
+                if elapsed >= 60:
+                    _m, _s = int(elapsed // 60), int(elapsed % 60)
+                    elapsed_str = f"{_m}m {_s}s"
+                else:
+                    elapsed_str = f"{elapsed:.1f}s"
+                rendered += f"  ({elapsed_str})"
+            text_width = self._status_bar_display_width(rendered)
+            return max(1, math.ceil(text_width / width))
         return 1
 
     def _get_voice_status_fragments(self, width: Optional[int] = None):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -212,6 +212,13 @@ class TestCLIStatusBar:
         assert cli_obj._use_minimal_tui_chrome(width=63) is True
         assert cli_obj._use_minimal_tui_chrome(width=64) is False
 
+    def test_spinner_widget_height_counts_cjk_display_width(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "穿行迷宫" * 8
+        cli_obj._tool_start_time = 0.0
+
+        assert cli_obj._spinner_widget_height(width=64) == 2
+
     def test_bottom_input_rule_hides_on_narrow_terminals(self):
         cli_obj = _make_cli()
 


### PR DESCRIPTION
## Summary
- compute spinner widget height from the rendered display width instead of raw string length
- mirror the existing spinner elapsed suffix when estimating wrapped rows
- add a regression test covering wrapped CJK spinner text

## Why
The interactive TUI currently estimates spinner height with `len(_spinner_text) + 16`, which undercounts wide CJK characters. When the spinner wraps to an extra row but the layout still reserves one row, subsequent input can render outside the input box.

## Testing
- `PYTHONPATH=. /Users/muzhen/.hermes/hermes-agent/venv/bin/pytest tests/cli/test_cli_status_bar.py -q`