### PR TITLE
feat(models): add MiniMax highspeed variants

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -176,15 +176,23 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "minimax": [
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
+        "MiniMax-M2-highspeed",
     ],
     "minimax-cn": [
         "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
+        "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
+        "MiniMax-M2.1-highspeed",
         "MiniMax-M2",
+        "MiniMax-M2-highspeed",
     ],
     "anthropic": [
         "claude-opus-4-7",

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -95,9 +95,13 @@ class TestMinimaxModelCatalog:
         for provider in ("minimax", "minimax-cn"):
             models = _PROVIDER_MODELS[provider]
             assert "MiniMax-M2.7" in models
+            assert "MiniMax-M2.7-highspeed" in models
             assert "MiniMax-M2.5" in models
+            assert "MiniMax-M2.5-highspeed" in models
             assert "MiniMax-M2.1" in models
+            assert "MiniMax-M2.1-highspeed" in models
             assert "MiniMax-M2" in models
+            assert "MiniMax-M2-highspeed" in models
 
     def test_catalog_excludes_m1_family(self):
         """M1 models are not available on the /anthropic endpoint."""
@@ -106,14 +110,15 @@ class TestMinimaxModelCatalog:
             models = _PROVIDER_MODELS[provider]
             assert "MiniMax-M1" not in models
 
-    def test_catalog_excludes_highspeed(self):
-        """Highspeed variants are available but not shown in default catalog
-        (users can still specify them manually)."""
+    def test_catalog_includes_highspeed(self):
+        """Highspeed variants are part of the curated MiniMax catalog."""
         from hermes_cli.models import _PROVIDER_MODELS
         for provider in ("minimax", "minimax-cn"):
             models = _PROVIDER_MODELS[provider]
-            assert "MiniMax-M2.7-highspeed" not in models
-            assert "MiniMax-M2.5-highspeed" not in models
+            assert "MiniMax-M2.7-highspeed" in models
+            assert "MiniMax-M2.5-highspeed" in models
+            assert "MiniMax-M2.1-highspeed" in models
+            assert "MiniMax-M2-highspeed" in models
 
 
 class TestMinimaxBetaHeaders:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -596,6 +596,31 @@ class TestRuntimeProviderResolution:
         assert result["args"] == ["--acp", "--stdio", "--debug"]
 
 
+class TestAuthenticatedProviderLists:
+
+    def test_minimax_provider_list_includes_highspeed_variants(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "mm-key")
+        monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        providers = list_authenticated_providers(current_provider="openrouter")
+        minimax = next((p for p in providers if p["slug"] == "minimax"), None)
+
+        assert minimax is not None
+        assert minimax["models"] == [
+            "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.1",
+            "MiniMax-M2.1-highspeed",
+            "MiniMax-M2",
+            "MiniMax-M2-highspeed",
+        ]
+        assert minimax["total_models"] == 8
+
+
 # =============================================================================
 # _has_any_provider_configured tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- add the four MiniMax `-highspeed` variants to the curated provider catalogs for `minimax` and `minimax-cn`
- update the MiniMax catalog regression to assert the highspeed variants are present
- add `/model`-path coverage that checks authenticated MiniMax provider listings expose the full eight-model curated list

Closes #11367.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts= tests/agent/test_minimax_provider.py tests/hermes_cli/test_api_key_providers.py -q`