### PR TITLE
feat(ollama) local Ollama provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), [Ollama](https://ollama.com) (local and cloud models), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -73,6 +73,9 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "ollama-launch": "ollama",
+    "ollama_launch": "ollama",
+    "ollama-local": "ollama",
 }
 
 
@@ -1569,6 +1572,8 @@ def resolve_provider_client(
 
         creds = resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
+        if provider == "ollama" and not api_key:
+            api_key = "no-key-required"
         if not api_key:
             tried_sources = list(pconfig.api_key_env_vars)
             if provider == "copilot":
@@ -1583,6 +1588,8 @@ def resolve_provider_client(
         )
 
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")
+        if provider == "ollama":
+            default_model = _read_main_model() or default_model or "qwen3:latest"
         final_model = _normalize_resolved_model(model or default_model, provider)
 
         # Provider-specific headers

--- a/cli.py
+++ b/cli.py
@@ -4542,6 +4542,31 @@ class HermesCLI:
         scroll_offset = max(0, min(scroll_offset, n - visible))
         return scroll_offset, visible
 
+    def _model_picker_max_index(self, state: Optional[dict] = None) -> int:
+        """Return the maximum valid index for the current model picker stage."""
+        state = state or self._model_picker_state
+        if not state:
+            return -1
+        if state.get("stage") == "provider":
+            # Provider rows plus trailing "Cancel"
+            return len(state.get("providers") or [])
+        # Model rows plus trailing "Back" and "Cancel"
+        return len(state.get("model_list") or []) + 1
+
+    def _move_model_picker_selection(self, delta: int) -> None:
+        """Move model picker selection with wrap-around navigation."""
+        state = self._model_picker_state
+        if not state:
+            return
+        max_idx = self._model_picker_max_index(state)
+        if max_idx < 0:
+            return
+        current = int(state.get("selected", 0))
+        if delta < 0:
+            state["selected"] = max_idx if current <= 0 else current - 1
+        elif delta > 0:
+            state["selected"] = 0 if current >= max_idx else current + 1
+
     def _apply_model_switch_result(self, result, persist_global: bool) -> None:
         if not result.success:
             _cprint(f"  ✗ {result.error_message}")
@@ -8707,7 +8732,7 @@ class HermesCLI:
         @kb.add('up', filter=Condition(lambda: bool(self._model_picker_state)))
         def model_picker_up(event):
             if self._model_picker_state:
-                self._model_picker_state["selected"] = max(0, self._model_picker_state.get("selected", 0) - 1)
+                self._move_model_picker_selection(-1)
                 event.app.invalidate()
 
         @kb.add('down', filter=Condition(lambda: bool(self._model_picker_state)))
@@ -8715,11 +8740,7 @@ class HermesCLI:
             state = self._model_picker_state
             if not state:
                 return
-            if state.get("stage") == "provider":
-                max_idx = len(state.get("providers") or [])
-            else:
-                max_idx = len(state.get("model_list") or []) + 1
-            state["selected"] = min(max_idx, state.get("selected", 0) + 1)
+            self._move_model_picker_selection(1)
             event.app.invalidate()
 
         @kb.add('escape', filter=Condition(lambda: bool(self._model_picker_state)), eager=True)
@@ -9513,6 +9534,8 @@ class HermesCLI:
                 for p in state.get("providers") or []:
                     count = p.get("total_models", len(p.get("models", [])))
                     label = f"{p['name']} ({count} model{'s' if count != 1 else ''})"
+                    if p.get("warning"):
+                        label += "  [warning]"
                     if p.get("is_current"):
                         label += "  ← current"
                     choices.append(label)
@@ -9527,6 +9550,9 @@ class HermesCLI:
                     hint = f"Select a model ({len(model_list)} available)"
                 else:
                     hint = "No models listed for this provider. Use Back or Cancel."
+                warning_text = (provider_data.get("warning") or "").strip()
+                if warning_text:
+                    hint = f"{hint} | Warning: {warning_text}"
 
             box_width = _panel_box_width(title, [hint] + choices, min_width=46, max_width=84)
             inner_text_width = max(8, box_width - 6)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -37,7 +37,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 import yaml
 
-from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
+from hermes_cli.config import get_hermes_home, get_config_path, get_env_value, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,7 @@ DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434/v1"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
@@ -293,6 +294,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("XIAOMI_API_KEY",),
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "ollama": ProviderConfig(
+        id="ollama",
+        name="Ollama",
+        auth_type="api_key",
+        inference_base_url=DEFAULT_OLLAMA_BASE_URL,
+        api_key_env_vars=(),
+    ),
     "ollama-cloud": ProviderConfig(
         id="ollama-cloud",
         name="Ollama Cloud",
@@ -404,9 +412,12 @@ def _resolve_api_key_provider_secret(
         return "", ""
 
     for env_var in pconfig.api_key_env_vars:
-        val = os.getenv(env_var, "").strip()
-        if has_usable_secret(val):
-            return val, env_var
+        env_val = os.getenv(env_var, "").strip()
+        if has_usable_secret(env_val):
+            return env_val, env_var
+        file_val = (get_env_value(env_var) or "").strip()
+        if has_usable_secret(file_val):
+            return file_val, f".env:{env_var}"
 
     return "", ""
 
@@ -860,7 +871,9 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         for env_var in pconfig.api_key_env_vars:
             if env_var in _IMPLICIT_ENV_VARS:
                 continue
-            if has_usable_secret(os.getenv(env_var, "")):
+            env_val = os.getenv(env_var, "")
+            file_val = get_env_value(env_var) or ""
+            if has_usable_secret(env_val) or has_usable_secret(file_val):
                 return True
 
     return False
@@ -985,9 +998,10 @@ def resolve_provider(
         "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
-        # Local server aliases — route through the generic custom provider
+        # Local server aliases — route through custom except native local Ollama
         "lmstudio": "custom", "lm-studio": "custom", "lm_studio": "custom",
-        "ollama": "custom", "ollama_cloud": "ollama-cloud",
+        "ollama": "ollama", "ollama_cloud": "ollama-cloud",
+        "ollama-launch": "ollama", "ollama_launch": "ollama", "ollama-local": "ollama",
         "vllm": "custom", "llamacpp": "custom",
         "llama.cpp": "custom", "llama-cpp": "custom",
     }
@@ -1024,7 +1038,12 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    if (
+        has_usable_secret(os.getenv("OPENAI_API_KEY"))
+        or has_usable_secret(get_env_value("OPENAI_API_KEY"))
+        or has_usable_secret(os.getenv("OPENROUTER_API_KEY"))
+        or has_usable_secret(get_env_value("OPENROUTER_API_KEY"))
+    ):
         return "openrouter"
 
     # Auto-detect API-key providers by checking their env vars
@@ -1037,7 +1056,9 @@ def resolve_provider(
         if pid == "copilot":
             continue
         for env_var in pconfig.api_key_env_vars:
-            if has_usable_secret(os.getenv(env_var, "")):
+            env_val = os.getenv(env_var, "")
+            file_val = get_env_value(env_var) or ""
+            if has_usable_secret(env_val) or has_usable_secret(file_val):
                 return pid
 
     # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).
@@ -1052,7 +1073,7 @@ def resolve_provider(
     raise AuthError(
         "No inference provider configured. Run 'hermes model' to choose a "
         "provider and model, or set an API key (OPENROUTER_API_KEY, "
-        "OPENAI_API_KEY, etc.) in ~/.hermes/.env.",
+        "OPENAI_API_KEY, OLLAMA_API_KEY, etc.) in ~/.hermes/.env.",
         code="no_provider_configured",
     )
 
@@ -2528,7 +2549,10 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = (
+            os.getenv(pconfig.base_url_env_var, "").strip()
+            or (get_env_value(pconfig.base_url_env_var) or "").strip()
+        )
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -2623,7 +2647,10 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        env_url = (
+            os.getenv(pconfig.base_url_env_var, "").strip()
+            or (get_env_value(pconfig.base_url_env_var) or "").strip()
+        )
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1023,8 +1023,9 @@ def select_provider_and_model(args=None):
     try:
         active = resolve_provider(effective_provider)
     except AuthError as exc:
-        warning = format_auth_error(exc)
-        print(f"Warning: {warning} Falling back to auto provider detection.")
+        if exc.code != "no_provider_configured":
+            warning = format_auth_error(exc)
+            print(f"Warning: {warning} Falling back to auto provider detection.")
         try:
             active = resolve_provider("auto")
         except AuthError:
@@ -1143,7 +1144,7 @@ def select_provider_and_model(args=None):
         _model_flow_kimi(config, current_model)
     elif selected_provider == "bedrock":
         _model_flow_bedrock(config, current_model)
-    elif selected_provider in ("gemini", "deepseek", "xai", "zai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee", "nvidia", "ollama-cloud"):
+    elif selected_provider in ("gemini", "deepseek", "xai", "zai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee", "nvidia", "ollama", "ollama-cloud"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
     # ── Post-switch cleanup: clear stale OPENAI_BASE_URL ──────────────
@@ -2765,20 +2766,29 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         deactivate_provider,
     )
     from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
-    from hermes_cli.models import fetch_api_models, opencode_model_api_mode, normalize_opencode_model_id
+    from hermes_cli.models import (
+        fetch_api_models,
+        normalize_opencode_model_id,
+        ollama_seed_models,
+        opencode_model_api_mode,
+        probe_api_models,
+        probe_ollama_native_models,
+    )
 
     pconfig = PROVIDER_REGISTRY[provider_id]
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
     base_url_env = pconfig.base_url_env_var or ""
+    keyless_provider = provider_id == "ollama"
 
     # Check / prompt for API key
     existing_key = ""
-    for ev in pconfig.api_key_env_vars:
-        existing_key = get_env_value(ev) or os.getenv(ev, "")
-        if existing_key:
-            break
+    if not keyless_provider:
+        for ev in pconfig.api_key_env_vars:
+            existing_key = get_env_value(ev) or os.getenv(ev, "")
+            if existing_key:
+                break
 
-    if not existing_key:
+    if not keyless_provider and not existing_key:
         print(f"No {pconfig.name} API key configured.")
         if key_env:
             try:
@@ -2793,6 +2803,9 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             save_env_value(key_env, new_key)
             print("API key saved.")
             print()
+    elif keyless_provider:
+        print(f"  {pconfig.name} runs locally and does not require an API key.")
+        print()
     else:
         print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓")
         print()
@@ -2820,8 +2833,41 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
     #   2. Curated static fallback list (offline insurance)
     #   3. Live /models endpoint probe (small providers without models.dev data)
     #
+    # Ollama local: OpenAI-compatible /models first, then native /api/tags.
+    if provider_id == "ollama":
+        used_seed_models = False
+        local_not_reachable = False
+        probe = probe_api_models("", effective_base)
+        api_probe_models = probe.get("models")
+        model_list = probe.get("models") or []
+        if probe.get("used_fallback") and probe.get("resolved_base_url"):
+            effective_base = probe["resolved_base_url"]
+
+        native_probe_models = None
+        if not model_list:
+            native_probe = probe_ollama_native_models(effective_base)
+            native_probe_models = native_probe.get("models")
+            model_list = native_probe.get("models") or []
+            if native_probe.get("used_fallback") and native_probe.get("resolved_base_url"):
+                effective_base = native_probe["resolved_base_url"]
+
+        if not model_list:
+            model_list = ollama_seed_models()
+            used_seed_models = True
+            local_not_reachable = api_probe_models is None and native_probe_models is None
+            if local_not_reachable:
+                print("  Ollama was not reachable. Make sure Ollama is running (ollama serve).")
+            else:
+                print("  No local Ollama models were discovered.")
+                print("  Pull/start a local model, or use cloud-backed models via Ollama Launch.")
+
+        if model_list:
+            if used_seed_models:
+                print(f"  Showing {len(model_list)} fallback model option(s)")
+            else:
+                print(f"  Found {len(model_list)} model(s) from local Ollama")
     # Ollama Cloud: dedicated merged discovery (live API + models.dev + disk cache)
-    if provider_id == "ollama-cloud":
+    elif provider_id == "ollama-cloud":
         from hermes_cli.models import fetch_ollama_cloud_models
         api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
         model_list = fetch_ollama_cloud_models(api_key=api_key_for_probe, base_url=effective_base)
@@ -4954,7 +5000,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "gemini", "xai", "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee", "nvidia"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "ollama", "ollama-cloud", "copilot-acp", "copilot", "anthropic", "gemini", "xai", "huggingface", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee", "nvidia"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -819,10 +819,41 @@ def list_authenticated_providers(
 
     # Build curated model lists keyed by hermes provider ID
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
+    ollama_warning: str = ""
     curated["openrouter"] = [mid for mid, _ in OPENROUTER_MODELS]
     # "nous" shares OpenRouter's curated list if not separately defined
     if "nous" not in curated:
         curated["nous"] = curated["openrouter"]
+    # Native local Ollama has dynamic discovery (OpenAI-compatible /models,
+    # then /api/tags, then baseline fallback when discovery is empty).
+    if "ollama" not in curated:
+        from hermes_cli.models import (
+            fetch_api_models as _fetch_api_models,
+            fetch_ollama_native_models as _fetch_ollama_native_models,
+            ollama_seed_models as _ollama_seed_models,
+        )
+
+        _ollama_cfg = PROVIDER_REGISTRY.get("ollama")
+        ollama_base_url = (
+            (_ollama_cfg.inference_base_url if _ollama_cfg else "")
+            or "http://localhost:11434/v1"
+        ).strip().rstrip("/")
+        api_models = _fetch_api_models("", ollama_base_url)
+        if api_models:
+            curated["ollama"] = api_models
+        else:
+            native_models = _fetch_ollama_native_models(ollama_base_url)
+            if native_models:
+                curated["ollama"] = native_models
+            else:
+                curated["ollama"] = _ollama_seed_models()
+                if api_models is None and native_models is None:
+                    ollama_warning = "Ollama was not reachable. Make sure Ollama is running (ollama serve)."
+                else:
+                    ollama_warning = (
+                        "No local Ollama models found. Pull/start a local model, "
+                        "or use cloud-backed models via Ollama Launch."
+                    )
     # Ollama Cloud uses dynamic discovery (no static curated list)
     if "ollama-cloud" not in curated:
         from hermes_cli.models import fetch_ollama_cloud_models
@@ -896,6 +927,9 @@ def list_authenticated_providers(
 
         # Check if credentials exist
         has_creds = False
+        # Native local Ollama is keyless and should appear in /model picker.
+        if hermes_slug == "ollama":
+            has_creds = True
         if overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type
@@ -963,7 +997,7 @@ def list_authenticated_providers(
         total = len(model_ids)
         top = model_ids[:max_models]
 
-        results.append({
+        row = {
             "slug": hermes_slug,
             "name": get_label(hermes_slug),
             "is_current": hermes_slug == current_provider or pid == current_provider,
@@ -971,7 +1005,10 @@ def list_authenticated_providers(
             "models": top,
             "total_models": total,
             "source": "hermes",
-        })
+        }
+        if hermes_slug == "ollama" and ollama_warning:
+            row["warning"] = ollama_warning
+        results.append(row)
         seen_slugs.add(pid.lower())
         seen_slugs.add(hermes_slug.lower())
 
@@ -991,6 +1028,8 @@ def list_authenticated_providers(
         # Check credentials via PROVIDER_REGISTRY (auth.py)
         _cp_config = _auth_registry.get(_cp.slug)
         _cp_has_creds = False
+        if _cp.slug == "ollama":
+            _cp_has_creds = True
         if _cp_config and _cp_config.api_key_env_vars:
             _cp_has_creds = any(os.environ.get(ev) for ev in _cp_config.api_key_env_vars)
         # Also check auth store and credential pool
@@ -1023,7 +1062,7 @@ def list_authenticated_providers(
         _cp_total = len(_cp_model_ids)
         _cp_top = _cp_model_ids[:max_models]
 
-        results.append({
+        row = {
             "slug": _cp.slug,
             "name": _cp.label,
             "is_current": _cp.slug == current_provider,
@@ -1031,7 +1070,10 @@ def list_authenticated_providers(
             "models": _cp_top,
             "total_models": _cp_total,
             "source": "canonical",
-        })
+        }
+        if _cp.slug == "ollama" and ollama_warning:
+            row["warning"] = ollama_warning
+        results.append(row)
         seen_slugs.add(_cp.slug.lower())
 
     # --- 3. User-defined endpoints from config ---

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -15,6 +15,7 @@ import time
 from difflib import get_close_matches
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
+from urllib.parse import urlparse
 
 COPILOT_BASE_URL = "https://api.githubcopilot.com"
 COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
@@ -549,6 +550,8 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
+    ProviderEntry("ollama",         "Ollama",                   "Ollama (local and cloud models)"),
+    ProviderEntry("ollama-cloud",   "Ollama Cloud",             "Ollama Cloud (cloud-hosted open models — ollama.com)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models — build.nvidia.com or local NIM)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
@@ -565,7 +568,6 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("minimax",        "MiniMax",                  "MiniMax (global direct API)"),
     ProviderEntry("minimax-cn",     "MiniMax (China)",          "MiniMax China (domestic direct API)"),
     ProviderEntry("alibaba",        "Alibaba Cloud (DashScope)","Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
-    ProviderEntry("ollama-cloud",   "Ollama Cloud",             "Ollama Cloud (cloud-hosted open models — ollama.com)"),
     ProviderEntry("arcee",          "Arcee AI",                 "Arcee AI (Trinity models — direct API)"),
     ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
@@ -637,7 +639,10 @@ _PROVIDER_ALIASES = {
     "nvidia-nim": "nvidia",
     "build-nvidia": "nvidia",
     "nemotron": "nvidia",
-    "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
+    "ollama": "ollama",  # bare "ollama" = local native provider; cloud models can be selected via the local daemon too
+    "ollama-launch": "ollama",
+    "ollama_launch": "ollama",
+    "ollama-local": "ollama",
     "ollama_cloud": "ollama-cloud",
 }
 
@@ -1321,6 +1326,15 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         live = fetch_ollama_cloud_models(force_refresh=force_refresh)
         if live:
             return live
+    if normalized == "ollama":
+        base_url = _get_custom_base_url() or "http://localhost:11434/v1"
+        live = fetch_api_models("", base_url)
+        if live:
+            return live
+        native_live = fetch_ollama_native_models(base_url)
+        if native_live:
+            return native_live
+        return ollama_seed_models()
     if normalized == "custom":
         base_url = _get_custom_base_url()
         if base_url:
@@ -1806,6 +1820,129 @@ def probe_api_models(
     }
 
 
+_LOCAL_OLLAMA_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+_OLLAMA_SEED_MODELS = ["kimi-k2.5:cloud", "glm-5.1:cloud"]
+
+
+def ollama_seed_models() -> list[str]:
+    """Return baseline models when local Ollama discovery yields none."""
+    return list(_OLLAMA_SEED_MODELS)
+
+
+def is_local_ollama_base_url(base_url: Optional[str]) -> bool:
+    """Return True when a URL clearly targets a local Ollama daemon."""
+    raw = (base_url or "").strip()
+    if not raw:
+        return False
+
+    candidate = raw if "://" in raw else f"http://{raw}"
+    try:
+        parsed = urlparse(candidate)
+    except Exception:
+        return False
+
+    host = (parsed.hostname or "").strip().lower()
+    if host not in _LOCAL_OLLAMA_HOSTS:
+        return False
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return False
+
+    return port == 11434
+
+
+def _extract_ollama_native_model_ids(payload: Any) -> list[str]:
+    """Extract ordered model IDs from an Ollama-native /api/tags payload."""
+    if not isinstance(payload, dict):
+        return []
+    items = payload.get("models")
+    if not isinstance(items, list):
+        return []
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("model") or item.get("name") or "").strip()
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        out.append(model_id)
+    return out
+
+
+def probe_ollama_native_models(
+    base_url: Optional[str],
+    timeout: float = 5.0,
+) -> dict[str, Any]:
+    """Probe Ollama-native ``/api/tags`` with the same base URL heuristics as /models."""
+    normalized = (base_url or "").strip().rstrip("/")
+    if not normalized:
+        return {
+            "models": None,
+            "probed_url": None,
+            "resolved_base_url": "",
+            "native_base_url": None,
+            "used_fallback": False,
+        }
+
+    if normalized.endswith("/v1"):
+        alternate_base = normalized[:-3].rstrip("/")
+    else:
+        alternate_base = normalized + "/v1"
+
+    openai_candidates: list[tuple[str, bool]] = [(normalized, False)]
+    if alternate_base and alternate_base != normalized:
+        openai_candidates.append((alternate_base, True))
+
+    # /api/tags lives on the native root (no /v1).
+    native_candidates: list[tuple[str, str, bool]] = []
+    seen_native: set[str] = set()
+    for candidate_base, is_fallback in openai_candidates:
+        native_base = candidate_base[:-3].rstrip("/") if candidate_base.endswith("/v1") else candidate_base
+        if not native_base or native_base in seen_native:
+            continue
+        seen_native.add(native_base)
+        native_candidates.append((candidate_base, native_base, is_fallback))
+
+    tried: list[str] = []
+    for candidate_base, native_base, is_fallback in native_candidates:
+        url = native_base.rstrip("/") + "/api/tags"
+        tried.append(url)
+        req = urllib.request.Request(url)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+            return {
+                "models": _extract_ollama_native_model_ids(data),
+                "probed_url": url,
+                "resolved_base_url": candidate_base.rstrip("/"),
+                "native_base_url": native_base.rstrip("/"),
+                "used_fallback": is_fallback,
+            }
+        except Exception:
+            continue
+
+    return {
+        "models": None,
+        "probed_url": tried[0] if tried else normalized.rstrip("/") + "/api/tags",
+        "resolved_base_url": normalized,
+        "native_base_url": None,
+        "used_fallback": False,
+    }
+
+
+def fetch_ollama_native_models(
+    base_url: Optional[str],
+    timeout: float = 5.0,
+) -> Optional[list[str]]:
+    """Fetch model IDs from Ollama-native ``/api/tags``."""
+    return probe_ollama_native_models(base_url, timeout=timeout).get("models")
+
+
 def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
     """Fetch available language models with tool-use from AI Gateway."""
     api_key = os.getenv("AI_GATEWAY_API_KEY", "").strip()
@@ -2069,6 +2206,63 @@ def validate_requested_model(
             "persist": True,
             "recognized": False,
             "message": message,
+        }
+
+    if normalized == "ollama":
+        effective_base = (base_url or _get_custom_base_url() or "http://localhost:11434/v1").strip()
+
+        probe = probe_api_models("", effective_base)
+        api_models = probe.get("models")
+        if api_models is None:
+            probe = probe_ollama_native_models(effective_base)
+            api_models = probe.get("models")
+
+        if api_models is not None:
+            if requested_for_lookup in set(api_models):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+
+            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            if auto:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": auto[0],
+                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                }
+
+            suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in Ollama's model listing "
+                    f"({probe.get('probed_url')}). It may still work if the daemon "
+                    f"supports aliases not returned by discovery. "
+                    f"Make sure Ollama is running and has models pulled."
+                    f"{suggestion_text}"
+                ),
+            }
+
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                f"Note: could not reach Ollama model discovery at `{probe.get('probed_url')}`. "
+                f"Hermes will still save `{requested}`. "
+                f"Make sure Ollama is running (ollama serve)."
+            ),
         }
 
     # OpenAI Codex has its own catalog path; /v1/models probing is not the right validation path.

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -151,6 +151,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.arcee.ai/api/v1",
         base_url_env_var="ARCEE_BASE_URL",
     ),
+    "ollama": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="http://localhost:11434/v1",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="OLLAMA_BASE_URL",
@@ -276,7 +280,11 @@ ALIASES: Dict[str, str] = {
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
     "lm_studio": "lmstudio",
-    "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
+    "ollama": "ollama",  # bare "ollama" = local instance
+    "ollama-launch": "ollama",
+    "ollama_launch": "ollama",
+    "ollama-local": "ollama",
+    "ollama_cloud": "ollama-cloud",
     "vllm": "local",
     "llamacpp": "local",
     "llama.cpp": "local",
@@ -295,6 +303,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "xiaomi": "Xiaomi MiMo",
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
+    "ollama": "Ollama",
     "ollama-cloud": "Ollama Cloud",
 }
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -632,6 +632,10 @@ def _resolve_explicit_runtime(
             api_key = creds.get("api_key", "")
             if not base_url:
                 base_url = creds.get("base_url", "").rstrip("/")
+        if provider == "ollama" and not has_usable_secret(api_key):
+            # Local Ollama does not require authentication, but the OpenAI SDK
+            # requires a non-empty api_key string.
+            api_key = "no-key-required"
 
         api_mode = "chat_completions"
         if provider == "copilot":
@@ -972,11 +976,14 @@ def resolve_runtime_provider(
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
         if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
             base_url = re.sub(r"/v1/?$", "", base_url)
+        api_key = creds.get("api_key", "")
+        if provider == "ollama" and not has_usable_secret(api_key):
+            api_key = "no-key-required"
         return {
             "provider": provider,
             "api_mode": api_mode,
             "base_url": base_url,
-            "api_key": creds.get("api_key", ""),
+            "api_key": api_key,
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
         }

--- a/run_agent.py
+++ b/run_agent.py
@@ -37,6 +37,7 @@ import time
 import threading
 from types import SimpleNamespace
 import uuid
+from urllib.parse import urlparse
 from typing import List, Dict, Any, Optional
 from openai import OpenAI
 import fire
@@ -1052,7 +1053,15 @@ class AIAgent:
                     # but no credentials were found, fail fast with a clear
                     # message instead of silently routing through OpenRouter.
                     _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                    if _explicit and _explicit not in (
+                        "auto",
+                        "openrouter",
+                        "custom",
+                        "ollama",
+                        "ollama-launch",
+                        "ollama_launch",
+                        "ollama-local",
+                    ):
                         # Look up the actual env var name from the provider
                         # config — some providers use non-standard names
                         # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
@@ -2083,6 +2092,38 @@ class AIAgent:
     def _is_openrouter_url(self) -> bool:
         """Return True when the base URL targets OpenRouter."""
         return "openrouter" in self._base_url_lower
+
+    @staticmethod
+    def _is_local_ollama_base_url(base_url: Optional[str]) -> bool:
+        """Return True when URL clearly points at a local Ollama daemon."""
+        raw = (base_url or "").strip()
+        if not raw:
+            return False
+
+        candidate = raw if "://" in raw else f"http://{raw}"
+        try:
+            parsed = urlparse(candidate)
+        except Exception:
+            return False
+
+        host = (parsed.hostname or "").strip().lower()
+        if host not in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}:
+            return False
+
+        try:
+            port = parsed.port
+        except ValueError:
+            return False
+        return port == 11434
+
+    def _is_ollama_reasoning_route(self) -> bool:
+        """Detect routes where Ollama-native ``think=false`` should be used."""
+        provider_lower = (self.provider or "").strip().lower()
+        if provider_lower in {"ollama", "ollama-launch", "ollama_launch", "ollama-local"}:
+            return True
+
+        base = self.base_url or ""
+        return self._is_local_ollama_base_url(base)
 
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:
@@ -6880,13 +6921,18 @@ class AIAgent:
             options["num_ctx"] = self._ollama_num_ctx
             extra_body["options"] = options
 
-        # Ollama / custom provider: pass think=false when reasoning is disabled.
+        # Ollama routes: pass think=false when reasoning is disabled.
         # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
         # field, so we use its native `think` parameter instead.
-        # This prevents thinking-capable models (Qwen3, etc.) from generating
-        # <think> blocks and producing empty-response errors when the user has
-        # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        # Applies to native "ollama" routes while preserving existing
+        # compatibility behavior for all custom endpoints. This prevents thinking-capable
+        # models (Qwen3, etc.) from generating <think> blocks and producing
+        # empty-response errors when reasoning is disabled.
+        if (
+            (self.provider == "custom" or self._is_ollama_reasoning_route())
+            and self.reasoning_config
+            and isinstance(self.reasoning_config, dict)
+        ):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -66,6 +66,10 @@ class TestNormalizeVisionProvider:
         from agent.auxiliary_client import _normalize_vision_provider
         assert _normalize_vision_provider("codex") == "openai-codex"
 
+    def test_ollama_launch_alias_normalizes(self):
+        from agent.auxiliary_client import _normalize_vision_provider
+        assert _normalize_vision_provider("ollama-launch") == "ollama"
+
     def test_auto_unchanged(self):
         from agent.auxiliary_client import _normalize_vision_provider
         assert _normalize_vision_provider("auto") == "auto"

--- a/tests/cli/test_cli_model_picker_navigation.py
+++ b/tests/cli/test_cli_model_picker_navigation.py
@@ -1,0 +1,61 @@
+from cli import HermesCLI
+
+
+def _make_cli_stub():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._model_picker_state = None
+    return cli
+
+
+def test_model_picker_provider_wraps_up_from_top_to_bottom():
+    cli = _make_cli_stub()
+    cli._model_picker_state = {
+        "stage": "provider",
+        "providers": [{"slug": "a"}, {"slug": "b"}],
+        "selected": 0,
+    }
+
+    cli._move_model_picker_selection(-1)
+
+    # providers(2) + cancel => last index 2
+    assert cli._model_picker_state["selected"] == 2
+
+
+def test_model_picker_provider_wraps_down_from_bottom_to_top():
+    cli = _make_cli_stub()
+    cli._model_picker_state = {
+        "stage": "provider",
+        "providers": [{"slug": "a"}, {"slug": "b"}],
+        "selected": 2,
+    }
+
+    cli._move_model_picker_selection(1)
+
+    assert cli._model_picker_state["selected"] == 0
+
+
+def test_model_picker_model_wraps_up_from_top_to_bottom():
+    cli = _make_cli_stub()
+    cli._model_picker_state = {
+        "stage": "model",
+        "model_list": ["m1", "m2", "m3"],
+        "selected": 0,
+    }
+
+    cli._move_model_picker_selection(-1)
+
+    # model_list(3) + back + cancel => last index 4
+    assert cli._model_picker_state["selected"] == 4
+
+
+def test_model_picker_model_wraps_down_from_bottom_to_top():
+    cli = _make_cli_stub()
+    cli._model_picker_state = {
+        "stage": "model",
+        "model_list": ["m1", "m2", "m3"],
+        "selected": 4,
+    }
+
+    cli._move_model_picker_selection(1)
+
+    assert cli._model_picker_state["selected"] == 0

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -540,6 +540,32 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
     assert "No change." in output
 
 
+def test_cmd_model_suppresses_warning_when_no_provider_configured(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "gpt-5"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+
+    def _resolve_provider(requested, **kwargs):
+        raise AuthError(
+            "No inference provider configured.",
+            code="no_provider_configured",
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", _resolve_provider)
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices, **kwargs: len(choices) - 1)
+    monkeypatch.setattr("sys.stdin", type("FakeTTY", (), {"isatty": lambda self: True})())
+
+    hermes_main.cmd_model(SimpleNamespace())
+    output = capsys.readouterr().out
+
+    assert "Warning:" not in output
+    assert "No change." in output
+
+
 def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     monkeypatch.setattr(
         "hermes_cli.config.get_env_value",
@@ -581,6 +607,149 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
+
+
+def test_model_flow_api_key_provider_ollama_discovers_and_persists(monkeypatch):
+    saved_cfg = {}
+    saved_model = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "", "provider": "ollama", "base_url": "http://localhost:11434/v1"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_model.setdefault("model", model))
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_list, current_model="": model_list[0] if model_list else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": ["qwen3:latest"],
+            "probed_url": "http://localhost:11434/v1/models",
+            "resolved_base_url": "http://localhost:11434/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_ollama_native_models",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("native probe should not run when /models succeeds")),
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+
+    hermes_main._model_flow_api_key_provider(
+        {"model": {"default": "", "provider": "ollama", "base_url": "http://localhost:11434/v1"}},
+        "ollama",
+        "",
+    )
+
+    assert saved_model["model"] == "qwen3:latest"
+    assert saved_cfg["model"]["provider"] == "ollama"
+    assert saved_cfg["model"]["base_url"] == "http://localhost:11434/v1"
+
+
+def test_model_flow_api_key_provider_ollama_uses_seed_models_when_discovery_empty(monkeypatch):
+    saved_cfg = {}
+    captured = {}
+    saved_model = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "", "provider": "ollama", "base_url": "http://localhost:11434/v1"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_model.setdefault("model", model))
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    def _capture_prompt(model_list, current_model=""):
+        captured["model_list"] = list(model_list)
+        return model_list[0] if model_list else None
+
+    monkeypatch.setattr("hermes_cli.auth._prompt_model_selection", _capture_prompt)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": None,
+            "probed_url": "http://localhost:11434/v1/models",
+            "resolved_base_url": "http://localhost:11434/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_ollama_native_models",
+        lambda *args, **kwargs: {
+            "models": [],
+            "probed_url": "http://localhost:11434/api/tags",
+            "resolved_base_url": "http://localhost:11434/v1",
+            "native_base_url": "http://localhost:11434",
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+
+    hermes_main._model_flow_api_key_provider(
+        {"model": {"default": "", "provider": "ollama", "base_url": "http://localhost:11434/v1"}},
+        "ollama",
+        "",
+    )
+
+    assert captured["model_list"] == ["kimi-k2.5:cloud", "glm-5.1:cloud"]
+    assert saved_model["model"] == "kimi-k2.5:cloud"
+    assert saved_cfg["model"]["provider"] == "ollama"
+    assert saved_cfg["model"]["base_url"] == "http://localhost:11434/v1"
+
+
+def test_model_flow_api_key_provider_ollama_prints_running_warning_when_unreachable(monkeypatch, capsys):
+    saved_cfg = {}
+    saved_model = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "", "provider": "ollama", "base_url": "http://localhost:11434/v1"}},
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_model.setdefault("model", model))
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection",
+        lambda model_list, current_model="": model_list[0] if model_list else None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": None,
+            "probed_url": "http://localhost:11434/v1/models",
+            "resolved_base_url": "http://localhost:11434/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_ollama_native_models",
+        lambda *args, **kwargs: {
+            "models": None,
+            "probed_url": "http://localhost:11434/api/tags",
+            "resolved_base_url": "http://localhost:11434/v1",
+            "native_base_url": "http://localhost:11434",
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+
+    hermes_main._model_flow_api_key_provider(
+        {"model": {"default": "", "provider": "ollama", "base_url": "http://localhost:11434/v1"}},
+        "ollama",
+        "",
+    )
+    out = capsys.readouterr().out
+
+    assert "Ollama was not reachable. Make sure Ollama is running (ollama serve)." in out
+    assert saved_model["model"] == "kimi-k2.5:cloud"
+    assert saved_cfg["model"]["provider"] == "ollama"
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -155,6 +155,7 @@ class TestNormalizeProvider:
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"
         assert normalize_provider("github-copilot") == "copilot"
+        assert normalize_provider("ollama_launch") == "ollama"
 
     def test_case_insensitive(self):
         assert normalize_provider("OpenRouter") == "openrouter"

--- a/tests/hermes_cli/test_ollama_cloud_provider.py
+++ b/tests/hermes_cli/test_ollama_cloud_provider.py
@@ -57,13 +57,16 @@ class TestOllamaCloudAliases:
         assert resolve_provider("ollama_cloud") == "ollama-cloud"
 
     def test_bare_ollama_stays_local(self):
-        """Bare 'ollama' alias routes to 'custom' (local) — not cloud."""
-        assert resolve_provider("ollama") == "custom"
+        """Bare 'ollama' alias routes to native local provider — not cloud."""
+        assert resolve_provider("ollama") == "ollama"
 
     def test_models_py_aliases(self):
         assert _PROVIDER_ALIASES.get("ollama_cloud") == "ollama-cloud"
         # bare "ollama" stays local
-        assert _PROVIDER_ALIASES.get("ollama") == "custom"
+        assert _PROVIDER_ALIASES.get("ollama") == "ollama"
+        assert _PROVIDER_ALIASES.get("ollama-launch") == "ollama"
+        assert _PROVIDER_ALIASES.get("ollama_launch") == "ollama"
+        assert _PROVIDER_ALIASES.get("ollama-local") == "ollama"
 
     def test_normalize_provider(self):
         assert normalize_provider("ollama-cloud") == "ollama-cloud"
@@ -74,6 +77,14 @@ class TestOllamaCloudAliases:
 class TestOllamaCloudAutoDetection:
     def test_auto_detects_ollama_api_key(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_API_KEY", "test-ollama-key")
+        assert resolve_provider("auto") == "ollama-cloud"
+
+    def test_auto_detects_ollama_api_key_from_env_file(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.auth.get_env_value",
+            lambda key: "test-ollama-key-from-file" if key == "OLLAMA_API_KEY" else "",
+        )
         assert resolve_provider("auto") == "ollama-cloud"
 
 
@@ -92,6 +103,23 @@ class TestOllamaCloudCredentials:
         monkeypatch.setenv("OLLAMA_BASE_URL", "https://custom.ollama/v1")
         creds = resolve_api_key_provider_credentials("ollama-cloud")
         assert creds["base_url"] == "https://custom.ollama/v1"
+
+    def test_resolve_with_env_file_base_url(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.auth.get_env_value",
+            lambda key: (
+                "test-ollama-key-from-file"
+                if key == "OLLAMA_API_KEY"
+                else "https://from-file.ollama/v1"
+                if key == "OLLAMA_BASE_URL"
+                else ""
+            ),
+        )
+        creds = resolve_api_key_provider_credentials("ollama-cloud")
+        assert creds["api_key"] == "test-ollama-key-from-file"
+        assert creds["base_url"] == "https://from-file.ollama/v1"
 
     def test_runtime_ollama_cloud(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_API_KEY", "ollama-key")
@@ -382,7 +410,7 @@ class TestOllamaCloudProvidersNew:
 
     def test_alias_resolves(self):
         from hermes_cli.providers import normalize_provider as np
-        assert np("ollama") == "custom"  # bare "ollama" = local
+        assert np("ollama") == "ollama"  # bare "ollama" = local
         assert np("ollama-cloud") == "ollama-cloud"
 
     def test_label_override(self):

--- a/tests/hermes_cli/test_ollama_local_provider.py
+++ b/tests/hermes_cli/test_ollama_local_provider.py
@@ -1,0 +1,167 @@
+"""Tests for native local Ollama provider behavior."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.models import (
+    _PROVIDER_ALIASES,
+    is_local_ollama_base_url,
+    probe_ollama_native_models,
+    provider_model_ids,
+    validate_requested_model,
+)
+
+
+def test_ollama_registered_as_first_class_provider():
+    pconfig = PROVIDER_REGISTRY["ollama"]
+    assert pconfig.id == "ollama"
+    assert pconfig.name == "Ollama"
+    assert pconfig.inference_base_url == "http://localhost:11434/v1"
+
+
+def test_ollama_aliases_resolve_to_native_provider():
+    assert resolve_provider("ollama") == "ollama"
+    assert resolve_provider("ollama-launch") == "ollama"
+    assert resolve_provider("ollama_launch") == "ollama"
+    assert resolve_provider("ollama-local") == "ollama"
+
+
+def test_models_aliases_map_ollama_variants():
+    assert _PROVIDER_ALIASES["ollama"] == "ollama"
+    assert _PROVIDER_ALIASES["ollama-launch"] == "ollama"
+    assert _PROVIDER_ALIASES["ollama_launch"] == "ollama"
+    assert _PROVIDER_ALIASES["ollama-local"] == "ollama"
+
+
+def test_is_local_ollama_base_url():
+    assert is_local_ollama_base_url("http://localhost:11434/v1") is True
+    assert is_local_ollama_base_url("http://127.0.0.1:11434") is True
+    assert is_local_ollama_base_url("https://ollama.com/v1") is False
+    assert is_local_ollama_base_url("http://localhost:8000/v1") is False
+
+
+def test_provider_model_ids_ollama_prefers_openai_models():
+    with (
+        patch("hermes_cli.models._get_custom_base_url", return_value="http://localhost:11434/v1"),
+        patch("hermes_cli.models.fetch_api_models", return_value=["qwen3:latest"]),
+        patch("hermes_cli.models.fetch_ollama_native_models", return_value=["llama3.2:latest"]) as native_mock,
+    ):
+        models = provider_model_ids("ollama")
+
+    assert models == ["qwen3:latest"]
+    native_mock.assert_not_called()
+
+
+def test_provider_model_ids_ollama_falls_back_to_native_tags():
+    with (
+        patch("hermes_cli.models._get_custom_base_url", return_value="http://localhost:11434/v1"),
+        patch("hermes_cli.models.fetch_api_models", return_value=None),
+        patch("hermes_cli.models.fetch_ollama_native_models", return_value=["qwen3:latest", "llama3.2:latest"]),
+    ):
+        models = provider_model_ids("ollama")
+
+    assert models == ["qwen3:latest", "llama3.2:latest"]
+
+
+def test_provider_model_ids_ollama_uses_seed_models_when_discovery_empty():
+    with (
+        patch("hermes_cli.models._get_custom_base_url", return_value="http://localhost:11434/v1"),
+        patch("hermes_cli.models.fetch_api_models", return_value=None),
+        patch("hermes_cli.models.fetch_ollama_native_models", return_value=[]),
+    ):
+        models = provider_model_ids("ollama")
+
+    assert models == ["kimi-k2.5:cloud", "glm-5.1:cloud"]
+
+
+def test_probe_ollama_native_models_reads_api_tags():
+    class _Resp:
+        def __init__(self, payload: dict):
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps(self._payload).encode("utf-8")
+
+    with patch(
+        "hermes_cli.models.urllib.request.urlopen",
+        return_value=_Resp({"models": [{"name": "qwen3:latest"}, {"model": "llama3.2:latest"}]}),
+    ):
+        probe = probe_ollama_native_models("http://localhost:11434/v1")
+
+    assert probe["models"] == ["qwen3:latest", "llama3.2:latest"]
+    assert probe["probed_url"] == "http://localhost:11434/api/tags"
+
+
+def test_validate_requested_model_ollama_native_fallback():
+    with (
+        patch(
+            "hermes_cli.models.probe_api_models",
+            return_value={
+                "models": None,
+                "probed_url": "http://localhost:11434/v1/models",
+                "resolved_base_url": "http://localhost:11434/v1",
+                "suggested_base_url": None,
+                "used_fallback": False,
+            },
+        ),
+        patch(
+            "hermes_cli.models.probe_ollama_native_models",
+            return_value={
+                "models": ["qwen3:latest", "llama3.2:latest"],
+                "probed_url": "http://localhost:11434/api/tags",
+                "resolved_base_url": "http://localhost:11434/v1",
+                "native_base_url": "http://localhost:11434",
+                "used_fallback": False,
+            },
+        ),
+    ):
+        result = validate_requested_model(
+            "qwen3:latest",
+            "ollama",
+            base_url="http://localhost:11434/v1",
+        )
+
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is True
+
+
+def test_model_picker_lists_ollama_without_api_key():
+    with (
+        patch("agent.models_dev.fetch_models_dev", return_value={}),
+        patch("hermes_cli.models.fetch_api_models", return_value=None),
+        patch("hermes_cli.models.fetch_ollama_native_models", return_value=[]),
+    ):
+        providers = list_authenticated_providers(current_provider="openrouter")
+
+    ollama = next((p for p in providers if p["slug"] == "ollama"), None)
+    assert ollama is not None, "ollama should appear in /model picker without API key"
+    assert ollama["total_models"] >= 2
+    assert "kimi-k2.5:cloud" in ollama["models"]
+    assert "glm-5.1:cloud" in ollama["models"]
+    assert "warning" in ollama
+    assert "No local Ollama models found" in ollama["warning"]
+
+
+def test_model_picker_warns_when_local_ollama_unreachable():
+    with (
+        patch("agent.models_dev.fetch_models_dev", return_value={}),
+        patch("hermes_cli.models.fetch_api_models", return_value=None),
+        patch("hermes_cli.models.fetch_ollama_native_models", return_value=None),
+    ):
+        providers = list_authenticated_providers(current_provider="openrouter")
+
+    ollama = next((p for p in providers if p["slug"] == "ollama"), None)
+    assert ollama is not None
+    assert "warning" in ollama
+    assert "Make sure Ollama is running" in ollama["warning"]

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1207,6 +1207,36 @@ def test_custom_provider_no_key_gets_placeholder(monkeypatch):
     assert resolved["base_url"] == "http://localhost:8080/v1"
 
 
+def test_ollama_provider_no_key_gets_placeholder(monkeypatch):
+    """Native ollama provider should resolve with no-key-required."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "ollama")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "ollama",
+            "base_url": "http://localhost:11434/v1",
+            "default": "qwen3:latest",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "",
+            "base_url": "http://localhost:11434/v1",
+            "source": "default",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda p: type("P", (), {"has_credentials": lambda self: False})())
+
+    resolved = rp.resolve_runtime_provider(requested="ollama")
+    assert resolved["provider"] == "ollama"
+    assert resolved["base_url"] == "http://localhost:11434/v1"
+    assert resolved["api_key"] == "no-key-required"
+
+
 def test_auto_detected_nous_auth_failure_falls_through_to_openrouter(monkeypatch):
     """When auto-detect picks Nous but credentials are revoked, fall through to OpenRouter."""
     from hermes_cli.auth import AuthError

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1025,6 +1025,26 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+    def test_native_ollama_think_false_on_effort_none(self, agent):
+        """Native ollama provider with effort=none should inject think=false."""
+        agent.provider = "ollama"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"effort": "none"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is False
+
+    def test_non_ollama_custom_provider_preserves_legacy_think_false(self, agent):
+        """Non-Ollama custom endpoints keep legacy think=false behavior."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:8000/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"effort": "none"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is False
+
     def test_non_custom_provider_unaffected(self, agent):
         """OpenRouter provider with effort=none should NOT inject think=false."""
         agent.provider = "openrouter"

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -54,6 +54,8 @@ Current provider families include:
 - Kilo Code
 - Hugging Face
 - OpenCode Zen / OpenCode Go
+- Ollama (`provider: ollama`) — native local daemon path with model discovery
+- Ollama Cloud (`provider: ollama-cloud`) — direct ollama.com API (`OLLAMA_API_KEY`)
 - Custom (`provider: custom`) — first-class provider for any OpenAI-compatible endpoint
 - Named custom providers (`custom_providers` list in config.yaml)
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -48,6 +48,8 @@ hermes setup       # Or configure everything at once
 | **Nous Portal** | Subscription-based, zero-config | OAuth login via `hermes model` |
 | **OpenAI Codex** | ChatGPT OAuth, uses Codex models | Device code auth via `hermes model` |
 | **Anthropic** | Claude models directly (Pro/Max or API key) | `hermes model` with Claude Code auth, or an Anthropic API key |
+| **Ollama** | Local daemon with dynamic model discovery (local + cloud-tagged models) | `hermes model` → select **Ollama** (default base URL: `http://localhost:11434/v1`) |
+| **Ollama Cloud** | Direct ollama.com cloud provider | Set `OLLAMA_API_KEY` (or choose in `hermes model`) |
 | **OpenRouter** | Multi-provider routing across many models | Enter your API key |
 | **Z.AI** | GLM / Zhipu-hosted models | Set `GLM_API_KEY` / `ZAI_API_KEY` |
 | **Kimi / Moonshot** | Moonshot-hosted coding and chat models | Set `KIMI_API_KEY` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -19,6 +19,8 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Pro/Max via Claude Code auth, Anthropic API key, or manual setup-token) |
+| **Ollama (local and cloud models)** | `hermes model` (native local provider, dynamic discovery; default base URL `http://localhost:11434/v1`) |
+| **Ollama Cloud** | `OLLAMA_API_KEY` in `~/.hermes/.env` (provider: `ollama-cloud`) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
@@ -386,9 +388,11 @@ Both approaches persist to `config.yaml`, which is the source of truth for model
 **To add a new provider:** Exit your session (`Ctrl+C` or `/quit`), run `hermes model`, set up the new provider, then start a new session.
 :::
 
-Once you have at least one custom endpoint configured, you can switch models mid-session:
+Once you have providers configured, you can switch models mid-session:
 
 ```
+/model ollama:qwen3.5:27b        # Switch to a model on local Ollama
+/model ollama                    # Re-probe local Ollama and auto-select if one model
 /model custom:qwen-2.5          # Switch to a model on your custom endpoint
 /model custom                    # Auto-detect the model from the endpoint
 /model openrouter:claude-sonnet-4 # Switch back to a cloud provider
@@ -404,14 +408,14 @@ If you have **named custom providers** configured (see below), use the triple sy
 When switching providers, Hermes persists the base URL and provider to config so the change survives restarts. When switching away from a custom endpoint to a built-in provider, the stale base URL is automatically cleared.
 
 :::tip
-`/model custom` (bare, no model name) queries your endpoint's `/models` API and auto-selects the model if exactly one is loaded. Useful for local servers running a single model.
+`/model ollama` probes local Ollama (`/v1/models`, then `/api/tags`) and auto-selects if exactly one model is discovered. `/model custom` does the same auto-detect behavior for generic OpenAI-compatible endpoints.
 :::
 
 Everything below follows this same pattern — just change the URL, key, and model name.
 
 ---
 
-### Ollama — Local Models, Zero Config
+### Ollama — Local and Cloud Models, Zero Config
 
 [Ollama](https://ollama.com/) runs open-weight models locally with one command. Best for: quick local experimentation, privacy-sensitive work, offline use. Supports tool calling via the OpenAI-compatible API.
 
@@ -425,10 +429,9 @@ Then configure Hermes:
 
 ```bash
 hermes model
-# Select "Custom endpoint (self-hosted / VLLM / etc.)"
-# Enter URL: http://localhost:11434/v1
-# Skip API key (Ollama doesn't need one)
-# Enter model name (e.g. qwen2.5-coder:32b)
+# Select "Ollama (local and cloud models)"
+# Base URL defaults to http://localhost:11434/v1
+# Pick a discovered model (or enter one manually)
 ```
 
 Or configure `config.yaml` directly:
@@ -436,10 +439,17 @@ Or configure `config.yaml` directly:
 ```yaml
 model:
   default: qwen2.5-coder:32b
-  provider: custom
+  provider: ollama
   base_url: http://localhost:11434/v1
   context_length: 32768   # See warning below
 ```
+
+:::tip
+If local Ollama is unreachable during setup or `/model`, Hermes shows:
+Ollama was not reachable. Make sure Ollama is running (ollama serve).
+When no models are discovered, Hermes still surfaces baseline options (`kimi-k2.5:cloud`, `glm-5.1:cloud`) so you can continue setup.
+Compatibility aliases like `ollama-launch`, `ollama_launch`, and `ollama-local` resolve to the same native `ollama` provider.
+:::
 
 :::caution Ollama defaults to very low context lengths
 Ollama does **not** use your model's full context window by default. Depending on your VRAM, the default is:
@@ -479,8 +489,29 @@ ollama ps
 ```
 
 :::tip
-List available models with `ollama list`. Pull any model from the [Ollama library](https://ollama.com/library) with `ollama pull <model>`. Ollama handles GPU offloading automatically — no configuration needed for most setups.
+List available models with `ollama list`. Pull any model from the [Ollama library](https://ollama.com/library) with `ollama pull <model>`. Ollama handles GPU offloading automatically — no configuration needed for most setups. Local discovery can include `:cloud` models exposed by your running Ollama instance.
 :::
+
+---
+
+### Ollama Cloud — Direct ollama.com API
+
+Use this when you want Ollama-hosted cloud inference without routing through a local daemon.
+
+```bash
+export OLLAMA_API_KEY=***
+hermes chat --provider ollama-cloud --model kimi-k2.5:cloud
+```
+
+Or set it permanently:
+
+```yaml
+model:
+  provider: "ollama-cloud"
+  default: "kimi-k2.5:cloud"
+```
+
+`OLLAMA_BASE_URL` optionally overrides the default cloud endpoint (`https://ollama.com/v1`).
 
 ---
 
@@ -688,7 +719,7 @@ Use that IP in your Hermes config:
 ```yaml
 model:
   default: qwen2.5-coder:32b
-  provider: custom
+  provider: ollama
   base_url: http://172.29.192.1:11434/v1   # Windows host IP, not localhost
 ```
 
@@ -798,7 +829,7 @@ Hermes auto-detects context length from your server's `/v1/models` endpoint. If 
 ```yaml
 model:
   default: your-model
-  provider: custom
+  provider: ollama
   base_url: http://localhost:11434/v1
   context_length: 32768
 ```
@@ -937,7 +968,7 @@ For custom endpoints, you can also set context length per model:
 ```yaml
 custom_providers:
   - name: "My Local LLM"
-    base_url: "http://localhost:11434/v1"
+    base_url: "http://localhost:8000/v1"
     models:
       qwen3.5:27b:
         context_length: 32768

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -139,6 +139,8 @@ Switch between already-configured models without leaving a session:
 /model                              # Show current model and available options
 /model claude-sonnet-4              # Switch model (auto-detects provider)
 /model zai:glm-5                    # Switch provider and model
+/model ollama:qwen3.5:27b           # Use a model on local Ollama
+/model ollama                       # Re-discover models from local Ollama
 /model custom:qwen-2.5              # Use model on your custom endpoint
 /model custom                       # Auto-detect model from custom endpoint
 /model custom:local:qwen-2.5        # Use a named custom provider

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -18,6 +18,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `AI_GATEWAY_BASE_URL` | Override AI Gateway base URL (default: `https://ai-gateway.vercel.sh/v1`) |
 | `OPENAI_API_KEY` | API key for custom OpenAI-compatible endpoints (used with `OPENAI_BASE_URL`) |
 | `OPENAI_BASE_URL` | Base URL for custom endpoint (VLLM, SGLang, etc.) |
+| `OLLAMA_API_KEY` | Ollama Cloud API key (used by provider `ollama-cloud` and ollama.com endpoints) |
+| `OLLAMA_BASE_URL` | Override Ollama Cloud base URL (default: `https://ollama.com/v1`) |
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API — first priority (OAuth `gho_*` or fine-grained PAT `github_pat_*`; classic PATs `ghp_*` are **not supported**) |
 | `GH_TOKEN` | GitHub token — second priority for Copilot (also used by `gh` CLI) |
 | `GITHUB_TOKEN` | GitHub token — third priority for Copilot |
@@ -73,7 +75,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `ollama`, `ollama-cloud`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -56,14 +56,13 @@ API calls go **only to the LLM provider you configure** (e.g., OpenRouter, your 
 
 ### Can I use it offline / with local models?
 
-Yes. Run `hermes model`, select **Custom endpoint**, and enter your server's URL:
+Yes. Run `hermes model` and choose either **Ollama (local and cloud models)** or **Custom endpoint**, then follow the prompts:
 
 ```bash
 hermes model
-# Select: Custom endpoint (enter URL manually)
-# API base URL: http://localhost:11434/v1
-# API key: ollama
-# Model name: qwen3.5:27b
+# Select: Ollama (local and cloud models)
+# Base URL: http://localhost:11434/v1   (default)
+# Pick a discovered model, or enter one manually
 # Context length: 32768   ← set this to match your server's actual context window
 ```
 
@@ -72,11 +71,13 @@ Or configure it directly in `config.yaml`:
 ```yaml
 model:
   default: qwen3.5:27b
-  provider: custom
+  provider: ollama
   base_url: http://localhost:11434/v1
 ```
 
-Hermes persists the endpoint, provider, and base URL in `config.yaml` so it survives restarts. If your local server has exactly one model loaded, `/model custom` auto-detects it. You can also set `provider: custom` in config.yaml — it's a first-class provider, not an alias for anything else.
+Hermes persists the endpoint, provider, and base URL in `config.yaml` so it survives restarts. If local Ollama has exactly one model available, `/model ollama` auto-selects it.
+
+For other local servers (vLLM, llama.cpp, SGLang, LocalAI), use `provider: custom` with your server's base URL.
 
 This works with Ollama, vLLM, llama.cpp server, SGLang, LocalAI, and others. See the [Configuration guide](../user-guide/configuration.md) for details.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -601,7 +601,7 @@ Every model slot in Hermes — auxiliary tasks, compression, fallback — uses t
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
-Available providers for auxiliary tasks: `auto`, `openrouter`, `nous`, `codex`, `copilot`, `anthropic`, `main`, `zai`, `kimi-coding`, `kimi-coding-cn`, `arcee`, `minimax`, any provider registered in the [provider registry](/docs/reference/environment-variables), or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
+Available providers for auxiliary tasks: `auto`, `openrouter`, `nous`, `codex`, `copilot`, `anthropic`, `ollama`, `ollama-cloud`, `main`, `zai`, `kimi-coding`, `kimi-coding-cn`, `arcee`, `minimax`, any provider registered in the [provider registry](/docs/reference/environment-variables), or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
 
 :::warning `"main"` is for auxiliary tasks only
 The `"main"` provider option means "use whatever provider my main agent uses" — it's only valid inside `auxiliary:`, `compression:`, and `fallback_model:` configs. It is **not** a valid value for your top-level `model.provider` setting. If you use a custom OpenAI-compatible endpoint, set `provider: custom` in your `model:` section. See [AI Providers](/docs/integrations/providers) for all main model provider options.

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -39,6 +39,8 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` |
 | Nous Portal | `nous` | `hermes auth` (OAuth) |
 | OpenAI Codex | `openai-codex` | `hermes model` (ChatGPT OAuth) |
+| Ollama (local and cloud models) | `ollama` | Local daemon running (default `http://localhost:11434/v1`) |
+| Ollama Cloud | `ollama-cloud` | `OLLAMA_API_KEY` |
 | GitHub Copilot | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` |
 | GitHub Copilot ACP | `copilot-acp` | External process (editor integration) |
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` or Claude Code credentials |
@@ -119,10 +121,9 @@ fallback_model:
 **Local model as fallback for cloud:**
 ```yaml
 fallback_model:
-  provider: custom
-  model: llama-3.1-70b
-  base_url: http://localhost:8000/v1
-  api_key_env: LOCAL_API_KEY
+  provider: ollama
+  model: qwen3.5:27b
+  base_url: http://localhost:11434/v1
 ```
 
 **Codex OAuth as fallback:**


### PR DESCRIPTION
## What does this PR do?

Adds a native local `ollama` provider (separate from `ollama-cloud`) with dynamic model discovery, onboarding visibility, and safer runtime behavior for keyless local usage.

It also keeps backward compatibility for existing alias usage (`ollama-launch`, `ollama_launch`, `ollama-local`), preserves custom-endpoint behavior, improves `/model` UX (including wrap-around navigation), and adds preflight warnings when local Ollama is unreachable.

This approach is preferred because it keeps local Ollama first-class (instead of overloading `custom`), reduces setup friction, and avoids regressions for existing users and cloud routes.

## Related Issue


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added native local provider identity + aliases:
  - `ollama` as canonical local provider
  - `ollama_cloud -> ollama-cloud`
  - compatibility aliases: `ollama-launch`, `ollama_launch`, `ollama-local -> ollama`
- Added native Ollama model discovery flow in setup/onboarding:
  - probe `/v1/models` first
  - fallback to Ollama-native `/api/tags`
  - fallback seed models when discovery fails (`kimi-k2.5:cloud`, `glm-5.1:cloud`)
- Updated runtime provider resolution for keyless local Ollama:
  - `ollama` works without API key
  - `ollama-cloud` continues to require `OLLAMA_API_KEY`
- Improved model picker behavior:
  - preflight warning when local Ollama is unreachable:
    - `Ollama was not reachable. Make sure Ollama is running (ollama serve).`
  - wrap-around navigation in `/model` provider picker
- Preserved behavior for custom/local compatibility routes (including reasoning/think handling where required)
- Added/updated tests across provider resolution, onboarding/model switch, runtime behavior, CLI picker navigation, and run-agent/provider interactions
- Updated docs across README + website docs for:
  - native `ollama` provider usage
  - `ollama-cloud` + `OLLAMA_API_KEY`
  - `/model ollama` usage
  - fallback/config/environment references

## How to Test

1. Local Ollama setup flow:
   - Start Ollama: `ollama serve`
   - Run `uv run hermes model`
   - Select `Ollama`
   - Confirm model discovery works and selected model is persisted with `provider: ollama`
2. In-session model switching:
   - Start Hermes: `uv run hermes`
   - Run `/model`
   - Verify `Ollama` appears and `/model ollama` discovery works
   - Verify picker wraps (up from first item goes to bottom, down from bottom goes to top)
3. Unreachable Ollama preflight:
   - Stop local daemon
   - Re-open `/model` and select Ollama
   - Confirm warning is shown exactly:
     - `Ollama was not reachable. Make sure Ollama is running (ollama serve).`
4. Ollama Cloud key path:
   - Set `OLLAMA_API_KEY`
   - Run `uv run hermes chat --provider ollama-cloud --model kimi-k2.5:cloud`
   - Confirm cloud route works and remains distinct from local `ollama`
5. Run targeted tests:
   - `python -m pytest tests/cli/test_cli_model_picker_navigation.py tests/hermes_cli/test_ollama_local_provider.py tests/cli/test_cli_provider_resolution.py -q`
   - `python -m pytest tests/hermes_cli/test_ollama_cloud_provider.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_opencode_go_in_model_list.py tests/hermes_cli/test_codex_cli_model_picker.py -q`
   - `python -m pytest tests/agent/test_auxiliary_named_custom_providers.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_run_agent.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test runs:

- `39 passed, 16 warnings in 2.20s`
- `68 passed, 16 warnings in 1.79s`
- `414 passed, 16 warnings in 5.26s`

<img width="896" height="652" alt="CleanShot 2026-04-16 at 18 37 57@2x" src="https://github.com/user-attachments/assets/ea4ab7fd-ebc9-4e76-889a-7e4e08991213" />
<img width="906" height="394" alt="CleanShot 2026-04-16 at 18 38 19@2x" src="https://github.com/user-attachments/assets/b4aa8d78-6610-4db7-8040-85c1e9e919bc" />
<img width="1028" height="84" alt="CleanShot 2026-04-16 at 18 38 41@2x" src="https://github.com/user-attachments/assets/503a66a2-8165-499c-93e3-d2166f5b699c" />
