### PR TITLE
fix(feishu): use thread_id as reply target when reply_to is empty

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3417,15 +3417,17 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
-        reply_in_thread = bool((metadata or {}).get("thread_id"))
-        if reply_to:
+        thread_id = (metadata or {}).get("thread_id")
+        reply_in_thread = bool(thread_id)
+        effective_reply_to = reply_to or (thread_id if reply_in_thread else None)
+        if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,
                 msg_type=msg_type,
                 reply_in_thread=reply_in_thread,
                 uuid_value=str(uuid.uuid4()),
             )
-            request = self._build_reply_message_request(reply_to, body)
+            request = self._build_reply_message_request(effective_reply_to, body)
             return await asyncio.to_thread(self._client.im.v1.message.reply, request)
 
         body = self._build_create_message_body(


### PR DESCRIPTION
## Summary

Fixes Feishu topic group (话题群) replies falling through to top-level messages instead of staying within the thread.

**Problem:** In Feishu topic groups, messages within a thread carry a `thread_id` in metadata but the `reply_to` parameter can be `None`. The existing code only checked `reply_to` to decide whether to use the reply API, so thread messages with no `reply_to` would silently fall back to `create_message` — posting a new top-level message instead of replying in-thread.

**Fix:** Extract `thread_id` from metadata and use it as a fallback when `reply_to` is absent. This ensures the reply API is called with the correct message target, keeping responses within the thread context.

## Changes

- `gateway/platforms/feishu.py`: 3 lines changed in `_send_single_message`
  - Extract `thread_id` before the reply decision
  - Compute `effective_reply_to = reply_to or thread_id`
  - Use `effective_reply_to` for both the guard condition and the reply request

## Testing

Tested in production with a Feishu bot deployed in topic groups (话题群). Before the fix, bot responses appeared as new top-level messages. After the fix, responses correctly appear within the originating thread.

Made with [Cursor](https://cursor.com)