### PR TITLE
fix(gateway): stop trusting email From for authorization

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -76,7 +76,7 @@ _ensure_ssl_certs()
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home
 from utils import atomic_yaml_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
@@ -1824,9 +1824,10 @@ class GatewayRunner:
         if not _any_allowlist and not _allow_all:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
-                "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "
+                "Set GATEWAY_ALLOW_ALL_USERS=true in %s/.env to allow open access, "
                 "or configure platform allowlists for non-email platforms "
-                "(e.g., TELEGRAM_ALLOWED_USERS=your_id)."
+                "(e.g., TELEGRAM_ALLOWED_USERS=your_id).",
+                display_hermes_home(),
             )
         self._warn_on_ineffective_email_auth_config()
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1748,6 +1748,28 @@ class GatewayRunner:
         task.add_done_callback(self._background_tasks.discard)
         return True
 
+    def _warn_on_ineffective_email_auth_config(self) -> None:
+        """Warn when spoofable email sender identity is configured as an auth signal."""
+        email_config = self.config.platforms.get(Platform.EMAIL)
+        if not email_config or not getattr(email_config, "enabled", False):
+            return
+
+        ineffective_vars = [
+            name
+            for name in ("EMAIL_ALLOWED_USERS", "GATEWAY_ALLOWED_USERS")
+            if os.getenv(name, "").strip()
+        ]
+        if not ineffective_vars:
+            return
+
+        verb = "is" if len(ineffective_vars) == 1 else "are"
+        logger.warning(
+            "%s %s ignored for gateway email authorization because email From headers are spoofable. "
+            "Use EMAIL_ALLOW_ALL_USERS=true or GATEWAY_ALLOW_ALL_USERS=true if you intentionally want to accept email senders.",
+            ", ".join(ineffective_vars),
+            verb,
+        )
+
     async def start(self) -> bool:
         """
         Start the gateway and all configured platform adapters.
@@ -1775,7 +1797,6 @@ class GatewayRunner:
             for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
                        "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
                        "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
-                       "EMAIL_ALLOWED_USERS",
                        "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
                        "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
                        "FEISHU_ALLOWED_USERS",
@@ -1804,8 +1825,10 @@ class GatewayRunner:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
                 "Set GATEWAY_ALLOW_ALL_USERS=true in ~/.hermes/.env to allow open access, "
-                "or configure platform allowlists (e.g., TELEGRAM_ALLOWED_USERS=your_id)."
+                "or configure platform allowlists for non-email platforms "
+                "(e.g., TELEGRAM_ALLOWED_USERS=your_id)."
             )
+        self._warn_on_ineffective_email_auth_config()
         
         # Discover and load event hooks
         self.hooks.discover_and_load()
@@ -2583,10 +2606,14 @@ class GatewayRunner:
         
         Checks in order:
         1. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
-        2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
-        3. DM pairing approved list
+        2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.) for non-email platforms
+        3. DM pairing approved list for non-email platforms
         4. Global allow-all (GATEWAY_ALLOW_ALL_USERS=true)
         5. Default: deny
+
+        Email is an exception: SMTP/IMAP From headers are spoofable, so email
+        senders are never authorized via allowlists or pairing based on
+        source.user_id. Email only honors explicit allow-all flags.
         """
         # Home Assistant events are system-generated (state changes), not
         # user-initiated messages.  The HASS_TOKEN already authenticates the
@@ -2606,7 +2633,6 @@ class GatewayRunner:
             Platform.WHATSAPP: "WHATSAPP_ALLOWED_USERS",
             Platform.SLACK: "SLACK_ALLOWED_USERS",
             Platform.SIGNAL: "SIGNAL_ALLOWED_USERS",
-            Platform.EMAIL: "EMAIL_ALLOWED_USERS",
             Platform.SMS: "SMS_ALLOWED_USERS",
             Platform.MATTERMOST: "MATTERMOST_ALLOWED_USERS",
             Platform.MATRIX: "MATRIX_ALLOWED_USERS",
@@ -2641,6 +2667,13 @@ class GatewayRunner:
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in ("true", "1", "yes"):
             return True
+
+        # Email identities are derived from the SMTP/IMAP "From" header,
+        # which is unauthenticated and can be spoofed. Never authorize email
+        # senders via allowlists or pairing based on source.user_id. Email
+        # only honors explicit allow-all flags.
+        if source.platform == Platform.EMAIL:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
 
         # Check pairing store (always checked, regardless of allowlists)
         platform_name = source.platform.value if source.platform else ""
@@ -2688,6 +2721,10 @@ class GatewayRunner:
 
     def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
         """Return how unauthorized DMs should be handled for a platform."""
+        if platform == Platform.EMAIL:
+            # Email sender identity comes from a spoofable From header, so do
+            # not advertise pairing for a channel we intentionally do not trust.
+            return "ignore"
         config = getattr(self, "config", None)
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
             return config.get_unauthorized_dm_behavior(platform)
@@ -2721,7 +2758,8 @@ class GatewayRunner:
             return None
         elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
-            # In DMs: offer pairing code. In groups: silently ignore.
+            # Pairing is only offered in DMs that allow pairing; otherwise
+            # unauthorized messages are silently ignored.
             if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
                 platform_name = source.platform.value if source.platform else "unknown"
                 # Rate-limit ALL pairing responses (code or rejection) to

--- a/tests/gateway/test_allowlist_startup_check.py
+++ b/tests/gateway/test_allowlist_startup_check.py
@@ -11,7 +11,6 @@ def _would_warn():
         for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
                    "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
                    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
-                   "EMAIL_ALLOWED_USERS",
                    "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
                    "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
                    "GATEWAY_ALLOWED_USERS")
@@ -37,8 +36,16 @@ class TestAllowlistStartupCheck:
         with patch.dict(os.environ, {"SIGNAL_GROUP_ALLOWED_USERS": "user1"}, clear=True):
             assert _would_warn() is False
 
+    def test_email_allowed_users_does_not_suppress_warning(self):
+        with patch.dict(os.environ, {"EMAIL_ALLOWED_USERS": "spoofable@example.com"}, clear=True):
+            assert _would_warn() is True
+
     def test_telegram_allow_all_users_suppresses_warning(self):
         with patch.dict(os.environ, {"TELEGRAM_ALLOW_ALL_USERS": "true"}, clear=True):
+            assert _would_warn() is False
+
+    def test_email_allow_all_users_suppresses_warning(self):
+        with patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}, clear=True):
             assert _would_warn() is False
 
     def test_gateway_allow_all_users_suppresses_warning(self):

--- a/tests/gateway/test_allowlist_startup_check.py
+++ b/tests/gateway/test_allowlist_startup_check.py
@@ -4,6 +4,9 @@ import os
 from unittest.mock import patch
 
 
+_TRUTHY = ("true", "1", "yes")
+
+
 def _would_warn():
     """Replicate the startup allowlist warning logic. Returns True if warning fires."""
     _any_allowlist = any(
@@ -12,16 +15,22 @@ def _would_warn():
                    "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
                    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
                    "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
-                   "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
+                   "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
+                   "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
+                   "WECOM_CALLBACK_ALLOWED_USERS", "WEIXIN_ALLOWED_USERS",
+                   "BLUEBUBBLES_ALLOWED_USERS", "QQ_ALLOWED_USERS",
                    "GATEWAY_ALLOWED_USERS")
     )
-    _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
-        os.getenv(v, "").lower() in ("true", "1", "yes")
+    _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in _TRUTHY or any(
+        os.getenv(v, "").lower() in _TRUTHY
         for v in ("TELEGRAM_ALLOW_ALL_USERS", "DISCORD_ALLOW_ALL_USERS",
                    "WHATSAPP_ALLOW_ALL_USERS", "SLACK_ALLOW_ALL_USERS",
                    "SIGNAL_ALLOW_ALL_USERS", "EMAIL_ALLOW_ALL_USERS",
                    "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
-                   "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS")
+                   "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS",
+                   "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
+                   "WECOM_CALLBACK_ALLOW_ALL_USERS", "WEIXIN_ALLOW_ALL_USERS",
+                   "BLUEBUBBLES_ALLOW_ALL_USERS", "QQ_ALLOW_ALL_USERS")
     )
     return not _any_allowlist and not _allow_all
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -271,8 +271,13 @@ class TestAuthorizationMaps(unittest.TestCase):
         """EMAIL_ALLOWED_USERS should not be trusted for email auth."""
         import gateway.run
         import inspect
+        import re
+
         source = inspect.getsource(gateway.run.GatewayRunner._is_user_authorized)
-        self.assertNotIn('Platform.EMAIL: "EMAIL_ALLOWED_USERS"', source)
+        self.assertFalse(
+            re.search(r'Platform\.EMAIL\s*:\s*[\'\"]EMAIL_ALLOWED_USERS[\'\"]', source),
+            "EMAIL must not appear in the allowed-users map.",
+        )
 
     def test_email_in_allow_all_map(self):
         """EMAIL_ALLOW_ALL_USERS should be in platform_allow_all_map."""
@@ -357,6 +362,22 @@ class TestAuthorizationMaps(unittest.TestCase):
         self.assertIn("GATEWAY_ALLOWED_USERS is ignored", output)
         self.assertIn("From headers are spoofable", output)
 
+    @patch.dict(os.environ, {"EMAIL_ALLOWED_USERS": "allowed@example.com"}, clear=True)
+    def test_email_platform_allowlist_warning_is_emitted(self):
+        """Startup warns when EMAIL_ALLOWED_USERS is set for email auth."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={Platform.EMAIL: PlatformConfig(enabled=True)})
+
+        with self.assertLogs("gateway.run", level="WARNING") as logs:
+            runner._warn_on_ineffective_email_auth_config()
+
+        output = "\n".join(logs.output)
+        self.assertIn("EMAIL_ALLOWED_USERS is ignored", output)
+        self.assertIn("From headers are spoofable", output)
+
     @patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}, clear=True)
     def test_email_platform_allow_all_is_honored(self):
         """Email access is allowed when EMAIL_ALLOW_ALL_USERS is enabled."""
@@ -377,9 +398,29 @@ class TestAuthorizationMaps(unittest.TestCase):
         )
         self.assertTrue(runner._is_user_authorized(source))
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_email_requires_explicit_allow_all_without_flags(self):
+        """Email access is denied unless an explicit allow-all flag is enabled."""
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            user_id="anyone@example.com",
+            chat_id="anyone@example.com",
+            user_name="Anyone",
+            chat_type="dm",
+        )
+        self.assertFalse(runner._is_user_authorized(source))
+
     @patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "true"}, clear=True)
-    def test_email_requires_explicit_allow_all(self):
-        """Email access is only allowed with explicit allow-all flags."""
+    def test_email_global_allow_all_is_honored(self):
+        """Email access is allowed when GATEWAY_ALLOW_ALL_USERS is enabled."""
         from gateway.config import Platform
         from gateway.run import GatewayRunner
         from gateway.session import SessionSource

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -258,7 +258,7 @@ class TestExtractAttachments(unittest.TestCase):
 
 
 class TestAuthorizationMaps(unittest.TestCase):
-    """Verify email is in authorization maps in gateway/run.py."""
+    """Verify email auth only trusts explicit allow-all flags."""
 
     def test_email_in_adapter_factory(self):
         """Email adapter creation branch should exist."""
@@ -267,12 +267,12 @@ class TestAuthorizationMaps(unittest.TestCase):
         source = inspect.getsource(gateway.run.GatewayRunner._create_adapter)
         self.assertIn("Platform.EMAIL", source)
 
-    def test_email_in_allowed_users_map(self):
-        """EMAIL_ALLOWED_USERS should be in platform_env_map."""
+    def test_email_not_in_allowed_users_map(self):
+        """EMAIL_ALLOWED_USERS should not be trusted for email auth."""
         import gateway.run
         import inspect
         source = inspect.getsource(gateway.run.GatewayRunner._is_user_authorized)
-        self.assertIn("EMAIL_ALLOWED_USERS", source)
+        self.assertNotIn('Platform.EMAIL: "EMAIL_ALLOWED_USERS"', source)
 
     def test_email_in_allow_all_map(self):
         """EMAIL_ALLOW_ALL_USERS should be in platform_allow_all_map."""
@@ -280,6 +280,122 @@ class TestAuthorizationMaps(unittest.TestCase):
         import inspect
         source = inspect.getsource(gateway.run.GatewayRunner._is_user_authorized)
         self.assertIn("EMAIL_ALLOW_ALL_USERS", source)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_email_pairing_approval_is_not_trusted_for_auth(self):
+        """Approved pairing should not authorize email senders."""
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = True
+
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            user_id="approved@example.com",
+            chat_id="approved@example.com",
+            user_name="Approved User",
+            chat_type="dm",
+        )
+        self.assertFalse(runner._is_user_authorized(source))
+
+    @patch.dict(os.environ, {"EMAIL_ALLOWED_USERS": "allowed@example.com"}, clear=True)
+    def test_email_allowlist_is_not_trusted_for_auth(self):
+        """Email allowlists are ignored because From headers are spoofable."""
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            user_id="allowed@example.com",
+            chat_id="allowed@example.com",
+            user_name="Allowed User",
+            chat_type="dm",
+        )
+        self.assertFalse(runner._is_user_authorized(source))
+
+    @patch.dict(os.environ, {"GATEWAY_ALLOWED_USERS": "allowed@example.com"}, clear=True)
+    def test_email_global_allowlist_is_not_trusted_for_auth(self):
+        """Global allowlists are also ignored for email auth."""
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            user_id="allowed@example.com",
+            chat_id="allowed@example.com",
+            user_name="Allowed User",
+            chat_type="dm",
+        )
+        self.assertFalse(runner._is_user_authorized(source))
+
+    @patch.dict(os.environ, {"GATEWAY_ALLOWED_USERS": "allowed@example.com"}, clear=True)
+    def test_email_global_allowlist_warning_is_emitted(self):
+        """Startup warns when email is configured with ineffective allowlists."""
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={Platform.EMAIL: PlatformConfig(enabled=True)})
+
+        with self.assertLogs("gateway.run", level="WARNING") as logs:
+            runner._warn_on_ineffective_email_auth_config()
+
+        output = "\n".join(logs.output)
+        self.assertIn("GATEWAY_ALLOWED_USERS is ignored", output)
+        self.assertIn("From headers are spoofable", output)
+
+    @patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}, clear=True)
+    def test_email_platform_allow_all_is_honored(self):
+        """Email access is allowed when EMAIL_ALLOW_ALL_USERS is enabled."""
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            user_id="anyone@example.com",
+            chat_id="anyone@example.com",
+            user_name="Anyone",
+            chat_type="dm",
+        )
+        self.assertTrue(runner._is_user_authorized(source))
+
+    @patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "true"}, clear=True)
+    def test_email_requires_explicit_allow_all(self):
+        """Email access is only allowed with explicit allow-all flags."""
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            user_id="anyone@example.com",
+            chat_id="anyone@example.com",
+            user_name="Anyone",
+            chat_type="dm",
+        )
+        self.assertTrue(runner._is_user_authorized(source))
 
 
 class TestSendMessageToolRouting(unittest.TestCase):

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -253,3 +253,24 @@ async def test_global_ignore_suppresses_pairing_reply(monkeypatch):
     assert result is None
     runner.pairing_store.generate_code.assert_not_called()
     adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_email_dm_is_silently_ignored(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={Platform.EMAIL: PlatformConfig(enabled=True)},
+    )
+    runner, adapter = _make_runner(Platform.EMAIL, config)
+
+    result = await runner._handle_message(
+        _make_event(
+            Platform.EMAIL,
+            "spoofed@example.com",
+            "spoofed@example.com",
+        )
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- The Email adapter derived `source.user_id` from the unauthenticated SMTP/IMAP `From` header, allowing a remote sender to spoof an allowlisted address and bypass gateway authorization. 
- The change prevents an authentication bypass by removing trust in `From` for allowlist/pairing decisions while preserving explicit allow-all opts.

### Description
- Added an early-return in `GatewayRunner._is_user_authorized()` to avoid using `source.user_id` for `Platform.EMAIL` authorization and only permit email traffic via explicit global allow-all flags (existing per-platform allow-all logic remains active). 
- This code change is located in `gateway/run.py` and only affects the email platform branch of the authorization flow. 
- Added regression tests in `tests/gateway/test_email.py` (`test_email_allowlist_is_not_trusted_for_auth`, `test_email_requires_explicit_allow_all`) to assert that `EMAIL_ALLOWED_USERS` no longer authorizes email senders and that `GATEWAY_ALLOW_ALL_USERS=true` still authorizes email traffic.

### Testing
- Running the project-level `pytest` with default options failed in this environment due to an external `-n` option (xdist) injected by the test config, not related to the change. 
- Ran the targeted suite with `python -m pytest -o addopts='' tests/gateway/test_email.py -q` and the tests passed: `71 passed, 1 warning`. 
- The added tests exercised the modified authorization behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16527157c8327b64949722d882ea0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/plgonzalezrx8/hermes-agent/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email access authorization can now be controlled via a global allow-all configuration setting, providing an alternative to pairing-store approval for system administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->