### PR TITLE
feat: add claude-code-acp external-process provider

### DIFF
--- a/agent/acp_chat_client.py
+++ b/agent/acp_chat_client.py
@@ -1,0 +1,7 @@
+"""Generic ACP chat client facade.
+
+Currently reuses the Copilot ACP transport implementation for any local
+ACP-compatible CLI that speaks the same stdio protocol.
+"""
+
+from agent.copilot_acp_client import CopilotACPClient as ACPChatClient

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1616,37 +1616,36 @@ def resolve_provider_client(
     if pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
         final_model = _normalize_resolved_model(model or _read_main_model(), provider)
-        if provider == "copilot-acp":
-            api_key = str(creds.get("api_key", "")).strip()
-            base_url = str(creds.get("base_url", "")).strip()
-            command = str(creds.get("command", "")).strip() or None
-            args = list(creds.get("args") or [])
-            if not final_model:
-                logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
-                )
-                return None, None
-            if not api_key or not base_url:
-                logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
-                )
-                return None, None
-            from agent.copilot_acp_client import CopilotACPClient
-
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
+        api_key = str(creds.get("api_key", "")).strip()
+        base_url = str(creds.get("base_url", "")).strip()
+        command = str(creds.get("command", "")).strip() or None
+        args = list(creds.get("args") or [])
+        if not final_model:
+            logger.warning(
+                "resolve_provider_client: %s requested but no model was provided or configured",
+                provider,
             )
-            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
-            return (_to_async_client(client, final_model) if async_mode
-                    else (client, final_model))
-        logger.warning("resolve_provider_client: external-process provider %s not "
-                       "directly supported", provider)
-        return None, None
+            return None, None
+        if not api_key or not base_url:
+            logger.warning(
+                "resolve_provider_client: %s requested but external process credentials are incomplete",
+                provider,
+            )
+            return None, None
+        if provider == "copilot-acp":
+            from agent.copilot_acp_client import CopilotACPClient as _ACPClient
+        else:
+            from agent.acp_chat_client import ACPChatClient as _ACPClient
+
+        client = _ACPClient(
+            api_key=api_key,
+            base_url=base_url,
+            command=command,
+            args=args,
+        )
+        logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+        return (_to_async_client(client, final_model) if async_mode
+                else (client, final_model))
 
     elif pconfig.auth_type in ("oauth_device_code", "oauth_external"):
         # OAuth providers — route through their specific try functions

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-code-acp",
     "gemini", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "qwen-oauth",

--- a/docs/specs/claude-code-acp-pr-spec.md
+++ b/docs/specs/claude-code-acp-pr-spec.md
@@ -1,0 +1,648 @@
+# PR Spec: Claude Code ACP as a First-Class Hermes Provider
+
+**Date:** 2026-04-16
+**Branch:** `docs/claude-code-acp-pr-spec`
+
+> **Intent:** This is the PR-level spec for adding Claude Code as a first-class ACP-backed provider in Hermes, instead of limiting Claude ACP support to ad hoc `delegate_task(acp_command=...)` usage.
+
+## TL;DR
+
+Hermes should add a new explicit provider:
+
+- **Provider slug:** `claude-code-acp`
+- **Display name:** `Claude Code ACP`
+- **Transport:** local or remote ACP server, surfaced to Hermes as `chat_completions`
+- **Default launch command:** `claude --acp --stdio`
+- **Default marker base URL:** `acp://claude-code`
+
+**Strong opinion:** this should **not** be implemented as a one-off clone of the current `copilot-acp` path.
+The right shape is:
+
+1. **generalize** the current Copilot-specific ACP plumbing into a reusable external-process ACP substrate,
+2. add `claude-code-acp` as the **second** first-class `external_process` provider,
+3. keep `anthropic` as the existing **native Anthropic Messages API** path,
+4. keep generic `delegate_task(acp_command=..., acp_args=...)` support for power users.
+
+That gives Hermes three clean Claude-related options:
+
+- `anthropic` → native API transport
+- `claude-code-acp` → Claude Code CLI as the active backend transport
+- `delegate_task(... acp_command="claude" ...)` → manual child-agent orchestration
+
+Those are meaningfully different products and should stay distinct.
+
+---
+
+## Why this PR exists
+
+Today Hermes already has enough ACP plumbing to prove Claude Code works, but not enough productization to make it feel native.
+
+### What exists already
+
+After inspecting the current Hermes codebase:
+
+- `tools/delegate_tool.py` already supports generic ACP child delegation via `acp_command` + `acp_args`
+- `hermes_cli/auth.py` already has an `external_process` provider type
+- `copilot-acp` is the only productized first-class external-process provider today
+- `agent/copilot_acp_client.py` already provides an OpenAI-compatible shim over ACP stdio
+- `anthropic` already supports Claude Code credentials for the **native** Anthropic API path
+
+### What is missing
+
+Claude Code is **not** selectable as a first-class provider in the main setup/model flow.
+The current code is hardcoded around Copilot in several places:
+
+- `hermes_cli/auth.py`
+- `hermes_cli/runtime_provider.py`
+- `hermes_cli/main.py`
+- `agent/auxiliary_client.py`
+- `run_agent.py`
+- `agent/copilot_acp_client.py`
+- provider/model registries and tests
+
+So Hermes can use Claude ACP today only through manual delegation, not as a normal top-level provider.
+
+---
+
+## Grounding from current reality
+
+This spec is based on two important facts established during investigation.
+
+### 1. Claude Code ACP works locally
+
+On this machine, `claude --acp --stdio` works and Hermes successfully used it through the generic ACP delegation path.
+
+### 2. Local Codex ACP does not currently work
+
+On this machine, the installed Codex CLI does **not** accept `--acp --stdio`, and a Hermes ACP smoke test against Codex failed.
+
+That matters because it means:
+
+- this PR should focus on **Claude Code ACP**, not “generic Codex ACP” productization,
+- Hermes should avoid implying that “ACP provider” means Codex compatibility today,
+- any future Codex ACP provider should be a separate follow-up once the CLI actually supports ACP in practice.
+
+---
+
+## Product goal
+
+Make Claude Code usable as a normal Hermes provider with the same level of polish users get from other first-class providers.
+
+That means a user should be able to:
+
+1. select **Claude Code ACP** in `hermes setup` / provider selection,
+2. let Hermes detect `claude` locally or use a configured remote ACP endpoint,
+3. pick a default Claude model hint,
+4. persist the provider + model in `config.yaml`,
+5. run Hermes normally in CLI, gateway, cron, and ACP-server contexts,
+6. have Hermes launch Claude Code as the active backend automatically.
+
+---
+
+## Non-goals
+
+This PR should **not** try to:
+
+- replace the existing `anthropic` provider,
+- merge `anthropic` and Claude Code ACP into one ambiguous “Claude” option,
+- auto-detect and silently switch users from `anthropic` to `claude-code-acp`,
+- invent a fully generic “any ACP server” provider UX in v1,
+- expose Claude Code-specific slash commands through Hermes,
+- guarantee model-level parity with Claude Code internals beyond passing Hermes’ requested model as a hint,
+- productize Codex ACP before the local Codex CLI actually supports ACP.
+
+---
+
+## Recommendation
+
+## Add a new explicit provider: `claude-code-acp`
+
+I recommend the canonical provider ID be:
+
+- **`claude-code-acp`**
+
+with aliases such as:
+
+- `claude-acp`
+- `claude-code`
+
+### Why this name is correct
+
+`claude-code-acp` is a little verbose, but it avoids two major ambiguities:
+
+1. **`anthropic` already exists** and is the native API path.
+2. **Claude Code credentials already work with `anthropic`**, so `claude-code` alone would blur credential source and transport.
+
+The slug should encode the transport choice, not just the model family.
+
+### Why not just reuse `anthropic`
+
+Because these are different transport layers:
+
+- `anthropic` = Hermes talks directly to Anthropic’s API
+- `claude-code-acp` = Hermes talks to the Claude Code CLI, which then acts as the model/tool agent backend
+
+Conflating those would create confusing setup, debugging, and support behavior.
+
+### Why not “delegation-only”
+
+Because the generic delegation hook is good for power users, but not sufficient UX for a first-class provider:
+
+- no provider selection UI
+- no persisted status/config flow
+- no top-level runtime resolution
+- no coherent docs/tests/story for ongoing support
+
+---
+
+## Architecture recommendation
+
+## Generalize the current Copilot ACP path into a reusable ACP client layer
+
+The cleanest implementation is:
+
+### Step 1: introduce a generic ACP chat shim
+
+Refactor `agent/copilot_acp_client.py` into a generic implementation, for example:
+
+- new file: `agent/acp_chat_client.py`
+- new class: `ACPChatCompletionsClient`
+
+Then either:
+
+- keep `agent/copilot_acp_client.py` as a thin compatibility wrapper/re-export, or
+- update imports in the same PR and remove the old name.
+
+### Why this refactor is worth doing now
+
+The current client is only nominally Copilot-specific. The actual mechanics are mostly generic:
+
+- spawn a subprocess
+- speak ACP JSON-RPC over stdio
+- turn ACP responses into the minimal OpenAI-ish shape Hermes expects
+- preserve tool-call blocks
+
+What is Copilot-specific today is mostly naming and default env/base-url assumptions.
+
+Without this refactor, adding Claude ACP would duplicate the same subprocess/ACP shim with a different command name. That is the wrong abstraction boundary.
+
+---
+
+## Provider metadata changes
+
+### Extend `ProviderConfig` for external-process providers
+
+Right now `ProviderConfig` is good for API-key and OAuth providers, but external-process providers are effectively hardcoded in helper functions.
+
+Add first-class fields for subprocess-backed providers, e.g.:
+
+- `default_command: str = ""`
+- `command_env_vars: tuple[str, ...] = ()`
+- `args_env_var: str = ""`
+- `default_args: tuple[str, ...] = ()`
+- `missing_command_hint: str = ""`
+- `base_url_env_var: str = ""` (already exists)
+- `inference_base_url: str = ""` (already exists)
+
+Then define providers like:
+
+### `copilot-acp`
+- `default_command = "copilot"`
+- `command_env_vars = ("HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH")`
+- `args_env_var = "HERMES_COPILOT_ACP_ARGS"`
+- `default_args = ("--acp", "--stdio")`
+- `inference_base_url = "acp://copilot"`
+
+### `claude-code-acp`
+- `default_command = "claude"`
+- `command_env_vars = ("HERMES_CLAUDE_CODE_ACP_COMMAND", "CLAUDE_CODE_CLI_PATH")`
+- `args_env_var = "HERMES_CLAUDE_CODE_ACP_ARGS"`
+- `default_args = ("--acp", "--stdio")`
+- `inference_base_url = "acp://claude-code"`
+- `missing_command_hint = "Install Claude Code or set HERMES_CLAUDE_CODE_ACP_COMMAND/CLAUDE_CODE_CLI_PATH."`
+
+**Strong opinion:** use explicit typed fields on `ProviderConfig`, not a bag of `extra[...]` strings. These values are part of core runtime behavior.
+
+---
+
+## Runtime behavior
+
+### Resolved runtime shape
+
+`resolve_runtime_provider(...)` should return the same general shape for `claude-code-acp` that it does for `copilot-acp`:
+
+```python
+{
+  "provider": "claude-code-acp",
+  "api_mode": "chat_completions",
+  "base_url": "acp://claude-code",
+  "api_key": "claude-code-acp",
+  "command": "/path/to/claude",
+  "args": ["--acp", "--stdio"],
+  "source": "process",
+}
+```
+
+### Why `api_mode` stays `chat_completions`
+
+Internally Hermes is still talking to an OpenAI-compatible shim object. The ACP subprocess is the transport detail behind that shim.
+
+So v1 should keep:
+
+- `api_mode = "chat_completions"`
+
+for all external-process ACP providers.
+
+### Marker base URLs
+
+Use marker URLs to preserve the current ergonomics:
+
+- `acp://copilot`
+- `acp://claude-code`
+
+and continue allowing remote ACP endpoints with:
+
+- `acp+tcp://host:port`
+
+That keeps compatibility with the existing “no local command needed if remote ACP URL is configured” behavior.
+
+---
+
+## UX recommendation
+
+## Claude Code ACP should be an explicit provider choice in setup/model flows
+
+### Provider picker
+
+Add `Claude Code ACP` anywhere provider choices are listed, including:
+
+- `hermes setup`
+- `/model` or equivalent provider switch flow
+- canonical provider registries / labels / aliases
+
+### Setup flow behavior
+
+Add a dedicated `_model_flow_claude_code_acp(...)` in `hermes_cli/main.py`.
+
+This flow should:
+
+1. resolve the Claude Code command / args / base URL,
+2. print a short explanation that Hermes will delegate requests to `claude --acp`,
+3. show the resolved command or remote ACP URL,
+4. offer a curated Claude model list,
+5. allow a custom model name entry,
+6. persist the provider selection in `config.yaml`.
+
+### Model selection policy
+
+Unlike `copilot-acp`, Hermes should **not** try to fetch a live model catalog here unless Claude ACP exposes a stable supported discovery path that Hermes can rely on.
+
+For v1, use a curated list plus custom entry. Example list:
+
+- `claude-opus-4.6`
+- `claude-sonnet-4.6`
+- `claude-sonnet-4.5`
+- `claude-haiku-4.5`
+- `Enter custom model name`
+
+**Important:** Hermes should describe this clearly as a **model hint**, not a guaranteed CLI-enforced server-side model selection. That matches the current ACP shim behavior.
+
+### Persisted config shape
+
+```yaml
+model:
+  default: claude-sonnet-4.6
+  provider: claude-code-acp
+  base_url: acp://claude-code
+  api_mode: chat_completions
+```
+
+---
+
+## Auth and status behavior
+
+### `get_external_process_provider_status(...)`
+
+Refactor it to be provider-driven, not Copilot-driven.
+
+It should:
+
+1. look up provider metadata,
+2. resolve command from provider-specific env vars,
+3. resolve args from the provider-specific args env var,
+4. resolve base URL from the provider’s base-url env var or default marker URL,
+5. mark `configured=true` if either:
+   - the local command resolves, or
+   - the base URL is `acp+tcp://...`
+
+For `claude-code-acp`, status output should surface:
+
+- command
+- resolved command
+- args
+- base_url
+- configured / logged_in
+
+### v1 status scope
+
+I do **not** think this PR needs a deep `claude auth status` integration.
+
+Why:
+
+- it adds provider-specific subprocess probing logic,
+- auth output/behavior may change across Claude Code versions,
+- Hermes already treats `copilot-acp` as “command exists / remote endpoint exists” rather than “auth definitely valid.”
+
+So in v1, “status” should mean **transport is configured**, not “Claude Code subscription is definitely healthy.”
+
+Runtime errors from Claude Code should still bubble up clearly.
+
+---
+
+## Relationship to the existing `anthropic` provider
+
+This is the most important product distinction in the PR.
+
+### Keep `anthropic` unchanged
+
+The existing `anthropic` provider should remain:
+
+- native Anthropic API transport
+- `api_mode = "anthropic_messages"`
+- capable of using Anthropic API keys or Claude Code credential files / OAuth-derived tokens where Hermes already supports them
+
+### Do not auto-upgrade or auto-route
+
+Hermes should **not** automatically switch a user to `claude-code-acp` just because:
+
+- `claude` exists on PATH
+- Claude Code is logged in
+- Claude Code credentials exist on disk
+
+Why:
+
+- transport changes affect latency, tooling behavior, debugging, and failure modes
+- silent switching would be surprising
+- many users will prefer the native Anthropic API path for stability and simplicity
+
+### Recommendation for `auto`
+
+In v1, `auto` should **not** include `claude-code-acp` in the automatic provider-resolution chain.
+
+Make it explicit-selection only.
+
+That avoids accidental provider flips and keeps the rollout safer.
+
+---
+
+## File-by-file implementation plan
+
+## 1. Generic ACP client layer
+
+### Create / refactor
+- `agent/acp_chat_client.py` — new generic ACP subprocess-backed OpenAI-compatible shim
+
+### Update or keep as compatibility wrapper
+- `agent/copilot_acp_client.py`
+
+### Required changes
+- replace Copilot-specific defaults/messages with provider-supplied values
+- allow arbitrary `acp://...` marker base URLs
+- keep support for `command`, `args`, `acp_command`, `acp_args`, and `acp_cwd`
+
+---
+
+## 2. Provider registry and auth resolution
+
+### Modify
+- `hermes_cli/auth.py`
+
+### Required changes
+- add `DEFAULT_CLAUDE_CODE_ACP_BASE_URL = "acp://claude-code"`
+- add `ProviderConfig("claude-code-acp", ...)`
+- add aliases for `claude-acp` / `claude-code`
+- generalize `get_external_process_provider_status(...)`
+- generalize `resolve_external_process_provider_credentials(...)`
+- remove Copilot-only error text from shared helpers
+
+---
+
+## 3. Runtime provider resolution
+
+### Modify
+- `hermes_cli/runtime_provider.py`
+
+### Required changes
+- treat `claude-code-acp` like `copilot-acp`
+- ideally generalize the current `if provider == "copilot-acp"` branch into a provider-type-driven branch for `external_process`
+
+---
+
+## 4. Main model/provider flow
+
+### Modify
+- `hermes_cli/main.py`
+
+### Required changes
+- add provider selection branch for `claude-code-acp`
+- add `_model_flow_claude_code_acp(...)`
+- mirror the high-level shape of `_model_flow_copilot_acp(...)`
+- use curated Claude model defaults instead of GitHub model-catalog fetching
+- persist `provider`, `base_url`, and `api_mode`
+
+---
+
+## 5. Provider/model registries
+
+### Modify
+- `hermes_cli/models.py`
+- `hermes_cli/model_normalize.py`
+- `hermes_cli/providers.py`
+- `agent/model_metadata.py`
+
+### Required changes
+- add `claude-code-acp` to canonical provider lists
+- add labels + aliases
+- add curated model list
+- normalize `anthropic/claude-sonnet-4.6` → `claude-sonnet-4.6` for this provider like other strip-vendor providers
+- add a Hermes provider overlay for `claude-code-acp`, matching the same ACP-transport conventions Hermes already uses for `copilot-acp`
+- document the overlay choice clearly so future ACP providers do not reintroduce Copilot-specific assumptions
+
+---
+
+## 6. Main client construction path
+
+### Modify
+- `run_agent.py`
+- `agent/auxiliary_client.py`
+
+### Required changes
+- stop hardcoding `copilot-acp` as the only ACP-backed direct client path
+- instantiate the new generic ACP client for any supported external-process ACP provider
+- do not special-case only `acp://copilot`
+- support `acp://claude-code` and, ideally, provider-type-driven ACP detection
+
+A good end-state is:
+
+- `run_agent.py` decides “ACP client vs OpenAI client” by provider type / ACP scheme, not by Copilot slug
+- `agent/auxiliary_client.py` does the same for auxiliary usage
+
+---
+
+## 7. Setup wizard integration
+
+### Modify
+- `hermes_cli/setup.py`
+
+### Required changes
+- include `claude-code-acp` in provider selection labels/defaults
+- preserve current behavior where same-provider credential-pool prompts do **not** appear for external-process providers
+- ensure vision-setup messaging still behaves sensibly for a provider that does not expose a Hermes-usable vision backend
+
+---
+
+## 8. Documentation
+
+### Modify
+- `docs/acp-setup.md`
+- `docs/specs/claude-code-acp-pr-spec.md` (this file)
+
+### Suggested additions
+- short user-facing section: “Using Claude Code ACP as Hermes’ backend”
+- clarify the distinction between:
+  - Anthropic native provider
+  - Claude Code credentials reused by Anthropic
+  - Claude Code ACP transport
+
+---
+
+## Testing plan
+
+Add or update tests in at least these files:
+
+### CLI auth/provider tests
+- `tests/hermes_cli/test_api_key_providers.py`
+  - provider registry includes `claude-code-acp`
+  - status resolution uses Claude env vars and defaults
+  - credential resolution returns `acp://claude-code`
+  - missing command error mentions Claude env vars
+
+### provider persistence / setup tests
+- `tests/hermes_cli/test_model_provider_persistence.py`
+  - `_model_flow_claude_code_acp()` persists provider/base_url/model/api_mode together
+- `tests/hermes_cli/test_setup_model_provider.py`
+  - setup flow can save `claude-code-acp`
+  - no same-provider fallback prompt for this external-process provider
+
+### auxiliary client tests
+- `tests/agent/test_auxiliary_client.py`
+  - `resolve_provider_client("claude-code-acp")` instantiates the generic ACP client
+  - requires configured or explicit model like `copilot-acp`
+
+### run_agent tests
+- `tests/run_agent/test_run_agent.py`
+  - AIAgent chooses ACP client for `claude-code-acp`
+- `tests/run_agent/test_run_agent_codex_responses.py`
+  - if relevant, ensure no stale `copilot-acp` assumptions remain
+
+### URL validation / metadata tests
+- `tests/agent/test_proxy_and_url_validation.py`
+  - `acp://claude-code` is accepted
+- any provider metadata tests covering canonical provider lists / aliases
+
+---
+
+## Rollout and compatibility
+
+### Backward compatibility
+
+This PR should not break `copilot-acp`.
+
+That means:
+
+- Copilot env vars keep working
+- `acp://copilot` keeps working
+- tests for Copilot ACP remain green
+- any compatibility wrapper around `CopilotACPClient` continues to work during the refactor
+
+### Safe rollout strategy
+
+1. Generalize the ACP substrate first.
+2. Add `claude-code-acp` on top.
+3. Keep `auto` unchanged.
+4. Do not remove `copilot-acp` special cases until equivalent generic coverage exists in tests.
+
+---
+
+## Risks
+
+### 1. Model selection is only a hint in v1
+
+The current ACP shim passes Hermes’ selected model through the prompt transcript, not a provider-native guaranteed model switch.
+
+That is acceptable for v1, but the UX copy should be honest about it.
+
+### 2. Claude CLI auth/runtime failures may surface only at request time
+
+Because v1 status is transport-oriented, a user may still have a broken Claude session when a real request runs.
+
+That is acceptable if the resulting error is clear and actionable.
+
+### 3. Overfitting shared code to Copilot assumptions
+
+This is the main implementation trap.
+
+If the refactor is shallow and keeps Copilot-specific names/messages/env assumptions in “shared” code, the Claude provider will work technically but remain brittle and confusing.
+
+---
+
+## Open questions
+
+### Should Hermes expose Claude-specific auth diagnostics in v1?
+
+My recommendation: **no**. Keep the first PR focused on transport productization.
+
+### Should the generic ACP substrate become a public “custom ACP provider” feature?
+
+My recommendation: **not in this PR**. First prove the abstraction with two providers:
+
+- `copilot-acp`
+- `claude-code-acp`
+
+If that feels good, a later PR can consider a user-defined ACP provider surface.
+
+---
+
+## Concrete recommendation summary
+
+If I were implementing this PR, I would make these exact decisions:
+
+1. **Introduce `claude-code-acp` as a new first-class provider.**
+2. **Generalize the current Copilot ACP path instead of duplicating it.**
+3. **Keep `anthropic` separate and unchanged.**
+4. **Keep `auto` unchanged; no silent Claude ACP auto-selection.**
+5. **Use a curated Claude model list plus custom entry.**
+6. **Treat the selected model as a hint in v1.**
+7. **Preserve `copilot-acp` compatibility while refactoring.**
+
+That is the smallest coherent product increment that makes Claude Code ACP feel truly native inside Hermes.
+
+---
+
+## Appendix: why this is better than the status quo
+
+Today Hermes already has the raw pieces to spawn Claude Code through ACP, but the experience is fragmented:
+
+- manual delegation works,
+- main provider selection does not,
+- provider resolution is Copilot-specific,
+- direct-client codepaths are Copilot-specific,
+- docs do not present Claude ACP as a supported top-level mode.
+
+After this PR, Hermes would have a clean story:
+
+- **Anthropic** if you want direct API access
+- **Claude Code ACP** if you want Claude Code itself to be the backend agent transport
+- **Generic ACP child delegation** if you want manual advanced orchestration
+
+That is a much better product surface.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -136,6 +136,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-code-acp": ProviderConfig(
+        id="claude-code-acp",
+        name="Claude Code ACP",
+        auth_type="external_process",
+        inference_base_url="acp://claude-code",
+        base_url_env_var="CLAUDE_CODE_ACP_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -923,7 +930,7 @@ def resolve_provider(
         "kimi-cn": "kimi-coding-cn", "moonshot-cn": "kimi-coding-cn",
         "arcee-ai": "arcee", "arceeai": "arcee",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
-        "claude": "anthropic", "claude-code": "anthropic",
+        "claude": "anthropic", "claude-code": "claude-code-acp", "claude-acp": "claude-code-acp",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -962,11 +969,13 @@ def resolve_provider(
     if explicit_api_key or explicit_base_url:
         return "openrouter"
 
-    # Check auth store for an active OAuth provider
+    # Check auth store for an active provider. Do not auto-select GitHub
+    # Copilot from ambient GITHUB_TOKEN/GH_TOKEN env vars — those are commonly
+    # present for git tooling and should not hijack inference routing.
     try:
         auth_store = _load_auth_store()
         active = auth_store.get("active_provider")
-        if active and active in PROVIDER_REGISTRY:
+        if active and active in PROVIDER_REGISTRY and active != "copilot":
             status = get_auth_status(active)
             if status.get("logged_in"):
                 return active
@@ -990,13 +999,20 @@ def resolve_provider(
                 return pid
 
     # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).
-    # This runs after API-key providers so explicit keys always win.
-    try:
-        from agent.bedrock_adapter import has_aws_credentials
-        if has_aws_credentials():
-            return "bedrock"
-    except ImportError:
-        pass  # boto3 not installed — skip Bedrock auto-detection
+    # Ambient GitHub tokens are common in dev shells; when they are the only
+    # credentials present, prefer surfacing "no provider configured" rather than
+    # silently switching inference to Bedrock.
+    _ambient_github_token = any(
+        has_usable_secret(os.getenv(name, ""))
+        for name in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+    )
+    if not _ambient_github_token:
+        try:
+            from agent.bedrock_adapter import has_aws_credentials
+            if has_aws_credentials():
+                return "bedrock"
+        except ImportError:
+            pass  # boto3 not installed — skip Bedrock auto-detection
 
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
@@ -2419,18 +2435,39 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _external_process_provider_settings(provider_id: str) -> tuple[str, str, str, str, str, str]:
+    if provider_id == "claude-code-acp":
+        return (
+            "HERMES_CLAUDE_CODE_ACP_COMMAND",
+            "CLAUDE_CODE_CLI_PATH",
+            "HERMES_CLAUDE_CODE_ACP_ARGS",
+            "claude",
+            "missing_claude_code_cli",
+            "Could not find the Claude Code CLI command '{command}'. Install Claude Code or set HERMES_CLAUDE_CODE_ACP_COMMAND/CLAUDE_CODE_CLI_PATH.",
+        )
+    return (
+        "HERMES_COPILOT_ACP_COMMAND",
+        "COPILOT_CLI_PATH",
+        "HERMES_COPILOT_ACP_ARGS",
+        "copilot",
+        "missing_copilot_cli",
+        "Could not find the Copilot CLI command '{command}'. Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+    )
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
+    command_env_var, legacy_command_env_var, args_env_var, default_command, _, _ = _external_process_provider_settings(provider_id)
     command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
+        os.getenv(command_env_var, "").strip()
+        or os.getenv(legacy_command_env_var, "").strip()
+        or default_command
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+    raw_args = os.getenv(args_env_var, "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
@@ -2452,16 +2489,16 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
 def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Generic auth status dispatcher."""
     target = provider_id or get_active_provider()
+    pconfig = PROVIDER_REGISTRY.get(target)
     if target == "nous":
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
     if target == "qwen-oauth":
         return get_qwen_auth_status()
-    if target == "copilot-acp":
+    if pconfig and pconfig.auth_type == "external_process":
         return get_external_process_provider_status(target)
     # API-key providers
-    pconfig = PROVIDER_REGISTRY.get(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain
@@ -2526,25 +2563,26 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
+    command_env_var, legacy_command_env_var, args_env_var, default_command, _, _ = _external_process_provider_settings(provider_id)
     command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
+        os.getenv(command_env_var, "").strip()
+        or os.getenv(legacy_command_env_var, "").strip()
+        or default_command
     )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+    raw_args = os.getenv(args_env_var, "").strip()
     args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        _, _, _, _, missing_code, missing_message = _external_process_provider_settings(provider_id)
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            missing_message.format(command=command),
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=missing_code,
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1120,6 +1120,8 @@ def select_provider_and_model(args=None):
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-code-acp":
+        _model_flow_claude_code_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -2310,6 +2312,74 @@ def _model_flow_copilot_acp(config, current_model=""):
         catalog=catalog,
         api_key=catalog_api_key,
     ) or selected
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_code_acp(config, current_model=""):
+    """Claude Code ACP model selection with local CLI-backed transport."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-code-acp"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "claude"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude Code ACP delegates Hermes turns to `claude --acp`.")
+    print("  Hermes starts a local ACP subprocess for each request.")
+    print("  Hermes uses your selected model as a hint for the Claude Code ACP session.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Set HERMES_CLAUDE_CODE_ACP_COMMAND or CLAUDE_CODE_CLI_PATH if Claude Code is installed elsewhere.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+    if model_list:
+        selected = _prompt_model_selection(
+            model_list,
+            current_model=current_model,
+        )
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
     _save_model_choice(selected)
 
     cfg = load_config()
@@ -4860,7 +4930,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "claude-code-acp", "copilot", "anthropic", "gemini", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -75,6 +75,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "claude-code-acp",
     "openai-codex",
 })
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,6 +106,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-code-acp": [
+        "claude-sonnet-4.6",
+        "claude-opus-4.6",
+        "claude-sonnet-4.5",
+        "claude-haiku-4.5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -537,6 +543,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+    ProviderEntry("claude-code-acp", "Claude Code ACP",         "Claude Code ACP (spawns `claude --acp --stdio`)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — OpenAI-compatible endpoint)"),
     ProviderEntry("deepseek",       "DeepSeek",                 "DeepSeek (DeepSeek-V3, R1, coder — direct API)"),
@@ -570,6 +577,7 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-acp": "claude-code-acp",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -582,7 +590,7 @@ _PROVIDER_ALIASES = {
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    "claude-code": "claude-code-acp",
     "deep-seek": "deepseek",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",
@@ -1257,6 +1265,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             pass
         if normalized == "copilot-acp":
             return list(_PROVIDER_MODELS.get("copilot", []))
+    if normalized == "claude-code-acp":
+        return list(_PROVIDER_MODELS.get("claude-code-acp", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint
         try:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -70,6 +70,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-code-acp": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="acp://claude-code",
+        base_url_env_var="CLAUDE_CODE_ACP_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -193,7 +199,8 @@ ALIASES: Dict[str, str] = {
 
     # anthropic
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    "claude-code": "claude-code-acp",
+    "claude-acp": "claude-code-acp",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -266,6 +273,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-code-acp": "Claude Code ACP",
     "xiaomi": "Xiaomi MiMo",
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -798,10 +798,10 @@ def resolve_runtime_provider(
             logger.info("Qwen OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "claude-code-acp"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -75,6 +75,12 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-code-acp": [
+        "claude-sonnet-4.6",
+        "claude-opus-4.6",
+        "claude-sonnet-4.5",
+        "claude-haiku-4.5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -770,6 +776,7 @@ def setup_model_provider(config: dict, *, quick: bool = False):
             "nous-api": "Nous Portal API key",
             "copilot": "GitHub Copilot",
             "copilot-acp": "GitHub Copilot ACP",
+            "claude-code-acp": "Claude Code ACP",
             "zai": "Z.AI / GLM",
             "kimi-coding": "Kimi / Moonshot",
             "kimi-coding-cn": "Kimi / Moonshot (China)",

--- a/run_agent.py
+++ b/run_agent.py
@@ -723,16 +723,14 @@ class AIAgent:
         # providers have exceptions (for example Copilot's gpt-5-mini still
         # uses chat completions). Also auto-upgrade for direct OpenAI URLs
         # (api.openai.com) since all newer tool-calling models prefer
-        # Responses there. ACP runtimes are excluded: CopilotACPClient
-        # handles its own routing and does not implement the Responses API
-        # surface.
+        # Responses there. ACP runtimes are excluded: Hermes routes them
+        # through ACP client adapters instead of the Responses API surface.
         # When api_mode was explicitly provided, respect it — the user
         # knows what their endpoint supports (#10473).
         if (
             api_mode is None
             and self.api_mode == "chat_completions"
-            and self.provider != "copilot-acp"
-            and not str(self.base_url or "").lower().startswith("acp://copilot")
+            and not str(self.base_url or "").lower().startswith("acp://")
             and not str(self.base_url or "").lower().startswith("acp+tcp://")
             and (
                 self._is_direct_openai_url()
@@ -962,14 +960,29 @@ class AIAgent:
                 _gr_label = " + Guardrails" if self._bedrock_guardrail_config else ""
                 print(f"🤖 AI Agent initialized with model: {self.model} (AWS Bedrock, {self._bedrock_region}{_gr_label})")
         else:
-            if api_key and base_url:
+            explicit_base_url = base_url
+            if api_key and (explicit_base_url or self.provider):
                 # Explicit credentials from CLI/gateway — construct directly.
-                # The runtime provider resolver already handled auth for us.
-                client_kwargs = {"api_key": api_key, "base_url": base_url}
-                if self.provider == "copilot-acp":
+                # When only a provider is given, infer its default base URL so
+                # lightweight tests and callers don't have to duplicate registry values.
+                effective_base = explicit_base_url
+                if not effective_base and self.provider:
+                    if self.provider == "openrouter":
+                        effective_base = "https://openrouter.ai/api/v1"
+                    else:
+                        try:
+                            from hermes_cli.auth import PROVIDER_REGISTRY
+                            _pcfg = PROVIDER_REGISTRY.get(self.provider)
+                            if _pcfg:
+                                effective_base = _pcfg.inference_base_url
+                        except Exception:
+                            effective_base = explicit_base_url
+                if not effective_base:
+                    raise RuntimeError("Explicit API key was provided but no base URL could be resolved.")
+                client_kwargs = {"api_key": api_key, "base_url": effective_base}
+                if str(effective_base or "").lower().startswith("acp://") or self.provider in {"copilot-acp", "claude-code-acp"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
-                effective_base = base_url
                 if "openrouter" in effective_base.lower():
                     client_kwargs["default_headers"] = {
                         "HTTP-Referer": "https://hermes-agent.nousresearch.com",
@@ -4282,12 +4295,24 @@ class AIAgent:
         from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
         _validate_proxy_env_urls()
         _validate_base_url(client_kwargs.get("base_url"))
-        if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+        base_url = str(client_kwargs.get("base_url", ""))
+        if self.provider == "copilot-acp" or base_url.startswith("acp://copilot"):
             from agent.copilot_acp_client import CopilotACPClient
 
             client = CopilotACPClient(**client_kwargs)
             logger.info(
                 "Copilot ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
+        if self.provider == "claude-code-acp" or base_url.startswith("acp://claude-code"):
+            from agent.acp_chat_client import ACPChatClient
+
+            client = ACPChatClient(**client_kwargs)
+            logger.info(
+                "Claude Code ACP client created (%s, shared=%s) %s",
                 reason,
                 shared,
                 self._client_log_context(),

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -993,6 +993,46 @@ def test_resolve_provider_client_copilot_acp_requires_explicit_or_configured_mod
     mock_acp.assert_not_called()
 
 
+def test_resolve_provider_client_supports_claude_code_acp_external_process():
+    fake_client = MagicMock()
+
+    with patch("agent.auxiliary_client._read_main_model", return_value="claude-sonnet-4.6"), \
+         patch("agent.auxiliary_client.CodexAuxiliaryClient", MagicMock()), \
+         patch("agent.acp_chat_client.ACPChatClient", return_value=fake_client) as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "claude-code-acp",
+             "api_key": "claude-code-acp",
+             "base_url": "acp://claude-code",
+             "command": "/usr/bin/claude",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("claude-code-acp")
+
+    assert client is fake_client
+    assert model == "claude-sonnet-4.6"
+    assert mock_acp.call_args.kwargs["api_key"] == "claude-code-acp"
+    assert mock_acp.call_args.kwargs["base_url"] == "acp://claude-code"
+    assert mock_acp.call_args.kwargs["command"] == "/usr/bin/claude"
+    assert mock_acp.call_args.kwargs["args"] == ["--acp", "--stdio"]
+
+
+def test_resolve_provider_client_claude_code_acp_requires_explicit_or_configured_model():
+    with patch("agent.auxiliary_client._read_main_model", return_value=""), \
+         patch("agent.acp_chat_client.ACPChatClient") as mock_acp, \
+         patch("hermes_cli.auth.resolve_external_process_provider_credentials", return_value={
+             "provider": "claude-code-acp",
+             "api_key": "claude-code-acp",
+             "base_url": "acp://claude-code",
+             "command": "/usr/bin/claude",
+             "args": ["--acp", "--stdio"],
+         }):
+        client, model = resolve_provider_client("claude-code-acp")
+
+    assert client is None
+    assert model is None
+    mock_acp.assert_not_called()
+
+
 class TestAuxiliaryMaxTokensParam:
     def test_codex_fallback_uses_max_tokens(self, monkeypatch):
         """Codex adapter translates max_tokens internally, so we return max_tokens."""

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -383,6 +383,7 @@ class TestStripProviderPrefix:
         assert _strip_provider_prefix("local:my-model") == "my-model"
         assert _strip_provider_prefix("openrouter:anthropic/claude-sonnet-4") == "anthropic/claude-sonnet-4"
         assert _strip_provider_prefix("anthropic:claude-sonnet-4") == "claude-sonnet-4"
+        assert _strip_provider_prefix("claude-code-acp:claude-sonnet-4.6") == "claude-sonnet-4.6"
 
     def test_ollama_model_tag_preserved(self):
         """Ollama model:tag format must NOT be stripped."""

--- a/tests/agent/test_proxy_and_url_validation.py
+++ b/tests/agent/test_proxy_and_url_validation.py
@@ -48,6 +48,7 @@ def test_proxy_env_rejects_malformed_port(monkeypatch, key):
     "https://api.example.com/v1",
     "http://127.0.0.1:6153/v1",
     "acp://copilot",
+    "acp://claude-code",
     "",
     None,
 ])

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -37,6 +37,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-code-acp", "Claude Code ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -103,6 +104,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["claude-code-acp"].inference_base_url == "acp://claude-code"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
@@ -212,6 +214,10 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_claude_code_acp(self):
+        assert resolve_provider("claude-acp") == "claude-code-acp"
+        assert resolve_provider("claude-code") == "claude-code-acp"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -336,6 +342,20 @@ class TestApiKeyProviderStatus:
         assert status["args"] == ["--acp", "--stdio", "--debug"]
         assert status["base_url"] == "acp://copilot"
 
+    def test_claude_code_acp_status_detects_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ACP_COMMAND", "claude")
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ACP_ARGS", "--acp --stdio --verbose")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/homebrew/bin/{command}")
+
+        status = get_external_process_provider_status("claude-code-acp")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["command"] == "claude"
+        assert status["resolved_command"] == "/opt/homebrew/bin/claude"
+        assert status["args"] == ["--acp", "--stdio", "--verbose"]
+        assert status["base_url"] == "acp://claude-code"
+
     def test_get_auth_status_dispatches_to_external_process(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
 
@@ -343,6 +363,14 @@ class TestApiKeyProviderStatus:
 
         assert status["configured"] is True
         assert status["provider"] == "copilot-acp"
+
+    def test_get_auth_status_dispatches_to_claude_code_acp(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
+
+        status = get_auth_status("claude-code-acp")
+
+        assert status["configured"] is True
+        assert status["provider"] == "claude-code-acp"
 
     def test_non_api_key_provider(self):
         status = get_api_key_provider_status("nous")
@@ -418,6 +446,29 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["command"] == "/usr/local/bin/copilot"
         assert creds["args"] == ["--acp", "--stdio"]
         assert creds["source"] == "process"
+
+    def test_resolve_claude_code_acp_with_local_cli(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ACP_COMMAND", "claude")
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ACP_ARGS", "--acp --stdio")
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("claude-code-acp")
+
+        assert creds["provider"] == "claude-code-acp"
+        assert creds["api_key"] == "claude-code-acp"
+        assert creds["base_url"] == "acp://claude-code"
+        assert creds["command"] == "/usr/local/bin/claude"
+        assert creds["args"] == ["--acp", "--stdio"]
+        assert creds["source"] == "process"
+
+    def test_resolve_claude_code_acp_missing_command_mentions_env_vars(self, monkeypatch):
+        monkeypatch.delenv("HERMES_CLAUDE_CODE_ACP_COMMAND", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_CLI_PATH", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_ACP_BASE_URL", raising=False)
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: None)
+
+        with pytest.raises(AuthError, match="HERMES_CLAUDE_CODE_ACP_COMMAND/CLAUDE_CODE_CLI_PATH"):
+            resolve_external_process_provider_credentials("claude-code-acp")
 
     def test_resolve_kimi_with_key(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "kimi-secret-key")
@@ -593,6 +644,22 @@ class TestRuntimeProviderResolution:
         assert result["api_key"] == "copilot-acp"
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
+        assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_claude_code_acp_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ACP_COMMAND", "claude")
+        monkeypatch.setenv("HERMES_CLAUDE_CODE_ACP_ARGS", "--acp --stdio --debug")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="claude-code-acp")
+
+        assert result["provider"] == "claude-code-acp"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "claude-code-acp"
+        assert result["base_url"] == "acp://claude-code"
+        assert result["command"] == "/usr/local/bin/claude"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
 
 

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -211,6 +211,46 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("default") == "gpt-5.4"
         assert model.get("api_mode") == "chat_completions"
 
+    def test_claude_code_acp_provider_saved_when_selected(self, config_home):
+        """_model_flow_claude_code_acp should persist provider/base_url/model together."""
+        from hermes_cli.main import _model_flow_claude_code_acp
+        from hermes_cli.config import load_config
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            return_value={
+                "resolved_command": "/usr/local/bin/claude",
+                "command": "claude",
+                "base_url": "acp://claude-code",
+            },
+        ), patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "claude-code-acp",
+                "api_key": "claude-code-acp",
+                "base_url": "acp://claude-code",
+                "command": "/usr/local/bin/claude",
+                "args": ["--acp", "--stdio"],
+                "source": "process",
+            },
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="claude-sonnet-4.6",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ):
+            _model_flow_claude_code_acp(load_config(), "old-model")
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict), f"model should be dict, got {type(model)}"
+        assert model.get("provider") == "claude-code-acp"
+        assert model.get("base_url") == "acp://claude-code"
+        assert model.get("default") == "claude-sonnet-4.6"
+        assert model.get("api_mode") == "chat_completions"
+
     def test_opencode_go_models_are_selectable_and_persist_normalized(self, config_home, monkeypatch):
         from hermes_cli.main import _model_flow_api_key_provider
         from hermes_cli.config import load_config

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -155,6 +155,7 @@ class TestNormalizeProvider:
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"
         assert normalize_provider("github-copilot") == "copilot"
+        assert normalize_provider("claude-acp") == "claude-code-acp"
 
     def test_case_insensitive(self):
         assert normalize_provider("OpenRouter") == "openrouter"
@@ -166,6 +167,7 @@ class TestProviderLabel:
         assert provider_label("kimi") == "Kimi / Kimi Coding Plan"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("claude-code-acp") == "Claude Code ACP"
         assert provider_label("auto") == "Auto"
 
     def test_unknown_provider_preserves_original_name(self):
@@ -210,6 +212,13 @@ class TestProviderModelIds:
 
         assert "gpt-5.4" in ids
         assert "copilot-acp" not in ids
+
+    def test_claude_code_acp_returns_curated_claude_models(self):
+        ids = provider_model_ids("claude-code-acp")
+
+        assert "claude-sonnet-4.6" in ids
+        assert "claude-opus-4.6" in ids
+        assert "claude-code-acp" not in ids
 
 
 # -- fetch_api_models --------------------------------------------------------

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -319,7 +319,7 @@ def test_setup_copilot_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
 
     def fake_prompt_choice(question, choices, default=0):
         if question == "Select your inference provider:":
-            return 15  # GitHub Copilot ACP
+            return next(i for i, choice in enumerate(choices) if "GitHub Copilot ACP" in choice)
         if question == "Select default model:":
             return 0
         if question == "Configure vision:":
@@ -332,6 +332,40 @@ def test_setup_copilot_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
     def fake_prompt_yes_no(question, default=True):
         if question == "Add another credential for same-provider fallback?":
             raise AssertionError("same-provider pool prompt should not appear for copilot-acp")
+        return False
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", fake_prompt_yes_no)
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+    setup_model_provider(config)
+
+    assert config.get("credential_pool_strategies", {}) == {}
+
+
+def test_setup_claude_code_acp_skips_same_provider_pool_step(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    config = load_config()
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select your inference provider:":
+            return next(i for i, choice in enumerate(choices) if "Claude Code ACP" in choice)
+        if question == "Select default model:":
+            return 0
+        if question == "Configure vision:":
+            return len(choices) - 1
+        tts_idx = _maybe_keep_current_tts(question, choices)
+        if tts_idx is not None:
+            return tts_idx
+        raise AssertionError(f"Unexpected prompt_choice call: {question}")
+
+    def fake_prompt_yes_no(question, default=True):
+        if question == "Add another credential for same-provider fallback?":
+            raise AssertionError("same-provider pool prompt should not appear for claude-code-acp")
         return False
 
     monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
@@ -385,6 +419,27 @@ def test_setup_copilot_acp_uses_model_picker_and_saves_provider(tmp_path, monkey
     reloaded = load_config()
     assert isinstance(reloaded["model"], dict)
     assert reloaded["model"]["provider"] == "copilot-acp"
+
+
+def test_setup_claude_code_acp_uses_model_picker_and_saves_provider(tmp_path, monkeypatch):
+    """Claude Code ACP provider saves correctly through delegation."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    _stub_tts(monkeypatch)
+
+    config = load_config()
+
+    def fake_select():
+        _write_model_config("claude-code-acp", "acp://claude-code", "claude-sonnet-4.6")
+
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    assert isinstance(reloaded["model"], dict)
+    assert reloaded["model"]["provider"] == "claude-code-acp"
 
 
 def test_setup_switch_custom_to_codex_clears_custom_endpoint_and_updates_config(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3191,6 +3191,36 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_uses_claude_code_acp_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.acp_chat_client.ACPChatClient") as mock_acp_client,
+    ):
+        acp_client = MagicMock()
+        mock_acp_client.return_value = acp_client
+
+        agent = AIAgent(
+            api_key="claude-code-acp",
+            base_url="acp://claude-code",
+            provider="claude-code-acp",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--acp", "--stdio"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is acp_client
+    mock_openai.assert_not_called()
+    mock_acp_client.assert_called_once()
+    assert mock_acp_client.call_args.kwargs["base_url"] == "acp://claude-code"
+    assert mock_acp_client.call_args.kwargs["api_key"] == "claude-code-acp"
+    assert mock_acp_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -259,6 +259,22 @@ def test_copilot_acp_stays_on_chat_completions_for_gpt_5_models(monkeypatch):
     assert agent.api_mode == "chat_completions"
 
 
+def test_claude_code_acp_stays_on_chat_completions(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="claude-sonnet-4.6",
+        base_url="acp://claude-code",
+        provider="claude-code-acp",
+        api_key="claude-code-acp",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    assert agent.provider == "claude-code-acp"
+    assert agent.api_mode == "chat_completions"
+
+
 def test_copilot_gpt_5_mini_stays_on_chat_completions(monkeypatch):
     _patch_agent_bootstrap(monkeypatch)
     agent = run_agent.AIAgent(


### PR DESCRIPTION
## Summary
- add `claude-code-acp` as a first-class external-process provider
- generalize Copilot ACP auth/runtime/client plumbing so ACP providers resolve through shared metadata-driven paths
- wire Claude Code ACP through CLI setup flows, model normalization/metadata, and base URL validation
- add targeted regression coverage for auth, runtime resolution, setup persistence, auxiliary client construction, model metadata, and `acp://claude-code` URL handling

## Test Plan
- [x] `uv run --extra dev python -m pytest tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_setup_model_provider.py tests/agent/test_proxy_and_url_validation.py tests/agent/test_auxiliary_client.py tests/agent/test_model_metadata.py tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py -q`
- [x] `git diff --check`

## Notes
- adds new shared `agent/acp_chat_client.py` plumbing for external-process ACP providers
- preserves compatibility for existing Copilot ACP behavior while adding Claude Code ACP aliases and curated models