### PR TITLE
fix(gateway): retryable platform failures stay alive instead of restart-looping

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1046,21 +1046,17 @@ class GatewayRunner:
             await self.stop()
         elif not self.adapters and self._failed_platforms:
             # All platforms are down and queued for background reconnection.
-            # If the error is retryable, exit with failure so systemd Restart=on-failure
-            # can restart the process. Otherwise stay alive and keep retrying in background.
-            if adapter.fatal_error_retryable:
-                self._exit_reason = adapter.fatal_error_message or "All messaging platforms failed with retryable errors"
-                self._exit_with_failure = True
-                logger.error(
-                    "All messaging platforms failed with retryable errors. "
-                    "Shutting down gateway for service restart (systemd will retry)."
-                )
-                await self.stop()
-            else:
-                logger.warning(
-                    "No connected messaging platforms remain, but %d platform(s) queued for reconnection",
-                    len(self._failed_platforms),
-                )
+            # Stay alive and let the retry loop recover — "retryable" means the
+            # error is transient (e.g. WhatsApp bridge QR timeout on an expired
+            # session, Discord reconnect blip), so cycling the whole process
+            # just wastes the retry queue and, in container runtimes that
+            # restart on exit, produces an endless boot loop that never
+            # makes progress. Non-retryable failures don't reach this branch
+            # because they aren't queued into _failed_platforms above.
+            logger.warning(
+                "No connected messaging platforms remain, but %d platform(s) queued for reconnection",
+                len(self._failed_platforms),
+            )
 
     def _request_clean_exit(self, reason: str) -> None:
         self._exit_cleanly = True


### PR DESCRIPTION
### Problem

In `GatewayRunner._handle_adapter_fatal_error` (`gateway/run.py`), when a platform adapter with `fatal_error_retryable=True` fires a fatal error and no other adapters are currently connected, the second `elif` branch currently calls `self.stop()` "so systemd Restart=on-failure can restart the process."

Under systemd this is fine. Under container runtimes with a restart policy (`docker-compose restart: always`, k8s `Always`), it produces an endless restart loop: `SIGTERM → container exits → runtime restarts it → same transient failure fires → exit → repeat`. The `_failed_platforms` retry queue populated three lines earlier never gets a chance to reconnect.

### Reproduction

1. Deploy a gateway with `WHATSAPP_ENABLED=true` in a container with an expired WhatsApp session file.
2. Bridge starts, generates QR codes for ~60s, nobody scans, bridge exits with code -15.
3. `whatsapp.py` calls `_set_fatal_error("whatsapp_bridge_exited", retryable=True)`.
4. `_handle_adapter_fatal_error` runs; `self.adapters` is empty after the adapter is popped; `self._failed_platforms` now contains WhatsApp.
5. The elif branch fires, `self._exit_with_failure = True`, `self.stop()` called, container exits.
6. Docker restarts it. Goto 1.

On a gateway with WhatsApp as the only enabled platform this is infinite. On one with Telegram + WhatsApp, Telegram never has time to connect before WhatsApp takes everyone down.

### Fix

Drop the retryable-exit branch. "Retryable" means the retry loop (`_reconnect_failed_platforms`, 30s cadence) can recover, so the gateway should stay alive and let that run. The existing `else` of that elif was already unreachable — non-retryable failures aren't queued into `_failed_platforms` above, so a non-retryable error reaching this branch with an empty `self.adapters` was impossible. Collapsing both into the warning simplifies the code path.

Non-retryable failures are unaffected: they still hit the first `if not self.adapters and not self._failed_platforms` branch and exit cleanly. If every retryable platform ends up permanently broken, `_failed_platforms` drains and the first if-branch catches that case on the next fatal.

### Test

Reproduced on a dockerised gateway with WhatsApp + stale bridge session; confirmed restart loop. Applied the patch; confirmed:

- `fatal_error_retryable=True` still fires the error log.
- `_failed_platforms` still gets the platform queued for reconnection.
- Process PID 1 stays alive across the fatal event (container `RestartCount` stays at 0 over 2+ minutes).
- Other platforms (Telegram) continue serving throughout.
- Healthcheck endpoint stays 200.

Verified across 6 production gateways after rollout.
