### PR TITLE
fix: only send think=false to Ollama, not all custom providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6786,7 +6786,14 @@ class AIAgent:
         # This prevents thinking-capable models (Qwen3, etc.) from generating
         # <think> blocks and producing empty-response errors when the user has
         # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        # Only send think=false to Ollama — other custom providers
+        # (Mistral, Fireworks, Together.ai, vLLM) reject unknown params. (#11237)
+        _is_ollama = bool(
+            self._ollama_num_ctx
+            or "ollama" in self._base_url_lower
+            or ":11434" in self._base_url_lower
+        )
+        if _is_ollama and self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:


### PR DESCRIPTION
## Problem

When `reasoning_effort: none` is set, Hermes sends `extra_body["think"] = false` to **every** custom provider endpoint. The `think` parameter is Ollama-specific and is rejected with HTTP 422 by non-Ollama providers (Mistral, Fireworks, Together.ai, vLLM).

## Fix

Gate `think=false` behind Ollama detection using the same pattern as `_is_ollama_glm_backend()`:
- `self._ollama_num_ctx` is set (auto-detected Ollama)
- OR base_url contains `ollama`
- OR base_url contains `:11434` (Ollama default port)

Fixes #11237