### PR TITLE
fix(gateway): prevent duplicate providers in /model picker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4670,11 +4670,22 @@ class GatewayRunner:
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
                 user_provs = cfg.get("providers")
-                try:
-                    from hermes_cli.config import get_compatible_custom_providers
-                    custom_provs = get_compatible_custom_providers(cfg)
-                except Exception:
-                    custom_provs = cfg.get("custom_providers")
+                # Only populate custom_provs when providers: dict is absent.
+                # When both formats exist, get_compatible_custom_providers()
+                # re-converts the same providers: entries into list format,
+                # causing list_authenticated_providers() to show duplicates
+                # (step 3 processes user_provs dict, step 4 processes the
+                # re-converted list — with different slug formats so dedup
+                # can't catch them).
+                if user_provs and isinstance(user_provs, dict):
+                    # Newer v12+ format present — use it directly
+                    custom_provs = None
+                else:
+                    try:
+                        from hermes_cli.config import get_compatible_custom_providers
+                        custom_provs = get_compatible_custom_providers(cfg)
+                    except Exception:
+                        custom_provs = cfg.get("custom_providers")
         except Exception:
             pass
 


### PR DESCRIPTION
## Problem

The `/model` picker in the gateway shows duplicate entries for user-defined providers (e.g. `rotator`, `nvidia.com`) when the `providers:` dict format is used in `config.yaml`.

## Root Cause

The gateway reads the config and populates **both** `user_provs` (from `providers:` dict) and `custom_provs` (via `get_compatible_custom_providers()` which re-converts the same `providers:` entries into legacy list format).

`list_authenticated_providers()` processes these in separate steps:
- **Step 3**: iterates `user_providers` dict, using raw dict keys as slugs (e.g. `"rotator"`)
- **Step 4**: iterates `custom_providers` list, using `custom:`-prefixed slugs (e.g. `"custom:rotator"`)

Since the slug formats differ, the `seen_slugs` dedup check never catches the overlap, and identical providers appear twice.

## Fix

Only populate `custom_provs` when the `providers:` dict is absent. When the newer v12+ format exists, pass `user_provs` directly and set `custom_provs=None`, letting step 4 skip entirely.

This is safe because:
- The v11→12 migration already moves `custom_providers:` → `providers:` and removes the legacy key
- Step 4 guards with `if custom_providers and isinstance(custom_providers, list)` so `None` is handled cleanly
- The compat layer fallback is preserved for configs still on the legacy format

## Testing

- 70 existing tests pass (model_switch, model_picker, authenticated_provider)
- Manual verification with config containing both formats confirms duplicates are eliminated