### PR TITLE
fix(tests): isolate cron scheduler tick lock per test

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -12,6 +12,14 @@ from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
 
+@pytest.fixture(autouse=True)
+def isolate_tick_lock(tmp_path, monkeypatch):
+    """Keep tick() tests hermetic by isolating the scheduler lock file."""
+    lock_dir = tmp_path / "cron-lock"
+    monkeypatch.setattr("cron.scheduler._LOCK_DIR", lock_dir)
+    monkeypatch.setattr("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock")
+
+
 class TestResolveOrigin:
     def test_full_origin(self):
         job = {


### PR DESCRIPTION
Fixes #11474.

## Summary
- isolate `cron.scheduler.tick()` lock state in `tests/cron/test_scheduler.py` by redirecting `_LOCK_DIR` and `_LOCK_FILE` to a per-test temporary path
- remove dependence on the real `~/.hermes/cron/.tick.lock` held by a local gateway process
- keep scheduler assertions focused on mocked cron behavior instead of host machine state

## Testing
- pytest -q -o addopts= tests/cron/test_scheduler.py