### PR TITLE
fix(bedrock): enable prompt caching for Bedrock+Claude on AnthropicBedrock SDK path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -809,7 +809,12 @@ class AIAgent:
         # conversation prefix. Uses system_and_3 strategy (4 breakpoints).
         is_openrouter = self._is_openrouter_url()
         is_claude = "claude" in self.model.lower()
-        is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider == "anthropic"
+        # Anthropic Messages API path: true for direct api.anthropic.com AND for
+        # AWS Bedrock + Claude routed through AnthropicBedrock SDK. Both flow
+        # through the same `anthropic_messages` adapter, which honours
+        # `cache_control` markers. Keeping Bedrock out of this check silently
+        # disabled prompt caching for every Bedrock+Claude deployment.
+        is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider in ("anthropic", "bedrock")
         self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
         self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
         
@@ -1740,7 +1745,9 @@ class AIAgent:
             )
 
         # ── Re-evaluate prompt caching ──
-        is_native_anthropic = api_mode == "anthropic_messages" and new_provider == "anthropic"
+        # Bedrock+Claude on the `anthropic_messages` path also supports caching
+        # (routed through AnthropicBedrock SDK). See init path for full context.
+        is_native_anthropic = api_mode == "anthropic_messages" and new_provider in ("anthropic", "bedrock")
         self._use_prompt_caching = (
             ("openrouter" in (self.base_url or "").lower() and "claude" in new_model.lower())
             or is_native_anthropic
@@ -6085,7 +6092,9 @@ class AIAgent:
                 }
 
             # Re-evaluate prompt caching for the new provider/model
-            is_native_anthropic = fb_api_mode == "anthropic_messages" and fb_provider == "anthropic"
+            # Bedrock+Claude on the `anthropic_messages` path also supports
+            # caching (routed through AnthropicBedrock SDK).
+            is_native_anthropic = fb_api_mode == "anthropic_messages" and fb_provider in ("anthropic", "bedrock")
             self._use_prompt_caching = (
                 ("openrouter" in fb_base_url.lower() and "claude" in fb_model.lower())
                 or is_native_anthropic

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -532,6 +532,57 @@ class TestInit:
             assert a.api_mode == "anthropic_messages"
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_bedrock_claude(self):
+        """Bedrock + Claude on the AnthropicBedrock SDK path should enable prompt caching.
+
+        When `provider: bedrock` is configured with a Claude model, Hermes routes
+        through `api_mode: anthropic_messages` via the AnthropicBedrock SDK (see
+        run_agent.py init path: `if is_anthropic_bedrock_model(...) → AnthropicBedrock`).
+        That path honours `cache_control` markers the same way native Anthropic does,
+        so prompt caching must be enabled for it — otherwise every Bedrock+Claude
+        deployment silently pays full input-token cost on every turn.
+        """
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter._anthropic_sdk"),
+            patch("agent.anthropic_adapter.build_anthropic_bedrock_client"),
+        ):
+            a = AIAgent(
+                api_key="aws-sdk",
+                model="eu.anthropic.claude-sonnet-4-6",
+                provider="bedrock",
+                api_mode="anthropic_messages",
+                base_url="https://bedrock-runtime.eu-central-1.amazonaws.com",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a.provider == "bedrock"
+            assert a._use_prompt_caching is True
+
+    def test_prompt_caching_bedrock_non_claude(self):
+        """Bedrock + non-Claude models use the `bedrock_converse` path, which
+        does not support cache_control. Prompt caching must stay off."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="aws-sdk",
+                model="us.amazon.nova-pro-v1:0",
+                provider="bedrock",
+                api_mode="bedrock_converse",
+                base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "bedrock_converse"
+            assert a._use_prompt_caching is False
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")


### PR DESCRIPTION
## Summary

When `provider: bedrock` is configured with a Claude model, Hermes routes
through the AnthropicBedrock SDK with `api_mode: anthropic_messages` — the
same path used by direct `api.anthropic.com` access, and the only Bedrock
path that supports prompt caching, thinking budgets, and adaptive thinking.

However, `AIAgent._use_prompt_caching` is gated on:

```python
is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider == "anthropic"
```

The literal `provider == "anthropic"` check excludes `provider == "bedrock"`,
so `apply_anthropic_cache_control()` (called on line 8674) never runs for
Bedrock+Claude deployments. Every turn pays full uncached input-token cost
even though Bedrock would happily honor `cache_control` markers via the
Anthropic pass-through.

## Root cause

The init path at [run_agent.py:900](https://github.com/NousResearch/hermes-agent/blob/main/run_agent.py#L900) is explicit:

> Bedrock + Claude → use AnthropicBedrock SDK for full feature parity
> (prompt caching, thinking budgets, adaptive thinking).

And `hermes_cli/runtime_provider.py` confirms:

> Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path

But the caching enablement check in three sibling spots still compares
`provider` against the string `"anthropic"` only, so the caching feature
that this routing was designed to unlock stays silently disabled.

## Fix

Accept `provider in (\"anthropic\", \"bedrock\")` in the `is_native_anthropic`
check at three sites:

| File | Line | Site |
|------|------|------|
| `run_agent.py` | 812 | `AIAgent.__init__` |
| `run_agent.py` | 1743 | `_switch_model` |
| `run_agent.py` | 6088 | fallback activation |

No control flow changes, no new branches — just widening one boolean.

## Verification

Tested live against `eu-central-1` Bedrock with Claude Sonnet 4.6 via an
application-inference-profile ARN. 13214-token system prompt, 3
back-to-back identical calls:

Before fix:
```
CALL 1: cache_creation=0  cache_read=0       input_tokens=13217
CALL 2: cache_creation=0  cache_read=0       input_tokens=13217
```

After fix:
```
CALL 1: cache_creation=13214  cache_read=0      input_tokens=3
CALL 2: cache_creation=0      cache_read=13214  input_tokens=3
CALL 3: cache_creation=0      cache_read=13214  input_tokens=3
```

Cache write on first call, ~90% input-token savings on subsequent calls.

## Tests

Added two tests to `tests/run_agent/test_run_agent.py::TestInit`:

- `test_prompt_caching_bedrock_claude` — Bedrock+Claude on
  `api_mode: anthropic_messages` enables caching
- `test_prompt_caching_bedrock_non_claude` — Bedrock+non-Claude on
  `api_mode: bedrock_converse` keeps caching off (no regression)

Locally all 10 `prompt_caching` tests pass (7 existing + 2 new + 1 unchanged).

## Out of scope (separate bug, worth a follow-up)

The fallback-activation path at [run_agent.py:6052](https://github.com/NousResearch/hermes-agent/blob/main/run_agent.py#L6052) hardcodes
`fb_api_mode = \"bedrock_converse\"` for `fb_provider == \"bedrock\"`,
so Claude models configured as Bedrock fallbacks still land on the
Converse API path and the caching this PR unlocks does not engage for
them. That needs a separate fix — either auto-detect Claude-on-Bedrock
via `is_anthropic_bedrock_model(fb_model)` and route to
`anthropic_messages`, or honor an explicit `api_mode` hint from the
fallback config dict. This PR deliberately keeps that change out of
scope: the caching check fixed here is correct on its own merits, and
the fallback routing deserves standalone review.

## Related

Companion to open PRs touching the same Bedrock path:
- [#10772](https://github.com/NousResearch/hermes-agent/pull/10772) — `preserve_dots` for Bedrock model IDs
- [#10745](https://github.com/NousResearch/hermes-agent/pull/10745) — bundled Bedrock fixes including dots + context-length probe + `aws_sdk` auxiliary warning

Both are necessary for bare EU inference profile IDs like
`eu.anthropic.claude-sonnet-4-6` to reach the Claude path at all. This
PR is independent of them — it fixes caching on whatever identifier
Hermes ends up routing through `anthropic_messages + bedrock`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)