### PR TITLE
fix: invalidate update cache in _update_via_zip path (#11327)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3120,7 +3120,11 @@ def _update_via_zip(args):
             print("  ✓ Skills are up to date")
     except Exception:
         pass
-    
+
+    # Invalidate the update-check cache so the banner doesn't show stale
+    # "commits behind" for up to 6 hours after a successful ZIP update.
+    _invalidate_update_cache()
+
     print()
     print("✓ Update complete!")
 


### PR DESCRIPTION
Fixes #11327

## Problem
After a successful update via the ZIP download path (`_update_via_zip`), the CLI banner still shows stale "commits behind" count for up to 6 hours because the `.update_check` cache is not invalidated.

The `_invalidate_update_cache()` function exists and is called in the git-based update paths in `cmd_update()`, but was missing from `_update_via_zip()`.

## Fix
Added `_invalidate_update_cache()` call in `_update_via_zip()` after skill sync completes.