### PR TITLE
fix(gateway): let /queue bypass active-session guard

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1579,7 +1579,7 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart"):
+            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart", "queue", "q"):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -176,6 +176,22 @@ class TestCommandBypassActiveSession:
             "/background response was not sent back to the user"
         )
 
+    @pytest.mark.asyncio
+    async def test_queue_bypasses_guard(self):
+        """/queue must bypass so it can queue without interrupting."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/queue follow up"))
+
+        assert sk not in adapter._pending_messages, (
+            "/queue was queued as a pending message instead of being dispatched"
+        )
+        assert any("handled:queue" in r for r in adapter.sent_responses), (
+            "/queue response was not sent back to the user"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: non-bypass messages still get queued


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram `/queue` while a session is already active.

The base platform adapter has an active-session guard that bypasses certain commands straight to the gateway runner instead of treating them like ordinary follow-up messages. `/queue` and `/q` were missing from that bypass list, so on Telegram they were being stashed as pending text, interrupting the current run, and then later getting discarded as leaked command input instead of actually queueing the next turn.

This change adds `/queue` and `/q` to that bypass path so they reach the existing queue handler in `gateway/run.py`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `/queue` and `/q` to the command-bypass list in `gateway/platforms/base.py`
- Added a regression test in `tests/gateway/test_command_bypass_active_session.py`

## How to Test

1. Start Hermes on Telegram and trigger a long-running turn.
2. Send `/queue follow up message` while that turn is still running.
3. Confirm Hermes replies `Queued for the next turn.` without interrupting the current task, then runs the queued prompt after the current turn finishes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression test passed:

`source venv/bin/activate && python -m pytest tests/gateway/test_command_bypass_active_session.py -q`

Full suite run requested by maintainer:

`source venv/bin/activate && python -m pytest tests/ -q -n 4`

Result:
- 36 failed
- 12158 passed
- 34 skipped

The failures were not concentrated in the `/queue` path and spanned pre-existing gateway, browser, setup, auth, and security test areas.
