### PR TITLE
fix(custom): apply compat User-Agent in main agent path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -236,6 +236,9 @@ def _routermint_headers() -> dict:
     }
 
 
+_CUSTOM_ENDPOINT_COMPAT_UA = "Mozilla/5.0 HermesCompat"
+
+
 def _pool_may_recover_from_rate_limit(
     pool, *, provider: str | None = None, base_url: str | None = None
 ) -> bool:
@@ -321,6 +324,11 @@ class _StreamErrorEvent(Exception):
                 "type": "error",
             }
         }
+
+
+def _custom_endpoint_headers() -> dict:
+    """Neutral User-Agent for OpenAI-compatible proxies that block SDK defaults."""
+    return {"User-Agent": _CUSTOM_ENDPOINT_COMPAT_UA}
 
 
 class AIAgent:

--- a/run_agent.py
+++ b/run_agent.py
@@ -664,6 +664,9 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
 _QWEN_CODE_VERSION = "0.14.1"
 
 
+_CUSTOM_ENDPOINT_COMPAT_UA = "Mozilla/5.0 HermesCompat"
+
+
 def _qwen_portal_headers() -> dict:
     """Return default HTTP headers required by Qwen Portal API."""
     import platform as _plat
@@ -675,6 +678,11 @@ def _qwen_portal_headers() -> dict:
         "X-DashScope-UserAgent": _ua,
         "X-DashScope-AuthType": "qwen-oauth",
     }
+
+
+def _custom_endpoint_headers() -> dict:
+    """Neutral User-Agent for OpenAI-compatible proxies that block SDK defaults."""
+    return {"User-Agent": _CUSTOM_ENDPOINT_COMPAT_UA}
 
 
 class AIAgent:
@@ -1193,6 +1201,8 @@ class AIAgent:
                 elif base_url_host_matches(effective_base, "chatgpt.com"):
                     from agent.auxiliary_client import _codex_cloudflare_headers
                     client_kwargs["default_headers"] = _codex_cloudflare_headers(api_key)
+                elif self.provider and self.provider.startswith("custom"):
+                    client_kwargs["default_headers"] = _custom_endpoint_headers()
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -5110,6 +5120,8 @@ class AIAgent:
             self._client_kwargs["default_headers"] = _codex_cloudflare_headers(
                 self._client_kwargs.get("api_key", "")
             )
+        elif self.provider and self.provider.startswith("custom"):
+            self._client_kwargs["default_headers"] = _custom_endpoint_headers()
         else:
             self._client_kwargs.pop("default_headers", None)
 


### PR DESCRIPTION
## Summary
- add a neutral compatibility User-Agent helper for custom OpenAI-compatible endpoints in the main agent path
- apply it when the resolved provider starts with `custom`
- cover both initial client construction and later `_client_kwargs` refresh

## Root Cause
The auxiliary client already uses a compatibility User-Agent strategy for custom endpoints, but the main agent path in `run_agent.py` still allowed custom-provider requests to go out with the default OpenAI SDK UA.

That leaves relays/proxies that block SDK-default UAs in a split-brain state where auxiliary requests work but main agent requests fail.

## Testing
- No direct targeted test existed for this header path in the current suite.
- Verified the PR only changes `run_agent.py` and isolates the custom-provider header behavior.

Fixes #11301
