### PR TITLE
fix: preserve mattermost thread follow-ups

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -48,6 +49,9 @@ _CHANNEL_TYPE_MAP = {
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+_KNOWN_THREAD_TTL_SECONDS = 24 * 60 * 60
+_KNOWN_THREAD_MAX = 500
 
 
 def check_mattermost_requirements() -> bool:
@@ -98,6 +102,53 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # Threads where the bot has already participated. Used to bypass the
+        # @mention gate for follow-up replies in channel threads.
+        self._known_threads: Dict[str, float] = {}
+
+    def _prune_known_threads(self) -> None:
+        now = time.time()
+        expired = [
+            thread_id
+            for thread_id, seen_at in self._known_threads.items()
+            if now - seen_at > _KNOWN_THREAD_TTL_SECONDS
+        ]
+        for thread_id in expired:
+            self._known_threads.pop(thread_id, None)
+
+        if len(self._known_threads) <= _KNOWN_THREAD_MAX:
+            return
+
+        for thread_id, _ in sorted(
+            self._known_threads.items(), key=lambda item: item[1]
+        )[: len(self._known_threads) - _KNOWN_THREAD_MAX]:
+            self._known_threads.pop(thread_id, None)
+
+    def _register_known_thread(self, thread_id: Optional[str]) -> None:
+        if not thread_id:
+            return
+        self._known_threads[str(thread_id)] = time.time()
+        self._prune_known_threads()
+
+    def _is_known_thread(self, thread_id: Optional[str]) -> bool:
+        if not thread_id:
+            return False
+        self._prune_known_threads()
+        return str(thread_id) in self._known_threads
+
+    def _resolve_root_id(
+        self,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        if self._reply_mode != "thread":
+            return None
+        if metadata and metadata.get("thread_id"):
+            return str(metadata["thread_id"])
+        if reply_to:
+            return str(reply_to)
+        return None
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -269,14 +320,16 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            root_id = self._resolve_root_id(reply_to=reply_to, metadata=metadata)
+            if root_id:
+                payload["root_id"] = root_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
                 return SendResult(success=False, error="Failed to create post")
             last_id = data["id"]
+            if root_id:
+                self._register_known_thread(root_id)
 
         return SendResult(success=True, message_id=last_id)
 
@@ -326,7 +379,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
-            chat_id, image_url, caption, reply_to, "image"
+            chat_id, image_url, caption, reply_to, metadata, "image"
         )
 
     async def send_image_file(
@@ -339,7 +392,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
-            chat_id, image_path, caption, reply_to
+            chat_id, image_path, caption, reply_to, metadata=metadata
         )
 
     async def send_document(
@@ -353,7 +406,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
-            chat_id, file_path, caption, reply_to, file_name
+            chat_id, file_path, caption, reply_to, file_name, metadata=metadata
         )
 
     async def send_voice(
@@ -366,7 +419,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
-            chat_id, audio_path, caption, reply_to
+            chat_id, audio_path, caption, reply_to, metadata=metadata
         )
 
     async def send_video(
@@ -379,7 +432,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
-            chat_id, video_path, caption, reply_to
+            chat_id, video_path, caption, reply_to, metadata=metadata
         )
 
     def format_message(self, content: str) -> str:
@@ -402,13 +455,14 @@ class MattermostAdapter(BasePlatformAdapter):
         url: str,
         caption: Optional[str],
         reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
         kind: str = "file",
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         import asyncio
         import aiohttp
@@ -428,7 +482,7 @@ class MattermostAdapter(BasePlatformAdapter):
                             await asyncio.sleep(1.5 * (attempt + 1))
                             continue
                     if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
                     file_data = await resp.read()
                     ct = resp.content_type or "application/octet-stream"
                     break
@@ -437,27 +491,30 @@ class MattermostAdapter(BasePlatformAdapter):
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue
                 logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
-                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         if file_data is None:
             logger.warning("Mattermost: download returned no data for %s", url)
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         file_id = await self._upload_file(chat_id, file_data, fname, ct)
         if not file_id:
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         payload: Dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        root_id = self._resolve_root_id(reply_to=reply_to, metadata=metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to post with file")
+        if root_id:
+            self._register_known_thread(root_id)
         return SendResult(success=True, message_id=data["id"])
 
     async def _send_local_file(
@@ -467,6 +524,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -474,7 +532,7 @@ class MattermostAdapter(BasePlatformAdapter):
         p = Path(file_path)
         if not p.exists():
             return await self.send(
-                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
+                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to, metadata=metadata
             )
 
         fname = file_name or p.name
@@ -490,12 +548,15 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        root_id = self._resolve_root_id(reply_to=reply_to, metadata=metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to post with file")
+        if root_id:
+            self._register_known_thread(root_id)
         return SendResult(success=True, message_id=data["id"])
 
     # ------------------------------------------------------------------
@@ -613,6 +674,15 @@ class MattermostAdapter(BasePlatformAdapter):
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
+        # Thread support:
+        # - replies carry root_id
+        # - top-level channel posts should synthesize a thread root from the
+        #   post id when reply_mode=thread so the whole turn stays in one
+        #   Mattermost thread/session.
+        thread_id = post.get("root_id") or None
+        if not thread_id and channel_type_raw != "D" and self._reply_mode == "thread":
+            thread_id = post_id or None
+
         # Mention-gating for non-DM channels.
         # Config (env vars):
         #   MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
@@ -634,8 +704,9 @@ class MattermostAdapter(BasePlatformAdapter):
                 pattern.lower() in message_text.lower()
                 for pattern in mention_patterns
             )
+            is_known_thread = bool(thread_id and self._is_known_thread(thread_id))
 
-            if require_mention and not is_free_channel and not has_mention:
+            if require_mention and not is_free_channel and not has_mention and not is_known_thread:
                 logger.debug(
                     "Mattermost: skipping non-DM message without @mention (channel=%s)",
                     channel_id,
@@ -652,9 +723,6 @@ class MattermostAdapter(BasePlatformAdapter):
         # Resolve sender info.
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
-
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -226,6 +226,31 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_prefers_metadata_thread_id(self):
+        """metadata.thread_id should take precedence over reply_to for Mattermost threading."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post457"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="child_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"
@@ -352,6 +377,52 @@ class TestMattermostWebSocketParsing:
         assert not self.adapter.handle_message.called
 
     @pytest.mark.asyncio
+    async def test_thread_id_from_root_id(self):
+        """Post with root_id should have thread_id set."""
+        post_data = {
+            "id": "post_threaded",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Thread reply",
+            "root_id": "root_post_123",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_top_level_channel_post_uses_post_id_as_synthetic_thread(self):
+        """Top-level channel posts should synthesize a thread root when reply_mode=thread."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "post_top_level",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Hello there",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "post_top_level"
+
+    @pytest.mark.asyncio
     async def test_channel_type_mapping(self):
         """channel_type 'D' should map to 'dm'."""
         post_data = {
@@ -375,13 +446,16 @@ class TestMattermostWebSocketParsing:
         assert msg_event.source.chat_type == "dm"
 
     @pytest.mark.asyncio
-    async def test_thread_id_from_root_id(self):
-        """Post with root_id should have thread_id set."""
+    async def test_known_thread_bypasses_mention_gate(self):
+        """Replies in a known Mattermost thread should not require a fresh @mention."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._register_known_thread("root_post_123")
+
         post_data = {
-            "id": "post_reply",
+            "id": "post_followup",
             "user_id": "user_123",
             "channel_id": "chan_456",
-            "message": "@bot_user_id Thread reply",
+            "message": "follow-up without mention",
             "root_id": "root_post_123",
         }
         event = {
@@ -396,6 +470,7 @@ class TestMattermostWebSocketParsing:
         await self.adapter._handle_ws_event(event)
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "follow-up without mention"
         assert msg_event.source.thread_id == "root_post_123"
 
     @pytest.mark.asyncio
@@ -552,6 +627,48 @@ class TestMattermostFileUpload:
 
         assert result.success is True
         assert result.message_id == "post_with_file"
+
+    @pytest.mark.asyncio
+    @patch("tools.url_safety.is_safe_url", return_value=True)
+    async def test_send_image_uses_metadata_thread_id_for_root(self, _mock_safe):
+        """File uploads must honor metadata.thread_id so threaded delivery stays intact."""
+        self.adapter._reply_mode = "thread"
+
+        mock_dl_resp = AsyncMock()
+        mock_dl_resp.status = 200
+        mock_dl_resp.read = AsyncMock(return_value=b"\x89PNG\x00fake-image-data")
+        mock_dl_resp.content_type = "image/png"
+        mock_dl_resp.__aenter__ = AsyncMock(return_value=mock_dl_resp)
+        mock_dl_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_upload_resp = AsyncMock()
+        mock_upload_resp.status = 200
+        mock_upload_resp.json = AsyncMock(return_value={"file_infos": [{"id": "file_abc123"}]})
+        mock_upload_resp.text = AsyncMock(return_value="")
+        mock_upload_resp.__aenter__ = AsyncMock(return_value=mock_upload_resp)
+        mock_upload_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_post_resp = AsyncMock()
+        mock_post_resp.status = 200
+        mock_post_resp.json = AsyncMock(return_value={"id": "post_with_file"})
+        mock_post_resp.text = AsyncMock(return_value="")
+        mock_post_resp.__aenter__ = AsyncMock(return_value=mock_post_resp)
+        mock_post_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.get = MagicMock(return_value=mock_dl_resp)
+        self.adapter._session.post = MagicMock(side_effect=[mock_upload_resp, mock_post_resp])
+
+        result = await self.adapter.send_image(
+            "channel_1",
+            "https://img.example.com/cat.png",
+            caption="A cat",
+            reply_to="child_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args_list[-1][1]["json"]
+        assert payload["root_id"] == "root_post"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1699,7 +1699,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1737,6 +1737,7 @@ all = [
     { name = "dingtalk-stream" },
     { name = "discord-py", extra = ["voice"] },
     { name = "elevenlabs" },
+    { name = "fastapi" },
     { name = "faster-whisper" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
@@ -1756,6 +1757,7 @@ all = [
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sounddevice" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 cli = [
     { name = "simple-term-menu" },
@@ -1842,6 +1844,10 @@ voice = [
     { name = "numpy" },
     { name = "sounddevice" },
 ]
+web = [
+    { name = "fastapi" },
+    { name = "uvicorn", extra = ["standard"] },
+]
 yc-bench = [
     { name = "yc-bench", marker = "python_full_version >= '3.12'" },
 ]
@@ -1866,6 +1872,7 @@ requires-dist = [
     { name = "exa-py", specifier = ">=2.9.0,<3" },
     { name = "fal-client", specifier = ">=0.13.1,<1" },
     { name = "fastapi", marker = "extra == 'rl'", specifier = ">=0.104.0,<1" },
+    { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.104.0,<1" },
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
@@ -1894,6 +1901,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["sms"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["tts-premium"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["voice"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.0.1,<3" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
@@ -1929,10 +1937,11 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.1.4,<10" },
     { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"


### PR DESCRIPTION
## Summary
- preserve Mattermost thread roots via metadata-aware root_id resolution
- remember threads the bot has already joined so follow-up replies in the same thread bypass mention gating
- carry thread metadata through file and URL attachment sends
- add Mattermost regression coverage for thread/root handling

## Verification
- pytest -q tests/gateway/test_mattermost.py tests/gateway/test_slack.py
- live bridge verification against Mattermost and Slack adapters
