### PR TITLE
fix 10721: fix NameError in summary model fallback path

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -730,7 +730,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic)  # retry with main model
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60


### PR DESCRIPTION
Fixes #10721

_generate_summary() fallback retry passed undefined messages variable and wrong-type summary_budget instead of turns_to_summarize and focus_topic parameters.

When summary model is unavailable (404/503), the fallback to main model crashed with NameError instead of gracefully retrying.