### PR TITLE
Fix: custom providers with multiple models not showing in /model menu

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2759,8 +2759,10 @@ class HermesCLI:
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
         runtime_model = runtime.get("model")
         if runtime_model and isinstance(runtime_model, str):
-            self.model = runtime_model
-
+            # However, if user explicitly selected a model via /model command,
+            # respect that choice and don't overwrite it.
+            if not getattr(self, '_explicit_model', None):
+                self.model = runtime_model
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
         # without `hermes model`), fall back to the provider's first catalog
         # model so the API call doesn't fail with "model must be non-empty".
@@ -4523,6 +4525,8 @@ class HermesCLI:
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
+        # Mark that user explicitly selected this model via /model command
+        self._explicit_model = result.new_model
         if result.api_key:
             self.api_key = result.api_key
             self._explicit_api_key = result.api_key

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1103,6 +1103,13 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            # Also read the models list if present (for multi-model custom providers)
+            models_list = entry.get("models", [])
+            if isinstance(models_list, list):
+                for m in models_list:
+                    m_stripped = (m or "").strip()
+                    if m_stripped and m_stripped not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_stripped)
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:


### PR DESCRIPTION
## Bug Description

When configuring a custom provider with multiple models in `config.yaml`, the `/model` menu only shows "(1 model)" and switching models does not persist across conversation turns.

## Configuration Example

```yaml
custom_providers:
- name: Newapi
  base_url: https://newapi.example.com/v1
  api_key: sk-xxx
  model: glm5
  models:
    - claude-haiku-4-5-20251001
    - claude-opus-4-6
    - claude-sonnet-4-6
    - deepseek-chat
    - glm5
    - kimi-k2.5
    - minimax-m2.5
```

## Expected Behavior

1. `/model` menu should show all configured models
2. Switching to a different model should persist for subsequent messages

## Actual Behavior

### Issue 1: Model Menu Only Shows One Model
The `/model` menu displays "(1 model)" instead of all configured models.

### Issue 2: Model Switch Doesn't Persist
When user switches model via `/model` command, subsequent messages still use the original model.

## Root Cause Analysis

### Issue 1: `model_switch.py`
The `list_authenticated_providers()` function only reads the `model` field and ignores the `models` list.

### Issue 2: `cli.py`
1. `_apply_model_switch_result()` doesn't mark the model as explicitly chosen
2. `_ensure_runtime_credentials()` unconditionally overwrites `self.model` with `runtime.get("model")` on every turn

## Fix Summary

- **model_switch.py**: Added code to read the `models` list from custom_providers config
- **cli.py**: Added `_explicit_model` tracking to prevent runtime override

## Testing

Tested with custom provider configuration containing 11 models. All models now appear in `/model` menu and switching persists across conversation turns.

## Files Changed

- `hermes_cli/model_switch.py`: +7 lines
- `cli.py`: +6 lines
