### PR TITLE
fix: align model context length across display and runtime

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4494,7 +4494,7 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None, config_context_length=None) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
@@ -4506,6 +4506,7 @@ class HermesCLI:
             "current_provider": current_provider,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
+            "config_context_length": config_context_length,
         }
         self._invalidate(min_interval=0.0)
 
@@ -4555,14 +4556,10 @@ class HermesCLI:
         _cprint(f"    Provider: {provider_label}")
 
         mi = result.model_info
-        if mi:
-            if mi.context_window:
-                _cprint(f"    Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                _cprint(f"    Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                _cprint(f"    Cost: {mi.format_cost()}")
-            _cprint(f"    Capabilities: {mi.format_capabilities()}")
+        if result.display_context_length:
+            _cprint(f"    Context: {result.display_context_length:,} tokens")
+        elif mi and mi.context_window:
+            _cprint(f"    Context: {mi.context_window:,} tokens")
         else:
             try:
                 from agent.model_metadata import get_model_context_length
@@ -4575,6 +4572,13 @@ class HermesCLI:
                 _cprint(f"    Context: {ctx:,} tokens")
             except Exception:
                 pass
+
+        if mi:
+            if mi.max_output:
+                _cprint(f"    Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                _cprint(f"    Cost: {mi.format_cost()}")
+            _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
         cache_enabled = (
             ("openrouter" in (result.base_url or "").lower() and "claude" in result.new_model.lower())
@@ -4649,6 +4653,7 @@ class HermesCLI:
                     explicit_provider=provider_data.get("slug"),
                     user_providers=state.get("user_provs"),
                     custom_providers=state.get("custom_provs"),
+                    config_context_length=state.get("config_context_length"),
                 )
                 self._close_model_picker()
                 self._apply_model_switch_result(result, persist_global)
@@ -4677,6 +4682,24 @@ class HermesCLI:
 
         user_provs = None
         custom_provs = None
+        config_context_length = None
+
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = get_compatible_custom_providers(cfg)
+            model_cfg = cfg.get("model", {})
+            if isinstance(model_cfg, dict):
+                raw_ctx = model_cfg.get("context_length")
+                if raw_ctx is not None and not isinstance(raw_ctx, bool):
+                    try:
+                        _parsed_ctx = int(raw_ctx)
+                        config_context_length = _parsed_ctx if _parsed_ctx > 0 else None
+                    except (TypeError, ValueError):
+                        config_context_length = None
+        except Exception:
+            pass
 
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
@@ -4716,7 +4739,9 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                config_context_length=config_context_length,
             )
+
             return
 
         # Perform the switch
@@ -4730,6 +4755,7 @@ class HermesCLI:
             explicit_provider=explicit_provider,
             user_providers=user_provs,
             custom_providers=custom_provs,
+            config_context_length=config_context_length,
         )
 
         if not result.success:
@@ -4781,14 +4807,10 @@ class HermesCLI:
 
         # Rich metadata from models.dev
         mi = result.model_info
-        if mi:
-            if mi.context_window:
-                _cprint(f"    Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                _cprint(f"    Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                _cprint(f"    Cost: {mi.format_cost()}")
-            _cprint(f"    Capabilities: {mi.format_capabilities()}")
+        if result.display_context_length:
+            _cprint(f"    Context: {result.display_context_length:,} tokens")
+        elif mi and mi.context_window:
+            _cprint(f"    Context: {mi.context_window:,} tokens")
         else:
             # Fallback to old context length lookup
             try:
@@ -4802,6 +4824,13 @@ class HermesCLI:
                 _cprint(f"    Context: {ctx:,} tokens")
             except Exception:
                 pass
+
+        if mi:
+            if mi.max_output:
+                _cprint(f"    Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                _cprint(f"    Cost: {mi.format_cost()}")
+            _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
         # Cache notice
         cache_enabled = (

--- a/docs/plans/2026-04-17-model-context-alignment-fix-plan.md
+++ b/docs/plans/2026-04-17-model-context-alignment-fix-plan.md
@@ -1,0 +1,66 @@
+# 模型上下文显示/运行时对齐修复计划
+
+日期：2026-04-17
+状态：已批准，实施中
+
+## 背景
+主人已批准对 Hermes Agent 中“模型切换回显 / 运行时上下文 / LCM 实际窗口”三层不一致问题做最小范围修复，并要求：
+1. 记录完整改动过程，确保中断后可恢复。
+2. 改完后做好提交与 PR 到 Hermes-Agent 官方库的准备。
+3. 优先控制改动面，不在本轮顺手改大范围配置/插件语义。
+
+当前已确认现象：
+- `yunfeiplus:gpt-5.4` 的配置声明窗口是 `524288`。
+- `/model` 切换后的显示会回退成 `128000`。
+- 运行中的 `AIAgent` / `LCMEngine` 实际仍吃到全局 `model.context_length=200000`。
+- LCM 当前阈值 `0.75` 来自插件默认，不应与内置 `compression.threshold` 混改。
+
+## 目标
+1. 修复模型切换成功回显，使其优先显示 custom provider per-model 的 `context_length`，不再错误显示 `128000`。
+2. 修复运行时 `AIAgent` 初始化与热切换时的 context_length 解析优先级，使 `custom_providers[].models[model].context_length` 优先于全局 `model.context_length`。
+3. 让 LCM 在当前模型为 `yunfeiplus:gpt-5.4` 时实际吃到 `524288`，阈值随之按 LCM 自身 `0.75` 规则计算。
+4. 补充定向测试与文档记录，为后续 git commit / PR 做准备。
+
+## 非目标
+- 本轮不修改 `~/.hermes/config.yaml` 作为临时 workaround。
+- 本轮不修改 LCM 插件阈值语义，不把其与内置 `compression.threshold` 对齐。
+- 本轮不扩大到无关 provider / gateway 其它信息展示重构，除非为共享修复所必需。
+- 本轮不直接重启 gateway；如需线上验证，待代码与测试完成后再单独决定。
+
+## 证据链
+- `~/.hermes/config.yaml`：
+  - `model.context_length: 200000`
+  - `context.engine: lcm`
+  - `custom_providers.yunfeiplus.models.gpt-5.4.context_length: 524288`
+- `cli.py`：模型切换回显 fallback 调 `get_model_context_length(...)` 时未传 config override。
+- `run_agent.py`：初始化时优先读取顶层 `model.context_length`，仅在其为 `None` 时才看 custom provider per-model 值。
+- `lcm_status()`：当前会话 `context_length=200000`，`threshold_tokens=150000`。
+
+## 实施步骤（冻结版）
+1. 建立计划/进度文档，记录基线与范围。
+2. 在 `hermes_cli/model_switch.py` 设计并实现统一展示值字段（如 `display_context_length`）。
+3. 在 `cli.py`（必要时含共享调用方）优先使用统一展示字段，消除 128K 显示回退。
+4. 在 `run_agent.py` 抽取共享 runtime context override 解析逻辑，并调整优先级为：custom provider per-model > 顶层 `model.context_length` > auto-detect。
+5. 修复 `switch_model()` 热切换路径，使其在切换后重新解析并刷新 `self._config_context_length` 与 context engine 的窗口值。
+6. 补充/更新定向测试，覆盖：
+   - custom provider 展示值正确
+   - runtime context 优先级正确
+   - 热切换后 context engine 上下文值正确
+7. 运行定向测试与最小脚本验证。
+8. 更新 progress 文档，核对 git 影响面，为 commit / PR 做准备。
+
+## Definition of Done
+- `/model gpt-5.4 --provider yunfeiplus` 的成功回显显示 `524,288`，不再错误回退到 `128,000`。
+- `AIAgent(model='gpt-5.4', provider='yunfeiplus', ...)` 初始化后 `context_compressor.context_length == 524288`。
+- 从其他模型热切换到 `yunfeiplus:gpt-5.4` 后，`context_compressor.context_length == 524288`。
+- 在 LCM 下，阈值按 `524288 * 0.75 = 393216` 计算。
+- 改动文件范围清晰、测试结果有记录、仓库可进入提交/PR 准备阶段。
+
+## 断点恢复入口
+- 本计划：`docs/plans/2026-04-17-model-context-alignment-fix-plan.md`
+- 本任务进度：`docs/progress/2026-04-17-model-context-alignment-fix-progress.md`
+- 关键代码：
+  - `hermes_cli/model_switch.py`
+  - `cli.py`
+  - `run_agent.py`
+  - `tests/...`（待补）

--- a/docs/progress/2026-04-17-model-context-alignment-fix-progress.md
+++ b/docs/progress/2026-04-17-model-context-alignment-fix-progress.md
@@ -1,0 +1,111 @@
+# 模型上下文显示/运行时对齐修复进度日志
+
+日期：2026-04-17
+状态：执行中
+关联方案：`docs/plans/2026-04-17-model-context-alignment-fix-plan.md`
+
+## 当前阶段
+- Phase 1：建立基线、冻结方案、准备实施
+
+## 基线状态
+- 当前分支：`main`
+- 初始工作区非本任务脏改动：
+  - `M gateway/config.py`
+  - `M package-lock.json`
+  - `?? docs/plans/2026-04-16-get-web-router-design-plan.md`
+  - `?? docs/plans/2026-04-16-get-web-router-implementation-plan.md`
+  - `?? docs/plans/2026-04-16-pr-10885-followup-plan.md`
+  - `?? docs/plans/2026-04-16-skill-publishing-guide-publish-plan.md`
+  - `?? docs/progress/`
+- 当前已确认问题：
+  - 显示层 fallback 到 `128000`
+  - 运行时/LCM 实际使用 `200000`
+  - 配置声明值为 `524288`
+
+## 本轮待办
+- [x] 建立计划文档
+- [x] 建立进度日志
+- [ ] 实现显示层统一展示值
+- [ ] 实现运行时 context 优先级修复
+- [ ] 补测试并运行验证
+- [ ] 核对 git 影响面并准备提交/PR
+
+## 执行日志
+
+### 2026-04-17 / Step 1
+- 动作：完成只读分析，确认显示层 / 运行时 / LCM 三层问题边界。
+- 结果：锁定最小修复范围为 `hermes_cli/model_switch.py`、`cli.py`、`gateway/run.py`、`run_agent.py` 及定向测试。
+- 影响文件：
+  - `docs/plans/2026-04-17-model-context-alignment-fix-plan.md`
+  - `docs/progress/2026-04-17-model-context-alignment-fix-progress.md`
+- 备注：本轮明确不改 `config.yaml` workaround，不改 LCM 阈值语义。
+
+### 2026-04-17 / Step 2
+- 动作：实现显示层统一展示值与 gateway/CLI 回显对齐。
+- 结果：
+  - `hermes_cli/model_switch.py` 新增 `ModelSwitchResult.display_context_length`。
+  - 新增 custom provider 匹配与 `context_length` 解析 helper，优先读取 matching custom provider per-model 值。
+  - `cli.py` 与 `gateway/run.py` 两条 `/model` 成功回显路径改为优先显示 `display_context_length`，避免 custom provider 走错误的 128K fallback。
+- 影响文件：
+  - `hermes_cli/model_switch.py`
+  - `cli.py`
+  - `gateway/run.py`
+- 备注：gateway picker 回调和普通 `/model ...` 文本路径都已覆盖。
+
+### 2026-04-17 / Step 3
+- 动作：实现运行时 `context_length` 优先级修复与热切换刷新。
+- 结果：
+  - `run_agent.py` 新增共享 helper：
+    - `_resolve_custom_provider_model_context_length()`
+    - `_resolve_runtime_config_context_length()`
+  - 初始化路径改为：matching custom provider per-model override > 全局 `model.context_length` > auto-detect。
+  - `AIAgent.switch_model()` 在切模型后重新 `load_config()` 并刷新 `self._config_context_length`，再更新 context engine。
+- 影响文件：
+  - `run_agent.py`
+- 备注：保持 LCM 阈值语义不变，只修其吃到的 `context_length` 值。
+
+### 2026-04-17 / Step 4
+- 动作：补定向回归测试并执行验证。
+- 结果：
+  - 新增 `tests/hermes_cli/test_model_switch_context_alignment.py`：覆盖 display context、runtime 优先级、热切换刷新。
+  - 更新 `tests/gateway/test_model_command_custom_providers.py`：覆盖 gateway `/model` 回显使用 `display_context_length`。
+  - 保持并复跑 `tests/hermes_cli/test_model_switch_opencode_anthropic.py`，确保本轮没有破坏既有 `/model` 切换修复。
+- 影响文件：
+  - `tests/hermes_cli/test_model_switch_context_alignment.py`
+  - `tests/gateway/test_model_command_custom_providers.py`
+- 最近一次验证：
+  - `pytest -q tests/hermes_cli/test_model_switch_context_alignment.py tests/hermes_cli/test_model_switch_opencode_anthropic.py tests/gateway/test_model_command_custom_providers.py`
+  - 结果：`15 passed, 6 warnings in 4.22s`
+  - warning 判断：来自 `tests/conftest.py` 的既有 `DeprecationWarning: There is no current event loop`，与本次修复无关。
+
+### 2026-04-17 / Step 5
+- 动作：执行 git / GitHub PR 预检，确认最小提交面与推送路径。
+- 结果：
+  - 当前仓库存在无关脏改动：`gateway/config.py`、`package-lock.json`、以及多份 2026-04-16 文档草稿；本任务提交时必须隔离。
+  - 本任务最小提交面：
+    - `cli.py`
+    - `gateway/run.py`
+    - `hermes_cli/model_switch.py`
+    - `run_agent.py`
+    - `tests/gateway/test_model_command_custom_providers.py`
+    - `tests/hermes_cli/test_model_switch_context_alignment.py`
+    - `docs/plans/2026-04-17-model-context-alignment-fix-plan.md`
+    - `docs/progress/2026-04-17-model-context-alignment-fix-progress.md`
+  - GitHub 权限预检：
+    - `origin = NousResearch/hermes-agent`，`viewerPermission = READ`，直推 dry-run 返回 `403`（符合预期，不能直接推 upstream）。
+    - `fork-leavrcn = leavrcn/hermes-agent`，`viewerPermission = ADMIN`。
+    - `git push --dry-run fork-leavrcn HEAD:refs/heads/fix/context-alignment-preflight` 成功，说明后续可走 fork 分支 + PR 到 upstream。
+- 最近一次验证：
+  - `git status --short -- <task files>` → 仅本任务文件处于 modified/untracked。
+  - `gh repo view NousResearch/hermes-agent --json ...` → `viewerPermission=READ`
+  - `gh repo view leavrcn/hermes-agent --json ...` → `viewerPermission=ADMIN`
+  - `git push --dry-run origin HEAD:refs/heads/fix/context-alignment-preflight` → `403`
+  - `git push --dry-run fork-leavrcn HEAD:refs/heads/fix/context-alignment-preflight` → success
+
+## 当前断点
+- 已完成：代码修复、定向测试、文档留痕、GitHub 推送路径预检。
+- 下一步：若主人批准，可进入“创建本地分支 → 按最小提交面暂存 → 提交 → 推送 fork → 创建 PR”。
+
+## 最近一次验证
+- `git status --short -- cli.py gateway/run.py hermes_cli/model_switch.py run_agent.py tests/hermes_cli/test_model_switch_context_alignment.py tests/gateway/test_model_command_custom_providers.py docs/plans/2026-04-17-model-context-alignment-fix-plan.md docs/progress/2026-04-17-model-context-alignment-fix-progress.md` → 仅本任务文件处于 modified/untracked
+- `git push --dry-run fork-leavrcn HEAD:refs/heads/fix/context-alignment-preflight` → success

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3644,14 +3644,6 @@ class GatewayRunner:
                         _hyg_model = _model_cfg
                     elif isinstance(_model_cfg, dict):
                         _hyg_model = _model_cfg.get("default") or _model_cfg.get("model") or _hyg_model
-                        # Read explicit context_length override from model config
-                        # (same as run_agent.py lines 995-1005)
-                        _raw_ctx = _model_cfg.get("context_length")
-                        if _raw_ctx is not None:
-                            try:
-                                _hyg_config_context_length = int(_raw_ctx)
-                            except (TypeError, ValueError):
-                                pass
                         # Read provider for accurate context detection
                         _hyg_provider = _model_cfg.get("provider") or None
                         _hyg_base_url = _model_cfg.get("base_url") or None
@@ -3677,33 +3669,17 @@ class GatewayRunner:
                 except Exception:
                     pass
 
-                # Check custom_providers per-model context_length
-                # (same fallback as run_agent.py lines 1171-1189).
-                # Must run after runtime resolution so _hyg_base_url is set.
-                if _hyg_config_context_length is None and _hyg_base_url:
-                    try:
-                        try:
-                            from hermes_cli.config import get_compatible_custom_providers as _gw_gcp
-                            _hyg_custom_providers = _gw_gcp(_hyg_data)
-                        except Exception:
-                            _hyg_custom_providers = _hyg_data.get("custom_providers")
-                            if not isinstance(_hyg_custom_providers, list):
-                                _hyg_custom_providers = []
-                        for _cp in _hyg_custom_providers:
-                            if not isinstance(_cp, dict):
-                                continue
-                            _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                            if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                _cp_models = _cp.get("models", {})
-                                if isinstance(_cp_models, dict):
-                                    _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                    if isinstance(_cp_model_cfg, dict):
-                                        _cp_ctx = _cp_model_cfg.get("context_length")
-                                        if _cp_ctx is not None:
-                                            _hyg_config_context_length = int(_cp_ctx)
-                                break
-                    except (TypeError, ValueError):
-                        pass
+                try:
+                    from run_agent import _resolve_runtime_config_context_length
+
+                    _hyg_config_context_length = _resolve_runtime_config_context_length(
+                        model=_hyg_model,
+                        provider=_hyg_provider or "",
+                        base_url=_hyg_base_url or "",
+                        agent_cfg=_hyg_data if isinstance(_hyg_data, dict) else {},
+                    )
+                except Exception:
+                    pass
             except Exception:
                 pass
 
@@ -4256,12 +4232,14 @@ class GatewayRunner:
         local models falling to the 128K default).
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+        from run_agent import _resolve_runtime_config_context_length
 
         model = _resolve_gateway_model()
         config_context_length = None
         provider = None
         base_url = None
         api_key = None
+        data = {}
 
         try:
             cfg_path = _hermes_home / "config.yaml"
@@ -4271,12 +4249,6 @@ class GatewayRunner:
                     data = _info_yaml.safe_load(f) or {}
                 model_cfg = data.get("model", {})
                 if isinstance(model_cfg, dict):
-                    raw_ctx = model_cfg.get("context_length")
-                    if raw_ctx is not None:
-                        try:
-                            config_context_length = int(raw_ctx)
-                        except (TypeError, ValueError):
-                            pass
                     provider = model_cfg.get("provider") or None
                     base_url = model_cfg.get("base_url") or None
         except Exception:
@@ -4285,11 +4257,21 @@ class GatewayRunner:
         # Resolve runtime credentials for probing
         try:
             runtime = _resolve_runtime_agent_kwargs()
-            provider = provider or runtime.get("provider")
-            base_url = base_url or runtime.get("base_url")
+            provider = runtime.get("provider") or provider
+            base_url = runtime.get("base_url") or base_url
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        try:
+            config_context_length = _resolve_runtime_config_context_length(
+                model=model,
+                provider=provider or "",
+                base_url=base_url or "",
+                agent_cfg=data if isinstance(data, dict) else {},
+            )
+        except Exception:
+            config_context_length = None
 
         context_length = get_model_context_length(
             model,
@@ -4659,6 +4641,7 @@ class GatewayRunner:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        config_context_length = None
         config_path = _hermes_home / "config.yaml"
         try:
             if config_path.exists():
@@ -4669,6 +4652,13 @@ class GatewayRunner:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    raw_ctx = model_cfg.get("context_length")
+                    if raw_ctx is not None and not isinstance(raw_ctx, bool):
+                        try:
+                            _parsed_ctx = int(raw_ctx)
+                            config_context_length = _parsed_ctx if _parsed_ctx > 0 else None
+                        except (TypeError, ValueError):
+                            config_context_length = None
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -4732,6 +4722,7 @@ class GatewayRunner:
                             explicit_provider=provider_slug,
                             user_providers=user_provs,
                             custom_providers=custom_provs,
+                            config_context_length=config_context_length,
                         )
                         if not result.success:
                             return f"Error: {result.error_message}"
@@ -4781,9 +4772,11 @@ class GatewayRunner:
                         lines = [f"Model switched to `{result.new_model}`"]
                         lines.append(f"Provider: {plabel}")
                         mi = result.model_info
+                        if result.display_context_length:
+                            lines.append(f"Context: {result.display_context_length:,} tokens")
+                        elif mi and mi.context_window:
+                            lines.append(f"Context: {mi.context_window:,} tokens")
                         if mi:
-                            if mi.context_window:
-                                lines.append(f"Context: {mi.context_window:,} tokens")
                             if mi.max_output:
                                 lines.append(f"Max output: {mi.max_output:,} tokens")
                             if mi.has_cost_data():
@@ -4845,6 +4838,7 @@ class GatewayRunner:
             explicit_provider=explicit_provider,
             user_providers=user_provs,
             custom_providers=custom_provs,
+            config_context_length=config_context_length,
         )
 
         if not result.success:
@@ -4918,14 +4912,10 @@ class GatewayRunner:
 
         # Rich metadata from models.dev
         mi = result.model_info
-        if mi:
-            if mi.context_window:
-                lines.append(f"Context: {mi.context_window:,} tokens")
-            if mi.max_output:
-                lines.append(f"Max output: {mi.max_output:,} tokens")
-            if mi.has_cost_data():
-                lines.append(f"Cost: {mi.format_cost()}")
-            lines.append(f"Capabilities: {mi.format_capabilities()}")
+        if result.display_context_length:
+            lines.append(f"Context: {result.display_context_length:,} tokens")
+        elif mi and mi.context_window:
+            lines.append(f"Context: {mi.context_window:,} tokens")
         else:
             try:
                 from agent.model_metadata import get_model_context_length
@@ -4938,6 +4928,13 @@ class GatewayRunner:
                 lines.append(f"Context: {ctx:,} tokens")
             except Exception:
                 pass
+
+        if mi:
+            if mi.max_output:
+                lines.append(f"Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                lines.append(f"Cost: {mi.format_cost()}")
+            lines.append(f"Capabilities: {mi.format_capabilities()}")
 
         # Cache notice
         cache_enabled = (

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from hermes_cli.providers import (
     custom_provider_slug,
@@ -238,6 +238,7 @@ class ModelSwitchResult:
     warning_message: str = ""
     provider_label: str = ""
     resolved_via_alias: str = ""
+    display_context_length: Optional[int] = None
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
@@ -252,6 +253,128 @@ class CustomAutoResult:
     base_url: str = ""
     api_key: str = ""
     error_message: str = ""
+
+
+def _normalize_base_url(url: str) -> str:
+    """Return a canonical base_url string for comparisons."""
+    return (url or "").strip().rstrip("/").lower()
+
+
+def _coerce_positive_context_length(raw: Any) -> Optional[int]:
+    """Return a positive integer context length, or None when invalid."""
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _custom_provider_match_score(
+    entry: dict[str, Any],
+    provider: str,
+    base_url: str,
+) -> int:
+    """Score how well a custom provider entry matches the requested runtime."""
+    requested_provider = (provider or "").strip().lower()
+    requested_base_url = _normalize_base_url(base_url)
+
+    entry_name = (entry.get("name") or "").strip()
+    provider_candidates: set[str] = set()
+    if entry_name:
+        provider_candidates.add(entry_name.lower())
+        provider_candidates.add(custom_provider_slug(entry_name))
+    provider_key = (entry.get("provider_key") or "").strip().lower()
+    if provider_key:
+        provider_candidates.add(provider_key)
+
+    if requested_provider.startswith("custom:") and requested_provider in provider_candidates:
+        return 2
+
+    entry_base_url = _normalize_base_url(
+        entry.get("base_url") or entry.get("url") or entry.get("api") or ""
+    )
+    if requested_base_url and entry_base_url and requested_base_url == entry_base_url:
+        return 1
+
+    return 0
+
+
+def _resolve_custom_provider_context_length(
+    provider: str,
+    base_url: str,
+    model: str,
+    custom_providers: Optional[list[dict[str, Any]]],
+) -> Optional[int]:
+    """Return per-model context_length from the best matching custom provider."""
+    best_score = 0
+    best_context_length: Optional[int] = None
+
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+
+        score = _custom_provider_match_score(entry, provider, base_url)
+        if score == 0 or score < best_score:
+            continue
+
+        resolved: Optional[int] = None
+        models = entry.get("models", {})
+        if isinstance(models, dict):
+            model_cfg = models.get(model, {})
+            if isinstance(model_cfg, dict):
+                raw = model_cfg.get("context_length")
+                resolved = _coerce_positive_context_length(raw)
+
+        if resolved is None and str(entry.get("model") or "").strip() == model:
+            raw = entry.get("context_length")
+            resolved = _coerce_positive_context_length(raw)
+
+        if resolved is not None:
+            best_score = score
+            best_context_length = resolved
+
+    return best_context_length
+
+
+def _resolve_display_context_length(
+    model: str,
+    provider: str,
+    base_url: str,
+    api_key: str,
+    model_info: Optional[ModelInfo],
+    custom_providers: Optional[list[dict[str, Any]]],
+    config_context_length: Optional[int] = None,
+) -> Optional[int]:
+    """Resolve the context window shown after a successful /model switch."""
+    custom_ctx = _resolve_custom_provider_context_length(
+        provider=provider,
+        base_url=base_url,
+        model=model,
+        custom_providers=custom_providers,
+    )
+    if custom_ctx is not None:
+        return custom_ctx
+
+    config_ctx = _coerce_positive_context_length(config_context_length)
+    if config_ctx is not None:
+        return config_ctx
+
+    if model_info and model_info.context_window:
+        return model_info.context_window
+
+    try:
+        from agent.model_metadata import get_model_context_length
+
+        return get_model_context_length(
+            model,
+            base_url=base_url,
+            api_key=api_key,
+            provider=provider,
+        )
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -418,6 +541,7 @@ def switch_model(
     explicit_provider: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
+    config_context_length: Optional[int] = None,
 ) -> ModelSwitchResult:
     """Core model-switching pipeline shared between CLI and gateway.
 
@@ -452,6 +576,7 @@ def switch_model(
         explicit_provider: From --provider flag (empty = no explicit provider).
         user_providers: The ``providers:`` dict from config.yaml (for user endpoints).
         custom_providers: The ``custom_providers:`` list from config.yaml.
+        config_context_length: Optional global ``model.context_length`` override from config.
 
     Returns:
         ModelSwitchResult with all information the caller needs.
@@ -769,6 +894,15 @@ def switch_model(
         warning_message=" | ".join(warnings) if warnings else "",
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,
+        display_context_length=_resolve_display_context_length(
+            model=new_model,
+            provider=target_provider,
+            base_url=base_url,
+            api_key=api_key,
+            model_info=model_info,
+            custom_providers=custom_providers,
+            config_context_length=config_context_length,
+        ),
         capabilities=capabilities,
         model_info=model_info,
         is_global=is_global,

--- a/run_agent.py
+++ b/run_agent.py
@@ -48,6 +48,7 @@ from hermes_constants import get_hermes_home
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.providers import custom_provider_slug
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -165,6 +166,174 @@ def _install_safe_stdio() -> None:
         stream = getattr(sys, stream_name, None)
         if stream is not None and not isinstance(stream, _SafeWriter):
             setattr(sys, stream_name, _SafeWriter(stream))
+
+
+def _normalize_context_lookup_base_url(url: str) -> str:
+    """Normalize base_url strings before matching config overrides."""
+    return (url or "").strip().rstrip("/").lower()
+
+
+def _coerce_positive_runtime_context_length(raw_value: Any) -> Optional[int]:
+    """Return a positive integer runtime context override, or None when invalid."""
+    if raw_value is None or isinstance(raw_value, bool):
+        return None
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _warn_invalid_global_context_length(raw_value: Any) -> None:
+    logger.warning(
+        "Invalid model.context_length in config.yaml: %r — must be a plain integer "
+        "(e.g. 256000, not '256K'). Falling back to auto-detection.",
+        raw_value,
+    )
+    print(
+        f"\n⚠ Invalid model.context_length in config.yaml: {raw_value!r}\n"
+        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+        f"  Falling back to auto-detected context window.\n",
+        file=sys.stderr,
+    )
+
+
+def _warn_invalid_custom_provider_context_length(model: str, raw_value: Any) -> None:
+    logger.warning(
+        "Invalid context_length for model %r in custom_providers: %r — must be a plain "
+        "integer (e.g. 256000, not '256K'). Falling back to auto-detection.",
+        model,
+        raw_value,
+    )
+    print(
+        f"\n⚠ Invalid context_length for model {model!r} in custom_providers: {raw_value!r}\n"
+        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+        f"  Falling back to auto-detected context window.\n",
+        file=sys.stderr,
+    )
+
+
+def _iter_compatible_custom_providers(agent_cfg: Optional[Dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return config custom_providers in the same compatibility view used elsewhere."""
+    cfg = agent_cfg if isinstance(agent_cfg, dict) else {}
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+
+        custom_providers = get_compatible_custom_providers(cfg)
+    except Exception:
+        custom_providers = cfg.get("custom_providers")
+        if not isinstance(custom_providers, list):
+            custom_providers = []
+    return [entry for entry in custom_providers if isinstance(entry, dict)]
+
+
+def _custom_provider_context_match_score(
+    entry: dict[str, Any],
+    provider: str,
+    base_url: str,
+) -> int:
+    requested_provider = (provider or "").strip().lower()
+    requested_base_url = _normalize_context_lookup_base_url(base_url)
+
+    entry_name = (entry.get("name") or "").strip()
+    provider_candidates: set[str] = set()
+    if entry_name:
+        provider_candidates.add(entry_name.lower())
+        provider_candidates.add(custom_provider_slug(entry_name))
+    provider_key = (entry.get("provider_key") or "").strip().lower()
+    if provider_key:
+        provider_candidates.add(provider_key)
+
+    if requested_provider.startswith("custom:") and requested_provider in provider_candidates:
+        return 2
+
+    entry_base_url = _normalize_context_lookup_base_url(
+        entry.get("base_url") or entry.get("url") or entry.get("api") or ""
+    )
+    if requested_base_url and entry_base_url and requested_base_url == entry_base_url:
+        return 1
+
+    return 0
+
+
+def _resolve_custom_provider_model_context_length(
+    model: str,
+    provider: str,
+    base_url: str,
+    agent_cfg: Optional[Dict[str, Any]],
+) -> Optional[int]:
+    """Resolve per-model context_length from matching custom_providers entries."""
+    best_score = 0
+    best_context_length: Optional[int] = None
+
+    for entry in _iter_compatible_custom_providers(agent_cfg):
+        score = _custom_provider_context_match_score(entry, provider, base_url)
+        if score == 0 or score < best_score:
+            continue
+
+        resolved: Optional[int] = None
+        models = entry.get("models", {})
+        if isinstance(models, dict):
+            model_cfg = models.get(model, {})
+            if isinstance(model_cfg, dict):
+                raw_ctx = model_cfg.get("context_length")
+                if raw_ctx is not None:
+                    resolved = _coerce_positive_runtime_context_length(raw_ctx)
+                    if resolved is None:
+                        _warn_invalid_custom_provider_context_length(model, raw_ctx)
+
+        if resolved is None and str(entry.get("model") or "").strip() == model:
+            raw_ctx = entry.get("context_length")
+            if raw_ctx is not None:
+                resolved = _coerce_positive_runtime_context_length(raw_ctx)
+                if resolved is None:
+                    _warn_invalid_custom_provider_context_length(model, raw_ctx)
+
+        if resolved is not None:
+            best_score = score
+            best_context_length = resolved
+
+    return best_context_length
+
+
+def _resolve_runtime_config_context_length(
+    model: str,
+    provider: str,
+    base_url: str,
+    agent_cfg: Optional[Dict[str, Any]],
+) -> Optional[int]:
+    """Resolve the effective runtime context_length override for the active model.
+
+    Priority:
+    1. matching custom_providers[].models[model].context_length
+    2. top-level model.context_length
+    3. None -> auto-detect later
+    """
+    custom_ctx = _resolve_custom_provider_model_context_length(
+        model=model,
+        provider=provider,
+        base_url=base_url,
+        agent_cfg=agent_cfg,
+    )
+    if custom_ctx is not None:
+        return custom_ctx
+
+    model_cfg = agent_cfg.get("model", {}) if isinstance(agent_cfg, dict) else {}
+    if not isinstance(model_cfg, dict):
+        return None
+
+    raw_ctx = model_cfg.get("context_length")
+    if raw_ctx is None:
+        return None
+
+    try:
+        value = _coerce_positive_runtime_context_length(raw_ctx)
+        if value is None:
+            raise ValueError(raw_ctx)
+        return value
+    except (TypeError, ValueError):
+        _warn_invalid_global_context_length(raw_ctx)
+        return None
 
 
 class IterationBudget:
@@ -1353,72 +1522,18 @@ class AIAgent:
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
 
-        # Read explicit context_length override from model config
-        _model_cfg = _agent_cfg.get("model", {})
-        if isinstance(_model_cfg, dict):
-            _config_context_length = _model_cfg.get("context_length")
-        else:
-            _config_context_length = None
-        if _config_context_length is not None:
-            try:
-                _config_context_length = int(_config_context_length)
-            except (TypeError, ValueError):
-                logger.warning(
-                    "Invalid model.context_length in config.yaml: %r — "
-                    "must be a plain integer (e.g. 256000, not '256K'). "
-                    "Falling back to auto-detection.",
-                    _config_context_length,
-                )
-                import sys
-                print(
-                    f"\n⚠ Invalid model.context_length in config.yaml: {_config_context_length!r}\n"
-                    f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                    f"  Falling back to auto-detected context window.\n",
-                    file=sys.stderr,
-                )
-                _config_context_length = None
+        # Read effective context_length override from config.
+        # Priority: matching custom provider per-model override > global model.context_length.
+        _config_context_length = _resolve_runtime_config_context_length(
+            model=self.model,
+            provider=self.provider,
+            base_url=self.base_url,
+            agent_cfg=_agent_cfg,
+        )
+        _model_cfg = _agent_cfg.get("model", {}) if isinstance(_agent_cfg, dict) else {}
 
         # Store for reuse in switch_model (so config override persists across model switches)
         self._config_context_length = _config_context_length
-
-        # Check custom_providers per-model context_length
-        if _config_context_length is None:
-            try:
-                from hermes_cli.config import get_compatible_custom_providers
-                _custom_providers = get_compatible_custom_providers(_agent_cfg)
-            except Exception:
-                _custom_providers = _agent_cfg.get("custom_providers")
-                if not isinstance(_custom_providers, list):
-                    _custom_providers = []
-            for _cp_entry in _custom_providers:
-                if not isinstance(_cp_entry, dict):
-                    continue
-                _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                if _cp_url and _cp_url == self.base_url.rstrip("/"):
-                    _cp_models = _cp_entry.get("models", {})
-                    if isinstance(_cp_models, dict):
-                        _cp_model_cfg = _cp_models.get(self.model, {})
-                        if isinstance(_cp_model_cfg, dict):
-                            _cp_ctx = _cp_model_cfg.get("context_length")
-                            if _cp_ctx is not None:
-                                try:
-                                    _config_context_length = int(_cp_ctx)
-                                except (TypeError, ValueError):
-                                    logger.warning(
-                                        "Invalid context_length for model %r in "
-                                        "custom_providers: %r — must be a plain "
-                                        "integer (e.g. 256000, not '256K'). "
-                                        "Falling back to auto-detection.",
-                                        self.model, _cp_ctx,
-                                    )
-                                    import sys
-                                    print(
-                                        f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
-                                        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                                        f"  Falling back to auto-detected context window.\n",
-                                        file=sys.stderr,
-                                    )
-                    break
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -1746,6 +1861,21 @@ class AIAgent:
             or is_native_anthropic
         )
 
+        # ── Refresh effective context_length override for the new runtime ──
+        _previous_config_context_length = getattr(self, "_config_context_length", None)
+        try:
+            from hermes_cli.config import load_config as _load_agent_config
+
+            _agent_cfg = _load_agent_config()
+            self._config_context_length = _resolve_runtime_config_context_length(
+                model=self.model,
+                provider=self.provider,
+                base_url=self.base_url,
+                agent_cfg=_agent_cfg,
+            )
+        except Exception:
+            self._config_context_length = _previous_config_context_length
+
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
@@ -1754,7 +1884,7 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=self._config_context_length,
             )
             self.context_compressor.update_model(
                 model=self.model,

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -3,6 +3,7 @@
 import yaml
 import pytest
 
+from hermes_cli.model_switch import ModelSwitchResult
 from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.run import GatewayRunner
@@ -14,6 +15,8 @@ def _make_runner():
     runner.adapters = {}
     runner._voice_mode = {}
     runner._session_model_overrides = {}
+    runner._session_key_for_source = lambda source: f"{source.platform.value}:{source.chat_id}"
+    runner._evict_cached_agent = lambda session_key: None
     return runner
 
 
@@ -61,3 +64,166 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_prefers_display_context_length_for_custom_provider_switch(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "glm-5",
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                },
+                "providers": {},
+                "custom_providers": [
+                    {
+                        "name": "yunfeiplus",
+                        "base_url": "https://api.yunfeiplus.com/v1",
+                        "models": {
+                            "gpt-5.4": {"context_length": 524288},
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        model_switch,
+        "switch_model",
+        lambda **_: ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="custom:yunfeiplus",
+            provider_changed=True,
+            api_key="***",
+            base_url="https://api.yunfeiplus.com/v1",
+            api_mode="chat_completions",
+            provider_label="yunfeiplus",
+            display_context_length=524288,
+            model_info=None,
+        ),
+    )
+
+    result = await _make_runner()._handle_model_command(
+        _make_event("/model gpt-5.4 --provider yunfeiplus")
+    )
+
+    assert result is not None
+    assert "Model switched to `gpt-5.4`" in result
+    assert "Provider: yunfeiplus" in result
+    assert "Context: 524,288 tokens" in result
+
+
+def test_format_session_info_prefers_custom_provider_context_override(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "context_length": 200000,
+                },
+                "custom_providers": [
+                    {
+                        "name": "yunfeiplus",
+                        "base_url": "https://api.yunfeiplus.com/v1",
+                        "models": {
+                            "gpt-5.4": {"context_length": 524288},
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "custom:yunfeiplus",
+            "base_url": "https://api.yunfeiplus.com/v1",
+            "api_key": "***",
+        },
+    )
+
+    result = _make_runner()._format_session_info()
+
+    assert "◆ Model: `gpt-5.4`" in result
+    assert "◆ Provider: custom:yunfeiplus" in result
+    assert "◆ Context: 524K tokens (config)" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_ignores_boolean_context_length_in_config(
+    tmp_path,
+    monkeypatch,
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "context_length": True,
+                },
+                "providers": {},
+                "custom_providers": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    captured = {}
+
+    def _fake_switch_model(**kwargs):
+        captured.update(kwargs)
+        return ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="***",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+            display_context_length=128000,
+            model_info=None,
+        )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(model_switch, "switch_model", _fake_switch_model)
+
+    result = await _make_runner()._handle_model_command(_make_event("/model gpt-5.4"))
+
+    assert result is not None
+    assert captured["config_context_length"] is None
+    assert "Context: 128,000 tokens" in result

--- a/tests/hermes_cli/test_model_switch_context_alignment.py
+++ b/tests/hermes_cli/test_model_switch_context_alignment.py
@@ -1,0 +1,384 @@
+"""Regression tests for model switch context-length alignment.
+
+Covers three layers fixed by the 2026-04-17 patch:
+1. /model switch result should expose a unified display_context_length.
+2. Runtime context override priority should prefer matching custom provider
+   per-model context_length over global model.context_length.
+3. AIAgent.switch_model() must refresh _config_context_length when a model is
+   switched mid-session so the context engine gets the new override.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_switch_model_uses_custom_provider_context_for_display():
+    """Custom provider per-model context_length should win for display metadata."""
+    custom_providers = [
+        {
+            "name": "yunfeiplus",
+            "base_url": "https://api.yunfeiplus.com/v1",
+            "models": {
+                "gpt-5.4": {
+                    "context_length": 524288,
+                }
+            },
+        }
+    ]
+
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "***",
+                "base_url": "https://api.yunfeiplus.com/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="gpt-5.4",
+            current_provider="openrouter",
+            current_model="glm-5",
+            current_base_url="https://openrouter.ai/api/v1",
+            current_api_key="***",
+            explicit_provider="yunfeiplus",
+            custom_providers=custom_providers,
+        )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "custom:yunfeiplus"
+    assert result.display_context_length == 524288
+
+
+def test_runtime_context_prefers_custom_provider_override_over_global_default():
+    """Runtime context lookup should prefer matching custom provider override."""
+    from run_agent import _resolve_runtime_config_context_length
+
+    agent_cfg = {
+        "model": {"context_length": 200000},
+        "custom_providers": [
+            {
+                "name": "yunfeiplus",
+                "base_url": "https://api.yunfeiplus.com/v1",
+                "models": {
+                    "gpt-5.4": {"context_length": 524288},
+                },
+            }
+        ],
+    }
+
+    resolved = _resolve_runtime_config_context_length(
+        model="gpt-5.4",
+        provider="custom:yunfeiplus",
+        base_url="https://api.yunfeiplus.com/v1",
+        agent_cfg=agent_cfg,
+    )
+
+    assert resolved == 524288
+
+
+def test_runtime_context_falls_back_to_global_default_when_no_matching_custom_provider():
+    """Global model.context_length should still apply when no custom override matches."""
+    from run_agent import _resolve_runtime_config_context_length
+
+    agent_cfg = {
+        "model": {"context_length": 200000},
+        "custom_providers": [
+            {
+                "name": "yunfeiplus",
+                "base_url": "https://api.yunfeiplus.com/v1",
+                "models": {
+                    "gpt-5.4": {"context_length": 524288},
+                },
+            }
+        ],
+    }
+
+    resolved = _resolve_runtime_config_context_length(
+        model="gpt-5.4",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        agent_cfg=agent_cfg,
+    )
+
+    assert resolved == 200000
+
+
+def test_runtime_context_ignores_non_positive_global_override():
+    """Non-positive global overrides should be treated as unset."""
+    from run_agent import _resolve_runtime_config_context_length
+
+    agent_cfg = {
+        "model": {"context_length": -1},
+        "custom_providers": [],
+    }
+
+    resolved = _resolve_runtime_config_context_length(
+        model="gpt-5.4",
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        agent_cfg=agent_cfg,
+    )
+
+    assert resolved is None
+
+
+def test_runtime_context_does_not_apply_name_collision_to_builtin_provider():
+    """Custom provider names colliding with built-ins must not hijack built-in provider context."""
+    from run_agent import _resolve_runtime_config_context_length
+
+    agent_cfg = {
+        "model": {"context_length": 200000},
+        "custom_providers": [
+            {
+                "name": "anthropic",
+                "base_url": "https://custom.example/v1",
+                "models": {
+                    "claude-sonnet-4-5": {"context_length": 777777},
+                },
+            }
+        ],
+    }
+
+    resolved = _resolve_runtime_config_context_length(
+        model="claude-sonnet-4-5",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        agent_cfg=agent_cfg,
+    )
+
+    assert resolved == 200000
+
+
+def test_switch_model_uses_global_config_context_for_display_when_no_custom_override():
+    """Display context should align with global model.context_length fallback."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "***",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="gpt-5.4",
+            current_provider="openrouter",
+            current_model="glm-5",
+            current_base_url="https://openrouter.ai/api/v1",
+            current_api_key="***",
+            config_context_length=200000,
+        )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "openrouter"
+    assert result.display_context_length == 200000
+
+
+def test_switch_model_ignores_non_positive_global_display_override():
+    """Display context should ignore invalid non-positive global overrides."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "***",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+        patch("agent.model_metadata.get_model_context_length", return_value=128000),
+    ):
+        result = switch_model(
+            raw_input="gpt-5.4",
+            current_provider="openrouter",
+            current_model="glm-5",
+            current_base_url="https://openrouter.ai/api/v1",
+            current_api_key="***",
+            config_context_length=-1,
+        )
+
+    assert result.success, result.error_message
+    assert result.display_context_length == 128000
+
+
+def test_switch_model_does_not_apply_name_collision_to_builtin_provider_display():
+    """Display resolver must not treat built-in provider slug collisions as custom matches."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "***",
+                "base_url": "https://api.anthropic.com",
+                "api_mode": "anthropic_messages",
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        result = switch_model(
+            raw_input="claude-sonnet-4-5",
+            current_provider="anthropic",
+            current_model="claude-3-5-sonnet",
+            current_base_url="https://api.anthropic.com",
+            current_api_key="***",
+            custom_providers=[
+                {
+                    "name": "anthropic",
+                    "base_url": "https://custom.example/v1",
+                    "models": {
+                        "claude-sonnet-4-5": {"context_length": 777777},
+                    },
+                }
+            ],
+            config_context_length=200000,
+        )
+
+    assert result.success, result.error_message
+    assert result.display_context_length == 200000
+
+
+def test_agent_switch_model_preserves_existing_context_override_when_config_reload_fails():
+    """Switch should keep the active override if config reload temporarily fails."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "glm-5"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_key = "***"
+    agent.api_mode = "chat_completions"
+    agent._client_kwargs = {}
+    agent._cached_system_prompt = None
+    agent._use_prompt_caching = False
+    agent._config_context_length = 200000
+    agent.context_compressor = MagicMock()
+    agent._create_openai_client = MagicMock(return_value=object())
+
+    def _fake_get_model_context_length(
+        model,
+        *,
+        base_url,
+        api_key,
+        provider,
+        config_context_length=None,
+    ):
+        return config_context_length
+
+    with (
+        patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=_fake_get_model_context_length,
+        ),
+    ):
+        agent.switch_model(
+            new_model="gpt-5.4",
+            new_provider="custom:yunfeiplus",
+            api_key="***",
+            base_url="https://api.yunfeiplus.com/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent._config_context_length == 200000
+    _, kwargs = agent.context_compressor.update_model.call_args
+    assert kwargs["context_length"] == 200000
+
+
+def test_agent_switch_model_refreshes_context_override_before_updating_context_engine():
+    """Mid-session switch should refresh _config_context_length for the new model."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "glm-5"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_key = "***"
+    agent.api_mode = "chat_completions"
+    agent._client_kwargs = {}
+    agent._cached_system_prompt = None
+    agent._use_prompt_caching = False
+    agent._config_context_length = 200000
+    agent.context_compressor = MagicMock()
+    agent.context_compressor.context_length = 524288
+    agent.context_compressor.threshold_tokens = 393216
+    agent.context_compressor.model = "gpt-5.4"
+    agent.context_compressor.base_url = "https://api.yunfeiplus.com/v1"
+    agent.context_compressor.api_key = "***"
+    agent.context_compressor.provider = "custom:yunfeiplus"
+    agent._create_openai_client = MagicMock(return_value=object())
+
+    cfg = {
+        "model": {"context_length": 200000},
+        "custom_providers": [
+            {
+                "name": "yunfeiplus",
+                "base_url": "https://api.yunfeiplus.com/v1",
+                "models": {
+                    "gpt-5.4": {"context_length": 524288},
+                },
+            }
+        ],
+    }
+
+    def _fake_get_model_context_length(
+        model,
+        *,
+        base_url,
+        api_key,
+        provider,
+        config_context_length=None,
+    ):
+        return config_context_length
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            side_effect=_fake_get_model_context_length,
+        ),
+    ):
+        agent.switch_model(
+            new_model="gpt-5.4",
+            new_provider="custom:yunfeiplus",
+            api_key="***",
+            base_url="https://api.yunfeiplus.com/v1",
+            api_mode="chat_completions",
+        )
+
+    assert agent._config_context_length == 524288
+    agent.context_compressor.update_model.assert_called_once()
+    _, kwargs = agent.context_compressor.update_model.call_args
+    assert kwargs["context_length"] == 524288


### PR DESCRIPTION
## Summary
- align `/model` display context resolution with runtime precedence for custom providers and global overrides
- refresh runtime context-length overrides safely across model switches and preserve the active override if config reload fails
- unify gateway session-info and hygiene paths with the same resolver, plus add regression tests for negative values, bools, and provider-name collisions

## Verification
- `pytest -q tests/hermes_cli/test_model_switch_context_alignment.py tests/hermes_cli/test_model_switch_opencode_anthropic.py tests/gateway/test_model_command_custom_providers.py`
- `python -m py_compile cli.py gateway/run.py hermes_cli/model_switch.py run_agent.py`

## Notes
- leaves unrelated local modifications (for example `gateway/config.py`, `package-lock.json`, and unrelated docs drafts) out of this PR