### PR TITLE
feat(acp): thread acp_cwd through AIAgent and delegate_task

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -557,8 +557,16 @@ class AIAgent:
         api_mode: str = None,
         acp_command: str = None,
         acp_args: list[str] | None = None,
+        # Working directory for the ACP subprocess (only used when provider is
+        # "copilot-acp"). `CopilotACPClient` already accepts this — without it,
+        # the subprocess falls back to `os.getcwd()`. Exposing the parameter on
+        # AIAgent lets a caller (or a delegated subagent — see
+        # `tools/delegate_tool.py`) target a specific project directory without
+        # having to chdir the whole Hermes process.
+        acp_cwd: str = None,
         command: str = None,
         args: list[str] | None = None,
+        cwd: str = None,  # Alias for acp_cwd, mirrors the command/args aliases.
         model: str = "",
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = 1.0,
@@ -683,6 +691,7 @@ class AIAgent:
         self.provider = provider_name or ""
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
+        self.acp_cwd = acp_cwd or cwd
         if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
             self.api_mode = api_mode
         elif self.provider == "openai-codex":
@@ -964,6 +973,8 @@ class AIAgent:
                 if self.provider == "copilot-acp":
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
+                    if self.acp_cwd:
+                        client_kwargs["acp_cwd"] = self.acp_cwd
                 effective_base = base_url
                 if "openrouter" in effective_base.lower():
                     client_kwargs["default_headers"] = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -251,6 +251,7 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_acp_cwd: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -325,6 +326,7 @@ def _build_child_agent(
     effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
     effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)
     effective_acp_args = list(override_acp_args if override_acp_args is not None else (getattr(parent_agent, "acp_args", []) or []))
+    effective_acp_cwd = override_acp_cwd or getattr(parent_agent, "acp_cwd", None)
 
     # Resolve reasoning config: delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
@@ -353,6 +355,7 @@ def _build_child_agent(
         api_mode=effective_api_mode,
         acp_command=effective_acp_command,
         acp_args=effective_acp_args,
+        acp_cwd=effective_acp_cwd,
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
@@ -628,6 +631,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
+    acp_cwd: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -720,6 +724,7 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
+                override_acp_cwd=t.get("acp_cwd") or acp_cwd,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -1080,6 +1085,17 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": "Per-task ACP args override.",
                         },
+                        "acp_cwd": {
+                            "type": "string",
+                            "description": (
+                                "Per-task ACP working directory override. Lets "
+                                "parallel subagents target different project "
+                                "subdirectories in one delegate_task call — "
+                                "e.g. one child editing `tools/`, another "
+                                "editing `agent/` — each reading the local "
+                                "CLAUDE.md for its subtree."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -1116,6 +1132,17 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
                 ),
             },
+            "acp_cwd": {
+                "type": "string",
+                "description": (
+                    "Working directory for the spawned ACP subprocess (e.g. "
+                    "`claude --acp --stdio`). The ACP agent will resolve local "
+                    "project files (CLAUDE.md, .cursorrules, skills, tests) "
+                    "relative to this path. Falls back to the Hermes process "
+                    "cwd when unset. Inherited from the parent AIAgent unless "
+                    "overridden per-task in the `tasks` array."
+                ),
+            },
         },
         "required": [],
     },
@@ -1137,6 +1164,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
+        acp_cwd=args.get("acp_cwd"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
## Summary

`CopilotACPClient.__init__` already accepts an `acp_cwd` parameter (`agent/copilot_acp_client.py:267`) and uses it to:

- set `subprocess.Popen(..., cwd=...)` when launching the ACP subprocess (line 369)
- resolve tool paths against a sandbox root (line 230 `_ensure_path_within_cwd`)
- advertise the session cwd to the ACP peer (line 474)

It falls back to `os.getcwd()` when unset (line 277).

However, **nothing in the user-facing code populates `client_kwargs["acp_cwd"]`** before `CopilotACPClient(**client_kwargs)` is constructed. In practice every ACP subprocess inherits the Hermes process cwd regardless of what the caller or the LLM would like it to be.

This PR plumbs an optional `acp_cwd` from `AIAgent` and `delegate_task` through to the client, including a per-task override for parallel delegation. No behavior change when the parameter is unset — everything continues to fall back to `os.getcwd()`.

## Changes

- `run_agent.py` — `AIAgent.__init__` accepts `acp_cwd` (and `cwd` alias, mirroring the existing `command` / `args` aliases). When provider is `copilot-acp`, it flows into `client_kwargs["acp_cwd"]`.
- `tools/delegate_tool.py` — `_build_child_agent` accepts `override_acp_cwd`; falls back to `parent_agent.acp_cwd`. `delegate_task` takes a top-level `acp_cwd` plus a per-task override. Tool schema exposes both.

Total diff: +39 lines across 2 files.

## Motivation — use cases this unlocks

1. **An orchestrator Hermes session spawning Claude Code** (`claude --acp --stdio`) as a subagent in a different repo so the child reads the right `CLAUDE.md` / `.cursorrules` / skills. Today you'd have to `chdir` the whole Hermes process.
2. **Parallel delegation where each child edits a different subtree** — one child in `tools/`, another in `agent/`, each reading the local `CLAUDE.md` for its subtree. This is the per-task use case and cannot be expressed with any currently-shipping knob (env vars only cover `HERMES_COPILOT_ACP_COMMAND` / `HERMES_COPILOT_ACP_ARGS`, not cwd).

Example tool call the LLM can now make:

```json
{
  "tasks": [
    {"goal": "Fix routing in delegate_tool.py", "acp_command": "claude", "acp_cwd": "/repo/tools/"},
    {"goal": "Write tests for copilot_acp_client", "acp_command": "claude", "acp_cwd": "/repo/agent/"}
  ]
}
```

## Backwards compatibility

- All new parameters default to `None`.
- Existing callers (including all tests and docs) continue to work unchanged.
- `CopilotACPClient`'s existing `acp_cwd or os.getcwd()` fallback means behavior is identical to today when the parameter is unset.

## Test plan

- [x] Existing `pytest tests/` suite passes unchanged (no new test infra — the change is additive plumbing).
- [ ] Live ACP spawn with `acp_cwd` pointing at a different directory to confirm `subprocess.Popen` picks it up (manual).
- [ ] `delegate_task(tasks=[{"acp_cwd": "/path1"}, {"acp_cwd": "/path2"}])` with `claude --acp --stdio` confirming children see distinct `CLAUDE.md`s (manual).

## Context

This change has been running in a downstream wrapper of `hermes-agent` (driving parallel Claude Code subagent delegation across a multi-subdir project) since April 2026. Filed upstream so the wrapper can drop its patch.