### PR TITLE
fix(cli): forward model.max_tokens from config to AIAgent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1722,6 +1722,9 @@ class HermesCLI:
             self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
         else:
             self.max_turns = 90
+
+        _mt = CLI_CONFIG["model"].get("max_tokens") if isinstance(CLI_CONFIG.get("model"), dict) else None
+        self.max_tokens = int(_mt) if _mt else None
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
@@ -2902,6 +2905,7 @@ class HermesCLI:
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
+                max_tokens=self.max_tokens,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,


### PR DESCRIPTION
# fix(cli): forward `model.max_tokens` from config to AIAgent

## Problem

`config.yaml` documents a `model.max_tokens` key (see `cli-config.yaml.example`) and `run_agent.py` expects `self.max_tokens` to gate whether a request includes a `max_tokens` parameter (`run_agent.py:6640`). However, `cli.py` never reads the config value and never forwards it to `AIAgent(...)`, so `self.max_tokens` on the agent remains `None` in every CLI chat session.

For most providers this is fine, but on OpenRouter the credit check rejects the request with HTTP 402 when no `max_tokens` is sent — OpenRouter reserves the model's full output cap against the key's per-request budget. Example with `qwen/qwen3.6-plus` (output cap 65 536):

```
HTTP 402: ... You requested up to 65536 tokens, but can only afford 20512
```

Setting `model.max_tokens: 16000` in `config.yaml` has no effect because the CLI never reads it. The error message at `run_agent.py:9191` ("set `model.max_tokens` in config.yaml") is therefore misleading — the key is documented but not wired through.

## Fix

Two small additions to `cli.py`:

1. After the `max_turns` resolution block (~line 1724), read `CLI_CONFIG["model"]["max_tokens"]` into `self.max_tokens`.
2. In the `AIAgent(...)` constructor call (~line 2907), forward it as `max_tokens=self.max_tokens`.

`AIAgent.__init__` already accepts a `max_tokens` kwarg, and `run_agent.py:6640` already gates on it — no changes needed there.

## Verification

On a fresh OpenRouter key with `model.max_tokens: 16000`:

- Before patch: `hermes chat -q "hi"` → HTTP 402 credit check failure.
- After patch: `hermes chat -q "Reply with exactly: HERMES_OK"` → returns `HERMES_OK` (HTTP 200).

## Scope

- Only affects the CLI chat path.
- No behavior change for users who don't set `model.max_tokens` (`self.max_tokens` stays `None`, same as before).
- No new config keys or env vars.

## Diff

See `cli-max-tokens.patch`.
