### PR TITLE
fix: preserve latest tail message during context compaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -765,7 +765,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 f"recent messages below and the current state of any files or resources."
             )
 
-        _merge_summary_into_tail = False
+        _merge_summary_into_head = False
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
         # Pick a role that avoids consecutive same-role with both neighbors.
@@ -783,23 +783,30 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             else:
                 # Both roles would create consecutive same-role messages
                 # (e.g. head=assistant, tail=user — neither role works).
-                # Merge the summary into the first tail message instead
-                # of inserting a standalone message that breaks alternation.
-                _merge_summary_into_tail = True
-        if not _merge_summary_into_tail:
+                # Merge the summary into the last head message instead of the
+                # first tail message.  Prepending the handoff block to the
+                # tail can contaminate the latest live user ask (or latest
+                # assistant message) with the entire compaction summary,
+                # which in practice causes stale-task fixation and visible
+                # prompt regurgitation.
+                _merge_summary_into_head = True
+        if _merge_summary_into_head and compressed:
+            compressed[-1]["content"] = self._merge_summary_text_into_content(
+                compressed[-1].get("content"),
+                summary,
+                prepend=False,
+            )
+        elif _merge_summary_into_head:
+            # No protected head exists (e.g. protect_first_n=0), so the
+            # head-collision was synthetic. Emit a standalone summary using
+            # the role opposite the first tail message.
+            summary_role = "assistant" if first_tail_role == "user" else "user"
+            compressed.append({"role": summary_role, "content": summary})
+        else:
             compressed.append({"role": summary_role, "content": summary})
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
-            if _merge_summary_into_tail and i == compress_end:
-                original = msg.get("content") or ""
-                msg["content"] = (
-                    summary
-                    + "\n\n--- END OF CONTEXT SUMMARY — "
-                    "respond to the message below, not the summary above ---\n\n"
-                    + original
-                )
-                _merge_summary_into_tail = False
             compressed.append(msg)
 
         self.compression_count += 1
@@ -818,3 +825,60 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             logger.info("Compression #%d complete", self.compression_count)
 
         return compressed
+
+    @staticmethod
+    def _merge_summary_text_into_content(
+        original_content: Any,
+        summary_text: str,
+        *,
+        prepend: bool = False,
+    ) -> Any:
+        """Merge summary text into a message content payload.
+
+        Supports both plain-string content and list-based multimodal content.
+        Replaces any previously embedded compaction summary instead of
+        accumulating multiple handoff blocks across repeated compressions.
+        """
+        if isinstance(original_content, str):
+            original_text = original_content
+            marker = "\n\n" + SUMMARY_PREFIX
+            if marker in original_text:
+                original_text = original_text.split(marker, 1)[0]
+            elif original_text.startswith(SUMMARY_PREFIX):
+                original_text = ""
+            if not original_text:
+                return summary_text
+            return (
+                summary_text + "\n\n" + original_text
+                if prepend
+                else original_text + "\n\n" + summary_text
+            )
+
+        summary_block = {"type": "text", "text": summary_text}
+
+        if isinstance(original_content, list):
+            cleaned_blocks = []
+            for block in original_content:
+                if isinstance(block, dict) and block.get("type") == "text" and SUMMARY_PREFIX in block.get("text", ""):
+                    continue
+                cleaned_blocks.append(block)
+            if not cleaned_blocks:
+                return [summary_block]
+            return [summary_block, *cleaned_blocks] if prepend else [*cleaned_blocks, summary_block]
+
+        if original_content is None:
+            return summary_text
+
+        original_text = str(original_content)
+        marker = "\n\n" + SUMMARY_PREFIX
+        if marker in original_text:
+            original_text = original_text.split(marker, 1)[0]
+        elif original_text.startswith(SUMMARY_PREFIX):
+            original_text = ""
+        if not original_text:
+            return summary_text
+        return (
+            summary_text + "\n\n" + original_text
+            if prepend
+            else original_text + "\n\n" + summary_text
+        )

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -352,8 +352,10 @@ class TestCompressWithClient:
         assert len(summary_msg) == 1
         assert summary_msg[0]["role"] == "user"
 
-    def test_summary_role_avoids_consecutive_user_when_head_ends_with_user(self):
-        """When last head message is 'user', summary must be 'assistant' to avoid two consecutive user messages."""
+    def test_double_collision_when_head_ends_with_user_preserves_tail(self):
+        """If the head ends with user and the tail also starts with assistant,
+        the compressor should preserve the tail message and merge the summary
+        back into the head side instead."""
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -363,7 +365,8 @@ class TestCompressWithClient:
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=2)
 
-        # Last head message (index 2) is "user" → summary should be "assistant"
+        # Last head message (index 2) is "user" and the first tail message is
+        # assistant, so both standalone summary roles would collide.
         msgs = [
             {"role": "system", "content": "system prompt"},
             {"role": "user", "content": "msg 1"},
@@ -376,11 +379,13 @@ class TestCompressWithClient:
         ]
         with patch("agent.context_compressor.call_llm", return_value=mock_response):
             result = c.compress(msgs)
-        summary_msg = [
-            m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)
-        ]
-        assert len(summary_msg) == 1
-        assert summary_msg[0]["role"] == "assistant"
+
+        merged_head = [m for m in result if "msg 2" in (m.get("content") or "")]
+        assert len(merged_head) == 1
+        assert SUMMARY_PREFIX in merged_head[0]["content"]
+
+        first_tail = [m for m in result if (m.get("content") or "") == "msg 5"]
+        assert len(first_tail) == 1
 
     def test_summary_role_flips_to_avoid_tail_collision(self):
         """When summary role collides with the first tail message but flipping
@@ -416,10 +421,13 @@ class TestCompressWithClient:
             if r1 in ("user", "assistant") and r2 in ("user", "assistant"):
                 assert r1 != r2, f"consecutive {r1} at indices {i-1},{i}"
 
-    def test_double_collision_merges_summary_into_tail(self):
-        """When neither role avoids collision with both neighbors, the summary
-        should be merged into the first tail message rather than creating a
-        standalone message that breaks role alternation.
+    def test_double_collision_merges_summary_into_head_to_preserve_tail(self):
+        """When neither role avoids collision with both neighbors, merge the
+        summary into the last head message instead of prepending it to the tail.
+
+        This preserves the most recent tail message (often the current user ask)
+        as a clean standalone message rather than polluting it with the full
+        compaction handoff block.
 
         Common scenario: head ends with 'assistant', tail starts with 'user'.
         summary='user' collides with tail, summary='assistant' collides with head.
@@ -455,14 +463,22 @@ class TestCompressWithClient:
             if r1 in ("user", "assistant") and r2 in ("user", "assistant"):
                 assert r1 != r2, f"consecutive {r1} at indices {i-1},{i}"
 
-        # The summary text should be merged into the first tail message
-        first_tail = [m for m in result if "msg 6" in (m.get("content") or "")]
-        assert len(first_tail) == 1
-        assert "summary text" in first_tail[0]["content"]
+        # The summary text should be merged into the last head message instead
+        # of contaminating the first tail / latest user message.
+        merged_head = [m for m in result if "msg 2" in (m.get("content") or "")]
+        assert len(merged_head) == 1
+        assert "summary text" in merged_head[0]["content"]
 
-    def test_double_collision_user_head_assistant_tail(self):
-        """Reverse double collision: head ends with 'user', tail starts with 'assistant'.
-        summary='assistant' collides with tail, 'user' collides with head → merge."""
+        first_tail = [m for m in result if (m.get("content") or "") == "msg 6"]
+        assert len(first_tail) == 1
+
+    def test_double_collision_user_head_assistant_tail_preserves_tail(self):
+        """Reverse double collision: merge into the last head message so the
+        first tail assistant message stays clean.
+
+        head ends with 'user', tail starts with 'assistant'.
+        summary='assistant' collides with tail, 'user' collides with head.
+        """
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "summary text"
@@ -495,10 +511,116 @@ class TestCompressWithClient:
             if r1 in ("user", "assistant") and r2 in ("user", "assistant"):
                 assert r1 != r2, f"consecutive {r1} at indices {i-1},{i}"
 
-        # The summary should be merged into the first tail message (assistant at index 5)
-        first_tail = [m for m in result if "msg 5" in (m.get("content") or "")]
+        # The summary should be merged into the last head message (user at index 1)
+        # rather than the first tail assistant message.
+        merged_head = [m for m in result if "msg 1" in (m.get("content") or "")]
+        assert len(merged_head) == 1
+        assert "summary text" in merged_head[0]["content"]
+
+        first_tail = [m for m in result if (m.get("content") or "") == "msg 5"]
         assert len(first_tail) == 1
-        assert "summary text" in first_tail[0]["content"]
+
+    def test_double_collision_with_no_protected_head_uses_standalone_summary(self):
+        """If protect_first_n=0, there is no head message to merge into.
+
+        The compressor should emit a standalone summary with the role opposite
+        the first tail message instead of recreating a same-role boundary.
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=0, protect_last_n=2)
+
+        msgs = [
+            {"role": "assistant", "content": "msg 1"},
+            {"role": "user", "content": "msg 2"},
+            {"role": "assistant", "content": "msg 3"},
+            {"role": "user", "content": "msg 4"},
+            {"role": "assistant", "content": "msg 5"},  # first tail
+            {"role": "user", "content": "msg 6"},
+            {"role": "assistant", "content": "msg 7"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        summary_msgs = [m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)]
+        assert len(summary_msgs) == 1
+        assert summary_msgs[0]["role"] == "user"
+
+        for i in range(1, len(result)):
+            r1 = result[i - 1].get("role")
+            r2 = result[i].get("role")
+            if r1 in ("user", "assistant") and r2 in ("user", "assistant"):
+                assert r1 != r2, f"consecutive {r1} at indices {i-1},{i}"
+
+    def test_double_collision_merges_into_list_content_head(self):
+        """Head merge should support list-based content, not just strings."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=3)
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "msg 1"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "msg 2"},
+                    {"type": "text", "text": "extra block"},
+                ],
+            },
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {"role": "user", "content": "msg 6"},
+            {"role": "assistant", "content": "msg 7"},
+            {"role": "user", "content": "msg 8"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        merged_head = [m for m in result if m.get("role") == "assistant" and isinstance(m.get("content"), list)]
+        assert len(merged_head) == 1
+        blocks = merged_head[0]["content"]
+        assert any(block.get("type") == "text" and block.get("text") == "msg 2" for block in blocks)
+        assert any(block.get("type") == "text" and SUMMARY_PREFIX in block.get("text", "") for block in blocks)
+
+    def test_repeated_double_collision_replaces_embedded_summary_in_head(self):
+        """Repeated compressions should replace the embedded head summary,
+        not accumulate multiple handoff blocks in a protected message."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=3, protect_last_n=3)
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "msg 1"},
+            {"role": "assistant", "content": "msg 2"},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {"role": "user", "content": "msg 6"},
+            {"role": "assistant", "content": "msg 7"},
+            {"role": "user", "content": "msg 8"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            first = c.compress(msgs)
+            second = c.compress(first + [
+                {"role": "assistant", "content": "msg 9"},
+                {"role": "user", "content": "msg 10"},
+            ])
+
+        merged_head = [m for m in second if "msg 2" in (m.get("content") or "")]
+        assert len(merged_head) == 1
+        assert merged_head[0]["content"].count(SUMMARY_PREFIX) == 1
 
     def test_no_collision_scenarios_still_work(self):
         """Verify that the common no-collision cases (head=assistant/tail=assistant,


### PR DESCRIPTION
## Bug Description

In a specific context-compaction edge case, Hermes could merge the compaction handoff into the first tail message.

If that tail message was the latest live user turn, the model could treat stale summary content and the fresh ask as one message. In practice that showed up as stale-task fixation, repeated answers, and rehashing already-approved next steps.

## Root Cause

The double-collision fallback in `ContextCompressor.compress()` merged the summary into the first tail message when neither standalone summary role would preserve alternation.

That preserved role alternation, but it polluted the newest tail message — often the current user instruction.

## Fix

- merge the summary into the last protected head message instead of the first tail message in the double-collision case
- preserve the newest tail message as a clean standalone turn
- handle the `protect_first_n=0` edge case with a safe standalone summary fallback
- support both string and list/multimodal content when embedding the summary
- replace previously embedded summary blocks instead of stacking them across repeated compressions
- add regression tests for all of the above

## How to Verify

1. Reproduce a double-collision compaction scenario where the head ends with assistant/user and the tail begins with the opposite role.
2. Confirm the newest tail message remains clean after compression.
3. Confirm repeated compressions do not accumulate multiple embedded summary blocks.
4. Run the targeted compression test suite.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

Targeted tests run:

- `python -m pytest tests/agent/test_context_compressor.py -q`
- `python -m pytest tests/run_agent/test_compression_boundary.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_413_compression.py -q`

## Risk Assessment

Low — the change is isolated to context compaction’s double-collision fallback and is covered by targeted regression tests for string content, list content, no-head fallback, and repeated compactions.
