### PR TITLE
fix: detect macOS gateway service processes reliably

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -88,16 +88,35 @@ def _get_service_pids() -> set:
                 capture_output=True, text=True, timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
+                pid_from_plist = None
+                label_matches = False
                 for line in result.stdout.strip().splitlines():
-                    parts = line.split()
+                    stripped = line.strip()
+
+                    # Older launchctl output: "PID\tStatus\tLabel"
+                    parts = stripped.split()
                     if len(parts) >= 3 and parts[2] == label:
                         try:
                             pid = int(parts[0])
                             if pid > 0:
                                 pids.add(pid)
+                                continue
                         except ValueError:
                             pass
+
+                    # Modern macOS output: plist-style dictionary
+                    if stripped.startswith('"PID"') and "=" in stripped:
+                        raw_pid = stripped.split("=", 1)[1].strip().rstrip(";")
+                        try:
+                            pid_from_plist = int(raw_pid)
+                        except ValueError:
+                            pid_from_plist = None
+                    elif stripped.startswith('"Label"') and "=" in stripped:
+                        raw_label = stripped.split("=", 1)[1].strip().rstrip(";").strip('"')
+                        label_matches = raw_label == label
+
+                if label_matches and pid_from_plist and pid_from_plist > 0:
+                    pids.add(pid_from_plist)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -221,8 +240,13 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
                             pass
                     current_cmd = ""
         else:
+            # macOS `ps` doesn't accept the BSD `e` flag the way Linux does,
+            # so we can't surface env vars there. As a result, gateways started
+            # on macOS with only `HERMES_HOME=<path>` (no `--profile` flag)
+            # won't be attributable to a named profile via `_matches_current_profile`.
+            ps_command = ["ps", "-Aww", "-o", "pid=,command="] if is_macos() else ["ps", "-A", "eww", "-o", "pid=,command="]
             result = subprocess.run(
-                ["ps", "-A", "eww", "-o", "pid=,command="],
+                ps_command,
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -475,7 +475,7 @@ def _scan_gateway_pids(
                     current_cmd = ""
         else:
             # Try /proc first (works in Docker without procps installed),
-            # fall back to ps -A eww.
+            # fall back to a platform-appropriate ps invocation.
             _found_via_proc = False
             if os.path.isdir("/proc"):
                 try:
@@ -501,8 +501,17 @@ def _scan_gateway_pids(
                     pass
 
             if not _found_via_proc:
+                # macOS `ps` doesn't accept the BSD `e` flag the way Linux does,
+                # so we can't surface env vars there. As a result, gateways started
+                # on macOS with only `HERMES_HOME=<path>` (no `--profile` flag)
+                # won't be attributable to a named profile via `_matches_current_profile`.
+                ps_command = (
+                    ["ps", "-Aww", "-o", "pid=,command="]
+                    if is_macos()
+                    else ["ps", "-A", "eww", "-o", "pid=,command="]
+                )
                 result = subprocess.run(
-                    ["ps", "-A", "eww", "-o", "pid=,command="],
+                    ps_command,
                     capture_output=True,
                     text=True, encoding='utf-8', errors='replace',
                     timeout=10,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -166,6 +166,68 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    def test_get_service_pids_parses_launchctl_plist_style_output(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        launchctl_stdout = """{
+\t\"PID\" = 80263;
+\t\"Label\" = \"ai.hermes.gateway\";
+};\n"""
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=5, **kwargs):
+            assert cmd == ["launchctl", "list", "ai.hermes.gateway"]
+            return SimpleNamespace(returncode=0, stdout=launchctl_stdout, stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._get_service_pids() == {80263}
+
+    def test_find_gateway_pids_uses_macos_ps_args(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: Path("/Users/test/.hermes"))
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway_cli.os, "getpid", lambda: 99999)
+
+        calls = []
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=10, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout="12345 /Users/test/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.find_gateway_pids() == [12345]
+        assert calls == [["ps", "-Aww", "-o", "pid=,command="]]
+
+    def test_find_gateway_pids_uses_linux_ps_args(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: Path("/home/test/.hermes"))
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr(gateway_cli.os, "getpid", lambda: 99999)
+
+        calls = []
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=10, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout="12345 /home/test/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.find_gateway_pids() == [12345]
+        assert calls == [["ps", "-A", "eww", "-o", "pid=,command="]]
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1551,6 +1551,55 @@ class TestGatewayServiceDetection:
 
         assert gateway_cli._is_service_running() is False
 
+class TestScanGatewayPidsPsSelection:
+    """The ps fallback in _scan_gateway_pids must use macOS-valid arguments.
+
+    macOS `ps` rejects the BSD `e` flag in the `-A eww` invocation, so when
+    /proc is unavailable (always true on macOS) the scan silently found
+    nothing and gateway/cron status reported a live gateway as down.
+    """
+
+    def _force_ps_fallback(self, monkeypatch, macos, home):
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: macos)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: Path(home))
+        monkeypatch.setattr(gateway_cli, "_get_ancestor_pids", lambda: set())
+
+        real_isdir = os.path.isdir
+        monkeypatch.setattr(
+            gateway_cli.os.path,
+            "isdir",
+            lambda path: False if path == "/proc" else real_isdir(path),
+        )
+
+        calls = []
+
+        def fake_run(cmd, capture_output=True, text=True, timeout=10, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    f"12345 {home}/hermes-agent/venv/bin/python"
+                    " -m hermes_cli.main gateway run --replace\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        return calls
+
+    def test_scan_uses_macos_ps_args_when_proc_unavailable(self, monkeypatch):
+        calls = self._force_ps_fallback(monkeypatch, macos=True, home="/Users/test/.hermes")
+
+        assert gateway_cli._scan_gateway_pids(set()) == [12345]
+        assert calls == [["ps", "-Aww", "-o", "pid=,command="]]
+
+    def test_scan_keeps_linux_ps_args_when_proc_unavailable(self, monkeypatch):
+        calls = self._force_ps_fallback(monkeypatch, macos=False, home="/home/test/.hermes")
+
+        assert gateway_cli._scan_gateway_pids(set()) == [12345]
+        assert calls == [["ps", "-A", "eww", "-o", "pid=,command="]]
+
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []


### PR DESCRIPTION
## Summary

Fixes false-negative gateway/cron status detection on macOS by making the manual process-table scan use a macOS-valid `ps` invocation.

> **Scope update (post-review):** the original version of this PR also taught `_get_service_pids()` to parse plist-style `launchctl list` output. That half has since landed on main separately (`_parse_launchd_pid_from_list_output()`, with parser and probe coverage), so per the sweeper review this branch was rebased onto main and narrowed to only the process-scan fix.

## Problem

On macOS, `_scan_gateway_pids()` falls back to `ps` when `/proc` is unavailable — which is always the case on macOS. The fallback invocation `ps -A eww -o pid=,command=` is rejected by macOS `ps`:

```
$ ps -A eww -o pid=,command=
ps: illegal argument: eww
```

so the scan silently found nothing, and commands like `hermes cron status` reported the gateway as down even while a launchd-managed gateway was alive.

## What changed

- `_scan_gateway_pids()` now selects `ps -Aww -o pid=,command=` on macOS and keeps the existing `ps -A eww -o pid=,command=` invocation everywhere else, so Linux behavior is untouched.
- New regression tests (`TestScanGatewayPidsPsSelection`) exercise the fallback with `/proc` forced unavailable: one asserts the macOS argv, the other preserves the existing Linux argv assertion.

## Notes

On macOS, `ps -Aww` cannot surface env vars the way Linux `ps eww` does, so gateways started with only `HERMES_HOME=<path>` in the environment (no `--profile` flag) won't be attributable to a named profile via `_matches_current_profile`. This is called out inline in the code; this PR does not attempt to change profile attribution behavior.

## Tests

- `tests/hermes_cli/test_gateway_service.py::TestScanGatewayPidsPsSelection` — 2 passed
- Full-file run on a macOS dev box: 186 passed; the few failures observed are also present on unmodified main in that environment and are unrelated to this change.
- Verified on macOS directly: `ps -A eww -o pid=,command=` exits 1 (`illegal argument: eww`), `ps -Aww -o pid=,command=` exits 0.
