### PR TITLE
fix: enable TCP keepalives to detect dead provider connections (#10324)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4395,6 +4395,41 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
+        # Inject TCP keepalives so the kernel detects dead provider connections
+        # instead of letting them sit silently in CLOSE-WAIT (#10324).  Without
+        # this, a peer that drops mid-stream leaves the socket in a state where
+        # epoll_wait never fires, ``httpx`` read timeout may not trigger, and
+        # the agent hangs until manually killed.  Probes after 30s idle, retry
+        # every 10s, give up after 3 → dead peer detected within ~60s.
+        #
+        # Safety against #10933: the ``client_kwargs = dict(client_kwargs)``
+        # above means this injection only lands in the local per-call copy,
+        # never back into ``self._client_kwargs``.  Each ``_create_openai_client``
+        # invocation therefore gets its OWN fresh ``httpx.Client`` whose
+        # lifetime is tied to the OpenAI client it is passed to.  When the
+        # OpenAI client is closed (rebuild, teardown, credential rotation),
+        # the paired ``httpx.Client`` closes with it, and the next call
+        # constructs a fresh one — no stale closed transport can be reused.
+        # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
+        # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
+        if "http_client" not in client_kwargs:
+            try:
+                import httpx as _httpx
+                import socket as _socket
+                _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
+                if hasattr(_socket, "TCP_KEEPIDLE"):
+                    # Linux
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
+                elif hasattr(_socket, "TCP_KEEPALIVE"):
+                    # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
+                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+                client_kwargs["http_client"] = _httpx.Client(
+                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                )
+            except Exception:
+                pass  # Fall through to default transport if socket opts fail
         client = OpenAI(**client_kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",


### PR DESCRIPTION
Re-land of #10933, now guarded by the regression tests merged in #11266.

## What this PR does

Re-introduces the TCP keepalive injection on the httpx transport so the kernel actively probes idle connections and surfaces dead peers within ~60s instead of letting the agent hang indefinitely on a CLOSE-WAIT socket. Kernel probes after 30s idle, retries every 10s, gives up after 3.

## Why the previous land (#10933) broke z.ai and everyone else

#10933 mutated `client_kwargs` in place when injecting the `httpx.Client`. Since callers pass `self._client_kwargs` by reference, the injected client leaked back into the instance dict. After request 1, the OpenAI SDK closed its `http_client` — including the injected one. Request 2 reused the same now-closed `httpx.Client` from `self._client_kwargs` and every subsequent chat raised:

```
APIConnectionError: Connection error.
  cause: RuntimeError('Cannot send a request, as the client has been closed')
```

This is AlexKucera's Discord report on 2026-04-16 — first chat worked, every subsequent chat failed with three retry attempts and then "API call failed after 3 retries: Connection error." It bit every user who ran `hermes update` during the ~90 minute window #10933 was on main.

## Why this land doesn't regress the same way

The defensive `client_kwargs = dict(client_kwargs)` copy from @taeuk178's #10978 is already on main. It means this injection only lands in the per-call local copy — never back into `self._client_kwargs`. Each `_create_openai_client` invocation gets its own fresh `httpx.Client` whose lifetime is tied to the paired `OpenAI` client. When that `OpenAI` client is closed (rebuild, teardown, credential rotation), its `httpx.Client` closes with it, and the next call constructs a fresh one. No stale closed transport can be reused.

## Validation

### 1. Four regression guards all green

```
tests/run_agent/test_create_openai_client_kwargs_isolation.py       PASS
tests/run_agent/test_create_openai_client_reuse.py (2 tests)        PASS
tests/run_agent/test_sequential_chats_live.py (HERMES_LIVE_TESTS=1) PASS
```

The live test does 3 real OpenRouter round trips with an explicit `_replace_primary_openai_client` call between turns 2 and 3. That's the exact shape of AlexKucera's bug, and it passes here on this branch.

### 2. Socket options confirmed on the wire

Introspected the live httpx transport on a running `AIAgent`:

```
_socket_options: [(1, 9, 1), (6, 4, 30), (6, 5, 10), (6, 6, 3)]
               = (SO_KEEPALIVE=1, TCP_KEEPIDLE=30s, TCP_KEEPINTVL=10s, TCP_KEEPCNT=3)
```

All four intended options present and set correctly on Linux.

### 3. Simulated the #10933 failure state and confirmed it's blocked

Before committing, I explicitly removed the defensive copy from this branch to reproduce the exact pre-#10978 buggy state. Live test failed there, as expected. With the defensive copy restored (current main), all four tests pass.

## What this PR still doesn't solve

macOS path (TCP_KEEPALIVE fallback) is not live-tested here — only Linux. Same limitation as the original #10933. The ARM / Raspberry Pi path (AlexKucera's environment) is also not live-tested here — but the failure mode was never platform-specific, it was a lifecycle bug in the Python code, so same-architecture CI is sufficient for the regression guard.

## Test plan

```bash
# Full regression guard:
HERMES_LIVE_TESTS=1 python -m pytest \
  tests/run_agent/test_create_openai_client_kwargs_isolation.py \
  tests/run_agent/test_create_openai_client_reuse.py \
  tests/run_agent/test_sequential_chats_live.py -n0 -v

# Socket options inspection (needs OPENROUTER_API_KEY):
python -c "
from run_agent import AIAgent
import os
a = AIAgent(model='google/gemini-2.5-flash', provider='openrouter',
            api_key=os.environ['OPENROUTER_API_KEY'],
            base_url='https://openrouter.ai/api/v1',
            quiet_mode=True, skip_context_files=True, skip_memory=True,
            disabled_toolsets=['*'])
print(a.client._client._transport._socket_options)
"
```

Closes #10324.