### PR TITLE
fix(agent): stop sending think=false to remote custom providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6731,13 +6731,10 @@ class AIAgent:
             options["num_ctx"] = self._ollama_num_ctx
             extra_body["options"] = options
 
-        # Ollama / custom provider: pass think=false when reasoning is disabled.
-        # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
-        # field, so we use its native `think` parameter instead.
-        # This prevents thinking-capable models (Qwen3, etc.) from generating
-        # <think> blocks and producing empty-response errors when the user has
-        # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        # Ollama-style custom providers: pass think=false when reasoning is
+        # disabled. Remote OpenAI-compatible custom endpoints reject Ollama's
+        # native `think` field with 4xx validation errors.
+        if self._should_send_ollama_think_flag() and self.reasoning_config and isinstance(self.reasoning_config, dict):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
@@ -6755,6 +6752,14 @@ class AIAgent:
             api_kwargs.update(self.request_overrides)
 
         return api_kwargs
+
+    def _should_send_ollama_think_flag(self) -> bool:
+        """Return True when a custom endpoint should receive Ollama's think flag."""
+        if (self.provider or "").lower() != "custom":
+            return False
+        if "ollama" in self._base_url_lower or ":11434" in self._base_url_lower:
+            return True
+        return bool(self.base_url and is_local_endpoint(self.base_url))
 
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1015,6 +1015,16 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+    def test_remote_custom_provider_does_not_receive_ollama_think_flag(self, agent):
+        """Remote OpenAI-compatible custom providers should not receive think=false."""
+        agent.provider = "custom"
+        agent.base_url = "https://api.mistral.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": False}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is None
+
     def test_non_custom_provider_unaffected(self, agent):
         """OpenRouter provider with effort=none should NOT inject think=false."""
         agent.provider = "openrouter"


### PR DESCRIPTION
Summary\n- only send Ollama's native \ flag to Ollama-style custom endpoints\n- keep existing local Ollama behavior intact while avoiding 4xx validation errors on remote OpenAI-compatible providers\n- add a regression test for remote custom providers\n\nWhy\n- \ currently injects \ for every endpoint when reasoning is disabled\n- remote custom providers like Mistral reject that Ollama-specific field with HTTP 422\n\nFixes #11237\n\nTesting\n- python3 -m pytest -o addopts='' tests/run_agent/test_run_agent.py -k "think_false or remote_custom_provider_does_not_receive_ollama_think_flag or non_custom_provider_unaffected"