### PR TITLE
fix(trajectory): detect incomplete scratchpad with ordered tag depth

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -12,6 +12,9 @@ from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
+_REASONING_SCRATCHPAD_OPEN = "<REASONING_SCRATCHPAD>"
+_REASONING_SCRATCHPAD_CLOSE = "</REASONING_SCRATCHPAD>"
+
 
 def convert_scratchpad_to_think(content: str) -> str:
     """Convert <REASONING_SCRATCHPAD> tags to <think> tags."""
@@ -21,10 +24,29 @@ def convert_scratchpad_to_think(content: str) -> str:
 
 
 def has_incomplete_scratchpad(content: str) -> bool:
-    """Check if content has an opening <REASONING_SCRATCHPAD> without a closing tag."""
+    """True if any <REASONING_SCRATCHPAD> block is still open at end of content.
+
+    Uses ordered depth matching so an earlier closing tag cannot hide a later
+    unclosed opening (avoids false negatives vs. global substring checks).
+    """
     if not content:
         return False
-    return "<REASONING_SCRATCHPAD>" in content and "</REASONING_SCRATCHPAD>" not in content
+    depth = 0
+    i = 0
+    n = len(content)
+    olen = len(_REASONING_SCRATCHPAD_OPEN)
+    clen = len(_REASONING_SCRATCHPAD_CLOSE)
+    while i < n:
+        if content.startswith(_REASONING_SCRATCHPAD_OPEN, i):
+            depth += 1
+            i += olen
+        elif content.startswith(_REASONING_SCRATCHPAD_CLOSE, i):
+            if depth > 0:
+                depth -= 1
+            i += clen
+        else:
+            i += 1
+    return depth > 0
 
 
 def save_trajectory(trajectory: List[Dict[str, Any]], model: str,

--- a/tests/agent/test_trajectory_scratchpad.py
+++ b/tests/agent/test_trajectory_scratchpad.py
@@ -1,0 +1,39 @@
+"""Regression tests for agent.trajectory scratchpad boundary detection (#11194)."""
+
+import pytest
+
+from agent.trajectory import has_incomplete_scratchpad
+
+OPEN = "<REASONING_SCRATCHPAD>"
+CLOSE = "</REASONING_SCRATCHPAD>"
+
+
+class TestHasIncompleteScratchpad:
+    def test_empty_not_incomplete(self):
+        assert has_incomplete_scratchpad("") is False
+
+    def test_plain_text_not_incomplete(self):
+        assert has_incomplete_scratchpad("hello") is False
+
+    def test_single_closed_pair_not_incomplete(self):
+        assert has_incomplete_scratchpad(f"{OPEN}thought{CLOSE}") is False
+
+    def test_adjacent_empty_pair_not_incomplete(self):
+        assert has_incomplete_scratchpad(f"{OPEN}{CLOSE}") is False
+
+    def test_two_closed_pairs_not_incomplete(self):
+        body = f"{OPEN}a{CLOSE} mid {OPEN}b{CLOSE}"
+        assert has_incomplete_scratchpad(body) is False
+
+    def test_second_block_unclosed_is_incomplete(self):
+        """Global '</...>' check wrongly returns False when an earlier pair closed."""
+        body = f"{OPEN}a{CLOSE}{OPEN}still streaming"
+        assert has_incomplete_scratchpad(body) is True
+
+    def test_orphan_close_then_open_unclosed_is_incomplete(self):
+        """Closing tag elsewhere must not mask a later unclosed block."""
+        body = f"{CLOSE}{OPEN}orphan prefix then real block"
+        assert has_incomplete_scratchpad(body) is True
+
+    def test_only_open_tag_is_incomplete(self):
+        assert has_incomplete_scratchpad(f"{OPEN}no close") is True


### PR DESCRIPTION
## Summary

Replace the substring-based `has_incomplete_scratchpad` check with a left-to-right depth counter over `<REASONING_SCRATCHPAD>` / `</REASONING_SCRATCHPAD>` tokens. This prevents a later unclosed block from being misclassified as "complete" when an earlier closing tag exists elsewhere in the same string.

Related: NousResearch/hermes-agent#11194 (same symptom class: false detection around incomplete scratchpads).

## Changes

- `agent/trajectory.py`: ordered open/close matching; ignore orphan closing tags when depth is zero.
- `tests/agent/test_trajectory_scratchpad.py`: regression coverage for paired blocks, a second unclosed block after a closed pair, and orphan-close + open tail cases.

## Test plan

```bash
pytest tests/agent/test_trajectory_scratchpad.py -q -o addopts=