### PR TITLE
feat: add claude-opus-4.7 to Nous Portal model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -76,6 +76,7 @@ def _codex_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "xiaomi/mimo-v2-pro",
+        "anthropic/claude-opus-4.7",
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
         "anthropic/claude-sonnet-4.5",


### PR DESCRIPTION
## Summary
Adds `anthropic/claude-opus-4.7` to the curated Nous Portal model list in `hermes_cli/models.py`, mirroring the OpenRouter list where 4.7 is already listed as the recommended model.

Surfaces the model in:
- `hermes model` picker (Nous Portal flow)
- Gateway `/model` command for Nous users

## Notes
- Context length (1M) is already covered by the existing `claude-opus-4.7` entry in `agent/model_metadata.py` DEFAULT_CONTEXT_LENGTHS, so fuzzy substring matching against `anthropic/claude-opus-4.7` resolves correctly.
- No test changes needed — tests don't enumerate the specific nous list contents.

## Test plan
```python
from hermes_cli.models import _PROVIDER_MODELS
assert 'anthropic/claude-opus-4.7' in _PROVIDER_MODELS['nous']
```