### PR TITLE
feat(debug): add local HERMES_HOME report

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -1,6 +1,7 @@
 """``hermes debug`` — debug tools for Hermes Agent.
 
 Currently supports:
+    hermes debug home     Print a local summary of the active HERMES_HOME.
     hermes debug share    Upload debug report (system info + logs) to a
                           paste service and print a shareable URL.
 """
@@ -10,10 +11,171 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from hermes_constants import get_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home, get_subprocess_home
+
+
+# ---------------------------------------------------------------------------
+# Local HERMES_HOME report
+# ---------------------------------------------------------------------------
+
+_HOME_REPORT_FILES = (
+    "config.yaml",
+    ".env",
+    "auth.json",
+    "state.db",
+    "SOUL.md",
+    ".container-mode",
+)
+
+_HOME_REPORT_DIRS = (
+    "logs",
+    "sessions",
+    "memories",
+    "skills",
+    "cron",
+    "home",
+)
+
+
+def _format_size(num_bytes: int) -> str:
+    """Return a compact human-readable byte count."""
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    if num_bytes < 1024 * 1024:
+        return f"{num_bytes / 1024:.1f} KB"
+    return f"{num_bytes / (1024 * 1024):.1f} MB"
+
+
+def _format_mtime(path: Path) -> str:
+    """Return a stable local timestamp for the file's mtime."""
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+    except OSError:
+        return "unknown"
+
+
+def _safe_iterdir_count(path: Path) -> str:
+    """Return the number of direct children for a directory."""
+    try:
+        return str(sum(1 for _ in path.iterdir()))
+    except OSError:
+        return "?"
+
+
+def _describe_file(path: Path) -> str:
+    """Describe a file path without reading its contents."""
+    if not path.exists():
+        return "missing"
+    if not path.is_file():
+        return "not a file"
+    try:
+        size = _format_size(path.stat().st_size)
+    except OSError:
+        size = "size unavailable"
+    return f"present  {size:<8} modified {_format_mtime(path)}"
+
+
+def _describe_dir(path: Path) -> str:
+    """Describe a directory path without traversing recursively."""
+    if not path.exists():
+        return "missing"
+    if not path.is_dir():
+        return "not a directory"
+    return f"present  {_safe_iterdir_count(path):>3} entries  modified {_format_mtime(path)}"
+
+
+def _top_level_entry_lines(home: Path) -> list[str]:
+    """Return report lines for immediate children inside HERMES_HOME."""
+    if not home.exists() or not home.is_dir():
+        return ["  (directory not found)"]
+
+    try:
+        entries = sorted(
+            home.iterdir(),
+            key=lambda entry: (not entry.is_dir(), entry.name.lower()),
+        )
+    except OSError as exc:
+        return [f"  (unable to read directory: {exc})"]
+
+    if not entries:
+        return ["  (empty)"]
+
+    lines: list[str] = []
+    for entry in entries:
+        kind = "dir" if entry.is_dir() else "file" if entry.is_file() else "other"
+        if kind == "dir":
+            detail = f"{_safe_iterdir_count(entry)} entries"
+        elif kind == "file":
+            try:
+                detail = _format_size(entry.stat().st_size)
+            except OSError:
+                detail = "size unavailable"
+        else:
+            detail = "special"
+        lines.append(f"  {entry.name:<18} {kind:<5} {detail}")
+    return lines
+
+
+def _log_status_lines() -> list[str]:
+    """Return report lines for the key log files Hermes rotates."""
+    lines: list[str] = []
+    for log_name in ("agent", "errors", "gateway"):
+        log_path = _resolve_log_path(log_name)
+        if log_path is None:
+            lines.append(f"  {log_name}.log{'':<8} missing")
+            continue
+        try:
+            size = _format_size(log_path.stat().st_size)
+        except OSError:
+            size = "size unavailable"
+        lines.append(
+            f"  {log_name}.log{'':<8} {log_path.name:<14} {size:<8} modified {_format_mtime(log_path)}"
+        )
+    return lines
+
+
+def collect_home_report() -> str:
+    """Build a local summary of the active HERMES_HOME contents."""
+    home = get_hermes_home()
+    display_home = display_hermes_home()
+    subprocess_home = get_subprocess_home()
+
+    buf = io.StringIO()
+    buf.write("Hermes Home Report\n")
+    buf.write("==================\n")
+    buf.write(f"Display path:    {display_home}\n")
+    buf.write(f"Resolved path:   {home}\n")
+    buf.write(f"Exists:          {'yes' if home.exists() else 'no'}\n")
+    buf.write(f"Directory:       {'yes' if home.is_dir() else 'no'}\n")
+    if subprocess_home:
+        buf.write(f"Subprocess HOME: {display_home.rstrip('/')}/home\n")
+
+    buf.write("\nKey files:\n")
+    for name in _HOME_REPORT_FILES:
+        buf.write(f"  {name:<16} {_describe_file(home / name)}\n")
+
+    buf.write("\nKey directories:\n")
+    for name in _HOME_REPORT_DIRS:
+        buf.write(f"  {name + '/':<16} {_describe_dir(home / name)}\n")
+
+    buf.write("\nTop-level entries:\n")
+    buf.write("\n".join(_top_level_entry_lines(home)))
+    buf.write("\n")
+
+    buf.write("\nLogs:\n")
+    buf.write("\n".join(_log_status_lines()))
+    buf.write("\n")
+    return buf.getvalue()
+
+
+def run_debug_home(args):
+    """Print a local HERMES_HOME report."""
+    del args  # subcommand reserved for future flags
+    print(collect_home_report(), end="")
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +618,9 @@ def run_debug_delete(args):
 def run_debug(args):
     """Route debug subcommands."""
     subcmd = getattr(args, "debug_command", None)
-    if subcmd == "share":
+    if subcmd == "home":
+        run_debug_home(args)
+    elif subcmd == "share":
         run_debug_share(args)
     elif subcmd == "delete":
         run_debug_delete(args)
@@ -465,8 +629,12 @@ def run_debug(args):
         print("Usage: hermes debug <command>")
         print()
         print("Commands:")
+        print("  home     Print a local HERMES_HOME report")
         print("  share    Upload debug report to a paste service and print URL")
         print("  delete   Delete a previously uploaded paste")
+        print()
+        print("Options (home):")
+        print("  (none)")
         print()
         print("Options (share):")
         print("  --lines N    Number of log lines to include (default: 200)")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5404,13 +5404,15 @@ For more help on a command:
     # =========================================================================
     debug_parser = subparsers.add_parser(
         "debug",
-        help="Debug tools — upload logs and system info for support",
-        description="Debug utilities for Hermes Agent. Use 'hermes debug share' to "
-                    "upload a debug report (system info + recent logs) to a paste "
+        help="Debug tools — inspect HERMES_HOME or share logs for support",
+        description="Debug utilities for Hermes Agent. Use 'hermes debug home' to "
+                    "inspect the active HERMES_HOME locally, or 'hermes debug share' "
+                    "to upload a debug report (system info + recent logs) to a paste "
                     "service and get a shareable URL.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
+    hermes debug home               Print a local HERMES_HOME report
     hermes debug share              Upload debug report and print URL
     hermes debug share --lines 500  Include more log lines
     hermes debug share --expire 30  Keep paste for 30 days
@@ -5419,6 +5421,10 @@ Examples:
 """,
     )
     debug_sub = debug_parser.add_subparsers(dest="debug_command")
+    debug_sub.add_parser(
+        "home",
+        help="Print a structured local report of the active HERMES_HOME",
+    )
     share_parser = debug_sub.add_parser(
         "share",
         help="Upload debug report to a paste service and print a shareable URL",

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -276,6 +276,64 @@ class TestCollectDebugReport:
         assert "(file not found)" in report
 
 
+class TestCollectHomeReport:
+    """Test the local HERMES_HOME report builder."""
+
+    def test_report_includes_profile_safe_paths_and_entries(self, tmp_path, monkeypatch):
+        from hermes_cli.debug import collect_home_report
+
+        home = tmp_path / ".hermes" / "profiles" / "coder"
+        (home / "logs").mkdir(parents=True)
+        (home / "sessions").mkdir()
+        (home / "memories").mkdir()
+        (home / "cron").mkdir()
+        (home / "home").mkdir()
+
+        (home / "config.yaml").write_text("model:\n  default: anthropic/test\n")
+        (home / ".env").write_text("OPENAI_API_KEY=test\n")
+        (home / "auth.json").write_text('{"active_provider":"openrouter"}\n')
+        (home / "state.db").write_text("")
+        (home / "SOUL.md").write_text("# Soul\n")
+        (home / "logs" / "agent.log").write_text("agent started\n")
+        (home / "logs" / "errors.log").write_text("gateway error\n")
+        (home / "logs" / "gateway.log.1").write_text("gateway rotated\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        report = collect_home_report()
+
+        assert "Hermes Home Report" in report
+        assert "Display path:    ~/.hermes/profiles/coder" in report
+        assert f"Resolved path:   {home}" in report
+        assert "Exists:          yes" in report
+        assert "Subprocess HOME: ~/.hermes/profiles/coder/home" in report
+        assert "config.yaml" in report
+        assert "state.db" in report
+        assert "logs/" in report
+        assert "Top-level entries:" in report
+        assert "home               dir" in report
+        assert "config.yaml        file" in report
+        assert "agent.log" in report
+        assert "gateway.log.1" in report
+
+    def test_missing_home_is_reported_cleanly(self, tmp_path, monkeypatch):
+        from hermes_cli.debug import collect_home_report
+
+        home = tmp_path / ".hermes" / "profiles" / "missing"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        report = collect_home_report()
+
+        assert "Display path:    ~/.hermes/profiles/missing" in report
+        assert "Exists:          no" in report
+        assert "Directory:       no" in report
+        assert "(directory not found)" in report
+        assert "agent.log" in report
+        assert "missing" in report
+
+
 # ---------------------------------------------------------------------------
 # CLI entry point — run_debug_share
 # ---------------------------------------------------------------------------
@@ -429,6 +487,7 @@ class TestRunDebug:
 
         out = capsys.readouterr().out
         assert "hermes debug" in out
+        assert "home" in out
         assert "share" in out
         assert "delete" in out
 
@@ -444,6 +503,18 @@ class TestRunDebug:
         with patch("hermes_cli.dump.run_dump"):
             run_debug(args)
 
+    def test_home_subcommand_routes(self, hermes_home, capsys):
+        from hermes_cli.debug import run_debug
+
+        args = MagicMock()
+        args.debug_command = "home"
+
+        run_debug(args)
+
+        out = capsys.readouterr().out
+        assert "Hermes Home Report" in out
+        assert str(hermes_home) in out
+
 
 # ---------------------------------------------------------------------------
 # Argparse integration
@@ -451,8 +522,9 @@ class TestRunDebug:
 
 class TestArgparseIntegration:
     def test_module_imports_clean(self):
-        from hermes_cli.debug import run_debug, run_debug_share
+        from hermes_cli.debug import run_debug, run_debug_home, run_debug_share
         assert callable(run_debug)
+        assert callable(run_debug_home)
         assert callable(run_debug_share)
 
     def test_cmd_debug_dispatches(self):
@@ -461,6 +533,16 @@ class TestArgparseIntegration:
         args = MagicMock()
         args.debug_command = None
         cmd_debug(args)
+
+    def test_main_parses_debug_home(self, hermes_home, monkeypatch, capsys):
+        from hermes_cli import main as cli_main
+
+        monkeypatch.setattr(sys, "argv", ["hermes", "debug", "home"])
+        cli_main.main()
+
+        out = capsys.readouterr().out
+        assert "Hermes Home Report" in out
+        assert str(hermes_home) in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `hermes debug home` under the existing debug command tree
- print a structured local report for the active `HERMES_HOME`, including display path, resolved path, key files, key directories, top-level entries, and log status
- keep output profile-safe by using `get_hermes_home()` for reads and `display_hermes_home()` for user-facing paths
- add regression coverage for routing, help text, missing-home behavior, and profile-safe output

Closes #11343.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/hermes_cli/test_debug.py -q -o addopts=`