### PR TITLE
fix(honcho): reject whitespace-only honcho_search and honcho_reasoning queries

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -959,7 +959,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": card})
 
             elif tool_name == "honcho_search":
-                query = args.get("query", "")
+                query = (args.get("query") or "").strip()
                 if not query:
                     return tool_error("Missing required parameter: query")
                 max_tokens = min(int(args.get("max_tokens", 800)), 2000)
@@ -972,7 +972,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 return json.dumps({"result": result})
 
             elif tool_name == "honcho_reasoning":
-                query = args.get("query", "")
+                query = (args.get("query") or "").strip()
                 if not query:
                     return tool_error("Missing required parameter: query")
                 peer = args.get("peer", "user")

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -450,6 +450,19 @@ class TestConcludeToolDispatch:
             peer="hermes",
         )
 
+    def test_honcho_search_rejects_whitespace_only_query(self):
+        """Whitespace-only query must not hit Honcho search API."""
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call("honcho_search", {"query": "  \t\n  "})
+        parsed = json.loads(result)
+        assert parsed == {"error": "Missing required parameter: query"}
+        provider._manager.search_context.assert_not_called()
+
     def test_honcho_reasoning_can_target_explicit_peer_id(self):
         provider = HonchoMemoryProvider()
         provider._session_initialized = True
@@ -469,6 +482,19 @@ class TestConcludeToolDispatch:
             reasoning_level=None,
             peer="hermes",
         )
+
+    def test_honcho_reasoning_rejects_whitespace_only_query(self):
+        """Whitespace-only query must not hit Honcho dialectic API."""
+        import json
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+
+        result = provider.handle_tool_call("honcho_reasoning", {"query": "   "})
+        parsed = json.loads(result)
+        assert parsed == {"error": "Missing required parameter: query"}
+        provider._manager.dialectic_query.assert_not_called()
 
     def test_honcho_conclude_missing_both_params_returns_error(self):
         """Calling honcho_conclude with neither conclusion nor delete_id returns a tool error."""


### PR DESCRIPTION
## Summary

- Validate `query` for `honcho_search` and `honcho_reasoning` with `(args.get("query") or "").strip()` before calling Honcho APIs.
- Prevents whitespace-only strings (e.g. spaces/tabs/newlines) from being treated as a real query; returns the same `tool_error` shape as an empty `query`: `Missing required parameter: query`.
- Adds regression tests in `tests/honcho_plugin/test_session.py` (`TestConcludeToolDispatch`) asserting the backend methods are not invoked for whitespace-only input.

## Context

Related upstream discussion / radar: #11192 (`fix(honcho): reject whitespace-only tool queries`).

## Test plan

- [x] `python -m pytest tests/honcho_plugin/test_session.py::TestConcludeToolDispatch -v -o addopts=`


Noticed this while setting up uv on Windows WSL2 — trivial guard, but it avoids pointless Honcho calls when the model sends blank queries.