### PR TITLE
fix(agent): handle dict-typed message in classify_api_error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -290,7 +290,7 @@ def classify_api_error(
     if isinstance(body, dict):
         _err_obj = body.get("error", {})
         if isinstance(_err_obj, dict):
-            _body_msg = (_err_obj.get("message") or "").lower()
+            _body_msg = str(_err_obj.get("message") or "").lower()
             # Parse metadata.raw for wrapped provider errors
             _metadata = _err_obj.get("metadata", {})
             if isinstance(_metadata, dict):
@@ -302,11 +302,11 @@ def classify_api_error(
                         if isinstance(_inner, dict):
                             _inner_err = _inner.get("error", {})
                             if isinstance(_inner_err, dict):
-                                _metadata_msg = (_inner_err.get("message") or "").lower()
+                                _metadata_msg = str(_inner_err.get("message") or "").lower()
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
-            _body_msg = (body.get("message") or "").lower()
+            _body_msg = str(body.get("message") or "").lower()
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
@@ -606,10 +606,10 @@ def _classify_400(
     if isinstance(body, dict):
         err_obj = body.get("error", {})
         if isinstance(err_obj, dict):
-            err_body_msg = (err_obj.get("message") or "").strip().lower()
+            err_body_msg = str(err_obj.get("message") or "").strip().lower()
         # Responses API (and some providers) use flat body: {"message": "..."}
         if not err_body_msg:
-            err_body_msg = (body.get("message") or "").strip().lower()
+            err_body_msg = str(body.get("message") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in ("error", "")
     is_large = approx_tokens > context_length * 0.4 or approx_tokens > 80000 or num_messages > 80
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -849,3 +849,45 @@ class TestAdversarialEdgeCases:
         )
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.model_not_found
+
+    def test_dict_typed_message_does_not_crash(self):
+        # Regression for #11233: Pydantic/FastAPI validation errors return
+        # `message` as a dict, not a string. Classifier must not raise
+        # AttributeError trying to call .lower() on the dict.
+        pydantic_body = {
+            "object": "error",
+            "message": {
+                "detail": [
+                    {
+                        "type": "extra_forbidden",
+                        "loc": ["body", "think"],
+                        "msg": "Extra inputs are not permitted",
+                    }
+                ]
+            },
+        }
+        # Flat body shape (hits the `body.get("message")` sites)
+        e_flat = MockAPIError("validation error", status_code=422, body=pydantic_body)
+        assert isinstance(classify_api_error(e_flat), ClassifiedError)
+
+        # Nested under "error" (hits the `err_obj.get("message")` sites)
+        e_nested = MockAPIError(
+            "validation error",
+            status_code=422,
+            body={"error": pydantic_body},
+        )
+        assert isinstance(classify_api_error(e_nested), ClassifiedError)
+
+        # OpenRouter-style wrapped inside metadata.raw (hits _metadata_msg site)
+        import json as _json
+        e_wrapped = MockAPIError(
+            "Provider returned error",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": _json.dumps({"error": pydantic_body})},
+                }
+            },
+        )
+        assert isinstance(classify_api_error(e_wrapped, provider="openrouter"), ClassifiedError)


### PR DESCRIPTION
## What does this PR do?

Fixes `AttributeError: 'dict' object has no attribute 'lower'` in `agent/error_classifier.py`. Pydantic/FastAPI validation errors return the `message` field as a dict (e.g. `{"detail": [...]}`) rather than a string. The existing `.get("message") or ""` fallback only guards falsy values — a non-empty dict is truthy and flowed straight into `.lower()`, crashing the error-handling pipeline and masking the original 4xx/5xx from the user.

Wraps all `body.get("message")` sites with `str()` before `.lower()` / `.strip().lower()`. `str()` is a no-op on strings; `str(dict)` / `str(list)` never raise. Pattern matching against the repr is safe — no classifier pattern (`"rate limit"`, `"context length"`, etc.) appears inside a Python dict repr.

## Related Issue

Fixes #11233

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/error_classifier.py` — wrap five `.get("message") or ""` call sites with `str()`:
  - line 293 — `_err_obj.get("message")` in `classify_api_error()`
  - line 305 — `_inner_err.get("message")` inside the OpenRouter `metadata.raw` nested-error unwrap
  - line 309 — `body.get("message")` flat-body fallback
  - line 609 — `err_obj.get("message")` in `_classify_400()`
  - line 612 — `body.get("message")` flat-body fallback in `_classify_400()`
- `tests/agent/test_error_classifier.py` — add `test_dict_typed_message_does_not_crash` covering all three body shapes (flat, nested under `"error"`, and OpenRouter `metadata.raw`-wrapped)

> The issue lists 4 sites; I also patched line 305 because it is the same bug pattern — a Pydantic-style error nested inside an OpenRouter wrapper would have crashed there too.

## How to Test

1. Reproduce on unpatched `main`:
   ```python
   import types
   from agent.error_classifier import classify_api_error
   e = types.SimpleNamespace(status_code=422, body={
       "object": "error",
       "message": {"detail": [{"type": "extra_forbidden", "loc": ["body", "think"], "msg": "Extra inputs are not permitted"}]},
   })
   classify_api_error(e)   # → AttributeError: 'dict' object has no attribute 'lower'
   ```
2. With this PR applied, the same call returns a `ClassifiedError` with `status_code=422` and the error surfaces cleanly to the user.
3. Run the suite:
   ```bash
   python -m pytest tests/agent/test_error_classifier.py -q   # 98 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/agent/test_error_classifier.py -q` and all 98 tests pass
- [x] I've added a regression test for the bug
- [x] I've tested on my platform: macOS 15 (darwin-arm64), Python 3.11.9

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or architectural changes
- [x] No cross-platform implications — `str()` behaves the same on all platforms
- [x] Tool schemas unchanged