### PR TITLE
fix: bump debug share paste TTL from 1 hour to 6 hours

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6889,7 +6889,7 @@ class GatewayRunner:
             except Exception as exc:
                 return f"✗ Failed to upload debug report: {exc}"
 
-            # Schedule auto-deletion after 1 hour
+            # Schedule auto-deletion after 6 hours
             _schedule_auto_delete(list(urls.values()))
 
             lines = [_GATEWAY_PRIVACY_NOTICE, "", "**Debug report uploaded:**", ""]
@@ -6898,7 +6898,7 @@ class GatewayRunner:
                 lines.append(f"`{label:<{label_width}}`  {url}")
 
             lines.append("")
-            lines.append("⏱ Pastes will auto-delete in 1 hour.")
+            lines.append("⏱ Pastes will auto-delete in 6 hours.")
             lines.append("For full log uploads, use `hermes debug share` from the CLI.")
             lines.append("Share these links with the Hermes team for support.")
             return "\n".join(lines)

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -27,8 +27,8 @@ _DPASTE_COM_URL = "https://dpaste.com/api/"
 # paste.rs caps at ~1 MB; we stay under that with headroom.
 _MAX_LOG_BYTES = 512_000
 
-# Auto-delete pastes after this many seconds (1 hour).
-_AUTO_DELETE_SECONDS = 3600
+# Auto-delete pastes after this many seconds (6 hours).
+_AUTO_DELETE_SECONDS = 21600
 
 
 # ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ _PRIVACY_NOTICE = """\
   • Full agent.log and gateway.log (up to 512 KB each — likely contains
     conversation content, tool outputs, and file paths)
 
-Pastes auto-delete after 1 hour.
+Pastes auto-delete after 6 hours.
 """
 
 _GATEWAY_PRIVACY_NOTICE = (
@@ -52,7 +52,7 @@ _GATEWAY_PRIVACY_NOTICE = (
     "(may contain conversation fragments) to a public paste service. "
     "Full logs are NOT included from the gateway — use `hermes debug share` "
     "from the CLI for full log uploads.\n"
-    "Pastes auto-delete after 1 hour."
+    "Pastes auto-delete after 6 hours."
 )
 
 
@@ -422,9 +422,9 @@ def run_debug_share(args):
     if failures:
         print(f"\n  (failed to upload: {', '.join(failures)})")
 
-    # Schedule auto-deletion after 1 hour
+    # Schedule auto-deletion after 6 hours
     _schedule_auto_delete(list(urls.values()))
-    print(f"\n⏱  Pastes will auto-delete in 1 hour.")
+    print(f"\n⏱  Pastes will auto-delete in 6 hours.")
 
     # Manual delete fallback
     print(f"To delete now:  hermes debug delete <url>")


### PR DESCRIPTION
## Summary

Bumps `_AUTO_DELETE_SECONDS` from 3600 (1 hour) to 21600 (6 hours) for pastes generated by `hermes debug share` and the gateway `/debug` command.

## Motivation

Users report missing debug reports before the auto-delete fires — by the time a bug report is triaged, the paste has already expired. 6 hours gives enough async window while still keeping sensitive log data (conversation fragments, file paths, full agent.log/gateway.log up to 512KB) off public paste services long-term.

## Changes

- `hermes_cli/debug.py`: constant + 2 user-facing notices + 2 print/comment strings
- `gateway/run.py`: gateway-side comment + user-facing notice

## Test plan

- `pytest tests/hermes_cli/test_debug.py -n0` — 45/45 pass
- `py_compile` on both modified files clean
- Existing tests only assert `"auto-delete" in out` (no literal "1 hour" string), so no test updates needed