### PR TITLE
fix(auth): parse OpenAI nested error shape in Codex token refresh

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1496,12 +1496,21 @@ def refresh_codex_oauth_pure(
         try:
             err = response.json()
             if isinstance(err, dict):
-                err_code = err.get("error")
-                if isinstance(err_code, str) and err_code.strip():
-                    code = err_code.strip()
-                err_desc = err.get("error_description") or err.get("message")
-                if isinstance(err_desc, str) and err_desc.strip():
-                    message = f"Codex token refresh failed: {err_desc.strip()}"
+                err_obj = err.get("error")
+                # OpenAI shape: {"error": {"code": "...", "message": "...", "type": "..."}}
+                if isinstance(err_obj, dict):
+                    nested_code = err_obj.get("code") or err_obj.get("type")
+                    if isinstance(nested_code, str) and nested_code.strip():
+                        code = nested_code.strip()
+                    nested_msg = err_obj.get("message")
+                    if isinstance(nested_msg, str) and nested_msg.strip():
+                        message = f"Codex token refresh failed: {nested_msg.strip()}"
+                # OAuth spec shape: {"error": "code_str", "error_description": "..."}
+                elif isinstance(err_obj, str) and err_obj.strip():
+                    code = err_obj.strip()
+                    err_desc = err.get("error_description") or err.get("message")
+                    if isinstance(err_desc, str) and err_desc.strip():
+                        message = f"Codex token refresh failed: {err_desc.strip()}"
         except Exception:
             pass
         if code in {"invalid_grant", "invalid_token", "invalid_request"}:

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -18,6 +18,7 @@ from hermes_cli.auth import (
     _import_codex_cli_tokens,
     get_codex_auth_status,
     get_provider_auth_state,
+    refresh_codex_oauth_pure,
     resolve_codex_runtime_credentials,
     resolve_provider,
 )
@@ -283,3 +284,121 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["source"] == "hermes-auth-store"
     assert creds["provider"] == "openai-codex"
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
+
+
+class _StubHTTPResponse:
+    def __init__(self, status_code: int, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload) if isinstance(payload, (dict, list)) else str(payload)
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _StubHTTPClient:
+    def __init__(self, response):
+        self._response = response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def post(self, *args, **kwargs):
+        return self._response
+
+
+def _patch_httpx(monkeypatch, response):
+    def _factory(*args, **kwargs):
+        return _StubHTTPClient(response)
+
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", _factory)
+
+
+def test_refresh_parses_openai_nested_error_shape_refresh_token_reused(monkeypatch):
+    """OpenAI returns {"error": {"code": "refresh_token_reused", "message": "..."}}
+    — parser must surface relogin_required and the dedicated message.
+    """
+    response = _StubHTTPResponse(
+        401,
+        {
+            "error": {
+                "message": "Your refresh token has already been used to generate a new access token. Please try signing in again.",
+                "type": "invalid_request_error",
+                "param": None,
+                "code": "refresh_token_reused",
+            }
+        },
+    )
+    _patch_httpx(monkeypatch, response)
+
+    with pytest.raises(AuthError) as exc_info:
+        refresh_codex_oauth_pure("access-old", "refresh-old")
+
+    err = exc_info.value
+    assert err.code == "refresh_token_reused"
+    assert err.relogin_required is True
+    # The existing dedicated branch should override the message with actionable guidance.
+    assert "already consumed by another client" in str(err)
+
+
+def test_refresh_parses_openai_nested_error_shape_generic_code(monkeypatch):
+    """Nested error with arbitrary code still surfaces code + message."""
+    response = _StubHTTPResponse(
+        400,
+        {
+            "error": {
+                "message": "Invalid client credentials.",
+                "type": "invalid_request_error",
+                "code": "invalid_client",
+            }
+        },
+    )
+    _patch_httpx(monkeypatch, response)
+
+    with pytest.raises(AuthError) as exc_info:
+        refresh_codex_oauth_pure("access-old", "refresh-old")
+
+    err = exc_info.value
+    assert err.code == "invalid_client"
+    assert "Invalid client credentials." in str(err)
+
+
+def test_refresh_parses_oauth_spec_flat_error_shape_invalid_grant(monkeypatch):
+    """Fallback path: OAuth spec-shape {"error": "invalid_grant", "error_description": "..."}
+    must still map to relogin_required=True via the existing code set.
+    """
+    response = _StubHTTPResponse(
+        400,
+        {
+            "error": "invalid_grant",
+            "error_description": "Refresh token is expired or revoked.",
+        },
+    )
+    _patch_httpx(monkeypatch, response)
+
+    with pytest.raises(AuthError) as exc_info:
+        refresh_codex_oauth_pure("access-old", "refresh-old")
+
+    err = exc_info.value
+    assert err.code == "invalid_grant"
+    assert err.relogin_required is True
+    assert "Refresh token is expired or revoked." in str(err)
+
+
+def test_refresh_falls_back_to_generic_message_on_unparseable_body(monkeypatch):
+    """No JSON body → generic 'with status 401' message; relogin_required stays False."""
+    response = _StubHTTPResponse(401, ValueError("not json"))
+    _patch_httpx(monkeypatch, response)
+
+    with pytest.raises(AuthError) as exc_info:
+        refresh_codex_oauth_pure("access-old", "refresh-old")
+
+    err = exc_info.value
+    assert err.code == "codex_refresh_failed"
+    assert err.relogin_required is False
+    assert "status 401" in str(err)


### PR DESCRIPTION
## Summary

- Codex token refresh at `hermes_cli/auth.py:refresh_codex_oauth_pure` fails to surface the correct `error` code/message when OpenAI returns a **401 `refresh_token_reused`** — the existing dedicated branch (with actionable re-auth guidance and `relogin_required=True`) never fires.
- Root cause: OpenAI returns errors as a **nested** object, not the OAuth spec's flat shape. The parser only understood the flat shape.
- Fix: handle both shapes; downstream code-based branches (`refresh_token_reused`, `invalid_grant`, `invalid_token`, `invalid_request`) now fire correctly.

### Before
User's access token expires, hermes attempts refresh, another Codex client (Codex CLI, VS Code extension) had already consumed the single-use refresh token. User sees:
> Provider authentication failed: Codex token refresh failed with status 401.

No indication that re-authentication is required. Every subsequent message fails the same way.

### After
Same scenario now surfaces the existing (but previously unreachable) message:
> Codex refresh token was already consumed by another client (e.g. Codex CLI or VS Code extension). Run `codex` in your terminal to generate fresh tokens, then run `hermes auth` to re-authenticate.

…with `relogin_required=True` so callers can prompt re-auth instead of silently retrying.

### The two error shapes

OpenAI (`https://auth.openai.com/oauth/token`):
```json
{\"error\": {\"code\": \"refresh_token_reused\", \"message\": \"...\", \"type\": \"invalid_request_error\"}}
```

OAuth 2.0 spec (what the old parser expected):
```json
{\"error\": \"invalid_grant\", \"error_description\": \"...\"}
```

Both are now handled. The nested `code`/`type` is mapped onto the same `code` variable so the existing branches at lines ~1253-1262 work without change.

## Test plan

- [x] New unit tests in `tests/hermes_cli/test_auth_codex_provider.py`:
  - nested `refresh_token_reused` → `code`, `relogin_required=True`, actionable message
  - nested generic code (`invalid_client`) → code + message surfaced
  - flat OAuth-spec `invalid_grant` → back-compat, still triggers `relogin_required=True`
  - unparseable body → generic `"status 401"` fallback, `relogin_required=False`
- [x] All 19 tests in the file pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)