### PR TITLE
fix: enforce Discord 8000-char limit on /skill command group

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -583,6 +583,90 @@ def discord_skill_commands(
     )
 
 
+# ── Discord command group size enforcement ─────────────────────────────
+# Discord imposes an 8000-character limit on the serialized JSON payload
+# of a single command group.  When the /skill group grows too large we
+# must shrink it — first by truncating descriptions, then by dropping
+# commands from the largest categories.
+
+_DISCORD_MAX_GROUP_SIZE = 8000
+
+# Conservative per-element overhead estimates (JSON keys, braces, option
+# metadata for the ``args`` parameter each handler declares).
+_CMD_FIXED_OVERHEAD = 155  # name/description/type/options envelope
+_GROUP_FIXED_OVERHEAD = 100  # category group envelope
+_TOP_GROUP_OVERHEAD = 100  # /skill group envelope
+
+
+def _estimate_group_size(
+    categories: dict[str, list[tuple[str, str, str]]],
+    uncategorized: list[tuple[str, str, str]],
+) -> int:
+    """Return an *estimated* JSON payload size for the ``/skill`` command group."""
+    size = _TOP_GROUP_OVERHEAD
+    for cat, entries in categories.items():
+        cat_desc = f"{cat.replace('-', ' ').title()} skills"
+        size += _GROUP_FIXED_OVERHEAD + len(cat) + len(cat_desc)
+        for name, desc, _key in entries:
+            size += _CMD_FIXED_OVERHEAD + len(name) + len(desc)
+    for name, desc, _key in uncategorized:
+        size += _CMD_FIXED_OVERHEAD + len(name) + len(desc)
+    return size
+
+
+def _enforce_command_group_size(
+    categories: dict[str, list[tuple[str, str, str]]],
+    uncategorized: list[tuple[str, str, str]],
+    max_size: int = _DISCORD_MAX_GROUP_SIZE,
+) -> tuple[dict[str, list[tuple[str, str, str]]], list[tuple[str, str, str]], int]:
+    """Shrink the skill group to fit within *max_size* characters.
+
+    Strategy (applied in order until the group fits):
+    1. Truncate all descriptions to 60 chars.
+    2. Truncate all descriptions to 40 chars.
+    3. Drop commands from the largest categories until it fits.
+
+    Returns ``(categories, uncategorized, hidden_count)``.
+    """
+    hidden = 0
+
+    # Phase 1 & 2: progressively shorten descriptions
+    for limit in (60, 40):
+        if _estimate_group_size(categories, uncategorized) <= max_size:
+            break
+
+        def _trunc(entries: list[tuple[str, str, str]]) -> list[tuple[str, str, str]]:
+            out = []
+            for n, d, k in entries:
+                if len(d) > limit:
+                    d = d[: limit - 3] + "..."
+                out.append((n, d, k))
+            return out
+
+        categories = {cat: _trunc(entries) for cat, entries in categories.items()}
+        uncategorized = _trunc(uncategorized)
+
+    # Phase 3: drop commands from largest categories
+    while _estimate_group_size(categories, uncategorized) > max_size:
+        if not categories and not uncategorized:
+            break
+        # Find the largest category
+        largest_cat = max(categories, key=lambda c: len(categories[c]), default=None)
+        largest_len = len(categories.get(largest_cat, [])) if largest_cat else 0
+        if largest_cat and largest_len > 0:
+            categories[largest_cat] = categories[largest_cat][:-1]
+            hidden += 1
+            if not categories[largest_cat]:
+                del categories[largest_cat]
+        elif uncategorized:
+            uncategorized = uncategorized[:-1]
+            hidden += 1
+        else:
+            break
+
+    return categories, uncategorized, hidden
+
+
 def discord_skill_commands_by_category(
     reserved_names: set[str],
 ) -> tuple[dict[str, list[tuple[str, str, str]]], list[tuple[str, str, str]], int]:
@@ -689,6 +773,12 @@ def discord_skill_commands_by_category(
     if len(uncategorized) > remaining_slots:
         hidden += len(uncategorized) - remaining_slots
         uncategorized = uncategorized[:remaining_slots]
+
+    # Enforce Discord 8000-char command group size limit --------------------
+    trimmed_categories, uncategorized, extra_hidden = _enforce_command_group_size(
+        trimmed_categories, uncategorized,
+    )
+    hidden += extra_hidden
 
     return trimmed_categories, uncategorized, hidden
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -672,3 +672,93 @@ def test_register_skill_group_handler_dispatches_command(adapter):
     # The callback name should reflect the skill
     assert "gif_search" in gif_cmd.callback.__name__
 
+
+# ------------------------------------------------------------------
+# Size limit enforcement (_enforce_command_group_size)
+# ------------------------------------------------------------------
+
+
+class TestEnforceCommandGroupSize:
+    """Tests for the Discord 8000-char command group size limit."""
+
+    def _make_entries(self, n, desc_len=80):
+        """Create *n* skill tuples with descriptions of *desc_len* chars."""
+        return [
+            (f"skill-{i}", "d" * desc_len, f"/skill-{i}")
+            for i in range(n)
+        ]
+
+    def test_small_group_unchanged(self):
+        """Groups well under the limit should pass through unchanged."""
+        from hermes_cli.commands import _enforce_command_group_size
+
+        cats = {"cat-a": self._make_entries(3, desc_len=50)}
+        uncat = self._make_entries(2, desc_len=50)
+        new_cats, new_uncat, hidden = _enforce_command_group_size(
+            cats, uncat, max_size=8000,
+        )
+        assert hidden == 0
+        assert len(new_cats["cat-a"]) == 3
+        assert len(new_uncat) == 2
+        # Descriptions should be untouched
+        assert new_cats["cat-a"][0][1] == "d" * 50
+
+    def test_descriptions_truncated_when_over_limit(self):
+        """Descriptions should be progressively shortened to fit."""
+        from hermes_cli.commands import _enforce_command_group_size, _estimate_group_size
+
+        cats = {f"cat-{c}": self._make_entries(10, desc_len=100) for c in range(5)}
+        uncat = []
+        # Ensure it's actually over the limit
+        assert _estimate_group_size(cats, uncat) > 4000
+
+        new_cats, new_uncat, hidden = _enforce_command_group_size(
+            cats, uncat, max_size=4000,
+        )
+        # All descriptions should now be ≤60 chars (or ≤40 if needed)
+        for entries in new_cats.values():
+            for _name, desc, _key in entries:
+                assert len(desc) <= 60
+
+    def test_commands_dropped_when_truncation_insufficient(self):
+        """Commands should be dropped from largest category if truncation isn't enough."""
+        from hermes_cli.commands import _enforce_command_group_size
+
+        # Create a very tight limit that can't fit everything even with short descs
+        cats = {"big": self._make_entries(20, desc_len=40)}
+        uncat = []
+        new_cats, new_uncat, hidden = _enforce_command_group_size(
+            cats, uncat, max_size=1500,
+        )
+        assert hidden > 0
+        total_remaining = sum(len(v) for v in new_cats.values()) + len(new_uncat)
+        assert total_remaining < 20
+
+    def test_estimate_group_size_basic(self):
+        """_estimate_group_size should return a positive integer."""
+        from hermes_cli.commands import _estimate_group_size
+
+        cats = {"media": [("gif-search", "Search for GIFs", "/gif-search")]}
+        uncat = [("dogfood", "QA testing", "/dogfood")]
+        size = _estimate_group_size(cats, uncat)
+        assert size > 0
+        assert isinstance(size, int)
+
+    def test_enforce_integration_with_registration(self, adapter):
+        """End-to-end: oversized skill set should still register without error."""
+        mock_categories = {
+            f"cat-{c}": [
+                (f"s-{c}-{i}", "x" * 100, f"/s-{c}-{i}")
+                for i in range(10)
+            ]
+            for c in range(5)
+        }
+        with patch(
+            "hermes_cli.commands.discord_skill_commands_by_category",
+            return_value=(mock_categories, [], 0),
+        ):
+            adapter._register_slash_commands()
+
+        tree = adapter._client.tree
+        assert "skill" in tree.commands
+


### PR DESCRIPTION
## Summary
Fixes #11321 — Discord slash command sync fails because the `/skill` group exceeds the 8000-character JSON payload limit.

## Changes
- Add `_estimate_group_size()` to estimate serialized JSON size of a command group
- Add `_enforce_command_group_size()` with progressive shrinking:
  1. Truncate descriptions to 60 chars
  2. Truncate descriptions to 40 chars
  3. Drop commands from the largest categories
- Called at the end of `discord_skill_commands_by_category()`
- 5 new tests covering: no-op for small groups, description truncation, command dropping, size estimation, and end-to-end registration

## Testing
All new tests pass. Existing tests unaffected.