### PR TITLE
fix: honor legacy config version alias

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1912,8 +1912,14 @@ def check_config_version() -> Tuple[int, int]:
     
     Returns (current_version, latest_version).
     """
-    config = load_config()
-    current = config.get("_config_version", 0)
+    raw_config = read_raw_config()
+    if "_config_version" in raw_config:
+        current = raw_config.get("_config_version", 0)
+    elif "config_version" in raw_config:
+        current = raw_config.get("config_version", 0)
+    else:
+        config = load_config()
+        current = config.get("_config_version", 0)
     latest = DEFAULT_CONFIG.get("_config_version", 1)
     return current, latest
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -592,6 +592,31 @@ class TestCustomProviderCompatibility:
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""
 
+    def test_legacy_config_version_alias_migrates_summary_compression(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "config_version": 13,
+                    "compression": {
+                        "summary_model": "MiniMax-M2.7",
+                        "summary_provider": "minimax-cn",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == 18
+        assert raw["auxiliary"]["compression"]["model"] == "MiniMax-M2.7"
+        assert raw["auxiliary"]["compression"]["provider"] == "minimax-cn"
+        assert "summary_model" not in raw["compression"]
+        assert "summary_provider" not in raw["compression"]
+
     def test_default_config_enables_interim_assistant_messages(self):
         assert DEFAULT_CONFIG["display"]["interim_assistant_messages"] is True
 


### PR DESCRIPTION
## Summary

Fixes migration of legacy configs that use `config_version` instead of `_config_version`.

## Root cause

`check_config_version()` read the merged config from `load_config()`. When a file used the legacy `config_version` key, the merge supplied the current default `_config_version`, so migrations were skipped and old `compression.summary_*` keys were left in place.

## Changes

- Read raw config version keys before defaults are merged.
- Treat `config_version` as a legacy alias only when `_config_version` is absent.
- Added regression coverage for `config_version: 13` migrating `compression.summary_model` and `compression.summary_provider` into `auxiliary.compression`.

## Validation

- `python -m pytest tests/hermes_cli/test_config.py::TestInterimAssistantMessageConfig::test_legacy_config_version_alias_migrates_summary_compression -q -n0`
- `python -m pytest tests/hermes_cli/test_config.py -q -n0`
- `python -m py_compile hermes_cli/config.py tests/hermes_cli/test_config.py`
- `git diff --check`

Fixes #11151