### PR TITLE
fix(cli): avoid treating no-remote worktrees as unpushed

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -782,6 +782,35 @@ def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
     return info
 
 
+def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> bool:
+    """Return whether a worktree has commits not reachable from any remote branch.
+
+    If the repo has no configured remotes, treat it as having no "unpushed"
+    commits because there is no remote baseline to compare against.
+    """
+    import subprocess
+
+    try:
+        remotes = subprocess.run(
+            ["git", "remote"],
+            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+        )
+        if remotes.returncode != 0:
+            return True
+        if not remotes.stdout.strip():
+            return False
+
+        result = subprocess.run(
+            ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
+            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+        )
+        if result.returncode != 0:
+            return True
+        return bool(result.stdout.strip())
+    except Exception:
+        return True
+
+
 def _cleanup_worktree(info: Dict[str, str] = None) -> None:
     """Remove a worktree and its branch on exit.
 
@@ -804,18 +833,7 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
     if not Path(wt_path).exists():
         return
 
-    # Check for unpushed commits — commits reachable from HEAD but not
-    # from any remote branch.  These represent real work the agent did
-    # but didn't push.
-    has_unpushed = False
-    try:
-        result = subprocess.run(
-            ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-            capture_output=True, text=True, timeout=10, cwd=wt_path,
-        )
-        has_unpushed = bool(result.stdout.strip())
-    except Exception:
-        has_unpushed = True  # Assume unpushed on error — don't delete
+    has_unpushed = _worktree_has_unpushed_commits(wt_path, timeout=10)
 
     if has_unpushed:
         print(f"\n\033[33m⚠ Worktree has unpushed commits, keeping: {wt_path}\033[0m")
@@ -885,15 +903,8 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
 
         if not force:
             # 24h–72h tier: only remove if no unpushed commits
-            try:
-                result = subprocess.run(
-                    ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-                    capture_output=True, text=True, timeout=5, cwd=str(entry),
-                )
-                if result.stdout.strip():
-                    continue  # Has unpushed commits — skip
-            except Exception:
-                continue  # Can't check — skip
+            if _worktree_has_unpushed_commits(str(entry), timeout=5):
+                continue  # Has unpushed commits or can't check — skip
 
         # Safe to remove
         try:

--- a/cli.py
+++ b/cli.py
@@ -785,19 +785,21 @@ def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
 def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> bool:
     """Return whether a worktree has commits not reachable from any remote branch.
 
-    If the repo has no configured remotes, treat it as having no "unpushed"
-    commits because there is no remote baseline to compare against.
+    ``git log HEAD --not --remotes`` compares against remote-tracking refs under
+    ``refs/remotes/*``. If a repo has no remote-tracking refs yet, there is no
+    usable remote baseline to compare against, so treat it as having no
+    "unpushed" commits.
     """
     import subprocess
 
     try:
-        remotes = subprocess.run(
-            ["git", "remote"],
+        remote_refs = subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname)", "refs/remotes"],
             capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
         )
-        if remotes.returncode != 0:
+        if remote_refs.returncode != 0:
             return True
-        if not remotes.stdout.strip():
+        if not remote_refs.stdout.strip():
             return False
 
         result = subprocess.run(

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -33,11 +33,37 @@ def git_repo(tmp_path):
         ["git", "commit", "-m", "Initial commit"],
         cwd=repo, capture_output=True,
     )
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://example.com/test-repo.git"],
+        cwd=repo, capture_output=True,
+    )
     # Add a fake remote ref so cleanup logic sees the initial commit as
-    # "pushed".  Without this, `git log HEAD --not --remotes` treats every
-    # commit as unpushed and cleanup refuses to delete worktrees.
+    # "pushed" when a remote is configured.
     subprocess.run(
         ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+        cwd=repo, capture_output=True,
+    )
+    return repo
+
+
+@pytest.fixture
+def git_repo_no_remote(tmp_path):
+    """Create a temporary git repo with no configured remotes."""
+    repo = tmp_path / "test-repo-no-remote"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo, capture_output=True,
+    )
+    (repo / "README.md").write_text("# Test Repo\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
         cwd=repo, capture_output=True,
     )
     return repo
@@ -87,6 +113,26 @@ def _setup_worktree(repo_root):
     }
 
 
+def _has_unpushed_commits(worktree_path, timeout=10):
+    """Test version of the worktree unpushed-commit helper."""
+    remotes = subprocess.run(
+        ["git", "remote"],
+        capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+    )
+    if remotes.returncode != 0:
+        return True
+    if not remotes.stdout.strip():
+        return False
+
+    result = subprocess.run(
+        ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
+        capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+    )
+    if result.returncode != 0:
+        return True
+    return bool(result.stdout.strip())
+
+
 def _cleanup_worktree(info):
     """Test version of _cleanup_worktree.
 
@@ -100,14 +146,7 @@ def _cleanup_worktree(info):
     if not Path(wt_path).exists():
         return
 
-    # Check for unpushed commits
-    result = subprocess.run(
-        ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-        capture_output=True, text=True, timeout=10, cwd=wt_path,
-    )
-    has_unpushed = bool(result.stdout.strip())
-
-    if has_unpushed:
+    if _has_unpushed_commits(wt_path, timeout=10):
         return False  # Did not clean up — has unpushed commits
 
     subprocess.run(
@@ -254,6 +293,17 @@ class TestWorktreeCleanup:
         result = _cleanup_worktree(info)
         assert result is False  # Kept — has unpushed commits
         assert Path(info["path"]).exists()
+
+    def test_clean_worktree_removed_without_remote(self, git_repo_no_remote):
+        """Clean worktrees in repos without remotes should still be removed."""
+        info = _setup_worktree(str(git_repo_no_remote))
+        assert info is not None
+        assert Path(info["path"]).exists()
+        assert _has_unpushed_commits(info["path"], timeout=10) is False
+
+        result = _cleanup_worktree(info)
+        assert result is True
+        assert not Path(info["path"]).exists()
 
     def test_branch_deleted_on_cleanup(self, git_repo):
         info = _setup_worktree(str(git_repo))
@@ -548,13 +598,49 @@ class TestStaleWorktreePruning:
         os.utime(info["path"], (old_time, old_time))
 
         # Check for unpushed commits (simulates prune logic)
-        result = subprocess.run(
-            ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-            capture_output=True, text=True, cwd=info["path"],
-        )
-        has_unpushed = bool(result.stdout.strip())
+        has_unpushed = _has_unpushed_commits(info["path"])
         assert has_unpushed  # Has unpushed commits → not pruned in soft tier
         assert Path(info["path"]).exists()
+
+    def test_prunes_old_clean_worktree_without_remote(self, git_repo_no_remote):
+        """Old clean worktrees in repos without remotes should not be kept."""
+        import time
+
+        info = _setup_worktree(str(git_repo_no_remote))
+        assert info is not None
+        assert Path(info["path"]).exists()
+
+        old_time = time.time() - (25 * 3600)
+        os.utime(info["path"], (old_time, old_time))
+
+        worktrees_dir = git_repo_no_remote / ".worktrees"
+        cutoff = time.time() - (24 * 3600)
+
+        for entry in worktrees_dir.iterdir():
+            if not entry.is_dir() or not entry.name.startswith("hermes-"):
+                continue
+            mtime = entry.stat().st_mtime
+            if mtime > cutoff:
+                continue
+            if _has_unpushed_commits(str(entry), timeout=5):
+                continue
+
+            branch_result = subprocess.run(
+                ["git", "branch", "--show-current"],
+                capture_output=True, text=True, timeout=5, cwd=str(entry),
+            )
+            branch = branch_result.stdout.strip()
+            subprocess.run(
+                ["git", "worktree", "remove", str(entry), "--force"],
+                capture_output=True, text=True, timeout=15, cwd=str(git_repo_no_remote),
+            )
+            if branch:
+                subprocess.run(
+                    ["git", "branch", "-D", branch],
+                    capture_output=True, text=True, timeout=10, cwd=str(git_repo_no_remote),
+                )
+
+        assert not Path(info["path"]).exists()
 
     def test_force_prunes_very_old_worktree(self, git_repo):
         """Worktrees older than 72h should be force-pruned regardless."""

--- a/tests/cli/test_worktree.py
+++ b/tests/cli/test_worktree.py
@@ -69,6 +69,33 @@ def git_repo_no_remote(tmp_path):
     return repo
 
 
+@pytest.fixture
+def git_repo_remote_no_tracking(tmp_path):
+    """Create a temporary git repo with a remote but no remote-tracking refs."""
+    repo = tmp_path / "test-repo-remote-no-tracking"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"],
+        cwd=repo, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=repo, capture_output=True,
+    )
+    (repo / "README.md").write_text("# Test Repo\n")
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=repo, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://example.com/test-repo.git"],
+        cwd=repo, capture_output=True,
+    )
+    return repo
+
+
 # ---------------------------------------------------------------------------
 # Lightweight reimplementations for testing (avoid importing cli.py)
 # ---------------------------------------------------------------------------
@@ -115,22 +142,25 @@ def _setup_worktree(repo_root):
 
 def _has_unpushed_commits(worktree_path, timeout=10):
     """Test version of the worktree unpushed-commit helper."""
-    remotes = subprocess.run(
-        ["git", "remote"],
-        capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
-    )
-    if remotes.returncode != 0:
-        return True
-    if not remotes.stdout.strip():
-        return False
+    try:
+        remote_refs = subprocess.run(
+            ["git", "for-each-ref", "--format=%(refname)", "refs/remotes"],
+            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+        )
+        if remote_refs.returncode != 0:
+            return True
+        if not remote_refs.stdout.strip():
+            return False
 
-    result = subprocess.run(
-        ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
-        capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
-    )
-    if result.returncode != 0:
+        result = subprocess.run(
+            ["git", "log", "--oneline", "HEAD", "--not", "--remotes"],
+            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
+        )
+        if result.returncode != 0:
+            return True
+        return bool(result.stdout.strip())
+    except Exception:
         return True
-    return bool(result.stdout.strip())
 
 
 def _cleanup_worktree(info):
@@ -297,6 +327,19 @@ class TestWorktreeCleanup:
     def test_clean_worktree_removed_without_remote(self, git_repo_no_remote):
         """Clean worktrees in repos without remotes should still be removed."""
         info = _setup_worktree(str(git_repo_no_remote))
+        assert info is not None
+        assert Path(info["path"]).exists()
+        assert _has_unpushed_commits(info["path"], timeout=10) is False
+
+        result = _cleanup_worktree(info)
+        assert result is True
+        assert not Path(info["path"]).exists()
+
+    def test_clean_worktree_removed_without_remote_tracking_refs(
+        self, git_repo_remote_no_tracking
+    ):
+        """Configured remotes without fetched refs should not block cleanup."""
+        info = _setup_worktree(str(git_repo_remote_no_tracking))
         assert info is not None
         assert Path(info["path"]).exists()
         assert _has_unpushed_commits(info["path"], timeout=10) is False
@@ -638,6 +681,50 @@ class TestStaleWorktreePruning:
                 subprocess.run(
                     ["git", "branch", "-D", branch],
                     capture_output=True, text=True, timeout=10, cwd=str(git_repo_no_remote),
+                )
+
+        assert not Path(info["path"]).exists()
+
+    def test_prunes_old_clean_worktree_without_remote_tracking_refs(
+        self, git_repo_remote_no_tracking
+    ):
+        """Old clean worktrees with no fetched remote refs should be pruned."""
+        import time
+
+        info = _setup_worktree(str(git_repo_remote_no_tracking))
+        assert info is not None
+        assert Path(info["path"]).exists()
+
+        old_time = time.time() - (25 * 3600)
+        os.utime(info["path"], (old_time, old_time))
+
+        worktrees_dir = git_repo_remote_no_tracking / ".worktrees"
+        cutoff = time.time() - (24 * 3600)
+
+        for entry in worktrees_dir.iterdir():
+            if not entry.is_dir() or not entry.name.startswith("hermes-"):
+                continue
+            mtime = entry.stat().st_mtime
+            if mtime > cutoff:
+                continue
+            if _has_unpushed_commits(str(entry), timeout=5):
+                continue
+
+            branch_result = subprocess.run(
+                ["git", "branch", "--show-current"],
+                capture_output=True, text=True, timeout=5, cwd=str(entry),
+            )
+            branch = branch_result.stdout.strip()
+            subprocess.run(
+                ["git", "worktree", "remove", str(entry), "--force"],
+                capture_output=True, text=True, timeout=15,
+                cwd=str(git_repo_remote_no_tracking),
+            )
+            if branch:
+                subprocess.run(
+                    ["git", "branch", "-D", branch],
+                    capture_output=True, text=True, timeout=10,
+                    cwd=str(git_repo_remote_no_tracking),
                 )
 
         assert not Path(info["path"]).exists()


### PR DESCRIPTION
## What does this PR do?

Fixes a worktree cleanup bug when a repository has no remote-tracking refs.

Hermes checks for unpushed commits with `git log HEAD --not --remotes`. Git compares that against `refs/remotes/*`, not just configured remotes. If a repo has no remote-tracking refs yet, Git treats the whole local history as unmatched. That makes a clean temporary worktree look like it has unpushed work, so Hermes keeps it instead of cleaning it up.

This change keeps the existing behavior when a real remote baseline exists, but skips the unpushed-commit check when there are no remote-tracking refs. That fixes both local-only repos and repos where a remote was added but nothing has been fetched yet.

This does not change the cleanup policy. It only avoids treating a missing remote baseline as unpushed work.

## Related Issue

Fixes #11318

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a small helper in `cli.py` to decide whether a worktree really has unpushed commits.
- Made that helper check for remote-tracking refs before running `git log HEAD --not --remotes`.
- Reused the helper in both `_cleanup_worktree()` and the 24h–72h stale-worktree prune path.
- Updated `tests/cli/test_worktree.py` to cover:
  - repos with remote-tracking refs
  - repos with no remotes
  - repos with a configured remote but no fetched remote-tracking refs yet
- Added regression tests for both cleanup and stale-worktree pruning.

## How to Test

1. `source /Users/blackishgreen03/workspace/hermes-agent/venv/bin/activate && python -m pytest tests/cli/test_worktree.py -q`
2. In a repo with no remote-tracking refs, create a temporary Hermes worktree and confirm cleanup no longer keeps it just because `git log HEAD --not --remotes` would list local history.
3. In a repo with a real remote-tracking ref and a real local-only commit, confirm the worktree is still preserved.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m pytest tests/cli/test_worktree.py -q` → `41 passed`
- The latest PR checks are green.
