### PR TITLE
Add SSRF protection for QQ voice attachment downloads

### DIFF
--- a/gateway/platforms/qqbot.py
+++ b/gateway/platforms/qqbot.py
@@ -64,6 +64,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_image_from_bytes,
 )
@@ -226,7 +227,11 @@ class QQAdapter(BasePlatformAdapter):
             return False
 
         try:
-            self._http_client = httpx.AsyncClient(timeout=30.0, follow_redirects=True)
+            self._http_client = httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=True,
+                event_hooks={"response": [_ssrf_redirect_guard]},
+            )
 
             # 1. Get access token
             await self._ensure_token()
@@ -1100,6 +1105,11 @@ class QQAdapter(BasePlatformAdapter):
             download_url = voice_wav_url
             is_pre_wav = True
             logger.info("[QQ] STT: using voice_wav_url (pre-converted WAV)")
+
+        from tools.url_safety import is_safe_url
+        if not is_safe_url(download_url):
+            logger.warning("[QQ] STT blocked unsafe URL: %s", download_url[:80])
+            return None
 
         try:
             # 2. Download audio (QQ CDN requires Authorization header)

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1,5 +1,6 @@
 """Tests for the QQ Bot platform adapter."""
 
+import asyncio
 import json
 import os
 import sys
@@ -148,6 +149,47 @@ class TestIsVoiceContentType:
     def test_audio_extension_amr(self):
         assert self._fn("", "recording.amr") is True
 
+
+# ---------------------------------------------------------------------------
+# Voice attachment SSRF protection
+# ---------------------------------------------------------------------------
+
+class TestVoiceAttachmentSSRFProtection:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    def test_stt_blocks_unsafe_download_url(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._http_client = mock.AsyncMock()
+
+        with mock.patch("tools.url_safety.is_safe_url", return_value=False):
+            transcript = asyncio.run(
+                adapter._stt_voice_attachment(
+                    "http://127.0.0.1/voice.silk",
+                    "audio/silk",
+                    "voice.silk",
+                )
+            )
+
+        assert transcript is None
+        adapter._http_client.get.assert_not_called()
+
+    def test_connect_uses_redirect_guard_hook(self):
+        from gateway.platforms.qqbot import QQAdapter, _ssrf_redirect_guard
+
+        client = mock.AsyncMock()
+        with mock.patch("gateway.platforms.qqbot.httpx.AsyncClient", return_value=client) as async_client_cls:
+            adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+            adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
+
+            connected = asyncio.run(adapter.connect())
+
+        assert connected is False
+        assert async_client_cls.call_count == 1
+        kwargs = async_client_cls.call_args.kwargs
+        assert kwargs.get("follow_redirects") is True
+        assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
 # ---------------------------------------------------------------------------
 # _strip_at_mention


### PR DESCRIPTION
### Motivation
- The QQ platform adapter downloaded voice attachment URLs (including redirect chains) without invoking the project's SSRF checks, allowing untrusted inbound messages to trigger requests to internal/private endpoints.
- The HTTP client was created with redirect-following enabled but without the shared redirect guard event hook, so redirect-based SSRF could bypass preflight checks.

### Description
- Attach the shared `_ssrf_redirect_guard` hook to the adapter's `httpx.AsyncClient` by passing `event_hooks={"response": [_ssrf_redirect_guard]}` when creating the client.
- Add an explicit preflight `is_safe_url(download_url)` check in `_stt_voice_attachment` and return early if the URL is unsafe, avoiding any outbound download attempts for blocked URLs.
- Import `_ssrf_redirect_guard` from `gateway.platforms.base` and `is_safe_url` from `tools.url_safety` in the QQ adapter as needed.
- Add regression tests `TestVoiceAttachmentSSRFProtection` to ensure unsafe voice URLs are blocked before a `get()` is attempted and that `connect()` configures `AsyncClient` with the redirect guard; tests use `asyncio.run` to exercise async code without requiring pytest async plugins.

### Testing
- Ran `python -m pytest tests/gateway/test_qqbot.py -q` which initially failed in this environment due to project `addopts` including `-n` (xdist) being unavailable.  
- Ran `python -m pytest -o addopts='' tests/gateway/test_qqbot.py -q` to bypass the `addopts` override, and the suite passed (`67 passed, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e246187c8327872e23f46595c980)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/plgonzalezrx8/hermes-agent/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
