### PR TITLE
fix(agent): pass focus_topic not summary_budget in compressor fallback

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -741,7 +741,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(messages, summary_budget)  # retry immediately
+                return self._generate_summary(messages, focus_topic=focus_topic)  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60

--- a/tests/agent/test_compressor_fallback.py
+++ b/tests/agent/test_compressor_fallback.py
@@ -1,0 +1,37 @@
+"""Tests for agent/context_compressor.py — _generate_summary fallback fix."""
+
+import inspect
+import pytest
+
+
+class TestGenerateSummaryFallback:
+    """Verify the summary model fallback doesn't pass int as focus_topic."""
+
+    def test_method_signature(self):
+        """_generate_summary second param should be focus_topic (str|None), not budget."""
+        from agent.context_compressor import ContextCompressor
+        sig = inspect.signature(ContextCompressor._generate_summary)
+        params = list(sig.parameters.values())
+        # params[0] is self, params[1] is turns_to_summarize, params[2] is focus_topic
+        assert len(params) >= 3
+        focus_param = params[2]
+        assert focus_param.name == "focus_topic"
+        assert focus_param.default is None
+
+    def test_fallback_call_uses_keyword(self):
+        """Read the source to verify line 744 uses focus_topic=, not positional int."""
+        import agent.context_compressor as mod
+        source = inspect.getsource(mod)
+        # The bug was: self._generate_summary(messages, summary_budget)
+        # The fix is:  self._generate_summary(messages, focus_topic=focus_topic)
+        assert "summary_budget" not in source.split("retry immediately")[0].split("_generate_summary(messages")[-1] or \
+               "focus_topic=focus_topic" in source
+        # Specifically check the fallback line
+        for line in source.split("\n"):
+            if "retry immediately" in line and "_generate_summary" in line:
+                assert "focus_topic=focus_topic" in line, (
+                    f"Fallback call should use keyword arg: {line.strip()}"
+                )
+                assert "summary_budget" not in line, (
+                    f"Fallback call should not pass summary_budget: {line.strip()}"
+                )


### PR DESCRIPTION
## What does this PR do?

When the summary model returns 404/503, `_generate_summary()` falls back to the main model via recursive call. The fallback call at line 744 passed `summary_budget` (an `int`) as the second positional argument, but the method signature expects `focus_topic` (a `str | None`). The fallback summary received garbage focus guidance like `4096` embedded in the prompt, degrading compression quality.

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` line 744: changed `self._generate_summary(messages, summary_budget)` to `self._generate_summary(messages, focus_topic=focus_topic)` — passes the original focus topic (or None) instead of an integer token budget
- `tests/agent/test_compressor_fallback.py` (new) — 2 tests verifying method signature and that the fallback call uses the keyword arg

## How to Test

1. `pytest tests/agent/test_compressor_fallback.py -v` — 2 passed
2. Code review: confirm `focus_topic` parameter is `str | None` (line 545) and the fallback call uses it correctly

## Checklist

- [X] I've read the Contributing Guide
- [X] Commit follows Conventional Commits: `fix(agent): pass focus_topic not summary_budget in compressor fallback`
- [X] No duplicate PRs found
- [X] PR contains only this one-line fix + test
- [X] `pytest tests/agent/test_compressor_fallback.py -v` — 2 passed
- [X] Tests added
- [X] Tested on: Ubuntu 24.04 (WSL2)
- [X] N/A: documentation, config, cross-platform, tool schemas