### PR TITLE
fix(agent): preserve dotted ZAI models on custom anthropic proxies

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6424,10 +6424,30 @@ class AIAgent:
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        preserve_dot_providers = {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}
+        provider = (getattr(self, "provider", "") or "").lower()
+        if provider in preserve_dot_providers:
             return True
+
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base
+        if "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base:
+            return True
+
+        # Opaque custom Anthropic proxies may hide the upstream vendor in the
+        # URL, so infer dot-preservation from the configured model family.
+        model_name = str(getattr(self, "model", "") or "")
+        if model_name:
+            try:
+                from hermes_cli.model_normalize import detect_vendor
+                from hermes_cli.models import normalize_provider
+
+                inferred_provider = normalize_provider(detect_vendor(model_name) or "")
+            except Exception:
+                inferred_provider = ""
+            if inferred_provider in {"alibaba", "minimax", "minimax-cn", "zai"}:
+                return True
+
+        return False
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -332,6 +332,26 @@ class TestMinimaxPreserveDots:
         from run_agent import AIAgent
         assert AIAgent._anthropic_preserve_dots(agent) is True
 
+    def test_opaque_custom_proxy_preserves_zai_model_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://proxy.example.com/anthropic",
+            model="z-ai/glm-5.1",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_opaque_custom_proxy_keeps_claude_hyphenation(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://proxy.example.com/anthropic",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
     def test_normalize_preserves_m25_free_dot(self):
         from agent.anthropic_adapter import normalize_model_name
         assert normalize_model_name("minimax-m2.5-free", preserve_dots=True) == "minimax-m2.5-free"


### PR DESCRIPTION
Fixes #11464.

## Summary
- preserve dotted ZAI/GLM model ids for opaque custom anthropic-compatible proxies by inferring dot-preserving vendors from the configured model when provider/base_url do not reveal the upstream
- keep Claude hyphenation unchanged on the same custom-proxy path
- add regression tests for both behaviors

## Testing
- pytest -q -o addopts= tests/agent/test_minimax_provider.py