### PR TITLE
fix(persistence): ensure structured content messages are JSON serialized for SQLite

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -32,6 +32,7 @@ T = TypeVar("T")
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
 SCHEMA_VERSION = 6
+_STRUCTURED_CONTENT_PREFIX = "__HERMES_STRUCTURED_CONTENT__:"
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -788,11 +789,33 @@ class SessionDB:
     # Message storage
     # =========================================================================
 
+    @staticmethod
+    def _serialize_message_content(content: Any) -> Any:
+        """Serialize non-string structured message content for SQLite storage."""
+        if content is None or isinstance(content, str):
+            return content
+        try:
+            return _STRUCTURED_CONTENT_PREFIX + json.dumps(content, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            logger.warning("Failed to serialize structured message content; coercing to string")
+            return str(content)
+
+    @staticmethod
+    def _deserialize_message_content(content: Any) -> Any:
+        """Restore structured message content previously serialized for SQLite."""
+        if not isinstance(content, str) or not content.startswith(_STRUCTURED_CONTENT_PREFIX):
+            return content
+        try:
+            return json.loads(content[len(_STRUCTURED_CONTENT_PREFIX):])
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Failed to deserialize structured message content; returning raw string")
+            return content
+
     def append_message(
         self,
         session_id: str,
         role: str,
-        content: str = None,
+        content: Any = None,
         tool_name: str = None,
         tool_calls: Any = None,
         tool_call_id: str = None,
@@ -818,6 +841,7 @@ class SessionDB:
             if codex_reasoning_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        serialized_content = self._serialize_message_content(content)
 
         # Pre-compute tool call count
         num_tool_calls = 0
@@ -833,7 +857,7 @@ class SessionDB:
                 (
                     session_id,
                     role,
-                    content,
+                    serialized_content,
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
@@ -874,6 +898,7 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
+            msg["content"] = self._deserialize_message_content(msg.get("content"))
             if msg.get("tool_calls"):
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
@@ -898,7 +923,10 @@ class SessionDB:
             rows = cursor.fetchall()
         messages = []
         for row in rows:
-            msg = {"role": row["role"], "content": row["content"]}
+            msg = {
+                "role": row["role"],
+                "content": self._deserialize_message_content(row["content"]),
+            }
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -565,6 +565,17 @@ class TestLoadTranscriptPreferLongerSource:
         assert result[0]["content"] == "db-q"
 
 
+    def test_sqlite_structured_content_round_trips(self, store_with_db):
+        """Structured content stored in SQLite should replay as structured content."""
+        sid = "structured_sqlite_session"
+        content = [{"type": "text", "text": "hello from sqlite"}]
+        store_with_db._db.create_session(session_id=sid, source="gateway", model="m")
+        store_with_db._db.append_message(session_id=sid, role="user", content=content)
+
+        result = store_with_db.load_transcript(sid)
+        assert result == [{"role": "user", "content": content}]
+
+
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -170,6 +170,20 @@ class TestMessageStorage:
         assert conv[0] == {"role": "user", "content": "Hello"}
         assert conv[1] == {"role": "assistant", "content": "Hi!"}
 
+    def test_structured_content_round_trips(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/p.png"}},
+        ]
+        db.append_message("s1", role="user", content=content)
+
+        messages = db.get_messages("s1")
+        conv = db.get_messages_as_conversation("s1")
+
+        assert messages[0]["content"] == content
+        assert conv[0] == {"role": "user", "content": content}
+
     def test_finish_reason_stored(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="assistant", content="Done", finish_reason="stop")


### PR DESCRIPTION
## Summary
This fixes a real transcript persistence bug in the SQLite session store.

Hermes now supports structured message content in multiple paths, including list/dict-based content blocks. The SQLite session layer still assumed content was always a plain string, which caused structured transcript messages to fail during persistence or replay incorrectly.

This change adds a narrow serialization/deserialization layer for non-string message content in SessionDB, so structured transcript content can be stored in SQLite and restored back in its original shape.

## Root cause
messages.content is stored in a TEXT column, but SessionDB.append_message() previously passed Python list/dict values through directly.

That worked for plain string content, but broke for structured content used by newer transcript/message flows. As a result:

SQLite writes could fail when content was a list/dict
transcript replay through get_messages() / get_messages_as_conversation() could not round-trip structured content safely
gateway transcript loading could diverge from the original in-memory message shape

## What changed
added a small internal serializer for non-string message content before SQLite writes
added the matching deserializer on SQLite reads
kept plain string and None behavior unchanged
limited the fix to the SQLite transcript/session store path only
Regression coverage
Added focused tests for:

structured content round-trip through SessionDB
structured content round-trip through gateway transcript loading when SQLite is the source of truth

## Tests
Passed:

python -m pytest tests/test_hermes_state.py -q -k structured_content_round_trips
python -m pytest tests/gateway/test_session.py -q -k sqlite_structured_content_round_trips
python -m pytest tests/test_hermes_state.py -q -k MessageStorage
python -m pytest tests/gateway/test_session.py -q -k LoadTranscriptPreferLongerSource