### PR TITLE
fix(bedrock): preserve Claude model IDs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6423,11 +6423,23 @@ class AIAgent:
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        Bedrock Claude model IDs also keep dots in the provider prefix."""
+        if (getattr(self, "provider", "") or "").lower() in {
+            "alibaba",
+            "minimax",
+            "minimax-cn",
+            "opencode-go",
+            "opencode-zen",
+            "zai",
+            "bedrock",
+        }:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base
+        return (
+            "dashscope" in base
+            or "aliyuncs" in base
+            or "minimax" in base
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -481,6 +481,12 @@ class TestNormalizeModelName:
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
+    def test_preserve_dots_for_bedrock_inference_profile(self):
+        assert normalize_model_name("us.anthropic.claude-sonnet-4-6", preserve_dots=True) == "us.anthropic.claude-sonnet-4-6"
+
+    def test_preserve_dots_for_bedrock_versioned_model(self):
+        assert normalize_model_name("us.anthropic.claude-opus-4-6-v1", preserve_dots=True) == "us.anthropic.claude-opus-4-6-v1"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -150,6 +150,21 @@ class TestRuntimeProvider:
         assert "bedrock-runtime.eu-west-1.amazonaws.com" in result["base_url"]
         assert result["api_key"] == "aws-sdk"
 
+    def test_bedrock_claude_runtime_uses_anthropic_messages(self, monkeypatch):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={"provider": "bedrock", "default": "us.anthropic.claude-sonnet-4-6"}):
+            result = resolve_runtime_provider(requested="bedrock")
+
+        assert result["provider"] == "bedrock"
+        assert result["api_mode"] == "anthropic_messages"
+        assert result["bedrock_anthropic"] is True
+
     def test_bedrock_runtime_default_region(self, monkeypatch):
         from hermes_cli.runtime_provider import resolve_runtime_provider
 

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -332,6 +332,18 @@ class TestMinimaxPreserveDots:
         from run_agent import AIAgent
         assert AIAgent._anthropic_preserve_dots(agent) is True
 
+    def test_bedrock_provider_preserves_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="bedrock", base_url="")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_bedrock_runtime_url_preserves_dots(self):
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="custom", base_url="https://bedrock-runtime.us-east-1.amazonaws.com")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
     def test_normalize_preserves_m25_free_dot(self):
         from agent.anthropic_adapter import normalize_model_name
         assert normalize_model_name("minimax-m2.5-free", preserve_dots=True) == "minimax-m2.5-free"


### PR DESCRIPTION
## What does this PR do?

Fixes a Bedrock Claude model ID bug in the Anthropic request path.

Hermes routes Bedrock Claude models through the Anthropic client path for feature parity, but `_anthropic_preserve_dots()` did not treat Bedrock as a dot-preserving provider. That caused Bedrock model IDs like `us.anthropic.claude-sonnet-4-6` to be normalized incorrectly before request dispatch, which leads Bedrock to reject the model identifier.

This PR keeps Bedrock Claude model IDs intact and adds regression coverage around the Bedrock-specific normalization and routing path.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `run_agent.py` so `AIAgent._anthropic_preserve_dots()` treats Bedrock as a dot-preserving Anthropic-compatible provider.
- Preserve dots for Bedrock runtime URLs such as `https://bedrock-runtime.us-east-1.amazonaws.com`.
- Add regression tests in `tests/agent/test_minimax_provider.py` covering Bedrock provider and Bedrock runtime URL handling.
- Add regression tests in `tests/agent/test_anthropic_adapter.py` verifying Bedrock model IDs remain unchanged when `preserve_dots=True`.
- Add a runtime test in `tests/agent/test_bedrock_integration.py` verifying Bedrock Claude models use the `anthropic_messages` path.

## How to Test

1. Run:
   `uv run --extra dev pytest tests/agent/test_minimax_provider.py tests/agent/test_anthropic_adapter.py tests/agent/test_bedrock_integration.py -q`
2. Configure Hermes to use AWS Bedrock with a Claude model such as `us.anthropic.claude-sonnet-4-6`.
3. Send a prompt and confirm Hermes no longer rewrites the Bedrock model ID before request dispatch.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reproduction before the fix:
<img width="1704" height="956" alt="image" src="https://github.com/user-attachments/assets/c267f07e-97fa-4aac-8bbb-07eef3645ca5" />


Focused regression suite run:

```text
uv run --extra dev pytest tests/agent/test_minimax_provider.py tests/agent/test_anthropic_adapter.py tests/agent/test_bedrock_integration.py -q
197 passed, 24 warnings in 4.71s
```