### PR TITLE
feat: improve prompt context loading, onboarding, lazy imports, and status visibility

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -419,6 +419,27 @@ def build_environment_hints() -> str:
 CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
+CONTEXT_ANCESTOR_HINT_MAX_WALK = 5
+
+
+# =========================================================================
+# Context files prompt cache
+# =========================================================================
+
+_CONTEXT_FILES_PROMPT_CACHE_MAX = 32
+_CONTEXT_FILES_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
+_CONTEXT_FILES_PROMPT_CACHE_LOCK = threading.Lock()
+_PROJECT_CONTEXT_DISCOVERY_CACHE_MAX = 64
+_PROJECT_CONTEXT_DISCOVERY_CACHE: OrderedDict[tuple, Optional[str]] = OrderedDict()
+_PROJECT_CONTEXT_DISCOVERY_CACHE_LOCK = threading.Lock()
+
+
+def clear_context_files_prompt_cache() -> None:
+    """Drop the in-process processed-context-files cache."""
+    with _CONTEXT_FILES_PROMPT_CACHE_LOCK:
+        _CONTEXT_FILES_PROMPT_CACHE.clear()
+    with _PROJECT_CONTEXT_DISCOVERY_CACHE_LOCK:
+        _PROJECT_CONTEXT_DISCOVERY_CACHE.clear()
 
 
 # =========================================================================
@@ -890,6 +911,82 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
+def _read_cached_context_file(
+    path: Path,
+    *,
+    display_name: str,
+    truncate_label: str,
+    strip_frontmatter: bool = False,
+) -> str:
+    """Read, sanitize, wrap, and cache one context file by stat-based key."""
+    try:
+        resolved = path.resolve()
+        st = resolved.stat()
+    except OSError as e:
+        logger.debug("Could not stat %s: %s", path, e)
+        return ""
+
+    cache_key = (
+        str(resolved),
+        display_name,
+        truncate_label,
+        strip_frontmatter,
+        st.st_mtime_ns,
+        st.st_size,
+    )
+    with _CONTEXT_FILES_PROMPT_CACHE_LOCK:
+        cached = _CONTEXT_FILES_PROMPT_CACHE.get(cache_key)
+        if cached is not None:
+            _CONTEXT_FILES_PROMPT_CACHE.move_to_end(cache_key)
+            return cached
+
+    try:
+        content = resolved.read_text(encoding="utf-8").strip()
+        if not content:
+            return ""
+        if strip_frontmatter:
+            content = _strip_yaml_frontmatter(content)
+        content = _scan_context_content(content, display_name)
+        result = _truncate_content(f"## {display_name}\n\n{content}", truncate_label)
+    except Exception as e:
+        logger.debug("Could not read %s: %s", resolved, e)
+        return ""
+
+    with _CONTEXT_FILES_PROMPT_CACHE_LOCK:
+        _CONTEXT_FILES_PROMPT_CACHE[cache_key] = result
+        _CONTEXT_FILES_PROMPT_CACHE.move_to_end(cache_key)
+        while len(_CONTEXT_FILES_PROMPT_CACHE) > _CONTEXT_FILES_PROMPT_CACHE_MAX:
+            _CONTEXT_FILES_PROMPT_CACHE.popitem(last=False)
+    return result
+
+
+def _project_context_search_dirs(cwd_path: Path, include_ancestor_hints: bool) -> list[Path]:
+    """Return directories searched by find_project_context_file()."""
+    search_dirs = [cwd_path]
+    if not include_ancestor_hints:
+        return search_dirs
+
+    stop_at = _find_git_root(cwd_path)
+    walked = 0
+    for directory in cwd_path.parents:
+        search_dirs.append(directory)
+        walked += 1
+        if stop_at and directory == stop_at:
+            break
+        if not stop_at and walked >= CONTEXT_ANCESTOR_HINT_MAX_WALK:
+            break
+    return search_dirs
+
+
+def _stat_fingerprint(path: Path) -> tuple[str, int | None, int | None]:
+    """Return a stable stat fingerprint for cache invalidation."""
+    try:
+        st = path.stat()
+    except OSError:
+        return (str(path), None, None)
+    return (str(path), st.st_mtime_ns, st.st_size)
+
+
 def load_soul_md() -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
@@ -904,18 +1001,16 @@ def load_soul_md() -> Optional[str]:
         logger.debug("Could not ensure HERMES_HOME before loading SOUL.md: %s", e)
 
     soul_path = get_hermes_home() / "SOUL.md"
-    if not soul_path.exists():
+    if not soul_path.is_file():
         return None
-    try:
-        content = soul_path.read_text(encoding="utf-8").strip()
-        if not content:
-            return None
-        content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
-        return content
-    except Exception as e:
-        logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)
+    result = _read_cached_context_file(
+        soul_path,
+        display_name="SOUL.md",
+        truncate_label="SOUL.md",
+    )
+    if not result:
         return None
+    return result.removeprefix("## SOUL.md\n\n")
 
 
 def _load_hermes_md(cwd_path: Path) -> str:
@@ -923,37 +1018,29 @@ def _load_hermes_md(cwd_path: Path) -> str:
     hermes_md_path = _find_hermes_md(cwd_path)
     if not hermes_md_path:
         return ""
+    rel = hermes_md_path.name
     try:
-        content = hermes_md_path.read_text(encoding="utf-8").strip()
-        if not content:
-            return ""
-        content = _strip_yaml_frontmatter(content)
-        rel = hermes_md_path.name
-        try:
-            rel = str(hermes_md_path.relative_to(cwd_path))
-        except ValueError:
-            pass
-        content = _scan_context_content(content, rel)
-        result = f"## {rel}\n\n{content}"
-        return _truncate_content(result, ".hermes.md")
-    except Exception as e:
-        logger.debug("Could not read %s: %s", hermes_md_path, e)
-        return ""
+        rel = str(hermes_md_path.relative_to(cwd_path))
+    except ValueError:
+        pass
+    return _read_cached_context_file(
+        hermes_md_path,
+        display_name=rel,
+        truncate_label=".hermes.md",
+        strip_frontmatter=True,
+    )
 
 
 def _load_agents_md(cwd_path: Path) -> str:
     """AGENTS.md — top-level only (no recursive walk)."""
     for name in ["AGENTS.md", "agents.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        if candidate.is_file():
+            return _read_cached_context_file(
+                candidate,
+                display_name=name,
+                truncate_label="AGENTS.md",
+            )
     return ""
 
 
@@ -961,15 +1048,12 @@ def _load_claude_md(cwd_path: Path) -> str:
     """CLAUDE.md / claude.md — cwd only."""
     for name in ["CLAUDE.md", "claude.md"]:
         candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "CLAUDE.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+        if candidate.is_file():
+            return _read_cached_context_file(
+                candidate,
+                display_name=name,
+                truncate_label="CLAUDE.md",
+            )
     return ""
 
 
@@ -977,30 +1061,92 @@ def _load_cursorrules(cwd_path: Path) -> str:
     """.cursorrules + .cursor/rules/*.mdc — cwd only."""
     cursorrules_content = ""
     cursorrules_file = cwd_path / ".cursorrules"
-    if cursorrules_file.exists():
-        try:
-            content = cursorrules_file.read_text(encoding="utf-8").strip()
-            if content:
-                content = _scan_context_content(content, ".cursorrules")
-                cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
-        except Exception as e:
-            logger.debug("Could not read .cursorrules: %s", e)
+    if cursorrules_file.is_file():
+        content = _read_cached_context_file(
+            cursorrules_file,
+            display_name=".cursorrules",
+            truncate_label=".cursorrules",
+        )
+        if content:
+            cursorrules_content += f"{content}\n\n"
 
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
     if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
-        mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
+        mdc_files = sorted(path for path in cursor_rules_dir.glob("*.mdc") if path.is_file())
         for mdc_file in mdc_files:
-            try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
-                    cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
-            except Exception as e:
-                logger.debug("Could not read %s: %s", mdc_file, e)
+            content = _read_cached_context_file(
+                mdc_file,
+                display_name=f".cursor/rules/{mdc_file.name}",
+                truncate_label=".cursorrules",
+            )
+            if content:
+                cursorrules_content += f"{content}\n\n"
 
     if not cursorrules_content:
         return ""
     return _truncate_content(cursorrules_content, ".cursorrules")
+
+
+def find_project_context_file(
+    cwd: Optional[str] = None,
+    *,
+    include_ancestor_hints: bool = False,
+) -> Optional[Path]:
+    """Return the highest-priority project context file for *cwd*, if any.
+
+    Discovery order matches ``build_context_files_prompt()``. By default only
+    ``.hermes.md`` walks ancestors; other hint files stay cwd-only to preserve
+    startup prompt semantics. When ``include_ancestor_hints`` is True, AGENTS /
+    CLAUDE / .cursorrules are also searched in ancestors up to the git root.
+    """
+    if cwd is None:
+        cwd = os.getcwd()
+
+    cwd_path = Path(cwd).resolve()
+    search_dirs = _project_context_search_dirs(cwd_path, include_ancestor_hints)
+    discovery_signature = tuple(
+        fp
+        for directory in search_dirs
+        for fp in (
+            _stat_fingerprint(directory),
+            _stat_fingerprint(directory / ".cursor" / "rules"),
+        )
+    )
+    cache_key = (str(cwd_path), include_ancestor_hints, discovery_signature)
+    with _PROJECT_CONTEXT_DISCOVERY_CACHE_LOCK:
+        cached = _PROJECT_CONTEXT_DISCOVERY_CACHE.get(cache_key)
+        if cached is not None or cache_key in _PROJECT_CONTEXT_DISCOVERY_CACHE:
+            _PROJECT_CONTEXT_DISCOVERY_CACHE.move_to_end(cache_key)
+            return Path(cached) if cached else None
+
+    hermes_md_path = _find_hermes_md(cwd_path)
+    if hermes_md_path:
+        result = hermes_md_path
+    else:
+        result = None
+        for directory in search_dirs:
+            for name in ["AGENTS.md", "agents.md", "CLAUDE.md", "claude.md", ".cursorrules"]:
+                candidate = directory / name
+                if candidate.is_file():
+                    result = candidate
+                    break
+
+            if result is not None:
+                break
+
+            cursor_rules_dir = directory / ".cursor" / "rules"
+            if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
+                mdc_files = sorted(path for path in cursor_rules_dir.glob("*.mdc") if path.is_file())
+                if mdc_files:
+                    result = mdc_files[0]
+                    break
+
+    with _PROJECT_CONTEXT_DISCOVERY_CACHE_LOCK:
+        _PROJECT_CONTEXT_DISCOVERY_CACHE[cache_key] = str(result) if result else None
+        _PROJECT_CONTEXT_DISCOVERY_CACHE.move_to_end(cache_key)
+        while len(_PROJECT_CONTEXT_DISCOVERY_CACHE) > _PROJECT_CONTEXT_DISCOVERY_CACHE_MAX:
+            _PROJECT_CONTEXT_DISCOVERY_CACHE.popitem(last=False)
+    return result
 
 
 def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:

--- a/cli.py
+++ b/cli.py
@@ -3723,6 +3723,13 @@ class HermesCLI:
         provider = getattr(self, "provider", None) or "unknown"
         model = getattr(self, "model", None) or "(unknown)"
         is_running = bool(getattr(self, "_agent_running", False))
+        todo_items = []
+        todo_store = getattr(agent, "_todo_store", None) if agent else None
+        if todo_store is not None:
+            try:
+                todo_items = todo_store.read() or []
+            except Exception:
+                todo_items = []
 
         lines = [
             "Hermes CLI Status",
@@ -3739,6 +3746,12 @@ class HermesCLI:
             f"Tokens: {total_tokens:,}",
             f"Agent Running: {'Yes' if is_running else 'No'}",
         ])
+        in_progress = [item for item in todo_items if item.get("status") == "in_progress"]
+        pending = [item for item in todo_items if item.get("status") == "pending"]
+        if in_progress or pending:
+            lines.append(f"Tasks: {len(in_progress)} in progress, {len(pending)} pending")
+            if in_progress:
+                lines.append(f"Current Task: {in_progress[0].get('content', '(no description)')}")
         self.console.print("\n".join(lines), highlight=False, markup=False)
     
     def _fast_command_available(self) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -77,7 +77,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_yaml_write, is_truthy_value
+from utils import atomic_json_write, atomic_yaml_write, is_truthy_value
+from agent.prompt_builder import find_project_context_file
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -324,6 +325,106 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
     return resolved
 
 logger = logging.getLogger(__name__)
+
+
+def _build_first_message_onboarding_note(
+    *, history: List[dict], has_any_sessions: bool, cwd: Optional[str]
+) -> str:
+    """Build the one-time onboarding system note for a user's first-ever message."""
+    if history or has_any_sessions:
+        return ""
+
+    note = (
+        "[System note: This is the user's very first message ever. Briefly introduce "
+        "yourself, mention that /help shows available commands, and mention /plan for "
+        "multi-step work."
+    )
+
+    if not find_project_context_file(cwd, include_ancestor_hints=True):
+        note += (
+            " If this is a project folder, suggest adding .hermes.md or AGENTS.md "
+            "for workspace-specific instructions."
+        )
+
+    note += " Keep the introduction concise -- one or two sentences max.]"
+    return note
+
+
+_PROJECT_ONBOARDING_STATE_VERSION = 1
+
+
+def _project_onboarding_state_path() -> Path:
+    return get_hermes_home() / ".project_onboarding_state.json"
+
+
+
+def _project_onboarding_key(cwd: Optional[str]) -> Optional[str]:
+    if not cwd:
+        return None
+    cwd_path = Path(cwd).resolve()
+    for parent in [cwd_path, *cwd_path.parents]:
+        if (parent / ".git").exists():
+            return str(parent)
+    ctx = find_project_context_file(str(cwd_path), include_ancestor_hints=True)
+    if ctx is not None:
+        return str(ctx.parent.resolve())
+    return str(cwd_path)
+
+
+
+def _load_project_onboarding_state() -> dict:
+    path = _project_onboarding_state_path()
+    if not path.exists():
+        return {"version": _PROJECT_ONBOARDING_STATE_VERSION, "seen_projects": []}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"version": _PROJECT_ONBOARDING_STATE_VERSION, "seen_projects": []}
+    if not isinstance(data, dict) or data.get("version") != _PROJECT_ONBOARDING_STATE_VERSION:
+        return {"version": _PROJECT_ONBOARDING_STATE_VERSION, "seen_projects": []}
+    seen = data.get("seen_projects")
+    if not isinstance(seen, list):
+        seen = []
+    return {"version": _PROJECT_ONBOARDING_STATE_VERSION, "seen_projects": [str(x) for x in seen]}
+
+
+
+def _mark_project_onboarding_seen(cwd: Optional[str]) -> None:
+    key = _project_onboarding_key(cwd)
+    if not key:
+        return
+    state = _load_project_onboarding_state()
+    seen = list(state.get("seen_projects") or [])
+    if key in seen:
+        return
+    seen.append(key)
+    try:
+        atomic_json_write(
+            _project_onboarding_state_path(),
+            {"version": _PROJECT_ONBOARDING_STATE_VERSION, "seen_projects": seen},
+        )
+    except Exception:
+        logger.debug("Could not persist project onboarding state", exc_info=True)
+
+
+
+def _build_project_onboarding_note(*, cwd: Optional[str]) -> str:
+    """Build a once-per-project onboarding hint for workspaces missing context files."""
+    if not cwd:
+        return ""
+    if find_project_context_file(cwd, include_ancestor_hints=True):
+        return ""
+    key = _project_onboarding_key(cwd)
+    if not key:
+        return ""
+    state = _load_project_onboarding_state()
+    if key in set(state.get("seen_projects") or []):
+        return ""
+    return (
+        "[System note: This looks like a project folder without workspace-specific "
+        "instructions. Suggest adding .hermes.md or AGENTS.md for project guidance. "
+        "Keep it concise -- one sentence max.]"
+    )
 
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
@@ -3844,12 +3945,21 @@ class GatewayRunner:
                         )
 
         # First-message onboarding -- only on the very first interaction ever
-        if not history and not self.session_store.has_any_sessions():
-            context_prompt += (
-                "\n\n[System note: This is the user's very first message ever. "
-                "Briefly introduce yourself and mention that /help shows available commands. "
-                "Keep the introduction concise -- one or two sentences max.]"
-            )
+        _onboarding_cwd = os.getenv("TERMINAL_CWD") or str(Path.home())
+        first_message_onboarding_note = _build_first_message_onboarding_note(
+            history=history,
+            has_any_sessions=self.session_store.has_any_sessions(),
+            cwd=_onboarding_cwd,
+        )
+        if first_message_onboarding_note:
+            context_prompt += f"\n\n{first_message_onboarding_note}"
+            if not find_project_context_file(_onboarding_cwd, include_ancestor_hints=True):
+                _mark_project_onboarding_seen(_onboarding_cwd)
+        else:
+            project_onboarding_note = _build_project_onboarding_note(cwd=_onboarding_cwd)
+            if project_onboarding_note:
+                context_prompt += f"\n\n{project_onboarding_note}"
+                _mark_project_onboarding_seen(_onboarding_cwd)
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
@@ -4466,6 +4576,15 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        todo_items = []
+        agent = self._running_agents.get(session_key)
+        todo_store = getattr(agent, "_todo_store", None) if agent not in (None, _AGENT_PENDING_SENTINEL) else None
+        if todo_store is not None:
+            try:
+                todo_items = todo_store.read() or []
+            except Exception:
+                todo_items = []
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -4478,6 +4597,14 @@ class GatewayRunner:
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Tokens:** {session_entry.total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
+        ])
+        in_progress = [item for item in todo_items if item.get("status") == "in_progress"]
+        pending = [item for item in todo_items if item.get("status") == "pending"]
+        if in_progress or pending:
+            lines.append(f"**Tasks:** {len(in_progress)} in progress, {len(pending)} pending")
+            if in_progress:
+                lines.append(f"**Current Task:** {in_progress[0].get('content', '(no description)')}")
+        lines.extend([
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ])

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -106,6 +106,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     CommandDef("personality", "Set a predefined personality", "Configuration",
                args_hint="[name]"),
+    CommandDef("plan", "Plan a multi-step task before implementation", "Configuration",
+               args_hint="<prompt>"),
     CommandDef("statusbar", "Toggle the context/model status bar", "Configuration",
                cli_only=True, aliases=("sb",)),
     CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -18,7 +19,9 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    find_project_context_file,
     build_environment_hints,
+    clear_context_files_prompt_cache,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -473,15 +476,31 @@ class TestBuildNousSubscriptionPrompt:
 
 
 class TestBuildContextFilesPrompt:
-    def test_empty_dir_loads_seeded_global_soul(self, tmp_path):
-        from unittest.mock import patch
+    @pytest.fixture(autouse=True)
+    def _clear_context_cache(self):
+        clear_context_files_prompt_cache()
+        yield
+        clear_context_files_prompt_cache()
 
+    def test_empty_dir_loads_seeded_global_soul(self, tmp_path):
         fake_home = tmp_path / "fake_home"
         fake_home.mkdir()
         with patch("pathlib.Path.home", return_value=fake_home):
             result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Project Context" in result
         assert "Hermes Agent" in result
+
+    def test_load_soul_md_ignores_directory_without_debug_noise(self, tmp_path, monkeypatch, caplog):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=False)
+
+        assert "## SOUL.md" not in result
+        assert "Could not read" not in caplog.text
 
     def test_loads_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
@@ -575,6 +594,230 @@ class TestBuildContextFilesPrompt:
         sub.mkdir(parents=True)
         result = build_context_files_prompt(cwd=str(sub))
         assert "Root project rules" in result
+
+    def test_find_project_context_file_prefers_hermes_md(self, tmp_path):
+        (tmp_path / "AGENTS.md").write_text("Agent guidelines here.")
+        (tmp_path / ".hermes.md").write_text("Hermes project rules.")
+
+        result = find_project_context_file(cwd=str(tmp_path))
+
+        assert result == (tmp_path / ".hermes.md")
+
+    def test_find_project_context_file_detects_cursor_rules_when_no_higher_priority_file(self, tmp_path):
+        rules_dir = tmp_path / ".cursor" / "rules"
+        rules_dir.mkdir(parents=True)
+        rule_file = rules_dir / "custom.mdc"
+        rule_file.write_text("Use ESLint.")
+
+        result = find_project_context_file(cwd=str(tmp_path))
+
+        assert result == rule_file
+
+    def test_find_project_context_file_can_walk_ancestors_for_agents_md(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Root instructions")
+        subdir = tmp_path / "backend" / "src"
+        subdir.mkdir(parents=True)
+
+        result = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+
+        assert result == agents_file
+
+    def test_find_project_context_file_can_walk_ancestors_for_claude_md(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        claude_file = tmp_path / "CLAUDE.md"
+        claude_file.write_text("Root claude rules")
+        subdir = tmp_path / "frontend" / "src"
+        subdir.mkdir(parents=True)
+
+        result = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+
+        assert result == claude_file
+
+    def test_find_project_context_file_can_walk_ancestors_for_cursorrules(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        cursorrules_file = tmp_path / ".cursorrules"
+        cursorrules_file.write_text("Root cursor rules")
+        subdir = tmp_path / "mobile" / "app"
+        subdir.mkdir(parents=True)
+
+        result = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+
+        assert result == cursorrules_file
+
+    def test_find_project_context_file_can_walk_ancestors_for_cursor_rules_mdc(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        rules_dir = tmp_path / ".cursor" / "rules"
+        rules_dir.mkdir(parents=True)
+        rule_file = rules_dir / "project.mdc"
+        rule_file.write_text("Root cursor rules")
+        subdir = tmp_path / "ios" / "client"
+        subdir.mkdir(parents=True)
+
+        result = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+
+        assert result == rule_file
+
+    def test_find_project_context_file_limits_ancestor_search_without_git_root(self, tmp_path):
+        outer_agents = tmp_path / "AGENTS.md"
+        outer_agents.write_text("Outer rules")
+        deep = tmp_path / "a" / "b" / "c" / "d" / "e" / "f"
+        deep.mkdir(parents=True)
+
+        result = find_project_context_file(cwd=str(deep), include_ancestor_hints=True)
+
+        assert result is None
+
+    def test_find_project_context_file_reuses_discovery_when_unchanged(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Root instructions")
+        subdir = tmp_path / "backend" / "src"
+        subdir.mkdir(parents=True)
+
+        original_find_hermes_md = find_project_context_file.__globals__["_find_hermes_md"]
+        calls = 0
+
+        def counting_find_hermes_md(cwd_path):
+            nonlocal calls
+            calls += 1
+            return original_find_hermes_md(cwd_path)
+
+        monkeypatch.setitem(find_project_context_file.__globals__, "_find_hermes_md", counting_find_hermes_md)
+
+        first = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+        second = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+
+        assert first == agents_file
+        assert second == agents_file
+        assert calls == 1
+
+    def test_find_project_context_file_invalidates_discovery_cache_when_new_file_appears(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "backend" / "src"
+        subdir.mkdir(parents=True)
+
+        original_find_hermes_md = find_project_context_file.__globals__["_find_hermes_md"]
+        calls = 0
+
+        def counting_find_hermes_md(cwd_path):
+            nonlocal calls
+            calls += 1
+            return original_find_hermes_md(cwd_path)
+
+        monkeypatch.setitem(find_project_context_file.__globals__, "_find_hermes_md", counting_find_hermes_md)
+
+        first = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+        (tmp_path / "AGENTS.md").write_text("Root instructions")
+        second = find_project_context_file(cwd=str(subdir), include_ancestor_hints=True)
+
+        assert first is None
+        assert second == (tmp_path / "AGENTS.md")
+        assert calls == 2
+
+    def test_find_project_context_file_ignores_directory_named_agents_md(self, tmp_path):
+        (tmp_path / "AGENTS.md").mkdir()
+
+        result = find_project_context_file(cwd=str(tmp_path))
+
+        assert result is None
+
+    def test_find_project_context_file_ignores_directory_named_cursor_rule_file(self, tmp_path):
+        rules_dir = tmp_path / ".cursor" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "fake.mdc").mkdir()
+
+        result = find_project_context_file(cwd=str(tmp_path))
+
+        assert result is None
+
+    def test_build_context_files_prompt_ignores_directory_named_cursor_rule_file_without_debug_noise(self, tmp_path, caplog):
+        rules_dir = tmp_path / ".cursor" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "fake.mdc").mkdir()
+        (rules_dir / "real.mdc").write_text("Use ESLint.")
+
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert "Use ESLint." in result
+        assert "Could not read" not in caplog.text
+
+    def test_build_context_files_prompt_ignores_directory_named_agents_md(self, tmp_path, caplog):
+        (tmp_path / "AGENTS.md").mkdir()
+
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert "Project Context" not in result
+        assert "## AGENTS.md" not in result
+        assert "Could not read" not in caplog.text
+
+    def test_build_context_files_prompt_ignores_directory_named_claude_md(self, tmp_path, caplog):
+        (tmp_path / "CLAUDE.md").mkdir()
+
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert "Project Context" not in result
+        assert "## CLAUDE.md" not in result
+        assert "Could not read" not in caplog.text
+
+    def test_build_context_files_prompt_ignores_directory_named_cursorrules(self, tmp_path, caplog):
+        (tmp_path / ".cursorrules").mkdir()
+
+        with caplog.at_level(logging.DEBUG, logger="agent.prompt_builder"):
+            result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert "Project Context" not in result
+        assert "## .cursorrules" not in result
+        assert "Could not read" not in caplog.text
+
+    def test_reuses_cached_processed_context_file_when_unchanged(self, tmp_path, monkeypatch):
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Use Ruff for linting.", encoding="utf-8")
+
+        read_count = 0
+        original_read_text = type(agents_file).read_text
+
+        def counting_read_text(path_self, *args, **kwargs):
+            nonlocal read_count
+            if path_self.resolve() == agents_file.resolve():
+                read_count += 1
+            return original_read_text(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(type(agents_file), "read_text", counting_read_text)
+
+        first = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+        second = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert first == second
+        assert "Ruff for linting" in second
+        assert read_count == 1
+
+    def test_invalidates_cached_context_file_when_contents_change(self, tmp_path, monkeypatch):
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Use Ruff for linting.", encoding="utf-8")
+
+        read_count = 0
+        original_read_text = type(agents_file).read_text
+
+        def counting_read_text(path_self, *args, **kwargs):
+            nonlocal read_count
+            if path_self.resolve() == agents_file.resolve():
+                read_count += 1
+            return original_read_text(path_self, *args, **kwargs)
+
+        monkeypatch.setattr(type(agents_file), "read_text", counting_read_text)
+
+        first = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+        agents_file.write_text("Use pytest for testing.", encoding="utf-8")
+        second = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
+
+        assert "Ruff for linting" in first
+        assert "Use pytest for testing." in second
+        assert read_count == 2
 
     def test_hermes_md_stops_at_git_root(self, tmp_path):
         """Should NOT walk past the git root."""

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -86,6 +86,27 @@ def test_show_session_status_prints_gateway_style_summary():
     assert kwargs.get("markup") is False
 
 
+def test_show_session_status_includes_todo_summary_when_present():
+    cli_obj = _make_cli()
+    cli_obj.agent = SimpleNamespace(
+        session_total_tokens=321,
+        _todo_store=SimpleNamespace(
+            read=lambda: [
+                {"id": "t1", "content": "Ship fix", "status": "in_progress"},
+                {"id": "t2", "content": "Write tests", "status": "pending"},
+                {"id": "t3", "content": "Done item", "status": "completed"},
+            ]
+        ),
+    )
+
+    with patch("cli.display_hermes_home", return_value="~/.hermes"):
+        cli_obj._show_session_status()
+
+    printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
+    assert "Tasks: 1 in progress, 1 pending" in printed
+    assert "Current Task: Ship fix" in printed
+
+
 def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path, capsys):
     """Profile detection works for custom-root deployments (not under ~/.hermes)."""
     cli_obj = _make_cli()

--- a/tests/gateway/test_first_message_onboarding.py
+++ b/tests/gateway/test_first_message_onboarding.py
@@ -1,0 +1,148 @@
+"""Tests for first-message onboarding guidance in the gateway."""
+
+from gateway.run import (
+    _build_first_message_onboarding_note,
+    _build_project_onboarding_note,
+    _mark_project_onboarding_seen,
+)
+
+
+def test_first_message_onboarding_mentions_help_and_plan(tmp_path):
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=False,
+        cwd=str(tmp_path),
+    )
+
+    assert "/help" in note
+    assert "/plan" in note
+
+
+def test_first_message_onboarding_mentions_project_context_when_missing(tmp_path):
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=False,
+        cwd=str(tmp_path),
+    )
+
+    assert ".hermes.md" in note
+    assert "AGENTS.md" in note
+
+
+def test_first_message_onboarding_skips_project_context_hint_when_present(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("rules")
+
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=False,
+        cwd=str(tmp_path),
+    )
+
+    assert "/help" in note
+    assert "/plan" in note
+    assert ".hermes.md" not in note
+    assert "AGENTS.md" not in note
+
+
+def test_first_message_onboarding_skips_project_context_hint_when_parent_agents_exists(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "AGENTS.md").write_text("rules")
+    subdir = tmp_path / "backend" / "src"
+    subdir.mkdir(parents=True)
+
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=False,
+        cwd=str(subdir),
+    )
+
+    assert "/help" in note
+    assert "/plan" in note
+    assert ".hermes.md" not in note
+    assert "AGENTS.md" not in note
+
+
+def test_first_message_onboarding_skips_project_context_hint_when_parent_claude_exists(tmp_path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "CLAUDE.md").write_text("rules")
+    subdir = tmp_path / "frontend" / "src"
+    subdir.mkdir(parents=True)
+
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=False,
+        cwd=str(subdir),
+    )
+
+    assert "/help" in note
+    assert "/plan" in note
+    assert ".hermes.md" not in note
+    assert "AGENTS.md" not in note
+
+
+def test_first_message_onboarding_skips_project_context_hint_when_parent_cursor_rules_exist(tmp_path):
+    (tmp_path / ".git").mkdir()
+    rules_dir = tmp_path / ".cursor" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "project.mdc").write_text("rules")
+    subdir = tmp_path / "mobile" / "app"
+    subdir.mkdir(parents=True)
+
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=False,
+        cwd=str(subdir),
+    )
+
+    assert "/help" in note
+    assert "/plan" in note
+    assert ".hermes.md" not in note
+    assert "AGENTS.md" not in note
+
+
+def test_first_message_onboarding_absent_after_first_session(tmp_path):
+    note = _build_first_message_onboarding_note(
+        history=[],
+        has_any_sessions=True,
+        cwd=str(tmp_path),
+    )
+
+    assert note == ""
+
+
+def test_project_onboarding_note_shows_for_missing_context_even_after_first_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    note = _build_project_onboarding_note(cwd=str(tmp_path))
+
+    assert ".hermes.md" in note
+    assert "AGENTS.md" in note
+    assert "/help" not in note
+
+
+def test_project_onboarding_note_is_suppressed_after_marking_project_seen(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    project_root = tmp_path / "repo"
+    subdir = project_root / "backend" / "src"
+    subdir.mkdir(parents=True)
+    (project_root / ".git").mkdir()
+
+    first = _build_project_onboarding_note(cwd=str(subdir))
+    _mark_project_onboarding_seen(str(subdir))
+    second = _build_project_onboarding_note(cwd=str(project_root))
+
+    assert ".hermes.md" in first
+    assert second == ""
+
+
+def test_project_onboarding_note_uses_persistent_state_file(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+
+    _mark_project_onboarding_seen(str(project_root))
+    note = _build_project_onboarding_note(cwd=str(project_root))
+
+    assert note == ""
+    assert (hermes_home / ".project_onboarding_state.json").exists()

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -112,6 +112,33 @@ async def test_status_command_includes_session_title_when_present():
 
 
 @pytest.mark.asyncio
+async def test_status_command_includes_todo_summary_when_present():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    todo_store = SimpleNamespace(
+        read=lambda: [
+            {"id": "t1", "content": "Ship fix", "status": "in_progress"},
+            {"id": "t2", "content": "Write tests", "status": "pending"},
+            {"id": "t3", "content": "Done item", "status": "completed"},
+        ]
+    )
+    runner._running_agents[build_session_key(_make_source())] = SimpleNamespace(_todo_store=todo_store)
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tasks:** 1 in progress, 1 pending" in result
+    assert "**Current Task:** Ship fix" in result
+
+
+@pytest.mark.asyncio
 async def test_handle_message_persists_agent_token_counts(monkeypatch):
     import gateway.run as gateway_run
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,8 @@
 """Tests for the central command registry and autocomplete."""
 
+import re
+from pathlib import Path
+
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -103,6 +106,9 @@ class TestResolveCommand:
         assert resolve_command("set-home").name == "sethome"
         assert resolve_command("reload_mcp").name == "reload-mcp"
 
+    def test_plan_resolves(self):
+        assert resolve_command("plan").name == "plan"
+
     def test_leading_slash_stripped(self):
         assert resolve_command("/help").name == "help"
         assert resolve_command("/bg").name == "background"
@@ -115,6 +121,21 @@ class TestResolveCommand:
 # ---------------------------------------------------------------------------
 # Derived dicts (backwards compat)
 # ---------------------------------------------------------------------------
+
+class TestBuiltinDispatchConsistency:
+    def test_builtin_dispatch_branches_have_registry_entries(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        branch_names: set[str] = set()
+        for rel_path in ("cli.py", "gateway/run.py"):
+            content = (repo_root / rel_path).read_text(encoding="utf-8")
+            branch_names.update(re.findall(r'canonical == \"([a-zA-Z0-9_-]+)\"', content))
+
+        registry_names = {cmd.name for cmd in COMMAND_REGISTRY}
+        assert branch_names <= registry_names, (
+            "Dispatch branches missing from COMMAND_REGISTRY: "
+            f"{sorted(branch_names - registry_names)}"
+        )
+
 
 class TestDerivedDicts:
     def test_commands_dict_excludes_gateway_only(self):
@@ -193,6 +214,16 @@ class TestGatewayHelpLines:
                 assert f"`/{cmd.name}" not in joined, \
                     f"cli_only command /{cmd.name} should not be in gateway help"
 
+    def test_includes_every_gateway_available_command(self):
+        lines = gateway_help_lines()
+        joined = "\n".join(lines)
+        from hermes_cli.commands import _is_gateway_available, _resolve_config_gates
+
+        overrides = _resolve_config_gates()
+        for cmd in COMMAND_REGISTRY:
+            if _is_gateway_available(cmd, overrides):
+                assert f"`/{cmd.name}" in joined, f"/{cmd.name} missing from gateway help"
+
     def test_includes_alias_note_for_bg(self):
         lines = gateway_help_lines()
         bg_line = [l for l in lines if "/background" in l]
@@ -227,6 +258,17 @@ class TestTelegramBotCommands:
                 tg_name = cmd.name.replace("-", "_")
                 assert tg_name not in names
 
+    def test_includes_every_gateway_available_canonical_command(self):
+        names = {name for name, _ in telegram_bot_commands()}
+        from hermes_cli.commands import _is_gateway_available, _resolve_config_gates, _sanitize_telegram_name
+
+        overrides = _resolve_config_gates()
+        for cmd in COMMAND_REGISTRY:
+            if _is_gateway_available(cmd, overrides):
+                tg_name = _sanitize_telegram_name(cmd.name)
+                if tg_name:
+                    assert tg_name in names, f"Telegram menu missing {cmd.name!r}"
+
 
 class TestSlackSubcommandMap:
     def test_returns_dict(self):
@@ -248,6 +290,17 @@ class TestSlackSubcommandMap:
         for cmd in COMMAND_REGISTRY:
             if cmd.cli_only and not cmd.gateway_config_gate:
                 assert cmd.name not in mapping
+
+    def test_includes_every_gateway_available_command_and_alias(self):
+        mapping = slack_subcommand_map()
+        from hermes_cli.commands import _is_gateway_available, _resolve_config_gates
+
+        overrides = _resolve_config_gates()
+        for cmd in COMMAND_REGISTRY:
+            if _is_gateway_available(cmd, overrides):
+                assert cmd.name in mapping, f"Slack map missing canonical command {cmd.name!r}"
+                for alias in cmd.aliases:
+                    assert alias in mapping, f"Slack map missing alias {alias!r} for {cmd.name!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -438,6 +491,26 @@ class TestSubcommands:
         """Commands with explicit subcommands on CommandDef are extracted."""
         assert "/skills" in SUBCOMMANDS
         assert "install" in SUBCOMMANDS["/skills"]
+
+    def test_every_explicit_subcommands_command_is_present(self):
+        expected = {f"/{cmd.name}" for cmd in COMMAND_REGISTRY if cmd.subcommands}
+        assert expected <= set(SUBCOMMANDS), (
+            "Commands with explicit subcommands missing from SUBCOMMANDS: "
+            f"{sorted(expected - set(SUBCOMMANDS))}"
+        )
+
+    def test_subcommands_extras_only_come_from_args_hint_pipe_extraction(self):
+        explicit = {f"/{cmd.name}" for cmd in COMMAND_REGISTRY if cmd.subcommands}
+        piped = {
+            f"/{cmd.name}"
+            for cmd in COMMAND_REGISTRY
+            if not cmd.subcommands and cmd.args_hint and "|" in cmd.args_hint
+        }
+        extras = set(SUBCOMMANDS) - explicit
+        assert extras <= piped, (
+            "Unexpected SUBCOMMANDS entries not backed by explicit subcommands or "
+            f"args_hint pipe extraction: {sorted(extras - piped)}"
+        )
 
     def test_reasoning_has_subcommands(self):
         assert "/reasoning" in SUBCOMMANDS
@@ -684,6 +757,18 @@ class TestTelegramMenuCommands:
             assert 1 <= len(name) <= _TG_NAME_LIMIT, (
                 f"Command '{name}' is {len(name)} chars (limit {_TG_NAME_LIMIT})"
             )
+
+    def test_includes_all_gateway_available_core_commands(self):
+        menu, _ = telegram_menu_commands(max_commands=100)
+        names = {name for name, _ in menu}
+        from hermes_cli.commands import _is_gateway_available, _resolve_config_gates, _sanitize_telegram_name
+
+        overrides = _resolve_config_gates()
+        for cmd in COMMAND_REGISTRY:
+            if _is_gateway_available(cmd, overrides):
+                tg_name = _sanitize_telegram_name(cmd.name)
+                if tg_name:
+                    assert tg_name in names, f"Telegram menu missing core command {cmd.name!r}"
 
     def test_excludes_telegram_disabled_skills(self, tmp_path, monkeypatch):
         """Skills disabled for telegram should not appear in the menu."""

--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -213,6 +213,28 @@ def test_managed_fal_submit_reuses_cached_sync_client(monkeypatch):
     assert captured["http_client"] is first_client
 
 
+def test_image_generation_tool_import_does_not_require_fal_client(monkeypatch):
+    import builtins
+
+    _install_fake_tools_package()
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "fal_client":
+            raise ModuleNotFoundError("simulated missing fal_client")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    image_generation_tool = _load_tool_module(
+        "tools.image_generation_tool",
+        "image_generation_tool.py",
+    )
+
+    assert hasattr(image_generation_tool, "image_generate_tool")
+    assert image_generation_tool.check_image_generation_requirements() is False
+
+
 def test_openai_tts_uses_managed_audio_gateway_when_direct_key_absent(monkeypatch, tmp_path):
     captured = {}
     _install_fake_tools_package()

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -24,12 +24,11 @@ import json
 import logging
 import os
 import datetime
+import importlib
 import threading
 import uuid
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urlencode
-
-import fal_client
 
 from tools.debug_helpers import DebugSession
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
@@ -277,6 +276,12 @@ _managed_fal_client_lock = threading.Lock()
 # ---------------------------------------------------------------------------
 # Managed FAL gateway (Nous Subscription)
 # ---------------------------------------------------------------------------
+
+def _import_fal_client():
+    """Import fal_client lazily so the tool module stays importable without it."""
+    return importlib.import_module("fal_client")
+
+
 def _resolve_managed_fal_gateway():
     """Return managed fal-queue gateway config when the user prefers the gateway
     or direct FAL credentials are absent."""
@@ -296,6 +301,7 @@ class _ManagedFalSyncClient:
     """Small per-instance wrapper around fal_client.SyncClient for managed queue hosts."""
 
     def __init__(self, *, key: str, queue_run_origin: str):
+        fal_client = _import_fal_client()
         sync_client_class = getattr(fal_client, "SyncClient", None)
         if sync_client_class is None:
             raise RuntimeError("fal_client.SyncClient is required for managed FAL gateway mode")
@@ -393,9 +399,10 @@ def _get_managed_fal_client(managed_gateway):
 
 def _submit_fal_request(model: str, arguments: Dict[str, Any]):
     """Submit a FAL request using direct credentials or the managed queue gateway."""
-    request_headers = {"x-idempotency-key": str(uuid.uuid4())}
     managed_gateway = _resolve_managed_fal_gateway()
+    request_headers = {"x-idempotency-key": str(uuid.uuid4())}
     if managed_gateway is None:
+        fal_client = _import_fal_client()
         return fal_client.submit(model, arguments=arguments, headers=request_headers)
 
     managed_client = _get_managed_fal_client(managed_gateway)


### PR DESCRIPTION
## Summary
This PR packages the fifth-round optimization work into one reviewable change set across prompt construction, onboarding behavior, optional dependency loading, and status visibility.

### What changed
1. **Prompt/context loading performance**
   - Cache prompt-builder context discovery and context file content loading.
   - Reduce repeated ancestor scans and unnecessary filesystem checks on hot paths.
   - Add regression coverage for cache reuse and invalidation when context files appear.

2. **First-use / onboarding UX**
   - Add project-level onboarding state persistence.
   - Only show the “missing project context file” onboarding once per project/git root.
   - Persist onboarding state in `~/.hermes/.project_onboarding_state.json`.

3. **Lazy loading for optional tooling dependencies**
   - Stop importing `fal_client` during `tools.image_generation_tool` module import.
   - Defer that import until image generation is actually invoked.
   - This keeps startup/module registration resilient even when the optional dependency is absent.

4. **Status/task visibility**
   - Extend `/status` in both CLI and gateway surfaces.
   - Include task counts and current task summary in status output.

## Files changed
- `agent/prompt_builder.py`
- `gateway/run.py`
- `tools/image_generation_tool.py`
- `cli.py`
- `hermes_cli/commands.py`
- `tests/agent/test_prompt_builder.py`
- `tests/gateway/test_first_message_onboarding.py`
- `tests/gateway/test_status_command.py`
- `tests/cli/test_cli_status_command.py`
- `tests/hermes_cli/test_commands.py`
- `tests/tools/test_managed_media_gateways.py`

## Validation
Relevant regression coverage reported locally for:
- `tests/cli/test_cli_status_command.py`
- `tests/gateway/test_status_command.py`
- `tests/tools/test_managed_media_gateways.py`
- `tests/agent/test_prompt_builder.py`
- `tests/gateway/test_first_message_onboarding.py`
- `tests/hermes_cli/test_commands.py`

Reported result: **273 passed, 1 skipped**

## Branch / commit
- Head branch: `MaskedHeroQAQ:feat/fifth-round-optimizations`
- Current commit: `263016a6`
