### PR TITLE
fix(model): support providers.*.models dict in Telegram /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1039,20 +1039,30 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
+            if ep_name.lower() in seen_slugs:
+                continue
             display_name = ep_cfg.get("name", "") or ep_name
-            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
-            default_model = ep_cfg.get("default_model", "")
+            api_url = (
+                ep_cfg.get("base_url", "")
+                or ep_cfg.get("api", "")
+                or ep_cfg.get("url", "")
+                or ""
+            )
+            default_model = ep_cfg.get("model", "") or ep_cfg.get("default_model", "")
 
-            # Build models list from both default_model and full models array
+            # Build models list from both default_model/model and full models config.
             models_list = []
             if default_model:
                 models_list.append(default_model)
-            # Also include the full models list from config
             cfg_models = ep_cfg.get("models", [])
             if isinstance(cfg_models, list):
                 for m in cfg_models:
                     if m and m not in models_list:
                         models_list.append(m)
+            elif isinstance(cfg_models, dict):
+                for model_name in cfg_models.keys():
+                    if model_name and model_name not in models_list:
+                        models_list.append(model_name)
 
             # Try to probe /v1/models if URL is set (but don't block on it)
             # For now just show what we know from config
@@ -1066,6 +1076,7 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            seen_slugs.add(ep_name.lower())
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -116,6 +116,69 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     assert user_prov["models"] == ["single-model"]
 
 
+def test_list_authenticated_providers_supports_new_shape_with_models_dict(monkeypatch):
+    """New providers.<name> shape should use base_url/model/models(dict)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "custom": {
+            "base_url": "http://example.com/v1",
+            "model": "gpt-5.4",
+            "models": {
+                "gpt-5.4": {},
+                "grok-4.20-beta": {},
+                "minimax-m2.7": {},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    custom = next((p for p in providers if p["slug"] == "custom"), None)
+    assert custom is not None
+    assert custom["api_url"] == "http://example.com/v1"
+    assert custom["models"] == ["gpt-5.4", "grok-4.20-beta", "minimax-m2.7"]
+    assert custom["total_models"] == 3
+
+
+def test_list_authenticated_providers_dedupes_when_user_and_custom_overlap(monkeypatch):
+    """Avoid duplicate rows when providers and custom_providers resolve same slug."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers={
+            "custom": {
+                "base_url": "http://example.com/v1",
+                "model": "gpt-5.4",
+                "models": {
+                    "gpt-5.4": {},
+                    "grok-4.20-beta": {},
+                },
+            }
+        },
+        custom_providers=[
+            {
+                "name": "custom",
+                "base_url": "http://example.com/v1",
+                "model": "legacy-only-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    matches = [p for p in providers if p["slug"] == "custom"]
+    assert len(matches) == 1
+    assert matches[0]["models"] == ["gpt-5.4", "grok-4.20-beta"]
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
﻿## Summary
- fix list_authenticated_providers() to support the new providers.<name> shape using base_url, model, and models as a dict
- include model names from models dict keys so Telegram /model picker shows the full configured model set
- dedupe user-provider slugs before merging legacy custom_providers, preventing duplicate rows like custom (0) / custom (1)

## Test plan
- [x] Run targeted regression tests in tests/hermes_cli/test_user_providers_model_switch.py
- [x] Added regression tests for new-shape dict models and providers/custom_providers slug overlap

Closes #11499.
