### PR TITLE
(fix) - Telegram webhook mode allows unauthenticated update spoofing

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -692,7 +692,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 # enables cloud platforms (Fly.io, Railway) to auto-wake
                 # suspended machines on inbound HTTP traffic.
                 webhook_port = int(os.getenv("TELEGRAM_WEBHOOK_PORT", "8443"))
-                webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip() or None
+                webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+                if not webhook_secret:
+                    message = (
+                        "TELEGRAM_WEBHOOK_SECRET must be set when TELEGRAM_WEBHOOK_URL is enabled."
+                    )
+                    logger.error("[%s] %s", self.name, message)
+                    self._set_fatal_error(
+                        "telegram_webhook_secret_missing",
+                        message,
+                        retryable=False,
+                    )
+                    await self._notify_fatal_error()
+                    return False
                 from urllib.parse import urlparse
                 webhook_path = urlparse(webhook_url).path or "/telegram"
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -76,6 +76,7 @@ from gateway.platforms.base import (
     utf16_len,
     _prefix_within_utf16_limit,
 )
+from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.telegram_network import (
     TelegramFallbackTransport,
     discover_fallback_ips,
@@ -131,6 +132,7 @@ class TelegramAdapter(BasePlatformAdapter):
     
     # Telegram message limits
     MAX_MESSAGE_LENGTH = 4096
+    _WEBHOOK_SECRET_MIN_LENGTH = 16
     # Threshold for detecting Telegram client-side message splits.
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
@@ -170,6 +172,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Dedup cache: prevents duplicate webhook/polling updates from being reprocessed.
+        self._update_dedup = MessageDeduplicator()
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -693,6 +697,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # suspended machines on inbound HTTP traffic.
                 webhook_port = int(os.getenv("TELEGRAM_WEBHOOK_PORT", "8443"))
                 webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+                try:
+                    from hermes_cli.auth import has_usable_secret
+                except ImportError:
+                    has_usable_secret = None  # type: ignore[assignment]
                 if not webhook_secret:
                     message = (
                         "TELEGRAM_WEBHOOK_SECRET must be set when TELEGRAM_WEBHOOK_URL is enabled."
@@ -700,6 +708,21 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("[%s] %s", self.name, message)
                     self._set_fatal_error(
                         "telegram_webhook_secret_missing",
+                        message,
+                        retryable=False,
+                    )
+                    await self._notify_fatal_error()
+                    return False
+                if has_usable_secret is not None and not has_usable_secret(
+                    webhook_secret, min_length=self._WEBHOOK_SECRET_MIN_LENGTH
+                ):
+                    message = (
+                        "TELEGRAM_WEBHOOK_SECRET must be a non-placeholder value of at least "
+                        f"{self._WEBHOOK_SECRET_MIN_LENGTH} characters when TELEGRAM_WEBHOOK_URL is enabled."
+                    )
+                    logger.error("[%s] %s", self.name, message)
+                    self._set_fatal_error(
+                        "telegram_webhook_secret_weak",
                         message,
                         retryable=False,
                     )
@@ -833,6 +856,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         self._app = None
         self._bot = None
+        if hasattr(self, "_update_dedup"):
+            self._update_dedup.clear()
         logger.info("[%s] Disconnected from Telegram", self.name)
 
     def _should_thread_reply(self, reply_to: Optional[str], chunk_index: int) -> bool:
@@ -1493,6 +1518,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle inline keyboard button clicks."""
         query = update.callback_query
         if not query or not query.data:
+            return
+        if self._should_skip_duplicate_update(update):
             return
         data = query.data
 
@@ -2210,6 +2237,20 @@ class TelegramAdapter(BasePlatformAdapter):
         cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
         return cleaned or text
 
+    def _should_skip_duplicate_update(self, update: Update) -> bool:
+        """Return True when Telegram redelivers an already-processed update."""
+        update_id = getattr(update, "update_id", None)
+        if update_id is None:
+            return False
+        dedup = getattr(self, "_update_dedup", None)
+        if dedup is None:
+            dedup = MessageDeduplicator()
+            self._update_dedup = dedup
+        if dedup.is_duplicate(str(update_id)):
+            logger.debug("[%s] Dropping duplicate Telegram update_id=%s", self.name, update_id)
+            return True
+        return False
+
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
@@ -2251,6 +2292,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not update.message or not update.message.text:
             return
+        if self._should_skip_duplicate_update(update):
+            return
         if not self._should_process_message(update.message):
             return
 
@@ -2262,6 +2305,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming command messages."""
         if not update.message or not update.message.text:
             return
+        if self._should_skip_duplicate_update(update):
+            return
         if not self._should_process_message(update.message, is_command=True):
             return
         
@@ -2271,6 +2316,8 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
         if not update.message:
+            return
+        if self._should_skip_duplicate_update(update):
             return
         if not self._should_process_message(update.message):
             return
@@ -2430,6 +2477,8 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
+            return
+        if self._should_skip_duplicate_update(update):
             return
         if not self._should_process_message(update.message):
             return

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -176,6 +176,7 @@ class TestTelegramApprovalCallback:
     """Test the approval callback handling in _handle_callback_query."""
 
     @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}, clear=False)
     async def test_resolves_approval_on_click(self):
         adapter = _make_adapter()
         # Set up approval state
@@ -187,11 +188,13 @@ class TestTelegramApprovalCallback:
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
+        query.from_user.id = 101
         query.from_user.first_name = "Norbert"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
         update = MagicMock()
+        update.update_id = 1001
         update.callback_query = query
         context = MagicMock()
 
@@ -206,6 +209,7 @@ class TestTelegramApprovalCallback:
         assert 1 not in adapter._approval_state
 
     @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}, clear=False)
     async def test_deny_button(self):
         adapter = _make_adapter()
         adapter._approval_state[2] = "some-session"
@@ -215,11 +219,13 @@ class TestTelegramApprovalCallback:
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
+        query.from_user.id = 102
         query.from_user.first_name = "Alice"
         query.answer = AsyncMock()
         query.edit_message_text = AsyncMock()
 
         update = MagicMock()
+        update.update_id = 1002
         update.callback_query = query
         context = MagicMock()
 
@@ -231,6 +237,7 @@ class TestTelegramApprovalCallback:
         assert "Denied" in edit_kwargs["text"]
 
     @pytest.mark.asyncio
+    @patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}, clear=False)
     async def test_already_resolved(self):
         adapter = _make_adapter()
         # No state for approval_id 99 — already resolved
@@ -240,10 +247,12 @@ class TestTelegramApprovalCallback:
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
+        query.from_user.id = 103
         query.from_user.first_name = "Bob"
         query.answer = AsyncMock()
 
         update = MagicMock()
+        update.update_id = 1003
         update.callback_query = query
         context = MagicMock()
 
@@ -266,8 +275,10 @@ class TestTelegramApprovalCallback:
         query.message = MagicMock()
         query.message.chat_id = 12345
         query.from_user = MagicMock()
+        query.from_user.id = 104
 
         update = MagicMock()
+        update.update_id = 1004
         update.callback_query = query
         context = MagicMock()
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -288,6 +288,58 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_webhook_requires_secret(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/telegram")
+    monkeypatch.delenv("TELEGRAM_WEBHOOK_SECRET", raising=False)
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        start_webhook=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.fatal_error_code == "telegram_webhook_secret_missing"
+    updater.start_webhook.assert_not_awaited()
+    fatal_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -340,6 +340,73 @@ async def test_connect_webhook_requires_secret(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_webhook_rejects_short_secret(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_URL", "https://example.com/telegram")
+    monkeypatch.setenv("TELEGRAM_WEBHOOK_SECRET", "too-short")
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        start_webhook=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.fatal_error_code == "telegram_webhook_secret_weak"
+    updater.start_webhook.assert_not_awaited()
+    fatal_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_text_message_deduplicates_update_id():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._should_process_message = MagicMock(return_value=True)
+    adapter._build_message_event = MagicMock(return_value=SimpleNamespace(text="hello"))
+    adapter._enqueue_text_event = MagicMock()
+
+    update = SimpleNamespace(update_id=12345, message=SimpleNamespace(text="hello"))
+
+    await adapter._handle_text_message(update, None)
+    await adapter._handle_text_message(update, None)
+
+    adapter._enqueue_text_event.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_disconnect_skips_inactive_updater_and_app(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 


### PR DESCRIPTION
## What does this PR do?

Requires `TELEGRAM_WEBHOOK_SECRET` whenever Telegram webhook mode is enabled via `TELEGRAM_WEBHOOK_URL`, rejects weak or placeholder webhook secrets before startup, and drops duplicate Telegram updates by `update_id` to reduce replay/redelivery impact.

Telegram webhooks support a secret token so inbound webhook requests can be authenticated. Starting webhook mode without a configured secret leaves the deployment in a weaker, fail-open configuration. A short or placeholder secret is not much better, so this change makes the adapter fail closed unless the secret is present and minimally strong. The adapter also deduplicates repeated updates before dispatch so webhook redelivery does not reprocess the same Telegram update twice.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/telegram.py` to require `TELEGRAM_WEBHOOK_SECRET` when `TELEGRAM_WEBHOOK_URL` is set.
- Added a minimum-strength check so webhook startup rejects placeholder or too-short secrets before binding the webhook server.
- Added duplicate `update_id` suppression before Telegram update handlers dispatch messages or callback queries.
- Added fatal error paths with codes `telegram_webhook_secret_missing` and `telegram_webhook_secret_weak` so webhook startup stops clearly and safely.
- Expanded regression coverage in `tests/gateway/test_telegram_conflict.py` and hardened callback-button tests so the new replay guard is exercised cleanly.

## How to Test

1. Run `source venv/bin/activate`.
2. Run `python -m pytest tests/gateway/test_telegram*.py -q`.
3. Confirm the suite passes and includes coverage for missing secrets, weak secrets, and duplicate `update_id` drops.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ source venv/bin/activate && python -m pytest tests/gateway/test_telegram*.py -q
257 passed in 3.97s
```
