### PR TITLE
fix(delegate): preserve explicit empty child toolsets

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -285,6 +285,28 @@ class TestDelegateTask(unittest.TestCase):
 
         self.assertIs(mock_child._print_fn, sink)
 
+    def test_explicit_empty_toolsets_do_not_inherit_parent_tools(self):
+        """toolsets=[] means no tools, not implicit inheritance from parent."""
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["terminal", "file", "web"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Review only",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["enabled_toolsets"], [])
+
     def test_child_uses_thinking_callback_when_progress_callback_available(self):
         parent = _make_mock_parent(depth=0)
         parent.tool_progress_callback = MagicMock()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -285,6 +285,27 @@ class TestDelegateTask(unittest.TestCase):
 
         self.assertIs(mock_child._print_fn, sink)
 
+    def test_explicit_empty_toolsets_do_not_inherit_parent_tools(self):
+        """toolsets=[] means no tools, not implicit inheritance from parent."""
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["terminal", "file", "web"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Review only",
+                context=None,
+                toolsets=[],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+            )
+
+        call_kwargs = MockAgent.call_args[1]
+        self.assertEqual(call_kwargs["enabled_toolsets"], [])
+
     def test_child_uses_thinking_callback_when_progress_callback_available(self):
         parent = _make_mock_parent(depth=0)
         parent.tool_progress_callback = MagicMock()

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -40,7 +40,7 @@ class TestToolsetIntersection:
         assert sorted(scoped) == ["terminal", "web"]
 
     def test_no_toolsets_requested_inherits_parent(self):
-        """When toolsets is None/empty, child inherits parent's set."""
+        """When toolsets is omitted (None), child inherits parent's set."""
         parent_toolsets = ["terminal", "file", "web"]
         child = _strip_blocked_tools(parent_toolsets)
         assert "terminal" in child

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -937,8 +937,9 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    if toolsets is not None:
         # Intersect with parent — subagent must not gain tools the parent lacks.
+        # An explicit empty list means "no tools", not "inherit from parent".
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -835,8 +835,9 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks
+    if toolsets is not None:
+        # Intersect with parent — subagent must not gain tools the parent lacks.
+        # An explicit empty list means "no tools", not "inherit from parent".
         child_toolsets = [t for t in toolsets if t in parent_toolsets]
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(


### PR DESCRIPTION
## Summary
- treat `toolsets=[]` as an explicit empty child toolset instead of falling back to inheritance
- keep `toolsets=None` on the existing inheritance path
- add a regression test for the explicit-empty case and tighten the adjacent test wording

## Root Cause
`_build_child_agent()` used `if toolsets:` to decide whether explicit child toolsets were provided. That made `[]` indistinguishable from an omitted argument, so review-only subagents could inherit the parent toolsets.

## Testing
- `/Users/keaneyan/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_delegate.py::TestDelegateTask::test_explicit_empty_toolsets_do_not_inherit_parent_tools -q`
- `/Users/keaneyan/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py -q`

Fixes #11274
