### PR TITLE
fix(environments,agent,cli): disown bg jobs, non-blocking drain, fix JSON truncation and resize ghosts

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -455,8 +455,10 @@ class ContextCompressor(ContextEngine):
             for tc in msg["tool_calls"]:
                 if isinstance(tc, dict):
                     args = tc.get("function", {}).get("arguments", "")
-                    if len(args) > 500:
-                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
+                    if isinstance(args, str) and len(args) > 500:
+                        # Don't truncate the JSON string mid-value — that breaks JSON parsing.
+                        # Instead, replace with a compact placeholder that stays valid JSON.
+                        tc = {**tc, "function": {**tc["function"], "arguments": '{"_truncated": true, "original_len": ' + str(len(args)) + '}'}}
                         modified = True
                 new_tcs.append(tc)
             if modified:

--- a/cli.py
+++ b/cli.py
@@ -9481,6 +9481,9 @@ class HermesCLI:
             except Exception:
                 pass  # never break resize handling
             _original_on_resize()
+            # Force a redraw after resize so status bar recalculates
+            # with the new terminal width immediately, avoiding ghost rows
+            app.invalidate()
 
         app._on_resize = _resize_clear_ghosts
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -9,6 +9,7 @@ or a temp file (local).
 import json
 import logging
 import os
+import select
 import shlex
 import subprocess
 import threading
@@ -344,8 +345,20 @@ class BaseEnvironment(ABC):
         )
         parts.append(f"cd {quoted_cwd} || exit 126")
 
-        # Run the actual command
-        parts.append(f"eval '{escaped}'")
+        # Run the actual command.
+        # If the command contains "&" (user-requested background), disown any
+        # resulting background jobs before the exit below so bash does not wait
+        # for them.  Without this, a command like "npm run dev &" keeps the
+        # wrapper bash alive forever because bash waits for all background jobs
+        # before exiting.
+        # DISOWN_FIX
+        if "&" in escaped:
+            # disown all jobs currently known to this shell (they were started
+            # by the eval).  Using "|| true" keeps the script running even if
+            # there are no jobs (e.g. the & was quoted/escaped and not active).
+            parts.append(f"eval '{escaped}'; disown -a 2>/dev/null || true")
+        else:
+            parts.append(f"eval '{escaped}'")
         parts.append("__hermes_ec=$?")
 
         # Re-dump env vars to snapshot (last-writer-wins for concurrent calls)
@@ -390,17 +403,45 @@ class BaseEnvironment(ABC):
         """
         output_chunks: list[str] = []
 
+        # Non-blocking drain: read stdout in short chunks with periodic
+        # interrupt checks.  This replaces the old blocking
+        #   for line in proc.stdout:
+        # which could hang indefinitely if the pipe is left in an
+        # inconsistent state after SIGKILL.
         def _drain():
-            try:
-                for line in proc.stdout:
-                    output_chunks.append(line)
-            except UnicodeDecodeError:
-                output_chunks.clear()
-                output_chunks.append(
-                    "[binary output detected — raw bytes not displayable]"
-                )
-            except (ValueError, OSError):
-                pass
+            chunk_buf = ""
+            _drain_interval = 0.1  # seconds between read attempts
+            while not is_interrupted():
+                # Only poll if the process has not yet exited.
+                # Checking here rather than relying on proc.poll() below
+                # lets us wake up promptly when the process exits.
+                try:
+                    ready, _, _ = select.select([proc.stdout], [], [], _drain_interval)
+                except (ValueError, OSError):
+                    # stdout fd closed or invalid — pipe is done
+                    break
+                if not ready:
+                    # No data available within the interval; loop and
+                    # check is_interrupted() again before retrying.
+                    continue
+                try:
+                    # text=True Popen wraps stdout in a TextIOWrapper.
+                    # read() on a TextIOWrapper decodes incrementally,
+                    # so this is safe even with multibyte UTF-8.
+                    chunk = proc.stdout.read(4096)
+                    if chunk:
+                        output_chunks.append(chunk)
+                    else:
+                        # EOF — pipe closed by the child
+                        break
+                except UnicodeDecodeError:
+                    output_chunks.append(
+                        "[binary output detected — raw bytes not displayable]"
+                    )
+                    break
+                except (ValueError, OSError):
+                    # Raised when stdout is already closed
+                    break
 
         drain_thread = threading.Thread(target=_drain, daemon=True)
         drain_thread.start()
@@ -411,14 +452,14 @@ class BaseEnvironment(ABC):
         while proc.poll() is None:
             if is_interrupted():
                 self._kill_process(proc)
-                drain_thread.join(timeout=2)
+                drain_thread.join(timeout=1.0)
                 return {
                     "output": "".join(output_chunks) + "\n[Command interrupted]",
                     "returncode": 130,
                 }
             if time.monotonic() > deadline:
                 self._kill_process(proc)
-                drain_thread.join(timeout=2)
+                drain_thread.join(timeout=1.0)
                 partial = "".join(output_chunks)
                 timeout_msg = f"\n[Command timed out after {timeout}s]"
                 return {
@@ -440,7 +481,7 @@ class BaseEnvironment(ABC):
                         pass
             time.sleep(0.2)
 
-        drain_thread.join(timeout=5)
+        drain_thread.join(timeout=2.0)
 
         try:
             proc.stdout.close()


### PR DESCRIPTION
## Summary

Four fixes across three files that address terminal hangs and UI issues:

### Fix 1: `tools/environments/base.py` — disown background jobs

**Problem:** When a user's command contains `&` (explicit request to background), the bash wrapper script hangs forever because bash waits for *all* background jobs to finish before executing `exit`. A command like `npm run dev &` never terminates, so Hermes hangs.

**Fix:** When `&` is detected in the escaped command, append `disown -a` after the eval. This tells bash to stop tracking background jobs, allowing `exit` to succeed immediately.

```python
if "&" in escaped:
    parts.append(f"eval '{escaped}'; disown -a 2>/dev/null || true")
else:
    parts.append(f"eval '{escaped}'")
```

### Fix 2: `tools/environments/base.py` — non-blocking drain thread

**Problem:** The drain thread used `for line in proc.stdout:` which blocks indefinitely on a closed/broken pipe after SIGKILL. The `readline()` call never returns on a broken pipe, causing the drain thread to hang forever.

**Fix:** Replace the blocking iterator with a `select.select`-based non-blocking read loop that wakes promptly on pipe EOF or interrupt, and joins the drain thread within 1-2 seconds instead of potentially forever.

### Fix 3: `agent/context_compressor.py`: fix JSON mid-value truncation

**Problem:** Tool call arguments were being sliced at 200 characters, which cuts JSON strings mid-value and produces invalid JSON like `{"key": "partial val"...`.

**Fix:** When arguments exceed 500 chars, replace with a valid JSON placeholder: `{"_truncated": true, "original_len": N}` instead of a broken truncated string.

### Fix 4: `cli.py`: force redraw after terminal resize

**Problem:** After terminal resize, the status bar leaves ghost rows because prompt_toolkit doesn't fully clear the old content before redrawing.

**Fix:** Call `app.invalidate()` after resize to force an immediate full redraw of the UI.

## Testing

```python
# Fix 1+2: before fix hangs 120s, after fix returns immediately
env.execute('python3 -m http.server 18765 > /tmp/s.log 2>&1 & sleep 2 && cat /tmp/s.log', timeout=8)
# → returncode: 0 (immediately), server continues running in background
```

## Root cause

- **Symptom:** `terminal(...)` with `npm run dev &`, `python -m http.server &`, etc. causes Hermes to hang
- **Root cause 1:** bash job control — `&` in wrapper's eval keeps bash waiting for background process before exit
- **Root cause 2:** blocking drain thread — SIGKILL leaves pipe in inconsistent state, readline() blocks forever
