### PR TITLE
feat(cli): make Ctrl+C priority configurable (interrupt_agent vs clear_input)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1779,6 +1779,9 @@ class HermesCLI:
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
+        # ctrl_c_priority: "interrupt_agent" (default) or "clear_input"
+        _ccp = CLI_CONFIG["display"].get("ctrl_c_priority", "interrupt_agent")
+        self.ctrl_c_priority = "clear_input" if str(_ccp).strip().lower() == "clear_input" else "interrupt_agent"
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -9440,13 +9443,21 @@ class HermesCLI:
                 event.app.invalidate()
                 return
 
+            # When the user prefers "clear_input", Ctrl+C behaves like bash:
+            # clear the buffer first; only interrupt the agent when the buffer is empty.
+            if self.ctrl_c_priority == "clear_input" and (event.app.current_buffer.text or self._attached_images):
+                event.app.current_buffer.reset()
+                self._attached_images.clear()
+                event.app.invalidate()
+                return
+
             if self._agent_running and self.agent:
                 if now - self._last_ctrl_c_time < 2.0:
                     print("\n⚡ Force exiting...")
                     self._should_exit = True
                     event.app.exit()
                     return
-                
+
                 self._last_ctrl_c_time = now
                 print("\n⚡ Interrupting agent... (press Ctrl+C again to force exit)")
                 self.agent.interrupt()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -584,6 +584,7 @@ DEFAULT_CONFIG = {
         "personality": "kawaii",
         "resume_display": "full",
         "busy_input_mode": "interrupt",
+        "ctrl_c_priority": "interrupt_agent",  # "interrupt_agent" | "clear_input"
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,


### PR DESCRIPTION
## Summary

Adds a `display.ctrl_c_priority` config option so users can choose whether `Ctrl+C` in the CLI clears the input buffer first (like a shell) or immediately interrupts the agent.

Closes #11352

## Changes

- `hermes_cli/config.py`: adds `"ctrl_c_priority": "interrupt_agent"` to `DEFAULT_CONFIG`.
- `cli.py`: when `ctrl_c_priority` is `"clear_input"`, `Ctrl+C` resets the input buffer and attached images; only interrupts the agent if the buffer is already empty.

## Usage

```yaml
display:
  ctrl_c_priority: "clear_input"  # default: "interrupt_agent"
```

## Testing

- [x] Local pytest passes
- [x] Rebased on latest `origin/main`

## Backwards compatibility

Default is `"interrupt_agent"`, preserving existing behavior.