### PR TITLE
fix(skills): handle binary bundle content in update hash

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -695,6 +695,27 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_accepts_binary_assets(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "same content",
+                "assets/sample.wav": b"RIFF\x00\x01fakewav",
+            },
+            source="official",
+            identifier="official/demo-skill",
+            trust_level="builtin",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("same content")
+        (skill_dir / "assets").mkdir()
+        (skill_dir / "assets" / "sample.wav").write_bytes(b"RIFF\x00\x01fakewav")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,10 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        h.update(content)
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Summary
- fix `bundle_content_hash()` so it correctly hashes mixed `str`/`bytes` bundle content
- add a regression test covering binary assets inside a `SkillBundle`
- restore `hermes skills check` for skills that ship binary files

## Test Plan
- `pytest tests/tools/test_skills_hub.py::TestCheckForSkillUpdates::test_bundle_content_hash_accepts_binary_assets -q`
- `pytest tests/tools/test_skills_hub.py::TestCheckForSkillUpdates -q`
- `pytest tests/tools/test_skills_hub.py -q`
- `source venv/bin/activate && hermes skills check`