### PR TITLE
feat(gateway): add Telegram inline clarify, commands, and resume flows

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4195,7 +4195,7 @@ class HermesCLI:
         if not silent:
             print("(^_^)v New session started!")
 
-    def _parse_resume_command_args(self, cmd_original: str) -> tuple[str, bool, bool] | None:
+    def _parse_resume_command_args(self, cmd_original: str, emit_errors: bool = True) -> tuple[str, bool, bool] | None:
         """Parse /resume [target] [--last|--list] arguments."""
         import shlex
 
@@ -4207,7 +4207,8 @@ class HermesCLI:
         try:
             tokens = shlex.split(raw_args)
         except ValueError as exc:
-            _cprint(f"  Invalid /resume arguments: {exc}")
+            if emit_errors:
+                _cprint(f"  Invalid /resume arguments: {exc}")
             return None
 
         resume_last = False
@@ -4221,20 +4222,23 @@ class HermesCLI:
                 resume_list = True
                 continue
             if token.startswith("-"):
-                _cprint(f"  Unknown /resume flag: {token}")
+                if emit_errors:
+                    _cprint(f"  Unknown /resume flag: {token}")
                 return None
             target_parts.append(token)
 
         if resume_last and resume_list:
-            _cprint("  /resume accepts at most one of --last or --list.")
+            if emit_errors:
+                _cprint("  /resume accepts at most one of --last or --list.")
             return None
         if (resume_last or resume_list) and not target_parts:
-            _cprint("  /resume --last and --list require a target.")
+            if emit_errors:
+                _cprint("  /resume --last and --list require a target.")
             return None
 
         return " ".join(target_parts).strip(), resume_last, resume_list
 
-    def _handle_resume_command(self, cmd_original: str) -> None:
+    def _handle_resume_command(self, cmd_original: str, use_terminal_handoff: bool = True) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
         parsed = self._parse_resume_command_args(cmd_original)
         if parsed is None:
@@ -4244,10 +4248,39 @@ class HermesCLI:
         if not self._session_db:
             _cprint("  Session database not available.")
             return
+        if self._agent_running:
+            _cprint("  Finish or interrupt the current turn before using /resume.")
+            return
+
+        if (
+            use_terminal_handoff
+            and not self._agent_running
+            and (not target or resume_list)
+        ):
+            import threading
+
+            app = self._app if self._app else None
+            app_running = bool(getattr(app, "is_running", False) or getattr(app, "_is_running", False))
+            if app and app_running and threading.current_thread() is threading.main_thread():
+                from prompt_toolkit.application import run_in_terminal
+
+                was_visible = self._status_bar_visible
+                self._status_bar_visible = False
+                app.invalidate()
+
+                def _resume_in_terminal():
+                    self._handle_resume_command(cmd_original, use_terminal_handoff=False)
+
+                task = run_in_terminal(_resume_in_terminal)
+
+                def _restore(_future):
+                    self._status_bar_visible = was_visible
+                    app.invalidate()
+
+                task.add_done_callback(_restore)
+                return
 
         if not target:
-            from hermes_cli.main import _session_browse_picker
-
             roots = self._list_resume_root_sessions(limit=50)
             if not roots:
                 _cprint("  No resumable sessions found.")
@@ -4256,7 +4289,7 @@ class HermesCLI:
 
             target_id = None
             while True:
-                root_id = _session_browse_picker(roots)
+                root_id = self._run_session_browse_picker(roots)
                 if not root_id:
                     return
 
@@ -4265,7 +4298,7 @@ class HermesCLI:
                     target_id = root_id
                     break
 
-                selected_id = _session_browse_picker(chain)
+                selected_id = self._run_session_browse_picker(chain)
                 if selected_id:
                     target_id = selected_id
                     break
@@ -4273,7 +4306,7 @@ class HermesCLI:
             target = target_id or ""
 
         # Resolve title or ID
-        from hermes_cli.main import _resolve_session_by_name_or_id, _session_browse_picker
+        from hermes_cli.main import _resolve_session_by_name_or_id
         resolved = _resolve_session_by_name_or_id(target)
         target_id = resolved or target
 
@@ -4284,7 +4317,7 @@ class HermesCLI:
         elif resume_list:
             chain = self._session_db.get_compression_continuation_chain(target_id) or []
             if len(chain) > 1:
-                selected_id = _session_browse_picker(chain)
+                selected_id = self._run_session_browse_picker(chain)
                 if not selected_id:
                     return
                 target_id = selected_id
@@ -4568,6 +4601,12 @@ class HermesCLI:
             _pick()
 
         return result[0]
+
+    def _run_session_browse_picker(self, sessions: list[dict]) -> str | None:
+        """Run the interactive session browser directly. Terminal handoff is handled by the caller."""
+        from hermes_cli.main import _session_browse_picker
+
+        return _session_browse_picker(sessions)
 
     def _prompt_text_input(self, prompt_text: str) -> str | None:
         """Prompt for free-text input safely inside or outside prompt_toolkit."""
@@ -4932,6 +4971,24 @@ class HermesCLI:
             base = text.split(None, 1)[0].lower().lstrip('/')
             cmd = resolve_command(base)
             return bool(cmd and cmd.name == "model")
+        except Exception:
+            return False
+
+    def _should_handle_resume_command_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True when /resume needs a modal picker and should stay on the UI thread."""
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            if not (cmd and cmd.name == "resume"):
+                return False
+            parsed = self._parse_resume_command_args(text, emit_errors=False)
+            if parsed is None:
+                return False
+            target, _resume_last, resume_list = parsed
+            return bool(not target or resume_list)
         except Exception:
             return False
 
@@ -8537,13 +8594,21 @@ class HermesCLI:
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
-                # Handle /model directly on the UI thread so interactive pickers
-                # can safely use prompt_toolkit terminal handoff helpers.
-                if self._should_handle_model_command_inline(text, has_images=has_images):
+                # Handle modal local commands directly on the UI thread so their
+                # interactive pickers can safely take over the terminal.
+                resume_modal = self._should_handle_resume_command_inline(text, has_images=has_images)
+                if (
+                    self._should_handle_model_command_inline(text, has_images=has_images)
+                    or (resume_modal and not self._agent_running)
+                ):
                     if not self.process_command(text):
                         self._should_exit = True
                         if event.app.is_running:
                             event.app.exit()
+                    event.app.current_buffer.reset(append_to_history=True)
+                    return
+                if resume_modal and self._agent_running:
+                    _cprint("  Finish or interrupt the current turn before opening the /resume browser.")
                     event.app.current_buffer.reset(append_to_history=True)
                     return
 

--- a/cli.py
+++ b/cli.py
@@ -4024,6 +4024,32 @@ class HermesCLI:
         print()
         return True
 
+    def _list_resume_root_sessions(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Return resumable root sessions for in-chat /resume navigation."""
+        if not self._session_db:
+            return []
+        try:
+            sessions = self._session_db.list_sessions_rich(
+                source="cli",
+                exclude_sources=["tool"],
+                limit=limit,
+                include_children=False,
+            )
+        except TypeError:
+            sessions = self._session_db.list_sessions_rich(
+                source="cli",
+                exclude_sources=["tool"],
+                limit=limit,
+            )
+        except Exception:
+            return []
+
+        roots = [
+            s for s in (sessions or [])
+            if s.get("id") != self.session_id and s.get("parent_session_id") is None
+        ]
+        return roots
+
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
@@ -4169,26 +4195,99 @@ class HermesCLI:
         if not silent:
             print("(^_^)v New session started!")
 
+    def _parse_resume_command_args(self, cmd_original: str) -> tuple[str, bool, bool] | None:
+        """Parse /resume [target] [--last|--list] arguments."""
+        import shlex
+
+        parts = cmd_original.split(None, 1)
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
+        if not raw_args:
+            return "", False, False
+
+        try:
+            tokens = shlex.split(raw_args)
+        except ValueError as exc:
+            _cprint(f"  Invalid /resume arguments: {exc}")
+            return None
+
+        resume_last = False
+        resume_list = False
+        target_parts: list[str] = []
+        for token in tokens:
+            if token == "--last":
+                resume_last = True
+                continue
+            if token == "--list":
+                resume_list = True
+                continue
+            if token.startswith("-"):
+                _cprint(f"  Unknown /resume flag: {token}")
+                return None
+            target_parts.append(token)
+
+        if resume_last and resume_list:
+            _cprint("  /resume accepts at most one of --last or --list.")
+            return None
+        if (resume_last or resume_list) and not target_parts:
+            _cprint("  /resume --last and --list require a target.")
+            return None
+
+        return " ".join(target_parts).strip(), resume_last, resume_list
+
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
-        parts = cmd_original.split(None, 1)
-        target = parts[1].strip() if len(parts) > 1 else ""
-
-        if not target:
-            _cprint("  Usage: /resume <session_id_or_title>")
-            if self._show_recent_sessions(reason="resume"):
-                return
-            _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
+        parsed = self._parse_resume_command_args(cmd_original)
+        if parsed is None:
             return
+        target, resume_last, resume_list = parsed
 
         if not self._session_db:
             _cprint("  Session database not available.")
             return
 
+        if not target:
+            from hermes_cli.main import _session_browse_picker
+
+            roots = self._list_resume_root_sessions(limit=50)
+            if not roots:
+                _cprint("  No resumable sessions found.")
+                _cprint("  Use /history or `hermes sessions list` to find sessions.")
+                return
+
+            target_id = None
+            while True:
+                root_id = _session_browse_picker(roots)
+                if not root_id:
+                    return
+
+                chain = self._session_db.get_compression_continuation_chain(root_id) or []
+                if len(chain) <= 1:
+                    target_id = root_id
+                    break
+
+                selected_id = _session_browse_picker(chain)
+                if selected_id:
+                    target_id = selected_id
+                    break
+
+            target = target_id or ""
+
         # Resolve title or ID
-        from hermes_cli.main import _resolve_session_by_name_or_id
+        from hermes_cli.main import _resolve_session_by_name_or_id, _session_browse_picker
         resolved = _resolve_session_by_name_or_id(target)
         target_id = resolved or target
+
+        if resume_last:
+            latest_id = self._session_db.get_latest_compression_continuation_id(target_id)
+            if latest_id:
+                target_id = latest_id
+        elif resume_list:
+            chain = self._session_db.get_compression_continuation_chain(target_id) or []
+            if len(chain) > 1:
+                selected_id = _session_browse_picker(chain)
+                if not selected_id:
+                    return
+                target_id = selected_id
 
         session_meta = self._session_db.get_session(target_id)
         if not session_meta:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1579,7 +1579,25 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart"):
+            from hermes_cli.commands import resolve_command as _resolve_gateway_command
+
+            _cmd_def = _resolve_gateway_command(cmd) if cmd else None
+            canonical = _cmd_def.name if _cmd_def else cmd
+
+            if canonical in (
+                # Session control / state mutation
+                "approve", "deny", "status", "stop", "new",
+                "background", "queue", "restart",
+                # Execute immediately while agent is busy
+                "help", "commands", "profile", "provider",
+                "usage", "insights", "sethome", "voice",
+                "yolo", "btw",
+                # Reject with a helpful message while agent is busy
+                "model", "retry", "undo", "title", "branch",
+                "compress", "rollback", "resume",
+                "reasoning", "fast", "personality",
+                "update", "reload-mcp",
+            ):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1086,6 +1086,27 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=str(e))
 
+    async def _send_message_with_thread_fallback(self, **kwargs):
+        """Send a Telegram message, retrying once without thread_id on 'thread not found'."""
+        if not self._bot:
+            raise RuntimeError("Not connected")
+
+        message_thread_id = kwargs.get("message_thread_id")
+        try:
+            return await self._bot.send_message(**kwargs)
+        except Exception as send_err:
+            err_lower = str(send_err).lower()
+            if message_thread_id is not None and "thread not found" in err_lower:
+                logger.warning(
+                    "[%s] Thread %s not found for inline/control message, retrying without message_thread_id",
+                    self.name,
+                    message_thread_id,
+                )
+                retry_kwargs = dict(kwargs)
+                retry_kwargs.pop("message_thread_id", None)
+                return await self._bot.send_message(**retry_kwargs)
+            raise
+
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -172,6 +172,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._approval_state: Dict[int, str] = {}
         # Inline menu state per chat
         self._commands_menu_state: Dict[str, dict] = {}
+        self._resume_menu_state: Dict[str, dict] = {}
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -1570,6 +1571,116 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_commands_menu failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    @staticmethod
+    def _relative_time(ts_str: str | None) -> str:
+        """Convert an ISO timestamp to a concise relative label."""
+        if not ts_str:
+            return ""
+        try:
+            from datetime import datetime, timezone
+
+            dt = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00"))
+            now = datetime.now(timezone.utc)
+            delta = now - dt
+            seconds = int(delta.total_seconds())
+            if seconds < 60:
+                return "just now"
+            minutes = seconds // 60
+            if minutes < 60:
+                return f"{minutes}m ago"
+            hours = minutes // 60
+            if hours < 24:
+                return f"{hours}h ago"
+            days = hours // 24
+            if days < 30:
+                return f"{days}d ago"
+            months = days // 30
+            return f"{months}mo ago"
+        except Exception:
+            return ""
+
+    def _render_resume_menu_text(self, mode: str = "root") -> str:
+        """Render the inline-menu body for /resume."""
+        if mode == "chain":
+            return "📋 *Resume Session*\n\nTap the point in time you want to resume:"
+        return "📋 *Named Sessions*\n\nTap a session to resume it:"
+
+    @staticmethod
+    def _resume_session_label(session: dict) -> str:
+        """Return the best available label for a /resume session entry."""
+        title = (session.get("title") or "").strip()
+        if title:
+            return title
+
+        preview = (session.get("preview") or "").strip()
+        if preview:
+            return preview
+
+        session_id = (session.get("id") or "").strip()
+        if session_id:
+            return session_id
+
+        return "Untitled"
+
+    def _build_resume_keyboard(self, sessions: list, *, show_back: bool = False) -> "InlineKeyboardMarkup":
+        """Build inline keyboard rows for /resume session selection."""
+        rows: list = []
+        for idx, session in enumerate(sessions):
+            title = self._resume_session_label(session)[:30]
+            rel = self._relative_time(session.get("last_active") or session.get("started_at"))
+            label = f"{title} — {rel}" if rel else title
+            if len(label) > 50:
+                label = label[:47] + "..."
+            rows.append([InlineKeyboardButton(label, callback_data=f"rs:{idx}")])
+
+        if show_back:
+            rows.append([InlineKeyboardButton("← Back", callback_data="rb")])
+        rows.append([InlineKeyboardButton("✗ Close", callback_data="rx")])
+        return InlineKeyboardMarkup(rows)
+
+    async def send_resume_menu(
+        self,
+        chat_id: str,
+        sessions: list,
+        session_key: str,
+        on_session_resumed,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an inline-keyboard session picker for /resume."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            menu_mode = (metadata or {}).get("resume_menu_mode") or "root"
+            root_sessions = (metadata or {}).get("resume_root_sessions")
+            keyboard = self._build_resume_keyboard(
+                sessions,
+                show_back=bool(menu_mode == "chain" and root_sessions),
+            )
+            thread_id = metadata.get("thread_id") if metadata else None
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": self._render_resume_menu_text(menu_mode),
+                "parse_mode": ParseMode.MARKDOWN,
+                "reply_markup": keyboard,
+            }
+            if thread_id:
+                kwargs["message_thread_id"] = int(thread_id)
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            self._resume_menu_state[str(chat_id)] = {
+                "sessions": sessions,
+                "root_sessions": root_sessions if root_sessions is not None else (sessions if menu_mode == "root" else None),
+                "mode": menu_mode,
+                "msg_id": msg.message_id,
+                "session_key": session_key,
+                "on_session_resumed": on_session_resumed,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_resume_menu failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def _handle_commands_callback(self, query, data: str, chat_id: str) -> None:
         """Handle /commands inline menu callbacks."""
         state = self._commands_menu_state.get(chat_id)
@@ -1617,6 +1728,120 @@ class TelegramAdapter(BasePlatformAdapter):
 
         await query.answer()
 
+    async def _handle_resume_callback(self, query, data: str, chat_id: str) -> None:
+        """Handle /resume inline menu callbacks."""
+        state = self._resume_menu_state.get(chat_id)
+        if not state:
+            await query.answer(text="Menu expired — use /resume again.")
+            return
+
+        expected_msg_id = state.get("msg_id")
+        actual_msg_id = getattr(getattr(query, "message", None), "message_id", None)
+        if expected_msg_id is not None and actual_msg_id != expected_msg_id:
+            await query.answer(text="Menu expired — use /resume again.")
+            return
+
+        if data.startswith("rs:"):
+            try:
+                idx = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid selection.")
+                return
+
+            sessions = state["sessions"]
+            if idx < 0 or idx >= len(sessions):
+                await query.answer(text="Session not found.")
+                return
+
+            session = sessions[idx]
+            chain = session.get("resume_chain") or []
+            if chain and state.get("mode") == "root":
+                state["sessions"] = chain
+                state["mode"] = "chain"
+                try:
+                    await query.edit_message_text(
+                        text=self._render_resume_menu_text("chain"),
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=self._build_resume_keyboard(chain, show_back=True),
+                    )
+                except Exception:
+                    pass
+                await query.answer()
+                return
+
+            session_id = session.get("id")
+            title = self._resume_session_label(session)
+            self._resume_menu_state.pop(chat_id, None)
+
+            try:
+                await query.edit_message_text(
+                    text=f"↻ Resuming **{title}**…",
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+
+            on_resume = state.get("on_session_resumed")
+            thread_id = getattr(getattr(query, "message", None), "message_thread_id", None)
+            if on_resume:
+                try:
+                    result_msg = await on_resume(session_id, title)
+                    if result_msg:
+                        kwargs: Dict[str, Any] = {
+                            "chat_id": int(chat_id),
+                            "text": result_msg,
+                            "parse_mode": ParseMode.MARKDOWN,
+                        }
+                        if thread_id:
+                            kwargs["message_thread_id"] = int(thread_id)
+                        await self._send_message_with_thread_fallback(**kwargs)
+                except Exception as exc:
+                    logger.error("Resume callback failed: %s", exc)
+                    try:
+                        kwargs = {
+                            "chat_id": int(chat_id),
+                            "text": f"❌ Failed to resume session: {exc}",
+                        }
+                        if thread_id:
+                            kwargs["message_thread_id"] = int(thread_id)
+                        await self._send_message_with_thread_fallback(**kwargs)
+                    except Exception:
+                        pass
+
+            await query.answer()
+            return
+
+        if data == "rb":
+            root_sessions = state.get("root_sessions") or []
+            if not root_sessions:
+                await query.answer(text="Menu expired — use /resume again.")
+                return
+
+            state["sessions"] = root_sessions
+            state["mode"] = "root"
+            try:
+                await query.edit_message_text(
+                    text=self._render_resume_menu_text("root"),
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=self._build_resume_keyboard(root_sessions),
+                )
+            except Exception:
+                pass
+            await query.answer()
+            return
+
+        if data == "rx":
+            self._resume_menu_state.pop(chat_id, None)
+            try:
+                await query.edit_message_text(text="📋 Session picker closed.", reply_markup=None)
+            except Exception:
+                pass
+            await query.answer()
+            return
+
+        await query.answer()
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -1638,6 +1863,13 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_commands_callback(query, data, chat_id)
+            return
+
+        # --- /resume menu callbacks (rs:/rb/rx) ---
+        if data.startswith(("rs:", "rb", "rx")):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_resume_callback(query, data, chat_id)
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -170,6 +170,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Clarify button state: prompt_id → payload
+        self._clarify_state: Dict[int, dict] = {}
         # Inline menu state per chat
         self._commands_menu_state: Dict[str, dict] = {}
         self._resume_menu_state: Dict[str, dict] = {}
@@ -1203,6 +1205,82 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: list[str],
+        session_key: str,
+        on_clarify_resolved,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Telegram-native clarify prompt with inline buttons."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            import itertools
+
+            if not hasattr(self, "_clarify_counter"):
+                self._clarify_counter = itertools.count(1)
+            clarify_id = next(self._clarify_counter)
+
+            prompt = question.strip()
+            lines = ["❓ <b>Clarification needed</b>", "", _html.escape(prompt)]
+            if choices:
+                lines.append("")
+                lines.extend(
+                    f"{idx}. {_html.escape(str(choice))}"
+                    for idx, choice in enumerate(choices, start=1)
+                )
+
+            keyboard_rows = []
+            for idx, choice in enumerate(choices):
+                keyboard_rows.append([
+                    InlineKeyboardButton(
+                        f"{idx + 1}. {str(choice)[:48]}",
+                        callback_data=f"cq:{clarify_id}:pick:{idx}",
+                    )
+                ])
+            keyboard_rows.append([
+                InlineKeyboardButton("✍️ Other", callback_data=f"cq:{clarify_id}:other"),
+                InlineKeyboardButton("❌ Cancel", callback_data=f"cq:{clarify_id}:cancel"),
+            ])
+
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": "\n".join(lines),
+                "parse_mode": ParseMode.HTML,
+                "reply_markup": InlineKeyboardMarkup(keyboard_rows),
+                **self._link_preview_kwargs(),
+            }
+            thread_id = self._metadata_thread_id(metadata)
+            message_thread_id = self._message_thread_id_for_send(thread_id)
+            if message_thread_id is not None:
+                kwargs["message_thread_id"] = message_thread_id
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            self._clarify_state[clarify_id] = {
+                "session_key": session_key,
+                "question": question,
+                "choices": list(choices or []),
+                "on_clarify_resolved": on_clarify_resolved,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_clarify failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    def clear_clarify(self, session_key: str) -> int:
+        """Drop any pending clarify button state for a gateway session."""
+        removed = 0
+        for clarify_id, state in list(self._clarify_state.items()):
+            if state.get("session_key") != session_key:
+                continue
+            self._clarify_state.pop(clarify_id, None)
+            removed += 1
+        return removed
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -1947,6 +2025,125 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+            return
+
+        # --- Clarify callbacks (cq:id:action[:value]) ---
+        if data.startswith("cq:"):
+            parts = data.split(":", 3)
+            if len(parts) < 3:
+                await query.answer(text="Invalid clarify data.")
+                return
+            try:
+                clarify_id = int(parts[1])
+            except (TypeError, ValueError):
+                await query.answer(text="Invalid clarify data.")
+                return
+
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(caller_id):
+                await query.answer(text="⛔ You are not authorized to answer clarification prompts.")
+                return
+
+            state = self._clarify_state.get(clarify_id)
+            if not state:
+                await query.answer(text="This clarification has already been resolved.")
+                return
+
+            action = parts[2]
+            payload = parts[3] if len(parts) == 4 else None
+            on_clarify_resolved = state.get("on_clarify_resolved")
+            if not callable(on_clarify_resolved):
+                self._clarify_state.pop(clarify_id, None)
+                await query.answer(text="Clarification callback missing.")
+                return
+
+            user_display = getattr(query.from_user, "first_name", "User")
+            user_display_html = _html.escape(str(user_display))
+            if action == "pick":
+                try:
+                    choice_index = int(payload or "")
+                    choice_value = state.get("choices", [])[choice_index]
+                except (ValueError, IndexError, TypeError):
+                    await query.answer(text="Invalid clarify choice.")
+                    return
+                status = on_clarify_resolved(
+                    action="select",
+                    value=choice_value,
+                    user_id=caller_id,
+                    user_name=user_display,
+                )
+                if status == "unauthorized":
+                    await query.answer(text="⛔ This prompt is waiting for someone else.")
+                    return
+                if status == "expired":
+                    self._clarify_state.pop(clarify_id, None)
+                    await query.answer(text="This clarification has already been resolved.")
+                    return
+                self._clarify_state.pop(clarify_id, None)
+                await query.answer(text="Clarification sent.")
+                try:
+                    await query.edit_message_text(
+                        text=(
+                            f"✅ Clarification answered by {user_display_html}: "
+                            f"{_html.escape(str(choice_value))}"
+                        ),
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                return
+
+            if action == "other":
+                status = on_clarify_resolved(
+                    action="other",
+                    user_id=caller_id,
+                    user_name=user_display,
+                )
+                if status == "unauthorized":
+                    await query.answer(text="⛔ This prompt is waiting for someone else.")
+                    return
+                if status == "expired":
+                    self._clarify_state.pop(clarify_id, None)
+                    await query.answer(text="This clarification has already been resolved.")
+                    return
+                await query.answer(text="Send your answer as a new message.")
+                try:
+                    await query.edit_message_text(
+                        text="✍️ Please type your answer in a new message.",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                return
+
+            if action == "cancel":
+                status = on_clarify_resolved(
+                    action="cancel",
+                    user_id=caller_id,
+                    user_name=user_display,
+                )
+                if status == "unauthorized":
+                    await query.answer(text="⛔ This prompt is waiting for someone else.")
+                    return
+                if status == "expired":
+                    self._clarify_state.pop(clarify_id, None)
+                    await query.answer(text="This clarification has already been resolved.")
+                    return
+                self._clarify_state.pop(clarify_id, None)
+                await query.answer(text="Clarification cancelled.")
+                try:
+                    await query.edit_message_text(
+                        text=f"❌ Clarification cancelled by {user_display_html}",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                return
+
+            await query.answer(text="Unknown clarification action.")
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -170,6 +170,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Inline menu state per chat
+        self._commands_menu_state: Dict[str, dict] = {}
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -1475,6 +1477,146 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    # ── /commands inline menu ──────────────────────────────────────────
+
+    _COMMANDS_PAGE_SIZE = 12
+
+    def _build_commands_keyboard(
+        self,
+        entries: list,
+        page: int,
+        page_size: int = 0,
+    ) -> tuple:
+        """Build pagination-only inline keyboard for /commands.
+
+        The command list itself stays in message text; buttons are only for
+        Prev/Next navigation and Close.
+        Returns ``(InlineKeyboardMarkup, page_info_text)``.
+        """
+        page_size = page_size or self._COMMANDS_PAGE_SIZE
+        total = len(entries)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        page = max(0, min(page, total_pages - 1))
+        start = page * page_size
+        end = min(start + page_size, total)
+
+        rows: list = []
+        if total_pages > 1:
+            nav: list = []
+            if page > 0:
+                nav.append(InlineKeyboardButton("◀ Prev", callback_data=f"cp:{page - 1}"))
+            nav.append(InlineKeyboardButton(f"{page + 1}/{total_pages}", callback_data="ci:noop"))
+            if page < total_pages - 1:
+                nav.append(InlineKeyboardButton("Next ▶", callback_data=f"cp:{page + 1}"))
+            rows.append(nav)
+
+        rows.append([InlineKeyboardButton("✗ Close", callback_data="cx")])
+        page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
+        return InlineKeyboardMarkup(rows), page_info
+
+    def _render_commands_menu_text(self, entries: list, page: int, total_pages: int) -> str:
+        """Render /commands page text as plain text for Telegram.
+
+        Skill descriptions can contain arbitrary markdown-ish content from SKILL.md
+        frontmatter. Rendering the menu in Telegram Markdown is brittle and can
+        make pagination silently fail when a later page contains malformed text.
+        """
+        page_size = self._COMMANDS_PAGE_SIZE
+        total = len(entries)
+        page = max(0, min(page, max(0, total_pages - 1)))
+        start = page * page_size
+        end = min(start + page_size, total)
+        page_entries = [str(entry or "") for entry in entries[start:end]]
+        text_lines = [
+            f"📚 Commands ({total} total, page {page + 1}/{total_pages})",
+            "",
+            *page_entries,
+        ]
+        return "\n".join(text_lines)
+
+    async def send_commands_menu(
+        self,
+        chat_id: str,
+        entries: list,
+        page: int = 0,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a paginated inline-keyboard /commands menu."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            page_size = self._COMMANDS_PAGE_SIZE
+            total_pages = max(1, (len(entries) + page_size - 1) // page_size)
+            page = max(0, min(page, total_pages - 1))
+            keyboard, _page_info = self._build_commands_keyboard(entries, page, page_size)
+            thread_id = metadata.get("thread_id") if metadata else None
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": self._render_commands_menu_text(entries, page, total_pages),
+                "parse_mode": None,
+                "reply_markup": keyboard,
+            }
+            if thread_id:
+                kwargs["message_thread_id"] = int(thread_id)
+
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            self._commands_menu_state[str(chat_id)] = {
+                "entries": entries,
+                "msg_id": msg.message_id,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_commands_menu failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_commands_callback(self, query, data: str, chat_id: str) -> None:
+        """Handle /commands inline menu callbacks."""
+        state = self._commands_menu_state.get(chat_id)
+        if not state:
+            await query.answer(text="Menu expired — use /commands again.")
+            return
+
+        expected_msg_id = state.get("msg_id")
+        actual_msg_id = getattr(getattr(query, "message", None), "message_id", None)
+        if expected_msg_id is not None and actual_msg_id != expected_msg_id:
+            await query.answer(text="Menu expired — use /commands again.")
+            return
+
+        entries = state["entries"]
+        if data.startswith("cp:"):
+            try:
+                page = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid page.")
+                return
+
+            page_size = self._COMMANDS_PAGE_SIZE
+            total_pages = max(1, (len(entries) + page_size - 1) // page_size)
+            page = max(0, min(page, total_pages - 1))
+            keyboard, _page_info = self._build_commands_keyboard(entries, page, page_size)
+            try:
+                await query.edit_message_text(
+                    text=self._render_commands_menu_text(entries, page, total_pages),
+                    parse_mode=None,
+                    reply_markup=keyboard,
+                )
+            except Exception:
+                pass
+            await query.answer()
+            return
+
+        if data == "cx":
+            self._commands_menu_state.pop(chat_id, None)
+            try:
+                await query.edit_message_text(text="📚 Commands menu closed.", reply_markup=None)
+            except Exception:
+                pass
+            await query.answer()
+            return
+
+        await query.answer()
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -1489,6 +1631,13 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- /commands menu callbacks (cp:/ci:/cx) ---
+        if data.startswith(("cp:", "ci:", "cx")):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_commands_callback(query, data, chat_id)
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2916,6 +2916,18 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "model":
                 return "Agent is running — wait or /stop first, then switch models."
 
+            # Commands that require an idle agent should bypass the adapter guard
+            # but still reject here with a helpful message instead of silently
+            # interrupting the current run.
+            _REJECT_IF_RUNNING = frozenset({
+                "retry", "undo", "title", "branch",
+                "compress", "rollback", "resume",
+                "reasoning", "fast", "personality",
+                "update", "reload-mcp",
+            })
+            if _cmd_def_inner and _cmd_def_inner.name in _REJECT_IF_RUNNING:
+                return "Agent is running — wait or /stop first."
+
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside
             # tools/approval.py — sending an interrupt won't unblock it.
@@ -2930,7 +2942,20 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
-            if event.message_type == MessageType.PHOTO:
+            # Informational/config commands should execute immediately without
+            # interrupting the active run. Let normal command dispatch below
+            # handle them.
+            _EXECUTE_IMMEDIATELY = frozenset({
+                "help", "commands", "profile", "provider",
+                "usage", "insights", "sethome", "voice",
+                "yolo", "btw",
+            })
+            if _cmd_def_inner and _cmd_def_inner.name in _EXECUTE_IMMEDIATELY:
+                logger.debug(
+                    "Busy session %s: executing '/%s' without interrupt",
+                    _quick_key[:20], _cmd_def_inner.name,
+                )
+            elif event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -2991,13 +3016,16 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
-            logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
-            running_agent.interrupt(event.text)
-            if _quick_key in self._pending_messages:
-                self._pending_messages[_quick_key] += "\n" + event.text
+            if _cmd_def_inner and _cmd_def_inner.name in _EXECUTE_IMMEDIATELY:
+                pass
             else:
-                self._pending_messages[_quick_key] = event.text
-            return None
+                logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
+                running_agent.interrupt(event.text)
+                if _quick_key in self._pending_messages:
+                    self._pending_messages[_quick_key] += "\n" + event.text
+                else:
+                    self._pending_messages[_quick_key] = event.text
+                return None
 
         # Check for commands
         command = event.get_command()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4949,11 +4949,22 @@ class GatewayRunner:
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
                 user_provs = cfg.get("providers")
-                try:
-                    from hermes_cli.config import get_compatible_custom_providers
-                    custom_provs = get_compatible_custom_providers(cfg)
-                except Exception:
-                    custom_provs = cfg.get("custom_providers")
+                # Only populate custom_provs when providers: dict is absent.
+                # When both formats exist, get_compatible_custom_providers()
+                # re-converts the same providers: entries into list format,
+                # causing list_authenticated_providers() to show duplicates
+                # (step 3 processes user_provs dict, step 4 processes the
+                # re-converted list — with different slug formats so dedup
+                # can't catch them).
+                if user_provs and isinstance(user_provs, dict):
+                    # Newer v12+ format present — use it directly
+                    custom_provs = None
+                else:
+                    try:
+                        from hermes_cli.config import get_compatible_custom_providers
+                        custom_provs = get_compatible_custom_providers(cfg)
+                    except Exception:
+                        custom_provs = cfg.get("custom_providers")
         except Exception:
             pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6409,6 +6409,232 @@ class GatewayRunner:
             else:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
+    async def _do_resume_session(self, session_key: str, source, target_id: str, name: str) -> str:
+        """Perform the actual session switch and return the confirmation text."""
+        current_entry = self.session_store.get_or_create_session(source)
+        if current_entry.session_id == target_id:
+            return f"📌 Already on session **{name}**."
+
+        try:
+            _flush_task = asyncio.create_task(
+                self._async_flush_memories(current_entry.session_id, session_key)
+            )
+            self._background_tasks.add(_flush_task)
+            _flush_task.add_done_callback(self._background_tasks.discard)
+        except Exception as e:
+            logger.debug("Memory flush on resume failed: %s", e)
+
+        if session_key in self._running_agents:
+            del self._running_agents[session_key]
+
+        new_entry = self.session_store.switch_session(session_key, target_id)
+        if not new_entry:
+            return "Failed to switch session."
+
+        title = self._session_db.get_session_title(target_id) or name
+        history = self.session_store.load_transcript(target_id)
+        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
+        msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
+        return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
+
+    def _parse_resume_command_args(self, raw_args: str) -> tuple[str, bool, bool]:
+        """Parse /resume [target] [--last|--list] arguments."""
+        if not raw_args:
+            return "", False, False
+
+        try:
+            tokens = shlex.split(raw_args)
+        except ValueError as exc:
+            raise ValueError(f"Invalid /resume arguments: {exc}") from exc
+
+        resume_last = False
+        resume_list = False
+        target_parts: list[str] = []
+        for token in tokens:
+            if token == "--last":
+                resume_last = True
+                continue
+            if token == "--list":
+                resume_list = True
+                continue
+            if token.startswith("-"):
+                raise ValueError(f"Unknown /resume flag: {token}")
+            target_parts.append(token)
+
+        if resume_last and resume_list:
+            raise ValueError("/resume accepts at most one of --last or --list.")
+        if (resume_last or resume_list) and not target_parts:
+            raise ValueError("/resume --last and --list require a target.")
+
+        return " ".join(target_parts).strip(), resume_last, resume_list
+
+    def _resume_session_label(self, session: dict) -> str:
+        """Return a deterministic plaintext label for /resume lists."""
+        title = (session.get("title") or "").strip()
+        if title:
+            return title
+
+        preview = (session.get("preview") or "").strip()
+        if preview:
+            return preview[:60]
+
+        session_id = (session.get("id") or "").strip()
+        if session_id:
+            return session_id
+
+        return "Untitled"
+
+    def _format_resume_selection_line(self, index: int, session: dict) -> str:
+        """Format a single deterministic plaintext /resume list line."""
+        session_id = (session.get("id") or "").strip()
+        label = self._resume_session_label(session)
+        if session_id and label and label != session_id:
+            return f"{index}. {session_id} | {label}"
+        if session_id:
+            return f"{index}. {session_id}"
+        return f"{index}. {label}"
+
+    def _format_resume_root_list(self, sessions: list[dict]) -> str:
+        """Format the non-Telegram /resume root-session fallback."""
+        lines = ["Resume Sessions:"]
+        lines.extend(
+            self._format_resume_selection_line(index, session)
+            for index, session in enumerate(sessions, start=1)
+        )
+        lines.append("Use: /resume <session name or id>")
+        return "\n".join(lines)
+
+    def _format_resume_chain_list(self, chain: list[dict]) -> str:
+        """Format the non-Telegram /resume --list fallback."""
+        lines = ["Resume Points:"]
+        lines.extend(
+            self._format_resume_selection_line(index, session)
+            for index, session in enumerate(chain, start=1)
+        )
+        lines.append("Use: /resume <session id>")
+        return "\n".join(lines)
+
+    def _list_resume_root_sessions(
+        self,
+        source_name: Optional[str],
+        current_session_id: Optional[str],
+        limit: int = 50,
+    ) -> list[dict]:
+        """Return root sessions for gateway /resume menus."""
+        try:
+            sessions = self._session_db.list_sessions_rich(
+                source=source_name,
+                exclude_sources=["tool"],
+                limit=limit,
+                include_children=False,
+            )
+        except TypeError:
+            sessions = self._session_db.list_sessions_rich(
+                source=source_name,
+                exclude_sources=["tool"],
+                limit=limit,
+            )
+
+        roots: list[dict] = []
+        for session in sessions or []:
+            if current_session_id and session.get("id") == current_session_id:
+                continue
+            entry = dict(session)
+            chain = self._session_db.get_compression_continuation_chain(entry["id"]) or []
+            if len(chain) > 1:
+                entry["resume_chain"] = chain
+            roots.append(entry)
+
+        roots.sort(key=lambda s: s.get("last_active") or s.get("started_at") or 0, reverse=True)
+        return roots[:limit]
+
+    async def _handle_resume_command(self, event: MessageEvent) -> str:
+        """Handle /resume command — switch to a previously-named session."""
+        if not self._session_db:
+            return "Session database not available."
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        raw_args = event.get_command_args().strip()
+        try:
+            name, resume_last, resume_list = self._parse_resume_command_args(raw_args)
+        except ValueError as exc:
+            return str(exc)
+
+        current_entry = self.session_store.get_or_create_session(source)
+        current_session_id = getattr(current_entry, "session_id", None)
+        user_source = source.platform.value if source.platform else None
+
+        if not name:
+            try:
+                sessions = self._list_resume_root_sessions(user_source, current_session_id, limit=50)
+                if not sessions:
+                    return (
+                        "No resumable sessions found.\n"
+                        "Use /title My Session to name your current session, "
+                        "then /resume <session name or id> to return to it later."
+                    )
+
+                from gateway.config import Platform
+                if source.platform == Platform.TELEGRAM:
+                    tg_adapter = self.adapters.get(Platform.TELEGRAM)
+                    if tg_adapter and hasattr(tg_adapter, "send_resume_menu"):
+                        async def on_session_resumed(session_id: str, title: str) -> str:
+                            return await self._do_resume_session(session_key, source, session_id, title)
+
+                        result = await tg_adapter.send_resume_menu(
+                            chat_id=source.chat_id,
+                            sessions=sessions,
+                            session_key=session_key,
+                            on_session_resumed=on_session_resumed,
+                            metadata={"thread_id": source.thread_id},
+                        )
+                        if result.success:
+                            return ""
+
+                return self._format_resume_root_list(sessions)
+            except Exception as e:
+                logger.debug("Failed to list resume sessions: %s", e)
+                return f"Could not list sessions: {e}"
+
+        anchor_id = self._session_db.resolve_resume_anchor(name, source=user_source)
+        if not anchor_id:
+            return (
+                f"No session found matching '**{name}**'.\n"
+                "Use `/resume` with no arguments to see available sessions."
+            )
+
+        if resume_list:
+            chain = self._session_db.get_compression_continuation_chain(anchor_id) or []
+            if len(chain) > 1:
+                from gateway.config import Platform
+                if source.platform == Platform.TELEGRAM:
+                    tg_adapter = self.adapters.get(Platform.TELEGRAM)
+                    if tg_adapter and hasattr(tg_adapter, "send_resume_menu"):
+                        async def on_session_resumed(session_id: str, title: str) -> str:
+                            return await self._do_resume_session(session_key, source, session_id, title)
+
+                        result = await tg_adapter.send_resume_menu(
+                            chat_id=source.chat_id,
+                            sessions=chain,
+                            session_key=session_key,
+                            on_session_resumed=on_session_resumed,
+                            metadata={
+                                "thread_id": source.thread_id,
+                                "resume_menu_mode": "chain",
+                            },
+                        )
+                        if result.success:
+                            return ""
+
+                return self._format_resume_chain_list(chain)
+
+        if resume_last:
+            target_id = self._session_db.get_latest_compression_continuation_id(anchor_id) or anchor_id
+        else:
+            target_id = anchor_id
+
+        return await self._do_resume_session(session_key, source, target_id, name)
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4636,6 +4636,19 @@ class GatewayRunner:
             return "No commands available."
 
         from gateway.config import Platform
+
+        if event.source.platform == Platform.TELEGRAM:
+            tg_adapter = self.adapters.get(Platform.TELEGRAM)
+            if tg_adapter and hasattr(tg_adapter, "send_commands_menu"):
+                result = await tg_adapter.send_commands_menu(
+                    chat_id=event.source.chat_id,
+                    entries=entries,
+                    page=requested_page - 1,
+                    metadata={"thread_id": event.source.thread_id},
+                )
+                if result.success:
+                    return ""
+
         page_size = 15 if event.source.platform == Platform.TELEGRAM else 20
         total_pages = max(1, (len(entries) + page_size - 1) // page_size)
         page = max(1, min(requested_page, total_pages))
@@ -6396,82 +6409,6 @@ class GatewayRunner:
             else:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
-    async def _handle_resume_command(self, event: MessageEvent) -> str:
-        """Handle /resume command — switch to a previously-named session."""
-        if not self._session_db:
-            return "Session database not available."
-
-        source = event.source
-        session_key = self._session_key_for_source(source)
-        name = event.get_command_args().strip()
-
-        if not name:
-            # List recent titled sessions for this user/platform
-            try:
-                user_source = source.platform.value if source.platform else None
-                sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
-                )
-                titled = [s for s in sessions if s.get("title")]
-                if not titled:
-                    return (
-                        "No named sessions found.\n"
-                        "Use `/title My Session` to name your current session, "
-                        "then `/resume My Session` to return to it later."
-                    )
-                lines = ["📋 **Named Sessions**\n"]
-                for s in titled[:10]:
-                    title = s["title"]
-                    preview = s.get("preview", "")[:40]
-                    preview_part = f" — _{preview}_" if preview else ""
-                    lines.append(f"• **{title}**{preview_part}")
-                lines.append("\nUsage: `/resume <session name>`")
-                return "\n".join(lines)
-            except Exception as e:
-                logger.debug("Failed to list titled sessions: %s", e)
-                return f"Could not list sessions: {e}"
-
-        # Resolve the name to a session ID
-        target_id = self._session_db.resolve_session_by_title(name)
-        if not target_id:
-            return (
-                f"No session found matching '**{name}**'.\n"
-                "Use `/resume` with no arguments to see available sessions."
-            )
-
-        # Check if already on that session
-        current_entry = self.session_store.get_or_create_session(source)
-        if current_entry.session_id == target_id:
-            return f"📌 Already on session **{name}**."
-
-        # Flush memories for current session before switching
-        try:
-            _flush_task = asyncio.create_task(
-                self._async_flush_memories(current_entry.session_id, session_key)
-            )
-            self._background_tasks.add(_flush_task)
-            _flush_task.add_done_callback(self._background_tasks.discard)
-        except Exception as e:
-            logger.debug("Memory flush on resume failed: %s", e)
-
-        # Clear any running agent for this session key
-        if session_key in self._running_agents:
-            del self._running_agents[session_key]
-
-        # Switch the session entry to point at the old session
-        new_entry = self.session_store.switch_session(session_key, target_id)
-        if not new_entry:
-            return "Failed to switch session."
-
-        # Get the title for confirmation
-        title = self._session_db.get_session_title(target_id) or name
-
-        # Count messages for context
-        history = self.session_store.load_transcript(target_id)
-        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
-        msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
-
-        return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -641,6 +641,12 @@ class GatewayRunner:
         # Key: session_key, Value: True when a prompt is waiting for user input.
         self._update_prompt_pending: Dict[str, bool] = {}
 
+        # Track pending clarify prompts per session. Entries are mutated by the
+        # gateway event loop (Telegram callback queries / user replies) while the
+        # agent thread blocks on a threading.Event waiting for the answer.
+        self._pending_clarify: Dict[str, Dict[str, Any]] = {}
+        self._pending_clarify_lock = _threading.Lock()
+
         # Persistent Honcho managers keyed by gateway session key.
         # This preserves write_frequency="session" semantics across short-lived
         # per-message AIAgent instances.
@@ -1368,6 +1374,217 @@ class GatewayRunner:
             if agent is not _AGENT_PENDING_SENTINEL
         }
 
+    def _resolve_gateway_clarify_action(
+        self,
+        session_key: str,
+        *,
+        action: str,
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        value: Optional[str] = None,
+    ) -> str:
+        """Resolve or update a pending clarify prompt from a gateway UI event."""
+        lock = getattr(self, "_pending_clarify_lock", None)
+        pending_map = getattr(self, "_pending_clarify", None)
+        if lock is None or pending_map is None:
+            return "expired"
+
+        with lock:
+            pending = pending_map.get(session_key)
+            if not pending:
+                return "expired"
+            expected_user = pending.get("user_id")
+            if expected_user and user_id and str(expected_user) != str(user_id):
+                return "unauthorized"
+
+            pending["last_user_id"] = user_id
+            pending["last_user_name"] = user_name
+
+            if action == "other":
+                pending["awaiting_text"] = True
+                return "awaiting_text"
+
+            if action == "cancel":
+                pending["response"] = pending.get(
+                    "cancel_response",
+                    "(clarify cancelled by user — continue without more input)",
+                )
+                pending["cancelled"] = True
+                pending["resolved"] = True
+                pending.get("event").set()
+                return "cancelled"
+
+            if action != "select":
+                return "invalid"
+
+            response = value if value is not None else pending.get(
+                "default_response",
+                "(clarify resolved without explicit value)",
+            )
+            pending["response"] = response
+            pending["resolved"] = True
+            pending["event"].set()
+            return "resolved"
+
+    def _map_clarify_text_response(self, raw: str, choices: list[str]) -> Optional[str]:
+        text = (raw or "").strip()
+        if not text:
+            return None
+        if text.isdigit():
+            index = int(text) - 1
+            if 0 <= index < len(choices):
+                return choices[index]
+        lowered = text.casefold()
+        for choice in choices:
+            if lowered == str(choice).strip().casefold():
+                return choice
+        return text
+
+    def _handle_pending_clarify_response(self, event: MessageEvent) -> Optional[str]:
+        session_key = self._session_key_for_source(event.source)
+        lock = getattr(self, "_pending_clarify_lock", None)
+        pending_map = getattr(self, "_pending_clarify", None)
+        if lock is None or pending_map is None:
+            return None
+
+        with lock:
+            pending = pending_map.get(session_key)
+            if not pending:
+                return None
+            if pending.get("resolved") or pending.get("cancelled"):
+                return None
+            expected_user = pending.get("user_id")
+            actual_user = getattr(event.source, "user_id", None)
+            if expected_user and actual_user and str(expected_user) != str(actual_user):
+                return "⛔ This clarification prompt is waiting for the original requester."
+
+            raw = (event.text or "").strip()
+            if not raw:
+                return "✗ Please reply with your clarification."
+
+            choices = pending.get("choices") or []
+            response = self._map_clarify_text_response(raw, choices) if choices else raw
+            pending["response"] = response
+            pending["resolved"] = True
+            pending["awaiting_text"] = False
+            pending["last_user_id"] = actual_user
+            pending["last_user_name"] = getattr(event.source, "user_name", None)
+            pending["event"].set()
+
+        adapter = self.adapters.get(event.source.platform)
+        if adapter and hasattr(adapter, "clear_clarify"):
+            try:
+                adapter.clear_clarify(session_key)
+            except Exception as exc:
+                logger.debug("clear_clarify failed for %s: %s", session_key, exc)
+
+        preview = str(response)
+        if len(preview) > 60:
+            preview = preview[:57] + "..."
+        return f"✓ Clarification received: `{preview}`"
+
+    def _build_gateway_clarify_callback(
+        self,
+        *,
+        adapter,
+        source: SessionSource,
+        session_key: str,
+        loop: asyncio.AbstractEventLoop,
+        metadata: Optional[Dict[str, Any]] = None,
+        timeout_seconds: float = 120.0,
+    ):
+        """Return a blocking clarify callback for gateway-backed agents."""
+
+        def _clarify_sync(question: str, choices: Optional[list[str]] = None) -> str:
+            choices_list = list(choices or [])
+            response_event = threading.Event()
+            pending_entry = {
+                "event": response_event,
+                "question": question,
+                "choices": choices_list,
+                "response": None,
+                "awaiting_text": not bool(choices_list),
+                "user_id": getattr(source, "user_id", None),
+                "chat_id": getattr(source, "chat_id", None),
+                "thread_id": getattr(source, "thread_id", None),
+            }
+
+            with self._pending_clarify_lock:
+                self._pending_clarify[session_key] = pending_entry
+
+            def _on_clarify_resolved(*, action: str, value: Optional[str] = None,
+                                     user_id: Optional[str] = None,
+                                     user_name: Optional[str] = None) -> str:
+                return self._resolve_gateway_clarify_action(
+                    session_key,
+                    action=action,
+                    value=value,
+                    user_id=user_id,
+                    user_name=user_name,
+                )
+
+            prompt_sent = False
+            if choices_list and getattr(type(adapter), "send_clarify", None) is not None:
+                try:
+                    send_result = asyncio.run_coroutine_threadsafe(
+                        adapter.send_clarify(
+                            chat_id=source.chat_id,
+                            question=question,
+                            choices=choices_list,
+                            session_key=session_key,
+                            on_clarify_resolved=_on_clarify_resolved,
+                            metadata=metadata,
+                        ),
+                        loop,
+                    ).result(timeout=15)
+                    prompt_sent = bool(getattr(send_result, "success", False))
+                except Exception as exc:
+                    logger.warning("Gateway clarify prompt send_clarify failed: %s", exc)
+
+            if not prompt_sent:
+                lines = ["❓ Clarification needed", "", question]
+                if choices_list:
+                    lines.append("")
+                    lines.extend(f"{idx}. {choice}" for idx, choice in enumerate(choices_list, start=1))
+                    lines.append("")
+                    lines.append("Reply with a button choice, a number, or free text.")
+                else:
+                    lines.append("")
+                    lines.append("Reply with your answer in a new message.")
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        adapter.send(
+                            source.chat_id,
+                            "\n".join(lines),
+                            metadata=metadata,
+                        ),
+                        loop,
+                    ).result(timeout=15)
+                except Exception as exc:
+                    logger.error("Failed to send fallback clarify prompt: %s", exc)
+
+            if not response_event.wait(timeout_seconds):
+                with self._pending_clarify_lock:
+                    current = self._pending_clarify.get(session_key)
+                    if current is pending_entry:
+                        self._pending_clarify.pop(session_key, None)
+                if hasattr(adapter, "clear_clarify"):
+                    try:
+                        adapter.clear_clarify(session_key)
+                    except Exception as exc:
+                        logger.debug("clear_clarify failed for %s after timeout: %s", session_key, exc)
+                return f"(clarify timed out after {int(timeout_seconds)}s — continue with best judgment)"
+
+            with self._pending_clarify_lock:
+                current = self._pending_clarify.get(session_key)
+                response = current.get("response") if current is pending_entry else pending_entry.get("response")
+                if current is pending_entry:
+                    self._pending_clarify.pop(session_key, None)
+
+            return response or "(clarify resolved without explicit response)"
+
+        return _clarify_sync
+
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
@@ -1407,6 +1624,23 @@ class GatewayRunner:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return False  # let default path handle it
+
+        # Clarify follow-up replies are expected while the agent is still blocked
+        # inside clarify(). Consume them directly instead of routing them through
+        # the generic busy-session interrupt path.
+        clarify_reply = self._handle_pending_clarify_response(event)
+        if clarify_reply is not None:
+            thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            try:
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=clarify_reply,
+                    reply_to=event.message_id,
+                    metadata=thread_meta,
+                )
+            except Exception as e:
+                logger.debug("Failed to send clarify reply while busy: %s", e)
+            return True
 
         # Store the message so it's processed as the next turn after the
         # interrupt causes the current run to exit.
@@ -2782,6 +3016,10 @@ class GatewayRunner:
                 _update_prompts.pop(_quick_key, None)
                 label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
                 return f"✓ Sent `{label}` to the update process."
+
+        _clarify_reply = self._handle_pending_clarify_response(event)
+        if _clarify_reply is not None:
+            return _clarify_reply
 
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
@@ -8707,6 +8945,13 @@ class GatewayRunner:
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
+            _clarify_callback_sync = self._build_gateway_clarify_callback(
+                adapter=_status_adapter,
+                source=source,
+                session_key=session_key,
+                loop=_loop_for_step,
+                metadata=_status_thread_metadata,
+            )
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None
             _stream_delta_cb = None
@@ -8843,6 +9088,7 @@ class GatewayRunner:
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    clarify_callback=_clarify_callback_sync,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
@@ -8856,6 +9102,7 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            agent.clarify_callback = _clarify_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -93,8 +93,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
-    CommandDef("resume", "Resume a previously-named session", "Session",
-               args_hint="[name]"),
+    CommandDef("resume", "Browse or resume a previous session", "Session",
+               args_hint="[target] [--last|--list]"),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -648,26 +648,18 @@ def _exec_in_container(container_info: dict, cli_args: list):
 
 
 def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
-    """Resolve a session name (title) or ID to a session ID.
+    """Resolve a session name (title lineage) or ID to a concrete session ID.
 
-    - If it looks like a session ID (contains underscore + hex), try direct lookup first.
-    - Otherwise, treat it as a title and use resolve_session_by_title (auto-latest).
-    - Falls back to the other method if the first doesn't match.
+    Uses explicit anchor semantics for ``--resume``/``/resume``: exact session ID
+    first, then title/numbered-title lineage, then unique ID prefix.
     """
     try:
         from hermes_state import SessionDB
         db = SessionDB()
-
-        # Try as exact session ID first
-        session = db.get_session(name_or_id)
-        if session:
+        try:
+            return db.resolve_resume_anchor(name_or_id)
+        finally:
             db.close()
-            return session["id"]
-
-        # Try as title (with auto-latest for lineage)
-        session_id = db.resolve_session_by_title(name_or_id)
-        db.close()
-        return session_id
     except Exception:
         pass
     return None
@@ -675,6 +667,17 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
 
 def cmd_chat(args):
     """Run interactive chat CLI."""
+    resume_last = bool(getattr(args, "last", False))
+    resume_list = bool(getattr(args, "resume_list", False))
+
+    if resume_last and resume_list:
+        print("Error: --last and --list cannot be used together.")
+        sys.exit(2)
+
+    if (resume_last or resume_list) and not getattr(args, "resume", None):
+        print("Error: --last and --list require --resume <target>.")
+        sys.exit(2)
+
     # Resolve --continue into --resume with the latest CLI session or by name
     continue_val = getattr(args, "continue_last", None)
     if continue_val and not getattr(args, "resume", None):
@@ -696,12 +699,36 @@ def cmd_chat(args):
                 print("No previous CLI session found to continue.")
                 sys.exit(1)
 
-    # Resolve --resume by title if it's not a direct session ID
+    # Resolve --resume by title or prefix without auto-following compression.
     resume_val = getattr(args, "resume", None)
     if resume_val:
         resolved = _resolve_session_by_name_or_id(resume_val)
         if resolved:
             args.resume = resolved
+
+        if resume_last or resume_list:
+            try:
+                from hermes_state import SessionDB
+                db = SessionDB()
+                try:
+                    anchor_id = args.resume
+                    if resume_last:
+                        latest_id = db.get_latest_compression_continuation_id(anchor_id)
+                        if latest_id:
+                            args.resume = latest_id
+                    elif resume_list:
+                        chain = db.get_compression_continuation_chain(anchor_id)
+                        if len(chain) > 1:
+                            selected_id = _session_browse_picker(chain)
+                            if not selected_id:
+                                print("Resume cancelled.")
+                                return
+                            args.resume = selected_id
+                finally:
+                    db.close()
+            except Exception as exc:
+                print(f"Could not resolve resume target: {exc}")
+                sys.exit(1)
         # If resolution fails, keep the original value — _init_agent will
         # report "Session not found" with the original input
 
@@ -4815,6 +4842,19 @@ For more help on a command:
         help="Resume a previous session by ID or title"
     )
     parser.add_argument(
+        "--last",
+        action="store_true",
+        default=False,
+        help="With --resume, follow the target's compression chain to the latest continuation"
+    )
+    parser.add_argument(
+        "--list",
+        dest="resume_list",
+        action="store_true",
+        default=False,
+        help="With --resume, choose from the target's compression continuation chain"
+    )
+    parser.add_argument(
         "--continue", "-c",
         dest="continue_last",
         nargs="?",
@@ -4900,7 +4940,20 @@ For more help on a command:
         "--resume", "-r",
         metavar="SESSION_ID",
         default=argparse.SUPPRESS,
-        help="Resume a previous session by ID (shown on exit)"
+        help="Resume a previous session by ID or title"
+    )
+    chat_parser.add_argument(
+        "--last",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="With --resume, follow the target's compression chain to the latest continuation"
+    )
+    chat_parser.add_argument(
+        "--list",
+        dest="resume_list",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="With --resume, choose from the target's compression continuation chain"
     )
     chat_parser.add_argument(
         "--continue", "-c",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -641,12 +641,17 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(self, title: str, source: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
-            )
+            if source:
+                cursor = self._conn.execute(
+                    "SELECT * FROM sessions WHERE title = ? AND source = ?", (title, source)
+                )
+            else:
+                cursor = self._conn.execute(
+                    "SELECT * FROM sessions WHERE title = ?", (title,)
+                )
             row = cursor.fetchone()
         return dict(row) if row else None
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -650,6 +650,111 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_compression_continuation_chain(self, session_id: str, max_hops: int = 100) -> List[Dict[str, Any]]:
+        """Return the anchor session followed by its compression continuation chain.
+
+        Traversal follows the current storage invariant used elsewhere in Hermes:
+        only continue while the current row has ``end_reason='compression'`` and,
+        when multiple children exist, pick the most recent child by
+        ``started_at DESC, id DESC``.
+        """
+        current = self.get_session(session_id)
+        if not current:
+            return []
+
+        chain: List[Dict[str, Any]] = []
+        visited: set[str] = set()
+
+        for _ in range(max_hops):
+            current_id = current["id"]
+            if current_id in visited:
+                break
+            visited.add(current_id)
+            chain.append(current)
+
+            if current.get("end_reason") != "compression":
+                break
+
+            with self._lock:
+                cursor = self._conn.execute(
+                    "SELECT id FROM sessions WHERE parent_session_id = ? "
+                    "ORDER BY started_at DESC, id DESC LIMIT 1",
+                    (current_id,),
+                )
+                row = cursor.fetchone()
+            if not row:
+                break
+
+            next_session = self.get_session(row["id"])
+            if not next_session:
+                break
+            current = next_session
+
+        return chain
+
+    def get_latest_compression_continuation_id(self, session_id: str) -> Optional[str]:
+        """Follow a compression continuation chain and return the latest session ID."""
+        chain = self.get_compression_continuation_chain(session_id)
+        if not chain:
+            return None
+        return chain[-1]["id"]
+
+    def resolve_resume_anchor(self, name_or_id: str, source: Optional[str] = None) -> Optional[str]:
+        """Resolve a resume target to its anchor row without auto-following compression.
+
+        Precedence:
+        1. exact session ID
+        2. exact title / numbered-title lineage
+        3. unique session ID prefix
+        """
+        session = self.get_session(name_or_id)
+        if session and (not source or session.get("source") == source):
+            return session["id"]
+
+        exact = self.get_session_by_title(name_or_id, source=source)
+        escaped = name_or_id.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        title_query = (
+            "SELECT id FROM sessions WHERE title LIKE ? ESCAPE '\\'"
+            + (" AND source = ?" if source else "")
+            + " ORDER BY started_at DESC"
+        )
+        title_params = [f"{escaped} #%"]
+        if source:
+            title_params.append(source)
+        with self._lock:
+            cursor = self._conn.execute(title_query, tuple(title_params))
+            numbered = cursor.fetchall()
+
+        if numbered:
+            return numbered[0]["id"]
+        if exact:
+            return exact["id"]
+
+        prefix_query = "SELECT id FROM sessions WHERE id LIKE ? ESCAPE '\\'"
+        prefix_params = [f"{escaped}%"]
+        if source:
+            prefix_query += " AND source = ?"
+            prefix_params.append(source)
+        prefix_query += " ORDER BY started_at DESC, id DESC LIMIT 2"
+        with self._lock:
+            cursor = self._conn.execute(prefix_query, tuple(prefix_params))
+            rows = cursor.fetchall()
+        if len(rows) == 1:
+            return rows[0]["id"]
+        return None
+
+    def resolve_resume_target(self, name_or_id: str, source: Optional[str] = None) -> Optional[str]:
+        """Resolve a /resume argument to the latest resumable session row.
+
+        Supports exact/unique-prefix session IDs and titles. When the matched
+        session has been continued through compression, returns the newest child
+        continuation instead of the stale parent row.
+        """
+        anchor_id = self.resolve_resume_anchor(name_or_id, source=source)
+        if not anchor_id:
+            return None
+        return self.get_latest_compression_continuation_id(anchor_id)
+
     def resolve_session_by_title(self, title: str) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -238,9 +238,8 @@ class TestHistoryDisplay:
         }.get(sid)
         cli._session_db.get_messages_as_conversation.return_value = []
 
-        import hermes_cli.main as main_mod
-        with patch.object(main_mod, "_session_browse_picker", side_effect=["root", "child"]):
-            cli._handle_resume_command("/resume")
+        cli._run_session_browse_picker = MagicMock(side_effect=["root", "child"])
+        cli._handle_resume_command("/resume")
 
         output = capsys.readouterr().out
         assert "Recent sessions" not in output
@@ -254,9 +253,8 @@ class TestHistoryDisplay:
             {"id": "root", "title": "Checking Running Hermes Agent", "preview": "check running gateways", "last_active": 0, "parent_session_id": None},
         ]
 
-        import hermes_cli.main as main_mod
-        with patch.object(main_mod, "_session_browse_picker", return_value=None):
-            cli._handle_resume_command("/resume")
+        cli._run_session_browse_picker = MagicMock(return_value=None)
+        cli._handle_resume_command("/resume")
 
         output = capsys.readouterr().out
         assert "Recent sessions" not in output
@@ -268,11 +266,10 @@ class TestHistoryDisplay:
         cli._session_db = MagicMock()
         cli._session_db.list_sessions_rich.return_value = []
 
-        import hermes_cli.main as main_mod
-        with patch.object(main_mod, "_session_browse_picker") as picker_mock:
-            cli._handle_resume_command("/resume")
+        cli._run_session_browse_picker = MagicMock()
+        cli._handle_resume_command("/resume")
 
-        picker_mock.assert_not_called()
+        cli._run_session_browse_picker.assert_not_called()
         assert cli.session_id == "current"
 
     def test_resume_last_flag_before_target_resumes_latest_chain_leaf(self):
@@ -307,8 +304,8 @@ class TestHistoryDisplay:
         cli._session_db.get_messages_as_conversation.return_value = []
 
         import hermes_cli.main as main_mod
-        with patch.object(main_mod, "_resolve_session_by_name_or_id", side_effect=lambda target: "root" if target == "My Project" else None), \
-             patch.object(main_mod, "_session_browse_picker", return_value="child"):
+        cli._run_session_browse_picker = MagicMock(return_value="child")
+        with patch.object(main_mod, "_resolve_session_by_name_or_id", side_effect=lambda target: "root" if target == "My Project" else None):
             cli._handle_resume_command("/resume My Project --list")
 
         assert cli.session_id == "child"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -3,7 +3,7 @@ that only manifest at runtime (not in mocked unit tests)."""
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -219,31 +219,99 @@ class TestHistoryDisplay:
         assert "/resume" in output
         assert "Current preview" not in output
 
-    def test_resume_without_target_lists_recent_sessions(self, capsys):
+    def test_resume_without_target_uses_picker_for_root_sessions(self, capsys):
         cli = _make_cli()
         cli.session_id = "current"
         cli._session_db = MagicMock()
         cli._session_db.list_sessions_rich.return_value = [
-            {
-                "id": "current",
-                "title": "Current",
-                "preview": "Current preview",
-                "last_active": 0,
-            },
-            {
-                "id": "20260401_201329_d85961",
-                "title": "Checking Running Hermes Agent",
-                "preview": "check running gateways for hermes agent",
-                "last_active": 0,
-            },
+            {"id": "current", "title": "Current", "preview": "Current preview", "last_active": 0, "parent_session_id": None},
+            {"id": "root", "title": "Checking Running Hermes Agent", "preview": "check running gateways", "last_active": 0, "parent_session_id": None},
+            {"id": "child", "title": None, "preview": "compressed tail", "last_active": 0, "parent_session_id": "root"},
+        ]
+        cli._session_db.get_compression_continuation_chain.return_value = [
+            {"id": "root", "title": "Checking Running Hermes Agent", "preview": "check running gateways", "last_active": 0, "parent_session_id": None},
+            {"id": "child", "title": None, "preview": "compressed tail", "last_active": 0, "parent_session_id": "root"},
+        ]
+        cli._session_db.get_session.side_effect = lambda sid: {
+            "root": {"id": "root", "title": "Checking Running Hermes Agent"},
+            "child": {"id": "child", "title": None},
+        }.get(sid)
+        cli._session_db.get_messages_as_conversation.return_value = []
+
+        import hermes_cli.main as main_mod
+        with patch.object(main_mod, "_session_browse_picker", side_effect=["root", "child"]):
+            cli._handle_resume_command("/resume")
+
+        output = capsys.readouterr().out
+        assert "Recent sessions" not in output
+        assert cli.session_id == "child"
+
+    def test_resume_without_target_cancel_leaves_session_untouched(self, capsys):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {"id": "root", "title": "Checking Running Hermes Agent", "preview": "check running gateways", "last_active": 0, "parent_session_id": None},
         ]
 
-        cli._handle_resume_command("/resume")
-        output = capsys.readouterr().out
+        import hermes_cli.main as main_mod
+        with patch.object(main_mod, "_session_browse_picker", return_value=None):
+            cli._handle_resume_command("/resume")
 
-        assert "Recent sessions" in output
-        assert "Checking Running Hermes Agent" in output
-        assert "Use /resume <session id or title> to continue" in output
+        output = capsys.readouterr().out
+        assert "Recent sessions" not in output
+        assert cli.session_id == "current"
+
+    def test_resume_without_target_when_no_roots_shows_tip(self):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = []
+
+        import hermes_cli.main as main_mod
+        with patch.object(main_mod, "_session_browse_picker") as picker_mock:
+            cli._handle_resume_command("/resume")
+
+        picker_mock.assert_not_called()
+        assert cli.session_id == "current"
+
+    def test_resume_last_flag_before_target_resumes_latest_chain_leaf(self):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.get_latest_compression_continuation_id.return_value = "child"
+        cli._session_db.get_session.side_effect = lambda sid: {
+            "child": {"id": "child", "title": "My Project #2"},
+            "root": {"id": "root", "title": "My Project"},
+        }.get(sid)
+        cli._session_db.get_messages_as_conversation.return_value = []
+
+        import hermes_cli.main as main_mod
+        with patch.object(main_mod, "_resolve_session_by_name_or_id", side_effect=lambda target: "root" if target == "My Project" else None):
+            cli._handle_resume_command("/resume --last My Project")
+
+        assert cli.session_id == "child"
+
+    def test_resume_list_flag_after_target_uses_chain_picker(self):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.get_compression_continuation_chain.return_value = [
+            {"id": "root", "title": "My Project", "preview": "", "last_active": 0},
+            {"id": "child", "title": None, "preview": "compressed tail", "last_active": 0},
+        ]
+        cli._session_db.get_session.side_effect = lambda sid: {
+            "child": {"id": "child", "title": None},
+            "root": {"id": "root", "title": "My Project"},
+        }.get(sid)
+        cli._session_db.get_messages_as_conversation.return_value = []
+
+        import hermes_cli.main as main_mod
+        with patch.object(main_mod, "_resolve_session_by_name_or_id", side_effect=lambda target: "root" if target == "My Project" else None), \
+             patch.object(main_mod, "_session_browse_picker", return_value="child"):
+            cli._handle_resume_command("/resume My Project --list")
+
+        assert cli.session_id == "child"
 
 
 class TestRootLevelProviderOverride:

--- a/tests/gateway/test_active_session_busy_commands.py
+++ b/tests/gateway/test_active_session_busy_commands.py
@@ -1,0 +1,133 @@
+"""Runner-level tests for slash commands while an agent is already running."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class _PendingAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="tester",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: _PendingAdapter()}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._pending_model_notes = {}
+    runner._update_prompt_pending = {}
+    runner._voice_mode = {}
+    runner._draining = False
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._session_db = MagicMock()
+    runner.session_store = MagicMock()
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=[])
+    runner.pairing_store = MagicMock()
+    runner._is_user_authorized = lambda _source: True
+    runner._queue_during_drain_enabled = lambda: False
+    return runner
+
+
+class TestBusySessionExecImmediateCommands:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("cmd", "canonical", "handler_attr"),
+        [
+            ("/help", "help", "_handle_help_command"),
+            ("/commands", "commands", "_handle_commands_command"),
+            ("/profile", "profile", "_handle_profile_command"),
+            ("/provider", "provider", "_handle_provider_command"),
+            ("/usage", "usage", "_handle_usage_command"),
+            ("/insights", "insights", "_handle_insights_command"),
+            ("/sethome", "sethome", "_handle_set_home_command"),
+            ("/set-home", "sethome", "_handle_set_home_command"),
+            ("/voice", "voice", "_handle_voice_command"),
+            ("/yolo", "yolo", "_handle_yolo_command"),
+            ("/btw side question", "btw", "_handle_btw_command"),
+        ],
+    )
+    async def test_exec_immediate_command_returns_without_interrupt(self, cmd, canonical, handler_attr):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        setattr(runner, handler_attr, AsyncMock(return_value=f"handled:{canonical}"))
+
+        result = await runner._handle_message(_make_event(cmd))
+
+        assert result == f"handled:{canonical}"
+        running_agent.interrupt.assert_not_called()
+        assert runner._pending_messages == {}
+
+
+class TestBusySessionRejectCommands:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            ("/model", "Agent is running — wait or /stop first, then switch models."),
+            ("/retry", "Agent is running — wait or /stop first."),
+            ("/undo", "Agent is running — wait or /stop first."),
+            ("/title", "Agent is running — wait or /stop first."),
+            ("/branch", "Agent is running — wait or /stop first."),
+            ("/fork", "Agent is running — wait or /stop first."),
+            ("/compress", "Agent is running — wait or /stop first."),
+            ("/rollback", "Agent is running — wait or /stop first."),
+            ("/resume", "Agent is running — wait or /stop first."),
+            ("/reasoning", "Agent is running — wait or /stop first."),
+            ("/fast", "Agent is running — wait or /stop first."),
+            ("/personality", "Agent is running — wait or /stop first."),
+            ("/update", "Agent is running — wait or /stop first."),
+            ("/reload-mcp", "Agent is running — wait or /stop first."),
+            ("/reload_mcp", "Agent is running — wait or /stop first."),
+        ],
+    )
+    async def test_reject_command_returns_helpful_message_without_interrupt(self, cmd, expected):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = build_session_key(source)
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+
+        result = await runner._handle_message(_make_event(cmd))
+
+        assert result == expected
+        running_agent.interrupt.assert_not_called()
+        assert runner._pending_messages == {}

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -58,6 +58,7 @@ def _make_event(text="hello", chat_id="123", platform_val="telegram"):
 def _make_runner():
     """Build a minimal GatewayRunner-like object for testing."""
     from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+    import threading
 
     runner = object.__new__(GatewayRunner)
     runner._running_agents = {}
@@ -70,6 +71,9 @@ def _make_runner():
     runner.session_store = None
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()
+    runner._pending_clarify = {}
+    runner._pending_clarify_lock = threading.Lock()
+    runner._session_key_for_source = lambda source: build_session_key(source)
     return runner, _AGENT_PENDING_SENTINEL
 
 
@@ -277,6 +281,39 @@ class TestBusySessionAck:
         assert result is True
         # Should still send ack
         adapter._send_with_retry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_pending_clarify_text_reply_does_not_interrupt_agent(self):
+        """When clarify is awaiting typed input, consume the reply instead of busy-interrupting."""
+        runner, sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="my custom answer")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+        clarify_event = MagicMock()
+        runner._pending_clarify[sk] = {
+            "event": clarify_event,
+            "user_id": event.source.user_id,
+            "choices": ["Option A", "Option B"],
+            "awaiting_text": True,
+            "response": None,
+        }
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+        adapter._send_with_retry.assert_called_once()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Clarification received" in content
+        assert runner._pending_clarify[sk]["response"] == "my custom answer"
+        clarify_event.set.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_no_adapter_falls_through(self):

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -327,3 +327,63 @@ class TestBypassWithBotnameSuffix:
 
         assert sk not in adapter._pending_messages
         assert any("handled:new" in r for r in adapter.sent_responses)
+
+
+# ---------------------------------------------------------------------------
+# Tests: expanded busy-session bypass coverage
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteImmediatelyCommands:
+    """Commands that should bypass and execute even while agent is running."""
+
+    EXEC_IMMEDIATE = [
+        "help", "commands", "profile", "provider",
+        "usage", "insights", "sethome", "set-home",
+        "voice", "yolo", "btw", "queue",
+        "model", "bg",
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cmd", EXEC_IMMEDIATE)
+    async def test_exec_immediate_bypasses_guard(self, cmd):
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        payload = f"/{cmd} test payload" if cmd in {"queue", "q", "bg"} else f"/{cmd}"
+        await adapter.handle_message(_make_event(payload))
+
+        assert sk not in adapter._pending_messages, (
+            f"/{cmd} was queued as pending instead of being dispatched"
+        )
+        assert any(f"handled:{cmd}" in r for r in adapter.sent_responses), (
+            f"/{cmd} response was not sent back to the user"
+        )
+
+
+class TestRejectWithMessageCommands:
+    """Commands that should bypass the adapter guard even though the runner will reject them."""
+
+    REJECT_COMMANDS = [
+        "retry", "undo", "title", "branch", "fork",
+        "compress", "rollback", "resume",
+        "reasoning", "fast", "personality",
+        "update", "reload-mcp", "reload_mcp",
+    ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cmd", REJECT_COMMANDS)
+    async def test_reject_command_bypasses_guard(self, cmd):
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event(f"/{cmd}"))
+
+        assert sk not in adapter._pending_messages, (
+            f"/{cmd} was queued as pending instead of being dispatched"
+        )
+        assert any(f"handled:{cmd}" in r for r in adapter.sent_responses), (
+            f"/{cmd} response was not sent back to the user"
+        )

--- a/tests/gateway/test_commands_command.py
+++ b/tests/gateway/test_commands_command.py
@@ -1,0 +1,60 @@
+"""Tests for /commands handler Telegram inline-menu behavior."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.session import SessionSource
+
+
+def _make_event(text="/commands", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._running_agents = {}
+    return runner
+
+
+class TestHandleCommandsCommand:
+    @pytest.mark.asyncio
+    async def test_telegram_uses_inline_menu_when_available(self):
+        runner = _make_runner()
+        event = _make_event(text="/commands")
+        tg_adapter = MagicMock()
+        tg_adapter.send_commands_menu = AsyncMock(return_value=SendResult(success=True, message_id="42"))
+        runner.adapters[Platform.TELEGRAM] = tg_adapter
+
+        result = await runner._handle_commands_command(event)
+
+        assert result == ""
+        tg_adapter.send_commands_menu.assert_called_once()
+        kwargs = tg_adapter.send_commands_menu.call_args.kwargs
+        assert kwargs["chat_id"] == "67890"
+        assert kwargs["page"] == 0
+        assert kwargs["metadata"] == {"thread_id": None}
+        assert any("`/help`" in entry for entry in kwargs["entries"])
+
+    @pytest.mark.asyncio
+    async def test_non_telegram_keeps_text_fallback(self):
+        runner = _make_runner()
+        event = _make_event(text="/commands", platform=Platform.DISCORD)
+
+        result = await runner._handle_commands_command(event)
+
+        assert "Commands" in result
+        assert "`/new`" in result

--- a/tests/gateway/test_gateway_clarify.py
+++ b/tests/gateway/test_gateway_clarify.py
@@ -1,0 +1,235 @@
+"""Tests for gateway Clarify handling on messaging platforms."""
+
+import asyncio
+import sys
+import types
+from threading import Event, Lock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+class _CapturingAgent:
+    """Fake agent that records init kwargs for assertions."""
+
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _DummyAdapter:
+    SUPPORTS_MESSAGE_EDITING = False
+
+    def __init__(self):
+        self.sent = []
+        self._pending_messages = {}
+        self.cleared_clarify = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.sent.append((chat_id, content, metadata))
+        return MagicMock(success=True, message_id="1")
+
+    async def edit_message(self, chat_id, message_id, content, metadata=None):
+        return MagicMock(success=True, message_id=message_id)
+
+    def clear_clarify(self, session_key):
+        self.cleared_clarify.append(session_key)
+        return 1
+
+    def get_pending_message(self, session_key):
+        return None
+
+    def has_pending_interrupt(self, session_key):
+        return False
+
+    def clear_interrupt(self, session_key):
+        return None
+
+
+def _make_source(user_id="user-1", chat_id="12345", thread_id=None):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_name="Telegram",
+        chat_type="dm",
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+
+
+def _make_event(text: str, user_id="user-1", chat_id="12345", thread_id=None):
+    return MessageEvent(text=text, source=_make_source(user_id=user_id, chat_id=chat_id, thread_id=thread_id))
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: _DummyAdapter()}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_clarify = {}
+    runner._pending_clarify_lock = Lock()
+    runner._session_db = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._session_key_for_source = lambda source: f"telegram:{source.chat_id}:{source.thread_id or 'root'}"
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_assigns_gateway_clarify_callback(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    _CapturingAgent.last_init = None
+    runner = _make_runner()
+
+    result = await runner._run_agent(
+        message="ping",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="telegram:12345:root",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert callable(_CapturingAgent.last_init["clarify_callback"])
+
+
+def test_resolve_gateway_clarify_action_other_keeps_prompt_pending():
+    runner = _make_runner()
+    event = Event()
+    runner._pending_clarify["telegram:12345:root"] = {
+        "event": event,
+        "user_id": "user-1",
+        "choices": ["Red", "Blue"],
+        "awaiting_text": False,
+        "response": None,
+    }
+
+    status = runner._resolve_gateway_clarify_action(
+        "telegram:12345:root",
+        action="other",
+        user_id="user-1",
+        user_name="Rahim",
+    )
+
+    assert status == "awaiting_text"
+    assert runner._pending_clarify["telegram:12345:root"]["awaiting_text"] is True
+    assert event.is_set() is False
+
+
+def test_handle_pending_clarify_response_maps_numeric_choice():
+    runner = _make_runner()
+    event = Event()
+    runner._pending_clarify["telegram:12345:root"] = {
+        "event": event,
+        "user_id": "user-1",
+        "choices": ["Red", "Blue"],
+        "awaiting_text": False,
+        "response": None,
+    }
+
+    reply = runner._handle_pending_clarify_response(_make_event("2"))
+
+    assert "Clarification received" in reply
+    assert event.is_set() is True
+    assert runner._pending_clarify["telegram:12345:root"]["response"] == "Blue"
+    assert runner.adapters[Platform.TELEGRAM].cleared_clarify == ["telegram:12345:root"]
+
+
+def test_handle_pending_clarify_response_rejects_wrong_user():
+    runner = _make_runner()
+    event = Event()
+    runner._pending_clarify["telegram:12345:root"] = {
+        "event": event,
+        "user_id": "user-1",
+        "choices": ["Red", "Blue"],
+        "awaiting_text": False,
+        "response": None,
+    }
+
+    reply = runner._handle_pending_clarify_response(_make_event("Blue", user_id="user-2"))
+
+    assert "original requester" in reply
+    assert event.is_set() is False
+    assert runner._pending_clarify["telegram:12345:root"]["response"] is None
+
+
+def test_handle_pending_clarify_response_ignores_already_resolved_prompt():
+    runner = _make_runner()
+    event = Event()
+    runner._pending_clarify["telegram:12345:root"] = {
+        "event": event,
+        "user_id": "user-1",
+        "choices": ["Red", "Blue"],
+        "awaiting_text": False,
+        "response": "Red",
+        "resolved": True,
+    }
+
+    reply = runner._handle_pending_clarify_response(_make_event("Blue"))
+
+    assert reply is None
+    assert runner._pending_clarify["telegram:12345:root"]["response"] == "Red"
+    assert runner.adapters[Platform.TELEGRAM].cleared_clarify == []
+
+
+@pytest.mark.asyncio
+async def test_gateway_clarify_timeout_clears_runner_and_adapter_state():
+    runner = _make_runner()
+    session_key = "telegram:12345:root"
+    callback = runner._build_gateway_clarify_callback(
+        adapter=runner.adapters[Platform.TELEGRAM],
+        source=_make_source(),
+        session_key=session_key,
+        loop=asyncio.get_running_loop(),
+        metadata=None,
+        timeout_seconds=0.05,
+    )
+
+    result = await asyncio.to_thread(callback, "Need more detail", None)
+
+    assert "timed out" in result
+    assert session_key not in runner._pending_clarify
+    assert runner.adapters[Platform.TELEGRAM].cleared_clarify == [session_key]

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -76,8 +76,8 @@ class TestHandleResumeCommand:
         assert "not available" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_list_named_sessions_when_no_arg(self, tmp_path):
-        """With no argument, lists recently titled sessions."""
+    async def test_list_sessions_when_no_arg_uses_plaintext_fallback(self, tmp_path):
+        """With no argument, fallback output is deterministic plaintext."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session("sess_001", "telegram")
@@ -88,23 +88,86 @@ class TestHandleResumeCommand:
         event = _make_event(text="/resume")
         runner = _make_runner(session_db=db, event=event)
         result = await runner._handle_resume_command(event)
-        assert "Research" in result
-        assert "Coding" in result
-        assert "Named Sessions" in result
+
+        assert result == (
+            "Resume Sessions:\n"
+            "1. sess_002 | Coding\n"
+            "2. sess_001 | Research\n"
+            "Use: /resume <session name or id>"
+        )
         db.close()
 
     @pytest.mark.asyncio
-    async def test_list_shows_usage_when_no_titled(self, tmp_path):
-        """With no arg and no titled sessions, shows instructions."""
+    async def test_telegram_no_arg_uses_inline_menu_when_available(self, tmp_path):
         from hermes_state import SessionDB
+
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")  # No title
+        db.create_session("sess_001", "telegram")
+        db.create_session("sess_002", "telegram")
+        db.set_session_title("sess_001", "Research")
+        db.set_session_title("sess_002", "Coding")
 
         event = _make_event(text="/resume")
         runner = _make_runner(session_db=db, event=event)
+        tg_adapter = MagicMock()
+        tg_adapter.send_resume_menu = AsyncMock(return_value=MagicMock(success=True, message_id="99"))
+        runner.adapters[Platform.TELEGRAM] = tg_adapter
+
         result = await runner._handle_resume_command(event)
-        assert "No named sessions" in result
-        assert "/title" in result
+
+        assert result == ""
+        tg_adapter.send_resume_menu.assert_called_once()
+        kwargs = tg_adapter.send_resume_menu.call_args.kwargs
+        assert kwargs["chat_id"] == "67890"
+        assert kwargs["session_key"] == "agent:main:telegram:dm:67890"
+        assert [s["title"] for s in kwargs["sessions"]] == ["Coding", "Research"]
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_telegram_no_arg_keeps_compressed_root_as_menu_anchor(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "telegram")
+        db.set_session_title("sess_root", "Research")
+        db.append_message("sess_root", "user", "old part")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "telegram", parent_session_id="sess_root")
+        db.append_message("sess_child", "user", "latest part")
+
+        event = _make_event(text="/resume")
+        runner = _make_runner(session_db=db, event=event)
+        tg_adapter = MagicMock()
+        tg_adapter.send_resume_menu = AsyncMock(return_value=MagicMock(success=True, message_id="99"))
+        runner.adapters[Platform.TELEGRAM] = tg_adapter
+
+        result = await runner._handle_resume_command(event)
+
+        assert result == ""
+        kwargs = tg_adapter.send_resume_menu.call_args.kwargs
+        assert kwargs["sessions"][0]["id"] == "sess_root"
+        assert kwargs["sessions"][0]["title"] == "Research"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_list_includes_untitled_sessions_with_preview_or_id_fallback(self, tmp_path):
+        """With no arg, untitled root sessions are still listed deterministically."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_preview", "discord")
+        db.append_message("sess_preview", "user", "latest untitled session preview")
+        db.create_session("sess_empty", "discord")
+
+        event = _make_event(text="/resume", platform=Platform.DISCORD)
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert result == (
+            "Resume Sessions:\n"
+            "1. sess_empty\n"
+            "2. sess_preview | latest untitled session preview\n"
+            "Use: /resume <session name or id>"
+        )
         db.close()
 
     @pytest.mark.asyncio
@@ -177,6 +240,137 @@ class TestHandleResumeCommand:
         # Should resolve to #2 (latest in lineage)
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "sess_v2"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_title_uses_anchor_session_without_auto_follow(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "telegram")
+        db.set_session_title("sess_root", "My Project")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "telegram", parent_session_id="sess_root")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume My Project")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_root"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_session_id_uses_anchor_session_without_auto_follow(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "telegram")
+        db.set_session_title("sess_root", "My Project")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "telegram", parent_session_id="sess_root")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume sess_root")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_root"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_title_with_last_follows_latest_compression_child(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "telegram")
+        db.set_session_title("sess_root", "My Project")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "telegram", parent_session_id="sess_root")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume My Project --last")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001", event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_child"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_session_id_with_last_follows_latest_compression_child(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "telegram")
+        db.set_session_title("sess_root", "My Project")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "telegram", parent_session_id="sess_root")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume sess_root --last")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001", event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "sess_child"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_title_with_list_on_telegram_opens_chain_menu(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "telegram")
+        db.set_session_title("sess_root", "My Project")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "telegram", parent_session_id="sess_root")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume My Project --list")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001", event=event)
+        tg_adapter = MagicMock()
+        tg_adapter.send_resume_menu = AsyncMock(return_value=MagicMock(success=True, message_id="99"))
+        runner.adapters[Platform.TELEGRAM] = tg_adapter
+
+        result = await runner._handle_resume_command(event)
+
+        assert result == ""
+        kwargs = tg_adapter.send_resume_menu.call_args.kwargs
+        assert [s["id"] for s in kwargs["sessions"]] == ["sess_root", "sess_child"]
+        assert kwargs["metadata"]["resume_menu_mode"] == "chain"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_title_with_list_uses_plaintext_fallback_on_non_telegram(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_root", "discord")
+        db.set_session_title("sess_root", "My Project")
+        db.end_session("sess_root", "compression")
+        db.create_session("sess_child", "discord", parent_session_id="sess_root")
+        db.set_session_title("sess_child", "My Project #2")
+        db.create_session("current_session_001", "discord")
+
+        event = _make_event(text="/resume sess_root --list", platform=Platform.DISCORD)
+        runner = _make_runner(session_db=db, current_session_id="current_session_001", event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert result == (
+            "Resume Points:\n"
+            "1. sess_root | My Project\n"
+            "2. sess_child | My Project #2\n"
+            "Use: /resume <session id>"
+        )
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -52,6 +52,7 @@ from gateway.config import Platform, PlatformConfig
 
 def _make_adapter(extra=None):
     """Create a TelegramAdapter with mocked internals."""
+    os.environ.pop("TELEGRAM_ALLOWED_USERS", None)
     config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
     adapter = TelegramAdapter(config)
     adapter._bot = AsyncMock()
@@ -358,3 +359,147 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+
+# ===========================================================================
+# Clarify inline keyboard prompts
+# ===========================================================================
+
+class TestTelegramClarify:
+    """Test Telegram-native clarify prompts and callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_sends_inline_keyboard_and_stores_state(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        on_resolved = MagicMock(return_value="resolved")
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick a color",
+            choices=["Red", "Blue"],
+            session_key="clarify-session",
+            on_clarify_resolved=on_resolved,
+        )
+
+        assert result.success is True
+        assert result.message_id == "77"
+        assert len(adapter._clarify_state) == 1
+
+        state = next(iter(adapter._clarify_state.values()))
+        assert state["session_key"] == "clarify-session"
+        assert state["question"] == "Pick a color"
+        assert state["choices"] == ["Red", "Blue"]
+        assert state["on_clarify_resolved"] is on_resolved
+
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert kwargs["chat_id"] == 12345
+        assert "Pick a color" in kwargs["text"]
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_clarify_callback_resolves_selection_and_cleans_state(self):
+        adapter = _make_adapter()
+        adapter._clarify_state[5] = {
+            "session_key": "clarify-session",
+            "question": "Pick one",
+            "choices": ["Red", "Blue"],
+            "on_clarify_resolved": MagicMock(return_value="resolved"),
+        }
+
+        query = AsyncMock()
+        query.data = "cq:5:pick:1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 123
+        query.from_user.first_name = "<Norbert&Co>"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        assert adapter._clarify_state.get(5) is None
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+        edit_text = query.edit_message_text.call_args.kwargs["text"]
+        assert "Blue" in edit_text
+        assert "<Norbert&Co>" not in edit_text
+        assert "&lt;Norbert&amp;Co&gt;" in edit_text
+
+    @pytest.mark.asyncio
+    async def test_clarify_callback_other_switches_to_text_mode(self):
+        on_resolved = MagicMock(return_value="awaiting_text")
+        adapter = _make_adapter()
+        adapter._clarify_state[8] = {
+            "session_key": "clarify-session",
+            "question": "Pick one",
+            "choices": ["Red", "Blue"],
+            "on_clarify_resolved": on_resolved,
+        }
+
+        query = AsyncMock()
+        query.data = "cq:8:other"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 123
+        query.from_user.first_name = "Norbert"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        assert 8 in adapter._clarify_state
+        on_resolved.assert_called_once()
+        edit_text = query.edit_message_text.call_args.kwargs["text"]
+        assert "type your answer" in edit_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_clarify_callback_pick_handles_expired_prompt(self):
+        adapter = _make_adapter()
+        adapter._clarify_state[9] = {
+            "session_key": "clarify-session",
+            "question": "Pick one",
+            "choices": ["Red", "Blue"],
+            "on_clarify_resolved": MagicMock(return_value="expired"),
+        }
+
+        query = AsyncMock()
+        query.data = "cq:9:pick:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 123
+        query.from_user.first_name = "Norbert"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        assert 9 not in adapter._clarify_state
+        query.answer.assert_called_once()
+        assert "already been resolved" in query.answer.call_args.kwargs["text"]
+        query.edit_message_text.assert_not_called()
+
+    def test_clear_clarify_removes_matching_session_entries(self):
+        adapter = _make_adapter()
+        adapter._clarify_state[1] = {"session_key": "keep"}
+        adapter._clarify_state[2] = {"session_key": "drop"}
+        adapter._clarify_state[3] = {"session_key": "drop"}
+
+        removed = adapter.clear_clarify("drop")
+
+        assert removed == 2
+        assert sorted(adapter._clarify_state.keys()) == [1]

--- a/tests/gateway/test_telegram_commands_menu.py
+++ b/tests/gateway/test_telegram_commands_menu.py
@@ -1,0 +1,259 @@
+"""Tests for /commands inline keyboard menu on Telegram."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    class _FakeInlineKeyboardButton:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class _FakeInlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    mod = MagicMock()
+    mod.InlineKeyboardButton = _FakeInlineKeyboardButton
+    mod.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter():
+    import gateway.platforms.telegram as telegram_mod
+
+    class _FakeInlineKeyboardButton:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class _FakeInlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    telegram_mod.InlineKeyboardButton = _FakeInlineKeyboardButton
+    telegram_mod.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    mock_msg = MagicMock()
+    mock_msg.message_id = 42
+    adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+    return adapter
+
+
+class TestBuildCommandsKeyboard:
+    def test_single_page_no_pagination(self):
+        adapter = _make_adapter()
+        entries = ["`/help` — Show help", "`/new` — New session"]
+        keyboard, page_info = adapter._build_commands_keyboard(entries, page=0, page_size=12)
+        assert len(keyboard.inline_keyboard) == 1  # close only
+        assert page_info == ""
+
+    def test_filters_non_command_entries(self):
+        adapter = _make_adapter()
+        entries = [
+            "`/help` — Show help",
+            "",
+            "⚡ **Skill Commands**:",
+            "`/study` — Review cards",
+        ]
+        keyboard, page_info = adapter._build_commands_keyboard(entries, page=0, page_size=12)
+        assert len(keyboard.inline_keyboard) == 1  # close only
+        assert page_info == ""
+
+    def test_multi_page_has_pagination(self):
+        adapter = _make_adapter()
+        entries = [f"`/cmd{i}` — Command {i}" for i in range(30)]
+        keyboard, page_info = adapter._build_commands_keyboard(entries, page=0, page_size=12)
+        assert len(keyboard.inline_keyboard) == 2  # nav + close
+        assert "1–12" in page_info
+
+    def test_close_button_always_present(self):
+        adapter = _make_adapter()
+        entries = ["`/help` — Show help"]
+        keyboard, _ = adapter._build_commands_keyboard(entries, page=0)
+        last_row = keyboard.inline_keyboard[-1]
+        assert any(button.callback_data == "cx" for button in last_row)
+
+
+class TestSendCommandsMenu:
+    @pytest.mark.asyncio
+    async def test_sends_menu_and_stores_state(self):
+        adapter = _make_adapter()
+        entries = ["`/help` — Show help", "`/new` — New session"]
+
+        result = await adapter.send_commands_menu(chat_id="12345", entries=entries, page=0)
+
+        assert result.success
+        assert adapter._commands_menu_state["12345"]["entries"] == entries
+        assert adapter._commands_menu_state["12345"]["msg_id"] == 42
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert kwargs.get("parse_mode") is None
+        assert "`/help` — Show help" in kwargs["text"]
+        assert "`/new` — New session" in kwargs["text"]
+        assert "Select a command" not in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_retries_without_thread_when_thread_not_found(self):
+        adapter = _make_adapter()
+        entries = ["`/help` — Show help"]
+        call_log = []
+
+        class FakeBadRequest(Exception):
+            pass
+
+        async def mock_send_message(**kwargs):
+            call_log.append(dict(kwargs))
+            if kwargs.get("message_thread_id") is not None:
+                raise FakeBadRequest("Message thread not found")
+            return SimpleNamespace(message_id=42)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        result = await adapter.send_commands_menu(
+            chat_id="12345",
+            entries=entries,
+            page=0,
+            metadata={"thread_id": "99999"},
+        )
+
+        assert result.success
+        assert len(call_log) == 2
+        assert call_log[0]["message_thread_id"] == 99999
+        assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_sends_plain_text_for_markdown_unsafe_entries(self):
+        adapter = _make_adapter()
+        entries = [
+            "`/help` — Show help",
+            "⚡ **Skill Commands**:",
+            "`/broken-skill` — Diagnose cases where `hermes -c \"<title>\"` picked `title",
+        ]
+
+        result = await adapter.send_commands_menu(chat_id="12345", entries=entries, page=0)
+
+        assert result.success
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert kwargs.get("parse_mode") is None
+        assert "`/help` — Show help" in kwargs["text"]
+        assert "⚡ **Skill Commands**:" in kwargs["text"]
+        assert "`/broken-skill` — Diagnose cases where `hermes -c \"<title>\"` picked `title" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_preserves_plain_text_underscores(self):
+        adapter = _make_adapter()
+        entries = ["`/env` — Explain HERMES_API_KEY and __init__.py in foo_bar_baz"]
+
+        result = await adapter.send_commands_menu(chat_id="12345", entries=entries, page=0)
+
+        assert result.success
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert "`/env` — Explain HERMES_API_KEY and __init__.py in foo_bar_baz" in kwargs["text"]
+
+
+class TestCommandsCallback:
+    @pytest.mark.asyncio
+    async def test_page_navigation_edits_message(self):
+        adapter = _make_adapter()
+        entries = [f"`/cmd{i}` — Command {i}" for i in range(20)]
+        adapter._commands_menu_state["12345"] = {"entries": entries, "msg_id": 42}
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=42)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_commands_callback(query, "cp:1", "12345")
+
+        query.edit_message_text.assert_called_once()
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_dismisses_menu(self):
+        adapter = _make_adapter()
+        adapter._commands_menu_state["12345"] = {"entries": ["`/help` — Show help"], "msg_id": 42}
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=42)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_commands_callback(query, "cx", "12345")
+
+        assert "12345" not in adapter._commands_menu_state
+        query.edit_message_text.assert_called_once()
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_expired_menu_answers(self):
+        adapter = _make_adapter()
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=42)
+        query.answer = AsyncMock()
+
+        await adapter._handle_commands_callback(query, "cp:0", "12345")
+
+        query.answer.assert_called_once()
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_stale_message_id_answers_expired(self):
+        adapter = _make_adapter()
+        adapter._commands_menu_state["12345"] = {"entries": ["`/help` — Show help"], "msg_id": 42}
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99)
+        query.answer = AsyncMock()
+
+        await adapter._handle_commands_callback(query, "cp:0", "12345")
+
+        query.answer.assert_called_once()
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_page_navigation_edits_plain_text_for_markdown_unsafe_entries(self):
+        adapter = _make_adapter()
+        entries = [f"`/cmd{i}` — Command {i}" for i in range(12)] + [
+            "`/broken-skill` — Diagnose cases where `hermes -c \"<title>\"` picked `title",
+            "⚡ **Skill Commands**:",
+        ]
+        adapter._commands_menu_state["12345"] = {"entries": entries, "msg_id": 42}
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=42)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_commands_callback(query, "cp:1", "12345")
+
+        kwargs = query.edit_message_text.call_args.kwargs
+        assert kwargs.get("parse_mode") is None
+        assert "`/broken-skill` — Diagnose cases where `hermes -c \"<title>\"` picked `title" in kwargs["text"]
+        assert "⚡ **Skill Commands**:" in kwargs["text"]
+        query.answer.assert_called_once()

--- a/tests/gateway/test_telegram_resume_menu.py
+++ b/tests/gateway/test_telegram_resume_menu.py
@@ -1,0 +1,386 @@
+"""Tests for /resume inline keyboard menu on Telegram."""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    class _FakeInlineKeyboardButton:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class _FakeInlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    mod = MagicMock()
+    mod.InlineKeyboardButton = _FakeInlineKeyboardButton
+    mod.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter():
+    import gateway.platforms.telegram as telegram_mod
+
+    class _FakeInlineKeyboardButton:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class _FakeInlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    telegram_mod.InlineKeyboardButton = _FakeInlineKeyboardButton
+    telegram_mod.InlineKeyboardMarkup = _FakeInlineKeyboardMarkup
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    mock_msg = MagicMock()
+    mock_msg.message_id = 99
+    adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+    return adapter
+
+
+class TestRelativeTime:
+    def test_just_now(self):
+        ts = datetime.now(timezone.utc).isoformat()
+        assert TelegramAdapter._relative_time(ts) == "just now"
+
+    def test_hours_ago(self):
+        ts = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+        assert TelegramAdapter._relative_time(ts) == "3h ago"
+
+    def test_days_ago(self):
+        ts = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+        assert TelegramAdapter._relative_time(ts) == "5d ago"
+
+    def test_empty_string(self):
+        assert TelegramAdapter._relative_time("") == ""
+
+    def test_none(self):
+        assert TelegramAdapter._relative_time(None) == ""
+
+
+class TestBuildResumeKeyboard:
+    def test_session_buttons_with_relative_time(self):
+        adapter = _make_adapter()
+        sessions = [
+            {
+                "id": "s1",
+                "title": "My Project",
+                "last_active": (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(),
+            },
+            {
+                "id": "s2",
+                "title": "Debug Session",
+                "last_active": (datetime.now(timezone.utc) - timedelta(days=1)).isoformat(),
+            },
+        ]
+
+        keyboard = adapter._build_resume_keyboard(sessions)
+
+        assert len(keyboard.inline_keyboard) == 3  # 2 sessions + close
+        button = keyboard.inline_keyboard[0][0]
+        assert "My Project" in button.text
+        assert "2h ago" in button.text
+        assert button.callback_data == "rs:0"
+
+    def test_close_button_present(self):
+        adapter = _make_adapter()
+        keyboard = adapter._build_resume_keyboard([{"id": "s1", "title": "Test"}])
+        assert any(button.callback_data == "rx" for button in keyboard.inline_keyboard[-1])
+
+    def test_back_button_present_for_chain_menu(self):
+        adapter = _make_adapter()
+        keyboard = adapter._build_resume_keyboard([{"id": "s1", "title": "Test"}], show_back=True)
+        assert any(button.callback_data == "rb" for button in keyboard.inline_keyboard[-2])
+
+    def test_empty_preview_falls_back_to_session_id_label(self):
+        adapter = _make_adapter()
+        keyboard = adapter._build_resume_keyboard([{"id": "s1", "title": None, "preview": ""}])
+        assert keyboard.inline_keyboard[0][0].text == "s1"
+
+
+class TestSendResumeMenu:
+    @pytest.mark.asyncio
+    async def test_sends_menu_and_stores_state(self):
+        adapter = _make_adapter()
+        sessions = [{"id": "s1", "title": "Test", "last_active": "2026-01-01T00:00:00+00:00"}]
+        on_resume = AsyncMock(return_value="Resumed!")
+
+        result = await adapter.send_resume_menu(
+            chat_id="12345",
+            sessions=sessions,
+            session_key="agent:main:telegram:dm",
+            on_session_resumed=on_resume,
+        )
+
+        assert result.success
+        state = adapter._resume_menu_state["12345"]
+        assert state["sessions"] == sessions
+        assert state["session_key"] == "agent:main:telegram:dm"
+        assert state["on_session_resumed"] is on_resume
+        assert state["msg_id"] == 99
+
+    @pytest.mark.asyncio
+    async def test_retries_without_thread_when_thread_not_found(self):
+        adapter = _make_adapter()
+        sessions = [{"id": "s1", "title": "Test", "last_active": "2026-01-01T00:00:00+00:00"}]
+        call_log = []
+
+        class FakeBadRequest(Exception):
+            pass
+
+        async def mock_send_message(**kwargs):
+            call_log.append(dict(kwargs))
+            if kwargs.get("message_thread_id") is not None:
+                raise FakeBadRequest("Message thread not found")
+            return SimpleNamespace(message_id=99)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        result = await adapter.send_resume_menu(
+            chat_id="12345",
+            sessions=sessions,
+            session_key="agent:main:telegram:dm",
+            on_session_resumed=AsyncMock(),
+            metadata={"thread_id": "99999"},
+        )
+
+        assert result.success
+        assert len(call_log) == 2
+        assert call_log[0]["message_thread_id"] == 99999
+        assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
+
+
+class TestResumeCallback:
+    @pytest.mark.asyncio
+    async def test_select_session_invokes_callback(self):
+        adapter = _make_adapter()
+        sessions = [
+            {"id": "s1", "title": "Project Alpha", "last_active": "2026-01-01T00:00:00+00:00"},
+            {"id": "s2", "title": "Project Beta", "last_active": "2026-01-02T00:00:00+00:00"},
+        ]
+        on_resume = AsyncMock(return_value="Resumed!")
+        adapter._resume_menu_state["12345"] = {
+            "sessions": sessions,
+            "msg_id": 99,
+            "session_key": "k",
+            "on_session_resumed": on_resume,
+        }
+
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99, message_thread_id=None)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_resume_callback(query, "rs:0", "12345")
+
+        on_resume.assert_called_once_with("s1", "Project Alpha")
+        assert "12345" not in adapter._resume_menu_state
+        query.edit_message_text.assert_called_once()
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_select_empty_untitled_session_uses_id_as_callback_label(self):
+        adapter = _make_adapter()
+        sessions = [{"id": "sess_empty", "title": None, "preview": ""}]
+        on_resume = AsyncMock(return_value="Resumed!")
+        adapter._resume_menu_state["12345"] = {
+            "sessions": sessions,
+            "msg_id": 99,
+            "session_key": "k",
+            "on_session_resumed": on_resume,
+        }
+
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99, message_thread_id=None)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_resume_callback(query, "rs:0", "12345")
+
+        on_resume.assert_called_once_with("sess_empty", "sess_empty")
+        kwargs = query.edit_message_text.call_args.kwargs
+        assert kwargs["text"] == "↻ Resuming **sess_empty**…"
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_select_root_with_resume_chain_opens_nested_menu(self):
+        adapter = _make_adapter()
+        roots = [{
+            "id": "root",
+            "title": "Project Alpha",
+            "last_active": "2026-01-02T00:00:00+00:00",
+            "resume_chain": [
+                {"id": "root", "title": "Project Alpha", "last_active": "2026-01-01T00:00:00+00:00"},
+                {"id": "child", "title": "Project Alpha #2", "last_active": "2026-01-02T00:00:00+00:00"},
+            ],
+        }]
+        on_resume = AsyncMock(return_value="Resumed!")
+        adapter._resume_menu_state["12345"] = {
+            "sessions": roots,
+            "root_sessions": roots,
+            "mode": "root",
+            "msg_id": 99,
+            "session_key": "k",
+            "on_session_resumed": on_resume,
+        }
+
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99, message_thread_id=None)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_resume_callback(query, "rs:0", "12345")
+
+        on_resume.assert_not_called()
+        state = adapter._resume_menu_state["12345"]
+        assert state["mode"] == "chain"
+        assert [s["id"] for s in state["sessions"]] == ["root", "child"]
+        kwargs = query.edit_message_text.call_args.kwargs
+        assert kwargs["text"] == adapter._render_resume_menu_text("chain")
+        assert kwargs["reply_markup"].inline_keyboard[-2][0].callback_data == "rb"
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_back_restores_root_resume_menu(self):
+        adapter = _make_adapter()
+        roots = [{"id": "root", "title": "Project Alpha", "last_active": "2026-01-02T00:00:00+00:00"}]
+        chain = [
+            {"id": "root", "title": "Project Alpha", "last_active": "2026-01-01T00:00:00+00:00"},
+            {"id": "child", "title": "Project Alpha #2", "last_active": "2026-01-02T00:00:00+00:00"},
+        ]
+        adapter._resume_menu_state["12345"] = {
+            "sessions": chain,
+            "root_sessions": roots,
+            "mode": "chain",
+            "msg_id": 99,
+            "session_key": "k",
+            "on_session_resumed": AsyncMock(),
+        }
+
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99, message_thread_id=None)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_resume_callback(query, "rb", "12345")
+
+        state = adapter._resume_menu_state["12345"]
+        assert state["mode"] == "root"
+        assert state["sessions"] == roots
+        kwargs = query.edit_message_text.call_args.kwargs
+        assert kwargs["text"] == adapter._render_resume_menu_text("root")
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_callback_router_routes_back_button_to_resume_handler(self):
+        adapter = _make_adapter()
+        query = MagicMock()
+        query.data = "rb"
+        query.message = SimpleNamespace(chat_id=12345)
+        update = SimpleNamespace(callback_query=query)
+        adapter._handle_resume_callback = AsyncMock()
+
+        await adapter._handle_callback_query(update, None)
+
+        adapter._handle_resume_callback.assert_awaited_once_with(query, "rb", "12345")
+
+    @pytest.mark.asyncio
+    async def test_resume_followup_retries_without_thread_when_needed(self):
+        adapter = _make_adapter()
+        sessions = [{"id": "s1", "title": "Project Alpha", "last_active": "2026-01-01T00:00:00+00:00"}]
+        on_resume = AsyncMock(return_value="Resumed!")
+        adapter._resume_menu_state["12345"] = {
+            "sessions": sessions,
+            "msg_id": 99,
+            "session_key": "k",
+            "on_session_resumed": on_resume,
+        }
+
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99, message_thread_id=777)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        call_log = []
+
+        class FakeBadRequest(Exception):
+            pass
+
+        async def mock_send_message(**kwargs):
+            call_log.append(dict(kwargs))
+            if kwargs.get("message_thread_id") is not None:
+                raise FakeBadRequest("Message thread not found")
+            return SimpleNamespace(message_id=123)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        await adapter._handle_resume_callback(query, "rs:0", "12345")
+
+        assert len(call_log) == 2
+        assert call_log[0]["message_thread_id"] == 777
+        assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_close_dismisses_menu(self):
+        adapter = _make_adapter()
+        adapter._resume_menu_state["12345"] = {
+            "sessions": [],
+            "msg_id": 99,
+            "session_key": "k",
+            "on_session_resumed": AsyncMock(),
+        }
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99)
+        query.edit_message_text = AsyncMock()
+        query.answer = AsyncMock()
+
+        await adapter._handle_resume_callback(query, "rx", "12345")
+
+        assert "12345" not in adapter._resume_menu_state
+        query.edit_message_text.assert_called_once()
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_expired_menu_answers(self):
+        adapter = _make_adapter()
+        query = MagicMock()
+        query.message = SimpleNamespace(message_id=99)
+        query.answer = AsyncMock()
+
+        await adapter._handle_resume_callback(query, "rs:0", "12345")
+
+        query.answer.assert_called_once()
+        assert "expired" in query.answer.call_args.kwargs["text"].lower()

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -28,6 +28,8 @@ def _build_parser():
     """
     parser = argparse.ArgumentParser(prog="hermes")
     parser.add_argument("--resume", "-r", metavar="SESSION", default=None)
+    parser.add_argument("--last", action="store_true", default=False)
+    parser.add_argument("--list", dest="resume_list", action="store_true", default=False)
     parser.add_argument(
         "--continue", "-c", dest="continue_last", nargs="?",
         const=True, default=None, metavar="SESSION_NAME",
@@ -49,6 +51,10 @@ def _build_parser():
     chat.add_argument("--pass-session-id", action="store_true",
                       default=argparse.SUPPRESS)
     chat.add_argument("--resume", "-r", metavar="SESSION_ID",
+                      default=argparse.SUPPRESS)
+    chat.add_argument("--last", action="store_true",
+                      default=argparse.SUPPRESS)
+    chat.add_argument("--list", dest="resume_list", action="store_true",
                       default=argparse.SUPPRESS)
     chat.add_argument(
         "--continue", "-c", dest="continue_last", nargs="?",
@@ -85,6 +91,18 @@ class TestFlagBeforeSubcommand:
         args = parser.parse_args(["-r", "abc123", "chat"])
         assert getattr(args, "resume", None) == "abc123"
 
+    def test_resume_last_before_chat(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-r", "abc123", "--last", "chat"])
+        assert getattr(args, "resume", None) == "abc123"
+        assert getattr(args, "last", False) is True
+
+    def test_resume_list_before_chat(self):
+        parser = _build_parser()
+        args = parser.parse_args(["-r", "abc123", "--list", "chat"])
+        assert getattr(args, "resume", None) == "abc123"
+        assert getattr(args, "resume_list", False) is True
+
 
 class TestFlagAfterSubcommand:
     """Flags placed after 'chat' must still work."""
@@ -108,6 +126,18 @@ class TestFlagAfterSubcommand:
         parser = _build_parser()
         args = parser.parse_args(["chat", "-r", "abc123"])
         assert getattr(args, "resume", None) == "abc123"
+
+    def test_resume_last_after_chat(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "-r", "abc123", "--last"])
+        assert getattr(args, "resume", None) == "abc123"
+        assert getattr(args, "last", False) is True
+
+    def test_resume_list_after_chat(self):
+        parser = _build_parser()
+        args = parser.parse_args(["chat", "-r", "abc123", "--list"])
+        assert getattr(args, "resume", None) == "abc123"
+        assert getattr(args, "resume_list", False) is True
 
 
 class TestNoSubcommandDefaults:

--- a/tests/hermes_cli/test_chat_skills_flag.py
+++ b/tests/hermes_cli/test_chat_skills_flag.py
@@ -99,3 +99,57 @@ def test_continue_worktree_and_skills_flags_work_together(monkeypatch):
         "skills": ["hermes-agent-dev"],
         "command": "chat",
     }
+
+
+def test_top_level_resume_last_flag_defaults_to_chat(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_chat(args):
+        captured["resume"] = args.resume
+        captured["last"] = getattr(args, "last", False)
+        captured["resume_list"] = getattr(args, "resume_list", False)
+        captured["command"] = args.command
+
+    monkeypatch.setattr(main_mod, "cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "--resume", "My", "Session", "--last"],
+    )
+
+    main_mod.main()
+
+    assert captured == {
+        "resume": "My Session",
+        "last": True,
+        "resume_list": False,
+        "command": "chat",
+    }
+
+
+def test_chat_subcommand_accepts_resume_list_flag(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_chat(args):
+        captured["resume"] = args.resume
+        captured["last"] = getattr(args, "last", False)
+        captured["resume_list"] = getattr(args, "resume_list", False)
+
+    monkeypatch.setattr(main_mod, "cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "chat", "--resume", "My", "Session", "--list"],
+    )
+
+    main_mod.main()
+
+    assert captured == {
+        "resume": "My Session",
+        "last": False,
+        "resume_list": True,
+    }

--- a/tests/hermes_cli/test_cli_model_picker.py
+++ b/tests/hermes_cli/test_cli_model_picker.py
@@ -1,0 +1,243 @@
+"""Tests for the interactive CLI /model picker (provider → model drill-down)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class _FakeBuffer:
+    def __init__(self, text="draft text"):
+        self.text = text
+        self.cursor_position = len(text)
+        self.reset_calls = []
+
+    def reset(self, append_to_history=False):
+        self.reset_calls.append(append_to_history)
+        self.text = ""
+        self.cursor_position = 0
+
+
+def _make_providers():
+    return [
+        {
+            "slug": "openrouter",
+            "name": "OpenRouter",
+            "is_current": True,
+            "is_user_defined": False,
+            "models": ["anthropic/claude-opus-4.6", "openai/gpt-5.4"],
+            "total_models": 2,
+            "source": "built-in",
+        },
+        {
+            "slug": "anthropic",
+            "name": "Anthropic",
+            "is_current": False,
+            "is_user_defined": False,
+            "models": ["claude-opus-4.6", "claude-sonnet-4.6"],
+            "total_models": 2,
+            "source": "built-in",
+        },
+        {
+            "slug": "custom:my-ollama",
+            "name": "My Ollama",
+            "is_current": False,
+            "is_user_defined": True,
+            "models": ["llama3", "mistral"],
+            "total_models": 2,
+            "source": "user-config",
+            "api_url": "http://localhost:11434/v1",
+        },
+    ]
+
+
+def _make_picker_cli(picker_return_value):
+    cli = MagicMock()
+    cli._run_curses_picker = MagicMock(return_value=picker_return_value)
+    cli._app = MagicMock()
+    cli._status_bar_visible = True
+    return cli
+
+
+def _make_modal_cli():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.model = "gpt-5.4"
+    cli.provider = "openrouter"
+    cli.requested_provider = "openrouter"
+    cli.base_url = ""
+    cli.api_key = ""
+    cli.api_mode = ""
+    cli._explicit_api_key = ""
+    cli._explicit_base_url = ""
+    cli._pending_model_switch_note = None
+    cli._model_picker_state = None
+    cli._modal_input_snapshot = None
+    cli._status_bar_visible = True
+    cli._invalidate = MagicMock()
+    cli._agent_running = False
+    cli.agent = None
+    cli.config = {}
+    cli.console = MagicMock()
+    cli._app = SimpleNamespace(
+        current_buffer=_FakeBuffer(),
+        invalidate=MagicMock(),
+        _is_running=True,
+    )
+    return cli
+
+
+def test_prompt_text_input_uses_run_in_terminal_when_app_active():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+
+    with (
+        patch("prompt_toolkit.application.run_in_terminal", side_effect=lambda fn: fn()) as run_mock,
+        patch("builtins.input", return_value="manual-value"),
+    ):
+        result = HermesCLI._prompt_text_input(cli, "Enter value: ")
+
+    assert result == "manual-value"
+    run_mock.assert_called_once()
+    assert cli._status_bar_visible is True
+
+
+def test_resume_command_uses_run_in_terminal_for_interactive_picker_flow():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+    cli.session_id = "current"
+    cli._session_db = MagicMock()
+    cli._session_db.list_sessions_rich.return_value = [
+        {"id": "current", "title": "Current", "preview": "Current preview", "last_active": 0, "parent_session_id": None},
+        {"id": "root", "title": "Checking Running Hermes Agent", "preview": "check running gateways", "last_active": 0, "parent_session_id": None},
+        {"id": "child", "title": None, "preview": "compressed tail", "last_active": 0, "parent_session_id": "root"},
+    ]
+    cli._session_db.get_compression_continuation_chain.return_value = [
+        {"id": "root", "title": "Checking Running Hermes Agent", "preview": "check running gateways", "last_active": 0, "parent_session_id": None},
+        {"id": "child", "title": None, "preview": "compressed tail", "last_active": 0, "parent_session_id": "root"},
+    ]
+    cli._session_db.get_session.side_effect = lambda sid: {
+        "root": {"id": "root", "title": "Checking Running Hermes Agent"},
+        "child": {"id": "child", "title": None},
+    }.get(sid)
+    cli._session_db.get_messages_as_conversation.return_value = []
+    cli._run_session_browse_picker = MagicMock(side_effect=["root", "child"])
+
+    task = MagicMock()
+    task.add_done_callback.side_effect = lambda cb: cb(task)
+
+    with patch("prompt_toolkit.application.run_in_terminal", side_effect=lambda fn: (fn(), task)[1]) as run_mock:
+        HermesCLI._handle_resume_command(cli, "/resume")
+
+    assert cli.session_id == "child"
+    run_mock.assert_called_once()
+    assert cli._run_session_browse_picker.call_count == 2
+    assert cli._status_bar_visible is True
+
+
+def test_should_handle_model_command_inline_uses_command_name_resolution():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+
+    with patch("hermes_cli.commands.resolve_command", return_value=SimpleNamespace(name="model")):
+        assert HermesCLI._should_handle_model_command_inline(cli, "/model") is True
+
+    with patch("hermes_cli.commands.resolve_command", return_value=SimpleNamespace(name="help")):
+        assert HermesCLI._should_handle_model_command_inline(cli, "/model") is False
+
+    assert HermesCLI._should_handle_model_command_inline(cli, "/model", has_images=True) is False
+
+
+def test_should_handle_resume_command_inline_uses_command_name_resolution():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+
+    with patch("hermes_cli.commands.resolve_command", return_value=SimpleNamespace(name="resume")):
+        assert HermesCLI._should_handle_resume_command_inline(cli, "/resume") is True
+        assert HermesCLI._should_handle_resume_command_inline(cli, "/r my-session --list") is True
+        assert HermesCLI._should_handle_resume_command_inline(cli, "/resume my-session") is False
+        assert HermesCLI._should_handle_resume_command_inline(cli, "/resume my-session --last") is False
+
+    with patch("hermes_cli.commands.resolve_command", return_value=SimpleNamespace(name="help")):
+        assert HermesCLI._should_handle_resume_command_inline(cli, "/resume") is False
+
+    with patch("cli._cprint") as cprint_mock, patch(
+        "hermes_cli.commands.resolve_command", return_value=SimpleNamespace(name="resume")
+    ):
+        assert HermesCLI._should_handle_resume_command_inline(cli, "/resume --last") is False
+    cprint_mock.assert_not_called()
+
+    assert HermesCLI._should_handle_resume_command_inline(cli, "/resume", has_images=True) is False
+
+
+def test_process_command_model_without_args_opens_modal_picker_and_captures_draft():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+    providers = _make_providers()
+
+    with (
+        patch("hermes_cli.model_switch.list_authenticated_providers", return_value=providers),
+        patch("cli._cprint"),
+    ):
+        result = cli.process_command("/model")
+
+    assert result is True
+    assert cli._model_picker_state is not None
+    assert cli._model_picker_state["stage"] == "provider"
+    assert cli._model_picker_state["selected"] == 0
+    assert cli._modal_input_snapshot == {"text": "draft text", "cursor_position": len("draft text")}
+    assert cli._app.current_buffer.text == ""
+
+
+def test_model_picker_provider_then_model_selection_applies_switch_result_and_restores_draft():
+    from cli import HermesCLI
+
+    cli = _make_modal_cli()
+    providers = _make_providers()
+
+    with (
+        patch("hermes_cli.model_switch.list_authenticated_providers", return_value=providers),
+        patch("cli._cprint"),
+    ):
+        assert cli.process_command("/model") is True
+
+    cli._model_picker_state["selected"] = 1
+    with patch("hermes_cli.models.provider_model_ids", return_value=["claude-opus-4.6", "claude-sonnet-4.6"]):
+        HermesCLI._handle_model_picker_selection(cli)
+
+    assert cli._model_picker_state["stage"] == "model"
+    assert cli._model_picker_state["provider_data"]["slug"] == "anthropic"
+    assert cli._model_picker_state["model_list"] == ["claude-opus-4.6", "claude-sonnet-4.6"]
+
+    cli._model_picker_state["selected"] = 0
+    switch_result = SimpleNamespace(
+        success=True,
+        error_message=None,
+        new_model="claude-opus-4.6",
+        target_provider="anthropic",
+        api_key="",
+        base_url="",
+        api_mode="anthropic_messages",
+        provider_label="Anthropic",
+        model_info=None,
+        warning_message=None,
+        provider_changed=True,
+    )
+
+    with (
+        patch("hermes_cli.model_switch.switch_model", return_value=switch_result) as switch_mock,
+        patch("cli._cprint"),
+    ):
+        HermesCLI._handle_model_picker_selection(cli)
+
+    assert cli._model_picker_state is None
+    assert cli.model == "claude-opus-4.6"
+    assert cli.provider == "anthropic"
+    assert cli.requested_provider == "anthropic"
+    assert cli._app.current_buffer.text == "draft text"
+    switch_mock.assert_called_once()
+    assert switch_mock.call_args.kwargs["explicit_provider"] == "anthropic"

--- a/tests/hermes_cli/test_coalesce_session_args.py
+++ b/tests/hermes_cli/test_coalesce_session_args.py
@@ -74,6 +74,24 @@ class TestCoalesceSessionNameArgs:
             ["-r", "My", "Session", "-w"]
         ) == ["-r", "My Session", "-w"]
 
+    def test_resume_multiword_then_last_modifier(self):
+        """hermes --resume My Session --last"""
+        assert _coalesce_session_name_args(
+            ["--resume", "My", "Session", "--last"]
+        ) == ["--resume", "My Session", "--last"]
+
+    def test_resume_multiword_then_list_modifier(self):
+        """hermes chat --resume My Session --list"""
+        assert _coalesce_session_name_args(
+            ["chat", "--resume", "My", "Session", "--list"]
+        ) == ["chat", "--resume", "My Session", "--list"]
+
+    def test_resume_does_not_swallow_unrelated_flag_after_chat(self):
+        """hermes chat --resume My Session --worktree"""
+        assert _coalesce_session_name_args(
+            ["chat", "--resume", "My", "Session", "--worktree"]
+        ) == ["chat", "--resume", "My Session", "--worktree"]
+
     # ── combined flags ───────────────────────────────────────────────────
 
     def test_worktree_and_continue_multiword(self):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1091,6 +1091,134 @@ class TestTitleLineage:
     def test_resolve_nonexistent_title(self, db):
         assert db.resolve_session_by_title("nonexistent") is None
 
+    def test_latest_compression_continuation_follows_chain(self, db):
+        db.create_session("root", "cli")
+        db.set_session_title("root", "my project")
+        db.end_session("root", "compression")
+        db.create_session("child", "cli", parent_session_id="root")
+        db.end_session("child", "compression")
+        db.create_session("grandchild", "cli", parent_session_id="child")
+
+        assert db.get_latest_compression_continuation_id("root") == "grandchild"
+
+    def test_resolve_resume_target_by_title_uses_latest_compression_child_even_if_untitled(self, db):
+        db.create_session("root", "telegram")
+        db.set_session_title("root", "my project")
+        db.end_session("root", "compression")
+        db.create_session("child", "telegram", parent_session_id="root")
+
+        assert db.resolve_resume_target("my project", source="telegram") == "child"
+
+    def test_resolve_resume_target_by_session_id_uses_latest_compression_child(self, db):
+        db.create_session("root", "telegram")
+        db.set_session_title("root", "my project")
+        db.end_session("root", "compression")
+        db.create_session("child", "telegram", parent_session_id="root")
+
+        assert db.resolve_resume_target("root", source="telegram") == "child"
+
+    def test_get_compression_continuation_chain_returns_root_when_no_children(self, db):
+        db.create_session("root", "cli")
+        db.set_session_title("root", "my project")
+
+        chain = db.get_compression_continuation_chain("root")
+
+        assert [entry["id"] for entry in chain] == ["root"]
+
+    def test_get_compression_continuation_chain_returns_full_root_to_leaf_chain(self, db):
+        db.create_session("root", "cli")
+        db.end_session("root", "compression")
+        db.create_session("child", "cli", parent_session_id="root")
+        db.end_session("child", "compression")
+        db.create_session("grandchild", "cli", parent_session_id="child")
+
+        chain = db.get_compression_continuation_chain("root")
+
+        assert [entry["id"] for entry in chain] == ["root", "child", "grandchild"]
+
+    def test_get_compression_continuation_chain_uses_latest_child_with_tiebreaker(self, db):
+        db.create_session("root", "cli")
+        db.end_session("root", "compression")
+        db.create_session("child_a", "cli", parent_session_id="root")
+        db.create_session("child_b", "cli", parent_session_id="root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id IN (?, ?)",
+            (12345.0, "child_a", "child_b"),
+        )
+        db._conn.commit()
+
+        chain = db.get_compression_continuation_chain("root")
+
+        assert [entry["id"] for entry in chain] == ["root", "child_b"]
+
+    def test_get_compression_continuation_chain_stops_on_cycle(self, db):
+        db.create_session("root", "cli")
+        db.end_session("root", "compression")
+        db.create_session("child", "cli", parent_session_id="root")
+        db.end_session("child", "compression")
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            ("child", "root"),
+        )
+        db._conn.commit()
+
+        chain = db.get_compression_continuation_chain("root")
+
+        assert [entry["id"] for entry in chain] == ["root", "child"]
+
+    def test_resolve_resume_anchor_by_title_does_not_follow_compression(self, db):
+        db.create_session("root", "telegram")
+        db.set_session_title("root", "my project")
+        db.end_session("root", "compression")
+        db.create_session("child", "telegram", parent_session_id="root")
+
+        assert db.resolve_resume_anchor("my project", source="telegram") == "root"
+        assert db.get_latest_compression_continuation_id("root") == "child"
+
+    def test_resolve_resume_anchor_by_child_id_starts_chain_at_child(self, db):
+        db.create_session("root", "telegram")
+        db.end_session("root", "compression")
+        db.create_session("child", "telegram", parent_session_id="root")
+        db.end_session("child", "compression")
+        db.create_session("grandchild", "telegram", parent_session_id="child")
+
+        assert db.resolve_resume_anchor("child", source="telegram") == "child"
+        assert [entry["id"] for entry in db.get_compression_continuation_chain("child")] == [
+            "child",
+            "grandchild",
+        ]
+
+    def test_resolve_resume_anchor_prefers_exact_id_over_title(self, db):
+        db.create_session("dup", "cli")
+        db.set_session_title("dup", "something else")
+        db.create_session("other", "cli")
+        db.set_session_title("other", "dup")
+
+        assert db.resolve_resume_anchor("dup", source="cli") == "dup"
+
+    def test_resolve_resume_anchor_prefers_exact_title_over_unique_prefix(self, db):
+        db.create_session("alpha_target_xyz", "cli")
+        db.set_session_title("alpha_target_xyz", "other title")
+        db.create_session("plain", "cli")
+        db.set_session_title("plain", "alpha")
+
+        assert db.resolve_resume_anchor("alpha", source="cli") == "plain"
+
+    def test_resolve_resume_anchor_returns_none_for_ambiguous_prefix(self, db):
+        db.create_session("prefix-aa", "cli")
+        db.create_session("prefix-ab", "cli")
+
+        assert db.resolve_resume_anchor("prefix-a", source="cli") is None
+
+    def test_resolve_resume_anchor_honors_source_filter(self, db):
+        db.create_session("cli-root", "cli")
+        db.set_session_title("cli-root", "shared title")
+        db.create_session("tg-root", "telegram")
+        db.set_session_title("tg-root", "shared title #2")
+
+        assert db.resolve_resume_anchor("shared title", source="telegram") == "tg-root"
+        assert db.resolve_resume_anchor("shared title", source="cli") == "cli-root"
+
     def test_next_title_no_existing(self, db):
         """With no existing sessions, base title is returned as-is."""
         assert db.get_next_title_in_lineage("my project") == "my project"


### PR DESCRIPTION
## Summary
- add Telegram inline clarify support with blocking gateway callback flow and typed-answer handling
- add inline Telegram `/commands` and `/resume` navigation plus CLI terminal handoff for interactive resume picking
- harden busy-session command handling and resume lineage traversal

## Test Plan
- source venv/bin/activate && python -m pytest tests/gateway/test_busy_session_ack.py tests/gateway/test_gateway_clarify.py tests/gateway/test_telegram_approval_buttons.py -q
- source venv/bin/activate && python -m pytest tests/tools/test_clarify_tool.py tests/gateway/test_reasoning_command.py -q

## Notes
- branch also includes the related resume/commands menu groundwork needed for the Telegram interaction flow