### PR TITLE
feat(feishu): add FEISHU_AUTO_THREAD for automatic thread replies

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1172,6 +1172,7 @@ class FeishuAdapter(BasePlatformAdapter):
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
+        self._last_inbound_message_ids: dict = {}  # chat_id -> message_id
         self._app_id = settings.app_id
         self._app_secret = settings.app_secret
         self._domain_name = settings.domain_name
@@ -2186,6 +2187,9 @@ class FeishuAdapter(BasePlatformAdapter):
         )
 
         chat_id = getattr(message, "chat_id", "") or ""
+        # Track last inbound message_id per chat for auto-thread reply
+        if chat_id and message_id:
+            self._last_inbound_message_ids[chat_id] = message_id
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id)
         source = self.build_source(
@@ -3272,7 +3276,11 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
-        reply_in_thread = bool((metadata or {}).get("thread_id"))
+        _auto_thread = os.getenv("FEISHU_AUTO_THREAD", "false").lower() in ("true", "1", "yes")
+        reply_in_thread = bool((metadata or {}).get("thread_id")) or _auto_thread
+        # When auto_thread is on and no reply_to, use last inbound message_id
+        if _auto_thread and not reply_to:
+            reply_to = self._last_inbound_message_ids.get(chat_id)
         if reply_to:
             body = self._build_reply_message_body(
                 content=payload,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7840,11 +7840,14 @@ class GatewayRunner:
                         buffer_threshold=_scfg.buffer_threshold,
                         cursor=_effective_cursor,
                     )
+                    _feishu_auto_thread = os.getenv("FEISHU_AUTO_THREAD", "false").lower() in ("true", "1", "yes")
+                    _sc_reply_to = event_message_id if (_feishu_auto_thread and source.platform == Platform.FEISHU) else None
                     _stream_consumer = GatewayStreamConsumer(
                         adapter=_adapter,
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        reply_to=_sc_reply_to,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
@@ -8406,11 +8409,14 @@ class GatewayRunner:
                             buffer_threshold=_scfg.buffer_threshold,
                             cursor=_effective_cursor,
                         )
+                        _feishu_auto_thread2 = os.getenv("FEISHU_AUTO_THREAD", "false").lower() in ("true", "1", "yes")
+                        _sc_reply_to2 = event_message_id if (_feishu_auto_thread2 and source.platform == Platform.FEISHU) else None
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=_sc_reply_to2,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -82,6 +82,7 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -89,7 +90,7 @@ class GatewayStreamConsumer:
         self.metadata = metadata
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
-        self._message_id: Optional[str] = None
+        self._message_id: Optional[str] = reply_to
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0


### PR DESCRIPTION
## Summary

- Adds `FEISHU_AUTO_THREAD` env var (default: `false`) that, when enabled, makes all Feishu replies land inside threads automatically
- Each new inbound message creates a new thread, isolating conversation context per thread and preventing unrelated conversations from mixing and exhausting the context window
- Works for both streaming and non-streaming reply paths

## How it works

Feishu's `reply` API supports a `reply_in_thread` flag, but the `create` API does not. Many code paths (streaming, agent tool calls) use `create` because they don't have a `reply_to` message ID.

This PR:
1. Tracks the last inbound `message_id` per `chat_id` in `FeishuAdapter`
2. In `_send_raw_message`, when `FEISHU_AUTO_THREAD=true` and no `reply_to` is provided, automatically uses the tracked message ID — routing through the `reply` API with `reply_in_thread=true`
3. Passes an initial `reply_to` to `GatewayStreamConsumer` so streaming replies also land in threads

## Configuration

```bash
# In ~/.hermes/.env
FEISHU_AUTO_THREAD=true
```

Defaults to `false` — no behavior change for existing users.

## Test plan

- [x] Verified in private chat: replies appear inside threads
- [x] Verified `reply_in_thread=true` is set in the reply API call
- [x] Verified backward compatibility: without `FEISHU_AUTO_THREAD`, behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)