### PR TITLE
fix: replace stale 'hermes web' references with 'hermes dashboard'

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4749,7 +4749,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     Args:
         web_dir: Path to the dashboard frontend source directory.
         fatal: If True, print error guidance and return False on failure
-               instead of a soft warning (used by ``hermes web``).
+               instead of a soft warning (used by ``hermes dashboard``).
 
     Returns True if the build succeeded or was skipped (no package.json).
     """
@@ -4816,7 +4816,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     if r1.returncode != 0:
         _say(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
-            + ("" if fatal else " (hermes web will not be available)")
+            + ("" if fatal else " (hermes dashboard will not be available)")
         )
         _relay(r1)
         if fatal:
@@ -4858,7 +4858,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
 
         _say(
             f"  {'✗' if fatal else '⚠'} Web UI build failed"
-            + ("" if fatal else " (hermes web will not be available)")
+            + ("" if fatal else " (hermes dashboard will not be available)")
         )
         _relay(r2)
         if fatal:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3304,7 +3304,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     Args:
         web_dir: Path to the ``web/`` source directory.
         fatal: If True, print error guidance and return False on failure
-               instead of a soft warning (used by ``hermes web``).
+               instead of a soft warning (used by ``hermes dashboard``).
 
     Returns True if the build succeeded or was skipped (no package.json).
     """
@@ -3321,14 +3321,14 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
     if r1.returncode != 0:
         print(f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
-              + ("" if fatal else " (hermes web will not be available)"))
+              + ("" if fatal else " (hermes dashboard will not be available)"))
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False
     r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
     if r2.returncode != 0:
         print(f"  {'✗' if fatal else '⚠'} Web UI build failed"
-              + ("" if fatal else " (hermes web will not be available)"))
+              + ("" if fatal else " (hermes dashboard will not be available)"))
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6056,7 +6056,7 @@ _oauth_sessions: Dict[str, Dict[str, Any]] = {}
 _oauth_sessions_lock = threading.Lock()
 
 # Import OAuth constants from canonical source instead of duplicating.
-# Guarded so hermes web still starts if anthropic_adapter is unavailable;
+# Guarded so hermes dashboard still starts if anthropic_adapter is unavailable;
 # Phase 2 endpoints will return 501 in that case.
 try:
     from agent.anthropic_adapter import (

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -56,7 +56,7 @@ try:
 except ImportError:
     raise SystemExit(
         "Web UI requires fastapi and uvicorn.\n"
-        "Run 'hermes web' to auto-install, or: pip install hermes-agent[web]"
+        "Run 'hermes dashboard' to auto-install, or: pip install hermes-agent[web]"
     )
 
 WEB_DIST = Path(__file__).parent / "web_dist"
@@ -1135,7 +1135,7 @@ _oauth_sessions: Dict[str, Dict[str, Any]] = {}
 _oauth_sessions_lock = threading.Lock()
 
 # Import OAuth constants from canonical source instead of duplicating.
-# Guarded so hermes web still starts if anthropic_adapter is unavailable;
+# Guarded so hermes dashboard still starts if anthropic_adapter is unavailable;
 # Phase 2 endpoints will return 501 in that case.
 try:
     from agent.anthropic_adapter import (

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -51,6 +51,9 @@ hermes model
 
 # Check health
 hermes doctor
+
+# Local web dashboard (v0.9+)
+hermes dashboard
 ```
 
 ---

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -50,6 +50,9 @@ hermes model
 
 # Check health
 hermes doctor
+
+# Local web dashboard (v0.9+)
+hermes dashboard
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Replaces stale `hermes web` wording in runtime messages/comments with `hermes dashboard`
- Updates web-server dependency guidance to instruct `hermes dashboard`
- Updates `skills/autonomous-ai-agents/hermes-agent/SKILL.md` Quick Start to include the dashboard command

## Why
`hermes web` is not a valid CLI subcommand in current releases (`dashboard` is). These stale strings can mislead users during setup/troubleshooting.

## Files changed
- `hermes_cli/main.py`
- `hermes_cli/web_server.py`
- `skills/autonomous-ai-agents/hermes-agent/SKILL.md`

## Validation
- ✅ `hermes dashboard --help` shows valid command
- ✅ `python -m compileall hermes_cli/main.py hermes_cli/web_server.py`
- ✅ repo grep for `\bhermes web\b` returns no matches
- ⚠️ `pytest -k dashboard` in this local environment fails during collection due to missing optional deps (`acp`, `openai`, `fire`), unrelated to this change
