### PR TITLE
fix(tui): replace bright yellow with dark_goldenrod for light bg contrast

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1353,12 +1353,15 @@ class ChatConsole:
 
     def __init__(self):
         from io import StringIO
+        import os
         self._buffer = StringIO()
+        no_color = os.environ.get("NO_COLOR") is not None
         self._inner = Console(
             file=self._buffer,
-            force_terminal=True,
-            color_system="truecolor",
+            force_terminal=not no_color,
+            color_system=None if no_color else "truecolor",
             highlight=False,
+            no_color=no_color,
         )
 
     def print(self, *args, **kwargs):
@@ -2169,7 +2172,7 @@ class HermesCLI:
                 if normalized_model and normalized_model != current_model:
                     if not self._model_is_default:
                         self.console.print(
-                            f"[yellow]⚠️  Normalized model '{current_model}' to '{normalized_model}' for {resolved_provider}.[/]"
+                            f"[dark_goldenrod]⚠️  Normalized model '{current_model}' to '{normalized_model}' for {resolved_provider}.[/]"
                         )
                     self.model = normalized_model
                     current_model = normalized_model
@@ -2185,7 +2188,7 @@ class HermesCLI:
                 if canonical and canonical != current_model:
                     if not self._model_is_default:
                         self.console.print(
-                            f"[yellow]⚠️  Normalized Copilot model '{current_model}' to '{canonical}'.[/]"
+                            f"[dark_goldenrod]⚠️  Normalized Copilot model '{current_model}' to '{canonical}'.[/]"
                         )
                     self.model = canonical
                     current_model = canonical
@@ -2207,7 +2210,7 @@ class HermesCLI:
                 if canonical and canonical != current_model:
                     if not self._model_is_default:
                         self.console.print(
-                            f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; using '{canonical}' for {resolved_provider}.[/]"
+                            f"[dark_goldenrod]⚠️  Stripped provider prefix from '{current_model}'; using '{canonical}' for {resolved_provider}.[/]"
                         )
                     self.model = canonical
                     current_model = canonical
@@ -2229,7 +2232,7 @@ class HermesCLI:
             slug = current_model.split("/", 1)[1]
             if not self._model_is_default:
                 self.console.print(
-                    f"[yellow]⚠️  Stripped provider prefix from '{current_model}'; "
+                    f"[dark_goldenrod]⚠️  Stripped provider prefix from '{current_model}'; "
                     f"using '{slug}' for OpenAI Codex.[/]"
                 )
             self.model = slug
@@ -3004,7 +3007,7 @@ class HermesCLI:
         if ctx_len and ctx_len <= 8192:
             self.console.print()
             self.console.print(
-                f"[yellow]⚠️  Context length is only {ctx_len:,} tokens — "
+                f"[dark_goldenrod]⚠️  Context length is only {ctx_len:,} tokens — "
                 f"this is likely too low for agent use with tools.[/]"
             )
             self.console.print(
@@ -3031,7 +3034,7 @@ class HermesCLI:
         if is_nous_hermes_non_agentic(model_name):
             self.console.print()
             self.console.print(
-                "[bold yellow]⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not "
+                "[bold dark_goldenrod]⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not "
                 "designed for use with Hermes Agent.[/]"
             )
             self.console.print(
@@ -3638,7 +3641,7 @@ class HermesCLI:
             
             if api_key_missing:
                 self.console.print()
-                self.console.print("[yellow]⚠️  Some tools disabled (missing API keys):[/]")
+                self.console.print("[dark_goldenrod]⚠️  Some tools disabled (missing API keys):[/]")
                 for item in api_key_missing:
                     tools_str = ", ".join(item["tools"][:2])  # Show first 2 tools
                     if len(item["tools"]) > 2:
@@ -4936,7 +4939,7 @@ class HermesCLI:
         try:
             access_token = get_valid_access_token()
         except GoogleOAuthError as exc:
-            self.console.print(f"  [yellow]{exc}[/]")
+            self.console.print(f"  [dark_goldenrod]{exc}[/]")
             self.console.print("  Run [bold]/model[/] and pick 'Google Gemini (OAuth)' to sign in.")
             return
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -411,7 +411,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             if name in disabled_tools:
                 colored_names.append(f"[red]{name}[/]")
             elif name in lazy_tools:
-                colored_names.append(f"[yellow]{name}[/]")
+                colored_names.append(f"[dark_goldenrod]{name}[/]")
             else:
                 colored_names.append(f"[{text}]{name}[/]")
 
@@ -432,7 +432,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                 elif name in disabled_tools:
                     colored_names.append(f"[red]{name}[/]")
                 elif name in lazy_tools:
-                    colored_names.append(f"[yellow]{name}[/]")
+                    colored_names.append(f"[dark_goldenrod]{name}[/]")
                 else:
                     colored_names.append(f"[{text}]{name}[/]")
             tools_str = ", ".join(colored_names)
@@ -507,8 +507,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             from hermes_cli.config import recommended_update_command
             commits_word = "commit" if behind == 1 else "commits"
             right_lines.append(
-                f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
-                f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
+                f"[bold dark_goldenrod]⚠ {behind} {commits_word} behind[/]"
+                f"[dim dark_goldenrod] — run [bold]{recommended_update_command()}[/bold] to update[/]"
             )
     except Exception:
         pass  # Never break the banner over an update check

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -144,7 +144,7 @@ def _copy_example_files(plugin_dir: Path, console) -> None:
                 )
             except OSError as e:
                 console.print(
-                    f"[yellow]Warning:[/yellow] Failed to copy {example_file.name}: {e}"
+                    f"[dark_goldenrod]Warning:[/dark_goldenrod] Failed to copy {example_file.name}: {e}"
                 )
 
 
@@ -297,7 +297,7 @@ def cmd_install(identifier: str, force: bool = False) -> None:
     # Warn about insecure / local URL schemes
     if git_url.startswith(("http://", "file://")):
         console.print(
-            "[yellow]Warning:[/yellow] Using insecure/local URL scheme. "
+            "[dark_goldenrod]Warning:[/dark_goldenrod] Using insecure/local URL scheme. "
             "Consider using https:// or git@ for production installs."
         )
 
@@ -376,7 +376,7 @@ def cmd_install(identifier: str, force: bool = False) -> None:
     # Validate it looks like a plugin
     if not (target / "plugin.yaml").exists() and not (target / "__init__.py").exists():
         console.print(
-            f"[yellow]Warning:[/yellow] {plugin_name} doesn't contain plugin.yaml "
+            f"[dark_goldenrod]Warning:[/dark_goldenrod] {plugin_name} doesn't contain plugin.yaml "
             f"or __init__.py. It may not be a valid Hermes plugin."
         )
 
@@ -531,7 +531,7 @@ def cmd_disable(name: str) -> None:
 
     disabled.add(name)
     _save_disabled_set(disabled)
-    console.print(f"[yellow]\u2298[/yellow] Plugin [bold]{name}[/bold] disabled. Takes effect on next session.")
+    console.print(f"[dark_goldenrod]\u2298[/dark_goldenrod] Plugin [bold]{name}[/bold] disabled. Takes effect on next session.")
 
 
 def cmd_list() -> None:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -52,13 +52,13 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
         return exact[0].identifier
 
     if len(exact) > 1:
-        c.print(f"\n[yellow]Multiple skills named '{name}' found:[/]")
+        c.print(f"\n[dark_goldenrod]Multiple skills named '{name}' found:[/]")
         table = Table()
         table.add_column("Source", style="dim")
         table.add_column("Trust", style="dim")
         table.add_column("Identifier", style="bold cyan")
         for r in exact:
-            trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(r.trust_level, "dim")
+            trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_goldenrod"}.get(r.trust_level, "dim")
             trust_label = "official" if r.source == "official" else r.trust_level
             table.add_row(r.source, f"[{trust_style}]{trust_label}[/]", r.identifier)
         c.print(table)
@@ -67,7 +67,7 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
 
     # No exact match — check if there are partial matches to suggest
     if results:
-        c.print(f"[yellow]No exact match for '{name}'. Did you mean one of these?[/]")
+        c.print(f"[dark_goldenrod]No exact match for '{name}'. Did you mean one of these?[/]")
         for r in results[:5]:
             c.print(f"  [cyan]{r.name}[/] — {r.identifier}")
         c.print()
@@ -166,7 +166,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     table.add_column("Identifier", style="dim")
 
     for r in results:
-        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(r.trust_level, "dim")
+        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_goldenrod"}.get(r.trust_level, "dim")
         trust_label = "official" if r.source == "official" else r.trust_level
         table.add_row(
             r.name,
@@ -268,7 +268,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 
     for i, r in enumerate(page_items, start=start + 1):
         trust_style = {"builtin": "bright_cyan", "trusted": "green",
-                       "community": "yellow"}.get(r.trust_level, "dim")
+                       "community": "dark_goldenrod"}.get(r.trust_level, "dim")
         trust_label = "★ official" if r.source == "official" else r.trust_level
 
         desc = r.description[:50]
@@ -301,7 +301,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
         c.print(f"  [dim]Sources: {', '.join(parts)}[/]")
 
     if timed_out:
-        c.print(f"  [yellow]⚡ Slow sources skipped: {', '.join(timed_out)} "
+        c.print(f"  [dark_goldenrod]⚡ Slow sources skipped: {', '.join(timed_out)} "
                 f"— run again for cached results[/]")
 
     c.print("[dim]Tip: 'hermes skills search <query>' searches deeper across all registries[/]\n")
@@ -344,7 +344,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print(f"[bold red]Error:[/] Could not fetch '{identifier}' from any source.")
         if rate_limited:
             c.print(
-                "[yellow]Hint:[/] GitHub API rate limit exhausted "
+                "[dark_goldenrod]Hint:[/] GitHub API rate limit exhausted "
                 "(unauthenticated: 60 requests/hour).\n"
                 "Set [bold]GITHUB_TOKEN[/] in your .env or install the "
                 "[bold]gh[/] CLI and run [bold]gh auth login[/] "
@@ -364,7 +364,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
     lock = HubLockFile()
     existing = lock.get_installed(bundle.name)
     if existing:
-        c.print(f"[yellow]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
+        c.print(f"[dark_goldenrod]Warning:[/] '{bundle.name}' is already installed at {existing['install_path']}")
         if not force:
             c.print("Use --force to reinstall.\n")
             return
@@ -421,13 +421,13 @@ def do_install(identifier: str, category: str = "", force: bool = False,
             ))
         else:
             c.print(Panel(
-                "[bold yellow]You are installing a third-party skill at your own risk.[/]\n\n"
+                "[bold dark_goldenrod]You are installing a third-party skill at your own risk.[/]\n\n"
                 "External skills can contain instructions that influence agent behavior,\n"
                 "shell commands, and scripts. Even after automated scanning, you should\n"
                 "review the installed files before use.\n\n"
                 f"Files will be at: [cyan]{display_hermes_home()}/skills/{category + '/' if category else ''}{bundle.name}/[/]",
                 title="Disclaimer",
-                border_style="yellow",
+                border_style="dark_goldenrod",
             ))
         c.print(f"[bold]Install '{bundle.name}'?[/]")
         try:
@@ -485,7 +485,7 @@ def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
         return
 
     c.print()
-    trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow"}.get(meta.trust_level, "dim")
+    trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_goldenrod"}.get(meta.trust_level, "dim")
     trust_label = "official" if meta.source == "official" else meta.trust_level
 
     info_lines = [
@@ -563,7 +563,7 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
         if source_filter != "all" and source_filter != source_type:
             continue
 
-        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "yellow", "local": "dim"}.get(trust, "dim")
+        trust_style = {"builtin": "bright_cyan", "trusted": "green", "community": "dark_goldenrod", "local": "dim"}.get(trust, "dim")
         trust_label = "official" if source_display == "official" else trust
         table.add_row(name, category, source_display, f"[{trust_style}]{trust_label}[/]")
 
@@ -641,7 +641,7 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None) -> N
     for entry in targets:
         skill_path = SKILLS_DIR / entry["install_path"]
         if not skill_path.exists():
-            c.print(f"[yellow]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
+            c.print(f"[dark_goldenrod]Warning:[/] {entry['name']} — path missing: {entry['install_path']}")
             continue
 
         result = scan_skill(skill_path, source=entry.get("identifier", entry["source"]))
@@ -712,7 +712,7 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
         if mgr.add(repo):
             c.print(f"[bold green]Added tap:[/] {repo}\n")
         else:
-            c.print(f"[yellow]Tap already exists:[/] {repo}\n")
+            c.print(f"[dark_goldenrod]Tap already exists:[/] {repo}\n")
 
     elif action == "remove":
         if not repo:
@@ -790,7 +790,7 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
             c.print(f"[bold red]Error:[/] {msg}\n")
 
     elif target == "clawhub":
-        c.print("[yellow]ClawHub publishing is not yet supported. "
+        c.print("[dark_goldenrod]ClawHub publishing is not yet supported. "
                 "Submit manually at https://clawhub.ai/submit[/]\n")
     else:
         c.print(f"[bold red]Unknown target:[/] {target}. Use 'github' or 'clawhub'.\n")
@@ -971,7 +971,7 @@ def do_snapshot_import(input_path: str, force: bool = False,
         identifier = entry.get("identifier", "")
         category = entry.get("category", "")
         if not identifier:
-            c.print(f"[yellow]Skipping entry with no identifier: {entry.get('name', '?')}[/]")
+            c.print(f"[dark_goldenrod]Skipping entry with no identifier: {entry.get('name', '?')}[/]")
             continue
 
         c.print(f"[bold]--- {entry.get('name', identifier)} ---[/]")

--- a/tests/hermes_cli/test_color_contrast.py
+++ b/tests/hermes_cli/test_color_contrast.py
@@ -1,0 +1,83 @@
+"""Tests for color contrast and NO_COLOR support (issue #11300).
+
+Ensures the TUI does not use bright yellow (#ffff00) which is unreadable
+on light terminal backgrounds, and that NO_COLOR is respected.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _collect_yellow_references(*paths: str) -> list[str]:
+    """Return lines containing problematic bright-yellow Rich markup."""
+    import re
+    hits = []
+    for path in paths:
+        with open(path) as f:
+            for i, line in enumerate(f, 1):
+                # Match Rich markup [yellow], [bold yellow], [dim yellow]
+                # but ignore comments and string literals about the word "yellow"
+                if re.search(r'\[(bold |dim )?yellow\]', line):
+                    hits.append(f"{path}:{i}: {line.rstrip()}")
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNoBrightYellowMarkup:
+    """No Rich [yellow] markup should remain in the TUI source files."""
+
+    SOURCE_FILES = [
+        "hermes_cli/banner.py",
+        "hermes_cli/skills_hub.py",
+        "hermes_cli/plugins_cmd.py",
+        "cli.py",
+    ]
+
+    def test_no_yellow_rich_markup(self):
+        hits = _collect_yellow_references(*self.SOURCE_FILES)
+        assert hits == [], (
+            "Found bright-yellow Rich markup (unreadable on light backgrounds):\n"
+            + "\n".join(hits)
+        )
+
+
+class TestNoColorEnvVar:
+    """NO_COLOR environment variable must suppress color output."""
+
+    def test_colors_module_respects_no_color(self):
+        from hermes_cli.colors import should_use_color
+        old = os.environ.get("NO_COLOR")
+        try:
+            os.environ["NO_COLOR"] = ""
+            assert should_use_color() is False
+        finally:
+            if old is None:
+                os.environ.pop("NO_COLOR", None)
+            else:
+                os.environ["NO_COLOR"] = old
+
+    def test_chat_console_respects_no_color(self):
+        """ChatConsole must disable color when NO_COLOR is set."""
+        old = os.environ.get("NO_COLOR")
+        try:
+            os.environ["NO_COLOR"] = "1"
+            # ChatConsole reads NO_COLOR at construction time
+            sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+            from cli import ChatConsole
+            cc = ChatConsole()
+            assert cc._inner.no_color is True
+        finally:
+            if old is None:
+                os.environ.pop("NO_COLOR", None)
+            else:
+                os.environ["NO_COLOR"] = old


### PR DESCRIPTION
## Summary
Fixes #11300 — TUI hardcodes bright yellow (`#ffff00`) for UI elements, which is unreadable on white/light terminal backgrounds.

## Changes
- Replaced all `[yellow]`/`[bold yellow]` Rich markup with `[dark_goldenrod]`/`[bold dark_goldenrod]` across CLI files (`cli.py`, `banner.py`, `plugins_cmd.py`, `skills_hub.py`)
- `dark_goldenrod` (#B8860B) provides sufficient contrast on both light and dark backgrounds
- Left standard ANSI escape codes (`\033[33m`) unchanged — terminals adapt these to their theme
- Added `NO_COLOR` env var support in `ChatConsole`
- Added tests verifying no bright yellow markup remains and `NO_COLOR` is respected

## Testing
- New test file: `tests/hermes_cli/test_color_contrast.py`