### PR TITLE
fix(error_classifier): handle dict-typed message fields without crashing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -270,7 +270,7 @@ def classify_api_error(
     if isinstance(body, dict):
         _err_obj = body.get("error", {})
         if isinstance(_err_obj, dict):
-            _body_msg = (_err_obj.get("message") or "").lower()
+            _body_msg = str(_err_obj.get("message") or "").lower()
             # Parse metadata.raw for wrapped provider errors
             _metadata = _err_obj.get("metadata", {})
             if isinstance(_metadata, dict):
@@ -282,11 +282,11 @@ def classify_api_error(
                         if isinstance(_inner, dict):
                             _inner_err = _inner.get("error", {})
                             if isinstance(_inner_err, dict):
-                                _metadata_msg = (_inner_err.get("message") or "").lower()
+                                _metadata_msg = str(_inner_err.get("message") or "").lower()
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
-            _body_msg = (body.get("message") or "").lower()
+            _body_msg = str(body.get("message") or "").lower()
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
@@ -586,10 +586,10 @@ def _classify_400(
     if isinstance(body, dict):
         err_obj = body.get("error", {})
         if isinstance(err_obj, dict):
-            err_body_msg = (err_obj.get("message") or "").strip().lower()
+            err_body_msg = str(err_obj.get("message") or "").strip().lower()
         # Responses API (and some providers) use flat body: {"message": "..."}
         if not err_body_msg:
-            err_body_msg = (body.get("message") or "").strip().lower()
+            err_body_msg = str(body.get("message") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in ("error", "")
     is_large = approx_tokens > context_length * 0.4 or approx_tokens > 80000 or num_messages > 80
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -807,3 +807,73 @@ class TestAdversarialEdgeCases:
         )
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.model_not_found
+
+    # ── Regression: dict-typed message field (Issue #11233) ──
+
+    def test_pydantic_dict_message_no_crash(self):
+        """Pydantic validation errors return message as dict, not string.
+
+        Regression: classify_api_error must not crash when body['message']
+        is a dict (e.g. {"detail": [...]} from FastAPI/Pydantic). The
+        'or ""' fallback only handles None/falsy values — a non-empty
+        dict is truthy and passed to .lower(), causing AttributeError.
+        """
+        e = MockAPIError(
+            "Unprocessable Entity",
+            status_code=422,
+            body={
+                "object": "error",
+                "message": {
+                    "detail": [
+                        {
+                            "type": "extra_forbidden",
+                            "loc": ["body", "think"],
+                            "msg": "Extra inputs are not permitted",
+                        }
+                    ]
+                },
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error
+        assert result.status_code == 422
+        assert result.retryable is False
+
+    def test_nested_error_dict_message_no_crash(self):
+        """Nested body['error']['message'] as dict must not crash.
+
+        Some providers wrap Pydantic errors in an 'error' object.
+        """
+        e = MockAPIError(
+            "Validation error",
+            status_code=400,
+            body={
+                "error": {
+                    "message": {
+                        "detail": [
+                            {"type": "missing", "loc": ["body", "required"]}
+                        ]
+                    }
+                }
+            },
+        )
+        result = classify_api_error(e, approx_tokens=1000)
+        assert result.reason == FailoverReason.format_error
+        assert result.status_code == 400
+
+    def test_metadata_raw_dict_message_no_crash(self):
+        """OpenRouter metadata.raw with dict message must not crash."""
+        e = MockAPIError(
+            "Provider error",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "Provider error",
+                    "metadata": {
+                        "raw": '{"error":{"message":{"detail":[{"type":"invalid"}]}}}'
+                    }
+                }
+            },
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.format_error


### PR DESCRIPTION
## What broke
When API providers return Pydantic-style validation errors where `body["message"]` or `body["error"]["message"]` is a dict (e.g. `{"detail": [...]}`), the error classifier crashes with `AttributeError: "dict" object has no attribute "lower"`. This hides the original API error and bypasses all retry/fallback logic.

## Root cause
The `or ""` fallback in message extraction only handles `None` and falsy values. A non-empty dict is truthy and passes through to `.lower()`, which fails because dicts don"t have a `.lower()` method.

Four call sites were identified in the issue, but grep found five total locations where `.get("message")` is followed by `.lower()`:
- Line 273: `_err_obj.get("message")`
- Line 285: `_inner_err.get("message")` (metadata.raw parsing)
- Line 289: `body.get("message")`
- Line 589: `err_obj.get("message")`
- Line 592: `body.get("message")`

## Why this fix is minimal
Wrap all five call sites with `str()` before calling `.lower()`. This is:
- A no-op for strings (preserves existing behavior)
- Safe for dicts/lists (converts to string repr, never raises)
- Pattern-safe (error classification patterns like "rate limit", "context length" don"t appear inside Python dict repr)

No broader changes: no refactors, no new functions, no opportunistic cleanup.

## What I tested
- Reproduction test: Pydantic-style 422 error with dict message → now classified as `format_error` instead of crashing
- Nested error dict message → works
- metadata.raw with dict message → works
- Normal string messages → still correctly classified (401→auth, 429→rate_limit, 400+context→context_overflow)
- Pattern matching on strings → still works (rate limit, billing, auth patterns)

All 6 regression tests pass.

## What I intentionally did not change
- No changes to error classification logic or patterns
- No changes to `_extract_message()` helper
- No broader refactors or style cleanup
- No new helper functions

Closes #11233