### PR TITLE
fix(tui): replace hardcoded yellow colors unreadable on light backgrounds

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2169,7 +2169,7 @@ class HermesCLI:
                 if normalized_model and normalized_model != current_model:
                     if not self._model_is_default:
                         self.console.print(
-                            f"[yellow]⚠️  Normalized model '{current_model}' to '{normalized_model}' for {resolved_provider}.[/]"
+                            f"[dark_orange3]⚠️  Normalized model '{current_model}' to '{normalized_model}' for {resolved_provider}.[/]"
                         )
                     self.model = normalized_model
                     current_model = normalized_model
@@ -2185,7 +2185,7 @@ class HermesCLI:
                 if canonical and canonical != current_model:
                     if not self._model_is_default:
                         self.console.print(
-                            f"[yellow]⚠️  Normalized Copilot model '{current_model}' to '{canonical}'.[/]"
+                            f"[dark_orange3]⚠️  Normalized Copilot model '{current_model}' to '{canonical}'.[/]"
                         )
                     self.model = canonical
                     current_model = canonical
@@ -2207,7 +2207,7 @@ class HermesCLI:
                 if canonical and canonical != current_model:
                     if not self._model_is_default:
                         self.console.print(
-                            f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; using '{canonical}' for {resolved_provider}.[/]"
+                            f"[dark_orange3]⚠️  Stripped provider prefix from '{current_model}'; using '{canonical}' for {resolved_provider}.[/]"
                         )
                     self.model = canonical
                     current_model = canonical
@@ -2229,7 +2229,7 @@ class HermesCLI:
             slug = current_model.split("/", 1)[1]
             if not self._model_is_default:
                 self.console.print(
-                    f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; "
+                    f"[dark_orange3]⚠️  Stripped provider prefix from '{current_model}'; "
                     f"using '{slug}' for OpenAI Codex.[/]"
                 )
             self.model = slug
@@ -3004,7 +3004,7 @@ class HermesCLI:
         if ctx_len and ctx_len <= 8192:
             self.console.print()
             self.console.print(
-                f"[yellow]⚠️  Context length is only {ctx_len:,} tokens — "
+                f"[dark_orange3]⚠️  Context length is only {ctx_len:,} tokens — "
                 f"this is likely too low for agent use with tools.[/]"
             )
             self.console.print(
@@ -3031,7 +3031,7 @@ class HermesCLI:
         if is_nous_hermes_non_agentic(model_name):
             self.console.print()
             self.console.print(
-                "[bold yellow]⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not "
+                "[bold dark_orange3]⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not "
                 "designed for use with Hermes Agent.[/]"
             )
             self.console.print(
@@ -3638,7 +3638,7 @@ class HermesCLI:
             
             if api_key_missing:
                 self.console.print()
-                self.console.print("[yellow]⚠️  Some tools disabled (missing API keys):[/]")
+                self.console.print("[dark_orange3]⚠️  Some tools disabled (missing API keys):[/]")
                 for item in api_key_missing:
                     tools_str = ", ".join(item["tools"][:2])  # Show first 2 tools
                     if len(item["tools"]) > 2:
@@ -4936,7 +4936,7 @@ class HermesCLI:
         try:
             access_token = get_valid_access_token()
         except GoogleOAuthError as exc:
-            self.console.print(f"  [yellow]{exc}[/]")
+            self.console.print(f"  [dark_orange3]{exc}[/]")
             self.console.print("  Run [bold]/model[/] and pick 'Google Gemini (OAuth)' to sign in.")
             return
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -411,7 +411,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             if name in disabled_tools:
                 colored_names.append(f"[red]{name}[/]")
             elif name in lazy_tools:
-                colored_names.append(f"[yellow]{name}[/]")
+                colored_names.append(f"[dark_orange3]{name}[/]")
             else:
                 colored_names.append(f"[{text}]{name}[/]")
 
@@ -432,7 +432,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                 elif name in disabled_tools:
                     colored_names.append(f"[red]{name}[/]")
                 elif name in lazy_tools:
-                    colored_names.append(f"[yellow]{name}[/]")
+                    colored_names.append(f"[dark_orange3]{name}[/]")
                 else:
                     colored_names.append(f"[{text}]{name}[/]")
             tools_str = ", ".join(colored_names)
@@ -507,8 +507,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             from hermes_cli.config import recommended_update_command
             commits_word = "commit" if behind == 1 else "commits"
             right_lines.append(
-                f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
-                f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
+                f"[bold dark_orange3]⚠ {behind} {commits_word} behind[/]"
+                f"[dim dark_orange3] — run [bold]{recommended_update_command()}[/bold] to update[/]"
             )
     except Exception:
         pass  # Never break the banner over an update check

--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -25,7 +25,7 @@ class Colors:
     DIM = "\033[2m"
     RED = "\033[31m"
     GREEN = "\033[32m"
-    YELLOW = "\033[33m"
+    YELLOW = "\033[38;5;178m"
     BLUE = "\033[34m"
     MAGENTA = "\033[35m"
     CYAN = "\033[36m"

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -144,7 +144,7 @@ def _copy_example_files(plugin_dir: Path, console) -> None:
                 )
             except OSError as e:
                 console.print(
-                    f"[yellow]Warning:[/yellow] Failed to copy {example_file.name}: {e}"
+                    f"[dark_orange3]Warning:[/dark_orange3] Failed to copy {example_file.name}: {e}"
                 )
 
 
@@ -297,7 +297,7 @@ def cmd_install(identifier: str, force: bool = False) -> None:
     # Warn about insecure / local URL schemes
     if git_url.startswith(("http://", "file://")):
         console.print(
-            "[yellow]Warning:[/yellow] Using insecure/local URL scheme. "
+            "[dark_orange3]Warning:[/dark_orange3] Using insecure/local URL scheme. "
             "Consider using https:// or git@ for production installs."
         )
 
@@ -376,7 +376,7 @@ def cmd_install(identifier: str, force: bool = False) -> None:
     # Validate it looks like a plugin
     if not (target / "plugin.yaml").exists() and not (target / "__init__.py").exists():
         console.print(
-            f"[yellow]Warning:[/yellow] {plugin_name} doesn't contain plugin.yaml "
+            f"[dark_orange3]Warning:[/dark_orange3] {plugin_name} doesn't contain plugin.yaml "
             f"or __init__.py. It may not be a valid Hermes plugin."
         )
 
@@ -531,7 +531,7 @@ def cmd_disable(name: str) -> None:
 
     disabled.add(name)
     _save_disabled_set(disabled)
-    console.print(f"[yellow]\u2298[/yellow] Plugin [bold]{name}[/bold] disabled. Takes effect on next session.")
+    console.print(f"[dark_orange3]\u2298[/dark_orange3] Plugin [bold]{name}[/bold] disabled. Takes effect on next session.")
 
 
 def cmd_list() -> None:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -52,13 +52,13 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
         return exact[0].identifier
 
     if len(exact) > 1:
-        c.print(f"\n[yellow]Multiple skills named '{name}' found:[/]")
+        c.print(f"\n[dark_orange3]Multiple skills named '{name}' found:[/]")
         table = Table()
         table.add_column("Source", style="dim")
         table.add_column("Trust", style="dim")
         table.add_column("Identifier", style="bold cyan")
         for r in exact:
-            trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(r.trust_level, "dim")
+            trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_orange3"}.get(r.trust_level, "dim")
             trust_label = "official" if r.source == "official" else r.trust_level
             table.add_row(r.source, f"[{trust_style}]{trust_label}[/]", r.identifier)
         c.print(table)
@@ -67,7 +67,7 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
 
     # No exact match — check if there are partial matches to suggest
     if results:
-        c.print(f"[yellow]No exact match for '{name}'. Did you mean one of these?[/]")
+        c.print(f"[dark_orange3]No exact match for '{name}'. Did you mean one of these?[/]")
         for r in results[:5]:
             c.print(f"  [cyan]{r.name}[/] — {r.identifier}")
         c.print()
@@ -166,7 +166,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     table.add_column("Identifier", style="dim")
 
     for r in results:
-        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(r.trust_level, "dim")
+        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_orange3"}.get(r.trust_level, "dim")
         trust_label = "official" if r.source == "official" else r.trust_level
         table.add_row(
             r.name,
@@ -268,7 +268,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 
     for i, r in enumerate(page_items, start=start + 1):
         trust_style = {"builtin": "bright_cyan", "trusted": "green",
-                       "community": "yellow"}.get(r.trust_level, "dim")
+                       "community": "dark_orange3"}.get(r.trust_level, "dim")
         trust_label = "★ official" if r.source == "official" else r.trust_level
 
         desc = r.description[:50]
@@ -301,7 +301,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
         c.print(f"  [dim]Sources: {', '.join(parts)}[/]")
 
     if timed_out:
-        c.print(f"  [yellow]⚡ Slow sources skipped: {', '.join(timed_out)} "
+        c.print(f"  [dark_orange3]⚡ Slow sources skipped: {', '.join(timed_out)} "
                 f"— run again for cached results[/]")
 
     c.print("[dim]Tip: 'hermes skills search <query>' searches deeper across all registries[/]\n")
@@ -344,7 +344,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print(f"[bold red]Error:[/] Could not fetch '{identifier}' from any source.")
         if rate_limited:
             c.print(
-                "[yellow]Hint:[/] GitHub API rate limit exhausted "
+                "[dark_orange3]Hint:[/] GitHub API rate limit exhausted "
                 "(unauthenticated: 60 requests/hour).\n"
                 "Set [bold]GITHUB_TOKEN[/] in your .env or install the "
                 "[bold]gh[/] CLI and run [bold]gh auth login[/] "
@@ -364,7 +364,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     lock = HubLockFile()
     existing = lock.get_installed(bundle.name)
     if existing:
-        c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
+        c.print(f"[dark_orange3]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
         if not force:
             c.print("Use --force to reinstall.\n")
             return
@@ -421,13 +421,13 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             ))
         else:
             c.print(Panel(
-                "[bold yellow]You are installing a third-party skill at your own risk.[/]\n\n"
+                "[bold dark_orange3]You are installing a third-party skill at your own risk.[/]\n\n"
                 "External skills can contain instructions that influence agent behavior,\n"
                 "shell commands, and scripts. Even after automated scanning, you should\n"
                 "review the installed files before use.\n\n"
                 f"Files will be at: [cyan]{display_hermes_home()}/skills/{category + '/' if category else ''}{bundle.name}/[/]",
                 title="Disclaimer",
-                border_style="yellow",
+                border_style="dark_orange3",
             ))
         c.print(f"[bold]Install '{bundle.name}'?[/]")
         try:
@@ -485,7 +485,7 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
         return
 
     c.print()
-    trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(meta.trust_level, "dim")
+    trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_orange3"}.get(meta.trust_level, "dim")
     trust_label = "official" if meta.source == "official" else meta.trust_level
 
     info_lines = [
@@ -563,7 +563,7 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
         if source_filter != "all" and source_filter != source_type:
             continue
 
-        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow", "local": "dim"}.get(trust, "dim")
+        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_orange3", "local": "dim"}.get(trust, "dim")
         trust_label = "official" if source_display == "official" else trust
         table.add_row(name, category, source_display, f"[{trust_style}]{trust_label}[/]")
 
@@ -641,7 +641,7 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> N
     for entry in targets:
         skill_path = SKILLS_DIR / entry["install_path"]
         if not skill_path.exists():
-            c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
+            c.print(f"[dark_orange3]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
         result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
@@ -712,7 +712,7 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
         if mgr.add(repo):
             c.print(f"[bold green]Added tap:[/] {repo}\n")
         else:
-            c.print(f"[yellow]Tap already exists:[/] {repo}\n")
+            c.print(f"[dark_orange3]Tap already exists:[/] {repo}\n")
 
     elif action == "remove":
         if not repo:
@@ -790,7 +790,7 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
             c.print(f"[bold red]Error:[/] {msg}\n")
 
     elif target == "clawhub":
-        c.print("[yellow]ClawHub publishing is not yet supported. "
+        c.print("[dark_orange3]ClawHub publishing is not yet supported. "
                 "Submit manually at https://clawhub.ai/submit[/]\n")
     else:
         c.print(f"[bold red]Unknown target:[/] {target}. Use 'github' or 'clawhub'.\n")
@@ -971,7 +971,7 @@ def do_snapshot_import(input_path: str, force: bool = False,
         identifier = entry.get("identifier", "")
         category = entry.get("category", "")
         if not identifier:
-            c.print(f"[yellow]Skipping entry with no identifier: {entry.get('name', '?')}[/]")
+            c.print(f"[dark_orange3]Skipping entry with no identifier: {entry.get('name', '?')}[/]")
             continue
 
         c.print(f"[bold]--- {entry.get('name', identifier)} ---[/]")

--- a/tests/cli/test_colors.py
+++ b/tests/cli/test_colors.py
@@ -1,0 +1,25 @@
+"""Tests for hermes_cli.colors — ensure no bright-yellow codes that are
+unreadable on light terminal backgrounds."""
+
+from hermes_cli.colors import Colors, color, should_use_color
+
+
+def test_yellow_is_not_ansi_33():
+    """Colors.YELLOW must NOT be plain \\033[33m (bright yellow, unreadable
+    on light backgrounds).  We use 256-color 178 (dark gold) instead."""
+    assert "\\033[33m" not in Colors.YELLOW
+    assert "178" in Colors.YELLOW
+
+
+def test_no_color_env(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert not should_use_color()
+    assert color("hello", Colors.YELLOW) == "hello"
+
+
+def test_color_wraps_when_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("TERM", raising=False)
+    # can't guarantee isatty in CI, so just ensure the function runs
+    result = color("hi", Colors.YELLOW)
+    assert "hi" in result


### PR DESCRIPTION
Fixes #11300

## Problem
The TUI chat interface uses bright yellow (`\033[33m`) and Rich `[yellow]` markup that is unreadable on light/white terminal backgrounds.

## Fix
- Changed `Colors.YELLOW` from ANSI 33 (bright yellow) to 256-color dark gold (`\033[38;5;178m`) — readable on both dark and light backgrounds
- Replaced all Rich `[yellow]`/`[bold yellow]`/`[dim yellow]` markup with `[dark_orange3]` variants across CLI modules
- `NO_COLOR` environment variable continues to be respected

## Tests
Added 3 tests verifying the color change and NO_COLOR behavior.