### PR TITLE
Fix stale update cache after successful updates

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -123,6 +123,21 @@ def get_available_skills() -> Dict[str, List[str]]:
 _UPDATE_CHECK_CACHE_SECONDS = 6 * 3600
 
 
+def _count_commits_behind(repo_dir: Path) -> Optional[int]:
+    """Return how many commits HEAD is behind origin/main using local refs only."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            return int((result.stdout or "").strip() or "0")
+    except Exception:
+        pass
+    return None
+
+
 def check_for_updates() -> Optional[int]:
     """Check how many commits behind origin/main the local repo is.
 
@@ -146,7 +161,16 @@ def check_for_updates() -> Optional[int]:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
             if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
-                return cached.get("behind")
+                cached_behind = cached.get("behind")
+                if isinstance(cached_behind, int) and cached_behind > 0:
+                    actual_behind = _count_commits_behind(repo_dir)
+                    if actual_behind is not None and actual_behind != cached_behind:
+                        try:
+                            cache_file.write_text(json.dumps({"ts": now, "behind": actual_behind}))
+                        except Exception:
+                            pass
+                        return actual_behind
+                return cached_behind
     except Exception:
         pass
 
@@ -161,18 +185,7 @@ def check_for_updates() -> Optional[int]:
         pass  # Offline or timeout — use stale refs, that's fine
 
     # Count commits behind
-    try:
-        result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
-            capture_output=True, text=True, timeout=5,
-            cwd=str(repo_dir),
-        )
-        if result.returncode == 0:
-            behind = int(result.stdout.strip())
-        else:
-            behind = None
-    except Exception:
-        behind = None
+    behind = _count_commits_behind(repo_dir)
 
     # Write cache
     try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -192,6 +192,7 @@ AUTHOR_MAP = {
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
     "cola-runner@users.noreply.github.com": "cola-runner",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "trevmanthony@gmail.com": "trevthefoolish",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -387,6 +387,7 @@ AUTHOR_MAP = {
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
     "cola-runner@users.noreply.github.com": "cola-runner",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "iamagenius00@users.noreply.github.com": "iamagenius00",

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -16,8 +16,8 @@ def test_version_string_no_v_prefix():
     assert not __version__.startswith("v"), f"__version__ should not start with 'v', got {__version__!r}"
 
 
-def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+def test_check_for_updates_uses_zero_cache_without_git(tmp_path, monkeypatch):
+    """Fresh zero-behind cache should return immediately without calling git."""
     from hermes_cli.banner import check_for_updates
 
     # Create a fake git repo and fresh cache
@@ -26,14 +26,34 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 0}))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
         result = check_for_updates()
 
-    assert result == 3
+    assert result == 0
     mock_run.assert_not_called()
+
+
+def test_check_for_updates_revalidates_fresh_positive_cache(tmp_path, monkeypatch):
+    """Fresh positive cache should be corrected from local refs after an update."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("hermes_cli.banner.subprocess.run", return_value=MagicMock(returncode=0, stdout="0\n")) as mock_run:
+        result = check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 1  # local git rev-list only — no fetch for fresh cache
+    assert json.loads(cache_file.read_text())["behind"] == 0
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- revalidate fresh positive update-cache entries against local git refs before showing the banner warning
- update the cache immediately when local `origin/main` refs now show fewer commits behind
- add regression coverage for both the zero-behind fast path and the stale positive-cache correction path

Closes #11007.

## Testing
- `source venv/bin/activate && python -m pytest tests/hermes_cli/test_update_check.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q` *(current environment still has unrelated pre-existing failures/errors in ACP, web server optional deps, gateway, and transcription tests; this change did not add new `test_update_check` failures)*
