### PR TITLE
fix(copilot): support GitHub Enterprise host for auth and base URL

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -129,6 +129,26 @@ LMSTUDIO_NOAUTH_PLACEHOLDER = "dummy-lm-api-key"
 # Provider Registry
 # =============================================================================
 
+def _resolve_copilot_base_url(default_base_url: str, env_url: str = "") -> str:
+    """Resolve Copilot base URL, including GitHub Enterprise hosts.
+
+    If COPILOT_API_BASE_URL is set, it always wins. Otherwise when a non-default
+    GitHub host is configured for Copilot auth (COPILOT_GH_HOST or
+    config.yaml->copilot.github_host), derive the GHES API path.
+    """
+    if env_url:
+        return env_url.rstrip("/")
+    try:
+        from hermes_cli.copilot_auth import resolve_copilot_github_host
+
+        host = resolve_copilot_github_host()
+    except Exception:
+        host = "github.com"
+    if host and host != "github.com":
+        return f"https://{host}/api/v3/copilot_internal"
+    return default_base_url
+
+
 @dataclass
 class ProviderConfig:
     """Describes a known inference provider."""
@@ -3534,6 +3554,8 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif provider_id == "zai":
         base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)
+    elif provider_id == "copilot":
+        base_url = _resolve_copilot_base_url(pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url.rstrip("/")
     else:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -87,6 +87,26 @@ GEMINI_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60  # refresh 60s before expiry
 # Provider Registry
 # =============================================================================
 
+def _resolve_copilot_base_url(default_base_url: str, env_url: str = "") -> str:
+    """Resolve Copilot base URL, including GitHub Enterprise hosts.
+
+    If COPILOT_API_BASE_URL is set, it always wins. Otherwise when a non-default
+    GitHub host is configured for Copilot auth (COPILOT_GH_HOST or
+    config.yaml->copilot.github_host), derive the GHES API path.
+    """
+    if env_url:
+        return env_url.rstrip("/")
+    try:
+        from hermes_cli.copilot_auth import resolve_copilot_github_host
+
+        host = resolve_copilot_github_host()
+    except Exception:
+        host = "github.com"
+    if host and host != "github.com":
+        return f"https://{host}/api/v3/copilot_internal"
+    return default_base_url
+
+
 @dataclass
 class ProviderConfig:
     """Describes a known inference provider."""
@@ -2599,6 +2619,8 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
     elif provider_id == "zai":
         base_url = _resolve_zai_base_url(api_key, pconfig.inference_base_url, env_url)
+    elif provider_id == "copilot":
+        base_url = _resolve_copilot_base_url(pconfig.inference_base_url, env_url)
     elif env_url:
         base_url = env_url.rstrip("/")
     else:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import subprocess
 import time
+from urllib.parse import urlparse
 from pathlib import Path
 from typing import Optional
 
@@ -124,7 +125,7 @@ def _try_gh_cli_token() -> Optional[str]:
     subprocess environment so ``gh`` reads from its own credential store
     (hosts.yml) instead of just echoing the env var back.
     """
-    hostname = os.getenv("COPILOT_GH_HOST", "").strip()
+    hostname = resolve_copilot_github_host()
 
     # Build a clean env so gh doesn't short-circuit on GITHUB_TOKEN / GH_TOKEN
     clean_env = {k: v for k, v in os.environ.items()
@@ -132,7 +133,7 @@ def _try_gh_cli_token() -> Optional[str]:
 
     for gh_path in _gh_cli_candidates():
         cmd = [gh_path, "auth", "token"]
-        if hostname:
+        if hostname and hostname != "github.com":
             cmd += ["--hostname", hostname]
         try:
             result = subprocess.run(
@@ -148,6 +149,49 @@ def _try_gh_cli_token() -> Optional[str]:
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
     return None
+
+
+def _normalize_github_host(raw: str) -> str:
+    """Normalize GitHub host inputs from env/config values."""
+    value = (raw or "").strip()
+    if not value:
+        return ""
+    if "://" in value:
+        parsed = urlparse(value)
+        value = parsed.netloc or parsed.path
+    value = value.strip().strip("/")
+    if "/" in value:
+        value = value.split("/", 1)[0]
+    return value.lower()
+
+
+def resolve_copilot_github_host(default: str = "github.com") -> str:
+    """Resolve target GitHub host for Copilot auth/device flow.
+
+    Priority:
+      1. COPILOT_GH_HOST environment variable
+      2. config.yaml -> copilot.github_host
+      3. default ("github.com")
+    """
+    env_host = _normalize_github_host(os.getenv("COPILOT_GH_HOST", ""))
+    if env_host:
+        return env_host
+
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        if isinstance(cfg, dict):
+            copilot_cfg = cfg.get("copilot", {})
+            if isinstance(copilot_cfg, dict):
+                cfg_host = _normalize_github_host(copilot_cfg.get("github_host", ""))
+                if cfg_host:
+                    return cfg_host
+    except Exception:
+        # Config parsing errors should not break auth flows.
+        pass
+
+    return _normalize_github_host(default) or "github.com"
 
 
 # ─── OAuth Device Code Flow ────────────────────────────────────────────────

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3693,9 +3693,12 @@ def _model_flow_copilot(config, current_model=""):
 
         if choice == "1":
             try:
-                from hermes_cli.copilot_auth import copilot_device_code_login
+                from hermes_cli.copilot_auth import (
+                    copilot_device_code_login,
+                    resolve_copilot_github_host,
+                )
 
-                token = copilot_device_code_login()
+                token = copilot_device_code_login(host=resolve_copilot_github_host())
                 if token:
                     save_env_value("COPILOT_GITHUB_TOKEN", token)
                     print("  Copilot token saved.")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2185,8 +2185,11 @@ def _model_flow_copilot(config, current_model=""):
 
         if choice == "1":
             try:
-                from hermes_cli.copilot_auth import copilot_device_code_login
-                token = copilot_device_code_login()
+                from hermes_cli.copilot_auth import (
+                    copilot_device_code_login,
+                    resolve_copilot_github_host,
+                )
+                token = copilot_device_code_login(host=resolve_copilot_github_host())
                 if token:
                     save_env_value("COPILOT_GITHUB_TOKEN", token)
                     print("  Copilot token saved.")

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -429,6 +429,24 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "https://api.githubcopilot.com"
         assert creds["source"] == "gh auth token"
 
+    def test_resolve_copilot_base_url_from_ghe_host(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_env_secret")
+        monkeypatch.setenv("COPILOT_GH_HOST", "ghe.example.com")
+        monkeypatch.delenv("COPILOT_API_BASE_URL", raising=False)
+
+        creds = resolve_api_key_provider_credentials("copilot")
+
+        assert creds["base_url"] == "https://ghe.example.com/api/v3/copilot_internal"
+
+    def test_resolve_copilot_base_url_prefers_env_override(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_env_secret")
+        monkeypatch.setenv("COPILOT_GH_HOST", "ghe.example.com")
+        monkeypatch.setenv("COPILOT_API_BASE_URL", "https://proxy.example/copilot")
+
+        creds = resolve_api_key_provider_credentials("copilot")
+
+        assert creds["base_url"] == "https://proxy.example/copilot"
+
     def test_resolve_lmstudio_uses_token_and_base_url_from_env(self, monkeypatch):
         monkeypatch.setenv("LM_API_KEY", "lm-token")
         monkeypatch.setenv("LM_BASE_URL", "http://lmstudio.remote:4321/v1")

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -380,6 +380,24 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "https://api.githubcopilot.com"
         assert creds["source"] == "gh auth token"
 
+    def test_resolve_copilot_base_url_from_ghe_host(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_env_secret")
+        monkeypatch.setenv("COPILOT_GH_HOST", "ghe.example.com")
+        monkeypatch.delenv("COPILOT_API_BASE_URL", raising=False)
+
+        creds = resolve_api_key_provider_credentials("copilot")
+
+        assert creds["base_url"] == "https://ghe.example.com/api/v3/copilot_internal"
+
+    def test_resolve_copilot_base_url_prefers_env_override(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_env_secret")
+        monkeypatch.setenv("COPILOT_GH_HOST", "ghe.example.com")
+        monkeypatch.setenv("COPILOT_API_BASE_URL", "https://proxy.example/copilot")
+
+        creds = resolve_api_key_provider_credentials("copilot")
+
+        assert creds["base_url"] == "https://proxy.example/copilot"
+
     def test_try_gh_cli_token_uses_homebrew_path_when_not_on_path(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.copilot_auth.shutil.which", lambda command: None)
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -184,6 +184,50 @@ class TestApiModeSelection:
         assert _should_use_copilot_responses_api("grok-code-fast-1") is False
 
 
+class TestCopilotHostResolution:
+    def test_resolve_host_from_env(self, monkeypatch):
+        from hermes_cli.copilot_auth import resolve_copilot_github_host
+
+        monkeypatch.setenv("COPILOT_GH_HOST", "https://ghe.example.com/")
+        assert resolve_copilot_github_host() == "ghe.example.com"
+
+    def test_resolve_host_from_config(self, monkeypatch):
+        from hermes_cli.copilot_auth import resolve_copilot_github_host
+
+        monkeypatch.delenv("COPILOT_GH_HOST", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"copilot": {"github_host": "ghe.internal.example"}},
+        )
+        assert resolve_copilot_github_host() == "ghe.internal.example"
+
+    def test_gh_cli_token_uses_host_flag_for_ghe(self, monkeypatch):
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        monkeypatch.setenv("COPILOT_GH_HOST", "ghe.example.com")
+        monkeypatch.setattr(
+            "hermes_cli.copilot_auth._gh_cli_candidates",
+            lambda: ["/usr/bin/gh"],
+        )
+
+        calls = []
+
+        class _Result:
+            returncode = 0
+            stdout = "gho_token\n"
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return _Result()
+
+        monkeypatch.setattr("hermes_cli.copilot_auth.subprocess.run", _fake_run)
+
+        assert _try_gh_cli_token() == "gho_token"
+        assert calls == [[
+            "/usr/bin/gh", "auth", "token", "--hostname", "ghe.example.com"
+        ]]
+
+
 class TestEnvVarOrder:
     """PROVIDER_REGISTRY has correct env var order."""
 


### PR DESCRIPTION
## What does this PR do?
This PR adds GitHub Enterprise Server (GHE) host support for the `copilot` provider flow.
Specifically, it makes Copilot auth/runtime host-aware by resolving a GitHub host from:
1. `COPILOT_GH_HOST` env var
2. `config.yaml -> copilot.github_host`
3. fallback: `github.com`
Then it applies that host in two places:
- Device code login flow (OAuth device endpoints)
- `gh auth token` lookup (`--hostname <host>` for GHE)
In addition, when `COPILOT_API_BASE_URL` is not explicitly set, Copilot runtime base URL is auto-derived for GHE as:
`https://<host>/api/v3/copilot_internal`
This keeps existing default behavior unchanged for `github.com`, while enabling out-of-the-box GHE support.
## Related Issue
Fixes #11442
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
- Updated `hermes_cli/copilot_auth.py`:
  - added `resolve_copilot_github_host()` with env+config fallback chain
  - normalized host parsing for URL/plain host forms
  - updated `gh auth token` flow to pass `--hostname` for non-default hosts
- Updated `hermes_cli/main.py`:
  - Copilot device login now uses resolved GitHub host
- Updated `hermes_cli/auth.py`:
  - added `_resolve_copilot_base_url()` for GHE base URL derivation
  - integrated this resolver into `resolve_api_key_provider_credentials("copilot")`
- Added regression tests:
  - `tests/hermes_cli/test_copilot_auth.py`
  - `tests/hermes_cli/test_api_key_providers.py`
## How to Test
1. Set a GHE host via env or config:
   - env: `export COPILOT_GH_HOST=ghe.example.com`
   - or config:
     ```yaml
     copilot:
       github_host: ghe.example.com
     ```
2. Run Copilot model setup/login flow and verify device login uses the GHE host.
3. Verify resolved copilot base URL becomes:
   - `https://ghe.example.com/api/v3/copilot_internal`
   when `COPILOT_API_BASE_URL` is unset.
4. Confirm explicit override still wins:
   - `COPILOT_API_BASE_URL=https://proxy.example/copilot`
## Screenshots / Logs
N/A (auth/runtime routing + tests)
