### PR TITLE
fix(cli): show active fallback model in /model Current: line

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4849,8 +4849,17 @@ class HermesCLI:
         )
         from hermes_cli.auth import resolve_provider as _resolve_provider
 
+        # Prefer the agent's live model/provider — _try_activate_fallback()
+        # mutates agent.model / agent.provider in place, while self.model
+        # and self.provider still reflect the originally configured primary.
+        # Without this the "Current:" line keeps showing the primary model
+        # after fallback has taken over the session.
+        agent = getattr(self, "agent", None)
+        active_model = (getattr(agent, "model", None) or self.model or "")
+        active_provider_raw = (getattr(agent, "provider", None) or self.provider or "")
+
         # Resolve current provider
-        raw_provider = normalize_provider(self.provider)
+        raw_provider = normalize_provider(active_provider_raw)
         if raw_provider == "auto":
             try:
                 current = _resolve_provider(
@@ -4864,7 +4873,9 @@ class HermesCLI:
             current = raw_provider
         current_label = _PROVIDER_LABELS.get(current, current)
 
-        print(f"\n  Current: {self.model} via {current_label}")
+        print(f"\n  Current: {active_model} via {current_label}")
+        if self.model and active_model and active_model != self.model:
+            print(f"  (configured primary: {self.model} — fallback active)")
         print()
 
         # Show all authenticated providers with their models
@@ -4882,12 +4893,12 @@ class HermesCLI:
                 # Fetch pricing for providers that support it (openrouter, nous)
                 pricing_map = get_pricing_for_provider(p["id"]) if p["id"] in ("openrouter", "nous") else {}
                 if curated and pricing_map:
-                    cur_model = self.model if is_active else ""
+                    cur_model = active_model if is_active else ""
                     for line in format_model_pricing_table(curated, pricing_map, current_model=cur_model):
                         print(line)
                 elif curated:
                     for mid, desc in curated:
-                        current_marker = " ← current" if (is_active and mid == self.model) else ""
+                        current_marker = " ← current" if (is_active and mid == active_model) else ""
                         print(f"      {mid}{current_marker}")
                 elif p["id"] == "custom":
                     from hermes_cli.models import _get_custom_base_url
@@ -4895,7 +4906,7 @@ class HermesCLI:
                     if custom_url:
                         print(f"      endpoint: {custom_url}")
                     if is_active:
-                        print(f"      model: {self.model} ← current")
+                        print(f"      model: {active_model} ← current")
                     print("      (use hermes model to change)")
                 else:
                     print("      (use hermes model to change)")

--- a/tests/cli/test_cli_show_model_fallback.py
+++ b/tests/cli/test_cli_show_model_fallback.py
@@ -1,0 +1,96 @@
+"""Regression tests for `/model` display after provider fallback (issue #7385).
+
+`_try_activate_fallback()` in run_agent.py mutates agent.model / agent.provider
+in place when the primary model fails.  The CLI's own self.model / self.provider
+still reflect the originally configured primary, so reading them for the
+"Current:" indicator shows a stale model name after fallback has taken over.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+def _make_cli(
+    *,
+    configured_model: str,
+    configured_provider: str,
+    agent_model: str | None,
+    agent_provider: str | None,
+):
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = configured_model
+    cli_obj.provider = configured_provider
+    cli_obj.requested_provider = configured_provider
+    cli_obj._explicit_api_key = None
+    cli_obj._explicit_base_url = None
+    if agent_model is None and agent_provider is None:
+        cli_obj.agent = None
+    else:
+        cli_obj.agent = SimpleNamespace(
+            model=agent_model,
+            provider=agent_provider,
+        )
+    return cli_obj
+
+
+def _patch_model_modules():
+    return patch.multiple(
+        "hermes_cli.models",
+        normalize_provider=lambda p: (p or "").lower(),
+        list_available_providers=lambda: [],
+        curated_models_for_provider=lambda p: [],
+        _PROVIDER_LABELS={"anthropic": "Anthropic", "openrouter": "OpenRouter"},
+        get_pricing_for_provider=lambda p: {},
+        format_model_pricing_table=lambda *a, **kw: [],
+    )
+
+
+def test_current_reflects_fallback_model_when_agent_switched(capsys):
+    cli_obj = _make_cli(
+        configured_model="glm-5.1",
+        configured_provider="anthropic",
+        agent_model="qwen/qwen3.6-plus",
+        agent_provider="openrouter",
+    )
+
+    with _patch_model_modules():
+        cli_obj._show_model_and_providers()
+
+    out = capsys.readouterr().out
+    assert "Current: qwen/qwen3.6-plus via OpenRouter" in out
+    assert "configured primary: glm-5.1" in out
+    assert "fallback active" in out
+
+
+def test_current_shows_configured_model_when_no_fallback(capsys):
+    cli_obj = _make_cli(
+        configured_model="glm-5.1",
+        configured_provider="anthropic",
+        agent_model="glm-5.1",
+        agent_provider="anthropic",
+    )
+
+    with _patch_model_modules():
+        cli_obj._show_model_and_providers()
+
+    out = capsys.readouterr().out
+    assert "Current: glm-5.1 via Anthropic" in out
+    assert "fallback active" not in out
+    assert "configured primary" not in out
+
+
+def test_current_falls_back_to_self_before_agent_ready(capsys):
+    cli_obj = _make_cli(
+        configured_model="glm-5.1",
+        configured_provider="anthropic",
+        agent_model=None,
+        agent_provider=None,
+    )
+
+    with _patch_model_modules():
+        cli_obj._show_model_and_providers()
+
+    out = capsys.readouterr().out
+    assert "Current: glm-5.1 via Anthropic" in out
+    assert "fallback active" not in out


### PR DESCRIPTION
## Summary
- `/model` shows **Current:** using `self.model` / `self.provider`, which stay pinned to the originally configured primary — after `_try_activate_fallback()` swaps `agent.model` / `agent.provider` the CLI keeps reporting the stale primary.
- Prefer `agent.model` / `agent.provider` when the agent is live (same pattern as the earlier TUI status-bar fix in 2f0a83dd), and when the active model differs from the configured primary, surface a `(configured primary: ... — fallback active)` note so users can still see what was configured.
- Pricing/highlight comparisons further down the `/model` output use the same `active_model` so the `← current` marker points at the model actually running.

Fixes #7385

## Test plan
- [x] `docker run … python -m pytest tests/cli/test_cli_show_model_fallback.py -v` — 3 new unit tests cover: fallback diverged, no fallback, and agent-not-yet-constructed.
- [x] `docker run … python -m pytest tests/cli/test_cli_status_bar.py -v` — existing status bar tests still pass (21 passed).