### PR TITLE
fix(cli): apply redact_secrets config before logging imports

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -143,6 +143,20 @@ from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 load_hermes_dotenv(project_env=PROJECT_ROOT / '.env')
 
+# Apply config-backed security env before logging imports.  setup_logging()
+# imports agent.redact, which snapshots HERMES_REDACT_SECRETS at import time.
+_early_cfg = None
+try:
+    from hermes_cli.config import load_config as _load_config_early
+    _early_cfg = _load_config_early()
+    _security_cfg = _early_cfg.get("security", {})
+    if isinstance(_security_cfg, dict):
+        _redact = _security_cfg.get("redact_secrets")
+        if _redact is not None:
+            os.environ["HERMES_REDACT_SECRETS"] = str(_redact).lower()
+except Exception:
+    _early_cfg = None
+
 # Initialize centralized file logging early — all `hermes` subcommands
 # (chat, setup, gateway, config, etc.) write to agent.log + errors.log.
 try:
@@ -153,15 +167,15 @@ except Exception:
 
 # Apply IPv4 preference early, before any HTTP clients are created.
 try:
-    from hermes_cli.config import load_config as _load_config_early
     from hermes_constants import apply_ipv4_preference as _apply_ipv4
-    _early_cfg = _load_config_early()
     _net = _early_cfg.get("network", {})
     if isinstance(_net, dict) and _net.get("force_ipv4"):
         _apply_ipv4(force=True)
-    del _early_cfg, _net
+    del _net
 except Exception:
     pass  # best-effort — don't crash if config isn't available yet
+finally:
+    del _early_cfg
 
 import logging
 import time as _time

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -68,3 +68,28 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_main_import_applies_config_redaction_before_logging(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "security:\n  redact_secrets: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+
+    for module_name in ("hermes_cli.main", "hermes_logging", "agent.redact"):
+        sys.modules.pop(module_name, None)
+
+    try:
+        importlib.import_module("hermes_cli.main")
+        import agent.redact as redact_mod
+
+        assert os.getenv("HERMES_REDACT_SECRETS") == "false"
+        assert redact_mod._REDACT_ENABLED is False
+    finally:
+        for module_name in ("hermes_cli.main", "hermes_logging", "agent.redact"):
+            sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary

Fixes the CLI startup-order bug in #11009 by applying `security.redact_secrets` from `config.yaml` before `setup_logging()` imports `agent.redact`.

This keeps the existing import-time freeze in `agent.redact` intact and limits the change to the startup path the issue describes.

## Why this shape

A related open PR (#8064) changes `agent.redact` semantics globally. This patch takes the narrower route from the issue report: fix the CLI import order directly without changing redaction behavior after startup.

## Testing

- `python3 -m pytest -o addopts= tests/hermes_cli/test_env_loader.py -q`
- `python3 -m pytest -o addopts= tests/test_hermes_logging.py -q`
- `python3 -m pytest -o addopts= tests/hermes_cli/test_skills_subparser.py -q`

Closes #11009
