### PR TITLE
feat: add live Codex limits reporting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5455,6 +5455,8 @@ class HermesCLI:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "limits":
+            self._show_limits()
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "debug":
@@ -6401,6 +6403,17 @@ class HermesCLI:
             print("(._.) No API calls made yet in this session.")
             return
 
+        # ── Plan limits for ChatGPT/Codex (shown first when available) ──
+        try:
+            from hermes_cli.codex_limits import get_codex_limits_text, should_show_codex_limits
+
+            if should_show_codex_limits(getattr(agent, "provider", None), getattr(agent, "base_url", None)):
+                print()
+                print(get_codex_limits_text())
+                print()
+        except Exception:
+            pass
+
         # ── Rate limits (shown first when available) ────────────────
         rl_state = agent.get_rate_limit_state()
         if rl_state and rl_state.has_data:
@@ -6474,6 +6487,19 @@ class HermesCLI:
             logging.getLogger().setLevel(logging.INFO)
             for quiet_logger in ('tools', 'run_agent', 'trajectory_compressor', 'cron', 'hermes_cli'):
                 logging.getLogger(quiet_logger).setLevel(logging.ERROR)
+
+    def _show_limits(self):
+        """Show current ChatGPT/Codex plan limits from the live backend."""
+        try:
+            from hermes_cli.codex_limits import CodexLimitsError, get_codex_limits_text
+
+            print()
+            print(get_codex_limits_text())
+            print()
+        except CodexLimitsError as exc:
+            print(f"(._.) {exc}")
+        except Exception as exc:
+            print(f"(._.) Failed to fetch Codex limits: {exc}")
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2753,6 +2753,9 @@ class GatewayRunner:
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "limits":
+            return await self._handle_limits_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
@@ -3817,6 +3820,7 @@ class GatewayRunner:
             error_type = type(e).__name__
             error_detail = str(e)[:300] if str(e) else "no details available"
             status_hint = ""
+            action_hint = "Try again or use /reset to start a fresh session."
             status_code = getattr(e, "status_code", None)
             _hist_len = len(history) if 'history' in locals() else 0
             if status_code == 401:
@@ -3831,13 +3835,11 @@ class GatewayRunner:
                 except Exception:
                     pass
                 if _err_json.get("type") == "usage_limit_reached":
-                    _resets_in = _err_json.get("resets_in_seconds")
-                    if _resets_in and _resets_in > 0:
-                        import math
-                        _hours = math.ceil(_resets_in / 3600)
-                        status_hint = f" Your plan's usage limit has been reached. It resets in ~{_hours}h."
-                    else:
-                        status_hint = " Your plan's usage limit has been reached. Please wait until it resets."
+                    _agent_obj = locals().get("agent")
+                    status_hint, action_hint = self._format_usage_limit_status_hint(
+                        error_payload=_err_json,
+                        agent=_agent_obj,
+                    )
                 else:
                     status_hint = " You are being rate-limited. Please wait a moment and try again."
             elif status_code == 529:
@@ -3858,7 +3860,7 @@ class GatewayRunner:
                 f"Sorry, I encountered an error ({error_type}).\n"
                 f"{error_detail}\n"
                 f"{status_hint}"
-                "Try again or use /reset to start a fresh session."
+                f"{action_hint}"
             )
         finally:
             # Restore session context variables to their pre-handler state
@@ -6161,6 +6163,41 @@ class GatewayRunner:
             f"Use `/resume` to switch back to the original."
         )
 
+    def _format_usage_limit_status_hint(self, *, error_payload: dict | None = None, agent=None) -> tuple[str, str]:
+        """Build a clearer message for plan usage exhaustion, including live limits when available."""
+        payload = error_payload if isinstance(error_payload, dict) else {}
+        resets_in = payload.get("resets_in_seconds")
+        status_hint = " Your plan limit has been reached."
+        if resets_in:
+            try:
+                import math
+                hours = math.ceil(float(resets_in) / 3600)
+                if hours > 0:
+                    status_hint += f" It resets in about {hours}h."
+            except Exception:
+                pass
+        else:
+            status_hint += " Wait for the next reset window."
+
+        limits_text = ""
+        try:
+            from hermes_cli.codex_limits import get_codex_limits_text, should_show_codex_limits
+
+            provider = getattr(agent, "provider", None) if agent is not None else None
+            base_url = getattr(agent, "base_url", None) if agent is not None else None
+            if should_show_codex_limits(provider, base_url):
+                limits_text = get_codex_limits_text().strip()
+        except Exception:
+            limits_text = ""
+
+        if limits_text:
+            status_hint += f"\n\n{limits_text}\n\n"
+        else:
+            status_hint += "\n\nRun /limits to see the current limit windows.\n\n"
+
+        action_hint = "Wait for one of the windows above to reset, or run /limits again later."
+        return status_hint, action_hint
+
     async def _handle_usage_command(self, event: MessageEvent) -> str:
         """Handle /usage command -- show token usage for the current session.
 
@@ -6184,6 +6221,16 @@ class GatewayRunner:
 
         if agent and hasattr(agent, "session_total_tokens") and agent.session_api_calls > 0:
             lines = []
+
+            # Plan limits for ChatGPT/Codex (shown first when available)
+            try:
+                from hermes_cli.codex_limits import get_codex_limits_text, should_show_codex_limits
+
+                if should_show_codex_limits(getattr(agent, "provider", None), getattr(agent, "base_url", None)):
+                    lines.append(get_codex_limits_text())
+                    lines.append("")
+            except Exception:
+                pass
 
             # Rate limits (when available from provider headers)
             rl_state = agent.get_rate_limit_state()
@@ -6255,6 +6302,18 @@ class GatewayRunner:
                 f"_(Detailed usage available after the first agent response)_"
             )
         return "No usage data available for this session."
+
+    async def _handle_limits_command(self, event: MessageEvent) -> str:
+        """Handle /limits command -- show live ChatGPT/Codex plan limits."""
+        try:
+            from hermes_cli.codex_limits import CodexLimitsError, get_codex_limits_text
+
+            return get_codex_limits_text()
+        except CodexLimitsError as exc:
+            return str(exc)
+        except Exception as exc:
+            logger.error("Limits command error: %s", exc, exc_info=True)
+            return f"Could not fetch Codex limits: {exc}"
 
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""

--- a/hermes_cli/codex_limits.py
+++ b/hermes_cli/codex_limits.py
@@ -1,0 +1,213 @@
+"""Fetch and format ChatGPT/Codex plan usage limits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, List, Optional
+
+import httpx
+
+from hermes_cli.auth import AuthError, resolve_codex_runtime_credentials
+
+_LIMITS_URL = "https://chatgpt.com/backend-api/wham/usage"
+
+
+@dataclass
+class LimitWindow:
+    label: str
+    remaining_percent: int
+    reset_after_seconds: int
+    reset_at: Optional[int] = None
+    window_seconds: int = 0
+
+
+class CodexLimitsError(RuntimeError):
+    """Raised when Codex limits cannot be fetched or parsed."""
+
+
+def fetch_codex_limits_payload() -> dict[str, Any]:
+    """Fetch raw plan usage data from the ChatGPT/Codex backend."""
+    try:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+    except AuthError as exc:
+        raise CodexLimitsError(str(exc)) from exc
+
+    access_token = str(creds.get("api_key") or "").strip()
+    if not access_token:
+        raise CodexLimitsError("Could not resolve a Codex access token.")
+
+    try:
+        response = httpx.get(
+            _LIMITS_URL,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Accept": "application/json",
+                "User-Agent": "Hermes-Agent/1.0",
+            },
+            timeout=15,
+        )
+    except Exception as exc:
+        raise CodexLimitsError(f"Could not fetch Codex limits: {exc}") from exc
+
+    if response.status_code == 401:
+        raise CodexLimitsError("Codex OAuth is expired or invalid. Run hermes auth to re-authenticate.")
+    if response.status_code == 403:
+        raise CodexLimitsError("Access to the Codex limits endpoint is forbidden for this account.")
+    if response.status_code == 404:
+        raise CodexLimitsError("The Codex limits endpoint was not found. OpenAI may have changed the API again.")
+    if response.status_code != 200:
+        detail = response.text.strip()
+        if len(detail) > 300:
+            detail = detail[:300] + "…"
+        raise CodexLimitsError(
+            f"Codex limits endpoint returned HTTP {response.status_code}: {detail or 'empty response body'}"
+        )
+
+    try:
+        data = response.json()
+    except Exception as exc:
+        raise CodexLimitsError(f"Codex limits endpoint returned a non-JSON response: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise CodexLimitsError("Codex limits endpoint returned an unexpected response format.")
+    return data
+
+
+def _window_label(window_seconds: Any) -> str:
+    try:
+        seconds = int(window_seconds)
+    except (TypeError, ValueError):
+        return "Unknown window"
+
+    mapping = {
+        60: "1 minute",
+        300: "5 minutes",
+        3600: "1 hour",
+        18000: "5 hours",
+        21600: "6 hours",
+        43200: "12 hours",
+        86400: "1 day",
+        604800: "Weekly",
+        2592000: "Monthly",
+    }
+    if seconds in mapping:
+        return mapping[seconds]
+    if seconds % 86400 == 0 and seconds >= 86400:
+        days = seconds // 86400
+        return f"{days} days" if days != 1 else "1 day"
+    if seconds % 3600 == 0 and seconds >= 3600:
+        hours = seconds // 3600
+        return f"{hours} hours" if hours != 1 else "1 hour"
+    return f"{seconds} seconds"
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_window(raw: Any, *, fallback_label: Optional[str] = None) -> Optional[LimitWindow]:
+    if not isinstance(raw, dict):
+        return None
+    limit_window_seconds = _safe_int(raw.get("limit_window_seconds"))
+    used_percent = max(0, min(100, _safe_int(raw.get("used_percent"))))
+    remaining_percent = max(0, 100 - used_percent)
+    reset_after_seconds = max(0, _safe_int(raw.get("reset_after_seconds")))
+    reset_at = raw.get("reset_at")
+    reset_at_int = _safe_int(reset_at, 0) or None
+    label = fallback_label or _window_label(limit_window_seconds)
+    return LimitWindow(
+        label=label,
+        remaining_percent=remaining_percent,
+        reset_after_seconds=reset_after_seconds,
+        reset_at=reset_at_int,
+        window_seconds=limit_window_seconds,
+    )
+
+
+def _extract_named_windows(limit_block: Any, *, name_prefix: str = "") -> List[LimitWindow]:
+    if not isinstance(limit_block, dict):
+        return []
+
+    windows: List[LimitWindow] = []
+    prefix = f"{name_prefix}: " if name_prefix else ""
+    for key in ("primary_window", "secondary_window"):
+        window = _normalize_window(limit_block.get(key))
+        if window is not None:
+            if prefix:
+                window.label = prefix + window.label
+            windows.append(window)
+    return windows
+
+
+def extract_codex_limit_windows(payload: dict[str, Any]) -> List[LimitWindow]:
+    """Extract the limit windows that actually exist in the API response."""
+    windows: List[LimitWindow] = []
+    windows.extend(_extract_named_windows(payload.get("rate_limit")))
+
+    code_review = payload.get("code_review_rate_limit")
+    if isinstance(code_review, dict):
+        windows.extend(_extract_named_windows(code_review, name_prefix="Code review"))
+
+    additional = payload.get("additional_rate_limits")
+    if isinstance(additional, list):
+        for item in additional:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or item.get("label") or item.get("type") or "Additional limit").strip()
+            windows.extend(_extract_named_windows(item, name_prefix=name))
+    elif isinstance(additional, dict):
+        for key, value in additional.items():
+            title = str(key).strip() or "Additional limit"
+            windows.extend(_extract_named_windows(value, name_prefix=title))
+
+    deduped: List[LimitWindow] = []
+    seen: set[tuple[str, int, int, Optional[int], int]] = set()
+    for window in windows:
+        sig = (window.label, window.remaining_percent, window.reset_after_seconds, window.reset_at, window.window_seconds)
+        if sig not in seen:
+            deduped.append(window)
+            seen.add(sig)
+    return deduped
+
+
+def _format_duration_hms(total_seconds: int) -> str:
+    seconds = max(0, int(total_seconds))
+    hours, remainder = divmod(seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    return f"{hours}:{minutes:02d}:{secs:02d}"
+
+
+def format_codex_limits(payload: dict[str, Any]) -> str:
+    """Render the limits response in concise English text."""
+    windows = extract_codex_limit_windows(payload)
+    if not windows:
+        return "Limits:\nNo limit windows were found in the API response."
+
+    lines = ["Limits:"]
+    for index, window in enumerate(windows):
+        lines.append(f"{window.label}: {window.remaining_percent}% remaining.")
+        if window.reset_at and window.window_seconds >= 604800:
+            dt = datetime.fromtimestamp(window.reset_at, tz=timezone.utc)
+            lines.append(f"Reset {dt.strftime('%b %d at %H:%M GMT')}")
+        else:
+            lines.append(f"Resets in {_format_duration_hms(window.reset_after_seconds)}.")
+        if index != len(windows) - 1:
+            lines.append("")
+    return "\n".join(lines)
+
+
+def should_show_codex_limits(provider: Any = None, base_url: Any = None) -> bool:
+    """Return True when the current session is using the ChatGPT/Codex backend."""
+    provider_text = str(provider or "").strip().lower()
+    base_url_text = str(base_url or "").strip().lower()
+    return provider_text == "openai-codex" or "chatgpt.com/backend-api/codex" in base_url_text
+
+
+def get_codex_limits_text() -> str:
+    """Fetch and format the current Codex limits in one call."""
+    payload = fetch_codex_limits_payload()
+    return format_codex_limits(payload)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -150,6 +150,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("limits", "Show current ChatGPT/Codex plan limits", "Info"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -286,6 +286,29 @@ class TestCLIUsageReport:
         assert "Session duration:" in output
         assert "Compressions:" in output
 
+    def test_show_usage_includes_codex_plan_limits(self, capsys):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.4"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.base_url = "https://chatgpt.com/backend-api/codex"
+        cli_obj.verbose = False
+
+        with patch("hermes_cli.codex_limits.get_codex_limits_text", return_value="Limits:\n5 hours: 32% remaining."), \
+             patch("hermes_cli.codex_limits.should_show_codex_limits", return_value=True):
+            cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Limits:" in output
+        assert "5 hours: 32% remaining." in output
+        assert "Session Token Usage" in output
+
     def test_show_usage_marks_unknown_pricing(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(model="local/my-custom-model"),

--- a/tests/gateway/test_limits_command.py
+++ b/tests/gateway/test_limits_command.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_handle_limits_command_returns_live_limits_text():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    event = MagicMock()
+
+    with patch("hermes_cli.codex_limits.get_codex_limits_text", return_value="Limits:\n5 hours: 35% remaining."):
+        result = await runner._handle_limits_command(event)
+
+    assert result == "Limits:\n5 hours: 35% remaining."
+
+
+@pytest.mark.asyncio
+async def test_handle_limits_command_returns_user_friendly_error():
+    from gateway.run import GatewayRunner
+    from hermes_cli.codex_limits import CodexLimitsError
+
+    runner = object.__new__(GatewayRunner)
+    event = MagicMock()
+
+    with patch("hermes_cli.codex_limits.get_codex_limits_text", side_effect=CodexLimitsError("no token")):
+        result = await runner._handle_limits_command(event)
+
+    assert result == "no token"

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -93,6 +93,22 @@ class TestUsageCachedAgent:
         assert "Compressions: 1" in result
 
     @pytest.mark.asyncio
+    async def test_codex_usage_includes_live_plan_limits(self):
+        agent = _make_mock_agent(provider="openai-codex")
+        runner = _make_runner(SK, cached_agent=agent)
+        event = MagicMock()
+
+        with patch("agent.rate_limit_tracker.format_rate_limit_compact", return_value="RPM: 50/60"), \
+             patch("agent.usage_pricing.estimate_usage_cost") as mock_cost, \
+             patch("hermes_cli.codex_limits.get_codex_limits_text", return_value="Limits:\n5 hours: 32% remaining."), \
+             patch("hermes_cli.codex_limits.should_show_codex_limits", return_value=True):
+            mock_cost.return_value = MagicMock(amount_usd=None, status="included")
+            result = await runner._handle_usage_command(event)
+
+        assert result.startswith("Limits:\n5 hours: 32% remaining.")
+        assert "Session Token Usage" in result
+
+    @pytest.mark.asyncio
     async def test_running_agent_preferred_over_cache(self):
         """When agent is in both dicts, the running one wins."""
         running = _make_mock_agent(session_api_calls=10, session_total_tokens=80_000)

--- a/tests/gateway/test_usage_limit_hint.py
+++ b/tests/gateway/test_usage_limit_hint.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    return object.__new__(GatewayRunner)
+
+
+def test_usage_limit_hint_includes_live_limits_for_codex():
+    runner = _make_runner()
+    agent = SimpleNamespace(provider="openai-codex", base_url="https://chatgpt.com/backend-api/codex")
+
+    with patch("hermes_cli.codex_limits.should_show_codex_limits", return_value=True), \
+         patch("hermes_cli.codex_limits.get_codex_limits_text", return_value="Limits:\n5 hours: 0% remaining.\nResets in 0:12:00."):
+        status_hint, action_hint = runner._format_usage_limit_status_hint(
+            error_payload={"type": "usage_limit_reached", "resets_in_seconds": 700},
+            agent=agent,
+        )
+
+    assert "Your plan limit has been reached." in status_hint
+    assert "It resets in about 1h." in status_hint
+    assert "Limits:" in status_hint
+    assert action_hint == "Wait for one of the windows above to reset, or run /limits again later."
+
+
+def test_usage_limit_hint_falls_back_to_limits_command_when_live_limits_unavailable():
+    runner = _make_runner()
+
+    with patch("hermes_cli.codex_limits.should_show_codex_limits", return_value=False):
+        status_hint, action_hint = runner._format_usage_limit_status_hint(
+            error_payload={"type": "usage_limit_reached"},
+            agent=None,
+        )
+
+    assert "Wait for the next reset window." in status_hint
+    assert "Run /limits" in status_hint
+    assert action_hint == "Wait for one of the windows above to reset, or run /limits again later."

--- a/tests/hermes_cli/test_codex_limits.py
+++ b/tests/hermes_cli/test_codex_limits.py
@@ -1,0 +1,83 @@
+from hermes_cli.codex_limits import (
+    extract_codex_limit_windows,
+    format_codex_limits,
+    should_show_codex_limits,
+)
+
+
+def test_format_codex_limits_with_primary_and_weekly_windows():
+    payload = {
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 64,
+                "limit_window_seconds": 18000,
+                "reset_after_seconds": 14730,
+                "reset_at": 1776413408,
+            },
+            "secondary_window": {
+                "used_percent": 15,
+                "limit_window_seconds": 604800,
+                "reset_after_seconds": 568655,
+                "reset_at": 1776967333,
+            },
+        },
+        "code_review_rate_limit": None,
+        "additional_rate_limits": None,
+    }
+
+    result = format_codex_limits(payload)
+
+    assert result == (
+        "Limits:\n"
+        "5 hours: 36% remaining.\n"
+        "Resets in 4:05:30.\n"
+        "\n"
+        "Weekly: 85% remaining.\n"
+        "Reset Apr 23 at 18:02 GMT"
+    )
+
+
+def test_extract_codex_limits_keeps_daily_and_named_additional_windows():
+    payload = {
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 10,
+                "limit_window_seconds": 18000,
+                "reset_after_seconds": 10,
+            },
+            "secondary_window": {
+                "used_percent": 58,
+                "limit_window_seconds": 86400,
+                "reset_after_seconds": 66163,
+                "reset_at": 1776475200,
+            },
+        },
+        "additional_rate_limits": [
+            {
+                "name": "Uploads",
+                "primary_window": {
+                    "used_percent": 25,
+                    "limit_window_seconds": 3600,
+                    "reset_after_seconds": 1200,
+                },
+            }
+        ],
+    }
+
+    windows = extract_codex_limit_windows(payload)
+    labels = [window.label for window in windows]
+    remaining = [window.remaining_percent for window in windows]
+
+    assert labels == ["5 hours", "1 day", "Uploads: 1 hour"]
+    assert remaining == [90, 42, 75]
+
+    result = format_codex_limits(payload)
+    assert "1 day: 42% remaining." in result
+    assert "Resets in 18:22:43." in result
+    assert "Uploads: 1 hour: 75% remaining." in result
+
+
+def test_should_show_codex_limits_for_provider_or_base_url():
+    assert should_show_codex_limits("openai-codex", None) is True
+    assert should_show_codex_limits(None, "https://chatgpt.com/backend-api/codex") is True
+    assert should_show_codex_limits("openrouter", "https://openrouter.ai/api/v1") is False


### PR DESCRIPTION
## Summary
- add a native /limits command for live ChatGPT/Codex plan windows
- include live plan-window output in /usage for Codex sessions
- show clearer usage-limit exhaustion messages with live limits when available
- standardize all new limit text in English

## Why this stays a native command
A bundled/system skill would be shadowed by the built-in /limits slash command in both CLI and gateway dispatch. This feature is deterministic and tool-backed, so a native command is the better fit than a skill.

## Test Plan
- source venv/bin/activate && python -m pytest tests/hermes_cli/test_codex_limits.py tests/gateway/test_limits_command.py tests/gateway/test_usage_limit_hint.py tests/gateway/test_usage_command.py tests/cli/test_cli_status_bar.py -q