### PR TITLE
fix(model_switch): read models dict keys from custom_providers entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1084,9 +1084,17 @@ def list_authenticated_providers(
                     "api_url": api_url,
                     "models": [],
                 }
+            # Read default model (single string field)
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+
+            # Read models dict ({model_name: {context_length, ...}}) — add each key
+            cfg_models = entry.get("models", {})
+            if isinstance(cfg_models, dict):
+                for m in cfg_models:
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:


### PR DESCRIPTION
## Summary

When building provider picker data from `custom_providers` config entries, `list_authenticated_providers()` in `hermes_cli/model_switch.py` only reads the top-level `entry.model` field (single string) and completely ignores `entry.models` (dict of `{model_name: {context_length, ...}}`). This causes the `/model` picker to show only 1 model even when multiple models are configured under a named custom provider.

**Before:** only `gpt-5.4` shown, even though `models: {gpt-5.4-mini: {}, gpt-5.1-codex-mini: {}}` was configured.

**After:** all model keys from the `models` dict are correctly listed.

## Fix

In the Section 4 block (custom_providers iteration), iterate `entry.get("models", {})` and add each dict key to the models list, deduplicating against the already-added `model` field.

## References

- Fixes #8216
- Fixes #8758