### PR TITLE
fix(cli): strip leaked bracketed-paste markers from user input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7949,8 +7949,11 @@ class HermesCLI:
         # Sanitize surrogate characters that can arrive via clipboard paste from
         # rich-text editors (Google Docs, Word, etc.).  Lone surrogates are invalid
         # UTF-8 and crash JSON serialization in the OpenAI SDK.
+        # Also strip leaked bracketed-paste wrappers (ESC[200~ / ESC[201~) that can
+        # slip through prompt_toolkit on terminals with fast paste delivery.
         if isinstance(message, str):
-            from run_agent import _sanitize_surrogates
+            from run_agent import _sanitize_surrogates, _strip_bracketed_paste_markers
+            message = _strip_bracketed_paste_markers(message)
             message = _sanitize_surrogates(message)
 
         # Add user message to history
@@ -9163,11 +9166,14 @@ class HermesCLI:
             # Normalise line endings — Windows \r\n and old Mac \r both become \n
             # so the 5-line collapse threshold and display are consistent.
             pasted_text = pasted_text.replace('\r\n', '\n').replace('\r', '\n')
+            # Strip any leaked bracketed-paste wrappers so they never reach the
+            # buffer even if the terminal delivered them inside event.data.
+            from run_agent import _sanitize_surrogates, _strip_bracketed_paste_markers
+            pasted_text = _strip_bracketed_paste_markers(pasted_text)
             if _should_auto_attach_clipboard_image_on_paste(pasted_text) and self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:
                 # Sanitize surrogate characters (e.g. from Word/Google Docs paste) before writing
-                from run_agent import _sanitize_surrogates
                 pasted_text = _sanitize_surrogates(pasted_text)
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
@@ -9298,7 +9304,17 @@ class HermesCLI:
                still batch newlines.  Alt+Enter only adds 1 newline per
                event so it never triggers this.
             """
-            text = buf.text
+            # Defensively strip leaked bracketed-paste markers before anything
+            # else so persisted paste files and tracked state never carry
+            # literal ESC[200~/201~ control sequences.
+            from run_agent import _strip_bracketed_paste_markers
+            raw = buf.text
+            cleaned = _strip_bracketed_paste_markers(raw)
+            if cleaned != raw:
+                buf.text = cleaned
+                buf.cursor_position = min(buf.cursor_position, len(cleaned))
+                return
+            text = raw
             chars_added = len(text) - _prev_text_len[0]
             _prev_text_len[0] = len(text)
             if _paste_just_collapsed[0]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -386,6 +386,27 @@ def _sanitize_structure_surrogates(payload: Any) -> bool:
     return found
 
 
+# Matches real ESC[200~/201~ bracketed-paste markers as well as the visible
+# ``^[[200~`` / ``^[[201~`` caret-escape forms that terminals or tooling can
+# render when the raw ESC leaks through.
+_BRACKETED_PASTE_MARKER_RE = re.compile(r'(?:\x1b|\^\[)\[20[01]~')
+
+
+def _strip_bracketed_paste_markers(text: str) -> str:
+    """Strip leaked bracketed-paste wrappers from text.
+
+    prompt_toolkit's bracketed-paste parser (observed on 3.0.52) can degrade
+    into emitting literal ``ESC[200~`` / ``ESC[201~`` into the buffer if the
+    paste prefix is flushed mid-read — a terminal-specific timing edge case
+    reported on Ghostty.  This helper removes both raw escape-sequence and
+    caret-escape renderings defensively so nothing downstream (UI buffer,
+    persisted paste files, API payloads) carries the control sequences.
+    """
+    if '\x1b[200~' in text or '\x1b[201~' in text or '^[[20' in text:
+        return _BRACKETED_PASTE_MARKER_RE.sub('', text)
+    return text
+
+
 def _sanitize_messages_surrogates(messages: list) -> bool:
     """Sanitize surrogate characters from all string content in a messages list.
 
@@ -8710,9 +8731,13 @@ class AIAgent:
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates
         # that are invalid UTF-8 and crash JSON serialization in the OpenAI SDK.
+        # Also strip leaked bracketed-paste wrappers (ESC[200~/201~) that can
+        # bypass the TUI handler on terminals with fast paste delivery.
         if isinstance(user_message, str):
+            user_message = _strip_bracketed_paste_markers(user_message)
             user_message = _sanitize_surrogates(user_message)
         if isinstance(persist_user_message, str):
+            persist_user_message = _strip_bracketed_paste_markers(persist_user_message)
             persist_user_message = _sanitize_surrogates(persist_user_message)
 
         # Strip leaked <memory-context> blocks from user input.  When Honcho's

--- a/tests/cli/test_bracketed_paste_sanitization.py
+++ b/tests/cli/test_bracketed_paste_sanitization.py
@@ -1,0 +1,106 @@
+"""Tests for defensive stripping of leaked bracketed-paste markers.
+
+Regression for the Ghostty-on-Arch paste bug where prompt_toolkit's
+bracketed-paste parser could leak literal ``ESC[200~`` / ``ESC[201~``
+wrappers (or their ``^[[200~`` / ``^[[201~`` caret-escape renderings)
+into the user buffer and persisted paste files.
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import _strip_bracketed_paste_markers
+
+
+class TestStripBracketedPasteMarkers:
+    def test_clean_text_unchanged_identity(self):
+        text = "hello world — normal paste with unicode café"
+        assert _strip_bracketed_paste_markers(text) is text
+
+    def test_empty_string(self):
+        assert _strip_bracketed_paste_markers("") == ""
+
+    def test_strips_real_start_marker(self):
+        dirty = "\x1b[200~Search personal knowledge bases"
+        assert _strip_bracketed_paste_markers(dirty) == "Search personal knowledge bases"
+
+    def test_strips_real_end_marker(self):
+        dirty = "pasted content\x1b[201~"
+        assert _strip_bracketed_paste_markers(dirty) == "pasted content"
+
+    def test_strips_both_real_wrappers(self):
+        dirty = "\x1b[200~multi line\npaste body\x1b[201~"
+        assert _strip_bracketed_paste_markers(dirty) == "multi line\npaste body"
+
+    def test_strips_caret_escape_start_form(self):
+        # The caret-escape rendering terminals and `cat -v` use for ESC
+        dirty = "qmd is built in? ^[[200~Search personal notes"
+        assert _strip_bracketed_paste_markers(dirty) == "qmd is built in? Search personal notes"
+
+    def test_strips_caret_escape_end_form(self):
+        dirty = "notes^[[201~"
+        assert _strip_bracketed_paste_markers(dirty) == "notes"
+
+    def test_strips_mixed_real_and_caret_escape(self):
+        dirty = "\x1b[200~body one^[[201~ and ^[[200~body two\x1b[201~"
+        assert _strip_bracketed_paste_markers(dirty) == "body one and body two"
+
+    def test_strips_multiple_leaked_markers(self):
+        dirty = "^[[200~a^[[200~b^[[201~c^[[201~"
+        assert _strip_bracketed_paste_markers(dirty) == "abc"
+
+    def test_does_not_strip_unrelated_escape_sequences(self):
+        # ANSI color sequences and unrelated CSI codes must survive
+        color = "\x1b[31mred\x1b[0m and [200 in brackets"
+        assert _strip_bracketed_paste_markers(color) == color
+
+    def test_does_not_strip_lookalike_text(self):
+        # "200~" without the ESC[ / ^[[ prefix is just text
+        text = "code 200~ok and [201~foo"
+        assert _strip_bracketed_paste_markers(text) == text
+
+
+class TestChatStripsBracketedPasteMarkers:
+    """Integration: AIAgent.run_conversation should strip leaked markers."""
+
+    @patch("run_agent.AIAgent._build_system_prompt")
+    @patch("run_agent.AIAgent._interruptible_streaming_api_call")
+    @patch("run_agent.AIAgent._interruptible_api_call")
+    def test_user_message_markers_stripped(self, mock_api, mock_stream, mock_sys):
+        from run_agent import AIAgent
+
+        mock_sys.return_value = "system prompt"
+        mock_choice = MagicMock()
+        mock_choice.message.content = "ok"
+        mock_choice.message.tool_calls = None
+        mock_choice.message.refusal = None
+        mock_choice.finish_reason = "stop"
+        mock_choice.message.reasoning_content = None
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        mock_response.model = "test-model"
+        mock_response.id = "test-id"
+        mock_stream.return_value = mock_response
+        mock_api.return_value = mock_response
+
+        agent = AIAgent(
+            model="test/model",
+            api_key="test-key",
+            base_url="http://localhost:1234/v1",
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+        )
+        agent.client = MagicMock()
+
+        result = agent.run_conversation(
+            user_message="\x1b[200~pasted body^[[201~",
+            conversation_history=[],
+        )
+
+        for msg in result.get("messages", []):
+            if msg.get("role") == "user":
+                content = msg["content"]
+                assert "\x1b[200~" not in content
+                assert "\x1b[201~" not in content
+                assert "^[[200~" not in content
+                assert "^[[201~" not in content


### PR DESCRIPTION
## Summary

Closes #7316.

When prompt_toolkit 3.0.52 flushes the bracketed-paste prefix mid-read — a terminal-specific timing edge case observed on Ghostty — literal `ESC[200~` / `ESC[201~` wrappers (or their `^[[200~` / `^[[201~` caret-escape renderings) can leak into the input buffer instead of being consumed as a `Keys.BracketedPaste` event. Once leaked, Hermes persisted them into `~/.hermes/pastes/*.txt` and forwarded them to the agent, which made the TUI feel frozen and polluted the API payload.

This PR adds a defensive `_strip_bracketed_paste_markers` helper alongside the existing `_sanitize_surrogates` and invokes it at four sites so neither the buffer, the persisted paste file, nor the outbound API payload can carry the control sequences:

- `cli.py` `handle_paste` — the explicit `Keys.BracketedPaste` handler
- `cli.py` `_on_text_changed` — the fallback large-paste collapse path
- `cli.py` `HermesCli.chat` — the CLI entry point before dispatching to the agent
- `run_agent.py` `AIAgent.run_conversation` — the API boundary, covers non-CLI callers too

The regex matches both the real ESC form and the caret-escape rendering while ignoring lookalike text (`"200~"`, `"[201~foo"`) and unrelated CSI codes such as color escapes, so normal pastes are unchanged.

## Test plan

- [x] `tests/cli/test_bracketed_paste_sanitization.py` — new unit + integration coverage (12 tests): clean-text no-op identity, empty string, real/caret forms in isolation and combined, mixed + repeated markers, unrelated ANSI color sequences preserved, `[200~`/`[201~` lookalike text preserved, and `run_conversation` end-to-end marker strip.
- [x] Existing `tests/cli/test_surrogate_sanitization.py` still passes — no regression in the adjacent sanitization path.
- [x] Validated in a disposable Python 3.13 Docker container: `pytest tests/cli/test_bracketed_paste_sanitization.py tests/cli/test_surrogate_sanitization.py` → 26 passed.