### PR TITLE
fix(skill/duckduckgo-search): use `-q` instead of deprecated `-k` flag

### DIFF
--- a/optional-skills/research/duckduckgo-search/SKILL.md
+++ b/optional-skills/research/duckduckgo-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: duckduckgo-search
 description: Free web search via DuckDuckGo — text, news, images, videos. No API key needed. Prefer the `ddgs` CLI when installed; use the Python DDGS library only after verifying that `ddgs` is available in the current runtime.
-version: 1.3.0
+version: 1.3.1
 author: gamedevCloudy
 license: MIT
 metadata:
@@ -57,37 +57,39 @@ Use the `ddgs` command via `terminal` when it exists. This is the preferred path
 
 ```bash
 # Text search
-ddgs text -k "python async programming" -m 5
+ddgs text -q "python async programming" -m 5
 
 # News search
-ddgs news -k "artificial intelligence" -m 5
+ddgs news -q "artificial intelligence" -m 5
 
 # Image search
-ddgs images -k "landscape photography" -m 10
+ddgs images -q "landscape photography" -m 10
 
 # Video search
-ddgs videos -k "python tutorial" -m 5
+ddgs videos -q "python tutorial" -m 5
 
 # With region filter
-ddgs text -k "best restaurants" -m 5 -r us-en
+ddgs text -q "best restaurants" -m 5 -r us-en
 
 # Recent results only (d=day, w=week, m=month, y=year)
-ddgs text -k "latest AI news" -m 5 -t w
+ddgs text -q "latest AI news" -m 5 -t w
 
 # JSON output for parsing
-ddgs text -k "fastapi tutorial" -m 5 -o json
+ddgs text -q "fastapi tutorial" -m 5 -o json
 ```
 
 ### CLI Flags
 
 | Flag | Description | Example |
 |------|-------------|---------|
-| `-k` | Keywords (query) — **required** | `-k "search terms"` |
+| `-q` | Query — **required** | `-q "search terms"` |
 | `-m` | Max results | `-m 5` |
 | `-r` | Region | `-r us-en` |
 | `-t` | Time limit | `-t w` (week) |
 | `-s` | Safe search | `-s off` |
 | `-o` | Output format | `-o json` |
+
+Note: older `ddgs` releases used `-k`/`--keywords` for the query. `-k` is now deprecated and broken on current `ddgs` versions (raises `AttributeError` instead of falling through to `-q`). Use `-q`/`--query`.
 
 ## Method 2: Python API (Only After Verification)
 
@@ -189,7 +191,7 @@ DuckDuckGo returns titles, URLs, and snippets — not full page content. To get 
 CLI example:
 
 ```bash
-ddgs text -k "fastapi deployment guide" -m 3 -o json
+ddgs text -q "fastapi deployment guide" -m 3 -o json
 ```
 
 Python example, only after verifying `ddgs` is installed in that runtime:
@@ -229,7 +231,7 @@ Then extract the best URL with `web_extract` or another content-retrieval tool.
 - **Do not assume the CLI exists**: Check `command -v ddgs` before using it.
 - **Do not assume `execute_code` can import `ddgs`**: `from ddgs import DDGS` may fail with `ModuleNotFoundError` unless that runtime was prepared separately.
 - **Package name**: The package is `ddgs` (previously `duckduckgo-search`). Install with `pip install ddgs`.
-- **Don't confuse `-k` and `-m`** (CLI): `-k` is for keywords, `-m` is for max results count.
+- **Don't confuse `-q` and `-m`** (CLI): `-q` is for the query, `-m` is for max results count.
 - **Empty results**: If `ddgs` returns nothing, it may be rate-limited. Wait a few seconds and retry.
 
 ## Validated With

--- a/optional-skills/research/duckduckgo-search/scripts/duckduckgo.sh
+++ b/optional-skills/research/duckduckgo-search/scripts/duckduckgo.sh
@@ -25,4 +25,4 @@ if ! command -v ddgs &> /dev/null; then
     exit 1
 fi
 
-ddgs text -k "$QUERY" -m "$MAX_RESULTS"
+ddgs text -q "$QUERY" -m "$MAX_RESULTS"


### PR DESCRIPTION
## Summary

Fixes #7361.

The optional `duckduckgo-search` skill recommends the `ddgs` CLI as the preferred search path and used the `-k`/`--keywords` flag throughout. Current `ddgs` releases mark `-k` as deprecated in favor of `-q`/`--query`, and the deprecation handler is broken — passing `-k` raises `AttributeError: 'NoneType' object has no attribute 'replace'` instead of falling through (upstream: deedy5/ddgs#414).

Result: the agent followed the skill's "Method 1: CLI Search (Preferred)" guidance, the CLI invocation crashed, and the agent only produced results after pivoting to the Python path. Every CLI-first invocation wasted one tool call.

This change updates every CLI example, the CLI Flags table, the search-then-extract example, the pitfalls note, and `scripts/duckduckgo.sh` to use `-q`. A short note in the flag section calls out the rename so users on older `ddgs` builds aren't confused.

## Test plan

- [x] `ddgs text --help` confirms `-q, --query` is the documented flag and `-k, --keywords` is `(Deprecated)` (verified in `python:3.13-slim` + `ddgs==9.14.0`).
- [x] `bash scripts/duckduckgo.sh 'fastapi tutorial' 2` returns results in a clean Docker container.
- [x] `grep -R "\-k '"` / `grep -R '\-k "'` over the skill directory shows no remaining uses of the deprecated flag.