### PR TITLE
fix(weixin): correct send_image_file parameter name to match base class

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1542,12 +1542,12 @@ class WeixinAdapter(BasePlatformAdapter):
     async def send_image_file(
         self,
         chat_id: str,
-        path: str,
+        image_path: str,
         caption: str = "",
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=path, caption=caption, metadata=metadata)
+        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
 
     async def send_document(
         self,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -232,6 +232,7 @@ AUTHOR_MAP = {
     "zhiheng.liu@bytedance.com": "ZaynJarvis",
     "mbelleau@Michels-MacBook-Pro.local": "malaiwah",
     "dhandhalyabhavik@gmail.com": "v1k22",
+    "rucchizhao@zhaochenfeideMacBook-Pro.local": "RucchiZ",
 }
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -520,3 +520,63 @@ class TestWeixinMediaBuilder:
         adapter = _make_adapter()
         media_type, builder = adapter._outbound_media_builder("recording.silk")
         assert media_type == weixin.MEDIA_VOICE
+
+
+class TestWeixinSendImageFileParameterName:
+    """Regression test for send_image_file parameter name mismatch.
+
+    The gateway calls send_image_file(chat_id=..., image_path=...) but the
+    WeixinAdapter previously used 'path' as the parameter name, causing
+    image sending to fail. This test ensures the interface stays correct.
+    """
+
+    @patch.object(WeixinAdapter, "send_document", new_callable=AsyncMock)
+    def test_send_image_file_uses_image_path_parameter(self, send_document_mock):
+        """Verify send_image_file accepts image_path and forwards to send_document."""
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+
+        send_document_mock.return_value = weixin.SendResult(success=True, message_id="test-id")
+
+        # This is the call pattern used by gateway/run.py extract_media
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                image_path="/tmp/test_image.png",
+                caption="Test caption",
+                metadata={"thread_id": "thread-123"},
+            )
+        )
+
+        assert result.success is True
+        send_document_mock.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/test_image.png",
+            caption="Test caption",
+            metadata={"thread_id": "thread-123"},
+        )
+
+    @patch.object(WeixinAdapter, "send_document", new_callable=AsyncMock)
+    def test_send_image_file_works_without_optional_params(self, send_document_mock):
+        """Verify send_image_file works with minimal required params."""
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+
+        send_document_mock.return_value = weixin.SendResult(success=True, message_id="test-id")
+
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                image_path="/tmp/test_image.jpg",
+            )
+        )
+
+        assert result.success is True
+        send_document_mock.assert_awaited_once_with(
+            "wxid_test123",
+            file_path="/tmp/test_image.jpg",
+            caption="",
+            metadata=None,
+        )


### PR DESCRIPTION
## Summary
Fixes a live bug in `WeixinAdapter.send_image_file()` where the parameter was named `path` but every caller passes `image_path=` as a keyword:

- `cron/scheduler.py:186` — `adapter.send_image_file(chat_id=..., image_path=media_path, ...)`
- `gateway/run.py:5568-5570` — same
- `gateway/run.py:5586-5588` — same

Result on any Weixin image send: `TypeError: got unexpected kwarg 'image_path'`. All other adapters (`QQBot`, `Discord`, `Slack`, base class) already use `image_path`.

## Salvage
Cherry-picked from #11186 by @RucchiZ. Their authorship is preserved in git log. Added AUTHOR_MAP entry for the release script.

This closes **nine** duplicate PRs all reporting and fixing the same issue:
#8781, #9285, #9304, #9349, #9517, #9607, #9772, #11062, #11186 — credit to each contributor who helped surface the bug.

## Scope
Strictly the `send_image_file` parameter rename + regression test. The broader media-signature alignment proposed in #8781 (updating `send_image`, `send_video`, `send_voice`, `send_document` to match base-class `**kwargs` patterns) is left for a follow-up — it's hygiene, not a live bug. The `send_document` `path → file_path` rename was already merged separately by @flobo3 in d8a52109.

## Test plan
- `tests/gateway/test_weixin.py::TestWeixinSendImageFileParameterName` — two new regression tests exercising the exact call pattern used by gateway/run.py and cron/scheduler.py
- Verified both tests fail on the buggy code (TypeError matches the live error) and pass on the fix
- Full weixin/qqbot/platform-base suite: 235 passed

Closes #9738 (partial — MEDIA image delivery still needs #9156 for the send() extraction path, tracked separately)
