### PR TITLE
fix(zai): autodetect endpoint during setup flow

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1143,7 +1143,9 @@ def select_provider_and_model(args=None):
         _model_flow_kimi(config, current_model)
     elif selected_provider == "bedrock":
         _model_flow_bedrock(config, current_model)
-    elif selected_provider in ("gemini", "deepseek", "xai", "zai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee", "ollama-cloud"):
+    elif selected_provider == "zai":
+        _model_flow_zai(config, current_model)
+    elif selected_provider in ("gemini", "deepseek", "xai", "kimi-coding-cn", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "xiaomi", "arcee", "ollama-cloud"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
     # ── Post-switch cleanup: clear stale OPENAI_BASE_URL ──────────────
@@ -2888,6 +2890,114 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             model["api_mode"] = opencode_model_api_mode(provider_id, selected)
         else:
             model.pop("api_mode", None)
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"Default model set to: {selected} (via {pconfig.name})")
+    else:
+        print("No change.")
+
+
+def _model_flow_zai(config, current_model=""):
+    """Z.AI / GLM model selection with auth-path endpoint autodetection.
+
+    Unlike generic API-key providers, Z.AI has multiple billing endpoints.
+    Reuse resolve_api_key_provider_credentials("zai") here so the interactive
+    setup flow stays aligned with the auth/runtime resolution path instead of
+    asking users to guess which base URL they need.
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
+        deactivate_provider, resolve_api_key_provider_credentials,
+    )
+    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.models import fetch_api_models
+
+    del config
+
+    provider_id = "zai"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
+    base_url_env = pconfig.base_url_env_var or ""
+
+    existing_key = ""
+    for ev in pconfig.api_key_env_vars:
+        existing_key = get_env_value(ev) or os.getenv(ev, "")
+        if existing_key:
+            break
+
+    if not existing_key:
+        print(f"No {pconfig.name} API key configured.")
+        if key_env:
+            try:
+                import getpass
+                new_key = getpass.getpass(f"{key_env} (or Enter to cancel): ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                return
+            if not new_key:
+                print("Cancelled.")
+                return
+            save_env_value(key_env, new_key)
+            existing_key = new_key
+            print("API key saved.")
+            print()
+    else:
+        print(f"  {pconfig.name} API key: {existing_key[:8]}... ✓")
+        print()
+
+    creds = resolve_api_key_provider_credentials(provider_id)
+    effective_base = creds.get("base_url") or pconfig.inference_base_url
+    explicit_base = get_env_value(base_url_env) or os.getenv(base_url_env, "") if base_url_env else ""
+    if explicit_base:
+        print(f"  Using explicit {base_url_env} override → {effective_base}")
+    else:
+        print(f"  Auto-detected Z.AI endpoint → {effective_base}")
+    print()
+
+    curated = _PROVIDER_MODELS.get(provider_id, [])
+    model_list = []
+
+    try:
+        from agent.models_dev import list_agentic_models
+        model_list = list_agentic_models(provider_id)
+    except Exception:
+        model_list = []
+
+    if model_list:
+        print(f"  Found {len(model_list)} model(s) from models.dev registry")
+    elif curated and len(curated) >= 8:
+        model_list = curated
+        print(f"  Showing {len(model_list)} curated models — use \"Enter custom model name\" for others.")
+    else:
+        live_models = fetch_api_models(existing_key, effective_base)
+        if live_models and len(live_models) >= len(curated):
+            model_list = live_models
+            print(f"  Found {len(model_list)} model(s) from {pconfig.name} API")
+        else:
+            model_list = curated
+            if model_list:
+                print(f"  Showing {len(model_list)} curated models — use \"Enter custom model name\" for others.")
+
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = provider_id
+        model["base_url"] = effective_base
+        model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -259,74 +259,78 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("api_mode") == "anthropic_messages"
 
 
-class TestBaseUrlValidation:
-    """Reject non-URL values in the base URL prompt (e.g. shell commands)."""
-
-    def test_invalid_base_url_rejected(self, config_home, monkeypatch, capsys):
-        """Typing a non-URL string should not be saved as the base URL."""
-        from hermes_cli.auth import PROVIDER_REGISTRY
-
-        pconfig = PROVIDER_REGISTRY.get("zai")
-        if not pconfig:
-            pytest.skip("zai not in PROVIDER_REGISTRY")
-
+class TestZaiSetupAutodetect:
+    def test_zai_setup_uses_resolved_endpoint_without_prompting_for_base_url(
+        self, config_home, monkeypatch
+    ):
         monkeypatch.setenv("GLM_API_KEY", "test-key")
 
-        from hermes_cli.main import _model_flow_api_key_provider
+        from hermes_cli.main import _model_flow_zai
         from hermes_cli.config import load_config, get_env_value
 
-        # User types a shell command instead of a URL at the base URL prompt
-        with patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
-             patch("hermes_cli.auth.deactivate_provider"), \
-             patch("builtins.input", return_value="nano ~/.hermes/.env"):
-            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "zai",
+                "api_key": "test-key",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "source": "GLM_API_KEY",
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["glm-5.1", "glm-5"],
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="glm-5.1",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ), patch(
+            "builtins.input",
+        ) as mock_input:
+            _model_flow_zai(load_config(), "old-model")
 
-        # The garbage value should NOT have been saved
-        saved = get_env_value("GLM_BASE_URL") or ""
-        assert not saved or saved.startswith(("http://", "https://")), \
-            f"Non-URL value was saved as GLM_BASE_URL: {saved}"
-        captured = capsys.readouterr()
-        assert "Invalid URL" in captured.out
+        import yaml
 
-    def test_valid_base_url_accepted(self, config_home, monkeypatch):
-        """A proper URL should be saved normally."""
-        from hermes_cli.auth import PROVIDER_REGISTRY
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "zai"
+        assert model.get("default") == "glm-5.1"
+        assert model.get("base_url") == "https://api.z.ai/api/coding/paas/v4"
+        assert get_env_value("GLM_BASE_URL") in ("", None)
+        mock_input.assert_not_called()
 
-        pconfig = PROVIDER_REGISTRY.get("zai")
-        if not pconfig:
-            pytest.skip("zai not in PROVIDER_REGISTRY")
-
+    def test_zai_setup_respects_explicit_base_url_override(self, config_home, monkeypatch):
         monkeypatch.setenv("GLM_API_KEY", "test-key")
+        monkeypatch.setenv("GLM_BASE_URL", "https://api.z.ai/api/paas/v4")
 
-        from hermes_cli.main import _model_flow_api_key_provider
-        from hermes_cli.config import load_config, get_env_value
+        from hermes_cli.main import _model_flow_zai
+        from hermes_cli.config import load_config
 
-        with patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
-             patch("hermes_cli.auth.deactivate_provider"), \
-             patch("builtins.input", return_value="https://custom.z.ai/api/paas/v4"):
-            _model_flow_api_key_provider(load_config(), "zai", "old-model")
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "provider": "zai",
+                "api_key": "test-key",
+                "base_url": "https://api.z.ai/api/paas/v4",
+                "source": "GLM_API_KEY",
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["glm-5", "glm-4.7"],
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="glm-5",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ):
+            _model_flow_zai(load_config(), "old-model")
 
-        saved = get_env_value("GLM_BASE_URL") or ""
-        assert saved == "https://custom.z.ai/api/paas/v4"
+        import yaml
 
-    def test_empty_base_url_keeps_default(self, config_home, monkeypatch):
-        """Pressing Enter (empty) should not change the base URL."""
-        from hermes_cli.auth import PROVIDER_REGISTRY
-
-        pconfig = PROVIDER_REGISTRY.get("zai")
-        if not pconfig:
-            pytest.skip("zai not in PROVIDER_REGISTRY")
-
-        monkeypatch.setenv("GLM_API_KEY", "test-key")
-        monkeypatch.delenv("GLM_BASE_URL", raising=False)
-
-        from hermes_cli.main import _model_flow_api_key_provider
-        from hermes_cli.config import load_config, get_env_value
-
-        with patch("hermes_cli.auth._prompt_model_selection", return_value="glm-5"), \
-             patch("hermes_cli.auth.deactivate_provider"), \
-             patch("builtins.input", return_value=""):
-            _model_flow_api_key_provider(load_config(), "zai", "old-model")
-
-        saved = get_env_value("GLM_BASE_URL") or ""
-        assert saved == "", "Empty input should not save a base URL"
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model")
+        assert isinstance(model, dict)
+        assert model.get("provider") == "zai"
+        assert model.get("default") == "glm-5"
+        assert model.get("base_url") == "https://api.z.ai/api/paas/v4"


### PR DESCRIPTION
## What does this PR do?

This fixes a mismatch between the Z.AI auth path and the interactive model/setup path.

Hermes already auto-detects the correct GLM endpoint at auth setup time in `hermes_cli/auth.py`, but the interactive provider flow in `hermes_cli/main.py` was still routing `zai` through the generic API-key provider flow. That generic flow prompts for `Base URL [...]` and defaults to the general GLM endpoint, which makes Coding Plan users guess the right endpoint even though Hermes already has autodetect logic.

This PR gives Z.AI its own setup flow and reuses `resolve_api_key_provider_credentials("zai")` so setup stays aligned with the existing auth/runtime endpoint detection and cache behavior.

This applies both to `hermes model` and to the model/provider section inside `hermes setup`, because the setup wizard delegates that step through the same `select_provider_and_model()` path in `hermes_cli/main.py`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a dedicated `_model_flow_zai()` in `hermes_cli/main.py`
- Routed `zai` provider selection through that dedicated flow instead of the generic API-key provider flow
- Reused `resolve_api_key_provider_credentials("zai")` so setup uses the same endpoint autodetect/cached resolution as the auth path
- Removed the interactive Z.AI base-URL prompt from the named `zai` provider flow
- Covered the shared provider-selection path used by both `hermes model` and the model/provider step in `hermes setup`
- Replaced the old Z.AI base-URL prompt tests with setup autodetect tests in `tests/hermes_cli/test_model_provider_persistence.py`

## How to Test

1. Run `hermes setup` and go through the model/provider step, or run `hermes model`
2. Select `zai`
3. Configure a Z.AI key for either general GLM or Coding Plan and verify Hermes no longer asks you to guess the endpoint
4. Confirm the saved `model.base_url` matches the resolved Z.AI endpoint

Focused test run completed:

`source venv/bin/activate && python -m pytest tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_api_key_providers.py -q`

Result: `136 passed in 9.05s`

Full suite run completed:

`source venv/bin/activate && python -m pytest tests/ -q -n 4`

Result: `38 failed, 12253 passed, 35 skipped in 333.60s (0:05:33)`

The failures are broad and appear unrelated to this change. They are clustered in existing-red areas including gateway/Discord, DM topics, API server, setup prompt menus, Bedrock auto-detection, Ollama Cloud auto-detection, backup/profile restoration, browser/camofox/browserbase, tirith, and a few other general suite failures. Nothing in the failing list is in the touched Z.AI setup files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused pytest:

`136 passed in 9.05s`

Full suite pytest:

`38 failed, 12253 passed, 35 skipped in 333.60s (0:05:33)`
