### PR TITLE
Handle invalid voice.record_key values without crashing CLI startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -30,7 +30,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -235,6 +235,94 @@ def _parse_service_tier_config(raw: str) -> str | None:
         return "priority"
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
+
+
+_DEFAULT_VOICE_RECORD_KEY = "ctrl+b"
+
+
+def _format_voice_record_key_display(raw_key: Any) -> str:
+    """Render a config-style voice hotkey as a user-facing label."""
+    value = str(raw_key or _DEFAULT_VOICE_RECORD_KEY).strip().lower()
+    if not value:
+        value = _DEFAULT_VOICE_RECORD_KEY
+
+    prefix = ""
+    key_name = value
+    if value.startswith("ctrl+"):
+        prefix = "Ctrl+"
+        key_name = value[len("ctrl+"):]
+    elif value.startswith("shift+"):
+        prefix = "Shift+"
+        key_name = value[len("shift+"):]
+
+    specials = {
+        "space": "Space",
+        "enter": "Enter",
+        "tab": "Tab",
+        "escape": "Escape",
+        "backspace": "Backspace",
+    }
+    label = specials.get(key_name, key_name.upper() if len(key_name) == 1 else key_name)
+    return f"{prefix}{label}" if prefix else label
+
+
+def _validate_voice_record_key_binding(binding: str) -> None:
+    """Ask prompt_toolkit to validate a key binding without registering it."""
+    probe = KeyBindings()
+
+    def _noop(_event):
+        return None
+
+    probe.add(binding)(_noop)
+
+
+def _normalize_voice_record_key(
+    raw_key: Any,
+    *,
+    validator: Optional[Callable[[str], None]] = None,
+) -> tuple[str, str]:
+    """Translate config values like ctrl+b into prompt_toolkit bindings."""
+    value = str(raw_key or _DEFAULT_VOICE_RECORD_KEY).strip().lower()
+    if not value:
+        value = _DEFAULT_VOICE_RECORD_KEY
+    if "alt+" in value:
+        raise ValueError("Alt modifier is not supported for voice.record_key")
+
+    binding = value
+    if value.startswith("ctrl+"):
+        binding = f"c-{value[len('ctrl+'):]}"
+    elif value.startswith("shift+"):
+        binding = f"s-{value[len('shift+'):]}"
+
+    (validator or _validate_voice_record_key_binding)(binding)
+    return binding, _format_voice_record_key_display(value)
+
+
+def _get_voice_record_key_binding(
+    *,
+    load_config_fn: Optional[Callable[[], dict]] = None,
+    validator: Optional[Callable[[str], None]] = None,
+) -> tuple[str, str]:
+    """Load, validate, and sanitize the configured voice push-to-talk key."""
+    if load_config_fn is None:
+        from hermes_cli.config import load_config as load_config_fn
+
+    try:
+        config = load_config_fn() or {}
+        raw_key = config.get("voice", {}).get("record_key", _DEFAULT_VOICE_RECORD_KEY)
+    except Exception:
+        raw_key = _DEFAULT_VOICE_RECORD_KEY
+
+    try:
+        return _normalize_voice_record_key(raw_key, validator=validator)
+    except Exception as exc:
+        logger.warning(
+            "Invalid voice.record_key %r; falling back to %s: %s",
+            raw_key,
+            _DEFAULT_VOICE_RECORD_KEY,
+            exc,
+        )
+        return _normalize_voice_record_key(_DEFAULT_VOICE_RECORD_KEY, validator=validator)
 
 
 
@@ -7812,13 +7900,7 @@ class HermesCLI:
         # _voice_message_prefix property and its usage in _process_message().
 
         tts_status = " (TTS enabled)" if self._voice_tts else ""
-        try:
-            from hermes_cli.config import load_config
-            _raw_ptt = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _ptt_key = _raw_ptt.lower().replace("ctrl+", "c-").replace("alt+", "a-")
-        except Exception:
-            _ptt_key = "c-b"
-        _ptt_display = _ptt_key.replace("c-", "Ctrl+").upper()
+        _ptt_display = _get_voice_record_key_binding()[1]
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
@@ -7884,8 +7966,7 @@ class HermesCLI:
         _cprint(f"  Mode:      {'ON' if self._voice_mode else 'OFF'}")
         _cprint(f"  TTS:       {'ON' if self._voice_tts else 'OFF'}")
         _cprint(f"  Recording: {'YES' if self._voice_recording else 'no'}")
-        _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-        _display_key = _raw_key.replace("ctrl+", "Ctrl+").upper() if "ctrl+" in _raw_key.lower() else _raw_key
+        _display_key = _get_voice_record_key_binding()[1]
         _cprint(f"  Record key: {_display_key}")
         _cprint(f"\n  {_BOLD}Requirements:{_RST}")
         for line in reqs["details"].split("\n"):
@@ -9615,14 +9696,8 @@ class HermesCLI:
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)
         # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search)
         # Config uses "ctrl+b" format; prompt_toolkit expects "c-b" format.
-        try:
-            from hermes_cli.config import load_config
-            _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _voice_key = _raw_key.lower().replace("ctrl+", "c-").replace("alt+", "a-")
-        except Exception:
-            _voice_key = "c-b"
+        _voice_key, _voice_display = _get_voice_record_key_binding()
 
-        @kb.add(_voice_key)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 
@@ -9681,6 +9756,18 @@ class HermesCLI:
 
                 threading.Thread(target=_start_recording, daemon=True).start()
                 event.app.invalidate()
+
+        try:
+            kb.add(_voice_key)(handle_voice_record)
+        except Exception as exc:
+            logger.warning(
+                "Failed to register voice.record_key %r; falling back to %s: %s",
+                _voice_display,
+                _DEFAULT_VOICE_RECORD_KEY,
+                exc,
+            )
+            kb.add("c-b")(handle_voice_record)
+
         from prompt_toolkit.keys import Keys
 
         @kb.add(Keys.BracketedPaste, eager=True)

--- a/cli.py
+++ b/cli.py
@@ -30,7 +30,7 @@ from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Any, Optional, Callable
+from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -235,94 +235,6 @@ def _parse_service_tier_config(raw: str) -> str | None:
         return "priority"
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
-
-
-_DEFAULT_VOICE_RECORD_KEY = "ctrl+b"
-
-
-def _format_voice_record_key_display(raw_key: Any) -> str:
-    """Render a config-style voice hotkey as a user-facing label."""
-    value = str(raw_key or _DEFAULT_VOICE_RECORD_KEY).strip().lower()
-    if not value:
-        value = _DEFAULT_VOICE_RECORD_KEY
-
-    prefix = ""
-    key_name = value
-    if value.startswith("ctrl+"):
-        prefix = "Ctrl+"
-        key_name = value[len("ctrl+"):]
-    elif value.startswith("shift+"):
-        prefix = "Shift+"
-        key_name = value[len("shift+"):]
-
-    specials = {
-        "space": "Space",
-        "enter": "Enter",
-        "tab": "Tab",
-        "escape": "Escape",
-        "backspace": "Backspace",
-    }
-    label = specials.get(key_name, key_name.upper() if len(key_name) == 1 else key_name)
-    return f"{prefix}{label}" if prefix else label
-
-
-def _validate_voice_record_key_binding(binding: str) -> None:
-    """Ask prompt_toolkit to validate a key binding without registering it."""
-    probe = KeyBindings()
-
-    def _noop(_event):
-        return None
-
-    probe.add(binding)(_noop)
-
-
-def _normalize_voice_record_key(
-    raw_key: Any,
-    *,
-    validator: Optional[Callable[[str], None]] = None,
-) -> tuple[str, str]:
-    """Translate config values like ctrl+b into prompt_toolkit bindings."""
-    value = str(raw_key or _DEFAULT_VOICE_RECORD_KEY).strip().lower()
-    if not value:
-        value = _DEFAULT_VOICE_RECORD_KEY
-    if "alt+" in value:
-        raise ValueError("Alt modifier is not supported for voice.record_key")
-
-    binding = value
-    if value.startswith("ctrl+"):
-        binding = f"c-{value[len('ctrl+'):]}"
-    elif value.startswith("shift+"):
-        binding = f"s-{value[len('shift+'):]}"
-
-    (validator or _validate_voice_record_key_binding)(binding)
-    return binding, _format_voice_record_key_display(value)
-
-
-def _get_voice_record_key_binding(
-    *,
-    load_config_fn: Optional[Callable[[], dict]] = None,
-    validator: Optional[Callable[[str], None]] = None,
-) -> tuple[str, str]:
-    """Load, validate, and sanitize the configured voice push-to-talk key."""
-    if load_config_fn is None:
-        from hermes_cli.config import load_config as load_config_fn
-
-    try:
-        config = load_config_fn() or {}
-        raw_key = config.get("voice", {}).get("record_key", _DEFAULT_VOICE_RECORD_KEY)
-    except Exception:
-        raw_key = _DEFAULT_VOICE_RECORD_KEY
-
-    try:
-        return _normalize_voice_record_key(raw_key, validator=validator)
-    except Exception as exc:
-        logger.warning(
-            "Invalid voice.record_key %r; falling back to %s: %s",
-            raw_key,
-            _DEFAULT_VOICE_RECORD_KEY,
-            exc,
-        )
-        return _normalize_voice_record_key(_DEFAULT_VOICE_RECORD_KEY, validator=validator)
 
 
 
@@ -7900,7 +7812,8 @@ class HermesCLI:
         # _voice_message_prefix property and its usage in _process_message().
 
         tts_status = " (TTS enabled)" if self._voice_tts else ""
-        _ptt_display = _get_voice_record_key_binding()[1]
+        from hermes_cli.voice_record_key import resolve as _resolve_ptt
+        _ptt_display = _resolve_ptt()[1]
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
@@ -7966,7 +7879,8 @@ class HermesCLI:
         _cprint(f"  Mode:      {'ON' if self._voice_mode else 'OFF'}")
         _cprint(f"  TTS:       {'ON' if self._voice_tts else 'OFF'}")
         _cprint(f"  Recording: {'YES' if self._voice_recording else 'no'}")
-        _display_key = _get_voice_record_key_binding()[1]
+        from hermes_cli.voice_record_key import resolve as _resolve_ptt
+        _display_key = _resolve_ptt()[1]
         _cprint(f"  Record key: {_display_key}")
         _cprint(f"\n  {_BOLD}Requirements:{_RST}")
         for line in reqs["details"].split("\n"):
@@ -9694,9 +9608,16 @@ class HermesCLI:
             run_in_terminal(_suspend)
 
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)
-        # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search)
-        # Config uses "ctrl+b" format; prompt_toolkit expects "c-b" format.
-        _voice_key, _voice_display = _get_voice_record_key_binding()
+        # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search).
+        # Config uses "ctrl+b" / "alt+space" form; prompt_toolkit wants
+        # "c-b" or an ("escape", key) sequence — the helper handles the
+        # translation and the alt+ → escape-prefix dance.
+        from hermes_cli.voice_record_key import (
+            DEFAULT as _DEFAULT_VOICE_RECORD_KEY,
+            parse as _parse_voice_record_key,
+            resolve as _resolve_voice_record_key,
+        )
+        _voice_keys, _voice_display = _resolve_voice_record_key()
 
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
@@ -9758,7 +9679,7 @@ class HermesCLI:
                 event.app.invalidate()
 
         try:
-            kb.add(_voice_key)(handle_voice_record)
+            kb.add(*_voice_keys)(handle_voice_record)
         except Exception as exc:
             logger.warning(
                 "Failed to register voice.record_key %r; falling back to %s: %s",
@@ -9766,7 +9687,7 @@ class HermesCLI:
                 _DEFAULT_VOICE_RECORD_KEY,
                 exc,
             )
-            kb.add("c-b")(handle_voice_record)
+            kb.add(*_parse_voice_record_key(_DEFAULT_VOICE_RECORD_KEY)[0])(handle_voice_record)
 
         from prompt_toolkit.keys import Keys
 

--- a/hermes_cli/voice_record_key.py
+++ b/hermes_cli/voice_record_key.py
@@ -1,0 +1,79 @@
+"""Translate ``voice.record_key`` config values into prompt_toolkit key bindings.
+
+The CLI accepts hotkeys in a friendly ``ctrl+b`` / ``alt+space`` form.
+prompt_toolkit expects its own spelling (``c-b``, plus ``escape``-prefix
+sequences for Alt-modified keys).  This module is the single bridge.
+
+Kept free of prompt_toolkit imports so its tests stay cheap.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT = "ctrl+b"
+
+_SPECIAL = {
+    "space": "Space",
+    "enter": "Enter",
+    "tab": "Tab",
+    "escape": "Esc",
+    "backspace": "Backspace",
+}
+
+
+def _pretty(key: str) -> str:
+    return _SPECIAL.get(key, key.upper() if len(key) == 1 else key.title())
+
+
+def parse(raw_key: str) -> Tuple[Tuple[str, ...], str]:
+    """Return ``(prompt_toolkit_keys, display_label)`` for *raw_key*.
+
+    Supported shapes:
+
+    - ``key`` (single key, e.g. ``"space"``)
+    - ``ctrl+key``  → ``("c-key",)`` displayed as ``Ctrl+Key``
+    - ``shift+key`` → ``("s-key",)`` displayed as ``Shift+Key``
+    - ``alt+key`` / ``meta+key`` → ``("escape", key)`` displayed as
+      ``Alt+Key``.  prompt_toolkit treats Alt as an Escape-prefix
+      sequence rather than a single ``a-`` key, which is why the original
+      ``"a-x"`` translation crashed at startup (#11387).
+
+    Raises ``ValueError`` on empty input or unsupported modifiers.
+    """
+    parts = tuple(p for p in (raw_key or "").strip().lower().split("+") if p)
+    if not parts:
+        raise ValueError("voice.record_key is empty")
+    if len(parts) == 1:
+        key = parts[0]
+        return (key,), _pretty(key)
+    if len(parts) == 2:
+        modifier, key = parts
+        if modifier == "ctrl":
+            return (f"c-{key}",), f"Ctrl+{_pretty(key)}"
+        if modifier == "shift":
+            return (f"s-{key}",), f"Shift+{_pretty(key)}"
+        if modifier in ("alt", "meta"):
+            return ("escape", key), f"Alt+{_pretty(key)}"
+    raise ValueError(f"unsupported voice.record_key {raw_key!r}")
+
+
+def resolve() -> Tuple[Tuple[str, ...], str]:
+    """Load ``voice.record_key`` from config; fall back to the default on any error."""
+    raw_key = DEFAULT
+    try:
+        from hermes_cli.config import load_config
+
+        raw_key = (load_config() or {}).get("voice", {}).get("record_key", DEFAULT)
+        return parse(raw_key)
+    except Exception as exc:
+        logger.warning(
+            "Invalid voice.record_key %r; falling back to %s: %s",
+            raw_key,
+            DEFAULT,
+            exc,
+        )
+        return parse(DEFAULT)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -326,6 +326,7 @@ AUTHOR_MAP = {
     "lrawnsley@users.noreply.github.com": "lrawnsley",
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "cola-runner@users.noreply.github.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",

--- a/tests/cli/test_voice_record_key.py
+++ b/tests/cli/test_voice_record_key.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _load_cli_module():
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}, clear=False
+    ):
+        import cli as cli_mod
+
+        return importlib.reload(cli_mod)
+
+
+def test_normalize_voice_record_key_keeps_valid_ctrl_binding():
+    cli_mod = _load_cli_module()
+
+    binding, display = cli_mod._normalize_voice_record_key(
+        "ctrl+space",
+        validator=lambda _binding: None,
+    )
+
+    assert binding == "c-space"
+    assert display == "Ctrl+Space"
+
+
+def test_get_voice_record_key_binding_falls_back_on_alt_modifier():
+    cli_mod = _load_cli_module()
+
+    binding, display = cli_mod._get_voice_record_key_binding(
+        load_config_fn=lambda: {"voice": {"record_key": "alt+space"}},
+        validator=lambda _binding: None,
+    )
+
+    assert binding == "c-b"
+    assert display == "Ctrl+B"
+
+
+def test_get_voice_record_key_binding_falls_back_when_validator_rejects_binding():
+    cli_mod = _load_cli_module()
+
+    def _reject(_binding: str) -> None:
+        if _binding == "s-space":
+            raise ValueError("Invalid key")
+
+    binding, display = cli_mod._get_voice_record_key_binding(
+        load_config_fn=lambda: {"voice": {"record_key": "shift+space"}},
+        validator=_reject,
+    )
+
+    assert binding == "c-b"
+    assert display == "Ctrl+B"

--- a/tests/cli/test_voice_record_key.py
+++ b/tests/cli/test_voice_record_key.py
@@ -1,69 +1,83 @@
-import importlib
-import sys
-from unittest.mock import MagicMock, patch
+"""Tests for ``hermes_cli.voice_record_key``.
+
+Regression coverage for #11387 — invalid ``voice.record_key`` values
+(notably ``alt+*``) used to crash CLI startup at prompt_toolkit binding
+registration time.
+"""
+
+import logging
+
+import pytest
+
+from hermes_cli import voice_record_key as vrk
 
 
-def _load_cli_module():
-    prompt_toolkit_stubs = {
-        "prompt_toolkit": MagicMock(),
-        "prompt_toolkit.history": MagicMock(),
-        "prompt_toolkit.styles": MagicMock(),
-        "prompt_toolkit.patch_stdout": MagicMock(),
-        "prompt_toolkit.application": MagicMock(),
-        "prompt_toolkit.layout": MagicMock(),
-        "prompt_toolkit.layout.processors": MagicMock(),
-        "prompt_toolkit.filters": MagicMock(),
-        "prompt_toolkit.layout.dimension": MagicMock(),
-        "prompt_toolkit.layout.menus": MagicMock(),
-        "prompt_toolkit.widgets": MagicMock(),
-        "prompt_toolkit.key_binding": MagicMock(),
-        "prompt_toolkit.completion": MagicMock(),
-        "prompt_toolkit.formatted_text": MagicMock(),
-        "prompt_toolkit.auto_suggest": MagicMock(),
-    }
-    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
-        "os.environ", {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}, clear=False
-    ):
-        import cli as cli_mod
+class TestParse:
+    def test_ctrl_letter(self):
+        assert vrk.parse("ctrl+b") == (("c-b",), "Ctrl+B")
 
-        return importlib.reload(cli_mod)
+    def test_shift_function_key(self):
+        assert vrk.parse("shift+f1") == (("s-f1",), "Shift+F1")
 
+    def test_alt_uses_escape_prefix(self):
+        # The original bug: alt+* was translated to "a-*" which prompt_toolkit
+        # rejects.  Alt is an Escape-prefix sequence.
+        assert vrk.parse("alt+space") == (("escape", "space"), "Alt+Space")
 
-def test_normalize_voice_record_key_keeps_valid_ctrl_binding():
-    cli_mod = _load_cli_module()
+    def test_meta_is_alt_alias(self):
+        assert vrk.parse("meta+x") == (("escape", "x"), "Alt+X")
 
-    binding, display = cli_mod._normalize_voice_record_key(
-        "ctrl+space",
-        validator=lambda _binding: None,
-    )
+    def test_uppercase_normalised(self):
+        assert vrk.parse("CTRL+B") == (("c-b",), "Ctrl+B")
 
-    assert binding == "c-space"
-    assert display == "Ctrl+Space"
+    def test_bare_key(self):
+        assert vrk.parse("space") == (("space",), "Space")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            vrk.parse("")
+
+    def test_unknown_modifier_raises(self):
+        with pytest.raises(ValueError):
+            vrk.parse("super+x")
+
+    def test_too_many_parts_raises(self):
+        with pytest.raises(ValueError):
+            vrk.parse("ctrl+alt+b")
 
 
-def test_get_voice_record_key_binding_falls_back_on_alt_modifier():
-    cli_mod = _load_cli_module()
+class TestResolve:
+    def test_uses_config_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"record_key": "alt+space"}},
+        )
+        keys, display = vrk.resolve()
+        assert keys == ("escape", "space")
+        assert display == "Alt+Space"
 
-    binding, display = cli_mod._get_voice_record_key_binding(
-        load_config_fn=lambda: {"voice": {"record_key": "alt+space"}},
-        validator=lambda _binding: None,
-    )
+    def test_falls_back_on_invalid_value(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"voice": {"record_key": "super+x"}},
+        )
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.voice_record_key"):
+            keys, display = vrk.resolve()
+        assert keys == ("c-b",)
+        assert display == "Ctrl+B"
+        assert "Invalid voice.record_key" in caplog.text
 
-    assert binding == "c-b"
-    assert display == "Ctrl+B"
+    def test_falls_back_when_config_unreadable(self, monkeypatch):
+        def _broken():
+            raise RuntimeError("config blew up")
 
+        monkeypatch.setattr("hermes_cli.config.load_config", _broken)
+        keys, display = vrk.resolve()
+        assert keys == ("c-b",)
+        assert display == "Ctrl+B"
 
-def test_get_voice_record_key_binding_falls_back_when_validator_rejects_binding():
-    cli_mod = _load_cli_module()
-
-    def _reject(_binding: str) -> None:
-        if _binding == "s-space":
-            raise ValueError("Invalid key")
-
-    binding, display = cli_mod._get_voice_record_key_binding(
-        load_config_fn=lambda: {"voice": {"record_key": "shift+space"}},
-        validator=_reject,
-    )
-
-    assert binding == "c-b"
-    assert display == "Ctrl+B"
+    def test_default_when_key_missing(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        keys, display = vrk.resolve()
+        assert keys == ("c-b",)
+        assert display == "Ctrl+B"


### PR DESCRIPTION
## Summary
- validate `voice.record_key` before registering the prompt_toolkit binding
- fall back to `ctrl+b` when the configured key uses an unsupported modifier like `alt+space`
- reuse the sanitized display label in voice status output and add regression tests for invalid bindings

## Testing
- source venv/bin/activate && python -m pytest tests/cli/test_voice_record_key.py tests/tools/test_voice_cli_integration.py tests/cli/test_cli_init.py -q
- source venv/bin/activate && python -m pytest tests/ -q

Full `tests/ -q` still reflects the current repo baseline in this environment: `72 failed, 12121 passed, 104 skipped, 50 errors`, dominated by existing ACP / FastAPI web / gateway / run_agent failures unrelated to this change.