### PR TITLE
fix(agent): sanitize unanswered tool_calls on interrupt to prevent transcript corruption

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2912,6 +2912,37 @@ class AIAgent:
             if isinstance(msg, dict) and msg.get("role") == "user":
                 msg["content"] = override
 
+    def _sanitize_unanswered_tool_calls(self, messages: List[Dict], error_msg: str = "Agent interrupted by user") -> None:
+        """Append synthetic error results for any unanswered tool_calls.
+
+        OpenAI/Anthropic require a `role="tool"` message for every
+        `tool_call_id` emitted by the assistant. If an interrupt or error
+        fires before all tools finish, this prevents the next API call from
+        failing with a "missing tool response" error.
+        """
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
+            if not isinstance(msg, dict):
+                break
+            if msg.get("role") == "tool":
+                continue
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                answered_ids = {
+                    m["tool_call_id"]
+                    for m in messages[idx + 1:]
+                    if isinstance(m, dict) and m.get("role") == "tool"
+                }
+                for tc in msg["tool_calls"]:
+                    if not tc or not isinstance(tc, dict):
+                        continue
+                    if tc["id"] not in answered_ids:
+                        messages.append({
+                            "role": "tool",
+                            "tool_call_id": tc["id"],
+                            "content": f"Error executing tool: {error_msg}",
+                        })
+                break
+
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
@@ -2921,6 +2952,8 @@ class AIAgent:
         if not self.persist_session:
             return
         self._apply_persist_user_message_override(messages)
+        # Guarantee API-valid transcript: every tool_call must have a matching tool result.
+        self._sanitize_unanswered_tool_calls(messages)
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
@@ -11512,33 +11545,7 @@ class AIAgent:
                     logger.error(error_msg)
                 
                 logger.debug("Outer loop error in API call #%d", api_call_count, exc_info=True)
-                
-                # If an assistant message with tool_calls was already appended,
-                # the API expects a role="tool" result for every tool_call_id.
-                # Fill in error results for any that weren't answered yet.
-                for idx in range(len(messages) - 1, -1, -1):
-                    msg = messages[idx]
-                    if not isinstance(msg, dict):
-                        break
-                    if msg.get("role") == "tool":
-                        continue
-                    if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                        answered_ids = {
-                            m["tool_call_id"]
-                            for m in messages[idx + 1:]
-                            if isinstance(m, dict) and m.get("role") == "tool"
-                        }
-                        for tc in msg["tool_calls"]:
-                            if not tc or not isinstance(tc, dict): continue
-                            if tc["id"] not in answered_ids:
-                                err_msg = {
-                                    "role": "tool",
-                                    "tool_call_id": tc["id"],
-                                    "content": f"Error executing tool: {error_msg}",
-                                }
-                                messages.append(err_msg)
-                    break
-                
+
                 # Non-tool errors don't need a synthetic message injected.
                 # The error is already printed to the user (line above), and
                 # the retry loop continues.  Injecting a fake user/assistant


### PR DESCRIPTION
## Summary

Fixes a bug where interrupting the agent during pending tool calls leaves the conversation transcript in an invalid state, causing the next API call to fail with a "missing tool response" error.

Closes #11351

## Changes

- Adds `_sanitize_unanswered_tool_calls()` helper to `AIAgent` in `run_agent.py`.
- Calls the helper from `_persist_session()` so every exit path guarantees an API-valid transcript.
- Removes the duplicated inline backfill logic from the outer-loop error handler.

## Testing

- [x] Local pytest passes
- [x] Rebased on latest `origin/main`

## Backwards compatibility

No behavior change for users — this only prevents a crash condition.