### PR TITLE
feat(gateway): add opt-in token usage footer to responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4016,6 +4016,45 @@ class GatewayRunner:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
+            # Append compact token usage footer if enabled
+            try:
+                from gateway.display_config import resolve_display_setting as _rds2
+                _show_usage_footer = _rds2(
+                    _load_gateway_config(),
+                    _platform_config_key(source.platform),
+                    "token_usage_footer",
+                    False,  # default off — opt-in to avoid surprising users
+                )
+            except Exception:
+                _show_usage_footer = False
+
+            if _show_usage_footer and response and not agent_result.get("failed"):
+                _input_toks = agent_result.get("input_tokens", 0) or 0
+                _output_toks = agent_result.get("output_tokens", 0) or 0
+                _model = agent_result.get("model", "") or ""
+                _cost_str = ""
+                try:
+                    from agent.usage_pricing import estimate_usage_cost, CanonicalUsage
+                    _cost = estimate_usage_cost(
+                        _model,
+                        CanonicalUsage(input_tokens=_input_toks, output_tokens=_output_toks),
+                    )
+                    if _cost.amount_usd is not None:
+                        _prefix = "~" if _cost.status == "estimated" else ""
+                        _cost_str = f" · {_prefix}${float(_cost.amount_usd):.4f}"
+                except Exception:
+                    pass
+                _model_short = _model.split("/")[-1] if "/" else _model
+
+                def _fmt(n):
+                    return f"{n/1000:.1f}k" if n >= 1000 else str(n)
+
+                response = (
+                    f"{response}\n\n"
+                    f"📊 {_fmt(_input_toks)} in · {_fmt(_output_toks)} out"
+                    f"{_cost_str} · `{_model_short}`"
+                )
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -549,6 +549,7 @@ DEFAULT_CONFIG = {
         "streaming": False,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
+        "token_usage_footer": False,  # Append compact token count after each gateway response
         "skin": "default",
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway

--- a/tests/gateway/test_token_usage_footer.py
+++ b/tests/gateway/test_token_usage_footer.py
@@ -1,0 +1,64 @@
+"""Tests for token usage footer formatting in gateway responses."""
+
+import pytest
+
+
+def _format_usage_footer(input_tokens, output_tokens, model, cost_amount=None, cost_status="estimated"):
+    """Extract the formatting logic from gateway/run.py for unit testing."""
+
+    def _fmt(n):
+        return f"{n/1000:.1f}k" if n >= 1000 else str(n)
+
+    _cost_str = ""
+    if cost_amount is not None:
+        _prefix = "~" if cost_status == "estimated" else ""
+        _cost_str = f" · {_prefix}${float(cost_amount):.4f}"
+
+    _model_short = model.split("/")[-1] if "/" else model
+
+    return (
+        f"📊 {_fmt(input_tokens)} in · {_fmt(output_tokens)} out"
+        f"{_cost_str} · `{_model_short}`"
+    )
+
+
+class TestUsageFooterFormatting:
+    def test_small_token_counts(self):
+        result = _format_usage_footer(500, 200, "anthropic/claude-sonnet-4")
+        assert "500 in" in result
+        assert "200 out" in result
+        assert "claude-sonnet-4" in result
+
+    def test_large_token_counts(self):
+        result = _format_usage_footer(12000, 5600, "openai/gpt-4o")
+        assert "12.0k in" in result
+        assert "5.6k out" in result
+        assert "gpt-4o" in result
+
+    def test_model_without_provider(self):
+        result = _format_usage_footer(100, 50, "claude-sonnet-4")
+        assert "claude-sonnet-4" in result
+
+    def test_estimated_cost(self):
+        result = _format_usage_footer(1000, 500, "claude", cost_amount=0.0234, cost_status="estimated")
+        assert "~$0.0234" in result
+
+    def test_exact_cost(self):
+        result = _format_usage_footer(1000, 500, "claude", cost_amount=0.0234, cost_status="cached")
+        assert "$0.0234" in result
+        assert "~$0.0234" not in result
+
+    def test_no_cost(self):
+        result = _format_usage_footer(100, 50, "claude")
+        assert "$" not in result
+
+    def test_zero_tokens(self):
+        result = _format_usage_footer(0, 0, "claude")
+        assert "0 in" in result
+        assert "0 out" in result
+
+
+class TestConfigDefault:
+    def test_token_usage_footer_default_false(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        assert DEFAULT_CONFIG["display"]["token_usage_footer"] is False


### PR DESCRIPTION
## What does this PR do?

Token data is tracked internally (`session_prompt_tokens`, `session_completion_tokens`) but only visible via explicit `/usage` command. Users report "token cost anxiety" — they want per-response visibility without asking.

**Changes:**
- New opt-in config: `display.token_usage_footer` (default: `false`)
- Appends compact footer after each gateway response: `📊 1.2k in · 456 out · ~$0.0234 · claude-sonnet-4`
- Gated by per-platform display config (same system as `show_reasoning`)
- Skipped on failed responses

## Type of Change

- [X] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py` — after reasoning display block, before `agent:end` hook: reads `display.token_usage_footer` config (via `resolve_display_setting`), formats compact footer with token counts + estimated cost + model name, appends to response
- `hermes_cli/config.py` — added `"token_usage_footer": False` to `display` defaults
- `tests/gateway/test_token_usage_footer.py` (new) — 8 tests covering formatting (small/large counts, cost/no-cost, model name extraction) and config default verification

## How to Test

1. `pytest tests/gateway/test_token_usage_footer.py -v` — all 8 tests pass
2. Set `display.token_usage_footer: true` in `~/.hermes/config.yaml`
3. Send a message via Telegram/Discord gateway — response should end with `📊 X in · Y out · $Z · model-name`
4. Disable config — footer disappears

## Checklist

- [X] I've read the Contributing Guide
- [X] Commit follows Conventional Commits: `feat(gateway): add opt-in token usage footer to responses`
- [X] No duplicate PRs found
- [X] PR contains only token usage footer changes
- [X] `pytest tests/gateway/test_token_usage_footer.py -v` — 8 passed
- [X] Tests added
- [X] Tested on: Ubuntu 24.04 (WSL2)
- [X] Config key added to `cli-config.yaml.example` — N/A (no example file for gateway display keys)