### PR TITLE
fix(web): show current language's flag in switcher, not target

### DIFF
--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -17,10 +17,10 @@ export function LanguageSwitcher() {
       title={t.language.switchTo}
       aria-label={t.language.switchTo}
     >
-      {/* Show the *other* language's flag as the clickable target */}
-      <span className="text-base leading-none">{locale === "en" ? "🇨🇳" : "🇬🇧"}</span>
+      {/* Show the *current* language's flag — tooltip advertises the click action */}
+      <span className="text-base leading-none">{locale === "en" ? "🇬🇧" : "🇨🇳"}</span>
       <span className="hidden sm:inline font-display tracking-wide uppercase text-[0.65rem]">
-        {locale === "en" ? "中文" : "EN"}
+        {locale === "en" ? "EN" : "中文"}
       </span>
     </button>
   );


### PR DESCRIPTION
## Summary

Inverts the dashboard language switcher so the flag reflects the **current** language instead of the target. Feedback from Cthulhu [NOUS] in Discord — seeing the Chinese flag while the UI is in English reads as a state mismatch, since a flag functions as a status indicator before the tooltip/label are read.

## Before → After

| Locale | Before (target flag) | After (current flag) |
|---|---|---|
| English | 🇨🇳 中文 | 🇬🇧 EN |
| Chinese | 🇬🇧 EN | 🇨🇳 中文 |

Tooltip and aria-label (`Switch to Chinese` / `切换到英文`) still advertise the click action — only the visual state indicator changed.

## Test plan

- Open dashboard in English → see UK flag + EN
- Click → switches to Chinese, now see CN flag + 中文
- Hover in either state → tooltip correctly says "Switch to <other>"

## Diff

3 lines in `web/src/components/LanguageSwitcher.tsx`.