### PR TITLE
fix: explicitly clear Slack "is thinking..." indicator after response

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -100,6 +100,8 @@ class SlackAdapter(BasePlatformAdapter):
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
         self._BOT_TS_MAX = 5000  # cap to avoid unbounded growth
+        # Track active typing status per chat_id so stop_typing can clear it.
+        self._typing_threads: Dict[str, str] = {}  # chat_id → thread_ts
         # Track threads where the bot has been @mentioned — once mentioned,
         # respond to ALL subsequent messages in that thread automatically.
         self._mentioned_threads: set = set()
@@ -361,10 +363,31 @@ class SlackAdapter(BasePlatformAdapter):
                 thread_ts=thread_ts,
                 status="is thinking...",
             )
+            self._typing_threads[chat_id] = thread_ts
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Explicitly clear the assistant 'is thinking...' status indicator.
+
+        The Slack Assistant API is supposed to auto-clear the status when the
+        bot sends a message, but this is unreliable — the indicator often
+        lingers well after the response is delivered.  Explicitly setting an
+        empty status removes it immediately.
+        """
+        thread_ts = self._typing_threads.pop(chat_id, None)
+        if not thread_ts or not self._app:
+            return
+        try:
+            await self._get_client(chat_id).assistant_threads_setStatus(
+                channel_id=chat_id,
+                thread_ts=thread_ts,
+                status="",
+            )
+        except Exception as e:
+            logger.debug("[Slack] clear assistant status failed: %s", e)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.


### PR DESCRIPTION
## Problem

The Slack Assistant API `assistant.threads.setStatus("is thinking...")` is supposed to auto-clear when the bot sends a reply to the thread. In practice, this is unreliable — the "is thinking..." indicator often lingers well after the response has been delivered, making it look like the bot is still processing.

## Fix

- Add a `stop_typing()` override to `SlackAdapter` that explicitly clears the status by calling `assistant.threads.setStatus(status="")`.
- Track the active `thread_ts` per `chat_id` in `_typing_threads` so `stop_typing` (which only receives `chat_id`) knows which thread to clear.
- The base class already calls `stop_typing()` at the correct points in the message lifecycle (after response delivery and in the finally block), so no changes needed outside the Slack adapter.

## Testing

Tested on a live Slack workspace with the assistant API enabled. The indicator now clears immediately when the response is sent.