### PR TITLE
fix(skills): surface skill-load failures instead of returning success

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -310,7 +310,13 @@ def build_skill_invocation_message(
         user_instruction: Optional text the user typed after the command.
 
     Returns:
-        The formatted message string, or None if the skill wasn't found.
+        The formatted message string, or ``None`` if the command is unknown
+        *or* if the skill payload failed to load (e.g., SKILL.md was deleted
+        or corrupted between scan and invocation). Callers that already know
+        the command is registered (via ``get_skill_commands()`` /
+        ``resolve_skill_command_key()``) should treat ``None`` as a load
+        failure and surface a real error to the user instead of silently
+        forwarding a placeholder string to the agent.
     """
     commands = get_skill_commands()
     skill_info = commands.get(cmd_key)
@@ -319,7 +325,13 @@ def build_skill_invocation_message(
 
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
-        return f"[Failed to load skill: {skill_info['name']}]"
+        logger.warning(
+            "Failed to load skill payload for %s (cmd_key=%s, skill_dir=%s)",
+            skill_info.get("name"),
+            cmd_key,
+            skill_info.get("skill_dir"),
+        )
+        return None
 
     loaded_skill, skill_dir, skill_name = loaded
     activation_note = (

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -387,6 +387,17 @@ class WebhookAdapter(BasePlatformAdapter):
                         if skill_content:
                             prompt = skill_content
                             break  # Load the first matching skill
+                        else:
+                            # Registered skill failed to load (e.g. SKILL.md
+                            # deleted/corrupted between scan and webhook
+                            # delivery). Log loudly and try the next skill
+                            # rather than silently injecting a placeholder
+                            # error string into the agent prompt (#11200).
+                            logger.error(
+                                "[webhook] Skill '%s' is registered but failed to load — "
+                                "skipping for this delivery",
+                                skill_name,
+                            )
                     else:
                         logger.warning(
                             "[webhook] Skill '%s' not found", skill_name

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3233,6 +3233,23 @@ class GatewayRunner:
                     if msg:
                         event.text = msg
                         # Fall through to normal message processing with skill content
+                    else:
+                        # Skill is registered (cmd_key resolved) but loading the
+                        # SKILL.md payload failed. Surface a real error to the
+                        # user instead of silently forwarding the bare /command
+                        # to the LLM as free text (#11200).
+                        _failed_name = skill_cmds[cmd_key].get("name", cmd_key.lstrip("/"))
+                        logger.warning(
+                            "Skill /%s resolved but failed to load — returning error to user",
+                            _failed_name,
+                        )
+                        return (
+                            f"Failed to load the **{_failed_name}** skill. "
+                            f"The skill is registered but its `SKILL.md` could "
+                            f"not be loaded (it may have been moved, deleted, "
+                            f"or be malformed). Run `hermes skills list` to "
+                            f"refresh the cache."
+                        )
                 else:
                     # Not an active skill — check if it's a known-but-disabled or
                     # uninstalled skill and give actionable guidance.

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -259,6 +259,25 @@ Generate some audio.
             msg = build_skill_invocation_message("/nonexistent")
         assert msg is None
 
+    def test_returns_none_when_payload_load_fails_after_scan(self, tmp_path):
+        """Regression for #11200: a skill that scans cleanly but whose
+        SKILL.md is removed/corrupted before invocation must return None
+        (not a truthy ``[Failed to load skill: ...]`` placeholder string,
+        which callers would treat as a successful invocation and forward
+        to the agent as conversation content).
+        """
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "demo")
+            scan_skill_commands()
+            # Simulate the SKILL.md being deleted between scan and invocation
+            (skill_dir / "SKILL.md").unlink()
+            msg = build_skill_invocation_message("/demo", "hello")
+
+        assert msg is None, (
+            "Load failure must surface as None so callers can show a real "
+            "error instead of forwarding a placeholder string to the agent."
+        )
+
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []


### PR DESCRIPTION
Fixes #11200

## Problem

`build_skill_invocation_message()` returned a truthy placeholder string (`[Failed to load skill: <name>]`) when a registered skill's `SKILL.md` could not be loaded (e.g. file deleted or corrupted between scan and invocation). Every caller used `if msg:` to distinguish success from failure, so the placeholder was treated as a successful invocation and silently fed into the agent as user prompt content. A missing/deleted/corrupt skill therefore looked like a working slash command from the user's perspective, while the model received `[Failed to load skill: ...]` as conversation input.

Affected call sites flagged in the bug report:
- `agent/skill_commands.py:311-313`
- `cli.py:5571-5580`
- `gateway/run.py:2877-2882`
- `gateway/platforms/webhook.py:383-388`

## Fix

- `build_skill_invocation_message()` now returns `None` on load failure (matching the existing "unknown skill" path) and logs a warning with the cmd_key + skill_dir for diagnosis. The docstring is updated to document the new contract.
- `gateway/run.py`: when the slash command resolves to a registered skill but loading fails, return a real error message to the user (instead of silently falling through and sending the bare `/cmd` to the LLM as free text).
- `gateway/platforms/webhook.py`: when a configured route skill is registered but fails to load, log loudly at ERROR and skip that skill rather than injecting the placeholder string into the prompt.
- `cli.py` already had `if not msg:` branches for both the skill slash handler and `_handle_plan_command`; those branches were effectively dead code under the old return contract and now fire correctly on real load failures.

## Reproduction

The reporter's reproduction now returns `None` instead of `'[Failed to load skill: demo]'`:

```python
import agent.skill_commands as sc
from pathlib import Path
from tempfile import TemporaryDirectory
from unittest.mock import patch

with TemporaryDirectory() as td:
    root = Path(td)
    skill_dir = root / "demo"
    skill_dir.mkdir(parents=True)
    (skill_dir / "SKILL.md").write_text("---
name: demo
description: demo
---

# Demo
", encoding="utf-8")
    with patch("agent.skill_utils.get_external_skills_dirs", return_value=[root]), \
         patch("tools.skills_tool.SKILLS_DIR", Path(td) / "missing_local_skills"):
        sc.scan_skill_commands()
        (skill_dir / "SKILL.md").unlink()
        print(sc.build_skill_invocation_message("/demo", "hello"))  # -> None
```

## Tests

- New `TestBuildSkillInvocationMessage::test_returns_none_when_payload_load_fails_after_scan` covers the regression: scan a skill, delete its `SKILL.md`, assert `build_skill_invocation_message` returns `None`.
- `pytest tests/agent/test_skill_commands.py` — 27 passed.
- `pytest tests/gateway/test_webhook_integration.py` — 4 passed.