### PR TITLE
fix(process_registry): size PTY background sessions from terminal dimensions

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -403,6 +403,71 @@ class TestSpawnEnvSanitization:
 
 
 # =========================================================================
+# PTY terminal dimensions (issue #7321)
+# =========================================================================
+
+class TestPtyTerminalDimensions:
+    def test_prefers_columns_lines_env(self, registry, monkeypatch):
+        monkeypatch.setenv("COLUMNS", "160")
+        monkeypatch.setenv("LINES", "45")
+        assert registry._get_terminal_dimensions() == (45, 160)
+
+    def test_ignores_non_positive_env_values(self, registry, monkeypatch):
+        monkeypatch.setenv("COLUMNS", "0")
+        monkeypatch.setenv("LINES", "not-a-number")
+        with patch(
+            "tools.process_registry.shutil.get_terminal_size",
+            return_value=os.terminal_size((200, 50)),
+        ):
+            assert registry._get_terminal_dimensions() == (50, 200)
+
+    def test_falls_back_to_default_when_all_sources_invalid(
+        self, registry, monkeypatch
+    ):
+        monkeypatch.delenv("COLUMNS", raising=False)
+        monkeypatch.delenv("LINES", raising=False)
+        with patch(
+            "tools.process_registry.shutil.get_terminal_size",
+            return_value=os.terminal_size((0, 0)),
+        ):
+            assert registry._get_terminal_dimensions() == (30, 120)
+
+    def test_spawn_local_pty_sets_columns_lines_and_dimensions(
+        self, registry, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        captured = {}
+        fake_thread = MagicMock()
+
+        class FakePty:
+            pid = 4242
+
+            @classmethod
+            def spawn(cls, cmd, **kwargs):
+                captured["cmd"] = cmd
+                captured.update(kwargs)
+                return cls()
+
+        monkeypatch.setitem(
+            sys.modules, "ptyprocess", SimpleNamespace(PtyProcess=FakePty)
+        )
+        monkeypatch.setattr(registry, "_get_terminal_dimensions", lambda: (50, 180))
+
+        with (
+            patch("tools.process_registry._find_shell", return_value="/bin/bash"),
+            patch("threading.Thread", return_value=fake_thread),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("echo hi", cwd="/tmp", use_pty=True)
+
+        assert session.pid == 4242
+        assert captured["dimensions"] == (50, 180)
+        assert captured["env"]["LINES"] == "50"
+        assert captured["env"]["COLUMNS"] == "180"
+
+
+# =========================================================================
 # Checkpoint
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -34,6 +34,7 @@ import logging
 import os
 import platform
 import shlex
+import shutil
 import signal
 import subprocess
 import threading
@@ -283,6 +284,37 @@ class ProcessRegistry:
     # ----- Spawn -----
 
     @staticmethod
+    def _get_terminal_dimensions() -> tuple:
+        """Best-effort PTY size as (rows, columns).
+
+        Prefer COLUMNS/LINES from the current environment when both are valid
+        positive integers, then shutil.get_terminal_size(), then fall back to
+        the historical (30, 120) default.
+        """
+        def _positive(value: Optional[str]) -> Optional[int]:
+            if not value:
+                return None
+            try:
+                n = int(value)
+            except (TypeError, ValueError):
+                return None
+            return n if n > 0 else None
+
+        cols = _positive(os.environ.get("COLUMNS"))
+        rows = _positive(os.environ.get("LINES"))
+        if rows and cols:
+            return (rows, cols)
+
+        try:
+            size = shutil.get_terminal_size(fallback=(0, 0))
+            if size.columns > 0 and size.lines > 0:
+                return (size.lines, size.columns)
+        except (OSError, ValueError):
+            pass
+
+        return (30, 120)
+
+    @staticmethod
     def _env_temp_dir(env: Any) -> str:
         """Return the writable sandbox temp dir for env-backed background tasks."""
         get_temp_dir = getattr(env, "get_temp_dir", None)
@@ -333,11 +365,14 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                rows, cols = self._get_terminal_dimensions()
+                pty_env["LINES"] = str(rows)
+                pty_env["COLUMNS"] = str(cols)
                 pty_proc = _PtyProcessCls.spawn(
                     [user_shell, "-lic", f"set +m; {command}"],
                     cwd=session.cwd,
                     env=pty_env,
-                    dimensions=(30, 120),
+                    dimensions=(rows, cols),
                 )
                 session.pid = pty_proc.pid
                 # Store the pty handle on the session for read/write


### PR DESCRIPTION
## What does this PR do?

PTY-backed background sessions in `tools/process_registry.py` were spawned with a hardcoded `dimensions=(30, 120)` and no `COLUMNS` / `LINES` in the PTY environment. As a result, terminal-aware commands inside `terminal(..., background=true, pty=true)` sessions rendered as if the terminal had a fixed, often wrong size.

This PR sizes PTY sessions at spawn time from the current terminal and exports `COLUMNS` / `LINES` into the PTY environment.

## Related Issue

Fixes #7321

Note: an earlier PR (#7328) from the issue reporter addresses the same bug but carries whole-file reformatting and is currently in merge-conflict state. This PR offers a narrower alternative with no unrelated changes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py`:
  - add `ProcessRegistry._get_terminal_dimensions()` (prefers `COLUMNS`/`LINES`, then `shutil.get_terminal_size()`, falls back to `(30, 120)`)
  - in `spawn_local` PTY path: set `LINES`/`COLUMNS` in `pty_env` and pass the computed `(rows, cols)` to `PtyProcess.spawn`
- `tests/tools/test_process_registry.py`: add `TestPtyTerminalDimensions` covering env preference, invalid-value handling, fallback, and PTY spawn wiring

## How to Test

```
python -m pytest tests/tools/test_process_registry.py -q
```

Validated in a Python 3.13 Docker container: all 46 tests in `tests/tools/test_process_registry.py` pass, including the 4 new ones.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix (no reformatting or unrelated cleanup)
- [x] Tests added for the new behavior
- [x] Tested on Linux (Docker, Python 3.13)

### Documentation & Housekeeping

- [x] No public API / config key changes — N/A
- [x] Cross-platform: `_get_terminal_dimensions()` relies on stdlib (`os.environ`, `shutil.get_terminal_size`) so it is safe on Windows/macOS/Linux; the existing Windows winpty branch is unchanged in behavior other than now receiving accurate dimensions.

## Notes

Scope is intentionally limited to spawn-time sizing. Live resize propagation for already-running PTY sessions (forwarding SIGWINCH) is out of scope and can be handled separately.