### PR TITLE
fix(gateway): double TimeoutStopSec to prevent SIGKILL before exit code 75

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -839,7 +839,11 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
             path_entries.append(resolved_node_dir)
 
     common_bin_paths = ["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"]
-    restart_timeout = max(60, int(_get_restart_drain_timeout() or 0))
+    # TimeoutStopSec must exceed drain timeout + cleanup overhead.
+    # If equal to drain timeout, systemd SIGKILLs the gateway before it
+    # can emit exit code 75, breaking the /restart → service-restart path.
+    _drain = int(_get_restart_drain_timeout() or 0)
+    restart_timeout = max(120, _drain * 2 if _drain else 120)
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)


### PR DESCRIPTION
## Problem
`/restart` command (especially on Telegram) fails silently because systemd SIGKILLs the gateway before it can emit exit code 75.

The root cause: `TimeoutStopSec` in the generated systemd unit was set equal to the drain timeout. If the drain takes even slightly longer (network delays, active sessions), systemd sends SIGKILL before the gateway finishes its clean shutdown sequence.

## Fix
- Change `TimeoutStopSec` from `max(60, drain_timeout)` to `max(120, drain_timeout * 2)`
- This gives the gateway enough headroom to drain connections AND emit the exit code 75 that triggers the service-restart recovery path

## Changes
- `hermes_cli/gateway.py`: Updated `generate_systemd_unit()` to double the stop timeout with a 120s minimum