### PR TITLE
fix(discord): don't lose the whole reply when reply-target vanishes

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -833,7 +833,12 @@ class DiscordAdapter(BasePlatformAdapter):
             if reply_to and self._reply_to_mode != "off":
                 try:
                     ref_msg = await channel.fetch_message(int(reply_to))
-                    reference = ref_msg
+                    # fail_if_not_exists=False degrades a deleted/vanished
+                    # target into a normal (non-reply) send instead of a
+                    # 400 Invalid Form Body (error code 10008). Without
+                    # this, deleting the message between fetch and send
+                    # throws away the whole chunked response.
+                    reference = ref_msg.to_reference(fail_if_not_exists=False)
                 except Exception as e:
                     logger.debug("Could not fetch reply-to message: %s", e)
 
@@ -848,21 +853,33 @@ class DiscordAdapter(BasePlatformAdapter):
                         reference=chunk_reference,
                     )
                 except Exception as e:
+                    # Defense in depth: fail_if_not_exists=False should have
+                    # prevented 10008 "Unknown Message" from the reference,
+                    # but if Discord ever rejects it for another reason
+                    # (50035 system-message target, legacy bots, etc.)
+                    # drop the reference and retry so the remaining chunks
+                    # still get delivered rather than losing the whole
+                    # response.
                     err_text = str(e)
-                    if (
-                        chunk_reference is not None
-                        and "error code: 50035" in err_text
-                        and "Cannot reply to a system message" in err_text
+                    _retryable_codes = ("error code: 10008", "error code: 50035")
+                    _retryable_msgs = ("Unknown Message", "Cannot reply to a system message")
+                    if chunk_reference is not None and (
+                        any(code in err_text for code in _retryable_codes)
+                        or any(m in err_text for m in _retryable_msgs)
                     ):
                         logger.warning(
-                            "[%s] Reply target %s is a Discord system message; retrying send without reply reference",
+                            "[%s] Reply target %s rejected by Discord (%s); retrying without reply reference",
                             self.name,
                             reply_to,
+                            err_text[:200],
                         )
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
                         )
+                        # Downgrade for remaining chunks too — no point
+                        # repeating the same reject-and-retry dance.
+                        reference = None
                     else:
                         raise
                 message_ids.append(str(msg.id))

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -108,6 +108,11 @@ def _make_discord_adapter(reply_to_mode: str = "first"):
     # Mock the Discord client and channel
     mock_channel = AsyncMock()
     ref_message = MagicMock()
+    # send() calls ref_message.to_reference(fail_if_not_exists=False) so the
+    # reference degrades gracefully when the target is deleted. For tests we
+    # let that return the same MagicMock so existing assertions like
+    # `call.kwargs.get("reference") is ref_message` still hold.
+    ref_message.to_reference = MagicMock(return_value=ref_message)
     mock_channel.fetch_message = AsyncMock(return_value=ref_message)
 
     sent_msg = MagicMock()
@@ -211,6 +216,108 @@ class TestSendWithReplyToMode:
         assert len(calls) == 2
         assert calls[0].kwargs.get("reference") is ref_msg
         assert calls[1].kwargs.get("reference") is None
+
+
+class TestReplyReferenceRobustness:
+    """S2: deleted / rejected reply targets must not lose the response."""
+
+    @pytest.mark.asyncio
+    async def test_reference_built_with_fail_if_not_exists_false(self):
+        """A reply target that is later deleted should NOT 400 the whole send.
+
+        discord.py's ``MessageReference`` defaults ``fail_if_not_exists=True``
+        so a deleted target raises ``HTTPException(400, 10008)``. We wrap the
+        fetched message via ``to_reference(fail_if_not_exists=False)`` which
+        degrades that to a normal send.
+        """
+        adapter, channel, ref_msg = _make_discord_adapter("first")
+        adapter.truncate_message = lambda content, max_len: ["only chunk"]
+
+        await adapter.send("12345", "test", reply_to="999")
+
+        ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
+
+    @pytest.mark.asyncio
+    async def test_10008_unknown_message_retries_without_reference(self):
+        """Belt-and-suspenders: if Discord rejects the reference anyway
+        (10008 Unknown Message, despite fail_if_not_exists=False), drop
+        the reference and retry so the chunked response still delivers.
+        """
+        adapter, channel, ref_msg = _make_discord_adapter("all")
+        adapter.truncate_message = lambda content, max_len: ["a", "b", "c"]
+
+        sent_msg = MagicMock()
+        sent_msg.id = 99
+        call_count = {"n": 0}
+
+        async def fake_send(*args, **kwargs):
+            call_count["n"] += 1
+            # First call fails with 10008, subsequent succeed
+            if call_count["n"] == 1 and kwargs.get("reference") is ref_msg:
+                raise Exception(
+                    "400 Bad Request (error code: 10008): Unknown Message"
+                )
+            return sent_msg
+
+        channel.send = AsyncMock(side_effect=fake_send)
+
+        result = await adapter.send("12345", "test", reply_to="999")
+
+        assert result.success is True
+        # First attempt (with ref) failed, then retried (no ref), plus 2 more chunks
+        assert call_count["n"] == 4
+        calls = channel.send.call_args_list
+        assert calls[0].kwargs.get("reference") is ref_msg   # initial attempt
+        assert calls[1].kwargs.get("reference") is None      # retry without ref
+        # Remaining chunks are sent without reference too — no point repeating
+        # the reject-and-retry dance for every chunk.
+        assert calls[2].kwargs.get("reference") is None
+        assert calls[3].kwargs.get("reference") is None
+
+    @pytest.mark.asyncio
+    async def test_50035_system_message_retries_without_reference(self):
+        """Regression: the existing 50035 fallback still works."""
+        adapter, channel, ref_msg = _make_discord_adapter("first")
+        adapter.truncate_message = lambda content, max_len: ["only chunk"]
+
+        sent_msg = MagicMock()
+        sent_msg.id = 77
+        call_count = {"n": 0}
+
+        async def fake_send(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1 and kwargs.get("reference") is ref_msg:
+                raise Exception(
+                    "400 Bad Request (error code: 50035): Invalid Form Body\n"
+                    "message_reference: Cannot reply to a system message"
+                )
+            return sent_msg
+
+        channel.send = AsyncMock(side_effect=fake_send)
+
+        result = await adapter.send("12345", "test", reply_to="999")
+
+        assert result.success is True
+        assert call_count["n"] == 2
+        calls = channel.send.call_args_list
+        assert calls[0].kwargs.get("reference") is ref_msg
+        assert calls[1].kwargs.get("reference") is None
+
+    @pytest.mark.asyncio
+    async def test_non_reference_errors_still_propagate(self):
+        """A real error unrelated to the reply reference must still raise
+        so the send() wrapper returns success=False with the real cause,
+        rather than silently swallowing it.
+        """
+        adapter, channel, ref_msg = _make_discord_adapter("first")
+        adapter.truncate_message = lambda content, max_len: ["only chunk"]
+
+        channel.send = AsyncMock(side_effect=Exception("403 Forbidden (error code: 50013): Missing Permissions"))
+
+        result = await adapter.send("12345", "test", reply_to="999")
+
+        assert result.success is False
+        assert "50013" in (result.error or "")
 
 
 class TestConfigSerialization:

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -48,7 +48,14 @@ from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 async def test_send_retries_without_reference_when_reply_target_is_system_message():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
+    # send() now calls ref_msg.to_reference(fail_if_not_exists=False) so the
+    # reference degrades gracefully when the target is deleted; route it back
+    # to the same namespace so `send_calls[0]["reference"] is ref_msg` still
+    # holds. Test-only — real discord.py's to_reference returns a distinct
+    # MessageReference object, but identity comparison isn't observable to
+    # the adapter either way.
     ref_msg = SimpleNamespace(id=99)
+    ref_msg.to_reference = MagicMock(return_value=ref_msg)
     sent_msg = SimpleNamespace(id=1234)
     send_calls = []
 


### PR DESCRIPTION
## Summary

Fixes #11342.

discord.py's `MessageReference` defaults `fail_if_not_exists=True`. When Hermes replies to a user message and that message is deleted between `fetch_message()` and the first chunk send, Discord returns `400 (error code: 10008) Unknown Message` and the per-chunk loop dies — every remaining chunk of a multi-chunk response is dropped.

Two changes in `gateway/platforms/discord.py:send()`:

1. Wrap the fetched target:
   ```python
   reference = ref_msg.to_reference(fail_if_not_exists=False)
   ```
   Discord now treats a missing target as "send normally, no reply chip" instead of a 400.

2. Extend the existing per-chunk error handler. It currently only recovers from `50035` (system message). Generalize to cover `10008` (Unknown Message) too, and once the reference is rejected on one chunk **drop `reference` for the remaining chunks** so we don't replay the reject-and-retry dance per chunk.

## Test plan

- [x] `pytest tests/gateway/test_discord_reply_mode.py` — 27/27 pass (4 new + all regression). Requires `pytest-asyncio`.
- [x] New cases under `TestReplyReferenceRobustness`:
  - `test_reference_built_with_fail_if_not_exists_false`
  - `test_10008_unknown_message_retries_without_reference`
  - `test_50035_system_message_retries_without_reference` (regression guard)
  - `test_non_reference_errors_still_propagate`

## Risk

Low. The only visible behavior change is: a reply to a deleted message now sends as a plain message instead of raising. For all other cases the wire-level send is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)