### PR TITLE
fix(agent): disable thinking on assistant-prefill continuation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6643,6 +6643,13 @@ class AIAgent:
         if self.provider_data_collection:
             provider_preferences["data_collection"] = self.provider_data_collection
 
+        _assistant_prefill_continuation = bool(
+            sanitized_messages
+            and isinstance(sanitized_messages[-1], dict)
+            and sanitized_messages[-1].get("role") == "assistant"
+            and not sanitized_messages[-1].get("tool_calls")
+        )
+
         api_kwargs = {
             "model": self.model,
             "messages": sanitized_messages,
@@ -6749,10 +6756,27 @@ class AIAgent:
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
+        # Assistant-prefill continuations ask the model to continue an
+        # already-started assistant turn. Explicit reasoning/thinking flags can
+        # conflict with that on OpenAI-compatible local backends (e.g. Gemma 4
+        # via llama.cpp forks), so strip them on the continuation request.
+        if _assistant_prefill_continuation:
+            _extra_body = api_kwargs.setdefault("extra_body", {})
+            if isinstance(_extra_body, dict):
+                _extra_body.pop("reasoning", None)
+                if self.provider == "custom":
+                    _extra_body["think"] = False
+
         # Priority Processing / generic request overrides (e.g. service_tier).
         # Applied last so overrides win over any defaults set above.
         if self.request_overrides:
             api_kwargs.update(self.request_overrides)
+            if _assistant_prefill_continuation:
+                _extra_body = api_kwargs.get("extra_body")
+                if isinstance(_extra_body, dict):
+                    _extra_body.pop("reasoning", None)
+                    if self.provider == "custom":
+                        _extra_body["think"] = False
 
         return api_kwargs
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1024,6 +1024,26 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+    def test_assistant_prefill_continuation_strips_reasoning_extra_body(self, agent):
+        """Trailing assistant prefill should not keep explicit reasoning enabled."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "qwen/qwen3.5-plus-02-15"
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        messages = [{"role": "assistant", "content": "Let me think this through..."}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "reasoning" not in kwargs.get("extra_body", {})
+
+    def test_custom_assistant_prefill_continuation_forces_think_false(self, agent):
+        """Custom backends should disable thinking on assistant-prefill continuation."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        messages = [{"role": "assistant", "content": "Structured reasoning only"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is False
+
 
 
 class TestBuildAssistantMessage:


### PR DESCRIPTION
## Summary
- strip explicit reasoning payloads from assistant-prefill continuation requests
- force `think=false` for custom OpenAI-compatible backends on those continuation calls
- add regression coverage for both reasoning-extra-body and custom backend paths

## Why
Fixes #11213.

Hermes uses a trailing assistant prefill when a model returns reasoning without visible text. Some OpenAI-compatible local backends reject that continuation request if Hermes also keeps reasoning/thinking enabled, returning:

`Assistant response prefill is incompatible with enable_thinking.`

The logged failures reproduce as `api_calls=2`, which lines up with the thinking-only continuation path.

## Testing
- `python3 -m pytest -o addopts= tests/run_agent/test_run_agent.py -k "assistant_prefill_continuation or ollama_think_false or reasoning_config"`
- `python3 -m pytest -o addopts= tests/run_agent/test_provider_parity.py -k "BuildApiKwargsCustomEndpoint or BuildApiKwargsOpenRouter or BuildApiKwargsAIGateway"`