### PR TITLE
whatsapp: fix group reply trigger via canonical JID normalization

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -199,6 +199,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if not value:
             return ""
         normalized = str(value).strip()
+
+        # Baileys may emit IDs with device suffixes like:
+        #   55001234567:2@s.whatsapp.net
+        #   77009876543210:2@lid
+        # Canonicalize to compare participant IDs reliably:
+        #   55001234567@s.whatsapp.net
+        #   77009876543210@lid
+        match = re.match(r"^([^:@]+)(?::\d+)?@(s\.whatsapp\.net|lid|g\.us)$", normalized)
+        if match:
+            return f"{match.group(1)}@{match.group(2)}"
+
         if ":" in normalized and "@" in normalized:
             normalized = normalized.replace(":", "@", 1)
         return normalized

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -64,7 +64,20 @@ function formatOutgoingMessage(message) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  const normalized = String(value).trim();
+
+  // Canonicalize Baileys device-suffixed IDs:
+  //   55001234567:2@s.whatsapp.net -> 55001234567@s.whatsapp.net
+  //   77009876543210:2@lid       -> 77009876543210@lid
+  const match = normalized.match(/^([^:@]+)(?::\d+)?@(s\.whatsapp\.net|lid|g\.us)$/);
+  if (match) {
+    return `${match[1]}@${match[2]}`;
+  }
+
+  if (normalized.includes(':') && normalized.includes('@')) {
+    return normalized.replace(':', '@');
+  }
+  return normalized;
 }
 
 function getMessageContent(msg) {
@@ -351,6 +364,20 @@ async function startSocket() {
         botIds,
         timestamp: msg.messageTimestamp,
       };
+
+      if (WHATSAPP_DEBUG) {
+        try {
+          console.log(JSON.stringify({
+            event: 'parsed',
+            chatId,
+            senderId,
+            mentionedIds,
+            quotedParticipant,
+            botIds,
+            contextInfo,
+          }));
+        } catch {}
+      }
 
       messageQueue.push(event);
       if (messageQueue.length > MAX_QUEUE_SIZE) {


### PR DESCRIPTION
## Summary
- canonicalize device-suffixed WhatsApp JIDs in gateway adapter
- canonicalize same JID format in WhatsApp bridge before emitting events
- preserve parsed debug event logging for verification

## Root cause
Baileys emits bot IDs with device suffixes while reply participant can arrive without suffix, so equality checks failed and group reply-to-bot did not trigger.

## Validation
- parsed event now normalizes IDs consistently
- reply to Hermes message in WhatsApp group now triggers response

## Files
- gateway/platforms/whatsapp.py
- scripts/whatsapp-bridge/bridge.js