### PR TITLE
fix(responses): drop orphan function_call_output when function name is empty (fixes HTTP 400)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3763,6 +3763,10 @@ class AIAgent:
     def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
         items: List[Dict[str, Any]] = []
+        # call_ids of function_call items skipped due to empty/missing name.
+        # Their paired function_call_output items must also be skipped to
+        # prevent orphan outputs that cause HTTP 400 (issue #11411).
+        _skipped_call_ids: set = set()
         seen_item_ids: set = set()
 
         for msg in messages:
@@ -3815,6 +3819,13 @@ class AIAgent:
                             fn = tc.get("function", {})
                             fn_name = fn.get("name")
                             if not isinstance(fn_name, str) or not fn_name.strip():
+                                # Track the call_id so the paired function_call_output
+                                # is also skipped — an orphan output with no matching
+                                # function_call causes the provider to reconstruct name
+                                # as an empty string, triggering HTTP 400 (issue #11411).
+                                _bad_id = tc.get("id") or tc.get("call_id")
+                                if isinstance(_bad_id, str) and _bad_id.strip():
+                                    _skipped_call_ids.add(_bad_id.strip())
                                 continue
 
                             embedded_call_id, embedded_response_item_id = self._split_responses_tool_id(
@@ -3860,6 +3871,14 @@ class AIAgent:
                     if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
                         call_id = raw_tool_call_id.strip()
                 if not isinstance(call_id, str) or not call_id.strip():
+                    continue
+                # Skip outputs whose paired function_call was dropped due to
+                # an empty/missing name — an orphan output triggers HTTP 400.
+                if call_id.strip() in _skipped_call_ids:
+                    logger.debug(
+                        "Responses serializer: dropping orphan function_call_output "
+                        "for skipped call_id %r (issue #11411)", call_id
+                    )
                     continue
                 items.append({
                     "type": "function_call_output",


### PR DESCRIPTION
## Problem

When serializing chat history to Responses API input items, a `function_call` with an empty/missing `name` is silently skipped. However the paired `function_call_output` was still emitted, creating an orphan item.

The provider tries to reconstruct the function name from the orphan output, produces an empty string, and rejects the request:

```
HTTP 400: Invalid 'input[n].name': empty string.
Expected a string with minimum length 1, but got an empty string instead.
```

The failing index varies across turns (`input[3]`, `[4]`, `[5]`, `[6]`, `[7]`, `[9]`, `[18]`, `[19]`) because it depends on how many items precede the orphan in the conversation history.

## Fix

Track skipped `call_id`s in `_skipped_call_ids` when a `function_call` is dropped due to empty/missing name. When processing `function_call_output` items, skip any whose `call_id` is in `_skipped_call_ids`.

Adds a `debug`-level log so the drop is visible in verbose sessions.

## Result

Orphan `function_call_output` items are never sent to the provider. Sessions with empty-name tool calls no longer produce HTTP 400 errors.

Fixes #11411