### PR TITLE
fix(cli): hide think tags in resume recap

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3126,17 +3126,30 @@ class HermesCLI:
         MAX_ASST_LINES = 3           # max lines of assistant text
 
         def _strip_reasoning(text: str) -> str:
-            """Remove <REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD> blocks
-            from displayed text (reasoning model internal thoughts)."""
+            """Remove hidden reasoning/thinking blocks from displayed text."""
             import re
-            cleaned = re.sub(
+            cleaned = text
+            block_patterns = (
+                r"<think>.*?</think>\s*",
+                r"<thinking>.*?</thinking>\s*",
+                r"<reasoning>.*?</reasoning>\s*",
                 r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
-                "", text, flags=re.DOTALL,
+                r"<thought>.*?</thought>\s*",
             )
-            # Also strip unclosed reasoning tags at the end
+            for pattern in block_patterns:
+                cleaned = re.sub(pattern, "", cleaned, flags=re.DOTALL | re.IGNORECASE)
+            # Also strip unclosed reasoning tags at the end.
             cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*$",
-                "", cleaned, flags=re.DOTALL,
+                r"<(?:think|thinking|reasoning|REASONING_SCRATCHPAD|thought)>.*$",
+                "",
+                cleaned,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+            cleaned = re.sub(
+                r"</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD|thought)>\s*",
+                "",
+                cleaned,
+                flags=re.IGNORECASE,
             )
             return cleaned.strip()
 

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -328,6 +328,22 @@ class TestDisplayResumedHistory:
         assert "Let me think step by step" not in output
         assert "The answer is 42" in output
 
+    def test_think_tags_stripped(self):
+        """<think> blocks should be stripped from resumed display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Think about this"},
+            {
+                "role": "assistant",
+                "content": "<think>\ninternal chain of thought\n</think>\nVisible answer",
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<think>" not in output
+        assert "internal chain of thought" not in output
+        assert "Visible answer" in output
+
     def test_pure_reasoning_message_skipped(self):
         """Assistant messages that are only reasoning should be skipped."""
         cli = _make_cli()
@@ -337,6 +353,19 @@ class TestDisplayResumedHistory:
                 "role": "assistant",
                 "content": "<REASONING_SCRATCHPAD>\nJust thinking...\n</REASONING_SCRATCHPAD>",
             },
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        output = self._capture_display(cli)
+
+        assert "Just thinking" not in output
+        assert "Hi there!" in output
+
+    def test_pure_think_message_skipped(self):
+        """Assistant messages that are only <think> blocks should be skipped."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "<think>\nJust thinking...\n</think>"},
             {"role": "assistant", "content": "Hi there!"},
         ]
         output = self._capture_display(cli)


### PR DESCRIPTION
## Summary
- strip hidden reasoning wrappers such as <think>, <thinking>, <reasoning>, and <thought> from resumed-session recap output
- keep pure reasoning-only assistant messages out of the recap entirely
- add regression coverage for visible answer preservation and pure-think message skipping

## Testing
- python3 -m pytest -o addopts='' tests/cli/test_resume_display.py
- python3 -m pytest -o addopts='' tests/cli/test_stream_delta_think_tag.py

Closes #11316