### PR TITLE
feat(gateway): Nextcloud Notifications + Activity background service

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -671,7 +671,15 @@ class GatewayConfig:
 
     # User-defined quick commands (slash commands that bypass the agent loop)
     quick_commands: Dict[str, Any] = field(default_factory=dict)
-    
+
+    # Background services (long-running observers/pollers registered by
+    # plugins via ``PluginContext.register_background_service``). Each entry
+    # mirrors a ``services.<name>`` block from config.yaml verbatim, including
+    # the ``enabled`` flag and arbitrary plugin-defined keys. The gateway
+    # looks each name up in ``gateway.service_registry.service_registry``
+    # at startup.
+    services: Dict[str, Any] = field(default_factory=dict)
+
     # Storage paths
     sessions_dir: Path = field(default_factory=lambda: get_hermes_home() / "sessions")
 
@@ -867,6 +875,14 @@ class GatewayConfig:
         if not isinstance(quick_commands, dict):
             quick_commands = {}
 
+        # Background services (see ``GatewayConfig.services`` docstring).
+        # Each entry maps a plugin-registered service name to its config dict.
+        # We preserve the dict verbatim — plugin owners define their own
+        # schema under ``services.<name>.extra`` / ``services.<name>.rules``.
+        services_cfg = data.get("services", {})
+        if not isinstance(services_cfg, dict):
+            services_cfg = {}
+
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
@@ -926,6 +942,7 @@ class GatewayConfig:
             reset_by_platform=reset_by_platform,
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),
             quick_commands=quick_commands,
+            services=services_cfg,
             sessions_dir=sessions_dir,
             write_sessions_json=_coerce_bool(data.get("write_sessions_json"), True),
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
@@ -1078,6 +1095,13 @@ def load_gateway_config() -> GatewayConfig:
 
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]
+
+            # ``services:`` mirrors a plugin-registered background-service
+            # block. Each entry is preserved verbatim; plugin owners define
+            # the per-service schema under ``services.<name>.extra``.
+            services_yaml = yaml_cfg.get("services")
+            if isinstance(services_yaml, dict):
+                gw_data["services"] = services_yaml
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3123,6 +3123,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # dormant before the drained backlog has a chance to update the clock.
         self._scale_to_zero_cooldown_until: float = 0.0
 
+        # Registered background services (see plugins/services/ and
+        # gateway/service_registry.py). Wired up in start() after platforms
+        # are connected; stopped before adapters in stop() so they don't
+        # try to deliver during teardown.
+        self.services: Dict[str, Any] = {}
+
 
     def _wire_teams_pipeline_runtime(self) -> None:
         """Bind the Teams meeting pipeline runtime to Graph webhook ingress.
@@ -7402,9 +7408,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # engages drain on the first tick.
         asyncio.create_task(self._drain_control_watcher())
 
+        # Start plugin-registered background services (Nextcloud notifications,
+        # file watchers, RSS pollers, etc.). Each entry in
+        # ``config.services.<name>`` whose ``enabled`` flag is set is matched
+        # against an entry in :data:`gateway.service_registry.service_registry`.
+        # Services that fail to start are logged but do not abort gateway
+        # startup — they can be retried after a config fix + restart.
+        try:
+            await self._start_plugin_background_services()
+        except Exception as _e:
+            logger.error("Plugin background services startup error: %s", _e, exc_info=True)
+
         logger.info("Press Ctrl+C to stop")
-        
+
         return True
+
+    async def _start_plugin_background_services(self) -> None:
+        """Instantiate and start each enabled background service.
+
+        Iterates ``self.config.services`` (loaded from ``services:`` in
+        config.yaml) and looks each name up in the global
+        ``service_registry``. Misses are logged and skipped — they're either
+        a typo, a disabled plugin, or a service we removed but config still
+        references.
+        """
+        from gateway.service_registry import service_registry
+
+        services_cfg = getattr(self.config, "services", None) or {}
+        if not services_cfg:
+            return
+
+        for svc_name, svc_config in services_cfg.items():
+            if not isinstance(svc_config, dict) or not svc_config.get("enabled", False):
+                continue
+
+            if not service_registry.is_registered(svc_name):
+                logger.warning(
+                    "Background service '%s' is enabled in config.yaml but no "
+                    "plugin registered it. Is the plugin installed and enabled?",
+                    svc_name,
+                )
+                continue
+
+            svc = service_registry.create_service(svc_name, svc_config, self)
+            if svc is None:
+                continue
+
+            try:
+                if await svc.start():
+                    self.services[svc_name] = svc
+                    logger.info("Background service '%s' started", svc_name)
+                else:
+                    logger.warning("Background service '%s' failed to start", svc_name)
+            except Exception as e:
+                logger.error("Background service '%s' startup error: %s", svc_name, e, exc_info=True)
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.
@@ -8289,6 +8346,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),
             )
+
+            # Stop plugin-registered background services. They may have
+            # held HTTP sessions or polling tasks; stopping AFTER adapters
+            # disconnect means in-flight notifications can't reach the
+            # platforms, which is what we want at shutdown.
+            _services = getattr(self, "services", None)
+            if _services:
+                for _svc_name, _svc in list(_services.items()):
+                    try:
+                        await _svc.stop()
+                        logger.info("Background service '%s' stopped", _svc_name)
+                    except Exception as _e:
+                        logger.error("Background service '%s' stop error: %s", _svc_name, _e)
+                _services.clear()
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:

--- a/gateway/service_registry.py
+++ b/gateway/service_registry.py
@@ -1,0 +1,184 @@
+"""
+Background Service Registry
+
+Allows long-running background services (Nextcloud notification pollers,
+file sync watchers, etc.) to self-register so the gateway can discover
+and instantiate them without hardcoded ``_create_service()`` if/elif
+chains in ``gateway/run.py``.
+
+Background services differ from platform adapters in two ways:
+
+* They do not receive user messages — they observe an external source
+  (a notification queue, a file system watcher, a webhook) and forward
+  events to platforms.
+* They have no ``MessageHandler`` plumbing — start/stop is the entire
+  interface plus whatever the service emits internally.
+
+Usage (plugin side)::
+
+    from gateway.service_registry import service_registry, BackgroundServiceEntry
+
+    service_registry.register(BackgroundServiceEntry(
+        name="nextcloud_notifications",
+        label="Nextcloud Notifications",
+        service_factory=lambda cfg, gateway: NextcloudNotificationService(cfg),
+        check_fn=lambda: True,
+        validate_config=lambda cfg: bool(cfg.get("enabled")),
+    ))
+
+Usage (gateway side)::
+
+    svc = service_registry.create_service("nextcloud_notifications", cfg, self)
+    if svc is not None:
+        await svc.start()
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackgroundServiceEntry:
+    """Metadata and factory for a single background service."""
+
+    # Identifier used in config.yaml under ``services.<name>``.
+    name: str
+
+    # Human-readable label.
+    label: str
+
+    # Factory callable: receives (config_dict, gateway_runner) and returns
+    # a service instance. The instance MUST expose ``async start()`` and
+    # ``async stop()`` methods (see ``gateway.services.base.BaseService``
+    # for the canonical interface). Using a factory instead of a bare class
+    # lets plugins do custom init / dependency injection without subclassing.
+    service_factory: Callable[[dict, Any], Any]
+
+    # Returns True when the service's dependencies are importable. Called
+    # before instantiation; if it returns False the gateway logs the install
+    # hint and skips creation.
+    check_fn: Callable[[], bool]
+
+    # Optional config-validity check. Receives the service's config dict
+    # (with ``enabled`` already verified by the caller) and returns True
+    # when the config is complete enough to start. If None, the registry
+    # skips this check.
+    validate_config: Optional[Callable[[dict], bool]] = None
+
+    # Env vars this service needs (for ``hermes config`` / dashboard display).
+    required_env: list = field(default_factory=list)
+
+    # Hint shown when ``check_fn`` returns False (e.g. ``pip install httpx``).
+    install_hint: str = ""
+
+    # ``"builtin"`` or ``"plugin"``.
+    source: str = "plugin"
+
+    # Name of the plugin that registered this entry (for diagnostics).
+    plugin_name: str = ""
+
+
+class BackgroundServiceRegistry:
+    """Central registry of background services.
+
+    Thread-safe for reads (dict lookups are atomic under GIL).
+    Writes happen at startup during sequential plugin discovery.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, BackgroundServiceEntry] = {}
+
+    def register(self, entry: BackgroundServiceEntry) -> None:
+        """Register a background service entry.
+
+        If an entry with the same name exists, it is replaced (last writer
+        wins — lets plugins override built-in services if desired).
+        """
+        if entry.name in self._entries:
+            prev = self._entries[entry.name]
+            logger.info(
+                "Background service '%s' re-registered (was %s, now %s)",
+                entry.name,
+                prev.source,
+                entry.source,
+            )
+        self._entries[entry.name] = entry
+        logger.debug(
+            "Registered background service: %s (%s)", entry.name, entry.source
+        )
+
+    def unregister(self, name: str) -> bool:
+        """Remove a service entry. Returns True if it existed."""
+        return self._entries.pop(name, None) is not None
+
+    def get(self, name: str) -> Optional[BackgroundServiceEntry]:
+        return self._entries.get(name)
+
+    def all_entries(self) -> list[BackgroundServiceEntry]:
+        return list(self._entries.values())
+
+    def plugin_entries(self) -> list[BackgroundServiceEntry]:
+        return [e for e in self._entries.values() if e.source == "plugin"]
+
+    def is_registered(self, name: str) -> bool:
+        return name in self._entries
+
+    def create_service(
+        self, name: str, config: dict, gateway_runner: Any
+    ) -> Optional[Any]:
+        """Create a service instance for the given service name.
+
+        Returns ``None`` if:
+
+        * No entry is registered for ``name``.
+        * ``check_fn()`` returns False (missing deps).
+        * ``validate_config()`` returns False (misconfigured).
+        * The factory raises an exception.
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            return None
+
+        if not entry.check_fn():
+            hint = f" ({entry.install_hint})" if entry.install_hint else ""
+            logger.warning(
+                "Background service '%s' requirements not met%s",
+                entry.label,
+                hint,
+            )
+            return None
+
+        if entry.validate_config is not None:
+            try:
+                if not entry.validate_config(config):
+                    logger.warning(
+                        "Background service '%s' config validation failed",
+                        entry.label,
+                    )
+                    return None
+            except Exception as e:
+                logger.warning(
+                    "Background service '%s' config validation error: %s",
+                    entry.label,
+                    e,
+                )
+                return None
+
+        try:
+            service = entry.service_factory(config, gateway_runner)
+            return service
+        except Exception as e:
+            logger.error(
+                "Failed to create background service '%s': %s",
+                entry.label,
+                e,
+                exc_info=True,
+            )
+            return None
+
+
+# Module-level singleton — same pattern as platform_registry.
+service_registry = BackgroundServiceRegistry()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1038,6 +1038,87 @@ class PluginContext:
             action_id,
         )
 
+    # -- background service registration ------------------------------------
+
+    def register_background_service(
+        self,
+        name: str,
+        label: str,
+        service_factory: Callable,
+        check_fn: Callable,
+        validate_config: Callable | None = None,
+        required_env: list | None = None,
+        install_hint: str = "",
+        **entry_kwargs: Any,
+    ) -> None:
+        """Register a long-running gateway background service.
+
+        Background services differ from platform adapters: they observe an
+        external event source (notification queue, file watcher, webhook
+        endpoint) and emit gateway-internal events rather than handling
+        user-to-agent messages directly. Examples: Nextcloud notification
+        poller, WebDAV file sync watcher, RSS feed monitor.
+
+        The ``service_factory`` callable receives ``(config_dict, gateway_runner)``
+        and returns an instance exposing ``async start()`` and ``async stop()``
+        methods. See ``gateway.services.base.BaseService`` for the canonical
+        interface and the bundled service plugins under
+        ``plugins/services/`` for examples.
+
+        After registration, the service is wired up by the gateway during
+        startup whenever ``services.<name>.enabled`` is True in config.yaml.
+
+        Args:
+            name: stable service key (snake_case). Used in
+                ``services.<name>`` in config.yaml.
+            label: human-readable name shown in logs and the dashboard.
+            service_factory: callable ``(cfg_dict, gateway_runner) -> service``.
+            check_fn: returns True when dependencies are importable. Called
+                before instantiation; on False the gateway logs the install
+                hint and skips creation.
+            validate_config: optional callable ``(cfg_dict) -> bool`` invoked
+                after ``enabled`` is verified by the caller. Use this for
+                deeper checks like "required keys present in extra".
+            required_env: list of env-var names the service needs, surfaced
+                in ``hermes config`` UI.
+            install_hint: shown when ``check_fn`` returns False
+                (e.g. ``pip install httpx``).
+            **entry_kwargs: forwarded to ``BackgroundServiceEntry`` for any
+                future fields (e.g. dashboard metadata).
+
+        Example::
+
+            ctx.register_background_service(
+                name="nextcloud_notifications",
+                label="Nextcloud Notifications",
+                service_factory=lambda cfg, gw: NextcloudNotificationService(cfg, gw),
+                check_fn=lambda: True,
+            )
+        """
+        from gateway.service_registry import (
+            service_registry,
+            BackgroundServiceEntry,
+        )
+
+        entry_kwargs.setdefault("plugin_name", self.manifest.name)
+        entry = BackgroundServiceEntry(
+            name=name,
+            label=label,
+            service_factory=service_factory,
+            check_fn=check_fn,
+            validate_config=validate_config,
+            required_env=required_env or [],
+            install_hint=install_hint,
+            source="plugin",
+            **entry_kwargs,
+        )
+        service_registry.register(entry)
+        logger.debug(
+            "Plugin %s registered background service: %s",
+            self.manifest.name,
+            name,
+        )
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------

--- a/plugins/services/nextcloud_notifications/__init__.py
+++ b/plugins/services/nextcloud_notifications/__init__.py
@@ -1,0 +1,83 @@
+"""Nextcloud Notifications background-service plugin entry point.
+
+Registers a long-running service via
+:meth:`PluginContext.register_background_service` so the gateway can
+start it after platforms come up and stop it before they disconnect.
+
+The service polls Nextcloud's Notifications + Activity APIs and routes
+matching events to the configured platform (typically Nextcloud Talk).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+try:
+    import httpx  # noqa: F401
+    _HTTPX = True
+except ImportError:
+    _HTTPX = False
+
+logger = logging.getLogger(__name__)
+
+
+def _check_requirements() -> bool:
+    return _HTTPX
+
+
+def _validate_config(cfg: dict) -> bool:
+    """The plugin needs at minimum a deliver target and either an env-provided
+    password or one of: an explicit ``app_password_env`` in extra, or a
+    Talk-platform-side credential we can inherit at runtime (the factory
+    handles inheritance — here we just sanity-check the shape).
+    """
+    extra = cfg.get("extra") or cfg  # tolerate flat-vs-nested config
+    return bool(extra.get("deliver"))
+
+
+def _service_factory(config: dict, gateway_runner: Any) -> Any:
+    """Build a ``NextcloudNotificationService`` from the gateway config dict.
+
+    The dict is the raw ``services.nextcloud_notifications`` block from
+    config.yaml (including ``enabled``, ``extra``, etc.). We inherit
+    Nextcloud credentials from the Talk adapter when ``extra.nextcloud_url``
+    is missing so operators don't have to duplicate URL/username.
+    """
+    from .service import NextcloudNotificationService
+
+    extra = dict(config.get("extra") or {})
+
+    # Inherit NC credentials from the Talk adapter when the operator
+    # hasn't duplicated them. Keeps config.yaml DRY for the common case
+    # where Notifications + Talk share an account.
+    if not extra.get("nextcloud_url") and gateway_runner is not None:
+        try:
+            from gateway.config import Platform
+            talk_cfg = gateway_runner.config.platforms.get(Platform("nextcloud_talk"))
+            if talk_cfg and getattr(talk_cfg, "extra", None):
+                talk_extra = talk_cfg.extra
+                extra.setdefault("nextcloud_url", talk_extra.get("nextcloud_url", ""))
+                extra.setdefault("username", talk_extra.get("username", "hermes"))
+                extra.setdefault(
+                    "app_password_env",
+                    talk_extra.get("app_password_env", "NEXTCLOUD_TALK_APP_PASSWORD"),
+                )
+        except Exception:
+            logger.debug("nc-notifications: could not inherit Talk credentials", exc_info=True)
+
+    return NextcloudNotificationService(extra, gateway_runner)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    ctx.register_background_service(
+        name="nextcloud_notifications",
+        label="Nextcloud Notifications",
+        service_factory=_service_factory,
+        check_fn=_check_requirements,
+        validate_config=_validate_config,
+        install_hint="pip install httpx   # already a Hermes dependency",
+    )
+
+
+__all__ = ["register"]

--- a/plugins/services/nextcloud_notifications/base.py
+++ b/plugins/services/nextcloud_notifications/base.py
@@ -1,0 +1,52 @@
+"""Shared base class + event dataclass for Nextcloud background services.
+
+Lives inside the plugin so the service module is self-contained and
+doesn't depend on a sibling ``gateway/services/`` directory in the core
+tree. Mirrors the canonical ``BaseService`` shape so future Hermes
+service plugins can adopt the same interface.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ServiceEvent:
+    """Event surfaced by a background service for routing/agent dispatch."""
+
+    service: str
+    notification_id: int
+    app: str
+    object_type: str
+    object_id: str
+    subject: str
+    message: str
+    link: str
+    sender: str
+    timestamp: str
+    action: str  # "react" (forward to agent) or "silent" (record only)
+    raw: dict = field(default_factory=dict)
+
+
+class BaseService(ABC):
+    """Background service that observes an external source and routes events.
+
+    The plugin-registered ``service_factory`` is called with
+    ``(config_dict, gateway_runner)`` — subclasses MUST accept both. The
+    factory contract is enforced by
+    ``gateway.service_registry.service_registry.create_service``.
+    """
+
+    name: str = "base"
+
+    def __init__(self, config: dict, gateway_runner: Optional[Any] = None):
+        self.config = config
+        self.gateway_runner = gateway_runner
+
+    @abstractmethod
+    async def start(self) -> bool:
+        """Start background tasks. Returns True on success."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Clean shutdown — cancel tasks, close connections."""

--- a/plugins/services/nextcloud_notifications/plugin.yaml
+++ b/plugins/services/nextcloud_notifications/plugin.yaml
@@ -1,0 +1,23 @@
+name: nextcloud-notifications-service
+label: Nextcloud Notifications
+kind: backend
+version: 1.0.0
+description: >
+  Background service that polls Nextcloud's Notifications and Activity
+  APIs and routes matching events to a configured platform (typically
+  the Nextcloud Talk adapter). Classification rules let operators
+  whitelist event types (calendar invites, mention-in-comment, deck
+  card assignments, etc.) and choose between "react" (forward to the
+  agent) and "silent" (record-only).
+
+  This plugin ships under ``plugins/services/nextcloud_notifications/``
+  and registers a background service via
+  ``PluginContext.register_background_service``. The gateway starts
+  it after platforms come up and stops it before they disconnect.
+author: nsyring
+requires_env: []
+optional_env:
+  - name: NEXTCLOUD_TALK_APP_PASSWORD
+    description: "Reused from the Nextcloud Talk adapter — same App Password unlocks the Notifications/Activity APIs"
+    prompt: "Nextcloud App Password (same as NC Talk)"
+    password: true

--- a/plugins/services/nextcloud_notifications/service.py
+++ b/plugins/services/nextcloud_notifications/service.py
@@ -1,0 +1,362 @@
+"""Nextcloud Notifications + Activity polling service.
+
+Polls both the NC Notifications API (ETag-optimized) and the Activity API
+to catch all Nextcloud events. Classifies events via configurable rules
+and routes them to a target platform adapter for agent processing.
+
+File handling (download, sync, local storage) is NOT part of this service.
+It will be handled by a separate NextcloudFilesService (pr/nextcloud-files).
+"""
+import asyncio
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from .base import BaseService, ServiceEvent
+from .store import NotificationStore
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_sender(raw: dict) -> str:
+    """Extract the actor/sender from a notification or activity dict.
+
+    Notifications API stores the actor in subjectRichParameters.actor.id.
+    Activity API stores it in subject_rich[1].actor.id or subject_rich[1].user.id.
+    The raw 'user' field is always the notification RECIPIENT (hermes), not the sender.
+    Falls back to raw['user'] only if no actor can be found.
+    """
+    # Notifications API: subjectRichParameters is a dict
+    srp = raw.get("subjectRichParameters")
+    if isinstance(srp, dict):
+        actor_id = srp.get("actor", {}).get("id", "")
+        if actor_id:
+            return actor_id
+
+    # Activity API: subject_rich is a list [template, params_dict]
+    sr = raw.get("subject_rich")
+    if isinstance(sr, list) and len(sr) >= 2 and isinstance(sr[1], dict):
+        actor_id = sr[1].get("actor", {}).get("id", "")
+        if actor_id:
+            return actor_id
+        # Some activity types use 'user' instead of 'actor'
+        user_id = sr[1].get("user", {}).get("id", "")
+        if user_id:
+            return user_id
+
+    return raw.get("user", "")
+
+
+def _classify_event(notification: dict, rules: list) -> str:
+    """Match a notification against rules, return action. First match wins.
+
+    Supports matching on app, object_type, and type fields.
+    The Activity API uses different field values than the Notifications API:
+      - Activity: object_type=files + type=shared (two fields)
+      - Notifications: object_type=shared (one field)
+    Use the 'type' field in rules for fine-grained Activity API filtering.
+    """
+    notif_app = notification.get("app", "")
+    notif_object_type = notification.get("object_type", "")
+    notif_type = notification.get("type", "")
+
+    for rule in rules:
+        rule_app = rule.get("app", "*")
+        rule_object_type = rule.get("object_type")
+        rule_type = rule.get("type")
+
+        if rule_app != "*" and rule_app != notif_app:
+            continue
+        if rule_object_type and rule_object_type != notif_object_type:
+            continue
+        if rule_type and rule_type != notif_type:
+            continue
+
+        return rule.get("action", "silent")
+
+    return "silent"
+
+
+def _parse_notification(raw: dict, rules: list) -> ServiceEvent:
+    """Parse a raw NC notification or activity dict into a ServiceEvent."""
+    action = _classify_event(raw, rules)
+    return ServiceEvent(
+        service="nextcloud_notifications",
+        notification_id=raw.get("notification_id", raw.get("activity_id", 0)),
+        app=raw.get("app", ""),
+        object_type=raw.get("object_type", raw.get("type", "")),
+        object_id=str(raw.get("object_id", "")),
+        subject=raw.get("subject", ""),
+        message=raw.get("message", ""),
+        link=raw.get("link", ""),
+        sender=_extract_sender(raw),
+        timestamp=raw.get("datetime", ""),
+        action=action,
+        raw=raw,
+    )
+
+
+class NotificationClient:
+    """Lightweight HTTP client for NC Notifications + Activity API."""
+
+    def __init__(self, base_url: str, username: str, password: str):
+        self._base_url = base_url.rstrip("/")
+        self._username = username
+        self._http = httpx.AsyncClient(
+            auth=(username, password),
+            headers={
+                "OCS-APIRequest": "true",
+                "Accept": "application/json",
+            },
+            timeout=30.0,
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+
+    async def fetch_notifications(self, etag: str = "") -> tuple:
+        """Fetch notifications. Returns (list_of_notifs, new_etag)."""
+        headers = {}
+        if etag:
+            headers["If-None-Match"] = etag
+
+        url = f"{self._base_url}/ocs/v2.php/apps/notifications/api/v2/notifications"
+        resp = await self._http.get(url, headers=headers)
+
+        if resp.status_code == 304:
+            return [], etag
+
+        resp.raise_for_status()
+        new_etag = resp.headers.get("ETag", etag)
+        data = resp.json().get("ocs", {}).get("data", [])
+        return data, new_etag
+
+    async def fetch_activities(self, last_known_id: int = 0) -> tuple:
+        """Fetch latest activities and return those newer than last_known_id.
+
+        NC Activity API 'since' param paginates backwards (returns older items),
+        so we always fetch the latest page and filter client-side.
+        Returns (new_activities, highest_id).
+        """
+        url = f"{self._base_url}/ocs/v2.php/apps/activity/api/v2/activity"
+        try:
+            resp = await self._http.get(url, params={"limit": 50})
+            if resp.status_code == 304:
+                return [], last_known_id
+            resp.raise_for_status()
+            data = resp.json().get("ocs", {}).get("data", [])
+            if not data:
+                return [], last_known_id
+            highest_id = max(a.get("activity_id", 0) for a in data)
+            new_activities = [a for a in data if a.get("activity_id", 0) > last_known_id]
+            return new_activities, highest_id
+        except Exception as e:
+            logger.warning("NC Activities: fetch failed: %s", e)
+            return [], last_known_id
+
+    async def delete_notification(self, notification_id: int):
+        """Mark notification as read/processed."""
+        url = f"{self._base_url}/ocs/v2.php/apps/notifications/api/v2/notifications/{notification_id}"
+        await self._http.delete(url)
+
+    async def close(self):
+        await self._http.aclose()
+
+
+class NextcloudNotificationService(BaseService):
+    """Polls Nextcloud Notifications + Activity API, classifies events, routes to platform.
+
+    This service handles event detection and routing only. File operations
+    (download, upload, sync) are handled by a separate NextcloudFilesService.
+    """
+
+    name = "nextcloud_notifications"
+
+    def __init__(self, config: dict, gateway_runner=None):
+        super().__init__(config, gateway_runner)
+        self._nc_url = config.get("nextcloud_url", "")
+        self._username = config.get("username", "hermes")
+        pw_env = config.get("app_password_env", "NEXTCLOUD_TALK_APP_PASSWORD")
+        self._password = os.environ.get(pw_env, "").strip()
+        self._poll_interval = config.get("poll_interval", 30)
+        self._rules = config.get("rules", [])
+
+        deliver = config.get("deliver", "")
+        if ":" in deliver:
+            self._deliver_platform, self._deliver_chat_id = deliver.split(":", 1)
+        else:
+            self._deliver_platform = deliver
+            self._deliver_chat_id = ""
+
+        store_path = config.get("store_path", "~/.hermes/notification_events.json")
+        self._store = NotificationStore(path=store_path)
+
+        self._client: Optional[NotificationClient] = None
+        self._poll_task: Optional[asyncio.Task] = None
+        self._shutdown = False
+        self._etag = ""
+        self._last_seen_id = 0
+        self._last_activity_id = 0
+
+    def _on_poll_done(self, task: asyncio.Task):
+        """Log if poll task dies unexpectedly."""
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc:
+            logger.error("[NC Notifications] Poll task died: %s", exc, exc_info=exc)
+
+    async def start(self) -> bool:
+        if not self._nc_url or not self._password:
+            logger.warning("NC Notifications: missing nextcloud_url or password")
+            return False
+        self._client = NotificationClient(self._nc_url, self._username, self._password)
+        self._shutdown = False
+        # Initialize activity ID to current latest to avoid processing old events
+        if self._last_activity_id == 0:
+            try:
+                _, last_id = await asyncio.wait_for(
+                    self._client.fetch_activities(0), timeout=10
+                )
+                self._last_activity_id = last_id
+                logger.warning("[NC Notifications] Activity baseline: %d", last_id)
+            except asyncio.TimeoutError:
+                logger.warning("[NC Notifications] Activity baseline fetch timed out, starting from 0")
+            except Exception as e:
+                logger.warning("[NC Notifications] Activity baseline fetch failed: %s", e)
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        self._poll_task.add_done_callback(self._on_poll_done)
+        logger.info("[NC Notifications] Started (poll_interval=%ds, stored_events=%d)",
+                    self._poll_interval, self._store.count())
+        return True
+
+    async def stop(self):
+        self._shutdown = True
+        if self._poll_task:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        if self._client:
+            await self._client.close()
+        logger.info("[NC Notifications] Stopped")
+
+    async def _poll_loop(self):
+        backoff = 5
+        while not self._shutdown:
+            try:
+                # Poll Notifications API
+                notifications, self._etag = await self._client.fetch_notifications(self._etag)
+                backoff = 5
+
+                for raw in notifications:
+                    nid = raw.get("notification_id", 0)
+                    if nid <= self._last_seen_id:
+                        continue
+                    self._last_seen_id = max(self._last_seen_id, nid)
+
+                    event = _parse_notification(raw, self._rules)
+                    await self.on_event(event)
+
+                    try:
+                        await self._client.delete_notification(nid)
+                    except Exception as e:
+                        logger.warning("NC Notifications: failed to delete %d: %s", nid, e)
+
+                # Also poll Activity API for events that don't generate notifications
+                activities, new_act_id = await self._client.fetch_activities(self._last_activity_id)
+                if new_act_id > self._last_activity_id:
+                    for act in activities:
+                        aid = act.get("activity_id", 0)
+                        if aid <= self._last_activity_id:
+                            continue
+                        event = _parse_notification(act, self._rules)
+                        # Skip events caused by hermes itself to avoid loops
+                        if event.sender == self._username:
+                            continue
+                        if event.action == "react":
+                            await self.on_event(event)
+                        else:
+                            self._store.add(event)
+                    self._last_activity_id = new_act_id
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("NC Notifications poll error: %s", e)
+                backoff = min(backoff * 2, 60)
+
+            await asyncio.sleep(self._poll_interval if backoff == 5 else backoff)
+
+    async def on_event(self, event: ServiceEvent):
+        if event.action == "ignore":
+            return
+        if event.action == "react":
+            await self._deliver_react(event)
+        else:
+            self._store.add(event)
+
+    async def _deliver_react(self, event: ServiceEvent):
+        """Inject event as MessageEvent into target platform adapter."""
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        runner = self.gateway_runner
+        if not runner:
+            logger.warning("NC Notifications: no gateway_runner, cannot deliver")
+            return
+
+        try:
+            platform = Platform(self._deliver_platform)
+        except ValueError:
+            logger.error("NC Notifications: unknown platform '%s'", self._deliver_platform)
+            return
+
+        adapter = runner.adapters.get(platform)
+        if not adapter:
+            logger.warning("NC Notifications: adapter for %s not connected", platform.value)
+            return
+
+        # Build message text
+        text = f"[NC Notification] {event.subject}"
+        if event.message:
+            text += f"\n{event.message}"
+        if event.link:
+            text += f"\nLink: {event.link}"
+
+        # For calendar reminders: add tool guidance
+        if event.app == "dav" and "calendar" in event.object_type.lower():
+            text += "\n\n[System] This is a calendar reminder. Execute the task described above."
+            text += " Use skill_view() to load relevant skills, then execute_code to run commands."
+            text += " Do NOT use non-existent tools — check available tools first."
+
+        # Use the event sender as user_id so the notification lands in their
+        # existing chat session, preserving context for follow-up questions.
+        user_id = event.sender or f"service:{self.name}"
+
+        # Determine chat_type the same way the adapter does, so the session
+        # key matches the user's existing chat session.
+        chat_type = "dm"
+        if hasattr(adapter, "_classify_chat"):
+            chat_type = adapter._classify_chat(self._deliver_chat_id)
+
+        source = adapter.build_source(
+            chat_id=self._deliver_chat_id,
+            user_id=user_id,
+            user_name=f"NC/{event.app} ({event.sender})",
+            chat_type=chat_type,
+        )
+
+        msg_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=f"ncnotif_{event.notification_id}",
+        )
+
+        await adapter.handle_message(msg_event)
+
+        # Also store react events for history
+        self._store.add(event)

--- a/plugins/services/nextcloud_notifications/store.py
+++ b/plugins/services/nextcloud_notifications/store.py
@@ -1,0 +1,64 @@
+"""Persistent JSON storage for notification events."""
+import json
+import logging
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import List, Optional
+
+from .base import ServiceEvent
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PATH = "~/.hermes/notification_events.json"
+_MAX_EVENTS = 200
+
+
+class NotificationStore:
+    """Simple JSON-file-backed event store."""
+
+    def __init__(self, path: Optional[str] = None, max_events: int = _MAX_EVENTS):
+        self._path = Path(os.path.expanduser(path or _DEFAULT_PATH))
+        self._max_events = max_events
+        self._events: List[dict] = []
+        self._load()
+
+    def _load(self):
+        if self._path.exists():
+            try:
+                self._events = json.loads(self._path.read_text(encoding="utf-8"))
+                if not isinstance(self._events, list):
+                    self._events = []
+            except Exception as e:
+                logger.warning("Failed to load notification store: %s", e)
+                self._events = []
+
+    def _save(self):
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps(self._events, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def add(self, event: ServiceEvent):
+        self._events.append(asdict(event))
+        if len(self._events) > self._max_events:
+            self._events = self._events[-self._max_events:]
+        self._save()
+
+    def query(self, since: Optional[str] = None, app: Optional[str] = None,
+              limit: int = 20) -> List[dict]:
+        """Query stored events, newest first."""
+        results = list(reversed(self._events))
+        if app:
+            results = [e for e in results if e.get("app") == app]
+        if since:
+            results = [e for e in results if e.get("timestamp", "") >= since]
+        return results[:limit]
+
+    def clear(self):
+        self._events = []
+        self._save()
+
+    def count(self) -> int:
+        return len(self._events)


### PR DESCRIPTION
## What does this PR do?

Adds a background service that polls Nextcloud's Notifications and Activity APIs, delivering events to the agent based on configurable rules.

**Architecture:** Introduces a `BaseService` abstraction for non-chat background services (alongside `BasePlatformAdapter` for chat platforms). The notification service runs as a background asyncio task within the gateway.

**Key features:**
- Polls both Notifications API (real-time alerts) and Activity API (app events)
- Configurable rules engine with first-match-wins semantics: `react` (deliver as message), `silent` (store for memory), `ignore` (drop)
- ETag optimization for Notifications API
- Self-loop prevention (filters out agent's own actions)
- Exponential backoff on poll errors
- Task supervision with crash logging
- Persistent notification store for silent events

**Depends on:** [feat/nextcloud-talk](#11458) for the platform adapter (notifications are delivered through Talk). Can be reviewed independently — the service only needs a running platform adapter for `react` delivery.

## Related Issue

No existing issue.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `gateway/services/base.py`: `BaseService` ABC + `ServiceEvent` dataclass
- `gateway/services/nextcloud_notifications.py`: Notification service (400 lines)
- `gateway/services/notification_store.py`: JSON-based event persistence
- `gateway/services/__init__.py`: Package init
- `gateway/config.py`: Service config parsing
- `gateway/run.py`: Service lifecycle (start before adapters, stop before disconnect)
- `cli-config.yaml.example`: Notification rules configuration
- `website/docs/user-guide/features/nextcloud-notifications.md`: Documentation
- `tests/gateway/test_nextcloud_notifications.py`: 26 tests

## How to Test

1. Configure notification rules in `config.yaml`:
   ```yaml
   services:
     nextcloud_notifications:
       notification_rules:
         - app: deck
           object_type: card
           action: react
         - app: "*"
           action: silent
   ```
2. Trigger a Nextcloud notification (e.g., assign a Deck card)
3. The agent should receive and respond to `react` events
4. Run `pytest tests/gateway/test_nextcloud_notifications.py -v` — all 26 tests pass

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have searched for existing PRs to avoid duplicates
- [x] This PR contains only related changes
- [x] `pytest tests/ -q` passes
- [x] I have added tests for my changes
- [x] I have tested on: Debian 13 (LXC, amd64)
- [x] I have updated relevant documentation
- [x] `cli-config.yaml.example` updated
- [x] Architecture: introduces BaseService pattern (documented in code)
- [x] Cross-platform: no effect on existing platforms
- [x] N/A — no tool schema changes