### PR TITLE
fix(cron): reconstruct DM origin from session key

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -4,6 +4,7 @@ import json
 import pytest
 
 from tools.cronjob_tools import (
+    _origin_from_env,
     _scan_cron_prompt,
     check_cronjob_requirements,
     cronjob,
@@ -578,6 +579,84 @@ class TestResolveModelOverride:
         )
         assert provider == "custom:cliproxy"
         assert model == "gpt-5.4"
+
+
+class TestOriginFromEnv:
+    @pytest.fixture(autouse=True)
+    def _reset_session_context(self):
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        tokens = set_session_vars()
+        yield
+        clear_session_vars(tokens)
+
+    def test_explicit_routing_context_takes_precedence_over_session_key(self):
+        from gateway.session_context import set_session_vars
+
+        set_session_vars(
+            platform="telegram",
+            chat_id="explicit-chat",
+            chat_name="Explicit chat",
+            thread_id="explicit-thread",
+            user_id="explicit-user",
+            session_key="agent:coder:weixin:dm:key-chat:key-thread",
+        )
+
+        assert _origin_from_env() == {
+            "platform": "telegram",
+            "chat_id": "explicit-chat",
+            "chat_name": "Explicit chat",
+            "thread_id": "explicit-thread",
+            "user_id": "explicit-user",
+        }
+
+    @pytest.mark.parametrize("profile", ["main", "coder"])
+    def test_standard_dm_session_key_reconstructs_origin(self, profile):
+        from gateway.session_context import set_session_vars
+
+        set_session_vars(
+            chat_name="Fallback chat",
+            user_id="fallback-user",
+            session_key=f"agent:{profile}:weixin:dm:chat-123",
+        )
+
+        assert _origin_from_env() == {
+            "platform": "weixin",
+            "chat_id": "chat-123",
+            "chat_name": "Fallback chat",
+            "thread_id": None,
+            "user_id": "fallback-user",
+        }
+
+    def test_threaded_dm_session_key_reconstructs_thread(self):
+        from gateway.session_context import set_session_vars
+
+        set_session_vars(session_key="agent:coder:telegram:dm:chat-123:topic-7")
+
+        assert _origin_from_env() == {
+            "platform": "telegram",
+            "chat_id": "chat-123",
+            "chat_name": None,
+            "thread_id": "topic-7",
+            "user_id": None,
+        }
+
+    def test_non_dm_session_key_is_not_used_as_delivery_origin(self):
+        from gateway.session_context import set_session_vars
+
+        set_session_vars(session_key="agent:main:telegram:group:chat-123")
+
+        assert _origin_from_env() is None
+
+    def test_chatless_dm_thread_key_is_not_misread_as_chat_id(self):
+        from gateway.session_context import set_session_vars
+
+        set_session_vars(
+            thread_id="topic-only",
+            session_key="agent:main:telegram:dm:topic-only",
+        )
+
+        assert _origin_from_env() is None
 
 
 class TestLocalDeliveryNotice:

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -305,6 +305,36 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             # gateway.mirror.mirror_to_session. Harmless for DMs/shared sessions.
             "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
         }
+
+    # Fallback: reconstruct from a DM session key when the explicit routing
+    # context was lost (for example across a worker-thread boundary).  The
+    # namespace slot is a profile name, not always the historical ``main``.
+    session_key = get_session_env("HERMES_SESSION_KEY")
+    parts = session_key.split(":") if session_key else []
+    if (
+        len(parts) in (5, 6)
+        and parts[0] == "agent"
+        and parts[1]
+        and parts[2]
+        and parts[3] == "dm"
+        and parts[4]
+        and (len(parts) == 5 or parts[5])
+    ):
+        # ``build_session_key`` also emits the five-part shape
+        # ``agent:<profile>:<platform>:dm:<thread_id>`` when a source has no
+        # chat id.  When the thread context identifies that shape, do not
+        # misroute a cron delivery by treating the thread id as a chat id.
+        explicit_thread_id = get_session_env("HERMES_SESSION_THREAD_ID") or None
+        if len(parts) == 5 and explicit_thread_id == parts[4]:
+            return None
+        return {
+            "platform": parts[2],
+            "chat_id": parts[4],
+            "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
+            "thread_id": parts[5] if len(parts) == 6 else None,
+            "user_id": get_session_env("HERMES_SESSION_USER_ID") or None,
+        }
+
     return None
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -85,6 +85,18 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
             "thread_id": thread_id,
         }
+
+    # Fallback: reconstruct from DM session key (e.g. agent:main:weixin:dm:<chat_id>[:<thread_id>])
+    session_key = get_session_env("HERMES_SESSION_KEY")
+    parts = session_key.split(":") if session_key else []
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main" and parts[3] == "dm":
+        return {
+            "platform": parts[2],
+            "chat_id": parts[4],
+            "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
+            "thread_id": parts[5] if len(parts) >= 6 else None,
+        }
+
     return None
 
 


### PR DESCRIPTION
## Summary
- reconstruct DM cron origins from `HERMES_SESSION_KEY` when explicit platform/chat context is unavailable
- preserve explicit routing context as the first priority
- accept both the historical `main` namespace and named-profile namespaces
- support standard and threaded DM keys
- avoid treating a known chatless DM thread key as a chat id
- add regression coverage for precedence, named profiles, standard/threaded DMs, non-DMs, and chatless DMs

## Tests
- `scripts/run_tests.sh tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py -q` (298 passed)
- `ruff check tools/cronjob_tools.py tests/tools/test_cronjob_tools.py`

Fixes #10605

Rebased onto current `main` (`e589b73`).