### PR TITLE
feat(tools): add TADA TTS provider for local HTTP speech synthesis

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -696,7 +696,7 @@ platform_toolsets:
 #   edge:
 #     voice: "en-US-AriaNeural"
 #   elevenlabs:
-#     voice_id: "pNInz6obpgDQGcFmaJgB"
+#     voice_id: "your-voice-id-here"
 #     model_id: "eleven_multilingual_v2"
 #   openai:
 #     model: "gpt-4o-mini-tts"

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -593,7 +593,7 @@ platform_toolsets:
 #   skills_hub   - skill_hub (search/install/manage from online registries — user-driven only)
 #   moa          - mixture_of_agents  (requires OPENROUTER_API_KEY)
 #   todo         - todo (in-memory task planning, no deps)
-#   tts          - text_to_speech  (Edge TTS free, or ELEVENLABS/OPENAI/MINIMAX/MISTRAL key)
+#   tts          - text_to_speech  (Edge TTS free, or ELEVENLABS/OPENAI/MINIMAX/MISTRAL/TADA server)
 #   cronjob      - cronjob (create/list/update/pause/resume/run/remove scheduled tasks)
 #   rl           - rl_list_environments, rl_start_training, etc. (requires TINKER_API_KEY)
 #
@@ -622,7 +622,7 @@ platform_toolsets:
 #   todo         - Task planning and tracking for multi-step work
 #   memory       - Persistent memory across sessions (personal notes + user profile)
 #   session_search - Search and recall past conversations (FTS5 + Gemini Flash summarization)
-#   tts          - Text-to-speech (Edge TTS free, ElevenLabs, OpenAI, MiniMax, Mistral)
+#   tts          - Text-to-speech (Edge TTS free, ElevenLabs, OpenAI, MiniMax, Mistral, TADA server)
 #   cronjob      - Schedule and manage automated tasks (CLI-only)
 #   rl           - RL training tools (Tinker-Atropos)
 #
@@ -685,6 +685,35 @@ platform_toolsets:
 #       allowed_models: []      # model whitelist (empty = all)
 #       max_tool_rounds: 5      # tool loop limit (0 = disable)
 #       log_level: "info"       # audit verbosity
+
+# =============================================================================
+# Text-to-Speech (TTS)
+# =============================================================================
+# Providers: edge (free) | elevenlabs | openai | minimax | mistral | neutts (local) | tada (local HTTP server)
+# Set the corresponding key in .env: ELEVENLABS_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, or MISTRAL_API_KEY.
+# tts:
+#   provider: "edge"           # edge | elevenlabs | openai | minimax | mistral | neutts | tada
+#   edge:
+#     voice: "en-US-AriaNeural"
+#   elevenlabs:
+#     voice_id: "pNInz6obpgDQGcFmaJgB"
+#     model_id: "eleven_multilingual_v2"
+#   openai:
+#     model: "gpt-4o-mini-tts"
+#     voice: "alloy"           # alloy | ash | coral | echo | fable | onyx | nova | sage | shimmer
+#   minimax:
+#     voice_id: "male-qn-qingse"
+#   mistral:
+#     model: "voxtral-mini-latest"
+#     voice_id: ""             # optional UUID from Mistral voice library
+#   neutts:
+#     model: "neuphonic/neutts-air-q4-gguf"
+#     device: "cpu"
+#     ref_audio: ""            # path to reference WAV (empty = bundled default)
+#     ref_text: ""             # transcript of ref_audio (empty = bundled default)
+#   tada:
+#     endpoint: "http://localhost:8050/tts"  # URL of a running TADA TTS server
+#                                            # (e.g. mlx-tada on an Apple Silicon Mac)
 
 # =============================================================================
 # Voice Transcription (Speech-to-Text)

--- a/tests/tools/test_tts_tada.py
+++ b/tests/tools/test_tts_tada.py
@@ -1,0 +1,233 @@
+"""Tests for the TADA TTS provider in tools/tts_tool.py."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("HERMES_SESSION_PLATFORM",):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _generate_tada unit tests
+# ---------------------------------------------------------------------------
+
+class TestGenerateTada:
+    def _make_response(self, content=b"fake-wav-bytes", status_code=200):
+        mock_resp = MagicMock()
+        mock_resp.status_code = status_code
+        mock_resp.content = content
+        mock_resp.raise_for_status = MagicMock()
+        return mock_resp
+
+    def test_successful_generation_wav(self, tmp_path):
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+        mock_resp = self._make_response(b"wav-audio")
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            result = _generate_tada("Hello world", output_path, {})
+
+        assert result == output_path
+        assert (tmp_path / "out.wav").read_bytes() == b"wav-audio"
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[0][0] == "http://localhost:8050/tts"
+        assert call_kwargs[1]["json"] == {"text": "Hello world"}
+
+    def test_custom_endpoint_from_config(self, tmp_path):
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+        mock_resp = self._make_response(b"audio")
+        config = {"tada": {"endpoint": "http://192.168.1.50:8050/tts"}}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            _generate_tada("Hi", output_path, config)
+
+        assert mock_post.call_args[0][0] == "http://192.168.1.50:8050/tts"
+
+    def test_default_endpoint_when_config_empty(self, tmp_path):
+        from tools.tts_tool import DEFAULT_TADA_ENDPOINT, _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+        mock_resp = self._make_response(b"audio")
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            _generate_tada("Hi", output_path, {})
+
+        assert mock_post.call_args[0][0] == DEFAULT_TADA_ENDPOINT
+
+    def test_default_endpoint_when_tada_key_missing(self, tmp_path):
+        from tools.tts_tool import DEFAULT_TADA_ENDPOINT, _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+        mock_resp = self._make_response(b"audio")
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            _generate_tada("Hi", output_path, {"tada": {}})
+
+        assert mock_post.call_args[0][0] == DEFAULT_TADA_ENDPOINT
+
+    def test_connection_error_raises_runtime_error(self, tmp_path):
+        import requests as req_module
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+
+        with patch("requests.post", side_effect=req_module.exceptions.ConnectionError("refused")):
+            with pytest.raises(RuntimeError, match="unreachable"):
+                _generate_tada("Hi", output_path, {})
+
+    def test_http_error_raises_runtime_error(self, tmp_path):
+        import requests as req_module
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+        mock_resp = self._make_response(b"", status_code=500)
+        mock_resp.raise_for_status.side_effect = req_module.exceptions.HTTPError("500")
+
+        with patch("requests.post", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="error"):
+                _generate_tada("Hi", output_path, {})
+
+    def test_timeout_raises_runtime_error(self, tmp_path):
+        import requests as req_module
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.wav")
+
+        with patch("requests.post", side_effect=req_module.exceptions.Timeout("timed out")):
+            with pytest.raises(RuntimeError, match="timed out"):
+                _generate_tada("Hi", output_path, {})
+
+    def test_non_wav_output_path_writes_wav_first(self, tmp_path):
+        """Output path .mp3 — TADA writes WAV then renames (no ffmpeg)."""
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.mp3")
+        mock_resp = self._make_response(b"wav-audio")
+
+        with patch("requests.post", return_value=mock_resp), \
+             patch("shutil.which", return_value=None):  # no ffmpeg
+            result = _generate_tada("Hi", output_path, {})
+
+        # Without ffmpeg, the WAV is renamed to the requested path
+        assert result == output_path
+
+    def test_non_wav_with_ffmpeg_converts(self, tmp_path):
+        """Output path .mp3 — ffmpeg present, WAV converted and original removed."""
+        from tools.tts_tool import _generate_tada
+
+        output_path = str(tmp_path / "out.mp3")
+        mock_resp = self._make_response(b"wav-audio")
+
+        # Write the WAV so os.remove doesn't fail
+        wav_path = str(tmp_path / "out.wav")
+
+        def fake_post(*args, **kwargs):
+            return mock_resp
+
+        import subprocess as sp
+        def fake_run(cmd, **kwargs):
+            # Simulate ffmpeg: write output file
+            out = cmd[-1]
+            with open(out, "wb") as f:
+                f.write(b"mp3-audio")
+            return MagicMock(returncode=0)
+
+        with patch("requests.post", side_effect=fake_post), \
+             patch("shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("subprocess.run", side_effect=fake_run):
+            result = _generate_tada("Hi", output_path, {})
+
+        assert result == output_path
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration tests
+# ---------------------------------------------------------------------------
+
+class TestTtsDispatcherTada:
+    def test_dispatcher_routes_to_tada(self, tmp_path):
+        mock_resp = MagicMock()
+        mock_resp.content = b"wav-audio"
+        mock_resp.raise_for_status = MagicMock()
+
+        output_path = str(tmp_path / "out.wav")
+        with patch("requests.post", return_value=mock_resp), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "tada"}):
+            result = json.loads(
+                __import__("tools.tts_tool", fromlist=["text_to_speech_tool"])
+                .text_to_speech_tool("Hello", output_path=output_path)
+            )
+
+        assert result["success"] is True
+        assert result["provider"] == "tada"
+
+    def test_dispatcher_tada_connection_error_returns_error_json(self, tmp_path):
+        import requests as req_module
+
+        output_path = str(tmp_path / "out.wav")
+        with patch("requests.post", side_effect=req_module.exceptions.ConnectionError("refused")), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "tada"}):
+            result = json.loads(
+                __import__("tools.tts_tool", fromlist=["text_to_speech_tool"])
+                .text_to_speech_tool("Hello", output_path=output_path)
+            )
+
+        assert result["success"] is False
+        assert "unreachable" in result["error"].lower()
+
+    def test_tada_telegram_produces_voice_compatible(self, tmp_path, monkeypatch):
+        """On Telegram, TADA WAV output triggers Opus conversion path."""
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        mock_resp = MagicMock()
+        mock_resp.content = b"wav-audio"
+        mock_resp.raise_for_status = MagicMock()
+
+        # Provide a .wav output_path so _generate_tada writes directly without
+        # invoking ffmpeg on fake bytes, then _convert_to_opus is called by the
+        # dispatcher's Telegram voice-note path.
+        wav_path = str(tmp_path / "out.wav")
+        ogg_path = str(tmp_path / "out.ogg")
+        with patch("requests.post", return_value=mock_resp), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "tada"}), \
+             patch("tools.tts_tool._convert_to_opus", return_value=ogg_path) as mock_opus:
+            result = json.loads(
+                __import__("tools.tts_tool", fromlist=["text_to_speech_tool"])
+                .text_to_speech_tool("Hello", output_path=wav_path)
+            )
+
+        # _convert_to_opus must be called — tada is in the WAV-output providers list
+        mock_opus.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# check_tts_requirements with tada provider configured
+# ---------------------------------------------------------------------------
+
+class TestCheckTtsRequirementsTada:
+    def test_tada_provider_configured_returns_true(self):
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "tada"}):
+            assert check_tts_requirements() is True
+
+    def test_no_tada_config_does_not_affect_other_providers(self):
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "edge"}):
+            assert check_tts_requirements() is False

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -683,6 +683,73 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
+# TADA (local HTTP TTS server — mlx-tada or compatible)
+# ===========================================================================
+
+DEFAULT_TADA_ENDPOINT = "http://localhost:8050/tts"
+
+
+def _generate_tada(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech by calling a TADA HTTP TTS endpoint.
+
+    TADA (https://github.com/HumeAI/tada) is a local speech synthesis server
+    that accepts ``{"text": "..."}`` POST requests and returns WAV audio.
+    The server can be run on any host reachable from the agent (e.g. a Mac Mini
+    on the LAN running ``mlx-tada``).  Configure the endpoint in config.yaml:
+
+    .. code-block:: yaml
+
+        tts:
+          provider: tada
+          tada:
+            endpoint: http://192.168.1.x:8050/tts
+
+    Outputs WAV; the caller handles Opus conversion for Telegram if needed.
+    """
+    import requests  # noqa: PLC0415 — lazy import kept consistent with other providers
+
+    tada_config = tts_config.get("tada", {})
+    endpoint = tada_config.get("endpoint", "") or DEFAULT_TADA_ENDPOINT
+
+    try:
+        resp = requests.post(
+            endpoint,
+            json={"text": text},
+            timeout=60,
+        )
+        resp.raise_for_status()
+    except requests.exceptions.ConnectionError as e:
+        raise RuntimeError(
+            f"TADA server unreachable at {endpoint}. "
+            "Is the server running? Check tts.tada.endpoint in config.yaml."
+        ) from e
+    except requests.exceptions.HTTPError as e:
+        raise RuntimeError(f"TADA server returned an error: {e}") from e
+    except requests.exceptions.Timeout as e:
+        raise RuntimeError(f"TADA request timed out after 60s: {e}") from e
+
+    # TADA returns raw WAV bytes — write to .wav regardless of the requested extension.
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with open(wav_path, "wb") as f:
+        f.write(resp.content)
+
+    # If the caller wants a different format, convert from WAV.
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            os.rename(wav_path, output_path)
+
+    return wav_path if wav_path == output_path else output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -877,6 +944,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with NeuTTS (local)...")
             _generate_neutts(text, file_str, tts_config)
 
+        elif provider == "tada":
+            logger.info("Generating speech with TADA TTS...")
+            _generate_tada(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -916,7 +987,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai", "tada") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1001,6 +1072,13 @@ def check_tts_requirements() -> bool:
         pass
     if _check_neutts_available():
         return True
+    # TADA: reachable if an endpoint is configured (no package required)
+    try:
+        tts_cfg = _load_tts_config()
+        if tts_cfg.get("provider") == "tada":
+            return True
+    except Exception:
+        pass
     return False
 
 


### PR DESCRIPTION
## Summary

- Adds `tada` as a new TTS provider in `tools/tts_tool.py`
- TADA (https://github.com/HumeAI/tada) is a local speech synthesis server — e.g. `mlx-tada` running on an Apple Silicon Mac — that accepts `POST {"text": "..."}` and returns WAV audio
- No new package dependencies: uses `requests` (already a hermes dependency) and the stdlib
- WAV output is included in the existing Opus conversion path, so Telegram voice notes work out of the box

## Changes

**`tools/tts_tool.py`**
- `DEFAULT_TADA_ENDPOINT` constant (`http://localhost:8050/tts`)
- `_generate_tada(text, output_path, tts_config)` — POSTs to the configured endpoint, writes WAV, handles ffmpeg conversion for non-WAV output paths; raises typed `RuntimeError` for connection, HTTP, and timeout failures
- `elif provider == "tada":` dispatch branch
- `"tada"` added to the Opus conversion set (same path as `edge`/`neutts`/`minimax`) so Telegram voice notes work
- `check_tts_requirements()` returns `True` when `tada` is the configured provider

**`tests/tools/test_tts_tada.py`** (new, 15 tests)
- Successful WAV generation, custom/default endpoint resolution
- Connection error, HTTP error, timeout error → typed `RuntimeError`
- Non-WAV output path without ffmpeg (rename) and with ffmpeg (convert + remove)
- Dispatcher routing, connection error JSON response
- Telegram voice-note path (`_convert_to_opus` called)
- `check_tts_requirements` with tada configured

**`cli-config.yaml.example`**
- New `# Text-to-Speech (TTS)` section documenting all providers including `tada`
- Updated toolset comment lines to mention TADA

## Config

```yaml
tts:
  provider: tada
  tada:
    endpoint: http://192.168.1.x:8050/tts  # URL of a running TADA server
```

## How to test

```bash
# Start a TADA server (e.g. mlx-tada on Apple Silicon):
pip install mlx-tada
python -c "
from mlx_tada import TadaForCausalLM, save_wav
from fastapi import FastAPI
from fastapi.responses import FileResponse
import uvicorn, uuid

app = FastAPI()
model = TadaForCausalLM.from_pretrained('HumeAI/mlx-tada-1b', quantize=4)
ref = model.load_reference('ljspeech.wav')

@app.post('/tts')
def tts(req: dict):
    out = f'/tmp/tada_{uuid.uuid4().hex}.wav'
    from mlx_tada import save_wav
    save_wav(model.generate(req['text'], ref).audio, out)
    return FileResponse(out, media_type='audio/wav')

uvicorn.run(app, host='0.0.0.0', port=8050)
"

# Configure hermes:
# tts:
#   provider: tada
#   tada:
#     endpoint: http://<server-ip>:8050/tts

# Run tests:
pytest tests/tools/test_tts_tada.py tests/tools/test_tts_speed.py tests/tools/test_tts_mistral.py -v
```

## Platforms tested

- Linux (hintonator, Ubuntu 24.04, Python 3.12) — all 43 TTS tests pass
- TADA server running on macOS 15.6 M4 (Apple Silicon) — live end-to-end verified