### PR TITLE
fix(feishu): register missing SDK event handlers (bot_p2p_chat_entered + message_recalled)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1226,6 +1226,8 @@ class FeishuAdapter(BasePlatformAdapter):
             .register_p2_card_action_trigger(self._on_card_action_trigger)
             .register_p2_im_chat_member_bot_added_v1(self._on_bot_added_to_chat)
             .register_p2_im_chat_member_bot_deleted_v1(self._on_bot_removed_from_chat)
+            .register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(self._on_p2p_chat_entered)
+            .register_p2_im_message_recalled_v1(self._on_message_recalled)
             .build()
         )
 
@@ -1956,6 +1958,12 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = str(getattr(event, "chat_id", "") or "")
         logger.info("[Feishu] Bot removed from chat: %s", chat_id)
         self._chat_info_cache.pop(chat_id, None)
+
+    def _on_p2p_chat_entered(self, data: Any) -> None:
+        logger.debug("[Feishu] User entered P2P chat with bot")
+
+    def _on_message_recalled(self, data: Any) -> None:
+        logger.debug("[Feishu] Message recalled by user")
 
     def _on_reaction_event(self, event_type: str, data: Any) -> None:
         """Route user reactions on bot messages as synthetic text events."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -54,6 +54,7 @@ AUTHOR_MAP = {
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",
     "milkoor@users.noreply.github.com": "milkoor",
+    "xuerui911@gmail.com": "Fatty911",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",
     "77628552+raulvidis@users.noreply.github.com": "raulvidis",
     "145567217+Aum08Desai@users.noreply.github.com": "Aum08Desai",

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -639,6 +639,14 @@ class TestAdapterBehavior(unittest.TestCase):
                 calls.append("bot_deleted")
                 return self
 
+            def register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(self, _handler):
+                calls.append("p2p_chat_entered")
+                return self
+
+            def register_p2_im_message_recalled_v1(self, _handler):
+                calls.append("message_recalled")
+                return self
+
             def build(self):
                 calls.append("build")
                 return "handler"
@@ -664,6 +672,8 @@ class TestAdapterBehavior(unittest.TestCase):
                 "card_action",
                 "bot_added",
                 "bot_deleted",
+                "p2p_chat_entered",
+                "message_recalled",
                 "build",
             ],
         )


### PR DESCRIPTION
## Summary

The lark-oapi SDK's `EventDispatcherHandler` raises `EventException("processor not found, type: ...")` when it receives an event whose type isn't registered. In WebSocket mode these exceptions are caught by the SDK, logged as ERROR, and returned to Feishu as HTTP 500 responses on the event frame. Persistent failures of this kind have been observed to eventually destabilize the WS connection.

Two common Feishu events were unregistered on `main`:

- `im.chat.access_event.bot_p2p_chat_entered_v1` — fires when a user opens a P2P chat with the bot
- `im.message.recalled_v1` — fires when a user unsends/recalls a message

Both have been visible in user logs (e.g. issue #6889 referenced this exact event type in the WARNING/ERROR stream).

## Fix

Register no-op debug-logged handlers for both events so the SDK dispatcher resolves them silently.

```python
.register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(self._on_p2p_chat_entered)
.register_p2_im_message_recalled_v1(self._on_message_recalled)
```

```python
def _on_p2p_chat_entered(self, data): logger.debug("[Feishu] User entered P2P chat with bot")
def _on_message_recalled(self, data): logger.debug("[Feishu] Message recalled by user")
```

No behavior change beyond silencing the spurious ERROR logs and HTTP 500 responses on these event frames.

## Attribution

Cherry-picked from #10712 by @Fatty911 — preserved authorship via plain `git cherry-pick` (no `--no-commit`). Follow-up commit by us extends the existing `test_build_event_handler_registers_reaction_and_card_processors` test fixture to cover the two new registrations and adds Fatty911 to the AUTHOR_MAP.

## Test plan

### Unit
- `test_build_event_handler_registers_reaction_and_card_processors` updated and passing
- All 111 `tests/gateway/test_feishu.py` tests pass

### E2E (real lark-oapi SDK, no mocks on the dispatcher)
1. Built the real `EventDispatcherHandler` via `adapter._build_event_handler()`
2. Verified both processor keys are registered in `handler._processorMap`:
   - `p2.im.chat.access_event.bot_p2p_chat_entered_v1` ✓
   - `p2.im.message.recalled_v1` ✓
3. Dispatched real-shape JSON payloads via `handler.do_without_validation(...)`
4. Confirmed both routed to our handlers without raising
5. Confirmed an unregistered bogus event type STILL raises (proving the fix targets these two events specifically without masking other unhandled events)

This caught a real subtlety — the SDK's builder method `register_p2_im_chat_access_event_bot_p2p_chat_entered_v1` registers under the key `p2.im.chat.access_event.bot_p2p_chat_entered_v1` (with a dot between `chat` and `access_event`), and that's exactly the format Feishu uses. Mock-only tests can't verify this end-to-end.

## Merge note

Use `--rebase` (not squash) to preserve Fatty911's per-commit authorship on the salvaged commit.

Closes #10712