### PR TITLE
fix(google-workspace): parse OAuth scopes from full redirect callback URL

### DIFF
--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -284,6 +284,7 @@ def exchange_auth_code(code: str):
         sys.exit(1)
 
     pending_auth = _load_pending_auth()
+    raw_callback = code
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
         print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
@@ -293,19 +294,13 @@ def exchange_auth_code(code: str):
     from google_auth_oauthlib.flow import Flow
     from urllib.parse import parse_qs, urlparse
 
-    # Extract granted scopes from the callback URL if present
-    if returned_state and "scope" in parse_qs(urlparse(code).query if isinstance(code, str) and code.startswith("http") else {}):
-        granted_scopes = parse_qs(urlparse(code).query)["scope"][0].split()
-    else:
-        # Try to extract from code_or_url parameter
-        if isinstance(code, str) and code.startswith("http"):
-            params = parse_qs(urlparse(code).query)
-            if "scope" in params:
-                granted_scopes = params["scope"][0].split()
-            else:
-                granted_scopes = SCOPES
-        else:
-            granted_scopes = SCOPES
+    # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
+    granted_scopes = list(SCOPES)
+    if isinstance(raw_callback, str) and raw_callback.startswith("http"):
+        params = parse_qs(urlparse(raw_callback).query)
+        scope_val = (params.get("scope") or [""])[0].strip()
+        if scope_val:
+            granted_scopes = scope_val.split()
 
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -177,6 +177,22 @@ class TestExchangeAuthCode:
         flow = FakeFlow.created[-1]
         assert flow.fetch_token_calls == [{"code": "4/extracted-code"}]
 
+    def test_passes_scopes_from_redirect_url_to_flow(self, setup_module):
+        """Callback URL carries space-delimited scope list; Flow must receive it (not full SCOPES)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        g1 = "https://www.googleapis.com/auth/gmail.readonly"
+        g2 = "https://www.googleapis.com/auth/calendar"
+        from urllib.parse import quote
+
+        scope_q = quote(f"{g1} {g2}", safe="")
+        setup_module.exchange_auth_code(
+            f"http://localhost:1/?code=4/extracted-code&state=saved-state&scope={scope_q}"
+        )
+        flow = FakeFlow.created[-1]
+        assert flow.scopes == [g1, g2]
+
     def test_rejects_state_mismatch(self, setup_module, capsys):
         setup_module.PENDING_AUTH_PATH.write_text(
             json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})


### PR DESCRIPTION
## Summary

- Preserve the user-pasted OAuth redirect URL before extracting the authorization code.
- If the input is an `http(s)` URL, read the `scope` query parameter and pass the parsed list into `Flow.from_client_secrets_file`.
- Otherwise keep the previous behavior (default to the full configured `SCOPES` list).

## Motivation / root cause

After `_extract_code_and_state`, the callback string is reduced to the bare `code` token. The prior logic attempted to infer `scope` from the stripped value, which cannot contain the original query string. Result: `Flow` was always constructed with the full `SCOPES` even when Google returned a narrower `scope` in the redirect URL.

## Changes

- `skills/productivity/google-workspace/scripts/setup.py`
  - Introduce `raw_callback`, branch on `http` prefix, `parse_qs(urlparse(...).query)` for `scope`.
- `tests/skills/test_google_oauth_setup.py`
  - Add `test_passes_scopes_from_redirect_url_to_flow` to assert `Flow.scopes` matches the callback query.

## Verification

- [x] `python -m pytest tests/skills/test_google_oauth_setup.py -v -o addopts=`

## Related

- Aligns with the Google Workspace / callback URL robustness thread in the team radar (see `#11176` on the upstream tracker).

## Notes for reviewers

- If PR `#11259` (ancestor-based `hermes_constants` resolution in the same script) lands first, expect a trivial merge/rebase conflict only around imports / path bootstrap; the scope-parsing block is localized to `exchange_auth_code`.