### PR TITLE
Fix invalid HERMES_CRON_TIMEOUT fallback in cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -486,6 +486,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 _DEFAULT_SCRIPT_TIMEOUT = 120  # seconds
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
+_DEFAULT_CRON_INACTIVITY_TIMEOUT = 600.0  # seconds
 
 
 def _get_script_timeout() -> int:
@@ -519,6 +520,35 @@ def _get_script_timeout() -> int:
         logger.debug("Failed to load cron script timeout from config: %s", exc)
 
     return _DEFAULT_SCRIPT_TIMEOUT
+
+
+def _get_cron_inactivity_limit() -> Optional[float]:
+    """Resolve cron inactivity timeout from env with a safe default."""
+    env_value = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    if not env_value:
+        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
+
+    try:
+        timeout = float(env_value)
+    except Exception:
+        logger.warning(
+            "Invalid HERMES_CRON_TIMEOUT=%r; using default %ss",
+            env_value,
+            int(_DEFAULT_CRON_INACTIVITY_TIMEOUT),
+        )
+        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
+
+    if timeout > 0:
+        return timeout
+    if timeout == 0:
+        return None
+
+    logger.warning(
+        "Invalid HERMES_CRON_TIMEOUT=%r; using default %ss",
+        env_value,
+        int(_DEFAULT_CRON_INACTIVITY_TIMEOUT),
+    )
+    return _DEFAULT_CRON_INACTIVITY_TIMEOUT
 
 
 def _run_job_script(script_path: str) -> tuple[bool, str]:
@@ -1026,8 +1056,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
-        _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        _cron_inactivity_limit = _get_cron_inactivity_limit()
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
         # Preserve scheduler-scoped ContextVar state (for example skill-declared

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -523,32 +523,25 @@ def _get_script_timeout() -> int:
 
 
 def _get_cron_inactivity_limit() -> Optional[float]:
-    """Resolve cron inactivity timeout from env with a safe default."""
-    env_value = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
-    if not env_value:
-        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
+    """Resolve cron inactivity timeout from HERMES_CRON_TIMEOUT.
 
+    Returns ``None`` for unlimited (any non-positive value, matching the
+    pre-fix behaviour), the parsed seconds for a positive value, or the
+    default when the env var is missing or unparseable.
+    """
+    raw = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    if not raw:
+        return _DEFAULT_CRON_INACTIVITY_TIMEOUT
     try:
-        timeout = float(env_value)
-    except Exception:
+        timeout = float(raw)
+    except ValueError:
         logger.warning(
             "Invalid HERMES_CRON_TIMEOUT=%r; using default %ss",
-            env_value,
+            raw,
             int(_DEFAULT_CRON_INACTIVITY_TIMEOUT),
         )
         return _DEFAULT_CRON_INACTIVITY_TIMEOUT
-
-    if timeout > 0:
-        return timeout
-    if timeout == 0:
-        return None
-
-    logger.warning(
-        "Invalid HERMES_CRON_TIMEOUT=%r; using default %ss",
-        env_value,
-        int(_DEFAULT_CRON_INACTIVITY_TIMEOUT),
-    )
-    return _DEFAULT_CRON_INACTIVITY_TIMEOUT
+    return timeout if timeout > 0 else None
 
 
 def _run_job_script(script_path: str) -> tuple[bool, str]:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -327,6 +327,7 @@ AUTHOR_MAP = {
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
     "cola-runner@users.noreply.github.com": "cola-runner",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "iamagenius00@users.noreply.github.com": "iamagenius00",

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -9,17 +9,15 @@ Tests cover:
 """
 
 import concurrent.futures
-import os
+import logging
 import sys
 import time
-import threading
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 # Ensure project root is importable
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.scheduler import _get_cron_inactivity_limit
 
 
 class FakeAgent:
@@ -172,18 +170,20 @@ class TestInactivityTimeout:
     def test_timeout_env_var_parsing(self, monkeypatch):
         """HERMES_CRON_TIMEOUT env var is respected."""
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "1200")
-        _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
-        assert _cron_timeout == 1200.0
-
-        _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
-        assert _cron_inactivity_limit == 1200.0
+        assert _get_cron_inactivity_limit() == 1200.0
 
     def test_timeout_zero_means_unlimited(self, monkeypatch):
         """HERMES_CRON_TIMEOUT=0 yields None (unlimited)."""
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
-        _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
-        _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
-        assert _cron_inactivity_limit is None
+        assert _get_cron_inactivity_limit() is None
+
+    def test_invalid_timeout_env_var_falls_back_to_default(self, monkeypatch, caplog):
+        """Malformed HERMES_CRON_TIMEOUT falls back to the default timeout."""
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "abc")
+
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            assert _get_cron_inactivity_limit() == 600.0
+        assert "Invalid HERMES_CRON_TIMEOUT" in caplog.text
 
     def test_timeout_error_includes_diagnostics(self):
         """The TimeoutError message should include last activity info."""

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -177,6 +177,16 @@ class TestInactivityTimeout:
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
         assert _get_cron_inactivity_limit() is None
 
+    def test_timeout_negative_means_unlimited(self, monkeypatch):
+        """Any non-positive value matches the pre-fix behaviour: unlimited."""
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "-30")
+        assert _get_cron_inactivity_limit() is None
+
+    def test_timeout_empty_uses_default(self, monkeypatch):
+        """Empty/whitespace HERMES_CRON_TIMEOUT falls back to the default."""
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "  ")
+        assert _get_cron_inactivity_limit() == 600.0
+
     def test_invalid_timeout_env_var_falls_back_to_default(self, monkeypatch, caplog):
         """Malformed HERMES_CRON_TIMEOUT falls back to the default timeout."""
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "abc")


### PR DESCRIPTION
## Summary
- parse `HERMES_CRON_TIMEOUT` defensively instead of calling `float(...)` inline in `run_job()`
- keep `0` as the unlimited sentinel, but fall back to the default inactivity timeout when the env var is malformed
- add regression coverage for valid, unlimited, and invalid timeout values via the shared scheduler helper

Closes #11319.

## Testing
- `source venv/bin/activate && python -m pytest tests/cron/test_cron_inactivity_timeout.py tests/cron/test_scheduler.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q` *(environment still has existing unrelated failures/errors in ACP, web server optional deps, transcription optional deps, and several pre-existing gateway/run_agent tests; the new cron regression is not among them)*
