### PR TITLE
feat(cli): Add Ctrl+X Ctrl+E external editor support

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8429,6 +8429,64 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
+        @kb.add('c-x', 'c-e')
+        def handle_ctrl_x_ctrl_e(event):
+            """Ctrl+X Ctrl+E: Open external editor (custom implementation)."""
+            import tempfile
+            import subprocess
+            import os
+            
+            # Get current buffer content
+            buff = event.current_buffer
+            text = buff.text
+            
+            # Create temporary file
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+                f.write(text)
+                temp_file = f.name
+            
+            # Get editor from environment variable
+            editor = os.environ.get('EDITOR') or os.environ.get('VISUAL') or 'vi'
+            
+            # Save current terminal state
+            from prompt_toolkit.application import get_app
+            app = get_app()
+            
+            # Hide the UI
+            app.renderer.erase()
+            app.output.flush()
+            
+            # Run editor
+            try:
+                returncode = subprocess.call([editor, temp_file])
+                
+                # Check if editor succeeded
+                if returncode == 0:
+                    # Read the edited content
+                    with open(temp_file, 'r', encoding='utf-8') as f:
+                        new_text = f.read()
+                    
+                    # Remove trailing newline if present
+                    if new_text.endswith('\n'):
+                        new_text = new_text[:-1]
+                    
+                    # Update buffer
+                    buff.text = new_text
+                    buff.cursor_position = len(new_text)
+                    
+                    # Invalidate to refresh the display
+                    app.invalidate()
+            finally:
+                # Clean up temporary file
+                try:
+                    os.unlink(temp_file)
+                except:
+                    pass
+                
+                # Restore the UI
+                app.renderer.reset()
+                app.invalidate()
+
         @kb.add('c-j')
         def handle_ctrl_enter(event):
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""

--- a/cli.py
+++ b/cli.py
@@ -8441,7 +8441,7 @@ class HermesCLI:
             text = buff.text
             
             # Create temporary file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
                 f.write(text)
                 temp_file = f.name
             


### PR DESCRIPTION
Add custom implementation for opening external editor via Ctrl+X Ctrl+E keybinding in the CLI input. This bypasses prompt_toolkit's built-in editor support which has compatibility issues with neovim.

## Features
- Opens system editor (respects $EDITOR/$VISUAL env vars)
- Falls back to `vi` if no environment variables set
- Works with system alternatives (e.g., `vi` → `nvim`)
- Syncs edited content back to CLI buffer
- Properly handles terminal state (hide/show UI)
- Cleans up temporary files
- Works with neovim, vim, nano, and other editors

## Technical notes
- Uses tempfile for safe content transfer
- Saves/restores terminal state via prompt_toolkit API
- Handles editor return codes and error cases
- Custom implementation avoids prompt_toolkit's neovim incompatibility
- No environment variable configuration required
- Uses `.md` suffix for better markdown syntax highlighting

## Tested on
- Ubuntu 24.04 + Ghostty + zsh + neovim
- Works with `vi` → `nvim` system alternatives