### PR TITLE
fix(agent): restrict auto-title to first exchange only

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -110,10 +110,10 @@ def maybe_auto_title(
 
     # Count user messages in history to detect first exchange.
     # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
+    # so for a first exchange we expect exactly 1 user message.
+    # Only generate a title on the very first exchange (user_msg_count == 1).
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
-    if user_msg_count > 2:
+    if user_msg_count > 1:
         return
 
     thread = threading.Thread(

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -136,6 +136,22 @@ class TestMaybeAutoTitle:
             time.sleep(0.1)
             mock_auto.assert_not_called()
 
+    def test_skips_on_second_exchange(self):
+        """Should not fire for conversations with exactly 2 user messages (second exchange)."""
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "response 1"},
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "response 2"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "second", "response 2", history)
+            import time
+            time.sleep(0.1)
+            mock_auto.assert_not_called()
+
     def test_fires_on_first_exchange(self):
         """Should fire a background thread for the first exchange."""
         db = MagicMock()


### PR DESCRIPTION
## Summary

maybe_auto_title() was intended to fire only on the first user-assistant exchange, but the boundary condition (user_msg_count > 2) allowed it to also fire on the second exchange. This could generate a title based on the second message instead of the opener.

## Changes

- **agent/title_generator.py**: Tighten guard from > 2 to > 1 so only the very first exchange triggers title generation
- **tests/agent/test_title_generator.py**: Add regression test for the 2-user-messages boundary case

## Root Cause

The comment said "first exchange only" but the code allowed user_msg_count == 2 to pass through. With the fix, exactly 1 user message in history is the only case that triggers auto-titling.

Fixes #11201
