### PR TITLE
fix(api_server): stream reasoning tokens as hermes.reasoning.delta SSE events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -668,6 +668,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -708,6 +709,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
+            reasoning_callback=reasoning_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
@@ -890,6 +892,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
+            def _on_reasoning(text):
+                """Forward reasoning/thinking tokens as a separate SSE event."""
+                if text is not None:
+                    _stream_q.put(("__reasoning__", {"text": text}))
+
             def _on_tool_progress(event_type, name, preview, args, **kwargs):
                 """Send tool progress as a separate SSE event.
 
@@ -930,6 +937,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                reasoning_callback=_on_reasoning,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
             ))
@@ -1051,6 +1059,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
+                    )
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    event_data = json.dumps(item[1])
+                    await response.write(
+                        f"event: hermes.reasoning.delta\ndata: {event_data}\n\n".encode()
                     )
                 else:
                     content_chunk = {
@@ -2155,6 +2168,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -2178,6 +2192,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
+                reasoning_callback=reasoning_callback,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -650,6 +650,98 @@ class TestChatCompletionsEndpoint:
                 assert '"label": "Python docs"' in body
 
     @pytest.mark.asyncio
+    async def test_stream_includes_reasoning_delta(self, adapter):
+        """reasoning_callback fires → reasoning tokens appear as hermes.reasoning.delta SSE events,
+        separate from delta.content so standard chat chunks stay clean."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                r_cb = kwargs.get("reasoning_callback")
+                # Simulate: model emits reasoning tokens, then actual content
+                if r_cb:
+                    r_cb("Let me think step by step...")
+                    r_cb(" The answer must be 42.")
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("The answer is 42.")
+                return (
+                    {"final_response": "The answer is 42.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 15, "output_tokens": 8, "total_tokens": 23},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "What is 1+1?"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                # Reasoning tokens must appear as a dedicated SSE event type
+                assert "event: hermes.reasoning.delta" in body
+                assert "Let me think step by step..." in body
+                assert " The answer must be 42." in body
+                # Final content must also be present
+                assert "The answer is 42." in body
+                # Reasoning tokens must NOT appear inside chat.completion.chunk delta.content
+                import json as _json
+                for line in body.splitlines():
+                    if line.startswith("data: ") and line.strip() != "data: [DONE]":
+                        try:
+                            chunk = _json.loads(line[len("data: "):])
+                        except _json.JSONDecodeError:
+                            continue
+                        if chunk.get("object") == "chat.completion.chunk":
+                            for choice in chunk.get("choices", []):
+                                content = choice.get("delta", {}).get("content", "") or ""
+                                assert "Let me think" not in content
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_none_is_ignored(self, adapter):
+        """reasoning_callback(None) must not crash or emit a malformed SSE event."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                r_cb = kwargs.get("reasoning_callback")
+                if r_cb:
+                    r_cb(None)  # Should be silently ignored
+                    r_cb("Valid reasoning token.")
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("Done.")
+                return (
+                    {"final_response": "Done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                # Valid reasoning must appear
+                assert "Valid reasoning token." in body
+                # No malformed events (null data)
+                assert "data: null" not in body
+
+    @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
**Title（标题）：**
```
fix(api_server): stream reasoning tokens as hermes.reasoning.delta SSE events
```

---

**Body（正文）：**

```markdown
## What does this PR do?

Adds support for streaming model reasoning/thinking tokens through the Gateway SSE interface.

Previously, `reasoning_callback` was never registered in the API server path, so reasoning tokens produced by thinking models (e.g. Qwen3, DeepSeek-R1) were silently dropped before reaching API clients.

This PR wires up the callback chain so that reasoning tokens are emitted as a dedicated named SSE event (`hermes.reasoning.delta`), keeping the standard `delta.content` stream clean and backward-compatible.

## Related Issue

Fixes #

## Type of Change

- ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Added `reasoning_callback` parameter to `_create_agent` and `_run_agent` in `APIServerAdapter`
- Registered `_on_reasoning` callback that enqueues reasoning tokens as `("__reasoning__", {"text": ...})` tuples into the SSE stream queue
- Extended `_emit` to handle `__reasoning__` tuples and emit them as `event: hermes.reasoning.delta\ndata: {"text": "..."}` SSE events

## Data Flow

```
model reasoning token
  → reasoning_callback(_on_reasoning)
  → _stream_q.put(("__reasoning__", {"text": ...}))
  → _emit() → SSE: event: hermes.reasoning.delta\ndata: {"text": "..."}
```

## How to Test

1. Configure a thinking-capable model (e.g. `qwen3`, `deepseek-r1`) as your Hermes agent model
2. Send a streaming chat completion request:
   ```bash
   curl -N -X POST http://localhost:<port>/v1/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer <api_key>" \
     -d '{"model":"hermes-agent","messages":[{"role":"user","content":"What is 1+1?"}],"stream":true}'
   ```
3. Verify that `event: hermes.reasoning.delta` events appear in the SSE stream before the regular `data:` content chunks
4. Verify that standard `delta.content` chunks are unaffected

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (new SSE event is self-describing)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've considered cross-platform impact — no platform-specific code
```

