### PR TITLE
fix(cli): support custom provider model dictionaries in model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -814,6 +814,15 @@ def list_authenticated_providers(
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
     seen_mdev_ids: set = set()  # prevent duplicate entries for aliases (e.g. kimi-coding + kimi-coding-cn)
+    seen_user_provider_keys: set = set()
+    seen_user_provider_name_urls: set = set()
+
+    def _normalize_provider_name_url(name: str, api_url: str) -> tuple[str, str] | None:
+        normalized_name = (name or "").strip().lower()
+        normalized_url = (api_url or "").strip().rstrip("/").lower()
+        if not normalized_name or not normalized_url:
+            return None
+        return (normalized_name, normalized_url)
 
     data = fetch_models_dev()
 
@@ -1040,19 +1049,28 @@ def list_authenticated_providers(
             if not isinstance(ep_cfg, dict):
                 continue
             display_name = ep_cfg.get("name", "") or ep_name
-            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
-            default_model = ep_cfg.get("default_model", "")
+            api_url = (
+                ep_cfg.get("api", "")
+                or ep_cfg.get("url", "")
+                or ep_cfg.get("base_url", "")
+                or ""
+            )
+            default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
 
-            # Build models list from both default_model and full models array
+            # Build models list from both default_model and full models array/dict
             models_list = []
-            if default_model:
+            if isinstance(default_model, str) and default_model:
                 models_list.append(default_model)
-            # Also include the full models list from config
             cfg_models = ep_cfg.get("models", [])
             if isinstance(cfg_models, list):
-                for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                iterable_models = cfg_models
+            elif isinstance(cfg_models, dict):
+                iterable_models = list(cfg_models.keys())
+            else:
+                iterable_models = []
+            for m in iterable_models:
+                if isinstance(m, str) and m and m not in models_list:
+                    models_list.append(m)
 
             # Try to probe /v1/models if URL is set (but don't block on it)
             # For now just show what we know from config
@@ -1066,6 +1084,13 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            ep_name_normalized = str(ep_name).strip().lower()
+            if ep_name_normalized:
+                seen_slugs.add(ep_name_normalized)
+                seen_user_provider_keys.add(ep_name_normalized)
+            name_url_pair = _normalize_provider_name_url(display_name, api_url)
+            if name_url_pair is not None:
+                seen_user_provider_name_urls.add(name_url_pair)
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named
@@ -1104,9 +1129,25 @@ def list_authenticated_providers(
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
 
+            cfg_models = entry.get("models")
+            if isinstance(cfg_models, list):
+                iterable_models = cfg_models
+            elif isinstance(cfg_models, dict):
+                iterable_models = list(cfg_models.keys())
+            else:
+                iterable_models = []
+            for model_name in iterable_models:
+                if isinstance(model_name, str) and model_name and model_name not in groups[slug]["models"]:
+                    groups[slug]["models"].append(model_name)
+
         for slug, grp in groups.items():
-            if slug.lower() in seen_slugs:
-                continue
+            normalized_slug = slug.lower()
+            normalized_pair = _normalize_provider_name_url(grp["name"], grp["api_url"])
+            if normalized_slug in seen_slugs:
+                if normalized_slug not in seen_user_provider_keys:
+                    continue
+                if normalized_pair is not None and normalized_pair in seen_user_provider_name_urls:
+                    continue
             results.append({
                 "slug": slug,
                 "name": grp["name"],

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -116,6 +116,127 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     assert user_prov["models"] == ["single-model"]
 
 
+def test_list_authenticated_providers_supports_v12_provider_shape(monkeypatch):
+    """providers.<name> should support base_url + model + models(dict)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "custom": {
+            "name": "custom",
+            "base_url": "http://example.com/v1",
+            "model": "gpt-5.4",
+            "models": {
+                "gpt-5.4": {},
+                "grok-4.20-beta": {},
+                "minimax-m2.7": {},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next((p for p in providers if p["slug"] == "custom"), None)
+
+    assert user_prov is not None
+    assert user_prov["api_url"] == "http://example.com/v1"
+    assert user_prov["total_models"] == 3
+    assert user_prov["models"] == ["gpt-5.4", "grok-4.20-beta", "minimax-m2.7"]
+
+
+def test_list_authenticated_providers_dedupes_compatible_custom_view_for_same_provider(monkeypatch):
+    """Don't show both providers.custom and its compatibility-layer custom_providers clone."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "custom": {
+            "name": "custom",
+            "base_url": "http://example.com/v1",
+            "model": "gpt-5.4",
+            "models": {
+                "gpt-5.4": {},
+                "grok-4.20-beta": {},
+            },
+        }
+    }
+    custom_providers = [
+        {
+            "name": "custom",
+            "base_url": "http://example.com/v1",
+            "model": "gpt-5.4",
+            "models": {
+                "gpt-5.4": {},
+                "grok-4.20-beta": {},
+            },
+            "provider_key": "custom",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    matching = [p for p in providers if p["slug"] == "custom"]
+    assert len(matching) == 1
+    assert matching[0]["models"] == ["gpt-5.4", "grok-4.20-beta"]
+    assert matching[0]["total_models"] == 2
+
+
+def test_list_authenticated_providers_keeps_distinct_custom_provider_same_name_different_url(monkeypatch):
+    """Keep distinct custom providers when only the display name matches."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "custom": {
+            "name": "custom",
+            "base_url": "http://example.com/v1",
+            "model": "gpt-5.4",
+            "models": {
+                "gpt-5.4": {},
+            },
+        }
+    }
+    custom_providers = [
+        {
+            "name": "custom",
+            "base_url": "http://other.example.com/v1",
+            "model": "grok-4.20-beta",
+            "models": {
+                "grok-4.20-beta": {},
+            },
+            "provider_key": "custom-secondary",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    matching = [p for p in providers if p["name"] == "custom"]
+    assert len(matching) == 2
+    assert {p["api_url"] for p in matching} == {
+        "http://example.com/v1",
+        "http://other.example.com/v1",
+    }
+    assert {tuple(p["models"]) for p in matching} == {
+        ("gpt-5.4",),
+        ("grok-4.20-beta",),
+    }
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes the shared model picker provider listing logic so custom providers configured with the newer `providers.<name>` shape are displayed correctly.

Previously, a custom provider using `base_url`, `model`, and `models` as a dict could appear with only its default model, and in some cases the picker could show duplicate provider rows such as `custom (0)` and `custom (1)`.

This change updates `list_authenticated_providers()` to support the newer config shape and deduplicate equivalent provider entries without collapsing distinct providers that only share the same display name.

## Related Issue

Fixes #11499

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `hermes_cli/model_switch.py` to:
  - accept `base_url` as a custom provider API URL source
  - accept `model` as a default model source
  - expand `models` when provided as a dict by using its keys as model names
  - deduplicate equivalent provider entries across `providers.<name>` and compatibility-layer `custom_providers`
  - keep distinct custom providers when they share a display name but use different URLs
- Added regression tests in `tests/hermes_cli/test_user_providers_model_switch.py` for:
  - newer `providers.<name>` config shape support
  - duplicate custom provider suppression
  - preserving distinct providers with the same display name when their endpoints differ

## How to Test

1. Configure a custom provider with the newer shape:

   ```yaml
   providers:
     custom:
       base_url: http://example.com/v1
       model: gpt-5.4
       models:
         gpt-5.4: {}
         grok-4.20-beta: {}
         minimax-m2.7: {}
   ```

2. Start the Telegram gateway and open the `/model` picker.
3. Verify the picker shows a single `custom` provider entry for the same endpoint.
4. Verify the picker lists all configured models instead of only the default model.
5. Run:

   ```bash
   source venv/bin/activate
   pytest tests/hermes_cli/test_user_providers_model_switch.py tests/gateway/test_model_command_custom_providers.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (trixie)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant regression tests pass:

```text
13 passed in 2.11s
```
