### PR TITLE
fix(memory): reject duplicate builtin MemoryProvider registration

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -103,6 +103,15 @@ class MemoryManager:
         """
         is_builtin = provider.name == "builtin"
 
+        if is_builtin:
+            if any(p.name == "builtin" for p in self._providers):
+                logger.warning(
+                    "Rejected memory provider '%s' — builtin provider is already "
+                    "registered. Only one builtin slot exists.",
+                    provider.name,
+                )
+                return
+
         if not is_builtin:
             if self._has_external:
                 existing = next(

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -155,6 +155,16 @@ class TestMemoryManager:
         assert [p.name for p in mgr.providers] == ["builtin", "mem0"]
         assert len(mgr.providers) == 2
 
+    def test_second_builtin_rejected(self):
+        """Only one provider with name builtin may exist; duplicate poisons routing."""
+        mgr = MemoryManager()
+        b1 = FakeMemoryProvider("builtin")
+        b2 = FakeMemoryProvider("builtin")
+        mgr.add_provider(b1)
+        mgr.add_provider(b2)
+        assert [p.name for p in mgr.providers] == ["builtin"]
+        assert mgr.providers[0] is b1
+
     def test_system_prompt_merges_blocks(self):
         mgr = MemoryManager()
         p1 = FakeMemoryProvider("builtin")


### PR DESCRIPTION
## Summary

`MemoryManager.add_provider` accepted multiple providers with `name == "builtin"`, violating the single-slot invariant documented on `MemoryProvider` / `MemoryManager` and risking duplicate tool routing and lifecycle calls.

## Changes

- Reject a second builtin registration with a `warning` log and early `return` (same pattern as the single-external cap).
- Add regression test `test_second_builtin_rejected`.

## Test plan

- `python -m pytest tests/agent/test_memory_provider.py -o addopts=`