### PR TITLE
fix(error_classifier): handle dict-typed message fields in classify_api_error()

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -290,7 +290,7 @@ def classify_api_error(
     if isinstance(body, dict):
         _err_obj = body.get("error", {})
         if isinstance(_err_obj, dict):
-            _body_msg = (_err_obj.get("message") or "").lower()
+            _body_msg = str(_err_obj.get("message") or "").lower()
             # Parse metadata.raw for wrapped provider errors
             _metadata = _err_obj.get("metadata", {})
             if isinstance(_metadata, dict):
@@ -302,11 +302,11 @@ def classify_api_error(
                         if isinstance(_inner, dict):
                             _inner_err = _inner.get("error", {})
                             if isinstance(_inner_err, dict):
-                                _metadata_msg = (_inner_err.get("message") or "").lower()
+                                _metadata_msg = str(_inner_err.get("message") or "").lower()
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
-            _body_msg = (body.get("message") or "").lower()
+            _body_msg = str(body.get("message") or "").lower()
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
@@ -606,10 +606,10 @@ def _classify_400(
     if isinstance(body, dict):
         err_obj = body.get("error", {})
         if isinstance(err_obj, dict):
-            err_body_msg = (err_obj.get("message") or "").strip().lower()
+            err_body_msg = str(err_obj.get("message") or "").strip().lower()
         # Responses API (and some providers) use flat body: {"message": "..."}
         if not err_body_msg:
-            err_body_msg = (body.get("message") or "").strip().lower()
+            err_body_msg = str(body.get("message") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in ("error", "")
     is_large = approx_tokens > context_length * 0.4 or approx_tokens > 80000 or num_messages > 80
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -849,3 +849,63 @@ class TestAdversarialEdgeCases:
         )
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.model_not_found
+
+    def test_dict_message_in_error_obj(self):
+        """body.error.message as dict (Pydantic validation) must not crash."""
+        e = MockAPIError(
+            "Bad request",
+            status_code=400,
+            body={"error": {"message": {"loc": ["body", "model"], "msg": "field required"}}},
+        )
+        result = classify_api_error(e, approx_tokens=1000)
+        # Should classify without raising — exact reason depends on heuristics
+        assert isinstance(result, ClassifiedError)
+
+    def test_dict_message_in_flat_body(self):
+        """body.message as dict (Pydantic validation) must not crash."""
+        e = MockAPIError(
+            "Bad request",
+            status_code=400,
+            body={"message": {"loc": ["body", "messages"], "msg": "value is not valid"}},
+        )
+        result = classify_api_error(e, approx_tokens=1000)
+        assert isinstance(result, ClassifiedError)
+
+    def test_dict_message_in_metadata_raw(self):
+        """metadata.raw inner error.message as dict must not crash."""
+        import json
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {
+                        "raw": json.dumps({"error": {"message": {"detail": "validation failed"}}})
+                    }
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter", approx_tokens=1000)
+        assert isinstance(result, ClassifiedError)
+
+    def test_dict_message_in_classify_400_error_obj(self):
+        """_classify_400 body.error.message as dict must not crash."""
+        e = MockAPIError(
+            "Error",
+            status_code=400,
+            body={"error": {"message": {"type": "missing", "msg": "Field required"}}},
+        )
+        # Large session to exercise the generic-400 heuristic path
+        result = classify_api_error(e, approx_tokens=100000, context_length=200000)
+        assert isinstance(result, ClassifiedError)
+
+    def test_dict_message_in_classify_400_flat_body(self):
+        """_classify_400 flat body.message as dict must not crash."""
+        e = MockAPIError(
+            "Error",
+            status_code=400,
+            body={"message": {"type": "missing", "msg": "Field required"}},
+        )
+        result = classify_api_error(e, approx_tokens=100000, context_length=200000)
+        assert isinstance(result, ClassifiedError)


### PR DESCRIPTION
Fixes #11233

## Problem
`classify_api_error()` calls `.lower()` on `body.get('message')` which crashes with `AttributeError: 'dict' object has no attribute 'lower'` when the API returns a dict-typed message (e.g. Pydantic validation errors).

## Fix
Wrap all 5 `body.get('message')` call sites with `str()` so dict values are safely stringified before `.lower()` is called.

## Tests
Added 5 tests covering dict-typed message fields across all affected code paths.