### PR TITLE
fix(cron): fall back on invalid timeout env

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -371,6 +371,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 _DEFAULT_SCRIPT_TIMEOUT = 120  # seconds
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
+_DEFAULT_CRON_INACTIVITY_TIMEOUT = 600.0  # seconds
 
 
 def _get_script_timeout() -> int:
@@ -404,6 +405,23 @@ def _get_script_timeout() -> int:
         logger.debug("Failed to load cron script timeout from config: %s", exc)
 
     return _DEFAULT_SCRIPT_TIMEOUT
+
+
+def _get_cron_inactivity_timeout() -> float:
+    """Resolve cron inactivity timeout from env with a safe default."""
+    env_value = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    if not env_value:
+        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
+
+    try:
+        return float(env_value)
+    except Exception:
+        logger.warning(
+            "Invalid HERMES_CRON_TIMEOUT=%r; using default %s",
+            env_value,
+            int(_DEFAULT_CRON_INACTIVITY_TIMEOUT),
+        )
+        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
 
 
 def _run_job_script(script_path: str) -> tuple[bool, str]:
@@ -767,7 +785,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
+        _cron_timeout = _get_cron_inactivity_timeout()
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -714,6 +714,45 @@ class TestRunJobSessionPersistence:
         # But the output log should show the placeholder
         assert "(No response generated)" in output
 
+    def test_run_job_invalid_cron_timeout_falls_back_to_default(self, caplog, tmp_path, monkeypatch):
+        job = {
+            "id": "timeout-fallback-job",
+            "name": "timeout fallback",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "abc")
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        assert any(
+            "Invalid HERMES_CRON_TIMEOUT='abc'; using default 600" in record.message
+            for record in caplog.records
+        ), f"Expected invalid timeout warning, got: {[record.message for record in caplog.records]}"
+
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
         tick() should mark the job as error so last_status != 'ok'.


### PR DESCRIPTION
## Summary
- fall back to the default cron inactivity timeout when HERMES_CRON_TIMEOUT is malformed
- warn instead of crashing before the cron job starts
- add a regression test covering the invalid env path through run_job()

## Testing
- python3 -m pytest -o addopts='' tests/cron/test_scheduler.py tests/cron/test_cron_inactivity_timeout.py

Closes #11319