### PR TITLE
fix(gateway): keep Telegram UTF-16 split points safe after natural break fallback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3118,6 +3118,14 @@ class BasePlatformAdapter(ABC):
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
 
+            if _len is not len:
+                # Re-clamp after natural-break adjustments so the final slice
+                # is still valid under custom unit counting (e.g. UTF-16).
+                safe_prefix = _prefix_within_utf16_limit(remaining[:split_at], headroom)
+                split_at = len(safe_prefix)
+                if split_at < 1:
+                    split_at = max(1, _custom_unit_to_cp(remaining, max(1, headroom), _len))
+
             chunk_body = remaining[:split_at]
             remaining = remaining[split_at:].lstrip()
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2125,6 +2125,14 @@ class BasePlatformAdapter(ABC):
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
 
+            if _len is not len:
+                # Re-clamp after natural-break adjustments so the final slice
+                # is still valid under custom unit counting (e.g. UTF-16).
+                safe_prefix = _prefix_within_utf16_limit(remaining[:split_at], headroom)
+                split_at = len(safe_prefix)
+                if split_at < 1:
+                    split_at = max(1, _custom_unit_to_cp(remaining, max(1, headroom), _len))
+
             chunk_body = remaining[:split_at]
             remaining = remaining[split_at:].lstrip()
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -633,6 +633,18 @@ class TestTruncateMessageUtf16:
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
 
+    def test_natural_break_split_keeps_utf16_safe_boundaries(self):
+        """Natural break preference must still produce UTF-16-safe chunks."""
+        msg = ("alpha 🎩 beta " * 400).strip()
+        chunks = BasePlatformAdapter.truncate_message(msg, 120, len_fn=utf16_len)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            # Regression guard: chunk should always be encodable and within limits.
+            chunk.encode("utf-16-le")
+            assert utf16_len(chunk) <= 120 + 20, (
+                f"Chunk {i} UTF-16 length {utf16_len(chunk)} exceeds limit"
+            )
+
 
 class TestProxyKwargsForAiohttp:
     """Verify proxy_kwargs_for_aiohttp routes all schemes through ProxyConnector."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -582,3 +582,15 @@ class TestTruncateMessageUtf16:
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
 
+    def test_natural_break_split_keeps_utf16_safe_boundaries(self):
+        """Natural break preference must still produce UTF-16-safe chunks."""
+        msg = ("alpha 🎩 beta " * 400).strip()
+        chunks = BasePlatformAdapter.truncate_message(msg, 120, len_fn=utf16_len)
+        assert len(chunks) > 1
+        for i, chunk in enumerate(chunks):
+            # Regression guard: chunk should always be encodable and within limits.
+            chunk.encode("utf-16-le")
+            assert utf16_len(chunk) <= 120 + 20, (
+                f"Chunk {i} UTF-16 length {utf16_len(chunk)} exceeds limit"
+            )
+


### PR DESCRIPTION
Re-clamp custom-length split positions after newline/space fallback so Telegram chunks remain UTF-16 safe. Add a regression test to ensure emoji-heavy natural-break chunking always stays encodable and within limits.
## What does this PR do?
This PR fixes a Telegram message chunking edge case in `truncate_message` when `len_fn=utf16_len` is used.
After selecting a natural break (`\n` or space), the final split point could drift from the original UTF-16-safe boundary logic. This change re-clamps the split point after natural-break adjustment to ensure every produced chunk remains valid under UTF-16 constraints and safely encodable.
A regression test is also added to verify that emoji-heavy messages split by natural breaks remain UTF-16 safe and within configured limits.
## Related Issue
Fixes #11467
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
- Updated `gateway/platforms/base.py`:
  - In `BasePlatformAdapter.truncate_message(...)`, added a post-natural-break UTF-16 re-clamp step:
    - Recompute a safe prefix using `_prefix_within_utf16_limit(...)`
    - Fallback to `_custom_unit_to_cp(...)` when needed to avoid invalid/empty split points
- Added regression test in `tests/gateway/test_platform_base.py`:
  - `test_natural_break_split_keeps_utf16_safe_boundaries`
  - Verifies chunk encodability (`utf-16-le`) and UTF-16 length constraints for emoji-heavy content
## How to Test
1. Run:
   - `python -m pytest -o addopts="-m 'not integration'" tests/gateway/test_platform_base.py -q`
2. Confirm the new test `test_natural_break_split_keeps_utf16_safe_boundaries` passes.
3. (Optional) Reproduce with a long emoji-heavy message and verify chunking remains valid and no encoding-related delivery failure occurs.
## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (RHEL-based), Python 3.11 venv
### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
## Screenshots / Logs

