### PR TITLE
fix(agent): add Mistral reasoning_effort support

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6780,13 +6780,22 @@ class AIAgent:
             options["num_ctx"] = self._ollama_num_ctx
             extra_body["options"] = options
 
+        mistral_reasoning_effort = self._mistral_reasoning_effort()
+        if mistral_reasoning_effort is not None:
+            api_kwargs["reasoning_effort"] = mistral_reasoning_effort
+
         # Ollama / custom provider: pass think=false when reasoning is disabled.
         # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
         # field, so we use its native `think` parameter instead.
         # This prevents thinking-capable models (Qwen3, etc.) from generating
         # <think> blocks and producing empty-response errors when the user has
         # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        if (
+            self.provider == "custom"
+            and not self._is_direct_mistral_custom_provider()
+            and self.reasoning_config
+            and isinstance(self.reasoning_config, dict)
+        ):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
@@ -6838,6 +6847,37 @@ class AIAgent:
             "qwen/qwen3",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
+
+    def _is_direct_mistral_custom_provider(self) -> bool:
+        """Return True for custom providers that target Mistral's native API."""
+        return self.provider == "custom" and "api.mistral.ai" in self._base_url_lower
+
+    def _mistral_reasoning_effort(self) -> str | None:
+        """Map Hermes reasoning config onto Mistral's native root-level field.
+
+        Mistral's OpenAI-compatible chat endpoint accepts `reasoning_effort`
+        only for the adjustable `mistral-small-*` family. Magistral reasons
+        natively and other Mistral families do not support the field.
+        """
+        if not self._is_direct_mistral_custom_provider():
+            return None
+
+        model_name = (self.model or "").strip().lower().split("/")[-1]
+        if not model_name.startswith("mistral-small-"):
+            return None
+
+        if self.reasoning_config and isinstance(self.reasoning_config, dict):
+            if self.reasoning_config.get("enabled") is False:
+                return "none"
+            requested_effort = str(
+                self.reasoning_config.get("effort", "medium")
+            ).strip().lower()
+        else:
+            requested_effort = "medium"
+
+        if requested_effort == "none":
+            return "none"
+        return "high"
 
     def _github_models_reasoning_extra_body(self) -> dict | None:
         """Format reasoning payload for GitHub Models/OpenAI-compatible routes."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1024,6 +1024,40 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+    def test_custom_mistral_small_uses_root_reasoning_effort(self, agent):
+        agent.provider = "custom"
+        agent.base_url = "https://api.mistral.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "mistral-small-latest"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["reasoning_effort"] == "high"
+        assert "reasoning" not in kwargs.get("extra_body", {})
+        assert kwargs.get("extra_body", {}).get("think") is None
+
+    def test_custom_mistral_small_disabled_uses_root_reasoning_effort_none(self, agent):
+        agent.provider = "custom"
+        agent.base_url = "https://api.mistral.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "mistral-small-latest"
+        agent.reasoning_config = {"enabled": False}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["reasoning_effort"] == "none"
+        assert kwargs.get("extra_body", {}).get("think") is None
+
+    @pytest.mark.parametrize("model", ["magistral-small-latest", "mistral-large-latest"])
+    def test_custom_mistral_unsupported_families_omit_root_reasoning_effort(self, agent, model):
+        agent.provider = "custom"
+        agent.base_url = "https://api.mistral.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = model
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "reasoning_effort" not in kwargs
+        assert kwargs.get("extra_body", {}).get("think") is None
+
 
 
 class TestBuildAssistantMessage:


### PR DESCRIPTION
## Summary
- send a root-level `reasoning_effort` for direct `https://api.mistral.ai/v1` custom-provider requests when the selected model is `mistral-small-*`
- keep unsupported Mistral families such as `magistral-*` and `mistral-large-*` from receiving the field
- prevent the Ollama-specific `think=false` fallback from leaking onto direct Mistral requests
- add regression coverage for supported vs unsupported Mistral model families

Closes #11243.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/run_agent/test_run_agent.py -q -o addopts= -k "mistral or think_false or reasoning_config_default_openrouter or reasoning_not_sent_for_unsupported_openrouter_model or reasoning_sent_for_supported_openrouter_model or reasoning_sent_for_nous_route or reasoning_sent_for_copilot_gpt5 or reasoning_xhigh_normalized_for_copilot or reasoning_omitted_for_non_reasoning_copilot_model or non_custom_provider_unaffected"`