### PR TITLE
feat(gateway): bidirectional Nextcloud file sync via WebDAV, notify_push, and inotify

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -671,7 +671,15 @@ class GatewayConfig:
 
     # User-defined quick commands (slash commands that bypass the agent loop)
     quick_commands: Dict[str, Any] = field(default_factory=dict)
-    
+
+    # Background services (long-running observers/pollers registered by
+    # plugins via ``PluginContext.register_background_service``). Each entry
+    # mirrors a ``services.<name>`` block from config.yaml verbatim, including
+    # the ``enabled`` flag and arbitrary plugin-defined keys. The gateway
+    # looks each name up in ``gateway.service_registry.service_registry``
+    # at startup.
+    services: Dict[str, Any] = field(default_factory=dict)
+
     # Storage paths
     sessions_dir: Path = field(default_factory=lambda: get_hermes_home() / "sessions")
 
@@ -867,6 +875,14 @@ class GatewayConfig:
         if not isinstance(quick_commands, dict):
             quick_commands = {}
 
+        # Background services (see ``GatewayConfig.services`` docstring).
+        # Each entry maps a plugin-registered service name to its config dict.
+        # We preserve the dict verbatim — plugin owners define their own
+        # schema under ``services.<name>.extra`` / ``services.<name>.rules``.
+        services_cfg = data.get("services", {})
+        if not isinstance(services_cfg, dict):
+            services_cfg = {}
+
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
@@ -926,6 +942,7 @@ class GatewayConfig:
             reset_by_platform=reset_by_platform,
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),
             quick_commands=quick_commands,
+            services=services_cfg,
             sessions_dir=sessions_dir,
             write_sessions_json=_coerce_bool(data.get("write_sessions_json"), True),
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
@@ -1078,6 +1095,13 @@ def load_gateway_config() -> GatewayConfig:
 
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]
+
+            # ``services:`` mirrors a plugin-registered background-service
+            # block. Each entry is preserved verbatim; plugin owners define
+            # the per-service schema under ``services.<name>.extra``.
+            services_yaml = yaml_cfg.get("services")
+            if isinstance(services_yaml, dict):
+                gw_data["services"] = services_yaml
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3123,6 +3123,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # dormant before the drained backlog has a chance to update the clock.
         self._scale_to_zero_cooldown_until: float = 0.0
 
+        # Registered background services (see plugins/services/ and
+        # gateway/service_registry.py). Wired up in start() after platforms
+        # are connected; stopped before adapters in stop() so they don't
+        # try to deliver during teardown.
+        self.services: Dict[str, Any] = {}
+
 
     def _wire_teams_pipeline_runtime(self) -> None:
         """Bind the Teams meeting pipeline runtime to Graph webhook ingress.
@@ -7402,9 +7408,60 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # engages drain on the first tick.
         asyncio.create_task(self._drain_control_watcher())
 
+        # Start plugin-registered background services (Nextcloud notifications,
+        # file watchers, RSS pollers, etc.). Each entry in
+        # ``config.services.<name>`` whose ``enabled`` flag is set is matched
+        # against an entry in :data:`gateway.service_registry.service_registry`.
+        # Services that fail to start are logged but do not abort gateway
+        # startup — they can be retried after a config fix + restart.
+        try:
+            await self._start_plugin_background_services()
+        except Exception as _e:
+            logger.error("Plugin background services startup error: %s", _e, exc_info=True)
+
         logger.info("Press Ctrl+C to stop")
-        
+
         return True
+
+    async def _start_plugin_background_services(self) -> None:
+        """Instantiate and start each enabled background service.
+
+        Iterates ``self.config.services`` (loaded from ``services:`` in
+        config.yaml) and looks each name up in the global
+        ``service_registry``. Misses are logged and skipped — they're either
+        a typo, a disabled plugin, or a service we removed but config still
+        references.
+        """
+        from gateway.service_registry import service_registry
+
+        services_cfg = getattr(self.config, "services", None) or {}
+        if not services_cfg:
+            return
+
+        for svc_name, svc_config in services_cfg.items():
+            if not isinstance(svc_config, dict) or not svc_config.get("enabled", False):
+                continue
+
+            if not service_registry.is_registered(svc_name):
+                logger.warning(
+                    "Background service '%s' is enabled in config.yaml but no "
+                    "plugin registered it. Is the plugin installed and enabled?",
+                    svc_name,
+                )
+                continue
+
+            svc = service_registry.create_service(svc_name, svc_config, self)
+            if svc is None:
+                continue
+
+            try:
+                if await svc.start():
+                    self.services[svc_name] = svc
+                    logger.info("Background service '%s' started", svc_name)
+                else:
+                    logger.warning("Background service '%s' failed to start", svc_name)
+            except Exception as e:
+                logger.error("Background service '%s' startup error: %s", svc_name, e, exc_info=True)
 
     async def _handoff_watcher(self, interval: float = 2.0) -> None:
         """Background task that processes pending CLI→gateway session handoffs.
@@ -8289,6 +8346,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Shutdown phase: all adapters disconnected at +%.2fs",
                 _phase_elapsed(),
             )
+
+            # Stop plugin-registered background services. They may have
+            # held HTTP sessions or polling tasks; stopping AFTER adapters
+            # disconnect means in-flight notifications can't reach the
+            # platforms, which is what we want at shutdown.
+            _services = getattr(self, "services", None)
+            if _services:
+                for _svc_name, _svc in list(_services.items()):
+                    try:
+                        await _svc.stop()
+                        logger.info("Background service '%s' stopped", _svc_name)
+                    except Exception as _e:
+                        logger.error("Background service '%s' stop error: %s", _svc_name, _e)
+                _services.clear()
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:

--- a/gateway/service_registry.py
+++ b/gateway/service_registry.py
@@ -1,0 +1,184 @@
+"""
+Background Service Registry
+
+Allows long-running background services (Nextcloud notification pollers,
+file sync watchers, etc.) to self-register so the gateway can discover
+and instantiate them without hardcoded ``_create_service()`` if/elif
+chains in ``gateway/run.py``.
+
+Background services differ from platform adapters in two ways:
+
+* They do not receive user messages — they observe an external source
+  (a notification queue, a file system watcher, a webhook) and forward
+  events to platforms.
+* They have no ``MessageHandler`` plumbing — start/stop is the entire
+  interface plus whatever the service emits internally.
+
+Usage (plugin side)::
+
+    from gateway.service_registry import service_registry, BackgroundServiceEntry
+
+    service_registry.register(BackgroundServiceEntry(
+        name="nextcloud_notifications",
+        label="Nextcloud Notifications",
+        service_factory=lambda cfg, gateway: NextcloudNotificationService(cfg),
+        check_fn=lambda: True,
+        validate_config=lambda cfg: bool(cfg.get("enabled")),
+    ))
+
+Usage (gateway side)::
+
+    svc = service_registry.create_service("nextcloud_notifications", cfg, self)
+    if svc is not None:
+        await svc.start()
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackgroundServiceEntry:
+    """Metadata and factory for a single background service."""
+
+    # Identifier used in config.yaml under ``services.<name>``.
+    name: str
+
+    # Human-readable label.
+    label: str
+
+    # Factory callable: receives (config_dict, gateway_runner) and returns
+    # a service instance. The instance MUST expose ``async start()`` and
+    # ``async stop()`` methods (see ``gateway.services.base.BaseService``
+    # for the canonical interface). Using a factory instead of a bare class
+    # lets plugins do custom init / dependency injection without subclassing.
+    service_factory: Callable[[dict, Any], Any]
+
+    # Returns True when the service's dependencies are importable. Called
+    # before instantiation; if it returns False the gateway logs the install
+    # hint and skips creation.
+    check_fn: Callable[[], bool]
+
+    # Optional config-validity check. Receives the service's config dict
+    # (with ``enabled`` already verified by the caller) and returns True
+    # when the config is complete enough to start. If None, the registry
+    # skips this check.
+    validate_config: Optional[Callable[[dict], bool]] = None
+
+    # Env vars this service needs (for ``hermes config`` / dashboard display).
+    required_env: list = field(default_factory=list)
+
+    # Hint shown when ``check_fn`` returns False (e.g. ``pip install httpx``).
+    install_hint: str = ""
+
+    # ``"builtin"`` or ``"plugin"``.
+    source: str = "plugin"
+
+    # Name of the plugin that registered this entry (for diagnostics).
+    plugin_name: str = ""
+
+
+class BackgroundServiceRegistry:
+    """Central registry of background services.
+
+    Thread-safe for reads (dict lookups are atomic under GIL).
+    Writes happen at startup during sequential plugin discovery.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, BackgroundServiceEntry] = {}
+
+    def register(self, entry: BackgroundServiceEntry) -> None:
+        """Register a background service entry.
+
+        If an entry with the same name exists, it is replaced (last writer
+        wins — lets plugins override built-in services if desired).
+        """
+        if entry.name in self._entries:
+            prev = self._entries[entry.name]
+            logger.info(
+                "Background service '%s' re-registered (was %s, now %s)",
+                entry.name,
+                prev.source,
+                entry.source,
+            )
+        self._entries[entry.name] = entry
+        logger.debug(
+            "Registered background service: %s (%s)", entry.name, entry.source
+        )
+
+    def unregister(self, name: str) -> bool:
+        """Remove a service entry. Returns True if it existed."""
+        return self._entries.pop(name, None) is not None
+
+    def get(self, name: str) -> Optional[BackgroundServiceEntry]:
+        return self._entries.get(name)
+
+    def all_entries(self) -> list[BackgroundServiceEntry]:
+        return list(self._entries.values())
+
+    def plugin_entries(self) -> list[BackgroundServiceEntry]:
+        return [e for e in self._entries.values() if e.source == "plugin"]
+
+    def is_registered(self, name: str) -> bool:
+        return name in self._entries
+
+    def create_service(
+        self, name: str, config: dict, gateway_runner: Any
+    ) -> Optional[Any]:
+        """Create a service instance for the given service name.
+
+        Returns ``None`` if:
+
+        * No entry is registered for ``name``.
+        * ``check_fn()`` returns False (missing deps).
+        * ``validate_config()`` returns False (misconfigured).
+        * The factory raises an exception.
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            return None
+
+        if not entry.check_fn():
+            hint = f" ({entry.install_hint})" if entry.install_hint else ""
+            logger.warning(
+                "Background service '%s' requirements not met%s",
+                entry.label,
+                hint,
+            )
+            return None
+
+        if entry.validate_config is not None:
+            try:
+                if not entry.validate_config(config):
+                    logger.warning(
+                        "Background service '%s' config validation failed",
+                        entry.label,
+                    )
+                    return None
+            except Exception as e:
+                logger.warning(
+                    "Background service '%s' config validation error: %s",
+                    entry.label,
+                    e,
+                )
+                return None
+
+        try:
+            service = entry.service_factory(config, gateway_runner)
+            return service
+        except Exception as e:
+            logger.error(
+                "Failed to create background service '%s': %s",
+                entry.label,
+                e,
+                exc_info=True,
+            )
+            return None
+
+
+# Module-level singleton — same pattern as platform_registry.
+service_registry = BackgroundServiceRegistry()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1038,6 +1038,87 @@ class PluginContext:
             action_id,
         )
 
+    # -- background service registration ------------------------------------
+
+    def register_background_service(
+        self,
+        name: str,
+        label: str,
+        service_factory: Callable,
+        check_fn: Callable,
+        validate_config: Callable | None = None,
+        required_env: list | None = None,
+        install_hint: str = "",
+        **entry_kwargs: Any,
+    ) -> None:
+        """Register a long-running gateway background service.
+
+        Background services differ from platform adapters: they observe an
+        external event source (notification queue, file watcher, webhook
+        endpoint) and emit gateway-internal events rather than handling
+        user-to-agent messages directly. Examples: Nextcloud notification
+        poller, WebDAV file sync watcher, RSS feed monitor.
+
+        The ``service_factory`` callable receives ``(config_dict, gateway_runner)``
+        and returns an instance exposing ``async start()`` and ``async stop()``
+        methods. See ``gateway.services.base.BaseService`` for the canonical
+        interface and the bundled service plugins under
+        ``plugins/services/`` for examples.
+
+        After registration, the service is wired up by the gateway during
+        startup whenever ``services.<name>.enabled`` is True in config.yaml.
+
+        Args:
+            name: stable service key (snake_case). Used in
+                ``services.<name>`` in config.yaml.
+            label: human-readable name shown in logs and the dashboard.
+            service_factory: callable ``(cfg_dict, gateway_runner) -> service``.
+            check_fn: returns True when dependencies are importable. Called
+                before instantiation; on False the gateway logs the install
+                hint and skips creation.
+            validate_config: optional callable ``(cfg_dict) -> bool`` invoked
+                after ``enabled`` is verified by the caller. Use this for
+                deeper checks like "required keys present in extra".
+            required_env: list of env-var names the service needs, surfaced
+                in ``hermes config`` UI.
+            install_hint: shown when ``check_fn`` returns False
+                (e.g. ``pip install httpx``).
+            **entry_kwargs: forwarded to ``BackgroundServiceEntry`` for any
+                future fields (e.g. dashboard metadata).
+
+        Example::
+
+            ctx.register_background_service(
+                name="nextcloud_notifications",
+                label="Nextcloud Notifications",
+                service_factory=lambda cfg, gw: NextcloudNotificationService(cfg, gw),
+                check_fn=lambda: True,
+            )
+        """
+        from gateway.service_registry import (
+            service_registry,
+            BackgroundServiceEntry,
+        )
+
+        entry_kwargs.setdefault("plugin_name", self.manifest.name)
+        entry = BackgroundServiceEntry(
+            name=name,
+            label=label,
+            service_factory=service_factory,
+            check_fn=check_fn,
+            validate_config=validate_config,
+            required_env=required_env or [],
+            install_hint=install_hint,
+            source="plugin",
+            **entry_kwargs,
+        )
+        service_registry.register(entry)
+        logger.debug(
+            "Plugin %s registered background service: %s",
+            self.manifest.name,
+            name,
+        )
+
     # -- hook registration --------------------------------------------------
 
     # -- auxiliary task registration ---------------------------------------

--- a/plugins/services/nextcloud_files/__init__.py
+++ b/plugins/services/nextcloud_files/__init__.py
@@ -1,0 +1,75 @@
+"""Nextcloud Files background-service plugin entry point.
+
+Registers a long-running bidirectional WebDAV sync service via
+:meth:`PluginContext.register_background_service` so the gateway can
+start it after platforms come up and stop it before they disconnect.
+
+The service syncs a remote Nextcloud folder with a local working
+directory via notify_push (incoming) + inotify (outgoing) and uses
+chunked uploads for files above the configured chunk size.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:
+    import httpx  # noqa: F401
+    _HTTPX = True
+except ImportError:
+    _HTTPX = False
+
+logger = logging.getLogger(__name__)
+
+
+def _check_requirements() -> bool:
+    return _HTTPX
+
+
+def _validate_config(cfg: dict) -> bool:
+    extra = cfg.get("extra") or cfg
+    return bool(extra.get("local_path") or extra.get("deliver"))
+
+
+def _service_factory(config: dict, gateway_runner: Any) -> Any:
+    """Build a ``NextcloudFilesService`` from the gateway config dict.
+
+    Inherits Nextcloud credentials from the Talk adapter when the
+    ``extra`` dict doesn't supply them explicitly, so config.yaml
+    stays DRY across NC services.
+    """
+    from .service import NextcloudFilesService
+
+    extra = dict(config.get("extra") or {})
+
+    if not extra.get("nextcloud_url") and gateway_runner is not None:
+        try:
+            from gateway.config import Platform
+            talk_cfg = gateway_runner.config.platforms.get(Platform("nextcloud_talk"))
+            if talk_cfg and getattr(talk_cfg, "extra", None):
+                talk_extra = talk_cfg.extra
+                extra.setdefault("nextcloud_url", talk_extra.get("nextcloud_url", ""))
+                extra.setdefault("username", talk_extra.get("username", "hermes"))
+                extra.setdefault(
+                    "app_password_env",
+                    talk_extra.get("app_password_env", "NEXTCLOUD_TALK_APP_PASSWORD"),
+                )
+        except Exception:
+            logger.debug("nc-files: could not inherit Talk credentials", exc_info=True)
+
+    return NextcloudFilesService(extra, gateway_runner)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    ctx.register_background_service(
+        name="nextcloud_files",
+        label="Nextcloud Files",
+        service_factory=_service_factory,
+        check_fn=_check_requirements,
+        validate_config=_validate_config,
+        install_hint="pip install httpx   # already a Hermes dependency",
+    )
+
+
+__all__ = ["register"]

--- a/plugins/services/nextcloud_files/base.py
+++ b/plugins/services/nextcloud_files/base.py
@@ -1,0 +1,52 @@
+"""Shared base class + event dataclass for Nextcloud background services.
+
+Lives inside the plugin so the service module is self-contained and
+doesn't depend on a sibling ``gateway/services/`` directory in the core
+tree. Mirrors the canonical ``BaseService`` shape so future Hermes
+service plugins can adopt the same interface.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ServiceEvent:
+    """Event surfaced by a background service for routing/agent dispatch."""
+
+    service: str
+    notification_id: int
+    app: str
+    object_type: str
+    object_id: str
+    subject: str
+    message: str
+    link: str
+    sender: str
+    timestamp: str
+    action: str  # "react" (forward to agent) or "silent" (record only)
+    raw: dict = field(default_factory=dict)
+
+
+class BaseService(ABC):
+    """Background service that observes an external source and routes events.
+
+    The plugin-registered ``service_factory`` is called with
+    ``(config_dict, gateway_runner)`` — subclasses MUST accept both. The
+    factory contract is enforced by
+    ``gateway.service_registry.service_registry.create_service``.
+    """
+
+    name: str = "base"
+
+    def __init__(self, config: dict, gateway_runner: Optional[Any] = None):
+        self.config = config
+        self.gateway_runner = gateway_runner
+
+    @abstractmethod
+    async def start(self) -> bool:
+        """Start background tasks. Returns True on success."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Clean shutdown — cancel tasks, close connections."""

--- a/plugins/services/nextcloud_files/client.py
+++ b/plugins/services/nextcloud_files/client.py
@@ -1,0 +1,336 @@
+"""Async HTTP client for Nextcloud WebDAV + OCS file operations."""
+import logging
+import uuid
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import unquote
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Share permission bits
+PERM_READ = 1
+PERM_UPDATE = 2
+PERM_CREATE = 4
+PERM_DELETE = 8
+PERM_SHARE = 16
+PERM_ALL = 31
+
+# XML namespaces used by NC WebDAV
+_NS = {
+    "d": "DAV:",
+    "oc": "http://owncloud.org/ns",
+    "nc": "http://nextcloud.org/ns",
+}
+
+
+@dataclass
+class FileInfo:
+    """Metadata for a remote Nextcloud file."""
+    path: str
+    etag: str
+    size: int
+    mtime: float
+    file_id: int
+    content_type: str = ""
+    is_dir: bool = False
+
+
+class NextcloudFilesClient:
+    """Async HTTP client for Nextcloud file operations.
+
+    Handles WebDAV (PROPFIND, GET, PUT, MKCOL, MOVE, DELETE) and
+    OCS (file ID resolution, sharing) APIs.
+    """
+
+    def __init__(self, base_url: str, username: str, password: str):
+        self._base_url = base_url.rstrip("/")
+        self._username = username
+        self._dav_base = f"/remote.php/dav/files/{username}"
+        self._http = httpx.AsyncClient(
+            auth=(username, password),
+            timeout=30.0,
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+        self._ocs_http = httpx.AsyncClient(
+            auth=(username, password),
+            headers={
+                "OCS-APIRequest": "true",
+                "Accept": "application/json",
+            },
+            timeout=30.0,
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+
+    def _dav_url(self, remote_path: str) -> str:
+        """Build full WebDAV URL from relative path."""
+        clean = remote_path.lstrip("/")
+        return f"{self._base_url}{self._dav_base}/{clean}"
+
+    def _parse_propfind(self, xml_text: str) -> List[FileInfo]:
+        """Parse a PROPFIND multistatus XML response into FileInfo list."""
+        root = ET.fromstring(xml_text)
+        results = []
+        for response in root.findall("d:response", _NS):
+            href = response.findtext("d:href", "", _NS)
+            decoded = unquote(href)
+            rel_path = decoded.removeprefix(self._dav_base)
+            if not rel_path or rel_path == "/":
+                continue
+
+            propstat = response.find("d:propstat", _NS)
+            if propstat is None:
+                continue
+            prop = propstat.find("d:prop", _NS)
+            if prop is None:
+                continue
+
+            rt = prop.find("d:resourcetype", _NS)
+            is_dir = rt is not None and rt.find("d:collection", _NS) is not None
+
+            size_text = prop.findtext("d:getcontentlength", "0", _NS)
+            size = int(size_text) if size_text else 0
+
+            etag = prop.findtext("d:getetag", "", _NS)
+            content_type = prop.findtext("d:getcontenttype", "", _NS)
+
+            mtime_text = prop.findtext("d:getlastmodified", "", _NS)
+            mtime = 0.0
+            if mtime_text:
+                try:
+                    mtime = parsedate_to_datetime(mtime_text).timestamp()
+                except Exception:
+                    pass
+
+            file_id_text = prop.findtext("oc:fileid", "0", _NS)
+            file_id = int(file_id_text) if file_id_text else 0
+
+            results.append(FileInfo(
+                path=rel_path.rstrip("/"),
+                etag=etag,
+                size=size,
+                mtime=mtime,
+                file_id=file_id,
+                content_type=content_type,
+                is_dir=is_dir,
+            ))
+        return results
+
+    async def propfind(self, path: str = "/", depth: str = "1") -> List[FileInfo]:
+        """List files at path via WebDAV PROPFIND.
+
+        depth: "0" (file only), "1" (direct children), "infinity" (recursive).
+        """
+        url = self._dav_url(path)
+        body = """<?xml version="1.0"?>
+        <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+          <d:prop>
+            <d:getcontentlength/>
+            <d:getetag/>
+            <d:getcontenttype/>
+            <d:getlastmodified/>
+            <d:resourcetype/>
+            <oc:fileid/>
+          </d:prop>
+        </d:propfind>"""
+        resp = await self._http.request(
+            method="PROPFIND",
+            url=url,
+            content=body,
+            headers={"Depth": depth, "Content-Type": "application/xml"},
+        )
+        resp.raise_for_status()
+        return self._parse_propfind(resp.text)
+
+    async def download(self, remote_path: str, local_path: Path) -> bool:
+        """Download a file from NC via streaming GET. Uses atomic .tmp write."""
+        import asyncio as _aio
+        url = self._dav_url(remote_path)
+        local_path = Path(local_path)
+        await _aio.to_thread(local_path.parent.mkdir, parents=True, exist_ok=True)
+        tmp_path = local_path.with_suffix(local_path.suffix + ".tmp")
+        try:
+            async with self._http.stream("GET", url) as resp:
+                resp.raise_for_status()
+                fh = await _aio.to_thread(open, tmp_path, "wb")
+                try:
+                    async for chunk in resp.aiter_bytes(chunk_size=65536):
+                        await _aio.to_thread(fh.write, chunk)
+                finally:
+                    await _aio.to_thread(fh.close)
+            await _aio.to_thread(tmp_path.rename, local_path)
+            return True
+        except Exception as e:
+            logger.error("Download failed %s: %s", remote_path, e)
+            if tmp_path.exists():
+                tmp_path.unlink()
+            return False
+
+    async def upload(self, local_path: Path, remote_path: str) -> Optional[str]:
+        """Upload a file via WebDAV PUT. Returns ETag on success, None on failure."""
+        url = self._dav_url(remote_path)
+        local_path = Path(local_path)
+        import asyncio as _aio
+        try:
+            data = await _aio.to_thread(local_path.read_bytes)
+            resp = await self._http.put(url, content=data)
+            resp.raise_for_status()
+            return resp.headers.get("ETag", "")
+        except Exception as e:
+            logger.error("Upload failed %s: %s", remote_path, e)
+            return None
+
+    async def upload_chunked(
+        self, local_path: Path, remote_path: str,
+        chunk_size: int = 5 * 1024 * 1024,
+    ) -> Optional[str]:
+        """Upload via NC Chunked Upload v2: MKCOL -> PUT chunks -> MOVE."""
+        local_path = Path(local_path)
+        file_size = local_path.stat().st_size
+        upload_id = uuid.uuid4().hex
+        upload_dir = f"/remote.php/dav/uploads/{self._username}/{upload_id}"
+        upload_dir_url = f"{self._base_url}{upload_dir}"
+
+        try:
+            resp = await self._http.request(method="MKCOL", url=upload_dir_url)
+            resp.raise_for_status()
+
+            import asyncio as _aio
+            offset = 0
+            chunk_num = 0
+            fh = await _aio.to_thread(open, local_path, "rb")
+            try:
+                while offset < file_size:
+                    data = await _aio.to_thread(fh.read, chunk_size)
+                    chunk_url = f"{upload_dir_url}/{chunk_num:05d}"
+                    resp = await self._http.put(chunk_url, content=data)
+                    resp.raise_for_status()
+                    offset += len(data)
+                    chunk_num += 1
+            finally:
+                await _aio.to_thread(fh.close)
+
+            dest_url = self._dav_url(remote_path)
+            resp = await self._http.request(
+                method="MOVE",
+                url=f"{upload_dir_url}/.file",
+                headers={"Destination": dest_url},
+            )
+            resp.raise_for_status()
+            return resp.headers.get("ETag", "")
+        except Exception as e:
+            logger.error("Chunked upload failed %s: %s", remote_path, e)
+            return None
+
+    async def mkdir(self, remote_path: str) -> bool:
+        """Create a directory via WebDAV MKCOL."""
+        url = self._dav_url(remote_path)
+        try:
+            resp = await self._http.request(method="MKCOL", url=url)
+            resp.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error("mkdir failed %s: %s", remote_path, e)
+            return False
+
+    async def delete(self, remote_path: str) -> bool:
+        """Delete a file or directory via WebDAV DELETE."""
+        url = self._dav_url(remote_path)
+        try:
+            resp = await self._http.delete(url)
+            resp.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error("delete failed %s: %s", remote_path, e)
+            return False
+
+    async def move(self, src: str, dst: str) -> bool:
+        """Move/rename a file via WebDAV MOVE."""
+        src_url = self._dav_url(src)
+        dst_url = self._dav_url(dst)
+        try:
+            resp = await self._http.request(
+                method="MOVE", url=src_url,
+                headers={"Destination": dst_url},
+            )
+            resp.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error("move failed %s -> %s: %s", src, dst, e)
+            return False
+
+    async def resolve_file_ids(self, file_ids: list) -> List[FileInfo]:
+        """Resolve NC file IDs to FileInfo via OCS Files API."""
+        results = []
+        for fid in file_ids:
+            url = f"{self._base_url}/ocs/v2.php/apps/files/api/v1/files/{fid}"
+            try:
+                resp = await self._ocs_http.get(url)
+                resp.raise_for_status()
+                data = resp.json().get("ocs", {}).get("data", {})
+                path = data.get("path", "")
+                name = data.get("name", "")
+                full_path = f"{path}/{name}" if path else f"/{name}"
+                results.append(FileInfo(
+                    path=full_path,
+                    etag=data.get("etag", ""),
+                    size=data.get("size", 0),
+                    mtime=float(data.get("mtime", 0)),
+                    file_id=data.get("id", fid),
+                    content_type=data.get("mimetype", ""),
+                    is_dir=data.get("mimetype") == "httpd/unix-directory",
+                ))
+            except Exception as e:
+                logger.warning("Failed to resolve file ID %d: %s", fid, e)
+        return results
+
+    async def share(
+        self, remote_path: str, user: str, permissions: int = PERM_ALL,
+    ) -> Optional[dict]:
+        """Share a file/folder with a user via OCS Sharing API."""
+        url = f"{self._base_url}/ocs/v2.php/apps/files_sharing/api/v1/shares"
+        try:
+            resp = await self._ocs_http.post(url, data={
+                "path": remote_path,
+                "shareWith": user,
+                "shareType": 0,
+                "permissions": permissions,
+            })
+            resp.raise_for_status()
+            return resp.json().get("ocs", {}).get("data", {})
+        except Exception as e:
+            logger.error("Share failed %s -> %s: %s", remote_path, user, e)
+            return None
+
+    async def unshare(self, share_id: int) -> bool:
+        """Remove a share by ID."""
+        url = f"{self._base_url}/ocs/v2.php/apps/files_sharing/api/v1/shares/{share_id}"
+        try:
+            resp = await self._ocs_http.delete(url)
+            resp.raise_for_status()
+            return True
+        except Exception as e:
+            logger.error("Unshare failed %d: %s", share_id, e)
+            return False
+
+    async def get_shares(self, path: Optional[str] = None) -> list:
+        """List shares, optionally filtered by path."""
+        url = f"{self._base_url}/ocs/v2.php/apps/files_sharing/api/v1/shares"
+        params = {}
+        if path:
+            params["path"] = path
+        try:
+            resp = await self._ocs_http.get(url, params=params)
+            resp.raise_for_status()
+            return resp.json().get("ocs", {}).get("data", [])
+        except Exception as e:
+            logger.error("get_shares failed: %s", e)
+            return []
+
+    async def close(self):
+        await self._http.aclose()
+        await self._ocs_http.aclose()

--- a/plugins/services/nextcloud_files/plugin.yaml
+++ b/plugins/services/nextcloud_files/plugin.yaml
@@ -1,0 +1,22 @@
+name: nextcloud-files-service
+label: Nextcloud Files
+kind: backend
+version: 1.0.0
+description: >
+  Background service that bidirectionally syncs a Nextcloud folder
+  with a local working directory. Subscribes to notify_push for
+  incoming change events, watches the local tree via inotify for
+  outgoing changes, and uses chunked WebDAV uploads for files larger
+  than the configured chunk size.
+
+  This plugin ships under ``plugins/services/nextcloud_files/`` and
+  registers a background service via
+  ``PluginContext.register_background_service``. The gateway starts
+  it after platforms come up and stops it before they disconnect.
+author: nsyring
+requires_env: []
+optional_env:
+  - name: NEXTCLOUD_TALK_APP_PASSWORD
+    description: "Reused from the Nextcloud Talk adapter — same App Password unlocks WebDAV access for sync"
+    prompt: "Nextcloud App Password (same as NC Talk)"
+    password: true

--- a/plugins/services/nextcloud_files/service.py
+++ b/plugins/services/nextcloud_files/service.py
@@ -1,0 +1,615 @@
+"""Nextcloud Files Service -- bidirectional file sync.
+
+Provides real local file paths for the agent by syncing files
+with Nextcloud via WebDAV API, notify_push WebSocket, and inotify.
+"""
+import asyncio
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+from .base import BaseService, ServiceEvent
+from .client import NextcloudFilesClient, FileInfo
+
+logger = logging.getLogger(__name__)
+
+
+class FileSyncState:
+    """JSON-file-backed persistent sync state.
+
+    Tracks remote ETags and local mtimes to enable efficient delta sync
+    on restart. Analogous to NotificationStore.
+    """
+
+    def __init__(self, path: Optional[str] = None):
+        default = "~/.hermes/file_sync_state.json"
+        self._path = Path(os.path.expanduser(path or default))
+        self._entries: Dict[str, dict] = {}
+        self._load()
+
+    def _load(self):
+        if self._path.exists():
+            try:
+                self._entries = json.loads(self._path.read_text(encoding="utf-8"))
+                if not isinstance(self._entries, dict):
+                    self._entries = {}
+            except Exception as e:
+                logger.warning("Failed to load file sync state: %s", e)
+                self._entries = {}
+
+    def save(self):
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps(self._entries, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    async def async_save(self):
+        """Non-blocking save via thread pool."""
+        await asyncio.to_thread(self.save)
+
+    def get(self, path: str) -> Optional[dict]:
+        return self._entries.get(path)
+
+    def set(self, path: str, etag: str, size: int, mtime: float):
+        self._entries[path] = {"etag": etag, "size": size, "mtime": mtime}
+        self.save()
+
+    def set_nosave(self, path: str, etag: str, size: int, mtime: float):
+        """Set entry without saving — call save() or async_save() after batch."""
+        self._entries[path] = {"etag": etag, "size": size, "mtime": mtime}
+
+    def remove(self, path: str):
+        self._entries.pop(path, None)
+        self.save()
+
+    def get_all(self) -> Dict[str, dict]:
+        return dict(self._entries)
+
+
+class FileWatcher:
+    """Watch local directory for file changes via inotifywait subprocess.
+
+    Yields (path, event_type) tuples for CREATE, CLOSE_WRITE, DELETE, MOVED_TO, MOVED_FROM.
+    Ignores .tmp files (used for atomic downloads).
+    Auto-restarts the subprocess if it dies.
+    """
+
+    def __init__(self, watch_path: Path):
+        self._watch_path = Path(watch_path)
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._running = False
+        self._event_queue: asyncio.Queue = asyncio.Queue()
+        self._reader_task: Optional[asyncio.Task] = None
+
+    def _parse_inotify_line(self, line: str):
+        """Parse inotifywait CSV line: 'dir,EVENT,filename'.
+
+        Returns (path, event_type) or None if the event should be ignored.
+        """
+        parts = line.strip().split(",", 2)
+        if len(parts) < 3:
+            return None
+        directory, event_type, filename = parts
+
+        if filename.endswith(".tmp"):
+            return None
+
+        if not filename:
+            return None
+
+        # Ignore NC-internal temp/lock files (.~hexhash, .sync_*, .nfs*)
+        basename = filename.rsplit("/", 1)[-1] if "/" in filename else filename
+        if basename.startswith("."):
+            return None
+
+        full_path = Path(directory) / filename
+        return full_path, event_type
+
+    async def start(self):
+        """Start the inotifywait subprocess."""
+        self._running = True
+        self._watch_path.mkdir(parents=True, exist_ok=True)
+        self._reader_task = asyncio.create_task(self._run_loop())
+
+    async def _run_loop(self):
+        """Run inotifywait, restart on failure."""
+        while self._running:
+            try:
+                self._process = await asyncio.create_subprocess_exec(
+                    "inotifywait", "-m", "-r", "-c",
+                    "-e", "create,close_write,delete,moved_to,moved_from",
+                    str(self._watch_path),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                logger.info("[FileWatcher] Started watching %s", self._watch_path)
+
+                async for line in self._process.stdout:
+                    decoded = line.decode("utf-8", errors="replace").strip()
+                    if not decoded:
+                        continue
+                    parsed = self._parse_inotify_line(decoded)
+                    if parsed:
+                        await self._event_queue.put(parsed)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("[FileWatcher] Error: %s", e)
+
+            if self._running:
+                logger.warning("[FileWatcher] Process died, restarting in 1s")
+                await asyncio.sleep(1)
+
+    async def get_event(self):
+        """Get next file event. Blocks until available."""
+        return await self._event_queue.get()
+
+    async def stop(self):
+        self._running = False
+        if self._process:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                self._process.kill()
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+
+
+class NotifyPushListener:
+    """WebSocket listener for NC notify_push file events.
+
+    Protocol:
+    1. GET capabilities -> extract notify_push.endpoints.websocket URL
+    2. Connect WebSocket
+    3. Send username, then app-password
+    4. Receive "authenticated"
+    5. Send "listen notify_file_id"
+    6. Receive "notify_file_id [id1 id2 ...]" events
+
+    Reconnects with exponential backoff on disconnect.
+    """
+
+    def __init__(self, base_url: str, username: str, password: str):
+        self._base_url = base_url.rstrip("/")
+        self._username = username
+        self._password = password
+        self._ws_url: Optional[str] = None
+        self._running = False
+        self._event_queue: asyncio.Queue = asyncio.Queue()
+        self._listener_task: Optional[asyncio.Task] = None
+        self._http = None
+
+    def _parse_push_message(self, message: str) -> list:
+        """Parse a notify_push message, return file IDs or empty list."""
+        if not message.startswith("notify_file_id "):
+            return []
+        parts = message.split()
+        try:
+            return [int(x) for x in parts[1:]]
+        except ValueError:
+            return []
+
+    async def _discover_ws_endpoint(self, http_client) -> Optional[str]:
+        """Discover WebSocket endpoint from NC capabilities."""
+        url = f"{self._base_url}/ocs/v2.php/cloud/capabilities"
+        try:
+            resp = await http_client.get(url, headers={
+                "OCS-APIRequest": "true",
+                "Accept": "application/json",
+            })
+            resp.raise_for_status()
+            caps = resp.json().get("ocs", {}).get("data", {}).get("capabilities", {})
+            ws_url = caps.get("notify_push", {}).get("endpoints", {}).get("websocket")
+            return ws_url
+        except Exception as e:
+            logger.error("[NotifyPush] Failed to discover endpoint: %s", e)
+            return None
+
+    async def start(self):
+        """Start the WebSocket listener."""
+        import httpx as _httpx
+        self._http = _httpx.AsyncClient(
+            auth=(self._username, self._password),
+            timeout=10.0,
+            limits=_httpx.Limits(max_keepalive_connections=0),
+        )
+        self._ws_url = await self._discover_ws_endpoint(self._http)
+        if not self._ws_url:
+            logger.warning("[NotifyPush] No WebSocket endpoint found")
+            return False
+        self._running = True
+        self._listener_task = asyncio.create_task(self._listen_loop())
+        return True
+
+    async def _listen_loop(self):
+        """Connect to WebSocket and listen, reconnect on failure."""
+        import websockets
+        backoff = 1
+        while self._running:
+            try:
+                async with websockets.connect(self._ws_url) as ws:
+                    await ws.send(self._username)
+                    await ws.send(self._password)
+                    auth_resp = await asyncio.wait_for(ws.recv(), timeout=10)
+                    if auth_resp != "authenticated":
+                        logger.error("[NotifyPush] Auth failed: %s", auth_resp)
+                        await asyncio.sleep(backoff)
+                        backoff = min(backoff * 2, 60)
+                        continue
+
+                    await ws.send("listen notify_file_id")
+                    logger.info("[NotifyPush] Connected and authenticated")
+                    backoff = 1
+
+                    async for message in ws:
+                        file_ids = self._parse_push_message(message)
+                        if file_ids:
+                            await self._event_queue.put(file_ids)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.warning("[NotifyPush] Connection error: %s (reconnect in %ds)", e, backoff)
+
+            if self._running:
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 60)
+
+    async def get_event(self):
+        """Get next file ID list. Blocks until available."""
+        return await self._event_queue.get()
+
+    async def stop(self):
+        self._running = False
+        if self._listener_task:
+            self._listener_task.cancel()
+            try:
+                await self._listener_task
+            except asyncio.CancelledError:
+                pass
+
+    async def close(self):
+        await self.stop()
+        if self._http:
+            await self._http.aclose()
+
+
+class NextcloudFilesService(BaseService):
+    """Bidirectional Nextcloud file sync service."""
+
+    name = "nextcloud_files"
+    DOWNLOAD_GRACE_PERIOD = 2.0
+
+    def __init__(self, config: dict, gateway_runner=None):
+        super().__init__(config, gateway_runner)
+        self._nc_url = config.get("nextcloud_url", "")
+        self._username = config.get("username", "hermes")
+        pw_env = config.get("app_password_env", "NEXTCLOUD_TALK_APP_PASSWORD")
+        self._password = os.environ.get(pw_env, "").strip()
+
+        local_path = config.get("local_path", "~/.hermes/nextcloud")
+        self._local_path = Path(os.path.expanduser(local_path))
+
+        deliver = config.get("deliver", "")
+        if ":" in deliver:
+            self._deliver_platform, self._deliver_chat_id = deliver.split(":", 1)
+        else:
+            self._deliver_platform = deliver
+            self._deliver_chat_id = ""
+
+        self._auto_share_with = config.get("auto_share_with", "")
+        self._max_file_size = config.get("max_file_size_mb", 500) * 1024 * 1024
+        self._chunk_size = config.get("chunk_size_mb", 5) * 1024 * 1024
+        self._do_initial_sync = config.get("initial_sync", True)
+
+        store_path = config.get("store_path")
+        self._sync_state = FileSyncState(path=store_path)
+
+        self._client: Optional[NextcloudFilesClient] = None
+        self._push_listener: Optional[NotifyPushListener] = None
+        self._file_watcher: Optional[FileWatcher] = None
+
+        self._downloading: set = set()
+        self._recently_downloaded: dict = {}
+        self._uploading: set = set()
+        self._recently_uploaded: dict = {}
+
+        self._incoming_task: Optional[asyncio.Task] = None
+        self._outgoing_task: Optional[asyncio.Task] = None
+        self._sync_task: Optional[asyncio.Task] = None
+
+    def _on_task_done(self, task_name: str, task: asyncio.Task):
+        """Log dead background tasks."""
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc:
+            logger.error("[NC Files] Background task %s died: %s", task_name, exc, exc_info=exc)
+
+    def _supervised_task(self, coro, name: str) -> asyncio.Task:
+        """Create a task with exception logging."""
+        task = asyncio.create_task(coro)
+        task.add_done_callback(lambda t: self._on_task_done(name, t))
+        return task
+
+    async def start(self) -> bool:
+        if not self._nc_url or not self._password:
+            logger.warning("[NC Files] Missing nextcloud_url or password")
+            return False
+
+        self._local_path.mkdir(parents=True, exist_ok=True)
+
+        self._client = NextcloudFilesClient(
+            self._nc_url, self._username, self._password,
+        )
+
+        self._push_listener = NotifyPushListener(
+            self._nc_url, self._username, self._password,
+        )
+        push_ok = await self._push_listener.start()
+        if push_ok:
+            self._incoming_task = self._supervised_task(self._incoming_loop(), "incoming_loop")
+        else:
+            logger.warning("[NC Files] notify_push not available, incoming sync disabled")
+
+        self._file_watcher = FileWatcher(self._local_path)
+        await self._file_watcher.start()
+        self._outgoing_task = self._supervised_task(self._outgoing_loop(), "outgoing_loop")
+
+        if self._do_initial_sync:
+            self._sync_task = self._supervised_task(self._initial_sync(), "initial_sync")
+
+        logger.info("[NC Files] Started (local_path=%s)", self._local_path)
+        return True
+
+    async def stop(self):
+        for task in [self._incoming_task, self._outgoing_task, self._sync_task]:
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        if self._push_listener:
+            await self._push_listener.close()
+        if self._file_watcher:
+            await self._file_watcher.stop()
+        if self._client:
+            await self._client.close()
+
+        self._sync_state.save()
+        logger.info("[NC Files] Stopped")
+
+    async def on_event(self, event: ServiceEvent):
+        pass
+
+    def _to_remote_path(self, local_path: Path) -> str:
+        resolved = local_path.resolve()
+        if not str(resolved).startswith(str(self._local_path.resolve())):
+            raise ValueError(f"Path traversal blocked: {local_path}")
+        return "/" + str(local_path.relative_to(self._local_path))
+
+    def _to_local_path(self, remote_path: str) -> Path:
+        candidate = (self._local_path / remote_path.lstrip("/")).resolve()
+        if not str(candidate).startswith(str(self._local_path.resolve())):
+            raise ValueError(f"Path traversal blocked: {remote_path}")
+        return candidate
+
+    async def _download_file(self, remote_path: str, file_info: FileInfo) -> bool:
+        local_path = self._to_local_path(remote_path)
+
+        if file_info.size > self._max_file_size:
+            logger.warning("[NC Files] Skipping %s (%.1f MB > limit %.1f MB)",
+                           remote_path, file_info.size / 1e6, self._max_file_size / 1e6)
+            return False
+
+        self._downloading.add(local_path)
+        try:
+            ok = await self._client.download(remote_path, local_path)
+            if ok:
+                self._sync_state.set(
+                    remote_path, etag=file_info.etag,
+                    size=file_info.size, mtime=file_info.mtime,
+                )
+            return ok
+        finally:
+            self._downloading.discard(local_path)
+            self._recently_downloaded[local_path] = time.monotonic()
+
+    def _is_own_operation(self, local_path: Path) -> bool:
+        """Check if a local change was caused by our own download or upload."""
+        if local_path in self._downloading or local_path in self._uploading:
+            return True
+        for cache in (self._recently_downloaded, self._recently_uploaded):
+            ts = cache.get(local_path)
+            if ts and (time.monotonic() - ts) < self.DOWNLOAD_GRACE_PERIOD:
+                return True
+            if ts:
+                del cache[local_path]
+        return False
+
+    async def _upload_file(self, local_path: Path):
+        remote_path = self._to_remote_path(local_path)
+        file_stat = await asyncio.to_thread(local_path.stat)
+        file_size = file_stat.st_size
+        self._uploading.add(local_path)
+
+        # Ensure parent directory exists on NC (WebDAV PUT doesn't auto-create)
+        parent = "/".join(remote_path.split("/")[:-1])
+        if parent and parent != "/":
+            await self._client.mkdir(parent)
+
+        if file_size > self._chunk_size:
+            etag = await self._client.upload_chunked(
+                local_path, remote_path, chunk_size=self._chunk_size,
+            )
+        else:
+            etag = await self._client.upload(local_path, remote_path)
+
+        if etag:
+            self._sync_state.set(
+                remote_path, etag=etag,
+                size=file_size, mtime=file_stat.st_mtime,
+            )
+            logger.info("[NC Files] Uploaded %s", remote_path)
+
+            if self._auto_share_with:
+                await self._client.share(remote_path, self._auto_share_with)
+        else:
+            logger.error("[NC Files] Upload failed for %s", remote_path)
+        self._uploading.discard(local_path)
+        self._recently_uploaded[local_path] = time.monotonic()
+
+    async def _incoming_loop(self):
+        while True:
+            try:
+                file_ids = await self._push_listener.get_event()
+                file_infos = await self._client.resolve_file_ids(file_ids)
+                for fi in file_infos:
+                    if fi.is_dir:
+                        continue
+                    stored = self._sync_state.get(fi.path)
+                    if stored and stored["etag"] == fi.etag:
+                        continue
+                    ok = await self._download_file(fi.path, fi)
+                    if ok:
+                        await self._notify_agent(fi)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("[NC Files] Incoming loop error: %s", e)
+                await asyncio.sleep(5)
+
+    async def _outgoing_loop(self):
+        while True:
+            try:
+                local_path, event_type = await self._file_watcher.get_event()
+
+                if self._is_own_operation(local_path):
+                    continue
+
+                if event_type in ("CREATE", "CLOSE_WRITE", "MOVED_TO"):
+                    if local_path.is_file():
+                        # Skip if file matches sync state (downloaded by us, not written by agent)
+                        remote_path = self._to_remote_path(local_path)
+                        stored = self._sync_state.get(remote_path)
+                        if stored and stored["size"] == local_path.stat().st_size:
+                            continue
+                        await self._upload_file(local_path)
+                elif event_type in ("DELETE", "MOVED_FROM"):
+                    remote_path = self._to_remote_path(local_path)
+                    await self._client.delete(remote_path)
+                    self._sync_state.remove(remote_path)
+                    logger.info("[NC Files] Deleted remote %s", remote_path)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("[NC Files] Outgoing loop error: %s", e)
+                await asyncio.sleep(1)
+
+    async def _initial_sync(self):
+        try:
+            remote_files = await self._client.propfind("/", depth="infinity")
+            stored_state = self._sync_state.get_all()
+            remote_paths = set()
+            downloaded = 0
+            uploaded = 0
+            total_bytes = 0
+
+            for fi in remote_files:
+                if fi.is_dir:
+                    continue
+                # Skip hidden/dot files
+                if fi.path.rsplit('/', 1)[-1].startswith('.'):
+                    continue
+                remote_paths.add(fi.path)
+                stored = stored_state.get(fi.path)
+
+                if stored and stored["etag"] == fi.etag:
+                    continue
+
+                ok = await self._download_file(fi.path, fi)
+                if ok:
+                    downloaded += 1
+                    total_bytes += fi.size
+                await asyncio.sleep(0)  # yield to event loop
+
+            if self._local_path.exists():
+                for local_file in self._local_path.rglob("*"):
+                    if not local_file.is_file():
+                        continue
+                    if local_file.suffix == ".tmp" or local_file.name.startswith("."):
+                        continue
+                    remote_path = self._to_remote_path(local_file)
+                    if remote_path not in remote_paths and remote_path not in stored_state:
+                        await self._upload_file(local_file)
+                        uploaded += 1
+
+            for path in list(stored_state):
+                if path not in remote_paths:
+                    local_path = self._to_local_path(path)
+                    if local_path.exists():
+                        local_path.unlink()
+                    self._sync_state.remove(path)
+
+            logger.info("[NC Files] Initial sync complete: %d downloaded (%.1f MB), %d uploaded",
+                        downloaded, total_bytes / 1e6, uploaded)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("[NC Files] Initial sync failed: %s", e)
+
+    async def _notify_agent(self, file_info: FileInfo):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        runner = self.gateway_runner
+        if not runner:
+            return
+
+        try:
+            platform = Platform(self._deliver_platform)
+        except ValueError:
+            logger.error("[NC Files] Unknown platform '%s'", self._deliver_platform)
+            return
+
+        adapter = runner.adapters.get(platform)
+        if not adapter:
+            return
+
+        local_path = self._to_local_path(file_info.path)
+        text = f"File synced: {file_info.path}\nLocal path: {local_path}"
+
+        user_id = "service:nextcloud_files"
+        chat_type = "dm"
+        if hasattr(adapter, "_classify_chat"):
+            chat_type = adapter._classify_chat(self._deliver_chat_id)
+
+        source = adapter.build_source(
+            chat_id=self._deliver_chat_id,
+            user_id=user_id,
+            user_name="NC/Files",
+            chat_type=chat_type,
+        )
+
+        msg_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=f"ncfile_{file_info.file_id}",
+        )
+
+        await adapter.handle_message(msg_event)

--- a/plugins/services/nextcloud_notifications/__init__.py
+++ b/plugins/services/nextcloud_notifications/__init__.py
@@ -1,0 +1,83 @@
+"""Nextcloud Notifications background-service plugin entry point.
+
+Registers a long-running service via
+:meth:`PluginContext.register_background_service` so the gateway can
+start it after platforms come up and stop it before they disconnect.
+
+The service polls Nextcloud's Notifications + Activity APIs and routes
+matching events to the configured platform (typically Nextcloud Talk).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+try:
+    import httpx  # noqa: F401
+    _HTTPX = True
+except ImportError:
+    _HTTPX = False
+
+logger = logging.getLogger(__name__)
+
+
+def _check_requirements() -> bool:
+    return _HTTPX
+
+
+def _validate_config(cfg: dict) -> bool:
+    """The plugin needs at minimum a deliver target and either an env-provided
+    password or one of: an explicit ``app_password_env`` in extra, or a
+    Talk-platform-side credential we can inherit at runtime (the factory
+    handles inheritance — here we just sanity-check the shape).
+    """
+    extra = cfg.get("extra") or cfg  # tolerate flat-vs-nested config
+    return bool(extra.get("deliver"))
+
+
+def _service_factory(config: dict, gateway_runner: Any) -> Any:
+    """Build a ``NextcloudNotificationService`` from the gateway config dict.
+
+    The dict is the raw ``services.nextcloud_notifications`` block from
+    config.yaml (including ``enabled``, ``extra``, etc.). We inherit
+    Nextcloud credentials from the Talk adapter when ``extra.nextcloud_url``
+    is missing so operators don't have to duplicate URL/username.
+    """
+    from .service import NextcloudNotificationService
+
+    extra = dict(config.get("extra") or {})
+
+    # Inherit NC credentials from the Talk adapter when the operator
+    # hasn't duplicated them. Keeps config.yaml DRY for the common case
+    # where Notifications + Talk share an account.
+    if not extra.get("nextcloud_url") and gateway_runner is not None:
+        try:
+            from gateway.config import Platform
+            talk_cfg = gateway_runner.config.platforms.get(Platform("nextcloud_talk"))
+            if talk_cfg and getattr(talk_cfg, "extra", None):
+                talk_extra = talk_cfg.extra
+                extra.setdefault("nextcloud_url", talk_extra.get("nextcloud_url", ""))
+                extra.setdefault("username", talk_extra.get("username", "hermes"))
+                extra.setdefault(
+                    "app_password_env",
+                    talk_extra.get("app_password_env", "NEXTCLOUD_TALK_APP_PASSWORD"),
+                )
+        except Exception:
+            logger.debug("nc-notifications: could not inherit Talk credentials", exc_info=True)
+
+    return NextcloudNotificationService(extra, gateway_runner)
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system at startup."""
+    ctx.register_background_service(
+        name="nextcloud_notifications",
+        label="Nextcloud Notifications",
+        service_factory=_service_factory,
+        check_fn=_check_requirements,
+        validate_config=_validate_config,
+        install_hint="pip install httpx   # already a Hermes dependency",
+    )
+
+
+__all__ = ["register"]

--- a/plugins/services/nextcloud_notifications/base.py
+++ b/plugins/services/nextcloud_notifications/base.py
@@ -1,0 +1,52 @@
+"""Shared base class + event dataclass for Nextcloud background services.
+
+Lives inside the plugin so the service module is self-contained and
+doesn't depend on a sibling ``gateway/services/`` directory in the core
+tree. Mirrors the canonical ``BaseService`` shape so future Hermes
+service plugins can adopt the same interface.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ServiceEvent:
+    """Event surfaced by a background service for routing/agent dispatch."""
+
+    service: str
+    notification_id: int
+    app: str
+    object_type: str
+    object_id: str
+    subject: str
+    message: str
+    link: str
+    sender: str
+    timestamp: str
+    action: str  # "react" (forward to agent) or "silent" (record only)
+    raw: dict = field(default_factory=dict)
+
+
+class BaseService(ABC):
+    """Background service that observes an external source and routes events.
+
+    The plugin-registered ``service_factory`` is called with
+    ``(config_dict, gateway_runner)`` — subclasses MUST accept both. The
+    factory contract is enforced by
+    ``gateway.service_registry.service_registry.create_service``.
+    """
+
+    name: str = "base"
+
+    def __init__(self, config: dict, gateway_runner: Optional[Any] = None):
+        self.config = config
+        self.gateway_runner = gateway_runner
+
+    @abstractmethod
+    async def start(self) -> bool:
+        """Start background tasks. Returns True on success."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Clean shutdown — cancel tasks, close connections."""

--- a/plugins/services/nextcloud_notifications/plugin.yaml
+++ b/plugins/services/nextcloud_notifications/plugin.yaml
@@ -1,0 +1,23 @@
+name: nextcloud-notifications-service
+label: Nextcloud Notifications
+kind: backend
+version: 1.0.0
+description: >
+  Background service that polls Nextcloud's Notifications and Activity
+  APIs and routes matching events to a configured platform (typically
+  the Nextcloud Talk adapter). Classification rules let operators
+  whitelist event types (calendar invites, mention-in-comment, deck
+  card assignments, etc.) and choose between "react" (forward to the
+  agent) and "silent" (record-only).
+
+  This plugin ships under ``plugins/services/nextcloud_notifications/``
+  and registers a background service via
+  ``PluginContext.register_background_service``. The gateway starts
+  it after platforms come up and stops it before they disconnect.
+author: nsyring
+requires_env: []
+optional_env:
+  - name: NEXTCLOUD_TALK_APP_PASSWORD
+    description: "Reused from the Nextcloud Talk adapter — same App Password unlocks the Notifications/Activity APIs"
+    prompt: "Nextcloud App Password (same as NC Talk)"
+    password: true

--- a/plugins/services/nextcloud_notifications/service.py
+++ b/plugins/services/nextcloud_notifications/service.py
@@ -1,0 +1,362 @@
+"""Nextcloud Notifications + Activity polling service.
+
+Polls both the NC Notifications API (ETag-optimized) and the Activity API
+to catch all Nextcloud events. Classifies events via configurable rules
+and routes them to a target platform adapter for agent processing.
+
+File handling (download, sync, local storage) is NOT part of this service.
+It will be handled by a separate NextcloudFilesService (pr/nextcloud-files).
+"""
+import asyncio
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+from .base import BaseService, ServiceEvent
+from .store import NotificationStore
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_sender(raw: dict) -> str:
+    """Extract the actor/sender from a notification or activity dict.
+
+    Notifications API stores the actor in subjectRichParameters.actor.id.
+    Activity API stores it in subject_rich[1].actor.id or subject_rich[1].user.id.
+    The raw 'user' field is always the notification RECIPIENT (hermes), not the sender.
+    Falls back to raw['user'] only if no actor can be found.
+    """
+    # Notifications API: subjectRichParameters is a dict
+    srp = raw.get("subjectRichParameters")
+    if isinstance(srp, dict):
+        actor_id = srp.get("actor", {}).get("id", "")
+        if actor_id:
+            return actor_id
+
+    # Activity API: subject_rich is a list [template, params_dict]
+    sr = raw.get("subject_rich")
+    if isinstance(sr, list) and len(sr) >= 2 and isinstance(sr[1], dict):
+        actor_id = sr[1].get("actor", {}).get("id", "")
+        if actor_id:
+            return actor_id
+        # Some activity types use 'user' instead of 'actor'
+        user_id = sr[1].get("user", {}).get("id", "")
+        if user_id:
+            return user_id
+
+    return raw.get("user", "")
+
+
+def _classify_event(notification: dict, rules: list) -> str:
+    """Match a notification against rules, return action. First match wins.
+
+    Supports matching on app, object_type, and type fields.
+    The Activity API uses different field values than the Notifications API:
+      - Activity: object_type=files + type=shared (two fields)
+      - Notifications: object_type=shared (one field)
+    Use the 'type' field in rules for fine-grained Activity API filtering.
+    """
+    notif_app = notification.get("app", "")
+    notif_object_type = notification.get("object_type", "")
+    notif_type = notification.get("type", "")
+
+    for rule in rules:
+        rule_app = rule.get("app", "*")
+        rule_object_type = rule.get("object_type")
+        rule_type = rule.get("type")
+
+        if rule_app != "*" and rule_app != notif_app:
+            continue
+        if rule_object_type and rule_object_type != notif_object_type:
+            continue
+        if rule_type and rule_type != notif_type:
+            continue
+
+        return rule.get("action", "silent")
+
+    return "silent"
+
+
+def _parse_notification(raw: dict, rules: list) -> ServiceEvent:
+    """Parse a raw NC notification or activity dict into a ServiceEvent."""
+    action = _classify_event(raw, rules)
+    return ServiceEvent(
+        service="nextcloud_notifications",
+        notification_id=raw.get("notification_id", raw.get("activity_id", 0)),
+        app=raw.get("app", ""),
+        object_type=raw.get("object_type", raw.get("type", "")),
+        object_id=str(raw.get("object_id", "")),
+        subject=raw.get("subject", ""),
+        message=raw.get("message", ""),
+        link=raw.get("link", ""),
+        sender=_extract_sender(raw),
+        timestamp=raw.get("datetime", ""),
+        action=action,
+        raw=raw,
+    )
+
+
+class NotificationClient:
+    """Lightweight HTTP client for NC Notifications + Activity API."""
+
+    def __init__(self, base_url: str, username: str, password: str):
+        self._base_url = base_url.rstrip("/")
+        self._username = username
+        self._http = httpx.AsyncClient(
+            auth=(username, password),
+            headers={
+                "OCS-APIRequest": "true",
+                "Accept": "application/json",
+            },
+            timeout=30.0,
+            limits=httpx.Limits(max_keepalive_connections=0),
+        )
+
+    async def fetch_notifications(self, etag: str = "") -> tuple:
+        """Fetch notifications. Returns (list_of_notifs, new_etag)."""
+        headers = {}
+        if etag:
+            headers["If-None-Match"] = etag
+
+        url = f"{self._base_url}/ocs/v2.php/apps/notifications/api/v2/notifications"
+        resp = await self._http.get(url, headers=headers)
+
+        if resp.status_code == 304:
+            return [], etag
+
+        resp.raise_for_status()
+        new_etag = resp.headers.get("ETag", etag)
+        data = resp.json().get("ocs", {}).get("data", [])
+        return data, new_etag
+
+    async def fetch_activities(self, last_known_id: int = 0) -> tuple:
+        """Fetch latest activities and return those newer than last_known_id.
+
+        NC Activity API 'since' param paginates backwards (returns older items),
+        so we always fetch the latest page and filter client-side.
+        Returns (new_activities, highest_id).
+        """
+        url = f"{self._base_url}/ocs/v2.php/apps/activity/api/v2/activity"
+        try:
+            resp = await self._http.get(url, params={"limit": 50})
+            if resp.status_code == 304:
+                return [], last_known_id
+            resp.raise_for_status()
+            data = resp.json().get("ocs", {}).get("data", [])
+            if not data:
+                return [], last_known_id
+            highest_id = max(a.get("activity_id", 0) for a in data)
+            new_activities = [a for a in data if a.get("activity_id", 0) > last_known_id]
+            return new_activities, highest_id
+        except Exception as e:
+            logger.warning("NC Activities: fetch failed: %s", e)
+            return [], last_known_id
+
+    async def delete_notification(self, notification_id: int):
+        """Mark notification as read/processed."""
+        url = f"{self._base_url}/ocs/v2.php/apps/notifications/api/v2/notifications/{notification_id}"
+        await self._http.delete(url)
+
+    async def close(self):
+        await self._http.aclose()
+
+
+class NextcloudNotificationService(BaseService):
+    """Polls Nextcloud Notifications + Activity API, classifies events, routes to platform.
+
+    This service handles event detection and routing only. File operations
+    (download, upload, sync) are handled by a separate NextcloudFilesService.
+    """
+
+    name = "nextcloud_notifications"
+
+    def __init__(self, config: dict, gateway_runner=None):
+        super().__init__(config, gateway_runner)
+        self._nc_url = config.get("nextcloud_url", "")
+        self._username = config.get("username", "hermes")
+        pw_env = config.get("app_password_env", "NEXTCLOUD_TALK_APP_PASSWORD")
+        self._password = os.environ.get(pw_env, "").strip()
+        self._poll_interval = config.get("poll_interval", 30)
+        self._rules = config.get("rules", [])
+
+        deliver = config.get("deliver", "")
+        if ":" in deliver:
+            self._deliver_platform, self._deliver_chat_id = deliver.split(":", 1)
+        else:
+            self._deliver_platform = deliver
+            self._deliver_chat_id = ""
+
+        store_path = config.get("store_path", "~/.hermes/notification_events.json")
+        self._store = NotificationStore(path=store_path)
+
+        self._client: Optional[NotificationClient] = None
+        self._poll_task: Optional[asyncio.Task] = None
+        self._shutdown = False
+        self._etag = ""
+        self._last_seen_id = 0
+        self._last_activity_id = 0
+
+    def _on_poll_done(self, task: asyncio.Task):
+        """Log if poll task dies unexpectedly."""
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc:
+            logger.error("[NC Notifications] Poll task died: %s", exc, exc_info=exc)
+
+    async def start(self) -> bool:
+        if not self._nc_url or not self._password:
+            logger.warning("NC Notifications: missing nextcloud_url or password")
+            return False
+        self._client = NotificationClient(self._nc_url, self._username, self._password)
+        self._shutdown = False
+        # Initialize activity ID to current latest to avoid processing old events
+        if self._last_activity_id == 0:
+            try:
+                _, last_id = await asyncio.wait_for(
+                    self._client.fetch_activities(0), timeout=10
+                )
+                self._last_activity_id = last_id
+                logger.warning("[NC Notifications] Activity baseline: %d", last_id)
+            except asyncio.TimeoutError:
+                logger.warning("[NC Notifications] Activity baseline fetch timed out, starting from 0")
+            except Exception as e:
+                logger.warning("[NC Notifications] Activity baseline fetch failed: %s", e)
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        self._poll_task.add_done_callback(self._on_poll_done)
+        logger.info("[NC Notifications] Started (poll_interval=%ds, stored_events=%d)",
+                    self._poll_interval, self._store.count())
+        return True
+
+    async def stop(self):
+        self._shutdown = True
+        if self._poll_task:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        if self._client:
+            await self._client.close()
+        logger.info("[NC Notifications] Stopped")
+
+    async def _poll_loop(self):
+        backoff = 5
+        while not self._shutdown:
+            try:
+                # Poll Notifications API
+                notifications, self._etag = await self._client.fetch_notifications(self._etag)
+                backoff = 5
+
+                for raw in notifications:
+                    nid = raw.get("notification_id", 0)
+                    if nid <= self._last_seen_id:
+                        continue
+                    self._last_seen_id = max(self._last_seen_id, nid)
+
+                    event = _parse_notification(raw, self._rules)
+                    await self.on_event(event)
+
+                    try:
+                        await self._client.delete_notification(nid)
+                    except Exception as e:
+                        logger.warning("NC Notifications: failed to delete %d: %s", nid, e)
+
+                # Also poll Activity API for events that don't generate notifications
+                activities, new_act_id = await self._client.fetch_activities(self._last_activity_id)
+                if new_act_id > self._last_activity_id:
+                    for act in activities:
+                        aid = act.get("activity_id", 0)
+                        if aid <= self._last_activity_id:
+                            continue
+                        event = _parse_notification(act, self._rules)
+                        # Skip events caused by hermes itself to avoid loops
+                        if event.sender == self._username:
+                            continue
+                        if event.action == "react":
+                            await self.on_event(event)
+                        else:
+                            self._store.add(event)
+                    self._last_activity_id = new_act_id
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error("NC Notifications poll error: %s", e)
+                backoff = min(backoff * 2, 60)
+
+            await asyncio.sleep(self._poll_interval if backoff == 5 else backoff)
+
+    async def on_event(self, event: ServiceEvent):
+        if event.action == "ignore":
+            return
+        if event.action == "react":
+            await self._deliver_react(event)
+        else:
+            self._store.add(event)
+
+    async def _deliver_react(self, event: ServiceEvent):
+        """Inject event as MessageEvent into target platform adapter."""
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        runner = self.gateway_runner
+        if not runner:
+            logger.warning("NC Notifications: no gateway_runner, cannot deliver")
+            return
+
+        try:
+            platform = Platform(self._deliver_platform)
+        except ValueError:
+            logger.error("NC Notifications: unknown platform '%s'", self._deliver_platform)
+            return
+
+        adapter = runner.adapters.get(platform)
+        if not adapter:
+            logger.warning("NC Notifications: adapter for %s not connected", platform.value)
+            return
+
+        # Build message text
+        text = f"[NC Notification] {event.subject}"
+        if event.message:
+            text += f"\n{event.message}"
+        if event.link:
+            text += f"\nLink: {event.link}"
+
+        # For calendar reminders: add tool guidance
+        if event.app == "dav" and "calendar" in event.object_type.lower():
+            text += "\n\n[System] This is a calendar reminder. Execute the task described above."
+            text += " Use skill_view() to load relevant skills, then execute_code to run commands."
+            text += " Do NOT use non-existent tools — check available tools first."
+
+        # Use the event sender as user_id so the notification lands in their
+        # existing chat session, preserving context for follow-up questions.
+        user_id = event.sender or f"service:{self.name}"
+
+        # Determine chat_type the same way the adapter does, so the session
+        # key matches the user's existing chat session.
+        chat_type = "dm"
+        if hasattr(adapter, "_classify_chat"):
+            chat_type = adapter._classify_chat(self._deliver_chat_id)
+
+        source = adapter.build_source(
+            chat_id=self._deliver_chat_id,
+            user_id=user_id,
+            user_name=f"NC/{event.app} ({event.sender})",
+            chat_type=chat_type,
+        )
+
+        msg_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=f"ncnotif_{event.notification_id}",
+        )
+
+        await adapter.handle_message(msg_event)
+
+        # Also store react events for history
+        self._store.add(event)

--- a/plugins/services/nextcloud_notifications/store.py
+++ b/plugins/services/nextcloud_notifications/store.py
@@ -1,0 +1,64 @@
+"""Persistent JSON storage for notification events."""
+import json
+import logging
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import List, Optional
+
+from .base import ServiceEvent
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PATH = "~/.hermes/notification_events.json"
+_MAX_EVENTS = 200
+
+
+class NotificationStore:
+    """Simple JSON-file-backed event store."""
+
+    def __init__(self, path: Optional[str] = None, max_events: int = _MAX_EVENTS):
+        self._path = Path(os.path.expanduser(path or _DEFAULT_PATH))
+        self._max_events = max_events
+        self._events: List[dict] = []
+        self._load()
+
+    def _load(self):
+        if self._path.exists():
+            try:
+                self._events = json.loads(self._path.read_text(encoding="utf-8"))
+                if not isinstance(self._events, list):
+                    self._events = []
+            except Exception as e:
+                logger.warning("Failed to load notification store: %s", e)
+                self._events = []
+
+    def _save(self):
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps(self._events, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def add(self, event: ServiceEvent):
+        self._events.append(asdict(event))
+        if len(self._events) > self._max_events:
+            self._events = self._events[-self._max_events:]
+        self._save()
+
+    def query(self, since: Optional[str] = None, app: Optional[str] = None,
+              limit: int = 20) -> List[dict]:
+        """Query stored events, newest first."""
+        results = list(reversed(self._events))
+        if app:
+            results = [e for e in results if e.get("app") == app]
+        if since:
+            results = [e for e in results if e.get("timestamp", "") >= since]
+        return results[:limit]
+
+    def clear(self):
+        self._events = []
+        self._save()
+
+    def count(self) -> int:
+        return len(self._events)


### PR DESCRIPTION
## What does this PR do?

Adds a Files Service that enables bidirectional file synchronization between a local directory and Nextcloud via WebDAV. The agent can receive files shared by the user and share files back, so tools like `read_file`, `write_file`, and `vision_analyze` work natively against Nextcloud-shared files.

**Architecture:** Extends `BaseService` (from [feat/nextcloud-notifications](https://github.com/NousResearch/hermes-agent/pull/11459)). Three components:
- **FileWatcher**: inotify-based local filesystem monitoring (subprocess-supervised)
- **NotifyPushListener**: Nextcloud `notify_push` WebSocket for server-side change events, with reconnect + delta-sync fallback
- **NextcloudFilesService**: orchestrator with echo suppression and persistent sync state

**Key features:**
- Bidirectional sync: local changes upload to NC, NC changes download locally
- Attribution / echo suppression via `_downloading` + `_recently_downloaded` + `_uploading` sets with grace-period TTL — prevents sync loops
- Atomic downloads (`.tmp` files renamed on completion)
- Chunked upload v2 for large files (`MKCOL` upload dir → `PUT` chunks → `MOVE` to assemble)
- `asyncio.to_thread` for all blocking file I/O (non-blocking event loop)
- Path-traversal protection (resolve() + prefix check on both directions)
- Supervised background tasks with crash logging via `add_done_callback`
- Sync state persistence (`~/.hermes/file_sync_state.json` with ETag + size + mtime per file)
- Initial sync on startup with ETag-based delta detection
- Dot-file filtering (ignores NC temp files like `.~hash`, `.sync_*`)
- httpx `max_keepalive_connections=0` (prevents CLOSE-WAIT accumulation)

**Depends on:** [feat/nextcloud-notifications](https://github.com/NousResearch/hermes-agent/pull/11459) for the `BaseService` abstraction. The notifications PR should land first.

## Related Issue

No existing issue.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `gateway/services/nextcloud_files.py` (615 lines): service + FileWatcher + NotifyPushListener + sync state
- `gateway/services/nextcloud_files_client.py` (336 lines): async WebDAV + OCS HTTP client
- `gateway/services/__init__.py`: export updates
- `gateway/run.py`: service factory entry
- `tests/gateway/test_nextcloud_files.py` (374 lines): 16 tests covering service orchestration, echo suppression, sync state, path conversion
- `tests/gateway/test_nextcloud_files_client.py` (379 lines): 2 high-level tests covering client operations end-to-end

(File counts from `git show feat/nextcloud-files --stat`. Test-method counts from `grep -cE '^    def test_'`.)

## How to Test

1. Configure in `config.yaml`:
   ```yaml
   services:
     nextcloud_files:
       enabled: true
       extra:
         local_path: ~/.hermes/nextcloud
         deliver: nextcloud_talk:<chat_token>
         initial_sync: true
         chunk_size_mb: 5
         max_file_size_mb: 500
   ```
2. Share a file with the agent user in Nextcloud → file appears in `~/.hermes/nextcloud/`
3. Write a file locally to `~/.hermes/nextcloud/` → uploads to Nextcloud
4. Run `pytest tests/gateway/test_nextcloud_files.py tests/gateway/test_nextcloud_files_client.py -v` — 18 tests pass
5. Tested live in production (Debian 13 LXC against Nextcloud 31)

## Checklist

- [x] Read the [Contributing Guide](CONTRIBUTING.md)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Searched for existing PRs to avoid duplicates
- [x] PR contains only related changes
- [x] `pytest tests/ -q` regression-tested against `upstream/main` baseline — no new failures
- [x] Tests added for service orchestration + client operations
- [x] Tested on: Debian 13 (LXC, amd64) against Nextcloud 31
- [x] Architecture: extends `BaseService` from #11459 (depends-on)
- [x] Cross-platform: no effect on existing platforms
- [x] Security: path-traversal protection via `resolve()` + prefix check
