### PR TITLE
fix(discord): apply is_safe_url SSRF guard to document attachment downloads

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2636,6 +2636,17 @@ class DiscordAdapter(BasePlatformAdapter):
                             "[Discord] Document too large (%s bytes), skipping: %s",
                             att.size, att.filename,
                         )
+                    elif not is_safe_url(att.url):
+                        # att.url is always a cdn.discordapp.com signed URL
+                        # today, but cache_image_from_url/cache_audio_from_url
+                        # already gate on is_safe_url for the same input — we
+                        # apply the same defense-in-depth check here to match,
+                        # and to close the door on any future Discord payload
+                        # schema drift that could surface non-CDN URLs.
+                        logger.warning(
+                            "[Discord] Blocked unsafe document URL for %s (SSRF guard)",
+                            att.filename,
+                        )
                     else:
                         try:
                             import aiohttp

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -277,6 +277,40 @@ class TestIncomingDocumentHandling:
         assert event.message_type == MessageType.DOCUMENT
 
     @pytest.mark.asyncio
+    async def test_unsafe_url_blocked_by_ssrf_guard(self, adapter, monkeypatch):
+        """A document attachment whose URL resolves to a private/internal
+        address must be dropped before the aiohttp download runs.
+
+        Discord's CDN always signs outbound URLs (ex=/is=/hm=), but the
+        adapter should still match the defense-in-depth check already
+        applied to image/audio attachments — so a payload-schema surprise
+        never becomes an SSRF into the internal network.
+        """
+        # Patch the adapter's is_safe_url reference — simulate the URL
+        # being rejected (private IP, metadata endpoint, etc.).
+        monkeypatch.setattr(discord_platform, "is_safe_url", lambda _u: False)
+
+        # If the download still runs, ClientSession will fail — we assert
+        # the guard short-circuits BEFORE aiohttp is even touched.
+        session = AsyncMock()
+        session.__aenter__ = AsyncMock(side_effect=AssertionError(
+            "SSRF guard must block the document download before aiohttp runs"
+        ))
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            msg = make_message([
+                make_attachment(filename="report.pdf", content_type="application/pdf")
+            ])
+            await adapter._handle_message(msg)
+
+        # Handler is still called — the unsafe attachment is skipped
+        # gracefully, not propagated as an exception.
+        adapter.handle_message.assert_called_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == []
+        assert event.media_types == []
+
+    @pytest.mark.asyncio
     async def test_download_error_handled(self, adapter):
         """If the HTTP download raises, the handler should not crash."""
         resp = AsyncMock()


### PR DESCRIPTION
## Summary

Fixes #11345.

`cache_image_from_url` and `cache_audio_from_url` in `gateway/platforms/base.py` both gate Discord `att.url` through `is_safe_url()` before fetching. The document-attachment branch in `DiscordAdapter._handle_message` calls `aiohttp.ClientSession.get(att.url)` directly with no such check. Discord's signed CDN URLs make this low-risk in practice, but the three paths should match and the guard is free defense-in-depth.

This PR adds the check inline in the document branch: if `is_safe_url(att.url)` returns False, log a warning and skip the attachment gracefully — `handle_message` still fires so the user message is processed. The aiohttp download never runs.

## Test plan

- [x] `pytest tests/gateway/test_discord_document_handling.py -p asyncio` — 12/12 pass
- [x] New case `test_unsafe_url_blocked_by_ssrf_guard`: patches `is_safe_url` to False, asserts `aiohttp.ClientSession` is never invoked and `media_urls` stays empty

## Risk

Minimal. If the Discord payload schema somehow produces a non-CDN URL targeting a private network, it is now blocked rather than fetched. Normal Discord CDN URLs (`cdn.discordapp.com`) pass `is_safe_url` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)