### PR TITLE
feat(gateway): add session_keying=gmail_thread_id mode for email adapter

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -17,6 +17,7 @@ Environment variables:
 
 import asyncio
 import email as email_lib
+import hashlib
 import imaplib
 import logging
 import os
@@ -240,18 +241,49 @@ class EmailAdapter(BasePlatformAdapter):
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Session-keying mode — controls whether inbound messages from the
+        # same sender share a session or are split per-thread.
+        #   "sender"           (default): one session per sender address,
+        #                                  preserving pre-existing behavior.
+        #   "gmail_thread_id": one session per Gmail thread, keyed by Gmail's
+        #                      X-GM-THRID IMAP extension. Requires an
+        #                      imap.gmail.com-style server that advertises the
+        #                      X-GM-EXT-1 capability (Google Workspace / Gmail).
+        # Configure via:
+        #   platforms:
+        #     email:
+        #       extra:
+        #         session_keying: gmail_thread_id
+        mode = (extra.get("session_keying") or "sender").lower()
+        if mode not in ("sender", "gmail_thread_id"):
+            logger.warning(
+                "[Email] Unknown session_keying=%r, falling back to 'sender'",
+                extra.get("session_keying"),
+            )
+            mode = "sender"
+        self._session_keying: str = mode
+        # Populated in connect() from imap.capability(); stays False until a
+        # successful login confirms the server advertises X-GM-EXT-1.
+        self._has_gmail_ext: bool = False
+
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map (sender_addr, message_id) -> subject/message-id/last_seen_ts for threading.
-        # Keyed by (sender, message_id) so two concurrent inbound messages from the
-        # same sender can coexist without one clobbering the other's reply headers.
+        # Map (sender_addr, thread_key) -> subject/message-id/last_seen_ts for threading.
+        # Keyed by a tuple so two concurrent inbound messages from the same
+        # sender can coexist without one clobbering the other's reply headers.
+        # In sender mode, thread_key is the inbound message_id. In
+        # gmail_thread_id mode, thread_key is the derived thread identifier
+        # (e.g. "gthr-1234567890").
         self._thread_context: Dict[Tuple[str, str], Dict[str, Any]] = {}
         self._thread_context_max: int = 500
 
-        logger.info("[Email] Adapter initialized for %s", self._address)
+        logger.info(
+            "[Email] Adapter initialized for %s (session_keying=%s)",
+            self._address, self._session_keying,
+        )
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -318,12 +350,42 @@ class EmailAdapter(BasePlatformAdapter):
                 latest = ctx
         return latest or {}
 
+    def _detect_gmail_extension(self, imap: imaplib.IMAP4_SSL) -> bool:
+        """Return True when the IMAP server advertises X-GM-EXT-1.
+
+        X-GM-EXT-1 is Gmail's IMAP extension capability — see
+        https://developers.google.com/gmail/imap/imap-extensions. Presence
+        guarantees `X-GM-THRID`, `X-GM-MSGID`, and `X-GM-LABELS` are
+        available as FETCH data items.
+        """
+        try:
+            status, data = imap.capability()
+            if status != "OK" or not data:
+                return False
+            caps_raw = b" ".join(data) if isinstance(data, list) else bytes(data)
+            return b"X-GM-EXT-1" in caps_raw.upper()
+        except Exception as e:
+            logger.warning("[Email] Capability probe failed: %s", e)
+            return False
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
+            # Probe for Gmail IMAP extension (X-GM-EXT-1). If the caller asked
+            # for gmail_thread_id mode but the server doesn't advertise the
+            # extension, degrade to sender mode with a warning so we fail
+            # loudly in logs rather than silently mis-route sessions.
+            self._has_gmail_ext = self._detect_gmail_extension(imap)
+            if self._session_keying == "gmail_thread_id" and not self._has_gmail_ext:
+                logger.warning(
+                    "[Email] session_keying=gmail_thread_id requested but "
+                    "server %s does not advertise X-GM-EXT-1; falling back to "
+                    "sender mode", self._imap_host,
+                )
+                self._session_keying = "sender"
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
@@ -385,9 +447,37 @@ class EmailAdapter(BasePlatformAdapter):
         for msg_data in messages:
             await self._dispatch_message(msg_data)
 
+    @staticmethod
+    def _parse_gm_thrid(fetch_response: Any) -> Optional[str]:
+        """Extract X-GM-THRID from a Gmail IMAP FETCH response.
+
+        Gmail returns the THRID inline with the RFC822 literal header, e.g.
+            b'5 (UID 5 X-GM-THRID 1234567890123456789 RFC822 {12345}'
+        Returns the decoded decimal THRID or None if not present.
+        """
+        try:
+            if not fetch_response or not isinstance(fetch_response, tuple):
+                return None
+            header = fetch_response[0]
+            if not isinstance(header, (bytes, bytearray)):
+                return None
+            m = re.search(rb"X-GM-THRID\s+(\d+)", header)
+            if m:
+                return m.group(1).decode("ascii")
+        except Exception as e:
+            logger.debug("[Email] THRID parse failed: %s", e)
+        return None
+
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
+        # Extend the FETCH payload to include X-GM-THRID when Gmail session
+        # keying is active. No-op server-side cost: THRID is already indexed
+        # on the Gmail side, and it's returned on the same round-trip.
+        use_gmail_thrid = (
+            self._session_keying == "gmail_thread_id" and self._has_gmail_ext
+        )
+        fetch_items = "(RFC822 X-GM-THRID)" if use_gmail_thrid else "(RFC822)"
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
@@ -406,9 +496,15 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, fetch_items)
                     if status != "OK":
                         continue
+
+                    # msg_data[0] is (header_bytes, rfc822_body) for a tuple
+                    # response, or a bare literal in edge cases.
+                    gmail_thrid: Optional[str] = None
+                    if use_gmail_thrid:
+                        gmail_thrid = self._parse_gm_thrid(msg_data[0])
 
                     raw_email = msg_data[0][1]
                     msg = email_lib.message_from_bytes(raw_email)
@@ -441,6 +537,7 @@ class EmailAdapter(BasePlatformAdapter):
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
+                        "gmail_thread_id": gmail_thrid,
                     })
             finally:
                 try:
@@ -484,10 +581,31 @@ class EmailAdapter(BasePlatformAdapter):
             if att["type"] == "image":
                 msg_type = MessageType.PHOTO
 
+        # Derive the session thread_id based on keying mode.
+        #   - sender mode: no thread_id, collapses all messages from this
+        #     sender into one session (pre-existing behavior).
+        #   - gmail_thread_id mode: use Gmail's X-GM-THRID prefixed with
+        #     "gthr-" so the session key is deterministic across restarts.
+        #     If THRID is missing (Gmail didn't return it — edge case on
+        #     delegated mailboxes, etc.), fall back to hashing the inbound
+        #     Message-ID so the message is treated as its own thread root.
+        thread_id: Optional[str] = None
+        if self._session_keying == "gmail_thread_id":
+            thrid = msg_data.get("gmail_thread_id")
+            if thrid:
+                thread_id = f"gthr-{thrid}"
+            else:
+                own_mid = msg_data.get("message_id") or ""
+                if own_mid:
+                    digest = hashlib.sha1(own_mid.encode("utf-8", errors="ignore")).hexdigest()[:12]
+                    thread_id = f"mid-{digest}"
+
         # Store thread context for reply threading.
-        # Key is (sender_addr, message_id) so concurrent inbound messages from
-        # the same sender don't overwrite each other's reply headers.
-        ctx_key = (sender_addr, msg_data["message_id"])
+        # In sender mode thread_id is None, so key on message_id (preserves
+        # the PR A clobber-prevention guarantee).
+        # In gmail_thread_id mode key on thread_id so multiple messages
+        # within the same thread accumulate on a single context entry.
+        ctx_key = (sender_addr, thread_id or msg_data["message_id"])
         self._thread_context[ctx_key] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
@@ -501,6 +619,7 @@ class EmailAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(
@@ -523,11 +642,18 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        `metadata["thread_id"]` (if present) is used to look up the exact
+        reply-threading context for the originating inbound message, so
+        concurrent threads from the same sender don't cross-pollinate reply
+        headers.
+        """
+        thread_id = (metadata or {}).get("thread_id")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, thread_id
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -539,16 +665,17 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply — helper finds the right entry under the
-        # (sender, message_id) tuple key. Without a thread_id hint (plumbed in
-        # PR B), falls back to the most-recent entry from this sender.
-        ctx = self._lookup_thread_context(to_addr)
+        # Thread context for reply — helper resolves to the exact stored entry
+        # when thread_id is present (PR B keying), otherwise falls back to
+        # the most-recent entry for this sender (PR A behavior).
+        ctx = self._lookup_thread_context(to_addr, thread_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -588,11 +715,16 @@ class EmailAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an image URL as part of an email body."""
+        """Send an image URL as part of an email body.
+
+        Accepts `metadata` so thread_id-scoped replies carry the correct
+        In-Reply-To / Message-ID headers in gmail_thread_id mode.
+        """
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata=metadata)
 
     async def send_document(
         self,
@@ -601,8 +733,14 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a file as an email attachment."""
+        """Send a file as an email attachment.
+
+        Accepts `metadata` so thread_id-scoped attachment replies thread
+        correctly in gmail_thread_id mode.
+        """
+        thread_id = (metadata or {}).get("thread_id")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -612,6 +750,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                thread_id,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -624,13 +763,14 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        thread_id: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._lookup_thread_context(to_addr)
+        ctx = self._lookup_thread_context(to_addr, thread_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -23,6 +23,7 @@ import os
 import re
 import smtplib
 import ssl
+import time
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -30,7 +31,7 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email import encoders
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -244,8 +245,11 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        # Map (sender_addr, message_id) -> subject/message-id/last_seen_ts for threading.
+        # Keyed by (sender, message_id) so two concurrent inbound messages from the
+        # same sender can coexist without one clobbering the other's reply headers.
+        self._thread_context: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._thread_context_max: int = 500
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -268,6 +272,51 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _trim_thread_context(self) -> None:
+        """Bound `_thread_context` size to prevent unbounded memory growth.
+
+        When the dict exceeds `_thread_context_max`, drop the oldest half by
+        insertion order (Python 3.7+ preserves dict insertion order). Snapshot
+        keys via `list(items())` before iterating so callers can safely invoke
+        this from inside a write path without tripping "dict changed size
+        during iteration".
+        """
+        if len(self._thread_context) <= self._thread_context_max:
+            return
+        items = list(self._thread_context.items())
+        keep = self._thread_context_max // 2
+        self._thread_context = dict(items[-keep:])
+        logger.debug("[Email] Trimmed thread context to %d entries", len(self._thread_context))
+
+    def _lookup_thread_context(
+        self,
+        to_addr: str,
+        thread_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Look up reply-threading context for an outbound send.
+
+        If `thread_id` is provided, try an exact `(to_addr, thread_id)` match
+        — this is how PR B's session-keyed callers resolve to the correct
+        thread. Otherwise, fall back to the most-recent entry (by
+        `last_seen_ts`) whose key's first element is `to_addr` — preserves the
+        pre-tuple-rekey "reply with this sender's latest subject" behavior
+        for callers that haven't been plumbed `thread_id` through yet.
+        """
+        if thread_id is not None:
+            ctx = self._thread_context.get((to_addr, thread_id))
+            if ctx is not None:
+                return ctx
+        latest: Optional[Dict[str, Any]] = None
+        latest_ts: float = -1.0
+        for (sender, _mid), ctx in self._thread_context.items():
+            if sender != to_addr:
+                continue
+            ts = ctx.get("last_seen_ts", 0.0)
+            if ts > latest_ts:
+                latest_ts = ts
+                latest = ctx
+        return latest or {}
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
@@ -435,11 +484,16 @@ class EmailAdapter(BasePlatformAdapter):
             if att["type"] == "image":
                 msg_type = MessageType.PHOTO
 
-        # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
+        # Store thread context for reply threading.
+        # Key is (sender_addr, message_id) so concurrent inbound messages from
+        # the same sender don't overwrite each other's reply headers.
+        ctx_key = (sender_addr, msg_data["message_id"])
+        self._thread_context[ctx_key] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "last_seen_ts": time.time(),
         }
+        self._trim_thread_context()
 
         source = self.build_source(
             chat_id=sender_addr,
@@ -491,8 +545,10 @@ class EmailAdapter(BasePlatformAdapter):
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
+        # Thread context for reply — helper finds the right entry under the
+        # (sender, message_id) tuple key. Without a thread_id hint (plumbed in
+        # PR B), falls back to the most-recent entry from this sender.
+        ctx = self._lookup_thread_context(to_addr)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -574,7 +630,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._lookup_thread_context(to_addr)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
@@ -616,7 +672,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""
-        ctx = self._thread_context.get(chat_id, {})
+        ctx = self._lookup_thread_context(chat_id)
         return {
             "name": chat_id,
             "type": "dm",

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -20,6 +20,7 @@ from email.mime.base import MIMEBase
 from email import encoders
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from gateway.platforms.base import SendResult
@@ -1279,6 +1280,353 @@ class TestImapConnectionCleanup(unittest.TestCase):
 
         self.assertEqual(results, [])
         mock_imap.logout.assert_called_once()
+
+
+class TestSessionKeying(unittest.TestCase):
+    """Tests for per-thread email session keying via Gmail's X-GM-THRID.
+
+    PR B opt-in via `platforms.email.extra.session_keying: gmail_thread_id`.
+    Default `sender` mode preserves the pre-PR-B single-session-per-sender
+    behavior.
+    """
+
+    _ENV = {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.gmail.com",
+        "EMAIL_SMTP_HOST": "smtp.gmail.com",
+    }
+
+    def _make_adapter(self, session_keying: Optional[str] = None):
+        from gateway.config import PlatformConfig
+        extra = {}
+        if session_keying is not None:
+            extra["session_keying"] = session_keying
+        with patch.dict(os.environ, self._ENV):
+            from gateway.platforms.email import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True, extra=extra))
+
+    @staticmethod
+    def _mock_fetch_response(uid: bytes, thrid: Optional[str], body: bytes):
+        """Build the payload that `imap.uid('fetch', ...)` returns for Gmail.
+
+        Real Gmail response when fetching (RFC822 X-GM-THRID) looks like:
+            ('OK', [(b'5 (UID 5 X-GM-THRID 1234567890 RFC822 {123}', <body>), b')'])
+        """
+        header = f"{uid.decode()} (UID {uid.decode()}".encode()
+        if thrid is not None:
+            header += f" X-GM-THRID {thrid}".encode()
+        header += b" RFC822 {" + str(len(body)).encode() + b"}"
+        return ("OK", [(header, body), b")"])
+
+    @staticmethod
+    def _raw_email(sender: str = "alice@example.com",
+                   subject: str = "Hello",
+                   message_id: str = "<a@x>") -> bytes:
+        msg = MIMEText("body", "plain", "utf-8")
+        msg["From"] = sender
+        msg["Subject"] = subject
+        msg["Message-ID"] = message_id
+        return msg.as_bytes()
+
+    # ---------------- default / sender-mode behavior ----------------
+
+    def test_sender_mode_is_default(self):
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._session_keying, "sender")
+
+    def test_sender_mode_produces_no_thread_id(self):
+        """In sender mode, source.thread_id stays None and the session key
+        reduces to the chat_id — preserves pre-PR-B behavior."""
+        import asyncio
+        adapter = self._make_adapter(session_keying="sender")
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+        adapter.handle_message = capture
+
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "alice@example.com",
+            "sender_name": "Alice",
+            "subject": "Hello",
+            "message_id": "<a@x>",
+            "in_reply_to": "",
+            "body": "Body",
+            "attachments": [],
+            "date": "",
+            "gmail_thread_id": None,
+        }))
+        self.assertEqual(len(captured), 1)
+        self.assertIsNone(captured[0].source.thread_id)
+
+    def test_unknown_mode_falls_back_to_sender(self):
+        adapter = self._make_adapter(session_keying="bogus_mode")
+        self.assertEqual(adapter._session_keying, "sender")
+
+    # ---------------- gmail_thread_id mode behavior ----------------
+
+    def test_gmail_mode_assigns_gthr_prefixed_thread_id(self):
+        """With THRID present, thread_id is `gthr-<digits>` — the prefix
+        makes thread IDs distinguishable from message-id fallbacks in logs."""
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+        adapter.handle_message = capture
+
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "alice@example.com",
+            "sender_name": "Alice",
+            "subject": "Hello",
+            "message_id": "<a@x>",
+            "in_reply_to": "",
+            "body": "Body",
+            "attachments": [],
+            "date": "",
+            "gmail_thread_id": "1234567890123456789",
+        }))
+        self.assertEqual(captured[0].source.thread_id, "gthr-1234567890123456789")
+
+    def test_gmail_mode_without_thrid_falls_back_to_message_id_hash(self):
+        """When THRID is absent (edge case — extension somehow off), treat
+        this message as its own thread root via a stable hash of its own
+        Message-ID."""
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+        adapter.handle_message = capture
+
+        asyncio.run(adapter._dispatch_message({
+            "uid": b"1",
+            "sender_addr": "alice@example.com",
+            "sender_name": "Alice",
+            "subject": "Hello",
+            "message_id": "<a@x>",
+            "in_reply_to": "",
+            "body": "Body",
+            "attachments": [],
+            "date": "",
+            "gmail_thread_id": None,
+        }))
+        tid = captured[0].source.thread_id
+        self.assertIsNotNone(tid)
+        self.assertTrue(tid.startswith("mid-"))
+
+    def test_gmail_mode_same_thrid_produces_same_thread_id(self):
+        """Multiple inbound messages with the same THRID must resolve to the
+        same session key — that's the point of the feature."""
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+        adapter.handle_message = capture
+
+        for i, mid in enumerate(["<a@x>", "<b@x>", "<c@x>"]):
+            asyncio.run(adapter._dispatch_message({
+                "uid": str(i).encode(),
+                "sender_addr": "alice@example.com",
+                "sender_name": "Alice",
+                "subject": "Thread topic",
+                "message_id": mid,
+                "in_reply_to": "",
+                "body": "Body",
+                "attachments": [],
+                "date": "",
+                "gmail_thread_id": "42",
+            }))
+        tids = {e.source.thread_id for e in captured}
+        self.assertEqual(tids, {"gthr-42"})
+
+    def test_gmail_mode_distinct_thrids_produce_distinct_thread_ids(self):
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+        adapter.handle_message = capture
+
+        for uid, mid, thrid in [
+            (b"1", "<a@x>", "11"),
+            (b"2", "<b@x>", "22"),
+        ]:
+            asyncio.run(adapter._dispatch_message({
+                "uid": uid,
+                "sender_addr": "alice@example.com",
+                "sender_name": "Alice",
+                "subject": "Hello",
+                "message_id": mid,
+                "in_reply_to": "",
+                "body": "Body",
+                "attachments": [],
+                "date": "",
+                "gmail_thread_id": thrid,
+            }))
+        tids = [e.source.thread_id for e in captured]
+        self.assertEqual(tids, ["gthr-11", "gthr-22"])
+
+    # ---------------- capability probe ----------------
+
+    def test_capability_probe_degrades_when_extension_missing(self):
+        """When the server doesn't advertise X-GM-EXT-1, the adapter must
+        fall back to sender mode rather than silently misroute sessions."""
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        self.assertEqual(adapter._session_keying, "gmail_thread_id")
+
+        mock_imap = MagicMock()
+        # Server without X-GM-EXT-1 — vanilla IMAP4REV1 only.
+        mock_imap.capability.return_value = ("OK", [b"IMAP4REV1 STARTTLS AUTH=PLAIN"])
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.connect())
+
+        self.assertFalse(adapter._has_gmail_ext)
+        self.assertEqual(adapter._session_keying, "sender")
+
+        # Clean up the poll task spun up by connect()
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    def test_capability_probe_keeps_mode_when_extension_present(self):
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+
+        mock_imap = MagicMock()
+        mock_imap.capability.return_value = ("OK", [b"IMAP4REV1 X-GM-EXT-1 AUTH=PLAIN"])
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_smtp.return_value = MagicMock()
+            asyncio.run(adapter.connect())
+
+        self.assertTrue(adapter._has_gmail_ext)
+        self.assertEqual(adapter._session_keying, "gmail_thread_id")
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
+
+    # ---------------- THRID parser ----------------
+
+    def test_parse_gm_thrid_extracts_decimal(self):
+        from gateway.platforms.email import EmailAdapter
+        response = (b"5 (UID 5 X-GM-THRID 1234567890123456789 RFC822 {123}", b"body")
+        self.assertEqual(
+            EmailAdapter._parse_gm_thrid(response),
+            "1234567890123456789",
+        )
+
+    def test_parse_gm_thrid_returns_none_when_absent(self):
+        from gateway.platforms.email import EmailAdapter
+        response = (b"5 (UID 5 RFC822 {123}", b"body")
+        self.assertIsNone(EmailAdapter._parse_gm_thrid(response))
+
+    def test_parse_gm_thrid_returns_none_for_malformed_input(self):
+        from gateway.platforms.email import EmailAdapter
+        self.assertIsNone(EmailAdapter._parse_gm_thrid(None))
+        self.assertIsNone(EmailAdapter._parse_gm_thrid("not a tuple"))
+
+    # ---------------- fetch wires THRID through ----------------
+
+    def test_fetch_populates_gmail_thread_id_when_gmail_mode_active(self):
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        adapter._has_gmail_ext = True  # bypass capability probe for unit test
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"5"])
+            if command == "fetch":
+                # Verify we asked for X-GM-THRID in addition to RFC822.
+                self.assertIn("X-GM-THRID", args[1])
+                return self._mock_fetch_response(
+                    b"5", "1234567890123456789", self._raw_email(),
+                )
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["gmail_thread_id"], "1234567890123456789")
+
+    def test_fetch_skips_extended_items_in_sender_mode(self):
+        """In sender mode, the FETCH call must stay on (RFC822) so we don't
+        send extra request bytes servers without the Gmail extension would
+        reject."""
+        adapter = self._make_adapter(session_keying="sender")
+
+        mock_imap = MagicMock()
+        seen_items = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"5"])
+            if command == "fetch":
+                seen_items.append(args[1])
+                return ("OK", [(b"5 (UID 5", self._raw_email()), b")"])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            adapter._fetch_new_messages()
+        self.assertEqual(seen_items, ["(RFC822)"])
+
+    # ---------------- metadata plumbing through send_image / send_document ----------------
+
+    def test_send_image_passes_metadata_through_to_send(self):
+        """Regression: pre-PR-B send_image dropped metadata, so image replies
+        in gmail_thread_id mode would fall back to the latest-subject heuristic
+        instead of threading into the exact thread."""
+        import asyncio
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="<x>"))
+        asyncio.run(adapter.send_image(
+            "alice@example.com",
+            "https://example.com/i.png",
+            caption="hi",
+            metadata={"thread_id": "gthr-42"},
+        ))
+        _, kwargs = adapter.send.call_args
+        self.assertEqual(kwargs.get("metadata"), {"thread_id": "gthr-42"})
+
+    def test_send_document_forwards_thread_id_to_attachment_sender(self):
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter(session_keying="gmail_thread_id")
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"content")
+            path = f.name
+
+        with patch.object(adapter, "_send_email_with_attachment",
+                          return_value="<x>") as spy:
+            asyncio.run(adapter.send_document(
+                "alice@example.com",
+                path,
+                caption="docs",
+                metadata={"thread_id": "gthr-99"},
+            ))
+        # Signature: _send_email_with_attachment(to_addr, body, file_path,
+        #                                         file_name, thread_id)
+        called_args = spy.call_args[0]
+        self.assertEqual(called_args[4], "gthr-99")
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -601,17 +601,21 @@ class TestThreadContext(unittest.TestCase):
         }
 
         asyncio.run(adapter._dispatch_message(msg_data))
-        ctx = adapter._thread_context.get("user@test.com")
+        # After PR A, _thread_context is keyed by (sender, message_id).
+        ctx = adapter._thread_context.get(("user@test.com", "<original@test.com>"))
         self.assertIsNotNone(ctx)
         self.assertEqual(ctx["subject"], "Project question")
         self.assertEqual(ctx["message_id"], "<original@test.com>")
+        self.assertIn("last_seen_ts", ctx)
 
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
+        import time
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
+        adapter._thread_context[("user@test.com", "<original@test.com>")] = {
             "subject": "Project question",
             "message_id": "<original@test.com>",
+            "last_seen_ts": time.time(),
         }
 
         with patch("smtplib.SMTP") as mock_smtp:
@@ -628,10 +632,12 @@ class TestThreadContext(unittest.TestCase):
 
     def test_reply_does_not_double_re(self):
         """If subject already has Re:, don't add another."""
+        import time
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
+        adapter._thread_context[("user@test.com", "<reply@test.com>")] = {
             "subject": "Re: Project question",
             "message_id": "<reply@test.com>",
+            "last_seen_ts": time.time(),
         }
 
         with patch("smtplib.SMTP") as mock_smtp:
@@ -656,6 +662,100 @@ class TestThreadContext(unittest.TestCase):
 
             send_call = mock_server.send_message.call_args[0][0]
             self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
+
+    def test_concurrent_threads_no_clobber(self):
+        """Two concurrent inbound emails from the same sender must keep both
+        thread contexts distinct so each reply threads to the correct
+        Message-ID. Pre-PR-A this clobbered the first thread with the second."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        async def noop_handle(event):
+            pass
+
+        adapter.handle_message = noop_handle
+
+        base = {
+            "sender_addr": "alice@example.com",
+            "sender_name": "Alice",
+            "in_reply_to": "",
+            "body": "x",
+            "attachments": [],
+            "date": "",
+        }
+        asyncio.run(adapter._dispatch_message({
+            **base, "uid": b"1", "subject": "Topic A", "message_id": "<a@x>",
+        }))
+        asyncio.run(adapter._dispatch_message({
+            **base, "uid": b"2", "subject": "Topic B", "message_id": "<b@x>",
+        }))
+
+        # Both entries must coexist under distinct tuple keys.
+        self.assertEqual(len(adapter._thread_context), 2)
+        self.assertIn(("alice@example.com", "<a@x>"), adapter._thread_context)
+        self.assertIn(("alice@example.com", "<b@x>"), adapter._thread_context)
+
+        # Explicit thread_id lookup returns the exact entry for each.
+        ctx_a = adapter._lookup_thread_context("alice@example.com", "<a@x>")
+        ctx_b = adapter._lookup_thread_context("alice@example.com", "<b@x>")
+        self.assertEqual(ctx_a["subject"], "Topic A")
+        self.assertEqual(ctx_b["subject"], "Topic B")
+
+    def test_thread_context_trim_bounds_memory(self):
+        """When _thread_context exceeds the cap, the trimmer keeps only the
+        most-recent entries (by insertion order) up to ~half the cap."""
+        import time
+        adapter = self._make_adapter()
+        adapter._thread_context_max = 10  # shrink cap for a fast test
+
+        for i in range(adapter._thread_context_max + 1):
+            adapter._thread_context[("alice@example.com", f"<m{i}@x>")] = {
+                "subject": f"s{i}",
+                "message_id": f"<m{i}@x>",
+                "last_seen_ts": time.time() + i,
+            }
+        adapter._trim_thread_context()
+
+        self.assertLessEqual(len(adapter._thread_context), adapter._thread_context_max)
+        # Most-recent entry survives (inserted last).
+        self.assertIn(
+            ("alice@example.com", f"<m{adapter._thread_context_max}@x>"),
+            adapter._thread_context,
+        )
+        # Oldest entry was dropped.
+        self.assertNotIn(("alice@example.com", "<m0@x>"), adapter._thread_context)
+
+    def test_lookup_helper_falls_back_to_latest_when_no_thread_id(self):
+        """Without thread_id, the helper returns the most-recent entry from
+        this sender. This preserves today's 'reply with sender's latest
+        subject' behavior for callers not yet plumbing thread_id."""
+        import time
+        adapter = self._make_adapter()
+        now = time.time()
+        adapter._thread_context[("alice@example.com", "<old@x>")] = {
+            "subject": "Old",
+            "message_id": "<old@x>",
+            "last_seen_ts": now - 100,
+        }
+        adapter._thread_context[("alice@example.com", "<new@x>")] = {
+            "subject": "New",
+            "message_id": "<new@x>",
+            "last_seen_ts": now,
+        }
+        # Decoy: different sender with a newer timestamp must NOT match.
+        adapter._thread_context[("bob@example.com", "<decoy@x>")] = {
+            "subject": "Decoy",
+            "message_id": "<decoy@x>",
+            "last_seen_ts": now + 100,
+        }
+
+        ctx = adapter._lookup_thread_context("alice@example.com")
+        self.assertEqual(ctx["subject"], "New")
+
+    def test_lookup_helper_returns_empty_for_unknown_sender(self):
+        """Helper returns {} when no entry matches."""
+        adapter = self._make_adapter()
+        self.assertEqual(adapter._lookup_thread_context("nobody@example.com"), {})
 
 
 class TestSendMethods(unittest.TestCase):
@@ -766,8 +866,13 @@ class TestSendMethods(unittest.TestCase):
     def test_get_chat_info(self):
         """get_chat_info should return email address as chat info."""
         import asyncio
+        import time
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {"subject": "Test", "message_id": "<m@t>"}
+        adapter._thread_context[("user@test.com", "<m@t>")] = {
+            "subject": "Test",
+            "message_id": "<m@t>",
+            "last_seen_ts": time.time(),
+        }
 
         info = asyncio.run(
             adapter.get_chat_info("user@test.com")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1062,3 +1062,51 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("reasoning") == "I need to think step by step."
         assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
+
+
+class TestEmailThreadIdSessionKey:
+    """Regression for QUIENG-503: when the email adapter populates
+    `source.thread_id` (gmail_thread_id mode), the session key must include
+    it — otherwise every Gmail thread from a given sender would collapse into
+    a single shared session and re-introduce the context-poisoning bug this
+    whole feature exists to fix."""
+
+    def test_email_dm_with_thread_id_includes_thread_in_key(self):
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            chat_id="alice@example.com",
+            chat_type="dm",
+            user_id="alice@example.com",
+            user_name="Alice",
+            thread_id="gthr-1234567890",
+        )
+        assert build_session_key(source) == (
+            "agent:main:email:dm:alice@example.com:gthr-1234567890"
+        )
+
+    def test_email_dm_without_thread_id_stays_chat_keyed(self):
+        """Sender mode (thread_id absent) should continue to collapse all
+        email from a sender into a single session."""
+        source = SessionSource(
+            platform=Platform.EMAIL,
+            chat_id="alice@example.com",
+            chat_type="dm",
+            user_id="alice@example.com",
+            user_name="Alice",
+        )
+        assert build_session_key(source) == "agent:main:email:dm:alice@example.com"
+
+    def test_email_distinct_thread_ids_produce_distinct_keys(self):
+        first = SessionSource(
+            platform=Platform.EMAIL,
+            chat_id="alice@example.com",
+            chat_type="dm",
+            thread_id="gthr-111",
+        )
+        second = SessionSource(
+            platform=Platform.EMAIL,
+            chat_id="alice@example.com",
+            chat_type="dm",
+            thread_id="gthr-222",
+        )
+        assert build_session_key(first) != build_session_key(second)


### PR DESCRIPTION
## Summary

Opt-in `platforms.email.extra.session_keying` setting that lets the email adapter route each visible-to-user mail thread to its own gateway session, keyed by Gmail's `X-GM-THRID` IMAP extension. Brings email parity with Slack / Discord / Telegram / Matrix, which already split sessions per thread.

**Stacked on #11418** (precursor `_thread_context` clobber bugfix). The diff below includes both commits; they should land in order.

## The user-visible problem

Today the email adapter omits `thread_id` when building the `SessionSource`, so every inbound message from a given sender collapses into one shared session forever:

1. **Context poisoning across unrelated topics** — memories the agent persists while handling Email A bleed into replies to unrelated Email B from the same sender.
2. **Monotonic token-cost bloat** — every new email's first turn replays the entire sender's prior conversation history.
3. **Broken `/reset` semantics** — resetting one thread destroys context for every other concurrent thread from the same sender.
4. **Reply-header clobber** — addressed in the precursor #11418.

## Why Gmail-only (for now)

`X-GM-THRID` is Gmail's stable, server-assigned thread identifier, returned in the same FETCH round-trip as the body:

```
UID FETCH <uid> (RFC822 X-GM-THRID)
```

It matches what users see as a thread in Gmail (web/mobile/Apple Mail), inherits Gmail's threading heuristics (subject changes mid-thread, forwards, cross-client replies), and is documented at https://developers.google.com/gmail/imap/imap-extensions.

The alternative (RFC 5322 `References` walking + subject-hash) is ~150 LoC of error-prone parsing; defer to a follow-up that adds a generic `thread_root` mode for non-Gmail deployments. Default stays `sender` — non-Gmail users see zero change.

## Changes

- **Config:** new `extra.session_keying` value, `\"sender\"` (default) or `\"gmail_thread_id\"`. Unknown values warn-and-degrade to `sender`.
- **Capability probe:** `connect()` runs `imap.capability()` and records `_has_gmail_ext`. If `gmail_thread_id` is requested but `X-GM-EXT-1` is absent, the adapter logs a warning and degrades to `sender` mode.
- **Extended FETCH:** `_fetch_new_messages` switches the FETCH payload to `(RFC822 X-GM-THRID)` when Gmail mode is active. Parses the THRID via a small `_parse_gm_thrid` helper.
- **Dispatch:** `_dispatch_message` derives `thread_id`:
  - `f\"gthr-{thrid}\"` when THRID is present, or
  - `f\"mid-{sha1(message_id)[:12]}\"` when it's missing (treats the message as its own thread root — always safe).
  Then passes `thread_id` to `build_source(...)` and stores `_thread_context` under the `(sender, thread_id)` tuple.
- **Outbound plumbing:** `send()` extracts `thread_id` from `metadata[\"thread_id\"]` and forwards it to `_send_email`. `_send_email` and `_send_email_with_attachment` accept `thread_id` and resolve via the helper added in #11418.
- **`send_image` / `send_document` extension:** these methods were missing the `metadata` parameter — without that fix, attachment replies would drop `thread_id` and fall back to the latest-subject heuristic. Signatures extended; metadata plumbed through `send`/`_send_email_with_attachment`.

## Tests

- `TestSessionKeying` (14 new tests): default-mode behavior, mode validation, Gmail thread-id derivation (with and without THRID), same-thrid → same key, distinct-thrid → distinct keys, capability probe degradation, FETCH payload shape per mode, THRID parser unit tests, metadata propagation through `send_image`/`send_document`.
- `TestEmailThreadIdSessionKey` in `tests/gateway/test_session.py` (3 new tests): regression that `build_session_key` for an email DM with thread_id produces `agent:main:email:dm:<addr>:<thread_id>`.

Local verification:
- Email + session focused: \`pytest tests/gateway/test_email.py tests/gateway/test_session.py\` → 154 passed.
- Broader sweep (excluding pre-existing flaky env-dependent tests for matrix/slack-approval/whatsapp): 2816 passed, 0 failed.

## Migration / risk

- Default stays `sender`. Existing installs: zero behavior change.
- Opting a profile into `gmail_thread_id` causes a one-time session fragmentation: the next message from a sender lands in a fresh thread session rather than the pre-existing flat one. Existing sessions remain accessible at their old keys; they simply stop accumulating new messages.
- Capability probe handles delegated-mailbox / Workspace-restricted edge cases gracefully (degrade with warning log). All Gmail / Google Workspace deployments advertise `X-GM-EXT-1`.

## Test plan

- [x] Unit tests pass (154/154 in scope).
- [ ] Smoke test on real Gmail IMAP: two back-to-back inbound emails on different topics from the same sender; confirm two distinct session keys (`agent:main:email:dm:<addr>:gthr-<digits>`) appear in the supervisord log.
- [ ] Multi-turn continuity: 3+ replies in one Gmail thread accumulate on a single session.
- [ ] `/reset` scope: resetting thread A leaves thread B's session untouched.
- [ ] Subject-change robustness: replying with a renamed subject still resolves to the same Gmail-assigned THRID.