### PR TITLE
fix(skills): remove invalid llm-wiki related skill

### DIFF
--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   hermes:
     tags: [wiki, knowledge-base, research, notes, markdown, rag-alternative]
     category: research
-    related_skills: [obsidian, arxiv, agentic-research-ideas]
+    related_skills: [obsidian, arxiv]
 ---
 
 # Karpathy's LLM Wiki


### PR DESCRIPTION
## Summary
- remove the nonexistent `agentic-research-ideas` entry from the llm-wiki skill metadata
- keep only valid related skill references so `skill_view` exposes accurate metadata

## Testing
- python3 -m pytest -o addopts='' tests/tools/test_skills_tool.py -q