### PR TITLE
Research lane pipeline: launch_research_lane tool + delegation hardening

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -704,9 +704,6 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
     
-    # Per-channel system prompt (resolved from config channel_prompts mapping)
-    channel_prompt: Optional[str] = None
-
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -631,6 +631,23 @@ def cleanup_document_cache(max_age_hours: int = 24) -> int:
     return removed
 
 
+def _normalize_media_path(p: str) -> str:
+    """Translate git-bash style paths to native Windows paths on Windows."""
+    import os, sys, re as _re
+    if sys.platform != "win32":
+        return p
+    m = _re.match(r"^/([a-zA-Z])/(.*)$", p)
+    if m:
+        return f"{m.group(1).upper()}:/{m.group(2)}"
+    if p.startswith("/tmp/"):
+        tmpdir = os.environ.get("TEMP", os.environ.get("TMP", ""))
+        if tmpdir:
+            return os.path.join(tmpdir, p[5:])
+    if p.startswith("~/"):
+        return os.path.expanduser(p)
+    return p
+
+
 class MessageType(Enum):
     """Types of incoming messages."""
     TEXT = "text"
@@ -687,6 +704,9 @@ class MessageEvent:
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
     
+    # Per-channel system prompt (resolved from config channel_prompts mapping)
+    channel_prompt: Optional[str] = None
+
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
@@ -1291,7 +1311,7 @@ class BasePlatformAdapter(ABC):
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
-                media.append((path, has_voice_tag))
+                media.append((_normalize_media_path(path), has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:

--- a/run_agent.py
+++ b/run_agent.py
@@ -607,6 +607,7 @@ class AIAgent:
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
         persist_session: bool = True,
+        gateway_session_key: str = None,
     ):
         """
         Initialize the AI Agent.
@@ -674,6 +675,7 @@ class AIAgent:
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
         self.persist_session = persist_session
+        self.gateway_session_key = gateway_session_key
         self._credential_pool = credential_pool
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
@@ -810,7 +812,7 @@ class AIAgent:
         is_openrouter = self._is_openrouter_url()
         is_claude = "claude" in self.model.lower()
         is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider == "anthropic"
-        self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
+        self._use_prompt_caching = is_openrouter or is_native_anthropic
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
         
         # Iteration budget: the LLM is only notified when it actually exhausts
@@ -1728,7 +1730,7 @@ class AIAgent:
         # ── Re-evaluate prompt caching ──
         is_native_anthropic = api_mode == "anthropic_messages" and new_provider == "anthropic"
         self._use_prompt_caching = (
-            ("openrouter" in (self.base_url or "").lower() and "claude" in new_model.lower())
+            ("openrouter" in (self.base_url or "").lower())
             or is_native_anthropic
         )
 
@@ -6022,7 +6024,7 @@ class AIAgent:
             # Re-evaluate prompt caching for the new provider/model
             is_native_anthropic = fb_api_mode == "anthropic_messages" and fb_provider == "anthropic"
             self._use_prompt_caching = (
-                ("openrouter" in fb_base_url.lower() and "claude" in fb_model.lower())
+                ("openrouter" in fb_base_url.lower())
                 or is_native_anthropic
             )
 
@@ -7336,6 +7338,26 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name == "launch_research_lane":
+            from tools.research_lane_launch_tool import launch_research_lane as _launch_lane
+            return _launch_lane(
+                lane=function_args.get("lane", ""),
+                topic=function_args.get("topic", ""),
+                request=function_args.get("request"),
+                playbook_slug=function_args.get("playbook_slug"),
+                deliver=function_args.get("deliver"),
+                create_playbook_if_missing=function_args.get("create_playbook_if_missing", True),
+                resume_existing=function_args.get("resume_existing", True),
+                background=function_args.get("background", True),
+                parent_agent=self,
+            )
+        elif function_name == "delegate_kill":
+            from tools.delegate_tool import delegate_kill as _delegate_kill
+            return _delegate_kill(
+                spawn_id=function_args.get("spawn_id", ""),
+                reason=function_args.get("reason", "Killed by user request"),
+                parent_agent=self,
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -7845,6 +7867,26 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "launch_research_lane":
+                from tools.research_lane_launch_tool import launch_research_lane as _launch_lane
+                function_result = _launch_lane(
+                    lane=function_args.get("lane", ""),
+                    topic=function_args.get("topic", ""),
+                    request=function_args.get("request"),
+                    playbook_slug=function_args.get("playbook_slug"),
+                    deliver=function_args.get("deliver"),
+                    create_playbook_if_missing=function_args.get("create_playbook_if_missing", True),
+                    resume_existing=function_args.get("resume_existing", True),
+                    background=function_args.get("background", True),
+                    parent_agent=self,
+                )
+            elif function_name == "delegate_kill":
+                from tools.delegate_tool import delegate_kill as _delegate_kill
+                function_result = _delegate_kill(
+                    spawn_id=function_args.get("spawn_id", ""),
+                    reason=function_args.get("reason", "Killed by user request"),
+                    parent_agent=self,
+                )
             elif self._context_engine_tool_names and function_name in self._context_engine_tool_names:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -607,7 +607,6 @@ class AIAgent:
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
         persist_session: bool = True,
-        gateway_session_key: str = None,
     ):
         """
         Initialize the AI Agent.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7880,6 +7880,7 @@ class AIAgent:
                     background=function_args.get("background", True),
                     parent_agent=self,
                 )
+                tool_duration = time.time() - tool_start_time
             elif function_name == "delegate_kill":
                 from tools.delegate_tool import delegate_kill as _delegate_kill
                 function_result = _delegate_kill(
@@ -7887,6 +7888,7 @@ class AIAgent:
                     reason=function_args.get("reason", "Killed by user request"),
                     parent_agent=self,
                 )
+                tool_duration = time.time() - tool_start_time
             elif self._context_engine_tool_names and function_name in self._context_engine_tool_names:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2,33 +2,38 @@
 """
 Delegate Tool -- Subagent Architecture
 
-Spawns child AIAgent instances with isolated context, restricted toolsets,
+Spawns subagent AIAgent instances with isolated context, restricted toolsets,
 and their own terminal sessions. Supports single-task and batch (parallel)
-modes. The parent blocks until all children complete.
+modes. The parent blocks until all subagents complete.
 
-Each child gets:
+Each subagent gets:
   - A fresh conversation (no parent history)
   - Its own task_id (own terminal session, file ops cache)
   - A restricted toolset (configurable, with blocked tools always stripped)
   - A focused system prompt built from the delegated goal + context
 
 The parent's context only sees the delegation call and the summary result,
-never the child's intermediate tool calls or reasoning.
+never the subagent's intermediate tool calls or reasoning.
 """
 
 import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+import re
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from hermes_constants import get_hermes_home
 from toolsets import TOOLSETS
+from utils import atomic_json_write
 
 
-# Tools that children must never have access to
+# Tools that subagents must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset([
     "delegate_task",   # no recursive delegation
     "clarify",         # no user interaction
@@ -50,7 +55,7 @@ _SUBAGENT_TOOLSETS = sorted(
 _TOOLSET_LIST_STR = ", ".join(f"'{n}'" for n in _SUBAGENT_TOOLSETS)
 
 _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
-MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
+MAX_DEPTH = 2  # parent (0) -> subagent (1) -> nested delegation rejected (2)
 
 
 def _get_max_concurrent_children() -> int:
@@ -79,7 +84,1270 @@ def _get_max_concurrent_children() -> int:
     return _DEFAULT_MAX_CONCURRENT_CHILDREN
 DEFAULT_MAX_ITERATIONS = 50
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
+DEFAULT_CHILD_TIMEOUT_SECONDS = 3600  # 1 hour wall-clock budget per subagent
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+_DELEGATION_REGISTRY_VERSION = 1
+_DELEGATION_REGISTRY_MAX_RECORDS = 200
+_DELEGATION_STALL_THRESHOLD_SECONDS = max(_HEARTBEAT_INTERVAL * 3, 90)
+_DELEGATION_REGISTRY_LOCK = threading.RLock()
+
+# Agent Activity topic for spawn/completion notifications.
+# Resolved at runtime from config.  Re-read every call to pick up
+# live topic ID changes without a gateway restart.
+_AGENT_ACTIVITY_CHAT_ID = None
+_AGENT_ACTIVITY_THREAD_ID = None
+_AGENT_ACTIVITY_RESOLVED_AT: float = 0.0  # epoch timestamp of last resolution
+_AGENT_ACTIVITY_TTL: float = 60.0  # seconds before re-reading config
+
+
+def _delegation_registry_path() -> Path:
+    return get_hermes_home() / "state" / "delegations.json"
+
+
+def _registry_now_ts() -> float:
+    return time.time()
+
+
+def _timestamp_to_iso(ts: Any) -> Optional[str]:
+    if ts in (None, ""):
+        return None
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return None
+
+
+def _seconds_since(ts: Any, now: Optional[float] = None) -> Optional[float]:
+    if ts in (None, ""):
+        return None
+    try:
+        current = float(now if now is not None else _registry_now_ts())
+        return round(max(0.0, current - float(ts)), 1)
+    except Exception:
+        return None
+
+
+def _default_delegation_registry() -> Dict[str, Any]:
+    return {
+        "version": _DELEGATION_REGISTRY_VERSION,
+        "updated_at_ts": 0.0,
+        "delegations": {},
+    }
+
+
+def _load_delegation_registry() -> Dict[str, Any]:
+    path = _delegation_registry_path()
+    if not path.exists():
+        return _default_delegation_registry()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("Could not load delegation registry %s: %s", path, exc)
+        return _default_delegation_registry()
+
+    if not isinstance(payload, dict):
+        return _default_delegation_registry()
+
+    payload.setdefault("version", _DELEGATION_REGISTRY_VERSION)
+    payload.setdefault("updated_at_ts", 0.0)
+    delegations = payload.get("delegations")
+    if not isinstance(delegations, dict):
+        payload["delegations"] = {}
+    return payload
+
+
+def _prune_delegation_registry(payload: Dict[str, Any]) -> None:
+    delegations = payload.get("delegations")
+    if not isinstance(delegations, dict) or len(delegations) <= _DELEGATION_REGISTRY_MAX_RECORDS:
+        return
+
+    ordered = sorted(
+        delegations.items(),
+        key=lambda item: float((item[1] or {}).get("created_at_ts") or 0.0),
+        reverse=True,
+    )
+    payload["delegations"] = dict(ordered[:_DELEGATION_REGISTRY_MAX_RECORDS])
+
+
+def _write_delegation_registry(payload: Dict[str, Any]) -> None:
+    payload = dict(payload or {})
+    payload["version"] = _DELEGATION_REGISTRY_VERSION
+    payload["updated_at_ts"] = _registry_now_ts()
+    _prune_delegation_registry(payload)
+    atomic_json_write(_delegation_registry_path(), payload)
+
+
+def _mutate_delegation_registry(mutator) -> Any:
+    with _DELEGATION_REGISTRY_LOCK:
+        payload = _load_delegation_registry()
+        result = mutator(payload)
+        _write_delegation_registry(payload)
+        return result
+
+
+def _normalize_task_status(raw_status: Any) -> str:
+    status = str(raw_status or "").strip().lower()
+    if status in {"spawned", "running", "stalled", "completed", "completed_with_issues", "failed", "timed_out", "interrupted"}:
+        return status
+    if status in {"error", "exception"}:
+        return "failed"
+    if status in {"timeout"}:
+        return "timed_out"
+    return status or "failed"
+
+
+def _make_registry_task_entry(
+    task_index: int,
+    task: Dict[str, Any],
+    *,
+    now_ts: float,
+    task_meta: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    task_meta = task_meta or {}
+    session_id = str(task_meta.get("session_id") or "").strip()
+    return {
+        "task_index": task_index,
+        "position": int(task_meta.get("position") or (task_index + 1)),
+        "task_class": str(task_meta.get("task_class") or _infer_delegation_task_class(task.get("goal", ""), task.get("context"), None)).strip() or "general",
+        "task_icon": str(task_meta.get("task_icon") or _task_class_icon(task_meta.get("task_class") or "general")).strip() or "🧩",
+        "goal_preview": str(task_meta.get("goal_preview") or _sentence_preview(task.get("goal", ""), 160)),
+        "session_id": session_id,
+        "session_id_short": str(task_meta.get("session_id_short") or _short_identifier(session_id or task_index + 1)),
+        "status": "spawned",
+        "created_at_ts": now_ts,
+        "updated_at_ts": now_ts,
+        "started_at_ts": None,
+        "finished_at_ts": None,
+        "last_heartbeat_at_ts": now_ts,
+        "last_activity": {},
+    }
+
+
+def _register_background_delegation(
+    spawn_id: str,
+    task_list: List[Dict[str, Any]],
+    *,
+    requested_deliver: str,
+    resolved_deliver: str,
+    activity_meta: Optional[Dict[str, Any]] = None,
+) -> None:
+    now_ts = _registry_now_ts()
+    tasks_meta = (activity_meta or {}).get("tasks") or []
+    task_meta_by_index = {
+        int(meta.get("task_index")): meta
+        for meta in tasks_meta
+        if isinstance(meta, dict) and isinstance(meta.get("task_index"), int)
+    }
+
+    def _mutator(payload: Dict[str, Any]) -> None:
+        payload.setdefault("delegations", {})
+        payload["delegations"][spawn_id] = {
+            "spawn_id": spawn_id,
+            "status": "spawned",
+            "created_at_ts": now_ts,
+            "updated_at_ts": now_ts,
+            "started_at_ts": None,
+            "finished_at_ts": None,
+            "last_heartbeat_at_ts": now_ts,
+            "stall_threshold_seconds": _DELEGATION_STALL_THRESHOLD_SECONDS,
+            "task_count": len(task_list),
+            "runtime_label": str((activity_meta or {}).get("runtime_label") or "").strip(),
+            "profile_label": str((activity_meta or {}).get("profile_label") or "").strip(),
+            "origin_label": str((activity_meta or {}).get("origin_label") or "").strip(),
+            "deliver_label": str((activity_meta or {}).get("deliver_label") or requested_deliver or resolved_deliver).strip(),
+            "task_class_summary": str((activity_meta or {}).get("task_class_summary") or "").strip(),
+            "deliver": {
+                "requested": requested_deliver,
+                "resolved": resolved_deliver,
+                "status": "pending",
+                "delivered_at_ts": None,
+                "last_error": None,
+            },
+            "tasks": [
+                _make_registry_task_entry(i, task, now_ts=now_ts, task_meta=task_meta_by_index.get(i))
+                for i, task in enumerate(task_list)
+            ],
+        }
+
+    _mutate_delegation_registry(_mutator)
+
+
+def _find_registry_task(entry: Dict[str, Any], task_index: int) -> Optional[Dict[str, Any]]:
+    tasks = entry.get("tasks") or []
+    for task in tasks:
+        if int(task.get("task_index", -1)) == int(task_index):
+            return task
+    return None
+
+
+def _mark_background_delegation_running(spawn_id: str) -> None:
+    now_ts = _registry_now_ts()
+
+    def _mutator(payload: Dict[str, Any]) -> None:
+        entry = (payload.get("delegations") or {}).get(spawn_id)
+        if not isinstance(entry, dict):
+            return
+        entry["status"] = "running"
+        entry["started_at_ts"] = entry.get("started_at_ts") or now_ts
+        entry["updated_at_ts"] = now_ts
+        entry["last_heartbeat_at_ts"] = now_ts
+
+    _mutate_delegation_registry(_mutator)
+
+
+def _update_background_task_heartbeat(
+    spawn_id: str,
+    task_index: int,
+    *,
+    activity: Optional[Dict[str, Any]] = None,
+) -> None:
+    now_ts = _registry_now_ts()
+    last_activity = {}
+    if isinstance(activity, dict):
+        last_activity = {
+            "description": activity.get("last_activity_desc"),
+            "current_tool": activity.get("current_tool"),
+            "api_call_count": activity.get("api_call_count"),
+            "max_iterations": activity.get("max_iterations"),
+            "seconds_since_activity": activity.get("seconds_since_activity"),
+        }
+
+    def _mutator(payload: Dict[str, Any]) -> None:
+        entry = (payload.get("delegations") or {}).get(spawn_id)
+        if not isinstance(entry, dict):
+            return
+        task = _find_registry_task(entry, task_index)
+        if task is None:
+            return
+        if task.get("status") in {"completed", "completed_with_issues", "failed", "timed_out", "interrupted"}:
+            return
+        entry["status"] = "running"
+        entry["started_at_ts"] = entry.get("started_at_ts") or now_ts
+        entry["updated_at_ts"] = now_ts
+        entry["last_heartbeat_at_ts"] = now_ts
+        task["status"] = "running"
+        task["started_at_ts"] = task.get("started_at_ts") or now_ts
+        task["updated_at_ts"] = now_ts
+        task["last_heartbeat_at_ts"] = now_ts
+        if last_activity:
+            task["last_activity"] = {k: v for k, v in last_activity.items() if v not in (None, "")}
+
+    _mutate_delegation_registry(_mutator)
+
+
+def _record_background_task_result(spawn_id: str, task_index: int, result: Dict[str, Any]) -> None:
+    now_ts = _registry_now_ts()
+    task_status = _normalize_task_status((result or {}).get("status"))
+
+    def _mutator(payload: Dict[str, Any]) -> None:
+        entry = (payload.get("delegations") or {}).get(spawn_id)
+        if not isinstance(entry, dict):
+            return
+        task = _find_registry_task(entry, task_index)
+        if task is None:
+            return
+        task["raw_status"] = str((result or {}).get("status") or "")
+        task["status"] = task_status
+        task["updated_at_ts"] = now_ts
+        task["finished_at_ts"] = now_ts
+        task["last_heartbeat_at_ts"] = now_ts
+        task["duration_seconds"] = (result or {}).get("duration_seconds")
+        task["api_calls"] = (result or {}).get("api_calls")
+        task["exit_reason"] = (result or {}).get("exit_reason")
+        task["model"] = (result or {}).get("model")
+        if (result or {}).get("summary"):
+            task["summary_preview"] = _truncate_preview((result or {}).get("summary"), 240)
+        if (result or {}).get("error"):
+            task["error"] = _truncate_preview((result or {}).get("error"), 240)
+        if isinstance((result or {}).get("last_activity"), dict):
+            task["last_activity"] = {
+                "description": result["last_activity"].get("description"),
+                "current_tool": result["last_activity"].get("current_tool"),
+                "api_call_count": result["last_activity"].get("api_calls"),
+                "max_iterations": result["last_activity"].get("max_iterations"),
+            }
+        entry["updated_at_ts"] = now_ts
+        entry["last_heartbeat_at_ts"] = now_ts
+
+    _mutate_delegation_registry(_mutator)
+
+
+def _compute_terminal_spawn_status(statuses: List[str]) -> str:
+    normalized = [_normalize_task_status(status) for status in statuses]
+    if not normalized:
+        return "failed"
+    if all(status == "completed" for status in normalized):
+        return "completed"
+    if all(status == "timed_out" for status in normalized):
+        return "timed_out"
+    if all(status in {"failed", "interrupted"} for status in normalized):
+        return "failed"
+    return "completed_with_issues"
+
+
+def _update_background_delivery_status(spawn_id: str, *, ok: bool, error: Optional[str] = None) -> None:
+    now_ts = _registry_now_ts()
+
+    def _mutator(payload: Dict[str, Any]) -> None:
+        entry = (payload.get("delegations") or {}).get(spawn_id)
+        if not isinstance(entry, dict):
+            return
+        deliver = entry.setdefault("deliver", {})
+        deliver["status"] = "delivered" if ok else "failed"
+        deliver["delivered_at_ts"] = now_ts
+        deliver["last_error"] = _truncate_preview(error, 240) if error else None
+        entry["updated_at_ts"] = now_ts
+
+    _mutate_delegation_registry(_mutator)
+
+
+def _finalize_background_delegation(
+    spawn_id: str,
+    *,
+    total_duration_seconds: Optional[float] = None,
+    fatal_error: Optional[str] = None,
+) -> None:
+    now_ts = _registry_now_ts()
+
+    def _mutator(payload: Dict[str, Any]) -> None:
+        entry = (payload.get("delegations") or {}).get(spawn_id)
+        if not isinstance(entry, dict):
+            return
+        tasks = entry.get("tasks") or []
+        if fatal_error:
+            for task in tasks:
+                current_status = _normalize_task_status(task.get("status"))
+                if current_status in {"spawned", "running", "stalled"}:
+                    task["status"] = "failed"
+                    task["error"] = _truncate_preview(fatal_error, 240)
+                    task["finished_at_ts"] = now_ts
+                    task["updated_at_ts"] = now_ts
+                    task["last_heartbeat_at_ts"] = now_ts
+            entry["runner_error"] = _truncate_preview(fatal_error, 240)
+
+        terminal_statuses = [_normalize_task_status(task.get("status")) for task in tasks]
+        entry["status"] = _compute_terminal_spawn_status(terminal_statuses)
+        entry["updated_at_ts"] = now_ts
+        entry["finished_at_ts"] = now_ts
+        entry["last_heartbeat_at_ts"] = now_ts
+        if total_duration_seconds is not None:
+            entry["duration_seconds"] = round(float(total_duration_seconds), 2)
+
+    _mutate_delegation_registry(_mutator)
+
+
+def _derive_task_status(task: Dict[str, Any], now_ts: Optional[float] = None) -> str:
+    now_ts = float(now_ts if now_ts is not None else _registry_now_ts())
+    status = _normalize_task_status(task.get("status"))
+    if status in {"spawned", "running"}:
+        heartbeat_ts = (
+            task.get("last_heartbeat_at_ts")
+            or task.get("updated_at_ts")
+            or task.get("started_at_ts")
+            or task.get("created_at_ts")
+        )
+        age = _seconds_since(heartbeat_ts, now_ts)
+        if age is not None and age >= _DELEGATION_STALL_THRESHOLD_SECONDS:
+            return "stalled"
+    return status
+
+
+def _derive_spawn_status(entry: Dict[str, Any], now_ts: Optional[float] = None) -> str:
+    now_ts = float(now_ts if now_ts is not None else _registry_now_ts())
+    raw_status = str(entry.get("status") or "").strip().lower()
+    tasks = entry.get("tasks") or []
+    if not tasks:
+        heartbeat_ts = entry.get("last_heartbeat_at_ts") or entry.get("updated_at_ts") or entry.get("created_at_ts")
+        age = _seconds_since(heartbeat_ts, now_ts)
+        if raw_status in {"spawned", "running"} and age is not None and age >= _DELEGATION_STALL_THRESHOLD_SECONDS:
+            return "stalled"
+        return raw_status or "unknown"
+
+    task_statuses = [_derive_task_status(task, now_ts) for task in tasks]
+    unfinished = [status for status in task_statuses if status in {"spawned", "running", "stalled"}]
+    if raw_status in {"failed", "timed_out"} and all(_normalize_task_status(task.get("status")) == "spawned" for task in tasks):
+        return raw_status
+    if unfinished:
+        if all(status == "stalled" for status in unfinished):
+            return "stalled"
+        if any(status == "running" for status in unfinished):
+            return "running"
+        return "spawned"
+    return _compute_terminal_spawn_status(task_statuses)
+
+
+def _serialize_delegation_entry(
+    entry: Dict[str, Any],
+    *,
+    now_ts: Optional[float] = None,
+    include_tasks: bool = True,
+) -> Dict[str, Any]:
+    now_ts = float(now_ts if now_ts is not None else _registry_now_ts())
+    tasks = sorted(entry.get("tasks") or [], key=lambda item: int(item.get("task_index", 0)))
+    serialized_tasks: List[Dict[str, Any]] = []
+    task_status_counts: Dict[str, int] = {}
+    for task in tasks:
+        derived_status = _derive_task_status(task, now_ts)
+        task_status_counts[derived_status] = task_status_counts.get(derived_status, 0) + 1
+        if include_tasks:
+            serialized_tasks.append({
+                "task_index": task.get("task_index"),
+                "position": task.get("position"),
+                "task_class": task.get("task_class"),
+                "goal_preview": task.get("goal_preview"),
+                "session_id": task.get("session_id"),
+                "session_id_short": task.get("session_id_short"),
+                "status": derived_status,
+                "raw_status": task.get("status"),
+                "created_at": _timestamp_to_iso(task.get("created_at_ts")),
+                "started_at": _timestamp_to_iso(task.get("started_at_ts")),
+                "finished_at": _timestamp_to_iso(task.get("finished_at_ts")),
+                "updated_at": _timestamp_to_iso(task.get("updated_at_ts")),
+                "last_heartbeat_at": _timestamp_to_iso(task.get("last_heartbeat_at_ts")),
+                "seconds_since_heartbeat": _seconds_since(task.get("last_heartbeat_at_ts"), now_ts),
+                "duration_seconds": task.get("duration_seconds"),
+                "api_calls": task.get("api_calls"),
+                "exit_reason": task.get("exit_reason"),
+                "model": task.get("model"),
+                "summary_preview": task.get("summary_preview"),
+                "error": task.get("error"),
+                "last_activity": task.get("last_activity") or None,
+            })
+
+    deliver = dict(entry.get("deliver") or {})
+    deliver["delivered_at"] = _timestamp_to_iso(deliver.get("delivered_at_ts"))
+
+    payload = {
+        "spawn_id": entry.get("spawn_id"),
+        "status": _derive_spawn_status(entry, now_ts),
+        "raw_status": entry.get("status"),
+        "task_count": len(tasks),
+        "task_status_counts": task_status_counts,
+        "created_at": _timestamp_to_iso(entry.get("created_at_ts")),
+        "started_at": _timestamp_to_iso(entry.get("started_at_ts")),
+        "finished_at": _timestamp_to_iso(entry.get("finished_at_ts")),
+        "updated_at": _timestamp_to_iso(entry.get("updated_at_ts")),
+        "last_heartbeat_at": _timestamp_to_iso(entry.get("last_heartbeat_at_ts")),
+        "seconds_since_heartbeat": _seconds_since(entry.get("last_heartbeat_at_ts"), now_ts),
+        "stall_threshold_seconds": entry.get("stall_threshold_seconds", _DELEGATION_STALL_THRESHOLD_SECONDS),
+        "duration_seconds": entry.get("duration_seconds"),
+        "profile_label": entry.get("profile_label"),
+        "runtime_label": entry.get("runtime_label"),
+        "origin_label": entry.get("origin_label"),
+        "deliver_label": entry.get("deliver_label"),
+        "task_class_summary": entry.get("task_class_summary"),
+        "deliver": deliver,
+        "runner_error": entry.get("runner_error"),
+    }
+    if include_tasks:
+        payload["tasks"] = serialized_tasks
+    return payload
+
+
+def delegate_status(
+    spawn_id: Optional[str] = None,
+    *,
+    limit: int = 10,
+    active_only: bool = False,
+    include_tasks: bool = True,
+) -> str:
+    """Return direct Hermes delegation status from the persistent registry."""
+    with _DELEGATION_REGISTRY_LOCK:
+        payload = _load_delegation_registry()
+    delegations = payload.get("delegations") or {}
+    now_ts = _registry_now_ts()
+
+    if spawn_id:
+        entry = delegations.get(str(spawn_id).strip())
+        if not isinstance(entry, dict):
+            return json.dumps({"error": f"No delegation found for spawn_id '{spawn_id}'."}, ensure_ascii=False)
+        return json.dumps(_serialize_delegation_entry(entry, now_ts=now_ts, include_tasks=include_tasks), ensure_ascii=False)
+
+    try:
+        safe_limit = max(1, min(int(limit), 100))
+    except Exception:
+        safe_limit = 10
+
+    entries = sorted(
+        delegations.values(),
+        key=lambda item: float((item or {}).get("created_at_ts") or 0.0),
+        reverse=True,
+    )
+    serialized = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        serialized_entry = _serialize_delegation_entry(entry, now_ts=now_ts, include_tasks=include_tasks)
+        if active_only and serialized_entry.get("status") not in {"spawned", "running", "stalled"}:
+            continue
+        serialized.append(serialized_entry)
+        if len(serialized) >= safe_limit:
+            break
+
+    return json.dumps({
+        "delegations": serialized,
+        "count": len(serialized),
+    }, ensure_ascii=False)
+
+
+def _resolve_agent_activity_target() -> Optional[Dict[str, Any]]:
+    """Resolve Agent Activity topic from config.yaml telegram.extra.group_topics.
+
+    Results are cached for _AGENT_ACTIVITY_TTL seconds so config changes
+    (topic ID updates, new topics) are picked up without a full restart.
+    """
+    global _AGENT_ACTIVITY_CHAT_ID, _AGENT_ACTIVITY_THREAD_ID, _AGENT_ACTIVITY_RESOLVED_AT
+    if _AGENT_ACTIVITY_CHAT_ID is not None and (time.time() - _AGENT_ACTIVITY_RESOLVED_AT) < _AGENT_ACTIVITY_TTL:
+        return {"chat_id": _AGENT_ACTIVITY_CHAT_ID, "thread_id": _AGENT_ACTIVITY_THREAD_ID}
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        for group in cfg.get("telegram", {}).get("extra", {}).get("group_topics", []):
+            for topic in group.get("topics", []):
+                if topic.get("name", "").lower().strip() in ("agent activity",):
+                    _AGENT_ACTIVITY_CHAT_ID = str(group["chat_id"])
+                    _AGENT_ACTIVITY_THREAD_ID = str(topic["thread_id"])
+                    _AGENT_ACTIVITY_RESOLVED_AT = time.time()
+                    return {"chat_id": _AGENT_ACTIVITY_CHAT_ID, "thread_id": _AGENT_ACTIVITY_THREAD_ID}
+    except Exception as exc:
+        logger.debug("Could not resolve Agent Activity topic: %s", exc)
+    return None
+
+
+def _send_telegram_sync(
+    chat_id: str,
+    thread_id: Optional[str],
+    text: str,
+    *,
+    context: str = "delegate_task",
+    target_label: Optional[str] = None,
+) -> bool:
+    """Fire-and-forget synchronous Telegram message via Bot API (urllib, no deps)."""
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    resolved_target = f"telegram:{chat_id}"
+    if thread_id:
+        resolved_target += f":{thread_id}"
+    label = target_label or resolved_target
+
+    try:
+        from pathlib import Path
+        env_path = Path(os.path.expanduser("~/.hermes/.env"))
+        token = None
+        if env_path.exists():
+            for line in env_path.read_text().splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                if k.strip() == "TELEGRAM_BOT_TOKEN":
+                    token = v.strip()
+                    break
+        if not token:
+            token = os.environ.get("TELEGRAM_BOT_TOKEN") or os.environ.get("HERMES_TELEGRAM_BOT_TOKEN")
+        if not token:
+            logger.debug("No Telegram bot token found for %s delivery to %s", context, label)
+            return False
+
+        params = {"chat_id": chat_id, "text": text, "disable_web_page_preview": "true"}
+        if thread_id:
+            params["message_thread_id"] = thread_id
+        data = urllib.parse.urlencode(params).encode()
+        req = urllib.request.Request(f"https://api.telegram.org/bot{token}/sendMessage", data=data)
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            body = json.loads(resp.read().decode())
+            ok = body.get("ok", False)
+            if not ok:
+                logger.warning(
+                    "Telegram delivery returned ok=false for %s target=%s resolved=%s body=%s",
+                    context,
+                    label,
+                    resolved_target,
+                    str(body)[:500],
+                )
+            return ok
+    except urllib.error.HTTPError as exc:
+        try:
+            error_body = exc.read().decode(errors="replace")
+        except Exception:
+            error_body = ""
+        logger.warning(
+            "Telegram delivery failed for %s: status=%s target=%s resolved=%s body=%s",
+            context,
+            getattr(exc, "code", "?"),
+            label,
+            resolved_target,
+            error_body[:500],
+        )
+        return False
+    except Exception as exc:
+        logger.warning(
+            "Telegram delivery failed for %s: target=%s resolved=%s error=%s",
+            context,
+            label,
+            resolved_target,
+            exc,
+        )
+        return False
+
+
+def _parse_deliver_target(deliver: str) -> Optional[Dict[str, str]]:
+    """Parse a deliver target string like 'telegram:chat_id:thread_id' or a topic name."""
+    if not deliver or not deliver.strip():
+        return None
+    deliver = deliver.strip()
+
+    # Format: telegram:chat_id:thread_id
+    if deliver.startswith("telegram:"):
+        parts = deliver.split(":")
+        if len(parts) >= 3:
+            return {"chat_id": parts[1], "thread_id": parts[2]}
+        elif len(parts) == 2:
+            return {"chat_id": parts[1], "thread_id": None}
+
+    # Format: topic name — resolve from config
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        deliver_lower = deliver.lower().strip()
+        for group in cfg.get("telegram", {}).get("extra", {}).get("group_topics", []):
+            for topic in group.get("topics", []):
+                if topic.get("name", "").lower().strip() == deliver_lower:
+                    return {"chat_id": str(group["chat_id"]), "thread_id": str(topic["thread_id"])}
+    except Exception as exc:
+        logger.debug("Could not resolve deliver target '%s': %s", deliver, exc)
+
+    return None
+
+
+def _load_full_config() -> dict:
+    """Load the full Hermes config when notification formatting needs routing metadata."""
+    try:
+        from hermes_cli.config import load_config
+        return load_config() or {}
+    except Exception:
+        return {}
+
+
+def _get_active_profile_label() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        profile = (get_active_profile_name() or "").strip()
+        return profile or "default"
+    except Exception:
+        return "default"
+
+
+def _short_identifier(value: Any, width: int = 8) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return "unknown"
+    compact = re.sub(r"[^A-Za-z0-9]", "", text)
+    if compact:
+        return compact[:width]
+    return text[:width]
+
+
+def _truncate_preview(text: Any, limit: int = 72) -> str:
+    preview = re.sub(r"\s+", " ", str(text or "").strip())
+    if len(preview) <= limit:
+        return preview
+    return preview[: max(1, limit - 1)].rstrip() + "…"
+
+
+def _sentence_preview(text: Any, limit: int = 160) -> str:
+    preview = re.sub(r"\s+", " ", str(text or "").strip())
+    if not preview:
+        return ""
+    if len(preview) <= limit:
+        return preview if preview[-1] in ".!?" else preview + "."
+
+    sentence_match = re.match(r"^(.{1," + str(limit) + r"}?[.!?])(?:\s|$)", preview)
+    if sentence_match:
+        sentence = sentence_match.group(1).strip()
+        return sentence if sentence[-1] in ".!?" else sentence + "."
+
+    clipped = preview[:limit].rstrip()
+    if " " in clipped:
+        clipped = clipped.rsplit(" ", 1)[0].rstrip()
+    clipped = clipped.rstrip(" ,;:-")
+    if not clipped:
+        clipped = preview[:limit].rstrip()
+    return clipped + "."
+
+
+def _format_duration_short(seconds: Any) -> str:
+    try:
+        total_seconds = max(0, int(round(float(seconds or 0))))
+    except (TypeError, ValueError):
+        total_seconds = 0
+
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+
+    minutes, secs = divmod(total_seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {secs:02d}s"
+
+    hours, minutes = divmod(minutes, 60)
+    if secs:
+        return f"{hours}h {minutes:02d}m {secs:02d}s"
+    return f"{hours}h {minutes:02d}m"
+
+
+def _task_class_icon(task_class: str) -> str:
+    return {
+        "build_execution": "🛠️",
+        "system_repair": "🩺",
+        "research": "🔎",
+    }.get((task_class or "").strip(), "🧩")
+
+
+def _lookup_topic_name(chat_id: Any, thread_id: Any, cfg: Optional[dict] = None) -> str:
+    chat_key = str(chat_id or "").strip()
+    thread_key = str(thread_id or "").strip()
+    if not chat_key or not thread_key:
+        return ""
+    cfg = cfg or _load_full_config()
+    for group in cfg.get("telegram", {}).get("extra", {}).get("group_topics", []):
+        if str(group.get("chat_id", "")).strip() != chat_key:
+            continue
+        for topic in group.get("topics", []):
+            if str(topic.get("thread_id", "")).strip() == thread_key:
+                return str(topic.get("name", "") or "").strip()
+    return ""
+
+
+def _format_origin_label(
+    *,
+    platform: str,
+    chat_id: str,
+    chat_name: str,
+    thread_id: str,
+    session_key: str,
+    cfg: Optional[dict] = None,
+) -> str:
+    platform_label = (platform or "").strip().lower()
+    pretty_platform = platform_label.capitalize() if platform_label else "Local"
+    chat_label = (chat_name or "").strip()
+    thread_label = (thread_id or "").strip()
+
+    if platform_label == "telegram":
+        topic_name = _lookup_topic_name(chat_id, thread_label, cfg)
+        if chat_label and topic_name:
+            return f"Telegram · {chat_label} / {topic_name} (#{thread_label})"
+        if topic_name:
+            return f"Telegram · {topic_name} (#{thread_label})"
+        if chat_label and thread_label:
+            return f"Telegram · {chat_label} / thread #{thread_label}"
+        if chat_label:
+            return f"Telegram · {chat_label}"
+        if chat_id and thread_label:
+            return f"Telegram · {chat_id}:{thread_label}"
+        if chat_id:
+            return f"Telegram · {chat_id}"
+
+    if chat_label and thread_label:
+        return f"{pretty_platform} · {chat_label} / thread {thread_label}"
+    if chat_label:
+        return f"{pretty_platform} · {chat_label}"
+    if session_key:
+        return f"{pretty_platform} · session {session_key}"
+    if platform_label:
+        return pretty_platform
+    return "unknown origin"
+
+
+def _format_deliver_label(
+    requested_deliver: str,
+    deliver_target: Optional[Dict[str, str]],
+    *,
+    source_chat_id: str = "",
+    source_chat_name: str = "",
+    cfg: Optional[dict] = None,
+) -> str:
+    requested = (requested_deliver or "").strip()
+    if not deliver_target:
+        return requested or "none"
+
+    chat_id = str(deliver_target.get("chat_id") or "").strip()
+    thread_id = str(deliver_target.get("thread_id") or "").strip()
+    resolved = f"telegram:{chat_id}"
+    if thread_id:
+        resolved += f":{thread_id}"
+
+    topic_name = _lookup_topic_name(chat_id, thread_id, cfg)
+    if topic_name and chat_id and chat_id == str(source_chat_id or "").strip() and source_chat_name:
+        friendly = f"{source_chat_name} / {topic_name} (#{thread_id})"
+    elif topic_name:
+        friendly = f"{topic_name} (#{thread_id})"
+    else:
+        friendly = resolved
+
+    if requested and requested != resolved and requested != topic_name:
+        return f"{requested} → {friendly}"
+    return friendly
+
+
+def _build_task_class_summary(tasks_meta: List[Dict[str, Any]]) -> str:
+    counts: Dict[str, int] = {}
+    order: List[str] = []
+    for task in tasks_meta:
+        task_class = str(task.get("task_class") or "general").strip() or "general"
+        if task_class not in counts:
+            counts[task_class] = 0
+            order.append(task_class)
+        counts[task_class] += 1
+
+    if len(order) == 1:
+        return order[0]
+    return ", ".join(
+        f"{task_class} ×{counts[task_class]}" if counts[task_class] > 1 else task_class
+        for task_class in order
+    )
+
+
+def _capture_activity_metadata(
+    task_list: List[Dict[str, Any]],
+    children: List,
+    parent_agent,
+    *,
+    requested_deliver: str,
+    deliver_target: Optional[Dict[str, str]],
+    spawn_id: str,
+) -> Dict[str, Any]:
+    cfg = _load_full_config()
+
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        def get_session_env(name: str, default: str = "") -> str:
+            return os.getenv(name, default)
+
+    platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or getattr(parent_agent, "platform", "") or "").strip()
+    chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+    chat_name = (get_session_env("HERMES_SESSION_CHAT_NAME", "") or "").strip()
+    thread_id = (get_session_env("HERMES_SESSION_THREAD_ID", "") or "").strip()
+    session_key = (get_session_env("HERMES_SESSION_KEY", "") or "").strip()
+
+    reference_agent = children[0][2] if children else parent_agent
+    runtime_model = str(getattr(reference_agent, "model", "") or getattr(parent_agent, "model", "") or "").strip()
+    runtime_provider = str(getattr(reference_agent, "provider", "") or getattr(parent_agent, "provider", "") or "").strip()
+    if runtime_model and runtime_provider:
+        runtime_label = f"{runtime_model} via {runtime_provider}"
+    else:
+        runtime_label = runtime_model or runtime_provider
+
+    tasks_meta = []
+    for position, (task_index, task, child) in enumerate(children, start=1):
+        task_class = _infer_delegation_task_class(task.get("goal", ""), task.get("context"), requested_deliver)
+        playbook_label = _extract_playbook_label(task.get("context") or "")
+        pipeline_label = _extract_pipeline_label(task.get("goal") or "", task.get("context") or "")
+        task_entry = {
+            "task_index": task_index,
+            "position": position,
+            "task_class": task_class,
+            "task_icon": _task_class_icon(task_class),
+            "goal_preview": _sentence_preview(task.get("goal", ""), 160),
+            "session_id": str(getattr(child, "session_id", "") or "").strip(),
+            "session_id_short": _short_identifier(getattr(child, "session_id", "") or position),
+        }
+        if playbook_label:
+            task_entry["playbook"] = playbook_label
+        if pipeline_label:
+            task_entry["pipeline_stage"] = pipeline_label
+        tasks_meta.append(task_entry)
+
+    return {
+        "spawn_id": spawn_id,
+        "profile_label": _get_active_profile_label(),
+        "runtime_label": runtime_label,
+        "origin_label": _format_origin_label(
+            platform=platform,
+            chat_id=chat_id,
+            chat_name=chat_name,
+            thread_id=thread_id,
+            session_key=session_key,
+            cfg=cfg,
+        ),
+        "deliver_label": _format_deliver_label(
+            requested_deliver,
+            deliver_target,
+            source_chat_id=chat_id,
+            source_chat_name=chat_name,
+            cfg=cfg,
+        ),
+        "task_class_summary": _build_task_class_summary(tasks_meta),
+        "tasks": tasks_meta,
+    }
+
+
+def _build_activity_spawn_message(activity_meta: Dict[str, Any]) -> str:
+    tasks_meta = activity_meta.get("tasks", [])
+    plural = len(tasks_meta) != 1
+    lines = [f"🚀 Spawned · {activity_meta.get('spawn_id', '')}"]
+
+    origin_label = str(activity_meta.get("origin_label") or "").strip()
+    if origin_label:
+        lines.append(f"From: {origin_label}")
+
+    deliver_label = str(activity_meta.get("deliver_label") or "none").strip() or "none"
+    lines.append(f"To: {deliver_label}")
+
+    runtime_label = str(activity_meta.get("runtime_label") or "").strip()
+    if runtime_label:
+        lines.append(f"Model: {runtime_label}")
+
+    if plural:
+        lines.append(f"Tasks: {len(tasks_meta)}")
+        for task in tasks_meta:
+            lines.append(f"• #{task.get('position')}: {task.get('goal_preview', '')}")
+    else:
+        task = tasks_meta[0] if tasks_meta else {}
+        lines.append(f"Task: {task.get('goal_preview', '')}")
+
+    # Include playbook and pipeline stage if available
+    first_task = tasks_meta[0] if tasks_meta else {}
+    playbook = first_task.get("playbook")
+    pipeline_stage = first_task.get("pipeline_stage")
+    if playbook:
+        lines.append(f"Playbook: {playbook}")
+    if pipeline_stage:
+        lines.append(f"Pipeline: {pipeline_stage}")
+
+    return "\n".join(lines)
+
+
+def _build_activity_completion_message(
+    activity_meta: Dict[str, Any],
+    results: List[Dict[str, Any]],
+    *,
+    total_duration_seconds: float,
+    deliver_ok: bool,
+) -> str:
+    tasks_meta = activity_meta.get("tasks", [])
+    plural = len(tasks_meta) != 1
+    result_map = {entry.get("task_index"): entry for entry in results}
+    completed_count = sum(1 for entry in results if entry.get("status") == "completed")
+    issue_count = max(0, len(results) - completed_count)
+
+    if issue_count == 0:
+        title = f"✅ Done · {activity_meta.get('spawn_id', '')}"
+    else:
+        title = f"⚠️ Issues · {activity_meta.get('spawn_id', '')}"
+
+    lines = [title]
+
+    origin_label = str(activity_meta.get("origin_label") or "").strip()
+    if origin_label:
+        lines.append(f"From: {origin_label}")
+
+    if deliver_ok:
+        lines.append(f"To: {activity_meta.get('deliver_label', 'none')}")
+    else:
+        lines.append(f"To: delivery failed → {activity_meta.get('deliver_label', 'none')}")
+
+    runtime_label = str(activity_meta.get("runtime_label") or "").strip()
+    if runtime_label:
+        lines.append(f"Model: {runtime_label}")
+
+    lines.append(
+        f"Outcome: {completed_count}/{len(results)} completed"
+        + (f" · {issue_count} issue{'s' if issue_count != 1 else ''}" if issue_count else "")
+    )
+    lines.append(f"Duration: {_format_duration_short(total_duration_seconds)}")
+
+    if plural:
+        lines.append(f"Tasks: {len(results)}")
+        for task in tasks_meta:
+            entry = result_map.get(task.get("task_index"), {})
+            status = str(entry.get("status") or "unknown")
+            status_icon = "✅" if status == "completed" else "⚠️"
+            detail = entry.get("summary") or entry.get("error") or status
+            detail_preview = _truncate_preview(detail, 180)
+            lines.append(
+                f"• #{task.get('position')} {status_icon} {task.get('goal_preview', '')}"
+                + (f" — {detail_preview}" if detail_preview else "")
+            )
+    else:
+        task = tasks_meta[0] if tasks_meta else {}
+        entry = result_map.get(task.get("task_index"), {})
+        status = str(entry.get("status") or "unknown")
+        status_label = "done" if status == "completed" else status
+        detail = entry.get("summary") or entry.get("error") or status
+        lines.append(f"Task: {task.get('goal_preview', '')}")
+        lines.append(f"Status: {status_label}")
+        if detail:
+            lines.append(f"Result: {_truncate_preview(detail, 220)}")
+
+    # Include playbook and pipeline stage if available
+    first_task = tasks_meta[0] if tasks_meta else {}
+    playbook = first_task.get("playbook")
+    pipeline_stage = first_task.get("pipeline_stage")
+    if playbook:
+        lines.append(f"Playbook: {playbook}")
+    if pipeline_stage:
+        lines.append(f"Pipeline: {pipeline_stage}")
+
+    return "\n".join(lines)
+
+
+def _background_delegation_runner(
+    task_list: List[Dict[str, Any]],
+    children: List,
+    parent_agent,
+    deliver_target: Optional[Dict[str, str]],
+    activity_target: Optional[Dict[str, str]],
+    spawn_id: str,
+    activity_meta: Optional[Dict[str, Any]] = None,
+    started_at: Optional[float] = None,
+):
+    """Run subagents in a background thread. On completion, deliver results and notify."""
+    import model_tools as _mt
+
+    start_ts = float(started_at if started_at is not None else time.monotonic())
+    results = []
+    max_children = _get_max_concurrent_children()
+    n_tasks = len(task_list)
+
+    if activity_meta is not None:
+        try:
+            _mark_background_delegation_running(spawn_id)
+        except Exception:
+            logger.exception("Background delegation %s could not be marked running", spawn_id)
+
+    try:
+        if n_tasks == 1:
+            _i, _t, child = children[0]
+            result = _run_single_child(0, _t["goal"], child, parent_agent)
+            results.append(result)
+        else:
+            with ThreadPoolExecutor(max_workers=max_children) as executor:
+                futures = {}
+                for i, t, child in children:
+                    future = executor.submit(_run_single_child, task_index=i, goal=t["goal"], child=child, parent_agent=parent_agent)
+                    futures[future] = i
+                for future in as_completed(futures):
+                    try:
+                        entry = future.result()
+                    except Exception as exc:
+                        idx = futures[future]
+                        entry = {"task_index": idx, "status": "error", "summary": None, "error": str(exc), "api_calls": 0, "duration_seconds": 0}
+                    results.append(entry)
+            results.sort(key=lambda r: r["task_index"])
+    except Exception as exc:
+        logger.exception("Background delegation %s crashed", spawn_id)
+        if activity_meta is not None:
+            _finalize_background_delegation(
+                spawn_id,
+                total_duration_seconds=round(time.monotonic() - start_ts, 2),
+                fatal_error=str(exc),
+            )
+        raise
+
+    # Build completion summary
+    summaries = []
+    for i, entry in enumerate(results):
+        status = entry.get("status", "unknown")
+        dur = entry.get("duration_seconds", 0)
+        goal_label = task_list[entry["task_index"]]["goal"][:60] if entry["task_index"] < len(task_list) else f"Task {i}"
+        summary_text = entry.get("summary", "") or "(no output)"
+
+        icon = "done" if status == "completed" else status
+        summaries.append(f"[{icon}] {goal_label} ({dur}s)\n{summary_text}")
+
+    full_report = "\n\n---\n\n".join(summaries)
+
+    # Deliver results to target topic
+    deliver_ok = True
+    resolved_deliver = None
+    if deliver_target:
+        resolved_deliver = f"telegram:{deliver_target['chat_id']}"
+        if deliver_target.get("thread_id"):
+            resolved_deliver += f":{deliver_target['thread_id']}"
+        # Truncate if too long for Telegram (4096 char limit)
+        deliver_text = full_report
+        if len(deliver_text) > 4000:
+            deliver_text = deliver_text[:3950] + "\n\n[truncated — full output exceeds message limit]"
+        deliver_ok = _send_telegram_sync(
+            deliver_target["chat_id"],
+            deliver_target.get("thread_id"),
+            deliver_text,
+            context="delegate_task result delivery",
+            target_label=resolved_deliver,
+        )
+        if activity_meta is not None:
+            error_text = None if deliver_ok else f"failed to send result delivery to {resolved_deliver}"
+            _update_background_delivery_status(spawn_id, ok=deliver_ok, error=error_text)
+
+    total_duration_seconds = round(time.monotonic() - start_ts, 2)
+    if activity_meta is not None:
+        _finalize_background_delegation(
+            spawn_id,
+            total_duration_seconds=total_duration_seconds,
+        )
+
+    # Post completion to Agent Activity (keep it short)
+    if activity_target:
+        if activity_meta is not None:
+            activity_msg = _build_activity_completion_message(
+                activity_meta,
+                results,
+                total_duration_seconds=total_duration_seconds,
+                deliver_ok=deliver_ok,
+            )
+        else:
+            all_ok = all(e.get("status") == "completed" for e in results)
+            goal_preview = task_list[0]["goal"][:140] if len(task_list) == 1 else f"{len(task_list)} tasks"
+            if all_ok:
+                activity_msg = (
+                    "✅ SUBAGENT DISPATCH CLOSED\n"
+                    "Agent: Hermes subagent\n"
+                    f"Task: {goal_preview}"
+                )
+            else:
+                failed = [e for e in results if e.get("status") != "completed"]
+                activity_msg = (
+                    "⚠️ SUBAGENT DISPATCH CLOSED WITH ISSUES\n"
+                    "Agent: Hermes subagent\n"
+                    f"Task: {goal_preview}\n"
+                    f"Issues: {len(failed)}"
+                )
+        _send_telegram_sync(
+            activity_target["chat_id"],
+            activity_target.get("thread_id"),
+            activity_msg,
+            context="delegate_task activity completion",
+            target_label="Agent Activity",
+        )
+
+    # Notify parent's memory provider
+    if parent_agent and hasattr(parent_agent, '_memory_manager') and parent_agent._memory_manager:
+        for entry in results:
+            try:
+                _task_goal = task_list[entry["task_index"]]["goal"] if entry["task_index"] < len(task_list) else ""
+                parent_agent._memory_manager.on_delegation(
+                    task=_task_goal,
+                    result=entry.get("summary", "") or "",
+                    child_session_id=getattr(children[entry["task_index"]][2], "session_id", "") if entry["task_index"] < len(children) else "",
+                )
+            except Exception:
+                pass
+
+    logger.info("Background delegation %s completed: %d tasks", spawn_id, len(results))
+
+
+def _tool_result_status(content: Any) -> str:
+    """Classify a tool result as ok/error without false positives.
+
+    Tool outputs are often JSON strings that include an "error" key with a null
+    value (for example terminal responses). Substring matching on the raw text
+    misclassifies those as failures, so prefer structured inspection first.
+    """
+    if content is None:
+        return "error"
+
+    parsed = content
+    if isinstance(content, str):
+        try:
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            text = content.strip()
+            if not text:
+                return "error"
+            return "error" if text.lower().startswith("error:") else "ok"
+
+    if isinstance(parsed, dict):
+        if parsed.get("error") is not None:
+            return "error"
+        if parsed.get("success") is False:
+            return "error"
+
+        inner_content = parsed.get("content")
+        if isinstance(inner_content, dict):
+            if inner_content.get("error") is not None:
+                return "error"
+            if inner_content.get("success") is False:
+                return "error"
+
+    return "ok"
+
+
+def _coerce_timeout_seconds(raw_timeout: Any) -> Optional[int]:
+    """Best-effort numeric timeout parsing for runtime-only values."""
+    if raw_timeout is None or isinstance(raw_timeout, bool):
+        return None
+    if not isinstance(raw_timeout, (int, float, str)):
+        return None
+
+    try:
+        timeout_seconds = int(float(raw_timeout))
+    except (TypeError, ValueError):
+        return None
+
+    return timeout_seconds if timeout_seconds > 0 else None
+
+
+def _get_subagent_timeout_seconds(cfg: Optional[dict] = None) -> Optional[int]:
+    """Resolve the wall-clock budget for subagents."""
+    if cfg is None:
+        cfg = _load_config()
+
+    raw = cfg.get("timeout_seconds")
+    if raw in (None, ""):
+        raw = os.getenv("HERMES_DELEGATION_TIMEOUT", DEFAULT_CHILD_TIMEOUT_SECONDS)
+
+    try:
+        timeout_seconds = int(float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.timeout_seconds=%r is invalid; using default %ds",
+            raw,
+            DEFAULT_CHILD_TIMEOUT_SECONDS,
+        )
+        timeout_seconds = DEFAULT_CHILD_TIMEOUT_SECONDS
+
+    return timeout_seconds if timeout_seconds > 0 else None
+
+
+def _build_timeout_checkpoint(
+    goal: str,
+    timeout_seconds: Optional[int],
+    activity: Optional[Dict[str, Any]] = None,
+    partial_summary: str = "",
+) -> str:
+    """Build a structured checkpoint when a subagent hits the wall-clock limit."""
+    timeout_seconds = int(timeout_seconds or DEFAULT_CHILD_TIMEOUT_SECONDS)
+    timeout_minutes = max(1, timeout_seconds // 60)
+    activity = activity or {}
+
+    lines = [
+        f"Subagent hit the {timeout_minutes}-minute wall-clock limit before finishing `{goal}`.",
+    ]
+
+    if partial_summary:
+        lines.append("Partial summary:")
+        lines.append(partial_summary)
+
+    last_desc = str(activity.get("last_activity_desc") or "").strip()
+    current_tool = str(activity.get("current_tool") or "").strip()
+    api_calls = activity.get("api_call_count")
+    max_iterations = activity.get("max_iterations")
+
+    if current_tool or last_desc:
+        detail = current_tool or last_desc
+        if current_tool and last_desc and last_desc != current_tool:
+            detail = f"{current_tool} ({last_desc})"
+        lines.append(f"Last active work: {detail}")
+
+    if isinstance(api_calls, int) and isinstance(max_iterations, int) and max_iterations > 0:
+        lines.append(f"Iteration progress: {api_calls}/{max_iterations}")
+
+    lines.append("Needs more time: yes")
+    lines.append("Next step: check in with Dax, share the checkpoint, and ask whether to continue the subagent.")
+    return "\n".join(lines)
 
 
 def check_delegate_requirements() -> bool:
@@ -87,25 +1355,311 @@ def check_delegate_requirements() -> bool:
     return True
 
 
-def _build_child_system_prompt(
+def _select_research_domain_playbook(playbook_dir, combined: str, deliver_lower: str):
+    alias_map = [
+        (("seo research", " seo ", "local seo", "keywords", "title tags"), "seo-research.md"),
+        (("gbp research", " google business profile", " gbp "), "gbp-research.md"),
+        (("geo research", " generative engine optimization", " ai search ", " geo "), "geo-research.md"),
+        (("website craft", "website research", "site teardown", "design patterns"), "website-research.md"),
+        (("paid advertising", "google ads", "meta ads", "ads research"), "paid-advertising-research.md"),
+        (("reviews", "reputation"), "reviews-reputation-research.md"),
+        (("social media", "instagram", "facebook strategy", "tiktok"), "social-media-research.md"),
+        (("agency business model", "business model"), "agency-business-model-research.md"),
+        (("client market analysis", "market analysis"), "client-market-analysis-research.md"),
+    ]
+    padded = f" {combined} "
+    for tokens, filename in alias_map:
+        if any(token in padded or token in deliver_lower for token in tokens):
+            candidate = playbook_dir / filename
+            if candidate.exists():
+                return candidate
+    return None
+
+
+
+def _auto_inject_playbook(goal: str, context: Optional[str], deliver: Optional[str]) -> Optional[str]:
+    """Auto-detect task type and load matching playbook + reference files.
+
+    Returns the loaded content to prepend to the subagent context, or None
+    if no matching playbook is found.  Uses the deliver target and goal
+    keywords to decide which playbook to inject.
+    """
+    from pathlib import Path
+
+    goal_lower = (goal or "").lower()
+    deliver_lower = (deliver or "").lower()
+    context_lower = (context or "").lower()
+    combined = f"{goal_lower} {deliver_lower} {context_lower}"
+
+    PLAYBOOK_DIR = Path(os.path.expanduser(
+        "~/Obsidian/Jarvis-Operations/🧠 Brain/playbooks"
+    ))
+    INDUSTRY_REF_DIR = Path(os.path.expanduser(
+        "~/Obsidian/Jarvis-Operations/🏗️ Projects/rww/templates/industry-references"
+    ))
+
+    research_signals = (
+        "seo" in combined or "lead" in combined or "market" in combined
+        or "competitive" in combined or "research" in combined
+        or deliver_lower in ("seo research", "leads", "geo research", "gbp research")
+    )
+    website_build_signals = (
+        "build" in combined or "website" in goal_lower
+        or deliver_lower in ("builds", "playbook - website build")
+    )
+
+    injected_parts = []
+
+    if research_signals:
+        pipeline_path = PLAYBOOK_DIR / "research-pipeline.md"
+        if pipeline_path.exists():
+            try:
+                pipeline_text = pipeline_path.read_text(errors="ignore")
+                injected_parts.append(
+                    "=== AUTO-INJECTED PLAYBOOK: research-pipeline.md ===\n"
+                    + pipeline_text
+                    + "\n=== END PLAYBOOK ===\n"
+                )
+            except Exception as exc:
+                logger.debug("Failed to load research pipeline playbook: %s", exc)
+
+        domain_playbook_path = _select_research_domain_playbook(PLAYBOOK_DIR, combined, deliver_lower)
+        if domain_playbook_path is not None:
+            try:
+                content_text = domain_playbook_path.read_text(errors="ignore")
+                injected_parts.append(
+                    f"=== AUTO-INJECTED PLAYBOOK: {domain_playbook_path.name} ===\n"
+                    + content_text
+                    + "\n=== END PLAYBOOK ===\n"
+                )
+            except Exception as exc:
+                logger.debug("Failed to load research playbook %s: %s", domain_playbook_path.name, exc)
+
+        if domain_playbook_path and domain_playbook_path.name == "seo-research.md":
+            craft_seo_path = INDUSTRY_REF_DIR.parent / "craft-guides" / "craft-seo.md"
+            if craft_seo_path.exists():
+                try:
+                    craft_text = craft_seo_path.read_text(errors="ignore")
+                    injected_parts.append(
+                        "=== AUTO-INJECTED REFERENCE: craft-seo.md ===\n"
+                        + craft_text
+                        + "\n=== END REFERENCE ===\n"
+                    )
+                except Exception as exc:
+                    logger.debug("Failed to load craft-seo.md: %s", exc)
+
+        for ref_file in sorted(INDUSTRY_REF_DIR.glob("*.md")):
+            if ref_file.name.startswith("craft-"):
+                continue
+            industry_slug = ref_file.stem
+            if industry_slug.replace("-", " ") in goal_lower or industry_slug.replace("-", " ") in context_lower:
+                try:
+                    ref_text = ref_file.read_text(errors="ignore")
+                    injected_parts.append(
+                        f"=== AUTO-INJECTED INDUSTRY REFERENCE: {ref_file.name} ===\n"
+                        + ref_text
+                        + "\n=== END INDUSTRY REFERENCE ===\n"
+                    )
+                except Exception as exc:
+                    logger.debug("Failed to load industry reference %s: %s", ref_file.name, exc)
+                break
+
+    elif website_build_signals:
+        playbook_path = PLAYBOOK_DIR / "website-build.md"
+        if playbook_path.exists():
+            try:
+                content_text = playbook_path.read_text(errors="ignore")
+                injected_parts.append(
+                    "=== AUTO-INJECTED PLAYBOOK: website-build.md ===\n"
+                    + content_text
+                    + "\n=== END PLAYBOOK ===\n"
+                )
+            except Exception as exc:
+                logger.debug("Failed to load build playbook: %s", exc)
+
+    if injected_parts:
+        logger.info(
+            "Auto-injected %d playbook/reference file(s) for subagent (deliver=%s)",
+            len(injected_parts), deliver,
+        )
+        return "\n\n".join(injected_parts)
+    return None
+
+
+
+def _infer_delegation_task_class(goal: str, context: Optional[str], deliver: Optional[str]) -> str:
+    combined = " ".join(filter(None, [(goal or "").lower(), (context or "").lower(), (deliver or "").lower()]))
+    if any(token in combined for token in ("build", "website", "landing page", "dashboard", "frontend", "ui")):
+        return "build_execution"
+    if any(token in combined for token in ("research", "seo", "market", "competitor", "lead", "geo")):
+        return "research"
+    if any(token in combined for token in ("fix", "debug", "repair", "incident", "broken", "failure")):
+        return "system_repair"
+    return "general"
+
+
+def _extract_playbook_label(context: str) -> Optional[str]:
+    """Extract playbook name from subagent context string.
+
+    Looks for patterns like:
+      === DOMAIN PLAYBOOK: gbp-research.md ===
+      playbook: seo-research
+    """
+    m = re.search(r"DOMAIN PLAYBOOK:\s*(\S+\.md)", context or "")
+    if m:
+        name = m.group(1).replace(".md", "")
+        return name
+    m = re.search(r"playbook[:\s]+([a-z0-9_-]+(?:-research|-build|-pipeline))", (context or "").lower())
+    if m:
+        return m.group(1)
+    return None
+
+
+def _extract_pipeline_label(goal: str, context: str) -> Optional[str]:
+    """Extract pipeline stage from goal/context strings.
+
+    Looks for patterns like:
+      [Stage 1 - Knowledge Assessment]
+      ACTIVE STAGE: stage-2-web-research
+      research-pipeline
+    """
+    m = re.search(r"\[Stage\s+(\d+)\s*[-–]\s*([^\]]+)\]", goal or "")
+    if m:
+        return f"Stage {m.group(1)}: {m.group(2).strip()}"
+    m = re.search(r"ACTIVE STAGE:\s*(stage-\d+-\S+)", context or "")
+    if m:
+        raw = m.group(1)
+        parts = raw.split("-", 2)
+        if len(parts) >= 3:
+            return f"Stage {parts[1]}: {parts[2].replace('-', ' ').title()}"
+        return raw
+    if "research pipeline" in (context or "").lower() or "research-pipeline" in (context or "").lower():
+        return "Research Pipeline"
+    return None
+
+
+def _looks_like_underinformed_context(goal: str, context: Optional[str], workspace_path: Optional[str]) -> List[str]:
+    notes: List[str] = []
+    text = (context or "").strip()
+    combined = f"{goal or ''} {text}".lower()
+    needs_repo_context = any(token in combined for token in (
+        "build", "code", "repo", "repository", "fix", "debug", "dashboard", "website", "frontend", "backend",
+    ))
+    has_path_hint = bool(re.search(r"(/Users/|~/|\.(py|ts|tsx|js|jsx|md|json|yaml|yml)\b)", f"{goal} {text}"))
+    if needs_repo_context and not workspace_path and not has_path_hint:
+        notes.append("No concrete workspace path or file path was supplied. Discover the repo/workdir before editing or running repo-specific commands.")
+    if len(text) < 40:
+        notes.append("Parent context is thin. Work from the stated goal, inspect source-of-truth files first, and verify assumptions before changing anything.")
+    return notes
+
+
+def _build_delegation_contract(
+    goal: str,
+    context: Optional[str],
+    *,
+    deliver: Optional[str],
+    workspace_path: Optional[str],
+    toolsets: Optional[List[str]],
+    wall_clock_timeout_seconds: Optional[int],
+) -> str:
+    task_class = _infer_delegation_task_class(goal, context, deliver)
+    missing_context_notes = _looks_like_underinformed_context(goal, context, workspace_path)
+    success_lines = [
+        "- Complete the delegated objective, not just analysis.",
+        "- Verify the result with the available tools before returning.",
+        "- Return a concise completion summary with files changed, findings, and remaining risks.",
+    ]
+    if deliver:
+        success_lines.append(f"- Produce a result that is ready to be delivered to: {deliver}.")
+    if task_class == "research":
+        success_lines.append("- Ground claims in source material or tool output; do not invent findings.")
+    elif task_class == "build_execution":
+        success_lines.append("- If code changes are needed, identify the exact files touched and the verification run.")
+    elif task_class == "system_repair":
+        success_lines.append("- Prefer direct repair plus verification over speculative explanation.")
+
+    lines = [
+        "DELEGATION CONTRACT:",
+        f"- Task class: {task_class}",
+        f"- Objective: {goal}",
+        f"- Deliver target: {deliver or 'none specified'}",
+        f"- Workspace hint: {workspace_path or 'none supplied'}",
+        f"- Toolsets: {', '.join(toolsets) if toolsets else 'inherit filtered parent toolsets'}",
+    ]
+    if wall_clock_timeout_seconds and wall_clock_timeout_seconds > 0:
+        lines.append(f"- Time budget seconds: {int(wall_clock_timeout_seconds)}")
+    lines.append("")
+    lines.append("SUCCESS CRITERIA:")
+    lines.extend(success_lines)
+    if missing_context_notes:
+        lines.append("")
+        lines.append("MISSING CONTEXT RISKS:")
+        lines.extend(f"- {note}" for note in missing_context_notes)
+    if context and context.strip():
+        lines.append("")
+        lines.append("PARENT CONTEXT:")
+        lines.append(context.strip())
+    return "\n".join(lines)
+
+
+def _build_subagent_system_prompt(
     goal: str,
     context: Optional[str] = None,
     *,
     workspace_path: Optional[str] = None,
+    wall_clock_timeout_seconds: Optional[int] = None,
+    deliver: Optional[str] = None,
+    toolsets: Optional[List[str]] = None,
 ) -> str:
-    """Build a focused system prompt for a child agent."""
+    """Build a focused system prompt for a subagent.
+
+    When ``deliver`` is provided, auto-detects the task type and injects
+    the matching playbook + reference files into the prompt so the subagent
+    has full operational context regardless of what the parent passed.
+    """
+    auto_context = _auto_inject_playbook(goal, context, deliver)
+    merged_context = context
+    if auto_context:
+        if merged_context and merged_context.strip():
+            merged_context = auto_context + "\n\n" + merged_context
+        else:
+            merged_context = auto_context
+
+    contract_text = _build_delegation_contract(
+        goal,
+        merged_context,
+        deliver=deliver,
+        workspace_path=workspace_path,
+        toolsets=toolsets,
+        wall_clock_timeout_seconds=wall_clock_timeout_seconds,
+    )
+
     parts = [
-        "You are a focused subagent working on a specific delegated task.",
+        "You are a focused subagent working on a specific delegated task. "
+        "You must complete this task fully using your available tools. "
+        "Do not describe what you would do — execute it. Keep calling tools "
+        "until the task is verifiably complete. If you encounter an error, "
+        "diagnose and fix it rather than reporting failure immediately.",
         "",
         f"YOUR TASK:\n{goal}",
+        f"\n{contract_text}",
     ]
-    if context and context.strip():
-        parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
         parts.append(
             "\nWORKSPACE PATH:\n"
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
+        )
+    if wall_clock_timeout_seconds and wall_clock_timeout_seconds > 0:
+        timeout_minutes = max(1, int(wall_clock_timeout_seconds // 60))
+        parts.append(
+            "\nTIME BUDGET:\n"
+            f"You have up to {timeout_minutes} minutes of wall-clock time for this delegated run.\n"
+            "If you cannot finish within that budget, stop cleanly and return a checkpoint that states:\n"
+            "- What is already complete\n"
+            "- What remains\n"
+            "- Whether you need more time\n"
+            "- The exact next step to resume from this checkpoint"
         )
     parts.append(
         "\nComplete this task using the tools available to you. "
@@ -123,7 +1677,7 @@ def _build_child_system_prompt(
 
 
 def _resolve_workspace_hint(parent_agent) -> Optional[str]:
-    """Best-effort local workspace hint for child prompts.
+    """Best-effort local workspace hint for subagent prompts.
 
     We only inject a path when we have a concrete absolute directory. This avoids
     teaching subagents a fake container path while still helping them avoid
@@ -155,15 +1709,15 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
-def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
-    """Build a callback that relays child agent tool calls to the parent display.
+def _build_subagent_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
+    """Build a callback that relays subagent tool calls to the parent display.
 
     Two display paths:
       CLI:     prints tree-view lines above the parent's delegation spinner
       Gateway: batches tool names and relays to parent's progress callback
 
     Returns None if no display mechanism is available, in which case the
-    child agent runs with no progress callback (identical to current behavior).
+    subagent runs with no progress callback (identical to current behavior).
     """
     spinner = getattr(parent_agent, '_delegate_spinner', None)
     parent_cb = getattr(parent_agent, 'tool_progress_callback', None)
@@ -235,7 +1789,7 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
     return _callback
 
 
-def _build_child_agent(
+def _build_subagent_agent(
     task_index: int,
     goal: str,
     context: Optional[str],
@@ -243,20 +1797,23 @@ def _build_child_agent(
     model: Optional[str],
     max_iterations: int,
     parent_agent,
+    wall_clock_timeout_seconds: Optional[int] = None,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
-    # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
+    # ACP transport overrides — lets a non-ACP parent spawn ACP subagents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Deliver target — passed through for auto-playbook injection
+    deliver: Optional[str] = None,
 ):
     """
-    Build a child AIAgent on the main thread (thread-safe construction).
-    Returns the constructed child agent without running it.
+    Build a subagent AIAgent on the main thread (thread-safe construction).
+    Returns the constructed subagent without running it.
 
-    When override_* params are set (from delegation config), the child uses
+    When override_* params are set (from delegation config), the subagent uses
     those credentials instead of inheriting from the parent.  This enables
     routing subagents to a different provider:model pair (e.g. cheap/fast
     model on OpenRouter while the parent runs on Nous Portal).
@@ -280,42 +1837,62 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
+    # MCP server names from config are system-level capabilities — they should
+    # pass through the parent intersection when explicitly requested, because
+    # the parent may not have them in its derived toolset set.
+    _mcp_server_names = set()
+    try:
+        from tools.mcp_tool import _load_mcp_config
+        _mcp_server_names = set(_load_mcp_config().keys())
+    except Exception:
+        pass
+
     if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks
-        child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
+        # Intersect with parent — subagent must not gain tools the parent lacks.
+        # MCP servers bypass the intersection since they're system-level config.
+        subagent_toolsets = _strip_blocked_tools(
+            [t for t in toolsets if t in parent_toolsets or t in _mcp_server_names]
+        )
     elif parent_agent and parent_enabled is not None:
-        child_toolsets = _strip_blocked_tools(parent_enabled)
+        subagent_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:
-        child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
+        subagent_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
     else:
-        child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+        subagent_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
-    child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
+    subagent_prompt = _build_subagent_system_prompt(
+        goal,
+        context,
+        workspace_path=workspace_hint,
+        wall_clock_timeout_seconds=wall_clock_timeout_seconds,
+        deliver=deliver,
+        toolsets=subagent_toolsets,
+    )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
     # Build progress callback to relay tool calls to parent display
-    child_progress_cb = _build_child_progress_callback(task_index, parent_agent)
+    subagent_progress_cb = _build_subagent_progress_callback(task_index, parent_agent)
 
     # Each subagent gets its own iteration budget capped at max_iterations
     # (configurable via delegation.max_iterations, default 50).  This means
     # total iterations across parent + subagents can exceed the parent's
     # max_iterations.  The user controls the per-subagent cap in config.yaml.
 
-    child_thinking_cb = None
-    if child_progress_cb:
-        def _child_thinking(text: str) -> None:
+    subagent_thinking_cb = None
+    if subagent_progress_cb:
+        def _subagent_thinking(text: str) -> None:
             if not text:
                 return
             try:
-                child_progress_cb("_thinking", text)
+                subagent_progress_cb("_thinking", text)
             except Exception as e:
-                logger.debug("Child thinking callback relay failed: %s", e)
+                logger.debug("Subagent thinking callback relay failed: %s", e)
 
-        child_thinking_cb = _child_thinking
+        subagent_thinking_cb = _subagent_thinking
 
     # Resolve effective credentials: config override > parent inherit
     effective_model = model or parent_agent.model
@@ -345,7 +1922,7 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    child = AIAgent(
+    subagent = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
         model=effective_model,
@@ -357,46 +1934,47 @@ def _build_child_agent(
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
-        enabled_toolsets=child_toolsets,
+        enabled_toolsets=subagent_toolsets,
         quiet_mode=True,
-        ephemeral_system_prompt=child_prompt,
+        ephemeral_system_prompt=subagent_prompt,
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
         skip_context_files=True,
         skip_memory=True,
         clarify_callback=None,
-        thinking_callback=child_thinking_cb,
+        thinking_callback=subagent_thinking_cb,
         session_db=getattr(parent_agent, '_session_db', None),
         parent_session_id=getattr(parent_agent, 'session_id', None),
         providers_allowed=parent_agent.providers_allowed,
         providers_ignored=parent_agent.providers_ignored,
         providers_order=parent_agent.providers_order,
         provider_sort=parent_agent.provider_sort,
-        tool_progress_callback=child_progress_cb,
+        tool_progress_callback=subagent_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
     )
-    child._print_fn = getattr(parent_agent, '_print_fn', None)
-    # Set delegation depth so children can't spawn grandchildren
-    child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
+    subagent._print_fn = getattr(parent_agent, '_print_fn', None)
+    # Set delegation depth so subagents can't recurse further.
+    subagent._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
+    subagent._delegate_timeout_seconds = wall_clock_timeout_seconds
 
-    # Share a credential pool with the child when possible so subagents can
+    # Share a credential pool with the subagent when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
-    child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
-    if child_pool is not None:
-        child._credential_pool = child_pool
+    subagent_pool = _resolve_subagent_credential_pool(effective_provider, parent_agent)
+    if subagent_pool is not None:
+        subagent._credential_pool = subagent_pool
 
-    # Register child for interrupt propagation
+    # Register subagent for interrupt propagation
     if hasattr(parent_agent, '_active_children'):
         lock = getattr(parent_agent, '_active_children_lock', None)
         if lock:
             with lock:
-                parent_agent._active_children.append(child)
+                parent_agent._active_children.append(subagent)
         else:
-            parent_agent._active_children.append(child)
+            parent_agent._active_children.append(subagent)
 
-    return child
+    return subagent
 
-def _run_single_child(
+def _run_single_subagent(
     task_index: int,
     goal: str,
     child=None,
@@ -404,10 +1982,11 @@ def _run_single_child(
     **_kwargs,
 ) -> Dict[str, Any]:
     """
-    Run a pre-built child agent. Called from within a thread.
+    Run a pre-built subagent. Called from within a thread.
     Returns a structured result dict.
     """
-    child_start = time.monotonic()
+    subagent_start = time.monotonic()
+    spawn_id = str(getattr(child, "_delegate_spawn_id", "") or "").strip()
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
@@ -430,6 +2009,17 @@ def _run_single_child(
             except Exception as exc:
                 logger.debug("Failed to bind child to leased credential: %s", exc)
 
+    if spawn_id:
+        _update_background_task_heartbeat(
+            spawn_id,
+            task_index,
+            activity={
+                "last_activity_desc": "starting subagent",
+                "api_call_count": 0,
+                "max_iterations": getattr(child, "max_iterations", None),
+            },
+        )
+
     # Heartbeat: periodically propagate child activity to the parent so the
     # gateway inactivity timeout doesn't fire while the subagent is working.
     # Without this, the parent's _last_activity_ts freezes when delegate_task
@@ -445,6 +2035,7 @@ def _run_single_child(
                 continue
             # Pull detail from the child's own activity tracker
             desc = f"delegate_task: subagent {task_index} working"
+            child_summary = None
             try:
                 child_summary = child.get_activity_summary()
                 child_tool = child_summary.get("current_tool")
@@ -464,9 +2055,40 @@ def _run_single_child(
                 touch(desc)
             except Exception:
                 pass
+            if spawn_id:
+                _update_background_task_heartbeat(spawn_id, task_index, activity=child_summary)
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
     _heartbeat_thread.start()
+
+    wall_clock_timeout = _coerce_timeout_seconds(
+        getattr(child, "_delegate_timeout_seconds", None)
+    )
+    _timeout_triggered = threading.Event()
+    _timeout_activity: Dict[str, Any] = {}
+    _timeout_timer = None
+
+    def _trigger_timeout() -> None:
+        try:
+            _timeout_activity.update(child.get_activity_summary())
+        except Exception:
+            pass
+        _timeout_triggered.set()
+        timeout_minutes = max(1, int((wall_clock_timeout or DEFAULT_CHILD_TIMEOUT_SECONDS) // 60))
+        timeout_message = (
+            f"Subagent wall-clock timeout reached after {timeout_minutes} minutes. "
+            "Stop now and return a checkpoint with completed work, remaining work, "
+            "and whether more time is needed."
+        )
+        try:
+            child.interrupt(timeout_message)
+        except Exception as exc:
+            logger.debug("Failed to interrupt child on delegation timeout: %s", exc)
+
+    if wall_clock_timeout and wall_clock_timeout > 0:
+        _timeout_timer = threading.Timer(float(wall_clock_timeout), _trigger_timeout)
+        _timeout_timer.daemon = True
+        _timeout_timer.start()
 
     try:
         result = child.run_conversation(user_message=goal)
@@ -478,14 +2100,17 @@ def _run_single_child(
             except Exception as e:
                 logger.debug("Progress callback flush failed: %s", e)
 
-        duration = round(time.monotonic() - child_start, 2)
+        duration = round(time.monotonic() - subagent_start, 2)
 
         summary = result.get("final_response") or ""
         completed = result.get("completed", False)
         interrupted = result.get("interrupted", False)
         api_calls = result.get("api_calls", 0)
+        timed_out = _timeout_triggered.is_set()
 
-        if interrupted:
+        if timed_out:
+            status = "timed_out"
+        elif interrupted:
             status = "interrupted"
         elif summary:
             # A summary means the subagent produced usable output.
@@ -517,12 +2142,9 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(
-                        content and "error" in content[:80].lower()
-                    )
                     result_meta = {
                         "result_bytes": len(content),
-                        "status": "error" if is_error else "ok",
+                        "status": _tool_result_status(content),
                     }
                     # Match by tool_call_id for parallel calls
                     tc_id = msg.get("tool_call_id")
@@ -534,7 +2156,9 @@ def _run_single_child(
                         tool_trace[-1].update(result_meta)
 
         # Determine exit reason
-        if interrupted:
+        if timed_out:
+            exit_reason = "timeout"
+        elif interrupted:
             exit_reason = "interrupted"
         elif completed:
             exit_reason = "completed"
@@ -560,15 +2184,33 @@ def _run_single_child(
             },
             "tool_trace": tool_trace,
         }
+        if timed_out:
+            checkpoint = _build_timeout_checkpoint(
+                goal,
+                wall_clock_timeout,
+                activity=_timeout_activity,
+                partial_summary=summary or "",
+            )
+            entry["summary"] = checkpoint
+            entry["needs_more_time"] = True
+            entry["timeout_seconds"] = int(wall_clock_timeout or DEFAULT_CHILD_TIMEOUT_SECONDS)
+            entry["last_activity"] = {
+                "description": _timeout_activity.get("last_activity_desc"),
+                "current_tool": _timeout_activity.get("current_tool"),
+                "api_calls": _timeout_activity.get("api_call_count"),
+                "max_iterations": _timeout_activity.get("max_iterations"),
+            }
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+        if spawn_id:
+            _record_background_task_result(spawn_id, task_index, entry)
 
         return entry
 
     except Exception as exc:
-        duration = round(time.monotonic() - child_start, 2)
+        duration = round(time.monotonic() - subagent_start, 2)
         logging.exception(f"[subagent-{task_index}] failed")
-        return {
+        entry = {
             "task_index": task_index,
             "status": "error",
             "summary": None,
@@ -576,8 +2218,14 @@ def _run_single_child(
             "api_calls": 0,
             "duration_seconds": duration,
         }
+        if spawn_id:
+            _record_background_task_result(spawn_id, task_index, entry)
+        return entry
 
     finally:
+        if _timeout_timer is not None:
+            _timeout_timer.cancel()
+
         # Stop the heartbeat thread so it doesn't keep touching parent activity
         # after the child has finished (or failed).
         _heartbeat_stop.set()
@@ -628,6 +2276,8 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
+    background: bool = False,
+    deliver: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -636,6 +2286,11 @@ def delegate_task(
     Supports two modes:
       - Single: provide goal (+ optional context, toolsets)
       - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+
+    When background=true, subagents run in a daemon thread and this function
+    returns immediately with a spawn confirmation. Results are delivered to
+    the 'deliver' target (a Telegram topic name or 'telegram:chat_id:thread_id')
+    when the subagent completes. Spawn/completion events are posted to Agent Activity.
 
     Returns JSON with results array, one entry per task.
     """
@@ -656,6 +2311,7 @@ def delegate_task(
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
+    child_timeout_seconds = _get_subagent_timeout_seconds(cfg)
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -687,10 +2343,15 @@ def delegate_task(
     if not task_list:
         return tool_error("No tasks provided.")
 
-    # Validate each task has a goal
+    # Validate each task has a goal and enrich thin contexts with a contract note.
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+        if not (task.get("context") or "").strip():
+            task["context"] = (
+                "No explicit parent context was provided. Start by inspecting the relevant source-of-truth files, "
+                "discovering the correct workspace/path if needed, and verifying assumptions before making changes."
+            )
 
     overall_start = time.monotonic()
     results = []
@@ -715,11 +2376,13 @@ def delegate_task(
                 task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets, model=creds["model"],
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
+                wall_clock_timeout_seconds=child_timeout_seconds,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
-                override_acp_command=t.get("acp_command") or acp_command,
-                override_acp_args=t.get("acp_args") or acp_args,
+                override_acp_command=t.get("acp_command") or acp_command or creds.get("command"),
+                override_acp_args=t.get("acp_args") or acp_args or creds.get("args"),
+                deliver=deliver,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -727,6 +2390,86 @@ def delegate_task(
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
         _model_tools._last_resolved_tool_names = _parent_tool_names
+
+    # --- Background mode: launch daemon thread and return immediately ---
+    if background:
+        requested_deliver = (deliver or "").strip()
+        if not requested_deliver:
+            return tool_error(
+                "background delegation requires a non-empty 'deliver' target. "
+                "Use a topic name or 'telegram:chat_id:thread_id'."
+            )
+
+        deliver_target = _parse_deliver_target(requested_deliver)
+        if not deliver_target:
+            return tool_error(
+                f"Could not resolve deliver target '{requested_deliver}'. "
+                "Use a valid topic name from config.yaml telegram.extra.group_topics "
+                "or an explicit 'telegram:chat_id:thread_id' target."
+            )
+
+        import hashlib
+        spawn_id = hashlib.sha256(f"{time.time()}-{id(children)}".encode()).hexdigest()[:8]
+        activity_target = _resolve_agent_activity_target()
+        resolved_deliver = f"telegram:{deliver_target['chat_id']}"
+        if deliver_target.get("thread_id"):
+            resolved_deliver += f":{deliver_target['thread_id']}"
+        background_started_at = time.monotonic()
+        activity_meta = _capture_activity_metadata(
+            task_list,
+            children,
+            parent_agent,
+            requested_deliver=requested_deliver,
+            deliver_target=deliver_target,
+            spawn_id=spawn_id,
+        )
+        _register_background_delegation(
+            spawn_id,
+            task_list,
+            requested_deliver=requested_deliver,
+            resolved_deliver=resolved_deliver,
+            activity_meta=activity_meta,
+        )
+
+        # Stamp spawn_id onto each child so _run_single_subagent can update
+        # the delegation registry with heartbeats and task-level status.
+        for _i, _t, child in children:
+            child._delegate_spawn_id = spawn_id
+
+        # Post spawn notification to Agent Activity (keep it short)
+        if activity_target:
+            activity_msg = _build_activity_spawn_message(activity_meta)
+            _send_telegram_sync(
+                activity_target["chat_id"],
+                activity_target.get("thread_id"),
+                activity_msg,
+                context="delegate_task activity spawn",
+                target_label="Agent Activity",
+            )
+
+        # Launch background thread
+        bg_thread = threading.Thread(
+            target=_background_delegation_runner,
+            args=(task_list, children, parent_agent, deliver_target, activity_target, spawn_id, activity_meta, background_started_at),
+            daemon=True,
+        )
+        bg_thread.start()
+
+        # Return immediately so the parent agent can keep talking
+        spawn_summary = {
+            "status": "spawned_background",
+            "spawn_id": spawn_id,
+            "task_count": n_tasks,
+            "tasks": [{"goal": t["goal"][:80]} for t in task_list],
+            "deliver": requested_deliver,
+            "resolved_deliver": resolved_deliver,
+            "message": (
+                f"Spawned {n_tasks} background subagent{'s' if n_tasks > 1 else ''}. "
+                f"Results will be delivered to {requested_deliver} ({resolved_deliver}) when complete. "
+                f"Spawn logged to Agent Activity. You can continue the conversation."
+            ),
+        }
+        return json.dumps(spawn_summary, ensure_ascii=False)
 
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
@@ -853,14 +2596,14 @@ def delegate_task(
     }, ensure_ascii=False)
 
 
-def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):
-    """Resolve a credential pool for the child agent.
+def _resolve_subagent_credential_pool(effective_provider: Optional[str], parent_agent):
+    """Resolve a credential pool for the subagent.
 
     Rules:
     1. Same provider as the parent -> share the parent's pool so cooldown state
        and rotation stay synchronized.
     2. Different provider -> try to load that provider's own pool.
-    3. No pool available -> return None and let the child keep the inherited
+    3. No pool available -> return None and let the subagent keep the inherited
        fixed credential behavior.
     """
     if not effective_provider:
@@ -878,7 +2621,7 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
             return pool
     except Exception as exc:
         logger.debug(
-            "Could not load credential pool for child provider '%s': %s",
+            "Could not load credential pool for subagent provider '%s': %s",
             effective_provider,
             exc,
         )
@@ -896,7 +2639,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     provider:model pair.
 
     If neither base_url nor provider is configured, returns None values so the
-    child inherits everything from the parent agent.
+    subagent inherits everything from the parent agent.
 
     Raises ValueError with a user-friendly message on credential failure.
     """
@@ -932,6 +2675,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "command": None,
+            "args": [],
         }
 
     if not configured_provider:
@@ -942,6 +2687,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "command": None,
+            "args": [],
         }
 
     # Provider is configured — resolve full credentials
@@ -953,7 +2700,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
             f"Check that the provider is configured (API key set, valid provider name), "
             f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
-            f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
+            f"Examples: openai-codex, openrouter, nous, zai, kimi-coding, minimax."
         ) from exc
 
     api_key = runtime.get("api_key", "")
@@ -997,6 +2744,15 @@ def _load_config() -> dict:
         return {}
 
 
+# Backwards-compatible aliases while callers/tests migrate to the new terminology.
+_get_child_timeout_seconds = _get_subagent_timeout_seconds
+_build_child_system_prompt = _build_subagent_system_prompt
+_build_child_progress_callback = _build_subagent_progress_callback
+_build_child_agent = _build_subagent_agent
+_run_single_child = _run_single_subagent
+_resolve_child_credential_pool = _resolve_subagent_credential_pool
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -1004,25 +2760,31 @@ def _load_config() -> dict:
 DELEGATE_TASK_SCHEMA = {
     "name": "delegate_task",
     "description": (
-        "Spawn one or more subagents to work on tasks in isolated contexts. "
-        "Each subagent gets its own conversation, terminal session, and toolset. "
-        "Only the final summary is returned -- intermediate tool results "
-        "never enter your context window.\n\n"
+        "YOUR PRIMARY TOOL. Spawn subagents to handle non-trivial work in "
+        "isolated contexts. Each subagent gets its own conversation, terminal "
+        "session, and toolset. Only the final summary is returned -- "
+        "intermediate tool results never enter your context window.\n\n"
+        "DEFAULT BEHAVIOR: You SHOULD delegate any task requiring 3+ tool calls, "
+        "producing artifacts (files, code, reports), or taking more than 2 minutes. "
+        "Only handle work directly if it is trivial (single lookup, quick answer).\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
         "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
         "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
         "All run concurrently and results are returned together.\n\n"
-        "WHEN TO USE delegate_task:\n"
-        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
-        "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
-        "WHEN NOT TO USE (use these instead):\n"
-        "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
-        "- Single tool call -> just call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
-        "IMPORTANT:\n"
-        "- Subagents have NO memory of your conversation. Pass all relevant "
-        "info (file paths, error messages, constraints) via the 'context' field.\n"
+        "CRITICAL — CONTEXT IS EVERYTHING:\n"
+        "- Subagents have NO memory of your conversation. The 'context' field is "
+        "their ONLY source of background information.\n"
+        "- Include: file paths, error messages, project structure, constraints, "
+        "design rules, playbook content, and any relevant prior findings.\n"
+        "- The more specific and complete the context, the better the result.\n"
+        "- Check playbooks/ for matching playbooks and include them in context.\n\n"
+        "BACKGROUND MODE (set background=true, ALWAYS USE THIS):\n"
+        "- Subagents run in a daemon thread — you return IMMEDIATELY\n"
+        "- Set 'deliver' to the topic name where results should land "
+        "(e.g. 'SEO Research', 'Builds', or 'telegram:chat_id:thread_id')\n"
+        "- Spawn and completion events are auto-posted to Agent Activity\n"
+        "- Tell the user what was spawned and where results will appear, then move on\n\n"
+        "CONSTRAINTS:\n"
         "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
         "execute_code.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
@@ -1092,6 +2854,25 @@ DELEGATE_TASK_SCHEMA = {
                     "When provided, top-level goal/context/toolsets are ignored."
                 ),
             },
+            "background": {
+                "type": "boolean",
+                "description": (
+                    "Defaults to true. Subagents run in background and return immediately. "
+                    "Set to false ONLY if you need the result before your next reply (rare). "
+                    "Results are delivered to the 'deliver' target when complete. "
+                    "Spawn/completion notifications go to Agent Activity automatically."
+                ),
+            },
+            "deliver": {
+                "type": "string",
+                "description": (
+                    "Where to deliver results when the subagent finishes. "
+                    "Use a topic name (e.g. 'SEO Research', 'Builds', 'Playbook - Website Build') "
+                    "or explicit format 'telegram:chat_id:thread_id'. "
+                    "Topic names are resolved from config.yaml telegram.extra.group_topics. "
+                    "Required when background=true."
+                ),
+            },
             "max_iterations": {
                 "type": "integer",
                 "description": (
@@ -1137,7 +2918,177 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
+        background=args.get("background", True),
+        deliver=args.get("deliver"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",
+)
+
+DELEGATE_STATUS_SCHEMA = {
+    "name": "delegate_status",
+    "description": (
+        "Check the status of spawned subagents. Use this to monitor background "
+        "delegations, see if they are still running, stalled, or completed, and "
+        "read their results.\n\n"
+        "USAGE:\n"
+        "- No arguments: list recent delegations (most recent first)\n"
+        "- spawn_id: check a specific delegation by its spawn ID\n"
+        "- active_only=true: only show running/spawned/stalled delegations\n\n"
+        "WHEN TO USE:\n"
+        "- After spawning a background subagent, check back on it\n"
+        "- When Dax asks about subagent progress\n"
+        "- Before reporting completion — verify the subagent actually finished\n"
+        "- To detect stalled or failed subagents that need intervention"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "spawn_id": {
+                "type": "string",
+                "description": "Check a specific delegation by spawn ID.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max delegations to return (default 10, max 100).",
+            },
+            "active_only": {
+                "type": "boolean",
+                "description": "Only return active (running/spawned/stalled) delegations.",
+            },
+        },
+        "required": [],
+    },
+}
+
+registry.register(
+    name="delegate_status",
+    toolset="delegation",
+    schema=DELEGATE_STATUS_SCHEMA,
+    handler=lambda args, **kw: delegate_status(
+        spawn_id=args.get("spawn_id"),
+        limit=args.get("limit", 10),
+        active_only=args.get("active_only", False),
+    ),
+    emoji="📊",
+)
+
+
+def delegate_kill(
+    spawn_id: str,
+    *,
+    reason: str = "Killed by user request",
+    parent_agent=None,
+) -> str:
+    """Kill an active background delegation by interrupting its subagent(s)."""
+    spawn_id = (spawn_id or "").strip()
+    if not spawn_id:
+        return json.dumps({"error": "spawn_id is required"}, ensure_ascii=False)
+
+    # 1. Find the delegation in the registry
+    with _DELEGATION_REGISTRY_LOCK:
+        payload = _load_delegation_registry()
+    delegations = payload.get("delegations") or {}
+    entry = delegations.get(spawn_id)
+    if not isinstance(entry, dict):
+        return json.dumps({"error": f"No delegation found for spawn_id '{spawn_id}'"}, ensure_ascii=False)
+
+    current_status = _derive_spawn_status(entry)
+    if current_status in {"completed", "completed_with_issues", "failed", "timed_out", "interrupted"}:
+        return json.dumps({
+            "status": "already_finished",
+            "spawn_id": spawn_id,
+            "final_status": current_status,
+            "message": f"Delegation {spawn_id} already finished with status '{current_status}'. Nothing to kill.",
+        }, ensure_ascii=False)
+
+    # 2. Find and interrupt active child agents
+    interrupted_count = 0
+    if parent_agent and hasattr(parent_agent, '_active_children'):
+        lock = getattr(parent_agent, '_active_children_lock', None)
+        children = []
+        if lock:
+            with lock:
+                children = list(parent_agent._active_children)
+        else:
+            children = list(parent_agent._active_children)
+
+        for child in children:
+            child_spawn_id = str(getattr(child, "_delegate_spawn_id", "") or "").strip()
+            if child_spawn_id == spawn_id:
+                try:
+                    child.interrupt(f"KILLED: {reason}")
+                    interrupted_count += 1
+                    logger.info("Interrupted child agent for spawn %s: %s", spawn_id, reason)
+                except Exception as exc:
+                    logger.warning("Failed to interrupt child for spawn %s: %s", spawn_id, exc)
+
+    # 3. Update registry to mark as killed
+    now_ts = _registry_now_ts()
+
+    def _mutator(reg: Dict[str, Any]) -> None:
+        e = (reg.get("delegations") or {}).get(spawn_id)
+        if not isinstance(e, dict):
+            return
+        e["status"] = "failed"
+        e["finished_at_ts"] = now_ts
+        e["updated_at_ts"] = now_ts
+        e["runner_error"] = f"Killed: {reason}"
+        for task in (e.get("tasks") or []):
+            if task.get("status") in ("spawned", "running", "stalled"):
+                task["status"] = "interrupted"
+                task["error"] = f"Killed: {reason}"
+                task["finished_at_ts"] = now_ts
+                task["updated_at_ts"] = now_ts
+
+    _mutate_delegation_registry(_mutator)
+
+    return json.dumps({
+        "status": "killed",
+        "spawn_id": spawn_id,
+        "interrupted_agents": interrupted_count,
+        "reason": reason,
+        "message": f"Delegation {spawn_id} killed. {interrupted_count} active agent(s) interrupted.",
+    }, ensure_ascii=False)
+
+
+DELEGATE_KILL_SCHEMA = {
+    "name": "delegate_kill",
+    "description": (
+        "Kill an active background delegation. Interrupts the running subagent(s) "
+        "and marks the delegation as failed in the registry.\n\n"
+        "USAGE:\n"
+        "- spawn_id (required): the spawn ID to kill\n"
+        "- reason (optional): why it's being killed\n\n"
+        "WHEN TO USE:\n"
+        "- Dax asks to kill/stop/cancel a subagent\n"
+        "- A delegation is stalled and needs to be terminated\n"
+        "- You need to abort a run that was started with wrong parameters"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "spawn_id": {
+                "type": "string",
+                "description": "The spawn ID of the delegation to kill.",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Why the delegation is being killed (optional, for logging).",
+            },
+        },
+        "required": ["spawn_id"],
+    },
+}
+
+registry.register(
+    name="delegate_kill",
+    toolset="delegation",
+    schema=DELEGATE_KILL_SCHEMA,
+    handler=lambda args, **kw: delegate_kill(
+        spawn_id=args.get("spawn_id"),
+        reason=args.get("reason", "Killed by user request"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    emoji="🛑",
 )

--- a/tools/research_lane_launch_tool.py
+++ b/tools/research_lane_launch_tool.py
@@ -1812,8 +1812,10 @@ LAUNCH_RESEARCH_LANE_SCHEMA = {
         "he explicitly asked for something specific.\n\n"
         "If Dax specifies a particular topic or question, use that as the topic. "
         "If he just says 'go deeper' or 'do more research', YOU decide the topic.\n\n"
-        "QUIET UX: Send one short acknowledgment, then deliver the Google Doc link "
-        "to the research topic when done. No status spam."
+        "QUIET UX — THIS IS CRITICAL: After calling this tool, reply to Dax with ONLY "
+        "'Got it, spawning now.' — nothing else. No explanation of what you're doing, "
+        "no breakdown of the topic, no status updates. Just 'Got it, spawning now.' "
+        "The Google Doc link will be delivered to the research topic automatically when done."
     ),
     "parameters": {
         "type": "object",

--- a/tools/research_lane_launch_tool.py
+++ b/tools/research_lane_launch_tool.py
@@ -1470,7 +1470,7 @@ def _run_lane_pipeline(
                 authority=authority,
                 stage_name=stage_name,
             )
-            result = _delegate_single(goal=goal, context=context, toolsets=["file"], max_iterations=15, parent_agent=parent_agent)
+            result = _delegate_single(goal=goal, context=context, toolsets=["file"], max_iterations=30, parent_agent=parent_agent)
             if result.get("error"):
                 _mark_stage_failed(state, stage_name, state_file, result["error"])
                 msg = _build_blocker_message(topic_title, result["error"], state_file)
@@ -1554,7 +1554,7 @@ def _run_lane_pipeline(
                 stage_inputs=stage_inputs,
                 google_docs_state=google_docs_state,
             )
-            result = _delegate_single(goal=goal, context=context, toolsets=stage3_toolsets, max_iterations=15, parent_agent=parent_agent)
+            result = _delegate_single(goal=goal, context=context, toolsets=stage3_toolsets, max_iterations=30, parent_agent=parent_agent)
             if result.get("error"):
                 _mark_stage_failed(state, stage_name, state_file, result["error"])
                 msg = _build_blocker_message(topic_title, result["error"], state_file)

--- a/tools/research_lane_launch_tool.py
+++ b/tools/research_lane_launch_tool.py
@@ -1444,9 +1444,11 @@ def _run_lane_pipeline(
         return {"status": "blocked", "blocker": blocker, "state_file": str(state_file)}
     if resume_stage is None:
         final_msg = _build_final_message(topic_title, state.get("stages", {}).get("stage-3-writeup", {}), state_file)
-        _send_telegram(origin_target, final_msg, context="research_lane_launch completion")
-        if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+        # Only deliver to the research topic — origin doesn't need the message
+        if deliver_target:
             _send_telegram(deliver_target, final_msg, context="research_lane_launch deliver", target_label=deliver)
+        elif origin_target:
+            _send_telegram(origin_target, final_msg, context="research_lane_launch completion")
         return {"status": "completed", "message": final_msg, "state_file": str(state_file)}
 
     stage_inputs: Dict[str, str] = {}
@@ -1578,9 +1580,11 @@ def _run_lane_pipeline(
                 extras["google_doc_url"] = payload.get("google_doc_url")
             _mark_stage_completed(state, stage_name, state_file, artifact=primary_artifact or None, artifacts=artifacts or None, extras=extras)
             final_message = _build_final_message(topic_title, payload, state_file)
-            _send_telegram(origin_target, final_message, context="research_lane_launch completion")
-            if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+            # Only deliver to the research topic — origin doesn't need the message
+            if deliver_target:
                 _send_telegram(deliver_target, final_message, context="research_lane_launch deliver", target_label=deliver)
+            elif origin_target:
+                _send_telegram(origin_target, final_message, context="research_lane_launch completion")
             return {
                 "status": "completed",
                 "message": final_message,

--- a/tools/research_lane_launch_tool.py
+++ b/tools/research_lane_launch_tool.py
@@ -1660,7 +1660,7 @@ def _launch_runner(
 def launch_research_lane(
     *,
     lane: str,
-    topic: str,
+    topic: Optional[str] = None,
     request: Optional[str] = None,
     playbook_slug: Optional[str] = None,
     deliver: Optional[str] = None,
@@ -1674,7 +1674,8 @@ def launch_research_lane(
     if not (lane or "").strip():
         return json.dumps({"error": "lane is required."})
     if not (topic or "").strip():
-        return json.dumps({"error": "topic is required."})
+        # Default to fundamentals for new lanes
+        topic = f"{lane.strip()} Fundamentals"
 
     lane_slug = _slugify(lane)
     topic_slug = _slugify(topic)
@@ -1797,21 +1798,42 @@ def launch_research_lane(
 
 LAUNCH_RESEARCH_LANE_SCHEMA = {
     "name": "launch_research_lane",
-    "description": "Create or resume a research lane: generate the lane playbook from the standard template when missing, create the Obsidian lane artifacts, stub the Google Drive step if needed, and run the first 3-stage research pipeline quietly in the background.",
+    "description": (
+        "Launch or continue research in a lane. Handles everything automatically: "
+        "creates the playbook, Telegram topic, Obsidian folder, and Google Drive folder "
+        "if they don't exist, then runs the 3-stage research pipeline in the background.\n\n"
+        "TWO MODES:\n"
+        "1. NEW LANE: Dax says 'I want to learn about X' — provide lane name. "
+        "The tool creates all setup and runs the first foundational research.\n"
+        "2. GO DEEPER: Dax says 'do more research on X' or 'go deeper on X' — "
+        "provide the lane name and pick the most logical next topic yourself based on "
+        "what's already been researched. Check the lane's knowledge-brief.md and existing "
+        "docs to decide what gap to fill next. Do NOT ask Dax follow-up questions unless "
+        "he explicitly asked for something specific.\n\n"
+        "If Dax specifies a particular topic or question, use that as the topic. "
+        "If he just says 'go deeper' or 'do more research', YOU decide the topic.\n\n"
+        "QUIET UX: Send one short acknowledgment, then deliver the Google Doc link "
+        "to the research topic when done. No status spam."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
             "lane": {
                 "type": "string",
-                "description": "Research lane/domain name, e.g. 'SEO', 'GBP', 'Reviews Reputation', 'Paid Advertising'.",
+                "description": "Research lane/domain name, e.g. 'SEO', 'GBP', 'Website Capabilities'.",
             },
             "topic": {
                 "type": "string",
-                "description": "Specific topic for the first run, e.g. 'local SEO quick wins'.",
+                "description": (
+                    "Specific research topic. If Dax specified one, use it. "
+                    "If Dax just said 'go deeper' or 'do more research', YOU pick "
+                    "the most logical next topic based on existing lane docs. "
+                    "For a brand new lane, use '{Lane} Fundamentals'."
+                ),
             },
             "request": {
                 "type": "string",
-                "description": "The actual research ask/scope to execute. Defaults to the topic if omitted.",
+                "description": "The actual research ask/scope. Defaults to the topic if omitted.",
             },
             "playbook_slug": {
                 "type": "string",
@@ -1819,25 +1841,25 @@ LAUNCH_RESEARCH_LANE_SCHEMA = {
             },
             "deliver": {
                 "type": "string",
-                "description": "Optional final delivery target for the short completion line (topic name or telegram:chat_id:thread_id). Defaults to origin if omitted.",
+                "description": "Optional delivery target. Usually auto-resolved from the lane's Telegram topic.",
             },
             "create_playbook_if_missing": {
                 "type": "boolean",
-                "description": "When true, generate a standardized domain playbook and index template if they do not exist yet.",
+                "description": "Generate playbook and index template if missing.",
                 "default": True,
             },
             "resume_existing": {
                 "type": "boolean",
-                "description": "When true, resume an interrupted pipeline-state.json instead of starting from scratch.",
+                "description": "Resume interrupted pipeline instead of starting fresh.",
                 "default": True,
             },
             "background": {
                 "type": "boolean",
-                "description": "Run the full lane launch in a background thread so Atlas can send a short acknowledgment immediately.",
+                "description": "Run in background thread.",
                 "default": True,
             },
         },
-        "required": ["lane", "topic"],
+        "required": ["lane"],
     },
 }
 

--- a/tools/research_lane_launch_tool.py
+++ b/tools/research_lane_launch_tool.py
@@ -1702,7 +1702,18 @@ def launch_research_lane(
         deliver = ensured["deliver"]
 
     state = _load_json(state_file)
-    if not state or not resume_existing:
+    # Start fresh if: no state, resume disabled, OR the old run is fully completed
+    # (a completed run means Dax wants a NEW research topic, not a replay)
+    old_run_completed = (
+        state
+        and all(
+            (state.get("stages") or {}).get(s, {}).get("status") == "completed"
+            for s in STAGE_SEQUENCE
+        )
+    )
+    # Also start fresh if the topic changed from the previous run
+    topic_changed = state and state.get("topic") != topic_slug
+    if not state or not resume_existing or old_run_completed or topic_changed:
         state = _default_state(
             lane_title=lane_title,
             lane_slug=lane_slug,

--- a/tools/research_lane_launch_tool.py
+++ b/tools/research_lane_launch_tool.py
@@ -1,0 +1,1858 @@
+#!/usr/bin/env python3
+"""Research lane launch orchestration.
+
+Creates or refreshes the local research lane scaffolding, optionally generates a
+standardized domain playbook from the canonical template, records/stubs the
+Google Drive folder step, and runs the first 3-stage research pipeline with a
+quiet messaging contract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OBSIDIAN_ROOT = Path(os.path.expanduser("~/Obsidian/Jarvis-Operations"))
+DEFAULT_PLAYBOOKS_DIR = DEFAULT_OBSIDIAN_ROOT / "🧠 Brain" / "playbooks"
+DEFAULT_TEMPLATES_DIR = DEFAULT_PLAYBOOKS_DIR / "templates"
+DEFAULT_RESEARCH_ROOT = DEFAULT_OBSIDIAN_ROOT / "🏗️ Projects" / "rww" / "research"
+
+STAGE_SEQUENCE = [
+    "stage-1-knowledge",
+    "stage-2-web-research",
+    "stage-3-writeup",
+]
+
+KNOWN_PLAYBOOK_ALIASES = {
+    "seo": "seo-research",
+    "seo-research": "seo-research",
+    "gbp": "gbp-research",
+    "gbp-research": "gbp-research",
+    "geo": "geo-research",
+    "geo-research": "geo-research",
+    "website-craft": "website-research",
+    "website-research": "website-research",
+    "reviews": "reviews-reputation-research",
+    "reviews-reputation": "reviews-reputation-research",
+    "reputation": "reviews-reputation-research",
+    "paid-advertising": "paid-advertising-research",
+    "social-media": "social-media-research",
+    "agency-business-model": "agency-business-model-research",
+    "client-market-analysis": "client-market-analysis-research",
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _today_str() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _slugify(value: str) -> str:
+    text = re.sub(r"[^a-z0-9]+", "-", (value or "").strip().lower())
+    return text.strip("-") or "research-topic"
+
+
+def _obsidian_root() -> Path:
+    override = os.getenv("HERMES_RESEARCH_OBSIDIAN_ROOT", "").strip()
+    return Path(override).expanduser() if override else DEFAULT_OBSIDIAN_ROOT
+
+
+def _playbooks_dir() -> Path:
+    override = os.getenv("HERMES_RESEARCH_PLAYBOOKS_DIR", "").strip()
+    return Path(override).expanduser() if override else (_obsidian_root() / "🧠 Brain" / "playbooks")
+
+
+def _templates_dir() -> Path:
+    override = os.getenv("HERMES_RESEARCH_TEMPLATES_DIR", "").strip()
+    return Path(override).expanduser() if override else (_playbooks_dir() / "templates")
+
+
+def _research_root() -> Path:
+    override = os.getenv("HERMES_RESEARCH_ROOT", "").strip()
+    return Path(override).expanduser() if override else (_obsidian_root() / "🏗️ Projects" / "rww" / "research")
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _load_json(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        logger.warning("Failed to parse JSON file %s", path)
+        return None
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _ensure_generic_index_standard_template() -> Path:
+    path = _templates_dir() / "research-index-standard-template.md"
+    if path.exists():
+        return path
+    content = f"""# Template: Research Index Standard
+
+**Asset Class:** Template
+**Last Updated:** {_today_str()}
+**Canonical Path:** `{path}`
+**Owner:** Atlas + Dax
+**Type:** Canonical template — base standard for domain research indexes
+
+---
+
+## Purpose
+
+This is the standard template for a domain research index. Each lane-specific index template should be generated from this structure so Stage 3 can create/update one consistent index for every domain.
+
+## Rules
+- Keep newest entries first within each section.
+- Preserve history; mark older docs `superseded` or `stale` instead of deleting them.
+- Every entry should point to both the durable markdown artifact and the Google Doc link record.
+- The index is the durable source of truth for freshness and scope.
+
+---
+
+# {{domain_name}} Research Index
+**Last Updated:** {{date}}
+**Owner:** Atlas + Dax
+
+## 1. Evergreen Foundation Docs
+
+### {{domain_name}} Fundamentals
+- **Doc Type:** foundation
+- **Status:** evergreen
+- **Last Updated:** {{date}}
+- **Scope:** Broad, durable domain knowledge to preserve long-term
+- **Google Doc:** {{url_or_tbd}}
+- **Markdown Artifact:** `{{foundation_markdown_path}}`
+- **Doc Link Record:** `{{foundation_doc_link_path}}`
+- **Notes:** Update only when baseline understanding materially changes.
+
+## 2. Central Index Records
+
+### {{domain_name}} Research Index
+- **Doc Type:** index
+- **Status:** evergreen
+- **Last Updated:** {{date}}
+- **Google Doc:** {{url_or_tbd}}
+- **Markdown Artifact:** `{{index_markdown_path}}`
+- **Doc Link Record:** `{{index_doc_link_path}}`
+- **Notes:** This file tracks all domain docs and their freshness.
+
+## 3. Topic-Specific Docs
+
+### {{date}} — {{topic_title}}
+- **Doc Type:** topic | audit | strategy | question | update
+- **Status:** current snapshot
+- **Scope:** {{exact_scope}}
+- **Freshness Window:** {{freshness_window}}
+- **Google Doc:** {{url}}
+- **Markdown Artifact:** `{{topic_markdown_pattern}}`
+- **Doc Link Record:** `{{topic_doc_link_pattern}}`
+- **Related Docs:** {{related_docs}}
+- **Supersedes:** {{supersedes}}
+- **Why This Exists:** {{why_this_exists}}
+
+## 4. Refresh Queue
+- {{refresh_item}}
+
+## 5. Superseded / Historical Docs
+- {{historical_item}}
+"""
+    _write_text(path, content)
+    return path
+
+
+def _render_lane_index_template(lane_title: str, lane_slug: str) -> str:
+    return _read_text(_ensure_generic_index_standard_template()).format(
+        domain_name=lane_title,
+        date=_today_str(),
+        url_or_tbd="{url-or-tbd}",
+        foundation_markdown_path=f"🏗️ Projects/rww/research/{lane_slug}/{lane_slug}-fundamentals-guide.md",
+        foundation_doc_link_path=f"🏗️ Projects/rww/research/{lane_slug}/doc-link.md",
+        index_markdown_path=f"🏗️ Projects/rww/research/{lane_slug}/{lane_slug}-research-index.md",
+        index_doc_link_path=f"🏗️ Projects/rww/research/{lane_slug}/index-doc-link.md",
+        topic_title="Topic Title",
+        exact_scope="{exact question, tactic, market, or subtopic}",
+        freshness_window="{e.g. 90 days unless confirmed still current}",
+        url="{url}",
+        topic_markdown_pattern=f"🏗️ Projects/rww/research/{lane_slug}/topics/{{topic-slug}}/{{YYYY-MM-DD}}-{{topic-slug}}.md",
+        topic_doc_link_pattern=f"🏗️ Projects/rww/research/{lane_slug}/topics/{{topic-slug}}/doc-link.md",
+        related_docs="{foundation doc / related topic docs / none}",
+        supersedes="{older doc or none}",
+        why_this_exists="{why this deserved its own doc instead of a foundation update}",
+        refresh_item="{doc name} — {why it needs refresh}",
+        historical_item="{doc name} — superseded by {newer doc path/link}",
+    )
+
+
+def _standard_playbook_template_path() -> Path:
+    return _templates_dir() / "research-playbook-standard-template.md"
+
+
+def _extract_copyable_playbook_template() -> Optional[str]:
+    template_text = _read_text(_standard_playbook_template_path())
+    if not template_text:
+        return None
+    marker = "## Copyable Template"
+    if marker not in template_text:
+        return None
+    copyable = template_text.split(marker, 1)[1].strip()
+    return copyable or None
+
+
+def _render_playbook_from_standard_template(
+    lane_title: str,
+    lane_slug: str,
+    playbook_path: Path,
+    index_template_path: Path,
+) -> Optional[str]:
+    template = _extract_copyable_playbook_template()
+    if not template:
+        return None
+
+    # Research root for artifact paths
+    research_root = str(_research_root()).replace(str(_obsidian_root()) + "/", "")
+
+    replacements = {
+        "{Domain Name}": f"{lane_title} Research",
+        "{YYYY-MM-DD}": _today_str(),
+        "{absolute path to this playbook}": str(playbook_path),
+        "{profile-name or omit if not used}": "Not used in this domain",
+        "{mode-1}": f"{lane_slug}-education",
+        "{mode-2}": f"{lane_slug}-audit",
+        "{mode-3}": f"{lane_slug}-market-scan",
+        "{one-sentence statement of what this research lane exists to accomplish}": f"Build durable, general-purpose {lane_title.lower()} knowledge progressing from beginner to mastery level, so Atlas has authoritative domain expertise ready to apply in any context.",
+        "{trigger 1}": f"Dax asks to learn, audit, compare, or evaluate anything in {lane_title.lower()}",
+        "{trigger 2}": "Dax wants a repeatable research lane instead of a one-off answer",
+        "{trigger 3}": f"A new scoped topic belongs under the {lane_title.lower()} lane",
+        "{trigger 4}": "A recurring research workflow needs standard setup and persistence",
+        "{phrase 1}": lane_title,
+        "{phrase 2}": lane_slug.replace("-", " "),
+        "{phrase 3}": "market scan",
+        "{Business Name}": "Dax's system",
+        "{what the business is}": "Atlas is building a general knowledge library. Research should produce domain expertise that is universally applicable, not tied to any single business.",
+        "{what the business is really selling}": "Research must produce clear, accurate, general domain knowledge that Atlas can later apply to any business context.",
+        "{primary}": "General domain knowledge applicable to any market",
+        "{secondary}": "Specific applications will be determined when the knowledge is used",
+        "{service or offer line 1}": "General domain expertise and research",
+        "{service or offer line 2}": "Knowledge that progresses from beginner to mastery",
+        "{relevant state of the business}": "This is a generated baseline playbook. Stage 1 should treat older lane docs as context and keep this lane clean as it matures.",
+        "{constraint 1}": "Produce general domain knowledge, not business-specific content",
+        "{constraint 2}": "Prefer durable doc structures over one-off note sprawl",
+        "{constraint 3}": "Scoped / time-sensitive work should become a topic doc, not bloat the foundation doc",
+        "{playbook-file}": playbook_path.stem,
+        "{absolute paths}": f"{research_root}/{lane_slug}/ and 🧠 Brain/playbooks/research-pipeline.md",
+        "{Domain}": lane_title,
+        "{domain}": lane_title.lower(),
+        "{absolute or vault-relative artifact path}": f"{research_root}/{lane_slug}/{lane_slug}-fundamentals-guide.md",
+        "{doc-link path}": f"{research_root}/{lane_slug}/doc-link.md",
+        "{index path}": f"{research_root}/{lane_slug}/{lane_slug}-research-index.md",
+        "{index doc-link path}": f"{research_root}/{lane_slug}/index-doc-link.md",
+        "{path pattern}": f"{research_root}/{lane_slug}/topics/{{topic-slug}}/{{YYYY-MM-DD}}-{{topic-slug}}.md",
+        "{doc-link pattern}": f"{research_root}/{lane_slug}/topics/{{topic-slug}}/doc-link.md",
+        "{market path pattern}": "Not used in this domain",
+        "{audit path pattern}": f"{research_root}/{lane_slug}/topics/{{topic-slug}}/{{YYYY-MM-DD}}-{{topic-slug}}.md",
+        "{experiment path pattern}": "Not used in this domain",
+        "{freshness window}": "90 days",
+        "{domain}-research-index-template.md": index_template_path.name,
+        "{mode-slug}": f"{lane_slug}-education",
+        "{what this mode is for}": f"Build general {lane_title.lower()} knowledge from the ground up — concepts, terminology, how it works, and why it matters.",
+        "{step 1}": "Run Stage 1 document classification.",
+        "{step 2}": "Research current domain fundamentals.",
+        "{step 3}": "Write a clear, readable summary for Dax.",
+        "{step 4}": "Persist findings to the correct foundation or topic artifact.",
+        "{step 5}": "Update the lane index and doc-link records.",
+        "{artifact(s) and where they go}": "Foundation doc or new topic doc, plus index/doc-link persistence in the lane folder.",
+        "{mode-slug-2}": f"{lane_slug}-audit",
+        "{max turns or budget}": "Max 20 turns per stage unless the pipeline playbook says otherwise",
+        "{hard limit}": "30 minutes per run (hard limit)",
+        "{Primary Artifact Name}": "Google Doc Link Record",
+        "{file-name}": "doc-link",
+        "{Artifact Title}": "<Doc Title>",
+        "{date}": "<date>",
+        "{exact scope}": "<exact scope this doc covers>",
+        "{high-level summary bullets}": "<high-level summary bullets>",
+        "{Telegram topic / destination}": f"{lane_title} Research topic in Library group chat (auto-created by lane launch)",
+        "{allowed action 1}": "Run any research mode within the pipeline",
+        "{allowed action 2}": "Create or update Obsidian artifacts within the lane folder",
+        "{allowed action 3}": "Update the central domain index",
+        "{approval-needed action 1}": "Deleting or significantly restructuring existing docs",
+        "{approval-needed action 2}": "Running research outside the defined domain scope",
+        "{approval-needed action 3}": "Sharing research externally beyond Telegram/Obsidian/Drive",
+        "{forbidden action 1}": "Inventing new storage patterns outside the doc architecture",
+        "{forbidden action 2}": "Combining unrelated topics into a single doc",
+        "{forbidden action 3}": "Skipping Stage 1 document classification",
+        "{what broad, durable knowledge belongs here}": f"Broad, evergreen {lane_title.lower()} knowledge that changes baseline understanding",
+        "{path}": f"{research_root}/{lane_slug}/",
+        "{path pattern}": f"{research_root}/{lane_slug}/topics/{{topic-slug}}/",
+    }
+
+    rendered = template
+    for old, new in replacements.items():
+        rendered = rendered.replace(old, new)
+    rendered = rendered.replace("{Domain} Research Index", f"{lane_title} Research Index")
+    rendered = rendered.replace("{Domain} Fundamentals", f"{lane_title} Fundamentals")
+    rendered = rendered.replace("{Domain} Research", f"{lane_title} Research")
+    # Strip any remaining "for Ridley Web Works" suffixes
+    rendered = rendered.replace(" for Ridley Web Works", "")
+    return rendered
+
+
+def _render_generated_playbook(lane_title: str, lane_slug: str, playbook_path: Path, index_template_path: Path) -> str:
+    rendered_from_template = _render_playbook_from_standard_template(
+        lane_title=lane_title,
+        lane_slug=lane_slug,
+        playbook_path=playbook_path,
+        index_template_path=index_template_path,
+    )
+    if rendered_from_template:
+        return rendered_from_template
+    return f"""# Playbook: {lane_title} Research
+
+**Asset Class:** Playbook
+**Last Updated:** {_today_str()}
+**Canonical Path:** `{playbook_path}`
+**Owner:** Atlas + Dax
+**Type:** Generated from `🧠 Brain/playbooks/templates/research-playbook-standard-template.md`
+
+---
+
+## IMPORTANT: Research Execution Pattern
+**All research uses the 3-stage pipeline.** See `🧠 Brain/playbooks/research-pipeline.md` for the execution pattern. This playbook provides the business context, output formats, domain rules, and persistence logic — the pipeline playbook provides the stage execution pattern.
+
+## 1. Identity
+- **Name:** {lane_title} Research
+- **Type:** on-demand, executed via 3-stage research pipeline
+- **Modes:** {lane_slug}-education, {lane_slug}-audit, {lane_slug}-market-scan
+- **Standing mission:** Build durable, general-purpose {lane_title.lower()} knowledge progressing from beginner to mastery level, so Atlas has authoritative domain expertise ready to apply in any context.
+
+## 2. When to Use This Playbook
+Atlas should load this playbook into a subagent's `context` when:
+- Dax asks to learn, audit, compare, or evaluate anything in {lane_title.lower()}
+- Dax wants a repeatable research lane instead of a one-off answer
+- A new scoped topic belongs under the {lane_title.lower()} lane
+- Any task involving: `{lane_title}`, `{lane_slug.replace('-', ' ')}`, `research`, `audit`, `market scan`
+
+## 3. Research Philosophy
+
+**Purpose:** Build general domain knowledge that Atlas can master and later apply to any business context.
+
+**Knowledge progression:** beginner → intermediate → adept → expert → mastery. Early runs should focus on foundational concepts. Later runs deepen into advanced topics.
+
+**Value proposition:** Research must produce clear, accurate, general domain expertise — not content scoped to a single business.
+
+**Current status:** This is a generated baseline playbook. Stage 1 should treat older lane docs as context and keep this lane clean as it matures.
+
+**Operating constraints:**
+- Produce general domain knowledge, not business-specific content
+- Prefer durable doc structures over one-off note sprawl
+- Scoped / time-sensitive work should become a topic doc, not bloat the foundation doc
+
+## 4. Required Context for Subagent
+
+Before spawning a research subagent, Atlas MUST load and pass in `context`:
+1. **This playbook** (the full text of `{playbook_path.name}`)
+2. **`🧠 Brain/playbooks/research-pipeline.md`**
+3. **Existing lane docs** from `🏗️ Projects/rww/research/{lane_slug}/`
+4. **The specific task** — what mode, what scope, what market, what deliverable
+
+If any required files cannot be loaded, do NOT spawn — fix the missing file first.
+
+## Durable {lane_title} Documentation Architecture
+
+### The 3-layer {lane_title.lower()} doc stack
+
+1. **Evergreen foundation doc**
+   - Purpose: durable baseline understanding to preserve long-term
+   - Canonical markdown artifact: `🏗️ Projects/rww/research/{lane_slug}/{lane_slug}-fundamentals-guide.md`
+   - Canonical Google Doc link record: `🏗️ Projects/rww/research/{lane_slug}/doc-link.md`
+
+2. **Central {lane_title.lower()} research index**
+   - Purpose: one index doc linking the foundation doc plus every topic-specific, audit-specific, market-specific, and experiment-specific doc in this lane
+   - Canonical markdown artifact: `🏗️ Projects/rww/research/{lane_slug}/{lane_slug}-research-index.md`
+   - Canonical Google Doc link record: `🏗️ Projects/rww/research/{lane_slug}/index-doc-link.md`
+   - Template source: `🧠 Brain/playbooks/templates/{index_template_path.name}`
+   - If the index does not exist yet, Stage 3 must create it from the template before closing the run.
+
+3. **Separate topic-specific / snapshot / audit docs**
+   - Purpose: keep scoped, time-sensitive, tactic-specific, market-specific, and question-specific work out of the foundation doc
+   - Topic / tactic / question path pattern: `🏗️ Projects/rww/research/{lane_slug}/topics/{{topic-slug}}/{{YYYY-MM-DD}}-{{topic-slug}}.md`
+   - Topic / tactic / question Google Doc link record: `🏗️ Projects/rww/research/{lane_slug}/topics/{{topic-slug}}/doc-link.md`
+   - Every one of these docs must also be added to the central {lane_title.lower()} research index.
+
+### Stage 1 document-classification rule
+Before Stage 2 web research begins, Stage 1 MUST read:
+- the foundation doc + its `doc-link.md`
+- the central index + its `doc-link.md` if they exist
+- related topic docs, prior raw findings, and any related Obsidian notes
+
+Then Stage 1 MUST return one of these document decisions:
+- `update-foundation`
+- `update-existing-doc`
+- `new-topic-doc`
+- `adjacent-topic-new-doc`
+
+### Freshness, scope, and anti-duplication rules
+- Every {lane_title.lower()} doc must state exact scope, date, and whether it is `evergreen` or a `snapshot`.
+- Treat docs older than 90 days as context, not automatically current truth, unless Stage 1 explicitly confirms they still hold.
+- When uncertain between `update` and `new doc`, choose the new scoped doc and link it back to the related prior doc.
+
+### Stage 3 persistence rules
+- Stage 3 must honor Stage 1's document decision.
+- Every Google Doc must have a companion Obsidian `doc-link.md` record.
+- Stage 3 must create or update the central research index on every run.
+- If Google Docs or Drive capabilities are unavailable, Stage 3 must write a clear Obsidian stub showing the exact missing external boundary.
+
+## 5. Research Modes
+
+### Mode: {lane_slug}-education
+**Goal:** Build general {lane_title.lower()} knowledge from the ground up — concepts, terminology, how it works, and why it matters.
+
+**Workflow:**
+1. Run Stage 1 document classification.
+2. Research current domain fundamentals.
+3. Write a clear, readable summary for Dax.
+4. Persist findings to the correct foundation or topic artifact.
+5. Update the lane index and doc-link records.
+
+**Output:** foundation doc or new topic doc, plus index/doc-link persistence.
+
+### Mode: {lane_slug}-audit
+**Goal:** Audit a business, page set, competitor set, or market through the lens of this domain.
+
+**Workflow:**
+1. Read target context and any prior audits.
+2. Use Stage 1 to classify whether this is a new snapshot or update.
+3. Research the relevant gaps live.
+4. Write prioritized findings.
+5. Save the audit and update the index.
+
+**Output:** scoped audit doc + doc-link + updated index entry.
+
+### Mode: {lane_slug}-market-scan
+**Goal:** Capture a market-specific or time-sensitive snapshot without polluting the evergreen foundation doc.
+
+**Workflow:**
+1. Read related lane docs and prior snapshots.
+2. Use Stage 1 to classify the run.
+3. Research the target market/topic live.
+4. Synthesize findings into a dated scoped doc.
+5. Update the index and doc-link records.
+
+**Output:** dated topic or market-scan doc + doc-link + updated index entry.
+
+## 6. Assigned Model
+- **Model:** gpt-5.4 via openai-codex
+- **Cost ceiling:** Max 20 turns per stage unless the pipeline playbook says otherwise
+- **Timeout:** 30 minutes per run (hard limit)
+- **Toolsets:** terminal, file, web
+
+## 7. Output Formats
+
+### Google Doc Link Record — doc-link.md
+```markdown
+# <Doc Title>
+**Date:** <date>
+**Doc Type:** <foundation|index|topic|audit|market-scan|experiment|update>
+**Scope:** <exact scope this doc covers>
+**Status:** <evergreen|current snapshot|superseded|stale>
+**Google Doc:** <url-or-pending>
+
+## Related Docs
+- <related doc path or \"none\">
+
+## Notes
+- <freshness window, supersedes note, or why this doc exists>
+```
+
+## 8. Quality Bar
+- [ ] Stage 1 checked the foundation doc, central index, and related prior docs before fresh research
+- [ ] Stage 1 explicitly classified the run as `update-foundation`, `update-existing-doc`, `new-topic-doc`, or `adjacent-topic-new-doc`
+- [ ] All claims are grounded in actual sources or actual local files
+- [ ] Time-sensitive / scoped work went into a dated doc instead of bloating the foundation guide
+- [ ] Every Google Doc has a paired `doc-link.md` record and an index entry
+- [ ] Missing external capabilities are recorded explicitly when Google Docs/Drive steps cannot complete
+
+## 9. Boundaries
+
+### May do autonomously
+- Create or refresh lane artifacts and playbooks in Obsidian
+- Run the standard 3-stage research pipeline
+- Create Google Docs when the tool is available and connected
+
+### Requires Dax approval
+- External outreach or sending results outside the normal research destinations
+- Any paid external tool activation beyond existing connected services
+
+## 10. Routing Contract
+- Long-form research docs live in the requested research destination.
+- Agent Activity receives concise spawn/completion visibility.
+- The origin conversation gets only: short acknowledgment at launch, then short completion/blocker at the end.
+
+## 11. Artifact Paths
+- Lane root: `🏗️ Projects/rww/research/{lane_slug}/`
+- Topic docs: `🏗️ Projects/rww/research/{lane_slug}/topics/{{topic-slug}}/`
+- Pipeline state: `🏗️ Projects/rww/research/{lane_slug}/topics/{{topic-slug}}/pipeline-state.json` (or lane root for foundation runs)
+- Google Drive note/stub: `drive-folder.md` in the active topic folder
+
+## 12. Revision Memory
+| Date | Change |
+|------|--------|
+| {_today_str()} | Generated lane playbook from the standard research template during lane launch. |
+"""
+
+
+def _resolve_playbook(lane_slug: str, playbook_slug: Optional[str]) -> Tuple[Path, str]:
+    if playbook_slug:
+        normalized = playbook_slug.strip().lower().removesuffix(".md")
+    else:
+        normalized = KNOWN_PLAYBOOK_ALIASES.get(lane_slug, f"{lane_slug}-research")
+    return _playbooks_dir() / f"{normalized}.md", normalized
+
+
+def _is_foundation_topic(lane_slug: str, topic_slug: str) -> bool:
+    normalized_lane = (lane_slug or "").strip().lower()
+    normalized_topic = (topic_slug or "").strip().lower()
+    if not normalized_lane or not normalized_topic:
+        return False
+    return normalized_topic in {
+        normalized_lane,
+        f"{normalized_lane}-fundamentals",
+        f"{normalized_lane}-fundamentals-guide",
+    }
+
+
+def _resolve_paths(lane_slug: str, topic_slug: str, playbook_path: Path, playbook_slug: str) -> Dict[str, Path]:
+    lane_root = _research_root() / lane_slug
+    topic_dir = lane_root if _is_foundation_topic(lane_slug, topic_slug) else (lane_root / "topics" / topic_slug)
+    date_str = _today_str()
+    return {
+        "lane_root": lane_root,
+        "topic_dir": topic_dir,
+        "state_file": topic_dir / "pipeline-state.json",
+        "lane_launch_note": topic_dir / "lane-launch.md",
+        "drive_note": topic_dir / "drive-folder.md",
+        "knowledge_brief": topic_dir / "knowledge-brief.md",
+        "raw_findings": topic_dir / "raw-findings.md",
+        "default_writeup": topic_dir / f"{date_str}-{topic_slug}.md",
+        "foundation_doc": lane_root / f"{lane_slug}-fundamentals-guide.md",
+        "index_doc": lane_root / f"{lane_slug}-research-index.md",
+        "doc_link": topic_dir / "doc-link.md",
+        "index_doc_link": lane_root / "index-doc-link.md",
+        "playbook": playbook_path,
+        "index_template": _templates_dir() / f"{lane_slug}-research-index-template.md",
+    }
+
+
+LIBRARY_CHAT_ID = "-1003727531067"
+GOOGLE_DRIVE_RESEARCH_PARENT_ID = "0ABiwxqF63XS0Uk9PVA"
+
+
+def _get_bot_token() -> Optional[str]:
+    """Read Telegram bot token from .env or environment."""
+    env_path = Path(os.path.expanduser("~/.hermes/.env"))
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            if k.strip() == "TELEGRAM_BOT_TOKEN":
+                return v.strip()
+    return os.environ.get("TELEGRAM_BOT_TOKEN") or os.environ.get("HERMES_TELEGRAM_BOT_TOKEN")
+
+
+def _create_telegram_topic(lane_title: str) -> Optional[Dict[str, Any]]:
+    """Create a forum topic in the Library group chat via Telegram Bot API.
+
+    Returns {"thread_id": int, "name": str} on success, None on failure.
+    """
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    token = _get_bot_token()
+    if not token:
+        logger.warning("No Telegram bot token — cannot create topic for %s", lane_title)
+        return None
+
+    topic_name = f"{lane_title} Research"
+    params = json.dumps({
+        "chat_id": int(LIBRARY_CHAT_ID),
+        "name": topic_name,
+        "icon_color": 7322096,  # blue
+    })
+
+    url = f"https://api.telegram.org/bot{token}/createForumTopic"
+    req = urllib.request.Request(
+        url,
+        data=params.encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read().decode("utf-8"))
+        if body.get("ok") and body.get("result"):
+            thread_id = body["result"].get("message_thread_id")
+            logger.info("Created Telegram topic '%s' (thread_id=%s) in Library chat", topic_name, thread_id)
+            return {"thread_id": thread_id, "name": topic_name}
+        logger.warning("createForumTopic returned ok=false: %s", body)
+        return None
+    except Exception as exc:
+        logger.warning("Failed to create Telegram topic for %s: %s", lane_title, exc)
+        return None
+
+
+def _register_topic_in_config(thread_id: int, topic_name: str) -> bool:
+    """Add the new topic to config.yaml group_topics and group_system_prompts."""
+    try:
+        import yaml
+        config_path = Path(os.path.expanduser("~/.hermes/config.yaml"))
+        if not config_path.exists():
+            return False
+        text = config_path.read_text(encoding="utf-8")
+        cfg = yaml.safe_load(text) or {}
+
+        # Add to group_topics
+        tg = cfg.setdefault("telegram", {}).setdefault("extra", {})
+        group_topics = tg.setdefault("group_topics", [])
+        library_group = None
+        for group in group_topics:
+            if str(group.get("chat_id")) == str(LIBRARY_CHAT_ID).lstrip("-"):
+                library_group = group
+                break
+            if str(group.get("chat_id")) == LIBRARY_CHAT_ID:
+                library_group = group
+                break
+        if library_group is None:
+            library_group = {"chat_id": int(LIBRARY_CHAT_ID), "topics": []}
+            group_topics.append(library_group)
+        topics = library_group.setdefault("topics", [])
+        # Check if already exists
+        if not any(t.get("thread_id") == thread_id for t in topics):
+            topics.append({"name": topic_name, "thread_id": thread_id})
+
+        # Add to group_system_prompts
+        prompts = cfg.setdefault("group_system_prompts", {})
+        chat_prompts = prompts.setdefault(LIBRARY_CHAT_ID, {})
+        tid_str = str(thread_id)
+        if tid_str not in chat_prompts:
+            clean_name = topic_name.upper()
+            chat_prompts[tid_str] = {
+                "name": topic_name,
+                "prompt": (
+                    f"You are Atlas in the {clean_name} workspace. "
+                    f"Keep this topic focused on {topic_name} only, "
+                    "and keep outputs research-first rather than execution management."
+                ),
+            }
+
+        config_path.write_text(yaml.dump(cfg, default_flow_style=False, allow_unicode=True, sort_keys=False), encoding="utf-8")
+        logger.info("Registered topic '%s' (thread_id=%s) in config.yaml", topic_name, thread_id)
+        return True
+    except Exception as exc:
+        logger.warning("Failed to register topic in config.yaml: %s", exc)
+        return False
+
+
+def _create_google_drive_folder(lane_title: str, parent_folder_id: Optional[str] = GOOGLE_DRIVE_RESEARCH_PARENT_ID) -> Optional[Dict[str, Any]]:
+    """Create a Google Drive folder for the research lane via MCP.
+
+    Returns {"folder_id": str, "url": str} on success, None if MCP unavailable.
+    """
+    try:
+        tool_names = set(registry.get_all_tool_names())
+        create_folder_tool = "mcp_maton_google_docs_google_drive_create_folder"
+        if create_folder_tool not in tool_names:
+            logger.debug("Google Drive create_folder tool not registered — cannot create folder")
+            return None
+
+        folder_name = f"{lane_title} Research"
+        args = {"name": folder_name}
+        if parent_folder_id:
+            args["parent_id"] = parent_folder_id
+
+        raw = registry.dispatch(create_folder_tool, args)
+        parsed = json.loads(raw) if isinstance(raw, str) else raw
+
+        # Extract folder ID from MCP response
+        folder_data = None
+        if isinstance(parsed, dict):
+            content = parsed.get("content")
+            if isinstance(content, list) and content:
+                text = content[0].get("text", "")
+                folder_data = json.loads(text) if text else {}
+            elif isinstance(parsed.get("result"), str):
+                folder_data = json.loads(parsed["result"])
+            elif isinstance(parsed.get("result"), dict):
+                folder_data = parsed["result"]
+            elif parsed.get("id"):
+                folder_data = parsed
+
+        if isinstance(folder_data, dict) and folder_data.get("id"):
+            folder_id = folder_data["id"]
+            url = f"https://drive.google.com/drive/folders/{folder_id}"
+            logger.info("Created Google Drive folder '%s' (id=%s)", folder_name, folder_id)
+            return {"folder_id": folder_id, "url": url, "name": folder_name}
+
+        logger.warning("Drive create_folder returned unexpected response: %s", str(parsed)[:200])
+        return None
+    except Exception as exc:
+        logger.warning("Google Drive folder creation failed: %s", exc)
+        return None
+
+
+def _ensure_lane_assets(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    request: str,
+    deliver: Optional[str],
+    playbook_path: Path,
+    playbook_slug: str,
+    create_playbook_if_missing: bool,
+) -> Dict[str, Any]:
+    paths = _resolve_paths(lane_slug, topic_slug, playbook_path, playbook_slug)
+    for key in ("lane_root", "topic_dir"):
+        paths[key].mkdir(parents=True, exist_ok=True)
+
+    _ensure_generic_index_standard_template()
+    generated_playbook = False
+    generated_index_template = False
+
+    if create_playbook_if_missing and not paths["index_template"].exists():
+        _write_text(paths["index_template"], _render_lane_index_template(lane_title, lane_slug))
+        generated_index_template = True
+
+    if create_playbook_if_missing and not playbook_path.exists():
+        playbook_path.parent.mkdir(parents=True, exist_ok=True)
+        _write_text(playbook_path, _render_generated_playbook(lane_title, lane_slug, playbook_path, paths["index_template"]))
+        generated_playbook = True
+
+    # --- Telegram topic creation ---
+    # Only create a topic for THIS lane. Check 3 sources before creating:
+    # 1. The lane's own topic-info file (survives config write failures)
+    # 2. Config.yaml (via _parse_deliver_target)
+    # 3. Explicit deliver target from the caller
+    telegram_topic = None
+    expected_topic_name = f"{lane_title} Research"
+    topic_info_file = paths["lane_root"] / "telegram-topic.json"
+
+    # Source 1: lane's own topic record (most reliable — not affected by config lock)
+    existing_topic_info = _load_json(topic_info_file)
+    if existing_topic_info and existing_topic_info.get("thread_id"):
+        tid = existing_topic_info["thread_id"]
+        deliver = f"telegram:{LIBRARY_CHAT_ID}:{tid}"
+        logger.info("Found existing topic record for lane %s: thread_id=%s", lane_slug, tid)
+    else:
+        # Source 2: config.yaml
+        from tools.delegate_tool import _parse_deliver_target
+        existing_target = _parse_deliver_target(expected_topic_name)
+        if existing_target:
+            deliver = f"telegram:{existing_target['chat_id']}"
+            if existing_target.get("thread_id"):
+                deliver += f":{existing_target['thread_id']}"
+            # Save to lane folder so we don't depend on config next time
+            _write_json(topic_info_file, {"thread_id": existing_target.get("thread_id"), "name": expected_topic_name, "chat_id": existing_target["chat_id"]})
+            logger.info("Found existing Telegram topic '%s' in config → deliver=%s", expected_topic_name, deliver)
+        elif not deliver or deliver == "origin":
+            # Source 3: No existing topic anywhere — create one for THIS lane only
+            telegram_topic = _create_telegram_topic(lane_title)
+            if telegram_topic and telegram_topic.get("thread_id"):
+                _register_topic_in_config(telegram_topic["thread_id"], telegram_topic["name"])
+                # Always save to lane folder as the durable record
+                _write_json(topic_info_file, {"thread_id": telegram_topic["thread_id"], "name": telegram_topic["name"], "chat_id": LIBRARY_CHAT_ID})
+                deliver = f"telegram:{LIBRARY_CHAT_ID}:{telegram_topic['thread_id']}"
+                logger.info("Auto-created Telegram topic for lane %s: %s → deliver=%s", lane_slug, telegram_topic["name"], deliver)
+        # If an explicit deliver was passed, use it as-is — do NOT create a new topic
+
+    # --- Google Drive folder creation ---
+    # Check if a Drive folder for this lane already exists (via drive note from prior run)
+    drive_result = None
+    existing_drive_note = _read_text(paths["drive_note"])
+    if "folder_id" in existing_drive_note or "drive.google.com/drive/folders/" in existing_drive_note:
+        logger.info("Drive folder already exists for lane %s — skipping creation", lane_slug)
+    else:
+        drive_result = _create_google_drive_folder(lane_title)
+    drive_status = _google_drive_capability_status()
+    if drive_result:
+        drive_status["folder_id"] = drive_result.get("folder_id")
+        drive_status["folder_url"] = drive_result.get("url")
+
+    _write_text(
+        paths["drive_note"],
+        _render_drive_note(
+            lane_title=lane_title,
+            lane_slug=lane_slug,
+            topic_title=topic_title,
+            topic_slug=topic_slug,
+            deliver=deliver,
+            drive_status=drive_status,
+        ),
+    )
+
+    _write_text(
+        paths["lane_launch_note"],
+        _render_lane_launch_note(
+            lane_title=lane_title,
+            lane_slug=lane_slug,
+            topic_title=topic_title,
+            topic_slug=topic_slug,
+            request=request,
+            deliver=deliver,
+            playbook_path=playbook_path,
+            drive_note=paths["drive_note"],
+            state_file=paths["state_file"],
+            generated_playbook=generated_playbook,
+            generated_index_template=generated_index_template,
+        ),
+    )
+
+    return {
+        "paths": paths,
+        "generated_playbook": generated_playbook,
+        "generated_index_template": generated_index_template,
+        "drive_status": drive_status,
+        "telegram_topic": telegram_topic,
+        "deliver": deliver,
+    }
+
+
+def _render_lane_launch_note(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    request: str,
+    deliver: Optional[str],
+    playbook_path: Path,
+    drive_note: Path,
+    state_file: Path,
+    generated_playbook: bool,
+    generated_index_template: bool,
+) -> str:
+    return f"""# Research Lane Launch — {topic_title}
+**Date:** {_today_str()}
+**Lane:** {lane_title} (`{lane_slug}`)
+**Topic:** {topic_title} (`{topic_slug}`)
+**Deliver Target:** {deliver or 'origin'}
+**Quiet UX Contract:** Acknowledge once up front, then report only final completion or blocker.
+
+## Request
+{request}
+
+## Assets
+- **Playbook:** `{playbook_path}`{' (generated during launch)' if generated_playbook else ''}
+- **Pipeline State:** `{state_file}`
+- **Drive Step Record:** `{drive_note}`
+- **Lane Root:** `🏗️ Projects/rww/research/{lane_slug}/`
+- **Topic Folder:** `🏗️ Projects/rww/research/{lane_slug}/topics/{topic_slug}/` if scoped topic
+
+## Setup Notes
+- Generated lane playbook this launch: {'yes' if generated_playbook else 'no'}
+- Generated lane index template this launch: {'yes' if generated_index_template else 'no'}
+- Google Drive step handled via `drive-folder.md`
+"""
+
+
+def _google_drive_capability_status() -> Dict[str, Any]:
+    tool_names = set(registry.get_all_tool_names())
+    drive_tools = sorted(name for name in tool_names if "drive" in name.lower())
+    folder_tools = sorted(name for name in drive_tools if "folder" in name.lower())
+    if folder_tools:
+        return {
+            "status": "available",
+            "detail": "Live Google Drive folder capability appears available.",
+            "tools": folder_tools,
+        }
+    return {
+        "status": "stubbed-unavailable",
+        "detail": "No live Google Drive folder creation tool is registered in Hermes yet.",
+        "tools": drive_tools,
+    }
+
+
+def _render_drive_note(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    deliver: Optional[str],
+    drive_status: Dict[str, Any],
+) -> str:
+    desired_folder = f"Research / {lane_title} / {topic_title}"
+    tools_line = ", ".join(drive_status.get("tools") or []) or "none"
+    return f"""# Google Drive Folder — {topic_title}
+**Date:** {_today_str()}
+**Lane:** {lane_title}
+**Topic:** {topic_title}
+**Desired Folder:** {desired_folder}
+**Status:** {drive_status.get('status')}
+
+## Capability Boundary
+- {drive_status.get('detail')}
+- Registered Drive-related tools seen by Hermes: {tools_line}
+
+## Next Action
+- If/when Drive folder creation becomes available, create the folder above and update this file with the real Drive URL / folder ID.
+- Until then, treat this file as the source-of-truth stub for the Drive step.
+
+## Related Paths
+- Lane root: `🏗️ Projects/rww/research/{lane_slug}/`
+- Topic folder: `🏗️ Projects/rww/research/{lane_slug}/topics/{topic_slug}/`
+- Deliver target: {deliver or 'origin'}
+"""
+
+
+def _default_state(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    playbook_slug: str,
+    request: str,
+    deliver: Optional[str],
+    paths: Dict[str, Path],
+    generated_playbook: bool,
+    drive_status: Dict[str, Any],
+) -> Dict[str, Any]:
+    now = _utc_now_iso()
+    return {
+        "topic": topic_slug,
+        "topic_title": topic_title,
+        "lane": lane_slug,
+        "lane_title": lane_title,
+        "pipeline": "research",
+        "playbook": playbook_slug,
+        "started_at": now,
+        "current_stage": "stage-1-knowledge",
+        "request": request,
+        "deliver": deliver or "origin",
+        "lane_launch": {
+            "status": "completed",
+            "completed_at": now,
+            "quiet_mode": True,
+            "playbook_path": str(paths["playbook"]),
+            "playbook_generated": generated_playbook,
+            "lane_root": str(paths["lane_root"]),
+            "topic_dir": str(paths["topic_dir"]),
+            "artifacts": [
+                str(paths["lane_launch_note"]),
+                str(paths["drive_note"]),
+            ],
+            "google_drive": drive_status,
+        },
+        "stages": {
+            "stage-1-knowledge": {"status": "pending", "artifact": str(paths["knowledge_brief"])} ,
+            "stage-2-web-research": {"status": "pending", "artifact": str(paths["raw_findings"])},
+            "stage-3-writeup": {"status": "pending", "artifact": str(paths["default_writeup"])} ,
+        },
+        "last_updated": now,
+    }
+
+
+def _artifact_exists(stage_name: str, stage_state: Dict[str, Any], paths: Dict[str, Path]) -> bool:
+    candidates: List[Path] = []
+    for key in ("artifact",):
+        value = stage_state.get(key)
+        if isinstance(value, str) and value.strip():
+            candidates.append(Path(value))
+    artifacts = stage_state.get("artifacts") or []
+    if isinstance(artifacts, list):
+        for item in artifacts:
+            if isinstance(item, str) and item.strip():
+                candidates.append(Path(item))
+    if stage_name == "stage-1-knowledge":
+        candidates.append(paths["knowledge_brief"])
+    elif stage_name == "stage-2-web-research":
+        candidates.append(paths["raw_findings"])
+    elif stage_name == "stage-3-writeup":
+        candidates.extend([paths["default_writeup"], paths["doc_link"], paths["index_doc"], paths["index_doc_link"]])
+    return any(path.exists() for path in candidates)
+
+
+def _required_stage3_artifacts_exist(paths: Dict[str, Path], artifacts: Optional[List[str]] = None) -> Tuple[bool, List[str]]:
+    required = [paths["doc_link"], paths["index_doc"], paths["index_doc_link"]]
+    markdown_present = paths["default_writeup"].exists()
+    if not markdown_present and isinstance(artifacts, list):
+        markdown_present = any(isinstance(item, str) and item.strip() and Path(item).exists() for item in artifacts)
+    missing = [str(path) for path in required if not path.exists()]
+    if not markdown_present:
+        missing.insert(0, str(paths["default_writeup"]))
+    return (len(missing) == 0), missing
+
+
+def _save_state(state: Dict[str, Any], state_file: Path) -> None:
+    state["last_updated"] = _utc_now_iso()
+    _write_json(state_file, state)
+
+
+def _mark_stage_in_progress(state: Dict[str, Any], stage_name: str, state_file: Path) -> None:
+    now = _utc_now_iso()
+    state["current_stage"] = stage_name
+    stage = state.setdefault("stages", {}).setdefault(stage_name, {})
+    stage["status"] = "in-progress"
+    stage["started_at"] = now
+    stage.pop("error", None)
+    _save_state(state, state_file)
+
+
+def _mark_stage_completed(
+    state: Dict[str, Any],
+    stage_name: str,
+    state_file: Path,
+    *,
+    artifact: Optional[str] = None,
+    artifacts: Optional[List[str]] = None,
+    extras: Optional[Dict[str, Any]] = None,
+) -> None:
+    now = _utc_now_iso()
+    stage = state.setdefault("stages", {}).setdefault(stage_name, {})
+    stage["status"] = "completed"
+    stage["completed_at"] = now
+    if artifact:
+        stage["artifact"] = artifact
+    if artifacts:
+        stage["artifacts"] = artifacts
+    if extras:
+        stage.update(extras)
+    _save_state(state, state_file)
+
+
+def _mark_stage_failed(state: Dict[str, Any], stage_name: str, state_file: Path, error: str) -> None:
+    now = _utc_now_iso()
+    stage = state.setdefault("stages", {}).setdefault(stage_name, {})
+    stage["status"] = "failed"
+    stage["failed_at"] = now
+    stage["error"] = error
+    state["current_stage"] = stage_name
+    _save_state(state, state_file)
+
+
+def _next_stage(stage_name: str) -> Optional[str]:
+    try:
+        idx = STAGE_SEQUENCE.index(stage_name)
+    except ValueError:
+        return None
+    return STAGE_SEQUENCE[idx + 1] if idx + 1 < len(STAGE_SEQUENCE) else None
+
+
+def _resolve_resume_stage(state: Dict[str, Any], paths: Dict[str, Path], state_file: Path) -> Tuple[Optional[str], Optional[str]]:
+    stages = state.setdefault("stages", {})
+    for stage_name in STAGE_SEQUENCE:
+        stage = stages.setdefault(stage_name, {"status": "pending"})
+        status = stage.get("status", "pending")
+        if status == "failed":
+            # Clear the failed status so we can retry instead of permanently blocking
+            stage["status"] = "pending"
+            stage.pop("error", None)
+            _save_state(state, state_file)
+            logger.info("Cleared failed status for %s — will retry", stage_name)
+            return stage_name, None
+        if status == "in-progress":
+            if _artifact_exists(stage_name, stage, paths):
+                _mark_stage_completed(
+                    state,
+                    stage_name,
+                    state_file,
+                    artifact=str(stage.get("artifact") or paths["knowledge_brief" if stage_name == "stage-1-knowledge" else "raw_findings" if stage_name == "stage-2-web-research" else "default_writeup"]),
+                    artifacts=stage.get("artifacts"),
+                )
+                return _next_stage(stage_name), None
+            return stage_name, None
+        if status == "completed":
+            # Verify artifacts actually exist on disk — don't trust status alone
+            if not _artifact_exists(stage_name, stage, paths):
+                logger.warning("Stage %s marked completed but artifacts missing on disk — rerunning", stage_name)
+                stage["status"] = "pending"
+                _save_state(state, state_file)
+                return stage_name, None
+            continue
+        # Pending or unknown status — start from here
+        return stage_name, None
+    return None, None
+
+
+def _resolve_origin_target() -> Optional[Dict[str, str]]:
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        def get_session_env(name: str, default: str = "") -> str:
+            return os.getenv(name, default)
+
+    platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+    if platform and platform != "telegram":
+        return None
+    chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+    thread_id = (get_session_env("HERMES_SESSION_THREAD_ID", "") or "").strip()
+    if not chat_id:
+        return None
+    return {"chat_id": chat_id, "thread_id": thread_id or None}
+
+
+def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
+    if not text or not isinstance(text, str):
+        return None
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"\{", text):
+        try:
+            payload, _ = decoder.raw_decode(text[match.start():])
+        except Exception:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+_TRANSIENT_ERROR_PATTERNS = (
+    "overloaded",
+    "try again later",
+    "rate limit",
+    "timeout",
+    "timed_out",
+    "connection refused",
+    "connection reset",
+    "502",
+    "503",
+    "504",
+    "APIError",
+    "request_id",
+)
+
+
+def _is_transient_error(error_text: str) -> bool:
+    lower = (error_text or "").lower()
+    return any(pattern.lower() in lower for pattern in _TRANSIENT_ERROR_PATTERNS)
+
+
+def _delegate_single(
+    *,
+    goal: str,
+    context: str,
+    toolsets: List[str],
+    max_iterations: int,
+    parent_agent,
+    max_retries: int = 1,
+) -> Dict[str, Any]:
+    import time as _time
+    from tools.delegate_tool import delegate_task
+
+    last_error = None
+    for attempt in range(1 + max_retries):
+        if attempt > 0:
+            logger.info("Retrying stage delegation (attempt %d/%d) after transient error: %s",
+                        attempt + 1, 1 + max_retries, last_error)
+            _time.sleep(min(10 * attempt, 30))
+
+        raw = delegate_task(
+            goal=goal,
+            context=context,
+            toolsets=toolsets,
+            max_iterations=max_iterations,
+            background=False,
+            parent_agent=parent_agent,
+        )
+        try:
+            parsed = json.loads(raw)
+        except Exception:
+            return {"error": f"delegate_task returned non-JSON: {raw[:500]}"}
+
+        if parsed.get("error"):
+            error_str = str(parsed["error"])
+            if attempt < max_retries and _is_transient_error(error_str):
+                last_error = error_str
+                continue
+            return {"error": error_str}
+
+        results = parsed.get("results") or []
+        if not results:
+            return {"error": "delegate_task returned no child results"}
+
+        first = results[0]
+        if first.get("error") and attempt < max_retries and _is_transient_error(str(first["error"])):
+            last_error = str(first["error"])
+            continue
+        if first.get("status") == "failed" and attempt < max_retries and _is_transient_error(str(first.get("error") or first.get("summary") or "")):
+            last_error = str(first.get("error") or first.get("summary") or "failed")
+            continue
+
+        return first
+
+    return {"error": f"Stage failed after {1 + max_retries} attempts. Last error: {last_error}"}
+
+
+def _google_docs_status(parent_agent=None) -> Dict[str, Any]:
+    tool_names = set(registry.get_all_tool_names())
+    required = {
+        "mcp_maton_google_docs_google_docs_check_connection",
+        "mcp_maton_google_docs_google_docs_create_document",
+        "mcp_maton_google_docs_google_docs_insert_text",
+    }
+    if not required.issubset(tool_names):
+        return {
+            "status": "unavailable",
+            "detail": "Google Docs MCP tools are not fully registered.",
+        }
+    try:
+        raw = registry.dispatch(
+            "mcp_maton_google_docs_google_docs_check_connection",
+            {},
+            parent_agent=parent_agent,
+        )
+        parsed = json.loads(raw)
+        payload = None
+        if isinstance(parsed, dict):
+            content = parsed.get("content")
+            if isinstance(content, list) and content:
+                text = content[0].get("text", "")
+                payload = json.loads(text) if text else {}
+            elif isinstance(parsed.get("result"), str) and parsed.get("result", "").strip():
+                payload = json.loads(parsed["result"])
+            elif isinstance(parsed.get("result"), dict):
+                payload = parsed.get("result")
+        if isinstance(payload, dict):
+            if payload.get("connected"):
+                return {"status": "connected", "detail": "Google Docs connection is active."}
+            if payload.get("connected") is False:
+                return {"status": "disconnected", "detail": "Google Docs MCP is registered but no active connection was found."}
+    except Exception as exc:
+        logger.debug("Google Docs connection check failed: %s", exc)
+    return {"status": "unknown", "detail": "Google Docs MCP tools are present but connection status could not be confirmed."}
+
+
+def _load_authority_texts(playbook_path: Path) -> Dict[str, str]:
+    pipeline_path = _playbooks_dir() / "research-pipeline.md"
+    return {
+        "pipeline": _read_text(pipeline_path),
+        "playbook": _read_text(playbook_path),
+    }
+
+
+def _build_stage_context(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    request: str,
+    paths: Dict[str, Path],
+    authority: Dict[str, str],
+    stage_name: str,
+    stage_inputs: Optional[Dict[str, str]] = None,
+    google_docs_state: Optional[Dict[str, Any]] = None,
+) -> str:
+    sections = [
+        f"RESEARCH LANE: {lane_title} ({lane_slug})",
+        f"TOPIC: {topic_title} ({topic_slug})",
+        f"REQUEST: {request}",
+        "QUIET UX CONTRACT: Do the work without asking the user for permission between stages unless genuinely blocked.",
+        f"LANE ROOT: {paths['lane_root']}",
+        f"TOPIC DIR: {paths['topic_dir']}",
+        f"PIPELINE STATE: {paths['state_file']}",
+        f"LANE LAUNCH NOTE: {paths['lane_launch_note']}",
+        f"DRIVE NOTE: {paths['drive_note']}",
+    ]
+    if authority.get("pipeline"):
+        sections.append("=== RESEARCH PIPELINE PLAYBOOK ===\n" + authority["pipeline"] + "\n=== END PLAYBOOK ===")
+    if authority.get("playbook"):
+        sections.append(f"=== DOMAIN PLAYBOOK: {paths['playbook'].name} ===\n" + authority["playbook"] + "\n=== END DOMAIN PLAYBOOK ===")
+    if stage_inputs:
+        if stage_inputs.get("knowledge_brief"):
+            sections.append("=== STAGE 1 KNOWLEDGE BRIEF ===\n" + stage_inputs["knowledge_brief"] + "\n=== END STAGE 1 ===")
+        if stage_inputs.get("raw_findings"):
+            sections.append("=== STAGE 2 RAW FINDINGS ===\n" + stage_inputs["raw_findings"] + "\n=== END STAGE 2 ===")
+    if google_docs_state:
+        sections.append("GOOGLE DOCS STATUS: " + json.dumps(google_docs_state, ensure_ascii=False))
+    sections.append(f"ACTIVE STAGE: {stage_name}")
+    return "\n\n".join(sections)
+
+
+def _stage_goal_stage1(topic_title: str, artifact_path: Path) -> str:
+    return (
+        f"[Stage 1 - Knowledge Assessment] {topic_title}. Read our existing local files and produce the knowledge brief. "
+        f"Write the full markdown brief to {artifact_path}. Return JSON only with keys: "
+        f"status, artifact, document_decision, summary."
+    )
+
+
+def _stage_goal_stage2(topic_title: str, artifact_path: Path) -> str:
+    return (
+        f"[Stage 2 - Web Research] {topic_title}. Research the gaps identified in the Stage 1 knowledge brief. "
+        f"Write the full raw findings markdown to {artifact_path}. Return JSON only with keys: "
+        f"status, artifact, sources_scraped, summary."
+    )
+
+
+def _stage_goal_stage3(
+    *,
+    lane_title: str,
+    topic_title: str,
+    default_artifact_path: Path,
+    doc_link_path: Path,
+    index_doc_path: Path,
+    index_doc_link_path: Path,
+    google_docs_state: Dict[str, Any],
+) -> str:
+    google_docs_instruction = (
+        "Create the Google Doc as the primary output, write the content into it, and include the final Google Doc URL in your JSON return. "
+        if google_docs_state.get("status") == "connected"
+        else "Google Docs is not available for live creation in this run. Create the markdown/doc-link/index artifacts anyway and clearly mark the external boundary in doc-link.md and your JSON return. "
+    )
+    return (
+        f"[Stage 3 - Write-up] {topic_title}. Write a clear, readable research doc for Dax. "
+        f"Honor the Stage 1 document decision. Default markdown target if no better playbook-defined path applies: {default_artifact_path}. "
+        f"Create or update the supporting doc-link at {doc_link_path}, the central index at {index_doc_path}, and the index doc-link at {index_doc_link_path}. "
+        f"{google_docs_instruction}"
+        f"Return JSON only with keys: status, artifact, artifacts, google_doc_url, google_doc_status, summary."
+    )
+
+
+def _stage_result_payload(result: Dict[str, Any]) -> Dict[str, Any]:
+    payload = _extract_json_object(result.get("summary") or "") or {}
+    payload.setdefault("status", result.get("status"))
+    payload.setdefault("summary", result.get("summary") or "")
+    if result.get("error") and not payload.get("error"):
+        payload["error"] = result.get("error")
+    return payload
+
+
+def _build_final_message(topic_title: str, stage3_payload: Dict[str, Any], state_file: Path) -> str:
+    google_doc_url = str(stage3_payload.get("google_doc_url") or "").strip()
+    artifact = str(stage3_payload.get("artifact") or "").strip()
+    if google_doc_url:
+        return f"{topic_title} research complete. {google_doc_url}"
+    if artifact:
+        return f"{topic_title} research complete. Markdown saved to {artifact}"
+    return f"{topic_title} research complete. State: {state_file}"
+
+
+def _build_blocker_message(topic_title: str, blocker: str, state_file: Path) -> str:
+    short = re.sub(r"\s+", " ", blocker or "Unknown blocker").strip()
+    if len(short) > 280:
+        short = short[:277].rstrip() + "..."
+    return f"{topic_title} research blocked. {short} State: {state_file}"
+
+
+def _send_telegram(target: Optional[Dict[str, str]], text: str, *, context: str, target_label: Optional[str] = None) -> bool:
+    if not target:
+        return False
+    from tools.delegate_tool import _send_telegram_sync
+
+    return _send_telegram_sync(
+        target["chat_id"],
+        target.get("thread_id"),
+        text,
+        context=context,
+        target_label=target_label,
+    )
+
+
+def _same_telegram_target(a: Optional[Dict[str, str]], b: Optional[Dict[str, str]]) -> bool:
+    if not a or not b:
+        return False
+    return str(a.get("chat_id") or "") == str(b.get("chat_id") or "") and str(a.get("thread_id") or "") == str(b.get("thread_id") or "")
+
+
+def _verify_stage3_artifacts(paths: Dict[str, Path], payload: Dict[str, Any]) -> Tuple[bool, str, List[str], str]:
+    artifact_candidates: List[Path] = []
+    primary_artifact = str(payload.get("artifact") or "").strip()
+    if primary_artifact:
+        artifact_candidates.append(Path(primary_artifact))
+    artifact_candidates.append(paths["default_writeup"])
+
+    found_primary = next((path for path in artifact_candidates if path.exists()), None)
+    if not found_primary:
+        return False, f"Stage 3 completed without writing a final markdown artifact at {paths['default_writeup']}", [], ""
+
+    required_supporting = [paths["doc_link"], paths["index_doc"], paths["index_doc_link"]]
+    missing_supporting = [str(path) for path in required_supporting if not path.exists()]
+    if missing_supporting:
+        return False, "Stage 3 completed without writing all required support artifacts", missing_supporting, str(found_primary)
+
+    artifacts: List[str] = []
+    raw_artifacts = payload.get("artifacts")
+    if isinstance(raw_artifacts, list):
+        for item in raw_artifacts:
+            if isinstance(item, str) and item.strip():
+                artifacts.append(item.strip())
+
+    required_all = [str(found_primary)] + [str(path) for path in required_supporting]
+    seen = set(artifacts)
+    for item in required_all:
+        if item not in seen:
+            artifacts.append(item)
+            seen.add(item)
+
+    return True, "", artifacts, str(found_primary)
+
+
+def _run_lane_pipeline(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    request: str,
+    deliver: Optional[str],
+    playbook_slug: str,
+    state: Dict[str, Any],
+    state_file: Path,
+    paths: Dict[str, Path],
+    parent_agent,
+    origin_target: Optional[Dict[str, str]],
+    deliver_target: Optional[Dict[str, str]],
+) -> Dict[str, Any]:
+    authority = _load_authority_texts(paths["playbook"])
+    google_docs_state = _google_docs_status(parent_agent)
+
+    resume_stage, blocker = _resolve_resume_stage(state, paths, state_file)
+    if blocker:
+        blocker_msg = _build_blocker_message(topic_title, blocker, state_file)
+        _send_telegram(origin_target, blocker_msg, context="research_lane_launch blocker")
+        if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+            _send_telegram(deliver_target, blocker_msg, context="research_lane_launch blocker deliver", target_label=deliver)
+        return {"status": "blocked", "blocker": blocker, "state_file": str(state_file)}
+    if resume_stage is None:
+        final_msg = _build_final_message(topic_title, state.get("stages", {}).get("stage-3-writeup", {}), state_file)
+        _send_telegram(origin_target, final_msg, context="research_lane_launch completion")
+        if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+            _send_telegram(deliver_target, final_msg, context="research_lane_launch deliver", target_label=deliver)
+        return {"status": "completed", "message": final_msg, "state_file": str(state_file)}
+
+    stage_inputs: Dict[str, str] = {}
+    if paths["knowledge_brief"].exists():
+        stage_inputs["knowledge_brief"] = _read_text(paths["knowledge_brief"])
+    if paths["raw_findings"].exists():
+        stage_inputs["raw_findings"] = _read_text(paths["raw_findings"])
+
+    for stage_name in STAGE_SEQUENCE[STAGE_SEQUENCE.index(resume_stage):]:
+        _mark_stage_in_progress(state, stage_name, state_file)
+
+        if stage_name == "stage-1-knowledge":
+            goal = _stage_goal_stage1(topic_title, paths["knowledge_brief"])
+            context = _build_stage_context(
+                lane_title=lane_title,
+                lane_slug=lane_slug,
+                topic_title=topic_title,
+                topic_slug=topic_slug,
+                request=request,
+                paths=paths,
+                authority=authority,
+                stage_name=stage_name,
+            )
+            result = _delegate_single(goal=goal, context=context, toolsets=["file"], max_iterations=15, parent_agent=parent_agent)
+            if result.get("error"):
+                _mark_stage_failed(state, stage_name, state_file, result["error"])
+                msg = _build_blocker_message(topic_title, result["error"], state_file)
+                _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+                if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                    _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+                return {"status": "blocked", "blocker": result["error"], "state_file": str(state_file)}
+            if not paths["knowledge_brief"].exists():
+                error = f"Stage 1 completed without writing {paths['knowledge_brief']}"
+                _mark_stage_failed(state, stage_name, state_file, error)
+                msg = _build_blocker_message(topic_title, error, state_file)
+                _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+                if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                    _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+                return {"status": "blocked", "blocker": error, "state_file": str(state_file)}
+            payload = _stage_result_payload(result)
+            stage_inputs["knowledge_brief"] = _read_text(paths["knowledge_brief"])
+            extras = {}
+            if payload.get("document_decision"):
+                extras["document_decision"] = payload.get("document_decision")
+            _mark_stage_completed(state, stage_name, state_file, artifact=str(paths["knowledge_brief"]), extras=extras)
+
+        elif stage_name == "stage-2-web-research":
+            goal = _stage_goal_stage2(topic_title, paths["raw_findings"])
+            context = _build_stage_context(
+                lane_title=lane_title,
+                lane_slug=lane_slug,
+                topic_title=topic_title,
+                topic_slug=topic_slug,
+                request=request,
+                paths=paths,
+                authority=authority,
+                stage_name=stage_name,
+                stage_inputs=stage_inputs,
+            )
+            result = _delegate_single(goal=goal, context=context, toolsets=["web", "file"], max_iterations=25, parent_agent=parent_agent)
+            if result.get("error"):
+                _mark_stage_failed(state, stage_name, state_file, result["error"])
+                msg = _build_blocker_message(topic_title, result["error"], state_file)
+                _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+                if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                    _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+                return {"status": "blocked", "blocker": result["error"], "state_file": str(state_file)}
+            if not paths["raw_findings"].exists():
+                error = f"Stage 2 completed without writing {paths['raw_findings']}"
+                _mark_stage_failed(state, stage_name, state_file, error)
+                msg = _build_blocker_message(topic_title, error, state_file)
+                _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+                if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                    _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+                return {"status": "blocked", "blocker": error, "state_file": str(state_file)}
+            payload = _stage_result_payload(result)
+            stage_inputs["raw_findings"] = _read_text(paths["raw_findings"])
+            extras = {}
+            if payload.get("sources_scraped") is not None:
+                extras["sources_scraped"] = payload.get("sources_scraped")
+            _mark_stage_completed(state, stage_name, state_file, artifact=str(paths["raw_findings"]), extras=extras)
+
+        elif stage_name == "stage-3-writeup":
+            goal = _stage_goal_stage3(
+                lane_title=lane_title,
+                topic_title=topic_title,
+                default_artifact_path=paths["default_writeup"],
+                doc_link_path=paths["doc_link"],
+                index_doc_path=paths["index_doc"],
+                index_doc_link_path=paths["index_doc_link"],
+                google_docs_state=google_docs_state,
+            )
+            stage3_toolsets = ["file"]
+            if google_docs_state.get("status") == "connected":
+                stage3_toolsets.append("maton-google-docs")
+            context = _build_stage_context(
+                lane_title=lane_title,
+                lane_slug=lane_slug,
+                topic_title=topic_title,
+                topic_slug=topic_slug,
+                request=request,
+                paths=paths,
+                authority=authority,
+                stage_name=stage_name,
+                stage_inputs=stage_inputs,
+                google_docs_state=google_docs_state,
+            )
+            result = _delegate_single(goal=goal, context=context, toolsets=stage3_toolsets, max_iterations=15, parent_agent=parent_agent)
+            if result.get("error"):
+                _mark_stage_failed(state, stage_name, state_file, result["error"])
+                msg = _build_blocker_message(topic_title, result["error"], state_file)
+                _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+                if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                    _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+                return {"status": "blocked", "blocker": result["error"], "state_file": str(state_file)}
+            payload = _stage_result_payload(result)
+            verified, verification_error, artifacts, primary_artifact = _verify_stage3_artifacts(paths, payload)
+            if not verified:
+                _mark_stage_failed(state, stage_name, state_file, verification_error)
+                msg = _build_blocker_message(topic_title, verification_error, state_file)
+                _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+                if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                    _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+                return {"status": "blocked", "blocker": verification_error, "state_file": str(state_file)}
+            extras = {
+                "google_doc_status": payload.get("google_doc_status") or google_docs_state.get("status"),
+            }
+            if payload.get("google_doc_url"):
+                extras["google_doc_url"] = payload.get("google_doc_url")
+            _mark_stage_completed(state, stage_name, state_file, artifact=primary_artifact or None, artifacts=artifacts or None, extras=extras)
+            final_message = _build_final_message(topic_title, payload, state_file)
+            _send_telegram(origin_target, final_message, context="research_lane_launch completion")
+            if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+                _send_telegram(deliver_target, final_message, context="research_lane_launch deliver", target_label=deliver)
+            return {
+                "status": "completed",
+                "message": final_message,
+                "state_file": str(state_file),
+                "google_doc_url": payload.get("google_doc_url"),
+            }
+
+    msg = _build_blocker_message(topic_title, "Pipeline exited unexpectedly before Stage 3 completion.", state_file)
+    _send_telegram(origin_target, msg, context="research_lane_launch blocker")
+    if deliver_target and not _same_telegram_target(origin_target, deliver_target):
+        _send_telegram(deliver_target, msg, context="research_lane_launch blocker deliver", target_label=deliver)
+    return {"status": "blocked", "blocker": "unexpected pipeline exit", "state_file": str(state_file)}
+
+
+def _launch_runner(
+    *,
+    lane_title: str,
+    lane_slug: str,
+    topic_title: str,
+    topic_slug: str,
+    request: str,
+    deliver: Optional[str],
+    playbook_slug: str,
+    state: Dict[str, Any],
+    state_file: Path,
+    paths: Dict[str, Path],
+    parent_agent,
+) -> None:
+    from tools.delegate_tool import _resolve_agent_activity_target
+
+    activity_target = _resolve_agent_activity_target()
+    if activity_target:
+        _send_telegram(
+            activity_target,
+            f"Research lane launch: {lane_slug}/{topic_slug}",
+            context="research_lane_launch activity start",
+            target_label="Agent Activity",
+        )
+
+    deliver_target = None
+    if deliver:
+        from tools.delegate_tool import _parse_deliver_target
+        deliver_target = _parse_deliver_target(deliver)
+    origin_target = _resolve_origin_target()
+
+    result = _run_lane_pipeline(
+        lane_title=lane_title,
+        lane_slug=lane_slug,
+        topic_title=topic_title,
+        topic_slug=topic_slug,
+        request=request,
+        deliver=deliver,
+        playbook_slug=playbook_slug,
+        state=state,
+        state_file=state_file,
+        paths=paths,
+        parent_agent=parent_agent,
+        origin_target=origin_target,
+        deliver_target=deliver_target,
+    )
+
+    if activity_target:
+        status = result.get("status", "unknown")
+        text = f"Research lane {status}: {lane_slug}/{topic_slug}"
+        _send_telegram(
+            activity_target,
+            text,
+            context="research_lane_launch activity done",
+            target_label="Agent Activity",
+        )
+
+
+def launch_research_lane(
+    *,
+    lane: str,
+    topic: str,
+    request: Optional[str] = None,
+    playbook_slug: Optional[str] = None,
+    deliver: Optional[str] = None,
+    create_playbook_if_missing: bool = True,
+    resume_existing: bool = True,
+    background: bool = True,
+    parent_agent=None,
+) -> str:
+    if parent_agent is None:
+        return json.dumps({"error": "launch_research_lane requires a parent agent context."})
+    if not (lane or "").strip():
+        return json.dumps({"error": "lane is required."})
+    if not (topic or "").strip():
+        return json.dumps({"error": "topic is required."})
+
+    lane_slug = _slugify(lane)
+    topic_slug = _slugify(topic)
+    lane_title = lane.strip()
+    topic_title = topic.strip()
+    request_text = (request or topic or lane).strip()
+
+    playbook_path, resolved_playbook_slug = _resolve_playbook(lane_slug, playbook_slug)
+    ensured = _ensure_lane_assets(
+        lane_title=lane_title,
+        lane_slug=lane_slug,
+        topic_title=topic_title,
+        topic_slug=topic_slug,
+        request=request_text,
+        deliver=deliver,
+        playbook_path=playbook_path,
+        playbook_slug=resolved_playbook_slug,
+        create_playbook_if_missing=create_playbook_if_missing,
+    )
+    paths = ensured["paths"]
+    state_file = paths["state_file"]
+    # Pick up the deliver target — may have been updated by auto-created Telegram topic
+    if ensured.get("deliver"):
+        deliver = ensured["deliver"]
+
+    state = _load_json(state_file)
+    if not state or not resume_existing:
+        state = _default_state(
+            lane_title=lane_title,
+            lane_slug=lane_slug,
+            topic_title=topic_title,
+            topic_slug=topic_slug,
+            playbook_slug=resolved_playbook_slug,
+            request=request_text,
+            deliver=deliver,
+            paths=paths,
+            generated_playbook=ensured["generated_playbook"],
+            drive_status=ensured["drive_status"],
+        )
+        _save_state(state, state_file)
+    else:
+        state.setdefault("lane_launch", {}).update(
+            {
+                "status": "completed",
+                "quiet_mode": True,
+                "playbook_path": str(paths["playbook"]),
+                "lane_root": str(paths["lane_root"]),
+                "topic_dir": str(paths["topic_dir"]),
+                "google_drive": ensured["drive_status"],
+            }
+        )
+        _save_state(state, state_file)
+
+    if background:
+        thread = threading.Thread(
+            target=_launch_runner,
+            kwargs={
+                "lane_title": lane_title,
+                "lane_slug": lane_slug,
+                "topic_title": topic_title,
+                "topic_slug": topic_slug,
+                "request": request_text,
+                "deliver": deliver,
+                "playbook_slug": resolved_playbook_slug,
+                "state": state,
+                "state_file": state_file,
+                "paths": paths,
+                "parent_agent": parent_agent,
+            },
+            daemon=True,
+            name=f"research-lane-{lane_slug}-{topic_slug}",
+        )
+        thread.start()
+        return json.dumps(
+            {
+                "status": "spawned",
+                "lane": lane_slug,
+                "topic": topic_slug,
+                "playbook": str(playbook_path),
+                "topic_dir": str(paths["topic_dir"]),
+                "state_file": str(state_file),
+                "deliver": deliver or "origin",
+                "message": f"Research lane launched for {topic_title}. I'll report back when it's done.",
+                "playbook_generated": ensured["generated_playbook"],
+                "index_template_generated": ensured["generated_index_template"],
+                "google_drive_status": ensured["drive_status"].get("status"),
+                "telegram_topic_created": ensured.get("telegram_topic") is not None,
+                "telegram_topic": ensured.get("telegram_topic"),
+            },
+            ensure_ascii=False,
+        )
+
+    if deliver:
+        from tools.delegate_tool import _parse_deliver_target
+        deliver_target = _parse_deliver_target(deliver)
+    else:
+        deliver_target = None
+
+    result = _run_lane_pipeline(
+        lane_title=lane_title,
+        lane_slug=lane_slug,
+        topic_title=topic_title,
+        topic_slug=topic_slug,
+        request=request_text,
+        deliver=deliver,
+        playbook_slug=resolved_playbook_slug,
+        state=state,
+        state_file=state_file,
+        paths=paths,
+        parent_agent=parent_agent,
+        origin_target=_resolve_origin_target(),
+        deliver_target=deliver_target,
+    )
+    result.setdefault("lane", lane_slug)
+    result.setdefault("topic", topic_slug)
+    result.setdefault("playbook", str(playbook_path))
+    result.setdefault("state_file", str(state_file))
+    return json.dumps(result, ensure_ascii=False)
+
+
+LAUNCH_RESEARCH_LANE_SCHEMA = {
+    "name": "launch_research_lane",
+    "description": "Create or resume a research lane: generate the lane playbook from the standard template when missing, create the Obsidian lane artifacts, stub the Google Drive step if needed, and run the first 3-stage research pipeline quietly in the background.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "lane": {
+                "type": "string",
+                "description": "Research lane/domain name, e.g. 'SEO', 'GBP', 'Reviews Reputation', 'Paid Advertising'.",
+            },
+            "topic": {
+                "type": "string",
+                "description": "Specific topic for the first run, e.g. 'local SEO quick wins'.",
+            },
+            "request": {
+                "type": "string",
+                "description": "The actual research ask/scope to execute. Defaults to the topic if omitted.",
+            },
+            "playbook_slug": {
+                "type": "string",
+                "description": "Optional explicit playbook slug (without .md), e.g. 'seo-research'.",
+            },
+            "deliver": {
+                "type": "string",
+                "description": "Optional final delivery target for the short completion line (topic name or telegram:chat_id:thread_id). Defaults to origin if omitted.",
+            },
+            "create_playbook_if_missing": {
+                "type": "boolean",
+                "description": "When true, generate a standardized domain playbook and index template if they do not exist yet.",
+                "default": True,
+            },
+            "resume_existing": {
+                "type": "boolean",
+                "description": "When true, resume an interrupted pipeline-state.json instead of starting from scratch.",
+                "default": True,
+            },
+            "background": {
+                "type": "boolean",
+                "description": "Run the full lane launch in a background thread so Atlas can send a short acknowledgment immediately.",
+                "default": True,
+            },
+        },
+        "required": ["lane", "topic"],
+    },
+}
+
+
+registry.register(
+    name="launch_research_lane",
+    toolset="delegation",
+    schema=LAUNCH_RESEARCH_LANE_SCHEMA,
+    handler=lambda args, **kw: launch_research_lane(
+        lane=args.get("lane", ""),
+        topic=args.get("topic", ""),
+        request=args.get("request"),
+        playbook_slug=args.get("playbook_slug"),
+        deliver=args.get("deliver"),
+        create_playbook_if_missing=args.get("create_playbook_if_missing", True),
+        resume_existing=args.get("resume_existing", True),
+        background=args.get("background", True),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=lambda: True,
+    emoji="🚀",
+)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -45,7 +45,7 @@ import logging
 import os
 import re
 import asyncio
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 import httpx
 from firecrawl import Firecrawl
 from agent.auxiliary_client import (
@@ -68,9 +68,60 @@ logger = logging.getLogger(__name__)
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
+_VALID_WEB_BACKENDS = ("exa", "tavily", "firecrawl", "parallel")
+_DEFAULT_WEB_BACKEND_ORDER = ("exa", "tavily", "firecrawl")
+_CONFIG_ERROR_HINTS = (
+    "api key",
+    "not set",
+    "not configured",
+    "missing",
+    "configuration",
+    "credential",
+    "unauthorized",
+    "forbidden",
+    "invalid key",
+    "invalid token",
+    "login to nous",
+)
+_PAYMENT_ERROR_HINTS = (
+    "payment required",
+    "credits exhausted",
+    "insufficient credits",
+    "credit balance",
+    "billing",
+    "quota",
+    "rate limit",
+    "too many requests",
+)
+_TIMEOUT_ERROR_HINTS = (
+    "timed out",
+    "timeout",
+    "deadline exceeded",
+)
+_NETWORK_ERROR_HINTS = (
+    "connection",
+    "network",
+    "dns",
+    "socket",
+    "reset by peer",
+    "connection refused",
+    "temporarily unavailable",
+)
+_PROVIDER_ERROR_HINTS = (
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "internal server error",
+    "upstream",
+    "provider",
+    "server error",
+)
+
+
 def _has_env(name: str) -> bool:
     val = os.getenv(name)
     return bool(val and val.strip())
+
 
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
@@ -80,31 +131,45 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
+
+def _get_configured_backend() -> Optional[str]:
+    """Return the configured backend when valid, otherwise None."""
+    configured = (_load_web_config().get("backend") or "").lower().strip()
+    if configured in _VALID_WEB_BACKENDS:
+        return configured
+    return None
+
+
 def _get_backend() -> str:
-    """Determine which web backend to use.
+    """Determine which web backend should be treated as primary.
 
     Reads ``web.backend`` from config.yaml (set by ``hermes tools``).
-    Falls back to whichever API key is present for users who configured
-    keys manually without running setup.
+    Without explicit config, Hermes prefers Exa → Tavily → Firecrawl, with
+    Parallel retained as a legacy/manual fallback when it is the only usable
+    backend.
     """
-    configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    configured = _get_configured_backend()
+    if configured:
         return configured
 
-    # Fallback for manual / legacy config — pick the highest-priority
-    # available backend. Firecrawl also counts as available when the managed
-    # tool gateway is configured for Nous subscribers.
-    backend_candidates = (
-        ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
-        ("parallel", _has_env("PARALLEL_API_KEY")),
-        ("tavily", _has_env("TAVILY_API_KEY")),
-        ("exa", _has_env("EXA_API_KEY")),
-    )
-    for backend, available in backend_candidates:
-        if available:
+    for backend in _DEFAULT_WEB_BACKEND_ORDER:
+        if _is_backend_available(backend):
             return backend
 
-    return "firecrawl"  # default (backward compat)
+    if _is_backend_available("parallel"):
+        return "parallel"
+
+    return _DEFAULT_WEB_BACKEND_ORDER[0]
+
+
+def _build_backend_order(primary: Optional[str] = None) -> List[str]:
+    """Build the backend attempt order for web search/extract fallback."""
+    preferred = primary or _get_backend()
+    order: List[str] = []
+    for backend in (preferred, *_DEFAULT_WEB_BACKEND_ORDER):
+        if backend in _VALID_WEB_BACKENDS and backend not in order:
+            order.append(backend)
+    return order
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -118,6 +183,55 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
     return False
+
+
+def _normalize_backend_error_message(exc: Exception) -> str:
+    """Return a compact, log-friendly backend error message."""
+    message = " ".join(str(exc).split())
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response is not None:
+        return f"HTTP {exc.response.status_code}: {message or exc.__class__.__name__}"
+    return message or exc.__class__.__name__
+
+
+def _classify_backend_failure(exc: Exception) -> Optional[str]:
+    """Return a fallback class when an error should trigger backend fallback."""
+    if isinstance(exc, (KeyboardInterrupt, asyncio.CancelledError)):
+        return None
+
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+        return "timeout"
+
+    if isinstance(exc, httpx.RequestError):
+        return "network"
+
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code if exc.response is not None else None
+        if status in (400, 401, 403, 409, 422):
+            return "configuration"
+        if status == 402:
+            return "payment"
+        if status in (408, 429):
+            return "timeout"
+        if status is not None and status >= 500:
+            return "provider"
+
+    message = _normalize_backend_error_message(exc).lower()
+    if any(hint in message for hint in _CONFIG_ERROR_HINTS):
+        return "configuration"
+    if any(hint in message for hint in _PAYMENT_ERROR_HINTS):
+        return "payment"
+    if any(hint in message for hint in _TIMEOUT_ERROR_HINTS):
+        return "timeout"
+    if any(hint in message for hint in _NETWORK_ERROR_HINTS):
+        return "network"
+    if any(hint in message for hint in _PROVIDER_ERROR_HINTS):
+        return "provider"
+    return None
+
+
+def _is_fallback_worthy_failure(exc: Exception) -> bool:
+    """Return True when a backend failure should trigger the fallback chain."""
+    return _classify_backend_failure(exc) is not None
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -440,6 +554,164 @@ def _extract_scrape_payload(scrape_result: Any) -> Dict[str, Any]:
         return nested
 
     return result_plain
+
+
+def _tavily_search(query: str, limit: int = 5) -> dict:
+    """Search using Tavily and normalize to the standard search response."""
+    logger.info("Tavily search: '%s' (limit=%d)", query, limit)
+    raw = _tavily_request("search", {
+        "query": query,
+        "max_results": min(limit, 20),
+        "include_raw_content": False,
+        "include_images": False,
+    })
+    return _normalize_tavily_search_results(raw)
+
+
+def _firecrawl_search(query: str, limit: int = 5) -> dict:
+    """Search using Firecrawl and normalize the response payload."""
+    logger.info("Firecrawl search: '%s' (limit=%d)", query, limit)
+    response = _get_firecrawl_client().search(
+        query=query,
+        limit=limit,
+    )
+    web_results = _extract_web_search_results(response)
+    return {
+        "success": True,
+        "data": {
+            "web": web_results,
+        },
+    }
+
+
+def _build_firecrawl_scrape_formats(format: Optional[str]) -> List[str]:
+    """Return the requested Firecrawl scrape formats."""
+    if format == "markdown":
+        return ["markdown"]
+    if format == "html":
+        return ["html"]
+    return ["markdown", "html"]
+
+
+async def _tavily_extract(urls: List[str]) -> List[Dict[str, Any]]:
+    """Extract content from URLs using Tavily and normalize the response."""
+    logger.info("Tavily extract: %d URL(s)", len(urls))
+    raw = _tavily_request("extract", {
+        "urls": urls,
+        "include_images": False,
+    })
+    return _normalize_tavily_documents(raw, fallback_url=urls[0] if urls else "")
+
+
+async def _firecrawl_extract(urls: List[str], format: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Extract content from URLs using Firecrawl scrape with timeout handling."""
+    formats = _build_firecrawl_scrape_formats(format)
+    results: List[Dict[str, Any]] = []
+
+    from tools.interrupt import is_interrupted as _is_interrupted
+
+    for url in urls:
+        if _is_interrupted():
+            results.append({"url": url, "error": "Interrupted", "title": ""})
+            continue
+
+        try:
+            logger.info("Firecrawl scrape: %s", url)
+            try:
+                scrape_result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        _get_firecrawl_client().scrape,
+                        url=url,
+                        formats=formats,
+                    ),
+                    timeout=60,
+                )
+            except asyncio.TimeoutError as exc:
+                raise TimeoutError(f"Firecrawl scrape timed out after 60s for {url}") from exc
+
+            scrape_payload = _extract_scrape_payload(scrape_result)
+            metadata = scrape_payload.get("metadata", {})
+            content_markdown = scrape_payload.get("markdown")
+            content_html = scrape_payload.get("html")
+
+            if not isinstance(metadata, dict):
+                if hasattr(metadata, "model_dump"):
+                    metadata = metadata.model_dump()
+                elif hasattr(metadata, "__dict__"):
+                    metadata = metadata.__dict__
+                else:
+                    metadata = {}
+
+            title = metadata.get("title", "")
+            final_url = metadata.get("sourceURL", url)
+            final_blocked = check_website_access(final_url)
+            if final_blocked:
+                logger.info(
+                    "Blocked redirected web_extract for %s by rule %s",
+                    final_blocked["host"],
+                    final_blocked["rule"],
+                )
+                results.append({
+                    "url": final_url,
+                    "title": title,
+                    "content": "",
+                    "raw_content": "",
+                    "error": final_blocked["message"],
+                    "blocked_by_policy": {
+                        "host": final_blocked["host"],
+                        "rule": final_blocked["rule"],
+                        "source": final_blocked["source"],
+                    },
+                })
+                continue
+
+            chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
+            results.append({
+                "url": final_url,
+                "title": title,
+                "content": chosen_content,
+                "raw_content": chosen_content,
+                "metadata": metadata,
+            })
+        except Exception as scrape_err:
+            if _is_fallback_worthy_failure(scrape_err):
+                raise
+            logger.debug("Firecrawl scrape failed for %s: %s", url, scrape_err)
+            results.append({
+                "url": url,
+                "title": "",
+                "content": "",
+                "raw_content": "",
+                "error": str(scrape_err),
+            })
+
+    return results
+
+
+def _run_search_backend(backend: str, query: str, limit: int) -> dict:
+    """Execute a web search against a specific backend."""
+    if backend == "parallel":
+        return _parallel_search(query, limit)
+    if backend == "exa":
+        return _exa_search(query, limit)
+    if backend == "tavily":
+        return _tavily_search(query, limit)
+    if backend == "firecrawl":
+        return _firecrawl_search(query, limit)
+    raise ValueError(f"Unsupported web search backend: {backend}")
+
+
+async def _run_extract_backend(backend: str, urls: List[str], format: Optional[str]) -> List[Dict[str, Any]]:
+    """Execute content extraction against a specific backend."""
+    if backend == "parallel":
+        return await _parallel_extract(urls)
+    if backend == "exa":
+        return _exa_extract(urls)
+    if backend == "tavily":
+        return await _tavily_extract(urls)
+    if backend == "firecrawl":
+        return await _firecrawl_extract(urls, format=format)
+    raise ValueError(f"Unsupported web extract backend: {backend}")
 
 
 DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION = 5000
@@ -1034,10 +1306,11 @@ async def _parallel_extract(urls: List[str]) -> List[Dict[str, Any]]:
 
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
-    Search the web for information using available search API backend.
+    Search the web for information using available search API backends.
 
     This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
+    with multiple backends and automatically falls back across the configured
+    backend chain when provider/config/payment/timeout failures occur.
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
     Use web_extract_tool to get full content from specific URLs.
@@ -1064,17 +1337,18 @@ def web_search_tool(query: str, limit: int = 5) -> str:
              }
     
     Raises:
-        Exception: If search fails or API key is not set
+        Exception: If all backend attempts fail
     """
     debug_call_data = {
         "parameters": {
             "query": query,
-            "limit": limit
+            "limit": limit,
         },
         "error": None,
         "results_count": 0,
         "original_response_size": 0,
-        "final_response_size": 0
+        "final_response_size": 0,
+        "backend_attempts": [],
     }
     
     try:
@@ -1082,74 +1356,71 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch to the configured backend
-        backend = _get_backend()
-        if backend == "parallel":
-            response_data = _parallel_search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
+        backends = _build_backend_order()
+        backend_failures: List[str] = []
 
-        if backend == "exa":
-            response_data = _exa_search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
+        for attempt_num, backend in enumerate(backends, start=1):
+            logger.info(
+                "web_search attempt %d/%d using backend=%s for query=%r",
+                attempt_num,
+                len(backends),
+                backend,
+                query,
+            )
+            try:
+                response_data = _run_search_backend(backend, query, limit)
+            except Exception as exc:
+                failure_kind = _classify_backend_failure(exc)
+                failure_message = _normalize_backend_error_message(exc)
+                debug_call_data["backend_attempts"].append({
+                    "backend": backend,
+                    "outcome": "fallback" if failure_kind and attempt_num < len(backends) else "error",
+                    "failure_kind": failure_kind,
+                    "error": failure_message,
+                })
+                if failure_kind:
+                    backend_failures.append(f"{backend} ({failure_kind}): {failure_message}")
+                    if attempt_num < len(backends):
+                        logger.warning(
+                            "web_search backend=%s failed (%s): %s. Falling back to next backend.",
+                            backend,
+                            failure_kind,
+                            failure_message,
+                        )
+                        continue
+                    logger.error(
+                        "web_search backend=%s failed (%s): %s",
+                        backend,
+                        failure_kind,
+                        failure_message,
+                    )
+                    break
+                raise
 
-        if backend == "tavily":
-            logger.info("Tavily search: '%s' (limit: %d)", query, limit)
-            raw = _tavily_request("search", {
-                "query": query,
-                "max_results": min(limit, 20),
-                "include_raw_content": False,
-                "include_images": False,
+            results_count = len(response_data.get("data", {}).get("web", []))
+            debug_call_data["results_count"] = results_count
+            debug_call_data["backend_attempts"].append({
+                "backend": backend,
+                "outcome": "success",
+                "results_count": results_count,
             })
-            response_data = _normalize_tavily_search_results(raw)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            logger.info(
+                "web_search backend=%s succeeded with %d result(s)%s",
+                backend,
+                results_count,
+                " (empty result set; no fallback)" if results_count == 0 else "",
+            )
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
             _debug.log_call("web_search_tool", debug_call_data)
             _debug.save()
             return result_json
 
-        logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
-
-        response = _get_firecrawl_client().search(
-            query=query,
-            limit=limit
-        )
-
-        web_results = _extract_web_search_results(response)
-        results_count = len(web_results)
-        logger.info("Found %d search results", results_count)
-        
-        # Build response with just search metadata (URLs, titles, descriptions)
-        response_data = {
-            "success": True,
-            "data": {
-                "web": web_results
-            }
-        }
-        
-        # Capture debug information
-        debug_call_data["results_count"] = results_count
-        
-        # Convert to JSON
-        result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-        
-        debug_call_data["final_response_size"] = len(result_json)
-        
-        # Log debug information
+        error_msg = "Error searching web: all backends failed. " + "; ".join(backend_failures)
+        debug_call_data["error"] = error_msg
         _debug.log_call("web_search_tool", debug_call_data)
         _debug.save()
-        
-        return result_json
+        return tool_error(error_msg)
         
     except Exception as e:
         error_msg = f"Error searching web: {str(e)}"
@@ -1217,151 +1488,113 @@ async def web_extract_tool(
         "original_response_size": 0,
         "final_response_size": 0,
         "compression_metrics": [],
-        "processing_applied": []
+        "processing_applied": [],
+        "backend_attempts": []
     }
     
     try:
         logger.info("Extracting content from %d URL(s)", len(urls))
 
-        # ── SSRF protection — filter out private/internal URLs before any backend ──
-        safe_urls = []
-        ssrf_blocked: List[Dict[str, Any]] = []
+        allowed_urls: List[str] = []
+        blocked_results: List[Dict[str, Any]] = []
         for url in urls:
             if not is_safe_url(url):
-                ssrf_blocked.append({
-                    "url": url, "title": "", "content": "",
+                blocked_results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
                     "error": "Blocked: URL targets a private or internal network address",
                 })
-            else:
-                safe_urls.append(url)
+                continue
 
-        # Dispatch only safe URLs to the configured backend
-        if not safe_urls:
+            blocked = check_website_access(url)
+            if blocked:
+                logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
+                blocked_results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": blocked["message"],
+                    "blocked_by_policy": {
+                        "host": blocked["host"],
+                        "rule": blocked["rule"],
+                        "source": blocked["source"],
+                    },
+                })
+                continue
+
+            allowed_urls.append(url)
+
+        backend_failures: List[str] = []
+        if not allowed_urls:
             results = []
         else:
-            backend = _get_backend()
-
-            if backend == "parallel":
-                results = await _parallel_extract(safe_urls)
-            elif backend == "exa":
-                results = _exa_extract(safe_urls)
-            elif backend == "tavily":
-                logger.info("Tavily extract: %d URL(s)", len(safe_urls))
-                raw = _tavily_request("extract", {
-                    "urls": safe_urls,
-                    "include_images": False,
-                })
-                results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
-            else:
-                # ── Firecrawl extraction ──
-                # Determine requested formats for Firecrawl v2
-                formats: List[str] = []
-                if format == "markdown":
-                    formats = ["markdown"]
-                elif format == "html":
-                    formats = ["html"]
-                else:
-                    # Default: request markdown for LLM-readiness and include html as backup
-                    formats = ["markdown", "html"]
-
-                # Always use individual scraping for simplicity and reliability
-                # Batch scraping adds complexity without much benefit for small numbers of URLs
-                results: List[Dict[str, Any]] = []
-
-                from tools.interrupt import is_interrupted as _is_interrupted
-                for url in safe_urls:
-                    if _is_interrupted():
-                        results.append({"url": url, "error": "Interrupted", "title": ""})
-                        continue
-
-                    # Website policy check — block before fetching
-                    blocked = check_website_access(url)
-                    if blocked:
-                        logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
-                        results.append({
-                            "url": url, "title": "", "content": "",
-                            "error": blocked["message"],
-                            "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
-                        })
-                        continue
-
-                    try:
-                        logger.info("Scraping: %s", url)
-                        # Run synchronous Firecrawl scrape in a thread with a
-                        # 60s timeout so a hung fetch doesn't block the session.
-                        try:
-                            scrape_result = await asyncio.wait_for(
-                                asyncio.to_thread(
-                                    _get_firecrawl_client().scrape,
-                                    url=url,
-                                    formats=formats,
-                                ),
-                                timeout=60,
+            backends = _build_backend_order()
+            results = []
+            backend_success = False
+            for attempt_num, backend in enumerate(backends, start=1):
+                logger.info(
+                    "web_extract attempt %d/%d using backend=%s for %d URL(s)",
+                    attempt_num,
+                    len(backends),
+                    backend,
+                    len(allowed_urls),
+                )
+                try:
+                    results = await _run_extract_backend(backend, allowed_urls, format)
+                except Exception as exc:
+                    failure_kind = _classify_backend_failure(exc)
+                    failure_message = _normalize_backend_error_message(exc)
+                    debug_call_data["backend_attempts"].append({
+                        "backend": backend,
+                        "outcome": "fallback" if failure_kind and attempt_num < len(backends) else "error",
+                        "failure_kind": failure_kind,
+                        "error": failure_message,
+                    })
+                    if failure_kind:
+                        backend_failures.append(f"{backend} ({failure_kind}): {failure_message}")
+                        if attempt_num < len(backends):
+                            logger.warning(
+                                "web_extract backend=%s failed (%s): %s. Falling back to next backend.",
+                                backend,
+                                failure_kind,
+                                failure_message,
                             )
-                        except asyncio.TimeoutError:
-                            logger.warning("Firecrawl scrape timed out for %s", url)
-                            results.append({
-                                "url": url, "title": "", "content": "",
-                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
-                            })
                             continue
+                        logger.error(
+                            "web_extract backend=%s failed (%s): %s",
+                            backend,
+                            failure_kind,
+                            failure_message,
+                        )
+                        break
+                    raise
 
-                        scrape_payload = _extract_scrape_payload(scrape_result)
-                        metadata = scrape_payload.get("metadata", {})
-                        title = ""
-                        content_markdown = scrape_payload.get("markdown")
-                        content_html = scrape_payload.get("html")
+                debug_call_data["backend_attempts"].append({
+                    "backend": backend,
+                    "outcome": "success",
+                    "results_count": len(results),
+                })
+                backend_success = True
+                logger.info(
+                    "web_extract backend=%s succeeded with %d result(s)%s",
+                    backend,
+                    len(results),
+                    " (empty result set; no fallback)" if len(results) == 0 else "",
+                )
+                break
+            else:
+                results = []
 
-                        # Ensure metadata is a dict (not an object)
-                        if not isinstance(metadata, dict):
-                            if hasattr(metadata, 'model_dump'):
-                                metadata = metadata.model_dump()
-                            elif hasattr(metadata, '__dict__'):
-                                metadata = metadata.__dict__
-                            else:
-                                metadata = {}
+            if backend_failures and not backend_success:
+                error_msg = "Error extracting content: all backends failed. " + "; ".join(backend_failures)
+                logger.debug("%s", error_msg)
+                debug_call_data["error"] = error_msg
+                _debug.log_call("web_extract_tool", debug_call_data)
+                _debug.save()
+                return tool_error(error_msg)
 
-                        # Get title from metadata
-                        title = metadata.get("title", "")
-
-                        # Re-check final URL after redirect
-                        final_url = metadata.get("sourceURL", url)
-                        final_blocked = check_website_access(final_url)
-                        if final_blocked:
-                            logger.info("Blocked redirected web_extract for %s by rule %s", final_blocked["host"], final_blocked["rule"])
-                            results.append({
-                                "url": final_url, "title": title, "content": "", "raw_content": "",
-                                "error": final_blocked["message"],
-                                "blocked_by_policy": {"host": final_blocked["host"], "rule": final_blocked["rule"], "source": final_blocked["source"]},
-                            })
-                            continue
-
-                        # Choose content based on requested format
-                        chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
-
-                        results.append({
-                            "url": final_url,
-                            "title": title,
-                            "content": chosen_content,
-                            "raw_content": chosen_content,
-                            "metadata": metadata  # Now guaranteed to be a dict
-                        })
-
-                    except Exception as scrape_err:
-                        logger.debug("Scrape failed for %s: %s", url, scrape_err)
-                        results.append({
-                            "url": url,
-                            "title": "",
-                            "content": "",
-                            "raw_content": "",
-                            "error": str(scrape_err)
-                        })
-
-        # Merge any SSRF-blocked results back in
-        if ssrf_blocked:
-            results = ssrf_blocked + results
-
-        response = {"results": results}
+        response = {"results": blocked_results + results}
         
         pages_extracted = len(response.get('results', []))
         logger.info("Extracted content from %d pages", pages_extracted)
@@ -1920,11 +2153,8 @@ def check_firecrawl_api_key() -> bool:
 
 
 def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
-        return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    """Check whether any backend in the active fallback chain is available."""
+    return any(_is_backend_available(backend) for backend in _build_backend_order())
 
 
 def check_auxiliary_model() -> bool:

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "delegate_status", "delegate_kill", "launch_research_lane",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -187,8 +187,8 @@ TOOLSETS = {
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Spawn subagents with isolated context for complex subtasks, launch full research lanes, monitor delegation progress, and kill active delegations",
+        "tools": ["delegate_task", "delegate_status", "delegate_kill", "launch_research_lane"],
         "includes": []
     },
 
@@ -237,7 +237,7 @@ TOOLSETS = {
             "browser_vision", "browser_console",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "launch_research_lane",
         ],
         "includes": []
     },
@@ -265,7 +265,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_status", "delegate_kill", "launch_research_lane",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)


### PR DESCRIPTION
## Summary

Adds `launch_research_lane` as a first-class delegation tool plus supporting infrastructure for multi-stage research pipelines. Includes several delegation-path bug fixes that surfaced while running this in production on my Hermes host.

## Commits (7 + 1 fixup, on top of current main)

### Big one
- `fix: lane launch pipeline chain, delegation tracking, and agent loop dispatch` — introduces `tools/research_lane_launch_tool.py`, adds `delegate_status` and `delegate_kill` tools, stamps `spawn_id` on child agents so heartbeats/results fire, adds `gateway_session_key` on `AIAgent.__init__`, adds stage retry logic for 5xx/timeout, Telegram topic auto-create with dedup, Google Drive folder creation via Maton, resume-verification artifact check, MCP toolset intersection fix, removes dead code, sets up Exa → Tavily → Firecrawl fallback chain.

### Small delegation fixes on the same path
- `fix: add missing tool_duration for launch_research_lane and delegate_kill dispatch` — plugs a `cannot access local variable 'tool_duration'` in the parallel/batch tool-call path.
- `fix: bump Stage 1 and Stage 3 iteration budget from 15 to 30` — the Stage-1 subagent was exhausting 15 iterations reading existing lane docs before writing its own brief.
- `fix: only send completion message to deliver target, not origin` — origin already gets the tool's return value; no need to double-post the Google Doc link.

### Feature + UX
- `feat: make topic optional in launch_research_lane` — 'go deeper on X' works without explicit topic; Atlas picks the next logical topic.
- `fix: enforce 'Got it, spawning now.' as only response after lane launch`
- `fix: start fresh pipeline when prior run is completed or topic changed`

### Fixup
- `fixup: remove duplicate fields after cherry-picking onto current main` — during local refold onto current main, auto-merge silently duplicated `gateway_session_key` on `AIAgent.__init__` and `channel_prompt` on `MessageEvent` because upstream had independently added them. `ast.parse` caught the first; `dataclass_fields` only kept the last. Removed the duplicates.

## Test plan
- `python -c 'import hermes_cli.main, run_agent, model_tools, tools.research_lane_launch_tool'` — all clean.
- `tools.registry.discover_builtin_tools()` picks up `tools.research_lane_launch_tool` automatically (22 tools discovered including it).
- Gateway running on refolded code at pid 17240 since 17:27 CDT today, zero tracebacks, 40 channel targets, Telegram connected.
- Happy to break this into separate PRs if reviewers prefer.