### PR TITLE
feat(cli): support custom profile alias names in profile list/show

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4551,7 +4551,8 @@ def cmd_profile(args):
                 print(f"Gateway:        {'running' if p.gateway_running else 'stopped'}")
                 print(f"Skills:         {p.skill_count} installed")
                 if p.alias_path:
-                    print(f"Alias:          {p.name} → hermes -p {p.name}")
+                    alias_display = p.alias_name or p.name
+                    print(f"Alias:          {alias_display} → hermes -p {p.name}")
                 break
         print()
         return
@@ -4573,7 +4574,7 @@ def cmd_profile(args):
             name = p.name
             model = (p.model or "—")[:26]
             gw = "running" if p.gateway_running else "stopped"
-            alias = p.name if p.alias_path else "—"
+            alias = p.alias_name if p.alias_name else (p.name if p.alias_path else "—")
             if p.is_default:
                 alias = "—"
             print(f"{marker}{name:<15} {model:<28} {gw:<12} {alias}")
@@ -4703,8 +4704,10 @@ def cmd_profile(args):
         print(f"Skills:  {skills}")
         print(f".env:    {'exists' if (profile_dir / '.env').exists() else 'not configured'}")
         print(f"SOUL.md: {'exists' if (profile_dir / 'SOUL.md').exists() else 'not configured'}")
-        if wrapper.exists():
-            print(f"Alias:   {wrapper}")
+        from hermes_cli.profiles import _find_alias_name, _get_wrapper_dir
+        alias_name = _find_alias_name(name, _get_wrapper_dir())
+        if alias_name:
+            print(f"Alias:   {alias_name}")
         print()
 
     elif action == "alias":

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -277,6 +277,7 @@ class ProfileInfo:
     has_env: bool = False
     skill_count: int = 0
     alias_path: Optional[Path] = None
+    alias_name: Optional[str] = None
 
 
 def _read_config_model(profile_dir: Path) -> tuple:
@@ -332,6 +333,27 @@ def _count_skills(profile_dir: Path) -> int:
 # CRUD operations
 # ---------------------------------------------------------------------------
 
+def _find_alias_name(profile_name: str, wrapper_dir: Path) -> Optional[str]:
+    """Scan wrapper_dir for a script that invokes hermes -p <profile_name>."""
+    if not wrapper_dir.is_dir():
+        return None
+    custom = None
+    default = None
+    for entry in wrapper_dir.iterdir():
+        if not entry.is_file():
+            continue
+        try:
+            content = entry.read_text()
+        except Exception:
+            continue
+        if f'hermes -p {profile_name}' in content or f'hermes --profile={profile_name}' in content:
+            if entry.name == profile_name:
+                default = entry.name
+            elif custom is None:
+                custom = entry.name
+    return custom if custom is not None else default
+
+
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
@@ -362,7 +384,8 @@ def list_profiles() -> List[ProfileInfo]:
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)
-            alias_path = wrapper_dir / name
+            alias_name = _find_alias_name(name, wrapper_dir)
+            alias_path = wrapper_dir / alias_name if alias_name else (wrapper_dir / name if (wrapper_dir / name).exists() else None)
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
@@ -372,7 +395,8 @@ def list_profiles() -> List[ProfileInfo]:
                 provider=provider,
                 has_env=(entry / ".env").exists(),
                 skill_count=_count_skills(entry),
-                alias_path=alias_path if alias_path.exists() else None,
+                alias_path=alias_path,
+                alias_name=alias_name,
             ))
 
     return profiles


### PR DESCRIPTION
Previously, `hermes profile list` and `hermes profile show` always displayed the profile name as the alias, even when a custom wrapper (e.g. `qiaobusi` pointing to `steve-jobs`) existed.

This patch:
- Adds `_find_alias_name()` to scan wrapper scripts and detect custom aliases that invoke `hermes -p <profile>`.
- Extends `ProfileInfo` with an `alias_name` field.
- Updates `profile list` to display the custom alias when present.
- Updates `profile show` to display the detected alias name.

Fixes the hard-coded assumption that alias == profile name.