### PR TITLE
fix(cli): strip <think> and other reasoning tags from /resume recap

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3126,17 +3126,28 @@ class HermesCLI:
         MAX_ASST_LINES = 3           # max lines of assistant text
 
         def _strip_reasoning(text: str) -> str:
-            """Remove <REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD> blocks
-            from displayed text (reasoning model internal thoughts)."""
+            """Remove reasoning/thinking blocks from displayed text.
+
+            Handles all tag variants used by reasoning models:
+            <think>, <thinking>, <reasoning>, <REASONING_SCRATCHPAD>,
+            <thought> — both closed and unclosed (truncated) blocks.
+            """
             import re
+            # Strip closed tag pairs for all known reasoning tag variants
+            cleaned = re.sub(r"<think>.*?</think>\s*", "", text, flags=re.DOTALL)
+            cleaned = re.sub(r"<thinking>.*?</thinking>\s*", "", cleaned, flags=re.DOTALL | re.IGNORECASE)
+            cleaned = re.sub(r"<reasoning>.*?</reasoning>\s*", "", cleaned, flags=re.DOTALL)
+            cleaned = re.sub(r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*", "", cleaned, flags=re.DOTALL)
+            cleaned = re.sub(r"<thought>.*?</thought>\s*", "", cleaned, flags=re.DOTALL | re.IGNORECASE)
+            # Strip unclosed (truncated) reasoning tags that extend to end of text
             cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
-                "", text, flags=re.DOTALL,
+                r"<(?:think|thinking|reasoning|REASONING_SCRATCHPAD|thought)>.*$",
+                "", cleaned, flags=re.DOTALL | re.IGNORECASE,
             )
-            # Also strip unclosed reasoning tags at the end
+            # Remove any leftover orphan closing tags
             cleaned = re.sub(
-                r"<REASONING_SCRATCHPAD>.*$",
-                "", cleaned, flags=re.DOTALL,
+                r"</(?:think|thinking|reasoning|REASONING_SCRATCHPAD|thought)>\s*",
+                "", cleaned, flags=re.IGNORECASE,
             )
             return cleaned.strip()
 

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -344,6 +344,131 @@ class TestDisplayResumedHistory:
         assert "Just thinking" not in output
         assert "Hi there!" in output
 
+    def test_think_tags_stripped(self):
+        """<think>...</think> blocks should be stripped from display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Solve this"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<think>\nI need to reason carefully here.\n</think>\n\nThe answer is 7."
+                ),
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<think>" not in output
+        assert "</think>" not in output
+        assert "I need to reason carefully here" not in output
+        assert "The answer is 7" in output
+
+    def test_thinking_tags_stripped(self):
+        """<thinking>...</thinking> blocks should be stripped from display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "What is 2+2?"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<thinking>\nLet me compute: 2 + 2 = 4\n</thinking>\n\nThe answer is 4."
+                ),
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<thinking>" not in output
+        assert "Let me compute" not in output
+        assert "The answer is 4" in output
+
+    def test_reasoning_tags_stripped(self):
+        """<reasoning>...</reasoning> blocks should be stripped from display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Explain gravity"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<reasoning>\nGravity is a fundamental force...\n</reasoning>\n\nGravity pulls objects together."
+                ),
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<reasoning>" not in output
+        assert "fundamental force" not in output
+        assert "Gravity pulls objects together" in output
+
+    def test_thought_tags_stripped(self):
+        """<thought>...</thought> blocks (Gemma-style) should be stripped."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Say hello"},
+            {
+                "role": "assistant",
+                "content": "<thought>\nInternal thought here.\n</thought>\n\nHello!",
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<thought>" not in output
+        assert "Internal thought here" not in output
+        assert "Hello!" in output
+
+    def test_unclosed_think_tag_stripped(self):
+        """An unclosed <think> block (truncated generation) should be stripped."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Truncated response"},
+            {
+                "role": "assistant",
+                "content": "Some text before.\n<think>\nUnfinished reasoning...",
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "<think>" not in output
+        assert "Unfinished reasoning" not in output
+        assert "Some text before" in output
+
+    def test_pure_think_block_message_skipped(self):
+        """Assistant messages consisting only of a <think> block are skipped."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": "<think>\nOnly internal thought, no visible reply.\n</think>",
+            },
+            {"role": "assistant", "content": "Hi there!"},
+        ]
+        output = self._capture_display(cli)
+
+        assert "Only internal thought" not in output
+        assert "Hi there!" in output
+
+    def test_multiple_reasoning_blocks_all_stripped(self):
+        """Multiple interleaved reasoning blocks in one message are all stripped."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Complex question"},
+            {
+                "role": "assistant",
+                "content": (
+                    "<think>\nFirst thought.\n</think>\n"
+                    "Partial text.\n"
+                    "<reasoning>\nSecond thought.\n</reasoning>\n"
+                    "Final answer."
+                ),
+            },
+        ]
+        output = self._capture_display(cli)
+
+        assert "First thought" not in output
+        assert "Second thought" not in output
+        assert "Partial text" in output
+        assert "Final answer" in output
+
     def test_assistant_with_text_and_tool_calls(self):
         """When an assistant message has both text content AND tool_calls."""
         cli = _make_cli()


### PR DESCRIPTION
## Summary

Fixes #11316.

`_strip_reasoning()` in `cli.py` (used by `_display_resumed_history()` when a session is resumed with `/resume`) previously only stripped `<REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD>` blocks. Any assistant message that used `<think>`, `<thinking>`, `<reasoning>`, or `<thought>` tags would leak its raw internal reasoning text verbatim into the recap panel shown to the user.

Meanwhile, `run_agent.py`'s `_strip_think_blocks()` already handled all of these variants correctly. This PR brings `_strip_reasoning()` in line with that broader set.

### Changes

- **`cli.py`**: Updated `_strip_reasoning()` to strip all known reasoning tag variants:
  - `<think>...</think>`
  - `<thinking>...</thinking>` (case-insensitive)
  - `<reasoning>...</reasoning>`
  - `<REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD>` (existing, preserved)
  - `<thought>...</thought>` (Gemma 4 style, case-insensitive)
  - Unclosed/truncated tags that extend to end-of-string
  - Orphaned closing tags
- **`tests/cli/test_resume_display.py`**: Added 7 new test cases covering each tag variant, unclosed tags, pure-reasoning-only messages, and multiple interleaved blocks in one message.

## Test plan

- [ ] `test_think_tags_stripped` — `<think>` blocks stripped, visible text preserved
- [ ] `test_thinking_tags_stripped` — `<thinking>` blocks stripped
- [ ] `test_reasoning_tags_stripped` — `<reasoning>` blocks stripped
- [ ] `test_thought_tags_stripped` — `<thought>` blocks stripped
- [ ] `test_unclosed_think_tag_stripped` — truncated/unclosed `<think>` stripped
- [ ] `test_pure_think_block_message_skipped` — messages that are only a think block produce no recap entry
- [ ] `test_multiple_reasoning_blocks_all_stripped` — multiple interleaved blocks all removed
- [ ] Existing `test_reasoning_scratchpad_stripped` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)