### PR TITLE
fix(discord): keep skill slash group within size limit

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -23,6 +23,9 @@ from typing import Callable, Dict, Optional, Any
 logger = logging.getLogger(__name__)
 
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
+_DISCORD_SKILL_GROUP_MAX_SIZE = 8000
+_DISCORD_SKILL_DESC_LIMIT = 40
+_DISCORD_SKILL_ARGS_DESC = "Arguments"
 
 try:
     import discord
@@ -78,6 +81,76 @@ def _clean_discord_id(entry: str) -> str:
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available."""
     return DISCORD_AVAILABLE
+
+
+def _discord_skill_description(name: str, description: str) -> str:
+    """Clamp /skill descriptions so the aggregate payload stays under Discord's cap."""
+    text = (description or f"Run the {name} skill").strip() or f"Run the {name} skill"
+    if len(text) > _DISCORD_SKILL_DESC_LIMIT:
+        text = text[: _DISCORD_SKILL_DESC_LIMIT - 3].rstrip() + "..."
+    return text
+
+
+def _estimate_discord_skill_group_size(
+    categories: dict[str, list[tuple[str, str, str]]],
+    uncategorized: list[tuple[str, str, str]],
+) -> int:
+    """Approximate the command payload size Discord enforces for /skill."""
+    size = len("skill") + len("Run a Hermes skill")
+
+    for cat_name in sorted(categories):
+        cat_desc = f"{cat_name.replace('-', ' ').title()} skills"
+        if len(cat_desc) > 100:
+            cat_desc = cat_desc[:97] + "..."
+        size += len(cat_name) + len(cat_desc)
+        for discord_name, description, _cmd_key in categories[cat_name]:
+            size += len(discord_name)
+            size += len(_discord_skill_description(discord_name, description))
+            size += len("args") + len(_DISCORD_SKILL_ARGS_DESC)
+
+    for discord_name, description, _cmd_key in uncategorized:
+        size += len(discord_name)
+        size += len(_discord_skill_description(discord_name, description))
+        size += len("args") + len(_DISCORD_SKILL_ARGS_DESC)
+
+    return size
+
+
+def _fit_discord_skill_group_within_limit(
+    categories: dict[str, list[tuple[str, str, str]]],
+    uncategorized: list[tuple[str, str, str]],
+) -> tuple[dict[str, list[tuple[str, str, str]]], list[tuple[str, str, str]], int]:
+    """Trim commands until /skill fits under Discord's 8000-byte group limit."""
+    fitted_categories = {name: list(items) for name, items in categories.items()}
+    fitted_uncategorized = list(uncategorized)
+    hidden = 0
+
+    while (
+        _estimate_discord_skill_group_size(fitted_categories, fitted_uncategorized)
+        > _DISCORD_SKILL_GROUP_MAX_SIZE
+    ):
+        largest_category = None
+        largest_count = 0
+        for cat_name, items in fitted_categories.items():
+            if len(items) > largest_count:
+                largest_category = cat_name
+                largest_count = len(items)
+
+        if largest_category and fitted_categories[largest_category]:
+            fitted_categories[largest_category].pop()
+            if not fitted_categories[largest_category]:
+                del fitted_categories[largest_category]
+            hidden += 1
+            continue
+
+        if fitted_uncategorized:
+            fitted_uncategorized.pop()
+            hidden += 1
+            continue
+
+        break
+
+    return fitted_categories, fitted_uncategorized, hidden
 
 
 class VoiceReceiver:
@@ -1923,6 +1996,11 @@ class DiscordAdapter(BasePlatformAdapter):
             categories, uncategorized, hidden = discord_skill_commands_by_category(
                 reserved_names=existing_names,
             )
+            categories, uncategorized, size_hidden = _fit_discord_skill_group_within_limit(
+                categories,
+                uncategorized,
+            )
+            hidden += size_hidden
 
             if not categories and not uncategorized:
                 return
@@ -1934,7 +2012,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # ── Helper: build a callback for a skill command key ──
             def _make_handler(_key: str):
-                @discord.app_commands.describe(args="Optional arguments for the skill")
+                @discord.app_commands.describe(args=_DISCORD_SKILL_ARGS_DESC)
                 async def _handler(interaction: discord.Interaction, args: str = ""):
                     await self._run_simple_slash(interaction, f"{_key} {args}".strip())
                 _handler.__name__ = f"skill_{_key.lstrip('/').replace('-', '_')}"
@@ -1944,7 +2022,7 @@ class DiscordAdapter(BasePlatformAdapter):
             for discord_name, description, cmd_key in uncategorized:
                 cmd = discord.app_commands.Command(
                     name=discord_name,
-                    description=description or f"Run the {discord_name} skill",
+                    description=_discord_skill_description(discord_name, description),
                     callback=_make_handler(cmd_key),
                 )
                 skill_group.add_command(cmd)
@@ -1962,7 +2040,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 for discord_name, description, cmd_key in categories[cat_name]:
                     cmd = discord.app_commands.Command(
                         name=discord_name,
-                        description=description or f"Run the {discord_name} skill",
+                        description=_discord_skill_description(discord_name, description),
                         callback=_make_handler(cmd_key),
                     )
                     cat_group.add_command(cmd)
@@ -1977,7 +2055,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             if hidden:
                 logger.warning(
-                    "[%s] %d skill(s) not registered (Discord subcommand limits)",
+                    "[%s] %d skill(s) not registered (Discord slash command limits)",
                     self.name, hidden,
                 )
         except Exception as exc:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -61,7 +61,13 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+from gateway.platforms.discord import (  # noqa: E402
+    DiscordAdapter,
+    _DISCORD_SKILL_DESC_LIMIT,
+    _DISCORD_SKILL_GROUP_MAX_SIZE,
+    _estimate_discord_skill_group_size,
+    _fit_discord_skill_group_within_limit,
+)
 
 
 class FakeTree:
@@ -672,3 +678,58 @@ def test_register_skill_group_handler_dispatches_command(adapter):
     # The callback name should reflect the skill
     assert "gif_search" in gif_cmd.callback.__name__
 
+
+def test_register_skill_group_clamps_descriptions_and_hides_excess(adapter):
+    """Oversized /skill payloads should be trimmed instead of breaking sync."""
+    long_desc = "L" * 200
+    mock_categories = {
+        f"cat{i:02d}": [
+            (f"skill{j:02d}-{i:02d}", long_desc, f"/skill{j:02d}-{i:02d}")
+            for j in range(5)
+        ]
+        for i in range(25)
+    }
+
+    with patch(
+        "hermes_cli.commands.discord_skill_commands_by_category",
+        return_value=(mock_categories, [], 0),
+    ):
+        adapter._register_slash_commands()
+
+    skill_group = adapter._client.tree.commands["skill"]
+    child_count = sum(
+        len(child._children) if hasattr(child, "_children") else 1
+        for child in skill_group._children.values()
+    )
+    assert child_count < 125, "Expected some skills to be hidden to fit Discord's size limit"
+
+    for child in skill_group._children.values():
+        if hasattr(child, "_children"):
+            for cmd in child._children.values():
+                assert len(cmd.description) <= _DISCORD_SKILL_DESC_LIMIT
+        else:
+            assert len(child.description) <= _DISCORD_SKILL_DESC_LIMIT
+
+
+def test_real_skill_catalog_fits_discord_size_budget():
+    """The current built-in /skill catalog must stay within Discord's group limit."""
+    from hermes_cli.commands import discord_skill_commands_by_category
+
+    categories, uncategorized, hidden = discord_skill_commands_by_category(
+        reserved_names=set(),
+    )
+    fitted_categories, fitted_uncategorized, size_hidden = _fit_discord_skill_group_within_limit(
+        categories,
+        uncategorized,
+    )
+
+    total_hidden = hidden + size_hidden
+    total_visible = sum(len(items) for items in fitted_categories.values()) + len(fitted_uncategorized)
+
+    if total_visible == 0:
+        pytest.skip("No built-in Discord skill catalog available in this test environment")
+    assert total_hidden >= 0
+    assert (
+        _estimate_discord_skill_group_size(fitted_categories, fitted_uncategorized)
+        <= _DISCORD_SKILL_GROUP_MAX_SIZE
+    )


### PR DESCRIPTION
## Summary
- clamp `/skill` command descriptions and the shared `args` description so the generated Discord payload stays compact
- trim excess `/skill` subcommands only when the generated group would still exceed Discord's 8000-byte limit
- add regression coverage for an oversized synthetic catalog and for the current built-in skill catalog budget

Closes #11321.

## Why
Discord currently rejects the generated `/skill` command group with:

```text
Command exceeds maximum size (8000)
```

That blocks slash-command sync during gateway startup. On the current built-in catalog, the pre-fix payload is about 12119 characters by the same estimator, while the compacted version fits at about 5703 without hiding any built-in skills.

## Testing
- `python3 -m pytest -o addopts='' tests/gateway/test_discord_slash_commands.py`
- `python3 -m pytest -o addopts='' tests/gateway/test_discord_connect.py tests/gateway/test_discord_send.py tests/gateway/test_discord_document_handling.py`
