### PR TITLE
fix(cron): show delivery failure inline with last-run status

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5105,7 +5105,12 @@ class HermesCLI:
                     print(f"  Skills: {', '.join(job['skills'])}")
                 print(f"  Prompt: {job.get('prompt_preview', '')}")
                 if job.get("last_run_at"):
-                    print(f"  Last run: {job['last_run_at']} ({job.get('last_status', '?')})")
+                    last_status = job.get("last_status", "?")
+                    delivery_err = job.get("last_delivery_error")
+                    status_str = f"{last_status} ⚠ delivery failed" if (last_status == "ok" and delivery_err) else last_status
+                    print(f"  Last run: {job['last_run_at']} ({status_str})")
+                    if delivery_err:
+                        print(f"  Delivery error: {delivery_err}")
                 print()
             return
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -96,15 +96,20 @@ def cron_list(show_all: bool = False):
 
         # Execution history
         last_status = job.get("last_status")
+        delivery_err = job.get("last_delivery_error")
         if last_status:
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
-                status_display = color("ok", Colors.GREEN)
+                if delivery_err:
+                    # Agent succeeded but delivery failed — flag it inline so the
+                    # warning isn't missed when scanning a long job list.
+                    status_display = color("ok", Colors.GREEN) + "  " + color("⚠ delivery failed", Colors.YELLOW)
+                else:
+                    status_display = color("ok", Colors.GREEN)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
             print(f"    Last run:  {last_run}  {status_display}")
 
-        delivery_err = job.get("last_delivery_error")
         if delivery_err:
             print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
 


### PR DESCRIPTION
## Problem

When a cron job's agent run succeeds but the delivery step fails (e.g. Discord/Telegram not configured), `last_status` correctly stays `"ok"` — but both cron list views misrepresented the outcome:

- **`hermes cron list`** (`hermes_cli/cron.py`): showed green `ok` on one line with `⚠ Delivery failed:` on the next — easy to overlook when scanning a long job list.
- **`/cron list` in chat** (`cli.py`): showed only `(ok)` and never displayed `last_delivery_error` at all.

## Fix

Both display paths now incorporate the delivery warning inline.

**`hermes cron list` — before:**

    Last run:  2026-04-16T10:00:00  ok
    ⚠ Delivery failed: platform 'discord' not configured

**`hermes cron list` — after:**

    Last run:  2026-04-16T10:00:00  ok  ⚠ delivery failed
    ⚠ Delivery failed: platform 'discord' not configured

The green `ok` is preserved (the agent run did succeed). The yellow `⚠ delivery failed` tag is now on the same line so it cannot be missed. Full error detail still appears on the line below.

**`/cron list` in chat — before:**

    Last run: 2026-04-16T10:00:00 (ok)

**`/cron list` in chat — after:**

    Last run: 2026-04-16T10:00:00 (ok ⚠ delivery failed)
    Delivery error: platform 'discord' not configured

## Scope

- No changes to `cron/jobs.py` — `last_status` continues to reflect agent execution success only, per the existing design.
- No changes to the data model — reads the existing `last_delivery_error` field already stored by `mark_job_run()`.
- Purely additive — when `last_delivery_error` is `None` or empty, both paths fall back to the original display unchanged.

Fixes #5861
