### PR TITLE
Surface routed model name when using OpenRouter auto router

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3944,6 +3944,23 @@ class GatewayRunner:
                     "results. This can happen with some models — try again or "
                     "rephrase your question."
                 )
+
+            # When the requested model is a router (e.g. openrouter/auto), the
+            # actual model that handled the request is returned in the API
+            # response and surfaced as agent_result["routed_model"].  Append a
+            # short marker so the user can see which model was chosen.
+            try:
+                _requested_model = agent_result.get("model") or ""
+                _routed_model = agent_result.get("routed_model") or ""
+                if (
+                    response
+                    and _routed_model
+                    and _routed_model != _requested_model
+                ):
+                    response = f"{response}\n\n[Model: {_routed_model}]"
+            except Exception:
+                pass
+
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)

--- a/run_agent.py
+++ b/run_agent.py
@@ -10353,6 +10353,16 @@ class AIAgent:
                 except Exception:
                     pass
 
+                # Track the last model returned by the API. This can differ from
+                # self.model when using routers like openrouter/auto, which pick
+                # the underlying model per-request and return the actual name in
+                # the response. Consumers (e.g. the gateway) can surface this to
+                # the user so they know which model was chosen.
+                try:
+                    self._last_routed_model = getattr(response, "model", None)
+                except Exception:
+                    pass
+
                 # Handle assistant response
                 if assistant_message.content and not self.quiet_mode:
                     if self.verbose_logging:
@@ -11223,6 +11233,7 @@ class AIAgent:
             "interrupted": interrupted,
             "response_previewed": getattr(self, "_response_was_previewed", False),
             "model": self.model,
+            "routed_model": getattr(self, "_last_routed_model", None),
             "provider": self.provider,
             "base_url": self.base_url,
             "input_tokens": self.session_input_tokens,


### PR DESCRIPTION
## Summary

When a user sets their model to a router like `openrouter/auto`, the OpenRouter API picks the actual underlying model per-request (e.g. `anthropic/claude-opus-4.6`, `xiaomi/mimo-v2-pro`, etc.) and returns its name in the completion response's `model` field.

Today Hermes captures that name in the `api_request` hook but doesn't persist it anywhere the gateway can read it. This PR threads it through to the final response so users can see which model actually handled their turn.

## Changes

- **`run_agent.py`**
  - Store `response.model` on `self._last_routed_model` after each API call.
  - Include it as `"routed_model"` in the result dict returned from `run_conversation`.
- **`gateway/run.py`**
  - After the agent returns, if `routed_model` is set and differs from the requested `model`, append `\n\n[Model: {routed_model}]` to the response before it is sent to the platform.

## Behavior

- No change when the requested model equals the routed model (i.e. when not using a router).
- No change when the API response lacks a model field.
- Wrapped in `try/except` so any unexpected attribute shapes fall through silently.

## Test plan

- [x] Manually verified the result dict now contains `routed_model` when the response object has a `model` attribute.
- [ ] Telegram: send a message to a gateway configured with `openrouter/auto` and confirm the reply ends with `[Model: ...]`.
- [ ] Telegram: send a message to a gateway with a direct model (e.g. `anthropic/claude-sonnet-4.6`) and confirm no marker is appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)