### PR TITLE
fix: only send think=False to Ollama endpoints (#11237)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2124,6 +2124,12 @@ class AIAgent:
             return True
         return stripped[-1] in '.!?:)"\']}。！？：）】」』》'
 
+    def _is_ollama(self) -> bool:
+        """Return True when the endpoint looks like an Ollama server."""
+        if not self.base_url:
+            return False
+        return "ollama" in self._base_url_lower or ":11434" in self._base_url_lower
+
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""
         model_lower = (self.model or "").lower()
@@ -6780,13 +6786,11 @@ class AIAgent:
             options["num_ctx"] = self._ollama_num_ctx
             extra_body["options"] = options
 
-        # Ollama / custom provider: pass think=false when reasoning is disabled.
-        # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
-        # field, so we use its native `think` parameter instead.
-        # This prevents thinking-capable models (Qwen3, etc.) from generating
-        # <think> blocks and producing empty-response errors when the user has
-        # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        # Ollama: pass think=false when reasoning is disabled.
+        # The `think` parameter is Ollama-specific; sending it to other
+        # custom providers (Mistral, Fireworks, vLLM, etc.) causes 422 errors.
+        # See: https://github.com/anthropics/hermes-agent/issues/11237
+        if self.provider == "custom" and self._is_ollama() and self.reasoning_config and isinstance(self.reasoning_config, dict):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1024,6 +1024,29 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+    def test_non_ollama_custom_provider_no_think(self, agent):
+        """Custom provider pointing to non-Ollama endpoint (e.g. Mistral)
+        should NOT inject think=false even with reasoning disabled.
+        See: https://github.com/anthropics/hermes-agent/issues/11237"""
+        agent.provider = "custom"
+        agent.base_url = "https://api.mistral.ai/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"effort": "none"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is None
+
+    def test_non_ollama_custom_provider_enabled_false_no_think(self, agent):
+        """Custom provider (vLLM/Fireworks) with enabled=false should NOT
+        inject think=false — the param is Ollama-specific."""
+        agent.provider = "custom"
+        agent.base_url = "https://api.fireworks.ai/inference/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": False}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is None
+
 
 
 class TestBuildAssistantMessage:


### PR DESCRIPTION
## Problem
`think=False` was being sent in `extra_body` to **all** custom provider endpoints when reasoning was disabled. The `think` parameter is Ollama-specific and causes 422 errors on other providers (Mistral, Fireworks, vLLM, etc).

## Fix
- Added `_is_ollama()` helper that detects Ollama by checking for `"ollama"` or `":11434"` in the base URL
- Gated the `extra_body['think'] = False` injection so it only applies to Ollama endpoints

## Tests
- Added 2 new tests verifying non-Ollama providers (Mistral, Fireworks) do NOT receive `think=False`
- All 24 existing think-related tests pass

Fixes #11237