### PR TITLE
fix(cron): broaden deliver=origin home-channel fallback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -48,6 +48,26 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
     "qqbot",
 })
+_ORIGIN_HOME_CHANNEL_FALLBACK_PLATFORMS = (
+    "matrix",
+    "telegram",
+    "discord",
+    "slack",
+    "bluebubbles",
+    "whatsapp",
+    "signal",
+    "mattermost",
+    "homeassistant",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "wecom_callback",
+    "weixin",
+    "sms",
+    "email",
+    "webhook",
+    "qqbot",
+)
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
@@ -93,7 +113,7 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             }
         # Origin missing (e.g. job created via API/script) — try each
         # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in ("matrix", "telegram", "discord", "slack", "bluebubbles"):
+        for platform_name in _ORIGIN_HOME_CHANNEL_FALLBACK_PLATFORMS:
             chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
             if chat_id:
                 logger.info(

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -175,6 +175,19 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_origin_without_origin_falls_back_to_non_legacy_home_channel(self, monkeypatch):
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "15551234567")
+        job = {
+            "id": "cron-whatsapp-fallback",
+            "deliver": "origin",
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "whatsapp",
+            "chat_id": "15551234567",
+            "thread_id": None,
+        }
+
     def test_explicit_discord_topic_target_with_thread_id(self):
         """deliver: 'discord:chat_id:thread_id' parses correctly."""
         job = {


### PR DESCRIPTION
## What
Fix cron `deliver=origin` fallback when a job has no origin metadata.

Previously, if a cron job used `deliver: origin` but no `origin` payload was available, Hermes only checked a hardcoded subset of home-channel platforms (`matrix`, `telegram`, `discord`, `slack`, `bluebubbles`). That caused valid configured home channels on other supported platforms like WhatsApp, Signal, Feishu, WeCom, Weixin, SMS, Email, Webhook, and QQBot to be ignored, and delivery failed with no resolved target.

This change replaces the narrow fallback list with a complete supported-platform fallback order.

## Why
This is a real delivery bug in existing behavior, not a feature addition:
- `deliver: origin` is supposed to recover to a home channel when origin context is missing
- many supported platforms were excluded from that recovery path
- jobs could silently fail to auto-deliver despite valid `*_HOME_CHANNEL` configuration

## Changes
- add `_ORIGIN_HOME_CHANNEL_FALLBACK_PLATFORMS` in `cron/scheduler.py`
- use that list for `deliver == "origin"` fallback resolution
- add a regression test covering a previously excluded platform (`WHATSAPP_HOME_CHANNEL`)

## Regression test
Added:
- `tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_origin_without_origin_falls_back_to_non_legacy_home_channel`

Verified:
```powershell
python -m pytest tests\cron\test_scheduler.py -q -k "origin_falls_back_to_non_legacy_home_channel or bare_platform_falls_back_to_home_channel"
python -m pytest tests\cron\test_scheduler.py -q -n 0 -k "failed_job_always_delivers"
