### PR TITLE
CLI Fix: Catch EINVAL from stdin selector registration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9789,7 +9789,7 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393).
             # This is the fallback for cases that slip past the fstat() guard.
-            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err) or "Invalid argument" in str(_stdin_err):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"


### PR DESCRIPTION
## Context
I just installed Hermes agent on my laptop. The installation went through but errored when I launched it. I know how to fix it in my local but it would be good to not crash in such cases.

### Error

On macOS with uv-managed Python, launching `hermes chat` crashes with an unhandled traceback on exit:

```
File ".../prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
  ...
  File ".../selectors.py", line 523, in register
    self._selector.control([kev], 0, 0)
OSError: [Errno 22] Invalid argument
```

### Fix

The existing `except (KeyError, OSError)` handler in `HermesCLI.run()` already tries to catch this class of error (#6393), but the string check only matches `"is not registered"` and `"Bad file descriptor"`. The macOS kqueue path raises `EINVAL` (`"Invalid argument"`), so the error fell through to `raise` instead of showing the friendly "reinstall Python via pyenv/Homebrew" message.

Added `"Invalid argument"` to the condition.