### PR TITLE
fix(installer): use line-based tty confirmation prompts (bash 3.2 compatible)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,6 +122,40 @@ log_error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+prompt_yes_no() {
+    local question="$1"
+    local default="${2:-yes}"
+    local prompt_suffix
+    local answer=""
+
+    case "${default,,}" in
+        y|yes|true|1) prompt_suffix="[Y/n]" ;;
+        *) prompt_suffix="[y/N]" ;;
+    esac
+
+    if [ "$IS_INTERACTIVE" = true ]; then
+        read -r -p "$question $prompt_suffix " answer || answer=""
+    elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        printf "%s %s " "$question" "$prompt_suffix" > /dev/tty
+        IFS= read -r answer < /dev/tty || answer=""
+    else
+        answer=""
+    fi
+
+    answer="${answer#"${answer%%[![:space:]]*}"}"
+    answer="${answer%"${answer##*[![:space:]]}"}"
+    answer="${answer,,}"
+
+    if [ -z "$answer" ]; then
+        case "${default,,}" in
+            y|yes|true|1) return 0 ;;
+            *) return 1 ;;
+        esac
+    fi
+
+    [[ "$answer" =~ ^y(es)?$ ]]
+}
+
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
@@ -606,9 +640,7 @@ install_system_packages() {
                 echo ""
                 log_info "sudo is needed ONLY to install optional system packages (${pkgs[*]}) via your package manager."
                 log_info "Hermes Agent itself does not require or retain root access."
-                read -p "Install ${description}? (requires sudo) [y/N] " -n 1 -r
-                echo
-                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                if prompt_yes_no "Install ${description}? (requires sudo)" "no"; then
                     if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd; then
                         [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
                         [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
@@ -621,9 +653,7 @@ install_system_packages() {
                 echo ""
                 log_info "sudo is needed ONLY to install optional system packages (${pkgs[*]}) via your package manager."
                 log_info "Hermes Agent itself does not require or retain root access."
-                read -p "Install ${description}? [Y/n] " -n 1 -r < /dev/tty
-                echo
-                if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+                if prompt_yes_no "Install ${description}?" "yes"; then
                     if sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a $install_cmd < /dev/tty; then
                         [ "$need_ripgrep" = true ] && HAS_RIPGREP=true && log_success "ripgrep installed"
                         [ "$need_ffmpeg" = true ]  && HAS_FFMPEG=true  && log_success "ffmpeg installed"
@@ -863,9 +893,7 @@ install_deps() {
                 else
                     log_info "sudo is needed ONLY to install build tools (build-essential, python3-dev, libffi-dev) via apt."
                     log_info "Hermes Agent itself does not require or retain root access."
-                    read -p "Install build tools? [Y/n] " -n 1 -r < /dev/tty
-                    echo
-                    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+                    if prompt_yes_no "Install build tools?" "yes"; then
                         sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -qq build-essential python3-dev libffi-dev >/dev/null 2>&1 || true
                         log_success "Build tools installed"
                     fi
@@ -1236,9 +1264,7 @@ maybe_start_gateway() {
             log_info "WhatsApp is enabled but not yet paired."
             log_info "Running 'hermes whatsapp' to pair via QR code..."
             echo ""
-            read -p "Pair WhatsApp now? [Y/n] " -n 1 -r
-            echo
-            if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+            if prompt_yes_no "Pair WhatsApp now?" "yes"; then
                 HERMES_CMD="$(get_hermes_command_path)"
                 $HERMES_CMD whatsapp || true
             fi
@@ -1253,14 +1279,18 @@ maybe_start_gateway() {
     fi
 
     echo ""
+    local should_install_gateway=false
     if [ "$DISTRO" = "termux" ]; then
-        read -p "Would you like to start the gateway in the background? [Y/n] " -n 1 -r < /dev/tty
+        if prompt_yes_no "Would you like to start the gateway in the background?" "yes"; then
+            should_install_gateway=true
+        fi
     else
-        read -p "Would you like to install the gateway as a background service? [Y/n] " -n 1 -r < /dev/tty
+        if prompt_yes_no "Would you like to install the gateway as a background service?" "yes"; then
+            should_install_gateway=true
+        fi
     fi
-    echo
 
-    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+    if [ "$should_install_gateway" = true ]; then
         HERMES_CMD="$(get_hermes_command_path)"
 
         if [ "$DISTRO" != "termux" ] && command -v systemctl &> /dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -128,8 +128,9 @@ prompt_yes_no() {
     local prompt_suffix
     local answer=""
 
-    case "${default,,}" in
-        y|yes|true|1) prompt_suffix="[Y/n]" ;;
+    # Use case patterns (not ${var,,}) so this works on bash 3.2 (macOS /bin/bash).
+    case "$default" in
+        [yY]|[yY][eE][sS]|[tT][rR][uU][eE]|1) prompt_suffix="[Y/n]" ;;
         *) prompt_suffix="[y/N]" ;;
     esac
 
@@ -144,16 +145,18 @@ prompt_yes_no() {
 
     answer="${answer#"${answer%%[![:space:]]*}"}"
     answer="${answer%"${answer##*[![:space:]]}"}"
-    answer="${answer,,}"
 
     if [ -z "$answer" ]; then
-        case "${default,,}" in
-            y|yes|true|1) return 0 ;;
+        case "$default" in
+            [yY]|[yY][eE][sS]|[tT][rR][uU][eE]|1) return 0 ;;
             *) return 1 ;;
         esac
     fi
 
-    [[ "$answer" =~ ^y(es)?$ ]]
+    case "$answer" in
+        [yY]|[yY][eE][sS]) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 is_termux() {


### PR DESCRIPTION
Salvages #11090 from @helix4u onto current main and adds a small follow-up fix for bash 3.2 compatibility.

## What this does

The installer's yes/no confirmation prompts (optional `ripgrep`/`ffmpeg`, build-tools, WhatsApp pairing, gateway install) currently use `read -p "..." -n 1 -r` — raw single-character reads. This breaks on WSL2 (ConPTY + Windows Terminal) and other piped-install environments where single-char tty mode misbehaves, leaving users stuck at the prompt with no way to accept or deny.

Reported on Discord — user on Windows + WSL2 hit the `ripgrep`/`ffmpeg` confirmation and could not respond to it during `curl | bash` install.

@helix4u's fix: add a `prompt_yes_no()` helper that does normal line-based reads (`y` + Enter), and route all 4 confirmation call sites through it.

## Follow-up bash 3.2 compat fix

The original helper used `${default,,}` and `${answer,,}` (bash 4+ lowercase parameter expansion). macOS default `/bin/bash` is 3.2.57, which parses but fails at runtime with:

```
bash: ${default,,}: bad substitution
```

With `set -e` at the top of the script, that aborts the whole installer for any macOS user without a newer bash on PATH. (`bash -n` syntax-check passes because `${var,,}` is parse-valid — only expansion-time fails.)

Swapped the lowercase expansions for POSIX-style case patterns (`[yY]|[yY][eE][sS]|[tT][rR][uU][eE]|1`) that behave identically and work on bash 3.2+.

## Verification

Behavior test with 15 cases (empty answers with various defaults, user typing `y`/`Y`/`yes`/`YES`/`n`, whitespace trimming, invalid inputs):

```
=== bash 5.x ===
Passed: 15, Failed: 0

=== bash 3.2 (macOS /bin/bash) ===
Passed: 15, Failed: 0
```

`bash -n scripts/install.sh` passes on both bash 3.2 and 5.2.

## Commits

- `fix(installer): use line-based tty confirmation prompts` — @helix4u (cherry-picked)
- `fix(installer): make prompt_yes_no bash 3.2 compatible` — follow-up

Closes #11090.