### PR TITLE
[codex] Respect proxy env for Codex clients

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4395,6 +4395,11 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
+        proxy_env_present = any(
+            str(os.environ.get(key) or "").strip()
+            for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy")
+        )
+
         # Inject TCP keepalives so the kernel detects dead provider connections
         # instead of letting them sit silently in CLOSE-WAIT (#10324).  Without
         # this, a peer that drops mid-stream leaves the socket in a state where
@@ -4412,7 +4417,11 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        #
+        # If proxy env vars are set, leave the SDK to build its default httpx
+        # transport. A hand-built HTTPTransport does not pick up trust_env
+        # proxy configuration, so proxied users would silently direct-connect.
+        if "http_client" not in client_kwargs and not proxy_env_present:
             try:
                 import httpx as _httpx
                 import socket as _socket

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -184,3 +184,36 @@ def test_replace_primary_openai_client_survives_repeated_rebuilds():
         "Some _create_openai_client calls returned the same object across "
         "a teardown — rebuild is not producing fresh clients"
     )
+
+
+def test_proxy_env_uses_sdk_default_transport(monkeypatch):
+    """When proxy env vars are present, do not inject a custom transport.
+
+    httpx applies HTTPS_PROXY/HTTP_PROXY through its default client transport.
+    Passing a hand-built HTTPTransport for keepalive socket options bypasses
+    that env proxy path, causing proxied Codex requests to direct-connect and
+    time out on networks that require a local proxy.
+    """
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    agent._client_kwargs = {
+        "api_key": "test-key-value",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    # Synthetic only: the fake OpenAI client prevents network I/O. The value
+    # just needs to be a valid proxy URL so the proxy-env branch is exercised.
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            agent._client_kwargs, reason="proxy_env", shared=True
+        )
+
+    assert len(constructed) == 1
+    assert constructed[0]._http_client is None, (
+        "Proxy environment variables must be handled by the SDK/httpx default "
+        "transport. Injecting a custom HTTPTransport here bypasses HTTPS_PROXY "
+        "and makes Codex requests direct-connect."
+    )


### PR DESCRIPTION
## Summary

- avoid injecting a custom `httpx.HTTPTransport` when proxy environment variables are present
- let the OpenAI SDK/httpx default transport honor `HTTPS_PROXY`, `HTTP_PROXY`, and `ALL_PROXY`
- add regression coverage for proxied Codex/OpenAI client creation

## Root Cause

Hermes injects a custom `httpx.Client(transport=httpx.HTTPTransport(...))` to add TCP keepalive socket options. When a custom transport is provided, httpx does not use its default environment proxy handling. Users behind local HTTP(S) proxies can therefore have Codex/OpenAI requests direct-connect even when `HTTPS_PROXY` is configured, resulting in connection timeouts.

## Impact

This keeps the existing keepalive behavior for users without proxy env vars, while allowing proxied setups to work through the SDK/httpx default proxy-aware transport.

## Validation

- `./venv/bin/python -m pytest tests/run_agent/test_create_openai_client_reuse.py -q`
- local smoke test: `./venv/bin/hermes chat -Q -t '' --max-turns 1 -q '只回复 OK 两个字母。'`
