### PR TITLE
fix(gateway): log full traceback when session suspension fails on startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1557,7 +1557,7 @@ class GatewayRunner:
                 if suspended:
                     logger.info("Suspended %d in-flight session(s) from previous run", suspended)
             except Exception as e:
-                logger.warning("Session suspension on startup failed: %s", e)
+                logger.warning("Session suspension on startup failed: %s", e, exc_info=True)
 
         connected_count = 0
         enabled_platform_count = 0


### PR DESCRIPTION
## Summary
- add `exc_info=True` to the startup session-suspension warning in `gateway/run.py`
- include the full traceback when crash-recovery session suspension fails during startup

## Why
Without `exc_info=True`, the warning only captures the exception message, making it difficult to diagnose why crash-recovery session suspension failed.

## Change
```python
logger.warning("Session suspension on startup failed: %s", e, exc_info=True)
```
