### PR TITLE
dashboard: show GATEWAY_HEALTH_URL instead of PID for remote gateways

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -467,6 +467,7 @@ async def get_status():
         "latest_config_version": latest_ver,
         "gateway_running": gateway_running,
         "gateway_pid": gateway_pid,
+        "gateway_health_url": _GATEWAY_HEALTH_URL,
         "gateway_state": gateway_state,
         "gateway_platforms": gateway_platforms,
         "gateway_exit_reason": gateway_exit_reason,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1122,6 +1122,7 @@ class TestStatusRemoteGateway:
         assert data["gateway_running"] is True
         assert data["gateway_pid"] == 999
         assert data["gateway_state"] == "running"
+        assert data["gateway_health_url"] == "http://gw:8642"
 
     def test_status_remote_probe_not_attempted_when_local_pid_found(self, monkeypatch):
         """When local PID check succeeds, the remote probe is never called."""
@@ -1158,6 +1159,7 @@ class TestStatusRemoteGateway:
         assert resp.status_code == 200
         data = resp.json()
         assert data["gateway_running"] is False
+        assert data["gateway_health_url"] is None
 
     def test_status_remote_running_null_pid(self, monkeypatch):
         """Remote gateway running but PID not in response — pid should be None."""

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -213,6 +213,7 @@ export interface StatusResponse {
   config_version: number;
   env_path: string;
   gateway_exit_reason: string | null;
+  gateway_health_url: string | null;
   gateway_pid: number | null;
   gateway_platforms: Record<string, PlatformStatus>;
   gateway_running: boolean;

--- a/web/src/pages/StatusPage.tsx
+++ b/web/src/pages/StatusPage.tsx
@@ -53,6 +53,7 @@ export default function StatusPage() {
   };
 
   function gatewayValue(): string {
+    if (status!.gateway_running && status!.gateway_health_url) return status!.gateway_health_url;
     if (status!.gateway_running && status!.gateway_pid) return `${t.status.pid} ${status!.gateway_pid}`;
     if (status!.gateway_running) return t.status.runningRemote;
     if (status!.gateway_state === "startup_failed") return t.status.startFailed;
@@ -137,14 +138,14 @@ export default function StatusPage() {
 
       <div className="grid gap-4 sm:grid-cols-3">
         {items.map(({ icon: Icon, label, value, badgeText, badgeVariant }) => (
-          <Card key={label}>
+          <Card key={label} className="min-w-0 overflow-hidden">
             <CardHeader className="flex flex-row items-center justify-between pb-2">
               <CardTitle className="text-sm font-medium">{label}</CardTitle>
               <Icon className="h-4 w-4 text-muted-foreground" />
             </CardHeader>
 
             <CardContent>
-              <div className="text-2xl font-bold font-display">{value}</div>
+              <div className="text-2xl font-bold font-display truncate" title={value}>{value}</div>
 
               {badgeText && (
                 <Badge variant={badgeVariant} className="mt-2">


### PR DESCRIPTION
Salvage of #11263 onto current main — cherry-picked benbarclay's commit, authorship preserved.

## Summary

When the dashboard runs in a separate container from the gateway and probes it via `GATEWAY_HEALTH_URL`, the Gateway status card currently displays the PID returned from the remote `/health/detailed` endpoint. That PID belongs to a process inside the remote container and is meaningless on the host where the dashboard is rendered — the comment on line 392 of `web_server.py` literally says "PID from the remote container (display only — not locally valid)".

This PR:
- Exposes `gateway_health_url` in the `/api/status` response
- Frontend prefers the URL over the remote PID in `gatewayValue()`
- Adds `truncate` + `title` tooltip so long URLs don't overflow the status card
- Adds `min-w-0 overflow-hidden` to status cards for proper flex truncation

## Test plan

- `pytest tests/hermes_cli/test_web_server.py` — 76 passed
- Includes new assertions on `gateway_health_url` in the remote-probe and no-URL scenarios

Original PR: #11263
Author: @benbarclay