### PR TITLE
fix(agent): restrict think=False to Ollama/local endpoints only

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6780,13 +6780,21 @@ class AIAgent:
             options["num_ctx"] = self._ollama_num_ctx
             extra_body["options"] = options
 
-        # Ollama / custom provider: pass think=false when reasoning is disabled.
+        # Ollama-only: pass think=false when reasoning is disabled.
         # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
         # field, so we use its native `think` parameter instead.
         # This prevents thinking-capable models (Qwen3, etc.) from generating
         # <think> blocks and producing empty-response errors when the user has
         # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        # NOTE: guard on Ollama/local endpoints only — cloud custom providers
+        # (Mistral, Fireworks, Together.ai, vLLM remote, etc.) reject the
+        # `think` parameter with HTTP 422.
+        _is_ollama_endpoint = (
+            "ollama" in self._base_url_lower
+            or ":11434" in self._base_url_lower
+            or is_local_endpoint(self.base_url or "")
+        )
+        if _is_ollama_endpoint and self.reasoning_config and isinstance(self.reasoning_config, dict):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:


### PR DESCRIPTION
## Summary

- Fixes #11237
- The `think=False` parameter in `extra_body` is Ollama-specific. The previous guard `if self.provider == "custom"` matched **all** custom providers (Mistral, Fireworks, Together.ai, vLLM remote, etc.), causing HTTP 422 errors from cloud APIs that do not recognise the `think` field.
- Replace the guard with an explicit Ollama/local endpoint check that mirrors the pattern already used elsewhere in `run_agent.py` (`_ollama_num_ctx`, `_is_glm_zai_direct`).

## Changes

In `_build_api_kwargs()`, replaced:

```python
if self.provider == "custom" and self.reasoning_config and ...:
```

with:

```python
_is_ollama_endpoint = (
    "ollama" in self._base_url_lower
    or ":11434" in self._base_url_lower
    or is_local_endpoint(self.base_url or "")
)
if _is_ollama_endpoint and self.reasoning_config and ...:
```

`is_local_endpoint` is already imported at the top of `run_agent.py` and `self._base_url_lower` is a cached lowercased copy of the base URL set in the `base_url` property setter.

## Test plan

- [ ] Ollama endpoint (`http://localhost:11434/v1`): `think=False` still sent when reasoning is disabled
- [ ] Ollama via URL keyword (`http://my-ollama-server/v1`): `think=False` still sent
- [ ] Cloud custom provider (e.g. Fireworks, Together.ai): `think=False` no longer sent; no HTTP 422
- [ ] Mistral, vLLM remote: `think=False` no longer sent; no HTTP 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)