### PR TITLE
fix(discord): make voice idle timeout configurable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -589,6 +589,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                if "voice_timeout_seconds" in discord_cfg and not os.getenv("DISCORD_VOICE_TIMEOUT_SECONDS"):
+                    os.environ["DISCORD_VOICE_TIMEOUT_SECONDS"] = str(discord_cfg["voice_timeout_seconds"])
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -427,13 +427,27 @@ class DiscordAdapter(BasePlatformAdapter):
     _SPLIT_THRESHOLD = 1900  # near the 2000-char split point
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
-    VOICE_TIMEOUT = 300
+    DEFAULT_VOICE_TIMEOUT_SECONDS = 300
+    _voice_timeout_seconds = DEFAULT_VOICE_TIMEOUT_SECONDS
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
+        voice_timeout_raw = os.getenv(
+            "DISCORD_VOICE_TIMEOUT_SECONDS",
+            str(self.DEFAULT_VOICE_TIMEOUT_SECONDS),
+        )
+        try:
+            self._voice_timeout_seconds = max(0, int(voice_timeout_raw))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid DISCORD_VOICE_TIMEOUT_SECONDS=%r; falling back to %s",
+                voice_timeout_raw,
+                self.DEFAULT_VOICE_TIMEOUT_SECONDS,
+            )
+            self._voice_timeout_seconds = self.DEFAULT_VOICE_TIMEOUT_SECONDS
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         # Text batching: merge rapid successive messages (Telegram-style)
@@ -1116,9 +1130,9 @@ class DiscordAdapter(BasePlatformAdapter):
         )
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
-        """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
+        """Auto-disconnect after the configured inactivity timeout."""
         try:
-            await asyncio.sleep(self.VOICE_TIMEOUT)
+            await asyncio.sleep(self._voice_timeout_seconds)
         except asyncio.CancelledError:
             return
         text_ch_id = self._voice_text_channels.get(guild_id)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -223,6 +223,23 @@ class TestLoadGatewayConfig:
         assert config.unauthorized_dm_behavior == "ignore"
         assert config.platforms[Platform.WHATSAPP].extra["unauthorized_dm_behavior"] == "pair"
 
+    def test_bridges_discord_voice_timeout_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  voice_timeout_seconds: 900\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_VOICE_TIMEOUT_SECONDS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ["DISCORD_VOICE_TIMEOUT_SECONDS"] == "900"
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -94,6 +94,22 @@ class SlowSyncBot(FakeBot):
         self.tree = SlowSyncTree()
 
 
+def test_voice_timeout_defaults_to_300_seconds(monkeypatch):
+    monkeypatch.delenv("DISCORD_VOICE_TIMEOUT_SECONDS", raising=False)
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    assert adapter._voice_timeout_seconds == 300
+
+
+def test_voice_timeout_reads_env_override(monkeypatch):
+    monkeypatch.setenv("DISCORD_VOICE_TIMEOUT_SECONDS", "900")
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    assert adapter._voice_timeout_seconds == 900
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("allowed_users", "expected_members_intent"),

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -175,6 +175,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |
+| `DISCORD_VOICE_TIMEOUT_SECONDS` | Auto-leave a Discord voice channel after this many idle seconds (default: `300`) |
 | `DISCORD_IGNORED_CHANNELS` | Comma-separated channel IDs where the bot never responds |
 | `DISCORD_NO_THREAD_CHANNELS` | Comma-separated channel IDs where bot responds without auto-threading |
 | `DISCORD_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all` |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -280,6 +280,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
+| `DISCORD_VOICE_TIMEOUT_SECONDS` | No | `300` | Auto-leave a Discord voice channel after this many idle seconds. Set to `0` to leave immediately once inactivity is detected. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
 | `DISCORD_REPLY_TO_MODE` | No | `"first"` | Controls reply-reference behavior: `"off"` — never reply to the original message, `"first"` — reply-reference on the first message chunk only (default), `"all"` — reply-reference on every chunk. |
@@ -295,6 +296,7 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  voice_timeout_seconds: 300      # Auto-leave voice after this many idle seconds
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
 
@@ -346,6 +348,14 @@ Controls whether the bot adds emoji reactions to messages as visual feedback:
 - ❌ added if an error occurs during processing
 
 Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
+
+#### `discord.voice_timeout_seconds`
+
+**Type:** integer — **Default:** `300`
+
+Auto-leave a Discord voice channel after this many idle seconds. This maps to `DISCORD_VOICE_TIMEOUT_SECONDS`; `config.yaml` provides the persistent default, and the env var still wins if both are set.
+
+Set it to `0` if you want the bot to leave immediately once inactivity is detected.
 
 #### `discord.ignored_channels`
 


### PR DESCRIPTION
## Summary
- expose Discord voice idle timeout via `discord.voice_timeout_seconds` in `config.yaml`
- bridge it to `DISCORD_VOICE_TIMEOUT_SECONDS` and read it in the Discord adapter
- document the new setting and cover config/default voice timeout behavior with tests

## Test Plan
- source venv/bin/activate && python -m pytest tests/gateway/test_config.py tests/gateway/test_discord_connect.py tests/gateway/test_voice_command.py -q