### PR TITLE
feat: add cron task watchdog heartbeats and blockers

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -48,11 +49,13 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
 })
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron import task_watchdog
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+BLOCKED_MARKER = "[BLOCKED]"
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
@@ -60,6 +63,73 @@ _hermes_home = get_hermes_home()
 # File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
 _LOCK_DIR = _hermes_home / "cron"
 _LOCK_FILE = _LOCK_DIR / ".tick.lock"
+
+
+def _parse_blocked_response(final_response: str) -> Optional[str]:
+    """Return blocker text when a cron response explicitly signals external blocking."""
+    text = (final_response or "").strip()
+    if not text:
+        return None
+
+    upper = text.upper()
+    if upper.startswith(BLOCKED_MARKER):
+        return text[len(BLOCKED_MARKER):].strip() or "Blocked pending user action."
+    if upper.startswith("BLOCKED:"):
+        return text.split(":", 1)[1].strip() or "Blocked pending user action."
+    return None
+
+
+def _get_cron_heartbeat_interval() -> float:
+    env_value = os.getenv("HERMES_CRON_HEARTBEAT_INTERVAL", "").strip()
+    if env_value:
+        try:
+            return max(1.0, float(env_value))
+        except Exception:
+            logger.warning("Invalid HERMES_CRON_HEARTBEAT_INTERVAL=%r; using config/default", env_value)
+    try:
+        cfg = load_config() or {}
+        configured = (cfg.get("cron", {}) or {}).get("heartbeat_interval_seconds")
+        if configured is not None:
+            return max(1.0, float(configured))
+    except Exception as exc:
+        logger.debug("Failed to load cron heartbeat interval from config: %s", exc)
+    return 300.0
+
+
+def _get_cron_timeout_warning_seconds() -> float:
+    env_value = os.getenv("HERMES_CRON_TIMEOUT_WARNING", "").strip()
+    if env_value:
+        try:
+            return max(0.0, float(env_value))
+        except Exception:
+            logger.warning("Invalid HERMES_CRON_TIMEOUT_WARNING=%r; using config/default", env_value)
+    try:
+        cfg = load_config() or {}
+        configured = (cfg.get("cron", {}) or {}).get("timeout_warning_seconds")
+        if configured is not None:
+            return max(0.0, float(configured))
+    except Exception as exc:
+        logger.debug("Failed to load cron timeout warning from config: %s", exc)
+    return 120.0
+
+
+def _format_activity_note(activity: dict | None) -> str:
+    if not isinstance(activity, dict) or not activity:
+        return "No activity details available yet."
+    last_desc = activity.get("last_activity_desc") or "unknown"
+    idle = activity.get("seconds_since_activity")
+    current_tool = activity.get("current_tool") or "none"
+    api_call_count = activity.get("api_call_count")
+    max_iterations = activity.get("max_iterations")
+    parts = [f"last activity: {last_desc}", f"current tool: {current_tool}"]
+    if idle is not None:
+        try:
+            parts.append(f"idle: {int(float(idle))}s")
+        except Exception:
+            parts.append(f"idle: {idle}")
+    if api_call_count is not None and max_iterations is not None:
+        parts.append(f"turns: {api_call_count}/{max_iterations}")
+    return "; ".join(parts)
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -507,8 +577,13 @@ def _build_job_prompt(job: dict) -> str:
         "final response and the system handles the rest. "
         "SILENT: If there is genuinely nothing new to report, respond "
         "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+        "[SILENT] suppresses delivery only when nothing new happened. "
         "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "findings normally, or say [SILENT] and nothing more. "
+        "BLOCKED: If you are truly blocked and need user action, start your "
+        "final response with \"[BLOCKED]\" followed by exactly what action the "
+        "user needs to take. You may also use \"BLOCKED:\". The blocker text "
+        "must clearly explain the required user action.]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -556,7 +631,7 @@ def _build_job_prompt(job: dict) -> str:
     return "\n".join(parts)
 
 
-def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def run_job(job: dict, adapters=None, loop=None) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
     
@@ -579,6 +654,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prompt = _build_job_prompt(job)
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _task_id = _cron_session_id
+    _tasks_file = _hermes_home / "cron" / "task_heartbeat.json"
+    delivery_target = None
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -605,6 +683,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
             if delivery_target.get("thread_id") is not None:
                 os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+
+        task_watchdog.register_task(
+            path=_tasks_file,
+            task_id=_task_id,
+            job_id=job_id,
+            job_name=job_name,
+            session_id=_cron_session_id,
+            delivery_target=delivery_target,
+            started_at=_hermes_now().isoformat(),
+            last_progress_note="Cron job started",
+            last_activity_desc="job_started",
+            activity_summary={},
+        )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -738,10 +829,14 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # _touch_activity() on every tool call, API call, and stream delta).
         _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        _timeout_warning = _get_cron_timeout_warning_seconds()
+        _heartbeat_interval = _get_cron_heartbeat_interval()
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         _cron_future = _cron_pool.submit(agent.run_conversation, prompt)
         _inactivity_timeout = False
+        _warning_sent = False
+        _last_heartbeat_sent = time.time()
         try:
             if _cron_inactivity_limit is None:
                 # Unlimited — just wait for the result.
@@ -757,12 +852,48 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         break
                     # Agent still running — check inactivity.
                     _idle_secs = 0.0
+                    _act = None
                     if hasattr(agent, "get_activity_summary"):
                         try:
-                            _act = agent.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
+                            _candidate = agent.get_activity_summary()
+                            if isinstance(_candidate, dict):
+                                _act = _candidate
+                                _idle_secs = _act.get("seconds_since_activity", 0.0)
+                                task_watchdog.update_task_activity(
+                                    path=_tasks_file,
+                                    task_id=_task_id,
+                                    activity_summary=_act,
+                                    last_progress_note=_format_activity_note(_act),
+                                    last_activity_desc=_act.get("last_activity_desc"),
+                                )
                         except Exception:
                             pass
+
+                    _now = time.time()
+                    if delivery_target and (_now - _last_heartbeat_sent) >= _heartbeat_interval:
+                        _deliver_result(
+                            job,
+                            f"Still working on {job_name}. {_format_activity_note(_act)}",
+                            adapters=adapters,
+                            loop=loop,
+                        )
+                        _last_heartbeat_sent = _now
+
+                    if (
+                        delivery_target
+                        and not _warning_sent
+                        and _cron_inactivity_limit is not None
+                        and _timeout_warning > 0
+                        and _idle_secs >= max(0.0, _cron_inactivity_limit - _timeout_warning)
+                    ):
+                        _deliver_result(
+                            job,
+                            f"Warning: cron job '{job_name}' appears stalled. {_format_activity_note(_act)}",
+                            adapters=adapters,
+                            loop=loop,
+                        )
+                        _warning_sent = True
+
                     if _idle_secs >= _cron_inactivity_limit:
                         _inactivity_timeout = True
                         break
@@ -777,7 +908,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _activity = {}
             if hasattr(agent, "get_activity_summary"):
                 try:
-                    _activity = agent.get_activity_summary()
+                    _candidate = agent.get_activity_summary()
+                    if isinstance(_candidate, dict):
+                        _activity = _candidate
                 except Exception:
                     pass
             _last_desc = _activity.get("last_activity_desc", "unknown")
@@ -795,6 +928,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
             if hasattr(agent, "interrupt"):
                 agent.interrupt("Cron job timed out (inactivity)")
+            timeout_message = (
+                f"Blocked on {job_name}. Cron job timed out after {int(_secs_ago)}s idle "
+                f"(limit {int(_cron_inactivity_limit)}s). {_format_activity_note(_activity)}"
+            )
+            task_watchdog.mark_task_failed(
+                path=_tasks_file,
+                task_id=_task_id,
+                blocker_reason=timeout_message,
+                user_action_needed=timeout_message,
+                activity_summary=_activity,
+                last_progress_note=timeout_message,
+            )
+            if delivery_target:
+                _deliver_result(job, timeout_message, adapters=adapters, loop=loop)
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
@@ -802,9 +949,40 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
 
         final_response = result.get("final_response", "") or ""
+        blocked_reason = _parse_blocked_response(final_response)
+        latest_activity = {}
+        if hasattr(agent, "get_activity_summary"):
+            try:
+                _candidate = agent.get_activity_summary()
+                if isinstance(_candidate, dict):
+                    latest_activity = _candidate
+            except Exception:
+                pass
+
+        if blocked_reason:
+            blocked_message = f"Blocked on {job_name}. {blocked_reason}"
+            task_watchdog.mark_task_blocked(
+                path=_tasks_file,
+                task_id=_task_id,
+                blocker_reason=blocked_reason,
+                user_action_needed=blocked_reason,
+                activity_summary=latest_activity,
+                last_progress_note=blocked_message,
+            )
+            if delivery_target:
+                _deliver_result(job, blocked_message, adapters=adapters, loop=loop)
+            final_response = ""
+        else:
+            task_watchdog.mark_task_completed(
+                path=_tasks_file,
+                task_id=_task_id,
+                activity_summary=latest_activity,
+                last_progress_note="Cron job completed",
+            )
+
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
-        logged_response = final_response if final_response else "(No response generated)"
+        logged_response = result.get("final_response", "") or "(No response generated)"
         
         output = f"""# Cron Job: {job_name}
 
@@ -827,6 +1005,17 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
+        try:
+            task_watchdog.mark_task_failed(
+                path=_tasks_file,
+                task_id=_task_id,
+                blocker_reason=error_msg,
+                user_action_needed=error_msg,
+                activity_summary={},
+                last_progress_note=error_msg,
+            )
+        except Exception:
+            pass
         
         output = f"""# Cron Job: {job_name} (FAILED)
 
@@ -918,7 +1107,10 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # One-shot jobs are left alone so they can retry on restart.
                 advance_next_run(job["id"])
 
-                success, output, final_response, error = run_job(job)
+                if adapters is None and loop is None:
+                    success, output, final_response, error = run_job(job)
+                else:
+                    success, output, final_response, error = run_job(job, adapters=adapters, loop=loop)
 
                 output_file = save_job_output(job["id"], output)
                 if verbose:

--- a/cron/task_watchdog.py
+++ b/cron/task_watchdog.py
@@ -1,0 +1,201 @@
+"""Cron task heartbeat registry for long-running/background task visibility."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from hermes_time import now as _hermes_now
+
+
+def _sanitize_json(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): _sanitize_json(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_sanitize_json(v) for v in value]
+    try:
+        json.dumps(value)
+        return value
+    except Exception:
+        return str(value)
+
+
+def _atomic_write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".task_heartbeat_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_tasks(path: str | Path) -> dict:
+    file_path = Path(path)
+    if not file_path.exists():
+        return {"tasks": [], "updated_at": None}
+    try:
+        data = json.loads(file_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"tasks": [], "updated_at": None}
+    tasks = data.get("tasks")
+    if not isinstance(tasks, list):
+        tasks = []
+    return {"tasks": tasks, "updated_at": data.get("updated_at")}
+
+
+def _save_tasks(path: str | Path, tasks: list[dict]) -> dict:
+    payload = {
+        "tasks": _sanitize_json(tasks),
+        "updated_at": _hermes_now().isoformat(),
+    }
+    _atomic_write_json(Path(path), payload)
+    return payload
+
+
+def _upsert_task(path: str | Path, task_id: str, updates: dict) -> dict:
+    payload = load_tasks(path)
+    tasks = payload["tasks"]
+    now_iso = _hermes_now().isoformat()
+    sanitized_updates = _sanitize_json(updates)
+    for task in tasks:
+        if task.get("task_id") == task_id:
+            task.update(sanitized_updates)
+            task["updated_at"] = now_iso
+            return _save_tasks(path, tasks)
+
+    new_task = {"task_id": task_id, "updated_at": now_iso}
+    new_task.update(sanitized_updates)
+    tasks.append(new_task)
+    return _save_tasks(path, tasks)
+
+
+def register_task(
+    *,
+    path: str | Path,
+    task_id: str,
+    job_id: str,
+    job_name: str,
+    session_id: str,
+    delivery_target: dict | None,
+    started_at: str | None = None,
+    status: str = "running",
+    activity_summary: dict | None = None,
+    last_progress_note: str | None = None,
+    last_activity_desc: str | None = None,
+) -> dict:
+    started = started_at or _hermes_now().isoformat()
+    return _upsert_task(
+        path,
+        task_id,
+        {
+            "job_id": job_id,
+            "job_name": job_name,
+            "session_id": session_id,
+            "status": status,
+            "started_at": started,
+            "last_progress_at": started,
+            "last_progress_note": last_progress_note,
+            "last_activity_desc": last_activity_desc,
+            "blocker_reason": None,
+            "user_action_needed": None,
+            "delivery_target": delivery_target,
+            "activity_summary": activity_summary or {},
+        },
+    )
+
+
+def update_task_activity(
+    *,
+    path: str | Path,
+    task_id: str,
+    activity_summary: dict | None = None,
+    last_progress_note: str | None = None,
+    last_activity_desc: str | None = None,
+) -> dict:
+    updates: dict[str, Any] = {"activity_summary": activity_summary or {}}
+    if last_progress_note:
+        updates["last_progress_note"] = last_progress_note
+        updates["last_progress_at"] = _hermes_now().isoformat()
+    if last_activity_desc is not None:
+        updates["last_activity_desc"] = last_activity_desc
+    return _upsert_task(path, task_id, updates)
+
+
+def mark_task_completed(
+    *,
+    path: str | Path,
+    task_id: str,
+    activity_summary: dict | None = None,
+    last_progress_note: str | None = None,
+) -> dict:
+    return _upsert_task(
+        path,
+        task_id,
+        {
+            "status": "completed",
+            "activity_summary": activity_summary or {},
+            "last_progress_note": last_progress_note,
+            "last_progress_at": _hermes_now().isoformat(),
+        },
+    )
+
+
+def mark_task_failed(
+    *,
+    path: str | Path,
+    task_id: str,
+    blocker_reason: str,
+    user_action_needed: str | None = None,
+    activity_summary: dict | None = None,
+    last_progress_note: str | None = None,
+) -> dict:
+    return _upsert_task(
+        path,
+        task_id,
+        {
+            "status": "failed",
+            "blocker_reason": blocker_reason,
+            "user_action_needed": user_action_needed,
+            "activity_summary": activity_summary or {},
+            "last_progress_note": last_progress_note,
+            "last_progress_at": _hermes_now().isoformat(),
+        },
+    )
+
+
+def mark_task_blocked(
+    *,
+    path: str | Path,
+    task_id: str,
+    blocker_reason: str,
+    user_action_needed: str | None = None,
+    activity_summary: dict | None = None,
+    last_progress_note: str | None = None,
+) -> dict:
+    return _upsert_task(
+        path,
+        task_id,
+        {
+            "status": "waiting_external",
+            "blocker_reason": blocker_reason,
+            "user_action_needed": user_action_needed or blocker_reason,
+            "activity_summary": activity_summary or {},
+            "last_progress_note": last_progress_note,
+            "last_progress_at": _hermes_now().isoformat(),
+        },
+    )

--- a/tests/cron/test_task_watchdog_phase1.py
+++ b/tests/cron/test_task_watchdog_phase1.py
@@ -1,0 +1,100 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from cron.scheduler import _build_job_prompt, run_job
+
+
+def _runtime_provider_stub():
+    return {
+        "api_key": "***",
+        "base_url": "https://example.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+
+
+def test_build_job_prompt_includes_blocked_guidance():
+    prompt = _build_job_prompt({"id": "job-1", "name": "Test", "prompt": "hello"})
+
+    assert "[SILENT]" in prompt
+    assert "[BLOCKED]" in prompt
+    assert "user action" in prompt.lower()
+
+
+def test_run_job_completed_writes_completed_watchdog_state(tmp_path):
+    job = {"id": "job-1", "name": "Test Job", "prompt": "hello"}
+    fake_db = MagicMock()
+    tasks_file = tmp_path / "cron" / "task_heartbeat.json"
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("dotenv.load_dotenv"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=_runtime_provider_stub()), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.get_activity_summary.return_value = {
+            "seconds_since_activity": 0.0,
+            "last_activity_desc": "tool_call",
+        }
+        mock_agent_cls.return_value = mock_agent
+
+        success, output, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final_response == "done"
+    assert "done" in output
+
+    payload = json.loads(tasks_file.read_text())
+    task = payload["tasks"][0]
+    assert task["job_id"] == "job-1"
+    assert task["job_name"] == "Test Job"
+    assert task["status"] == "completed"
+    assert task["delivery_target"] is None
+
+
+def test_run_job_blocked_writes_waiting_external_and_suppresses_final_delivery(tmp_path):
+    job = {
+        "id": "job-2",
+        "name": "Blocked Job",
+        "prompt": "hello",
+        "deliver": "telegram:123",
+    }
+    fake_db = MagicMock()
+    tasks_file = tmp_path / "cron" / "task_heartbeat.json"
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("dotenv.load_dotenv"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=_runtime_provider_stub()), \
+         patch("cron.scheduler._deliver_result") as deliver_mock, \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {
+            "final_response": "[BLOCKED] Please connect the GitHub token for this workspace."
+        }
+        mock_agent.get_activity_summary.return_value = {
+            "seconds_since_activity": 0.0,
+            "last_activity_desc": "waiting_on_user",
+        }
+        mock_agent_cls.return_value = mock_agent
+
+        success, output, final_response, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final_response == ""
+    assert "[BLOCKED]" in output
+    deliver_mock.assert_called_once()
+    delivered_text = deliver_mock.call_args.args[1]
+    assert "Blocked on Blocked Job" in delivered_text
+    assert "GitHub token" in delivered_text
+
+    payload = json.loads(tasks_file.read_text())
+    task = payload["tasks"][0]
+    assert task["status"] == "waiting_external"
+    assert task["blocker_reason"] == "Please connect the GitHub token for this workspace."
+    assert task["user_action_needed"] == "Please connect the GitHub token for this workspace."


### PR DESCRIPTION
## Summary
- add a cron task watchdog registry with atomic JSON heartbeat writes
- teach cron jobs about [BLOCKED] responses, periodic heartbeats, and timeout warnings
- add focused tests for watchdog completion and blocked-state suppression

## Test Plan
- source venv/bin/activate && pytest tests/cron/test_scheduler.py tests/cron/test_cron_inactivity_timeout.py tests/cron/test_task_watchdog_phase1.py -q
