### PR TITLE
fix(cli): use runtime pid fallback for gateway detection on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -171,6 +171,14 @@ def find_gateway_pids(exclude_pids: set | None = None, all_profiles: bool = Fals
     """
     _exclude = exclude_pids or set()
     pids = [pid for pid in _get_service_pids() if pid not in _exclude]
+
+    if not all_profiles:
+        from gateway.status import get_running_pid
+
+        current_pid = get_running_pid()
+        if current_pid is not None and current_pid not in pids and current_pid not in _exclude:
+            pids.append(current_pid)
+
     patterns = [
         "hermes_cli.main gateway",
         "hermes_cli.main --profile",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -450,6 +450,28 @@ class TestGatewayServiceDetection:
 
         assert gateway_cli._is_service_running() is False
 
+    def test_find_gateway_pids_uses_runtime_pid_for_current_profile(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4321)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.find_gateway_pids() == [4321]
+
+    def test_find_gateway_pids_respects_excluded_runtime_pid(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4321)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert gateway_cli.find_gateway_pids(exclude_pids={4321}) == []
+
 
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_self_requests_graceful_restart_and_waits(self, monkeypatch, capsys):


### PR DESCRIPTION
## What does this PR do?

Fixes a macOS gateway-status false negative where `find_gateway_pids()` can return an empty list even though the current profile's gateway is alive and healthy.

On this macOS setup, `hermes cron list` reported `Gateway is not running` while the gateway process was actually running and cron jobs were firing. The root problem is that `find_gateway_pids()` relies on service-manager / process-list probing that can miss the active gateway, while Hermes already has a more authoritative current-profile runtime check in `gateway.status.get_running_pid()`.

This PR takes the smallest possible approach:
- keep the existing cross-profile scan logic intact
- for the current profile only, consult `get_running_pid()` first
- merge that PID into the result when present

This approach is preferable because it reuses Hermes' existing PID-file/runtime validation helper instead of adding more macOS-specific parsing logic for `launchctl` or broadening platform-specific `ps` handling.

## Related Issue

No dedicated issue filed.

Related open PRs for the same symptom:
- #10636
- #10684

This PR intentionally takes a narrower approach by reusing the existing runtime PID helper and adding regression tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - update `find_gateway_pids()` to reuse `gateway.status.get_running_pid()` for the current profile before falling back to broader process scanning
- `tests/hermes_cli/test_gateway_service.py`
  - add regression test covering runtime PID fallback for the current profile
  - add regression test ensuring `exclude_pids` still takes precedence over the runtime PID fallback

## How to Test

1. On macOS, start a gateway for the current profile so that `gateway.status.get_running_pid()` returns a live PID.
2. Run `hermes cron list` (or call `find_gateway_pids()` directly) and verify the gateway is detected instead of being reported as not running.
3. Run:
   - `pytest -n 0 tests/hermes_cli/test_gateway_service.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant targeted test output:

```text
$ pytest -n 0 tests/hermes_cli/test_gateway_service.py -q
72 passed in 1.72s
```

Relevant user-visible symptom before the fix on macOS:

```text
hermes cron list
...
⚠  Gateway is not running — jobs won't fire automatically.
```

After applying the fix, `find_gateway_pids()` correctly returns the current profile gateway PID via `get_running_pid()`.
