### PR TITLE
fix(gateway): fire MemoryProvider.on_session_end on session expiry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -756,6 +756,46 @@ class GatewayRunner:
             logger.debug("Skipping memory flush for cron session: %s", old_session_id)
             return
 
+        # Fire MemoryProvider.on_session_end() on the live cached agent's
+        # memory manager BEFORE the bespoke flush agent runs.  The graceful
+        # CLI shutdown path (run_agent.py:shutdown_memory_provider) calls
+        # this hook at session boundaries; gateway sessions need the same
+        # contract so plugin providers get their documented final-pass
+        # extraction opportunity (idle expiry, scheduled reset, /reset).
+        # Wrapped in try/except so a misbehaving provider can't block the
+        # rest of the flush path (matches the per-provider error tolerance
+        # in MemoryManager.on_session_end itself).
+        try:
+            cached_agent = None
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+            if cache_lock is not None and session_key:
+                with cache_lock:
+                    _cached = self._agent_cache.get(session_key)
+                    cached_agent = (
+                        _cached[0] if isinstance(_cached, tuple)
+                        else _cached if _cached
+                        else None
+                    )
+            if cached_agent is None and session_key:
+                _running = self._running_agents.get(session_key)
+                if _running is not None and _running is not _AGENT_PENDING_SENTINEL:
+                    cached_agent = _running
+            if cached_agent is not None:
+                _mm = getattr(cached_agent, "_memory_manager", None)
+                if _mm is not None:
+                    _history = self.session_store.load_transcript(old_session_id) or []
+                    _msgs = [
+                        {"role": m.get("role"), "content": m.get("content")}
+                        for m in _history
+                        if m.get("role") in ("user", "assistant") and m.get("content")
+                    ]
+                    _mm.on_session_end(_msgs)
+        except Exception as exc:
+            logger.warning(
+                "MemoryProvider.on_session_end dispatch failed for session %s: %s",
+                old_session_id, exc,
+            )
+
         try:
             history = self.session_store.load_transcript(old_session_id)
             if not history or len(history) < 4:

--- a/tests/gateway/test_flush_memory_session_end.py
+++ b/tests/gateway/test_flush_memory_session_end.py
@@ -1,0 +1,166 @@
+"""Tests for MemoryProvider.on_session_end() dispatch on gateway session expiry (#11205).
+
+Verifies that the gateway's flush path invokes the memory provider lifecycle
+hook on the live cached agent's memory manager when a session ends — matching
+the contract the CLI graceful shutdown path already honors.
+"""
+
+import sys
+import threading
+import types
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(autouse=True)
+def _mock_dotenv(monkeypatch):
+    """gateway.run imports dotenv at module level; stub it so tests run without the package."""
+    fake = types.ModuleType("dotenv")
+    fake.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake)
+
+
+_TRANSCRIPT = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi there"},
+    {"role": "user", "content": "remember: my name is Alice"},
+    {"role": "assistant", "content": "Got it, Alice!"},
+]
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._honcho_managers = {}
+    runner._honcho_configs = {}
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner.adapters = {}
+    runner.hooks = MagicMock()
+    runner.session_store = MagicMock()
+    runner.session_store.load_transcript.return_value = _TRANSCRIPT
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def _patched_flush_env(monkeypatch):
+    """Return a context-manager-friendly dict of patches for the flush path."""
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = MagicMock(return_value=MagicMock())
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+class TestOnSessionEndDispatch:
+    """The flush path must dispatch on_session_end to the cached agent's memory manager."""
+
+    def test_on_session_end_called_for_cached_agent(self, monkeypatch):
+        """When an agent is in _agent_cache, its memory_manager.on_session_end fires."""
+        runner = _make_runner()
+        cached_agent = MagicMock()
+        cached_agent._memory_manager = MagicMock()
+        runner._agent_cache["agent:main:slack:dm:42"] = (cached_agent, "sig")
+
+        _patched_flush_env(monkeypatch)
+        with (
+            patch.object(runner, "_resolve_session_agent_runtime",
+                         return_value=("test-model", {"api_key": "k"})),
+            patch.object(runner, "_cleanup_agent_resources"),
+        ):
+            runner._flush_memories_for_session("session_xyz", "agent:main:slack:dm:42")
+
+        cached_agent._memory_manager.on_session_end.assert_called_once()
+        # Messages should be cleaned (role + content only) from the transcript
+        called_msgs = cached_agent._memory_manager.on_session_end.call_args.args[0]
+        assert called_msgs == _TRANSCRIPT
+
+    def test_on_session_end_called_for_running_agent(self, monkeypatch):
+        """If the agent is mid-turn (in _running_agents), still dispatch the hook."""
+        runner = _make_runner()
+        running_agent = MagicMock()
+        running_agent._memory_manager = MagicMock()
+        runner._running_agents["agent:main:telegram:dm:9"] = running_agent
+
+        _patched_flush_env(monkeypatch)
+        with (
+            patch.object(runner, "_resolve_session_agent_runtime",
+                         return_value=("test-model", {"api_key": "k"})),
+            patch.object(runner, "_cleanup_agent_resources"),
+        ):
+            runner._flush_memories_for_session("session_run", "agent:main:telegram:dm:9")
+
+        running_agent._memory_manager.on_session_end.assert_called_once()
+
+    def test_no_dispatch_when_no_cached_agent(self, monkeypatch):
+        """When no agent is cached for the session_key, the hook isn't called (no-op)."""
+        runner = _make_runner()
+        _patched_flush_env(monkeypatch)
+        with (
+            patch.object(runner, "_resolve_session_agent_runtime",
+                         return_value=("test-model", {"api_key": "k"})),
+            patch.object(runner, "_cleanup_agent_resources"),
+        ):
+            # Should not raise
+            runner._flush_memories_for_session("session_no_agent", "agent:main:slack:dm:99")
+
+    def test_provider_failure_does_not_break_flush(self, monkeypatch):
+        """A misbehaving on_session_end shouldn't block the bespoke flush agent."""
+        runner = _make_runner()
+        cached_agent = MagicMock()
+        cached_agent._memory_manager = MagicMock()
+        cached_agent._memory_manager.on_session_end.side_effect = RuntimeError("boom")
+        runner._agent_cache["agent:main:discord:dm:1"] = (cached_agent, "sig")
+
+        _patched_flush_env(monkeypatch)
+        captured_agent = {}
+
+        def _fake_ai_agent(*args, **kwargs):
+            agent = MagicMock()
+            captured_agent["instance"] = agent
+            return agent
+
+        sys.modules["run_agent"].AIAgent = _fake_ai_agent
+
+        with (
+            patch.object(runner, "_resolve_session_agent_runtime",
+                         return_value=("test-model", {"api_key": "k"})),
+            patch.object(runner, "_cleanup_agent_resources"),
+            patch.dict("sys.modules", {"tools.memory_tool": MagicMock()}),
+        ):
+            # Must not raise even though provider hook blew up
+            runner._flush_memories_for_session("session_brk", "agent:main:discord:dm:1")
+
+        # The bespoke flush agent should still have run
+        assert "instance" in captured_agent
+        captured_agent["instance"].run_conversation.assert_called_once()
+
+    def test_cron_session_skips_session_end_too(self, monkeypatch):
+        """Cron sessions skip the entire flush — including on_session_end."""
+        runner = _make_runner()
+        cached_agent = MagicMock()
+        cached_agent._memory_manager = MagicMock()
+        runner._agent_cache["agent:main:cron:job:1"] = (cached_agent, "sig")
+
+        runner._flush_memories_for_session("cron_daily_20260417", "agent:main:cron:job:1")
+
+        cached_agent._memory_manager.on_session_end.assert_not_called()
+
+    def test_no_session_key_skips_lookup(self, monkeypatch):
+        """When session_key is not provided, no cached-agent lookup occurs."""
+        runner = _make_runner()
+        # Even if there's a stray entry, it shouldn't be matched without a key.
+        cached_agent = MagicMock()
+        cached_agent._memory_manager = MagicMock()
+        runner._agent_cache["agent:main:slack:dm:foo"] = (cached_agent, "sig")
+
+        _patched_flush_env(monkeypatch)
+        with (
+            patch.object(runner, "_resolve_session_agent_runtime",
+                         return_value=("test-model", {"api_key": "k"})),
+            patch.object(runner, "_cleanup_agent_resources"),
+        ):
+            runner._flush_memories_for_session("session_nokey", None)
+
+        cached_agent._memory_manager.on_session_end.assert_not_called()


### PR DESCRIPTION
Fixes #11205

The gateway session-expiry code path shut sessions down without invoking `MemoryProvider.on_session_end()`, so memory providers never got a chance to flush state for expired sessions. This patch invokes the hook on the expiry path, mirroring the graceful-end behavior.

## What

`_flush_memories_for_session` (`gateway/run.py:743`) is the convergence point for all three gateway session-end paths:

1. Idle-timeout expiry from `_session_expiry_watcher` (`:2046`)
2. Daily scheduled reset (same watcher)
3. Explicit `/reset` from a platform handler (`:4343`, `:6422`)

Until now it only spawned a separate flush `AIAgent` to nudge the builtin memory tool — it never called `memory_manager.on_session_end(history)` on the **live** cached agent's memory manager. As a result, plugin `MemoryProvider`s that implement `on_session_end` as their documented final-pass extraction hook fired exactly zero times on gateway platforms (per the bug report log: many `periodic` / `pre_compress` triggers, zero `session_end`).

This patch dispatches the hook before the bespoke flush runs, looking up the live agent in `_agent_cache` first (where idle agents live) and falling back to `_running_agents` (in case the agent is still mid-turn when expiry fires). The dispatch is wrapped in `try/except` so a misbehaving provider can't block the rest of the flush sequence — matching the per-provider error tolerance that already exists inside `MemoryManager.on_session_end`.

This is the same structural class of bug as #7193 / #7192: the hook contract exists, the dispatch layer works, but one caller was missing.

## How

```python
# gateway/run.py — _flush_memories_for_session, after the cron-skip guard
try:
    cached_agent = ...  # _agent_cache[session_key] -> _running_agents[session_key]
    if cached_agent is not None:
        _mm = getattr(cached_agent, "_memory_manager", None)
        if _mm is not None:
            _msgs = [...]  # cleaned transcript, role+content only
            _mm.on_session_end(_msgs)
except Exception as exc:
    logger.warning("MemoryProvider.on_session_end dispatch failed for session %s: %s", ...)
```

The bespoke flush-agent path is left fully intact (it addresses an orthogonal concern tracked in #6157).

## Testing

New `tests/gateway/test_flush_memory_session_end.py` (6 tests, all passing) covers:

- Hook fires when the agent is in `_agent_cache` (idle path)
- Hook fires when the agent is in `_running_agents` (mid-turn fallback)
- No-op when no agent is cached for the session_key
- Provider failure does not break the bespoke flush downstream
- Cron sessions still bypass the entire flush (including the new hook)
- No `session_key` passed -> no cached-agent lookup, hook not called

Existing related tests (`test_async_memory_flush.py`, `test_flush_memory_stale_guard.py`, `test_memory_provider.py`) continue to pass — 82/82 green.

## Test plan

- [x] New unit tests for the dispatch + edge cases
- [x] Existing memory-flush + memory-provider tests still pass
- [ ] Manual verification on a live gateway: install a plugin that logs from `on_session_end`, let an idle session expire, confirm the log line now appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)