### PR TITLE
fix 11201: fix auto-title guard to use >= 2

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -113,7 +113,7 @@ def maybe_auto_title(
     # so for a first exchange we expect exactly 1 user message
     # (or 2 counting system). Be generous: generate on first 2 exchanges.
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
-    if user_msg_count > 2:
+    if user_msg_count >= 2:
         return
 
     thread = threading.Thread(


### PR DESCRIPTION
Fixes #11201

maybe_auto_title() claimed to generate titles only after the first exchange, but the guard was > 2 instead of >= 2, allowing auto-titling on the second exchange.