### PR TITLE
fix(docker): clean up orphaned containers when docker run fails

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -201,6 +201,75 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
     assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
 
 
+def test_docker_run_failure_removes_orphaned_container_by_name(monkeypatch):
+    """If `docker run -d` fails, any container it created must be removed by name.
+
+    Regression guard for #7439: Docker can register a container in Created
+    state before `docker run` returns a non-zero exit (e.g. daemon not ready,
+    exit 125). `self._container_id` never gets assigned in that path, so the
+    fallback is to `docker rm -f <name>` using the pre-generated name.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "run":
+                raise subprocess.CalledProcessError(
+                    returncode=125, cmd=cmd, output="", stderr="daemon not ready"
+                )
+            if cmd[1] == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    rm_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 3 and c[0][1] == "rm" and c[0][2] == "-f"]
+    assert run_calls, "docker run should have been attempted"
+    assert rm_calls, "docker rm -f <name> should be invoked after docker run failure"
+
+    # The rm target must be the same --name argument passed to docker run.
+    run_cmd = run_calls[0][0]
+    name_idx = run_cmd.index("--name") + 1
+    container_name = run_cmd[name_idx]
+    assert container_name.startswith("hermes-")
+    assert rm_calls[0][0][-1] == container_name
+
+
+def test_docker_run_timeout_removes_orphaned_container_by_name(monkeypatch):
+    """TimeoutExpired during `docker run -d` should also trigger cleanup-by-name."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "run":
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=120)
+            if cmd[1] == "rm":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _make_dummy_env()
+
+    rm_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 3 and c[0][1] == "rm" and c[0][2] == "-f"]
+    assert rm_calls, "docker rm -f <name> should be invoked after docker run timeout"
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persistent=false, cleanup() must schedule docker stop + rm."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -435,13 +435,20 @@ class DockerEnvironment(BaseEnvironment):
             "sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
         ]
         logger.debug(f"Starting container: {' '.join(run_cmd)}")
-        result = subprocess.run(
-            run_cmd,
-            capture_output=True,
-            text=True,
-            timeout=120,  # image pull may take a while
-            check=True,
-        )
+        try:
+            result = subprocess.run(
+                run_cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,  # image pull may take a while
+                check=True,
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            # Docker may have registered the container (Created state) before
+            # failing — e.g. exit 125 when the daemon isn't fully ready.
+            # Remove it by name so orphans don't accumulate across retries.
+            self._remove_container_by_name(container_name)
+            raise
         self._container_id = result.stdout.strip()
         logger.info(f"Started container {container_name} ({self._container_id[:12]})")
 
@@ -547,6 +554,26 @@ class DockerEnvironment(BaseEnvironment):
             _storage_opt_ok = False
         logger.debug("Docker --storage-opt support: %s", _storage_opt_ok)
         return _storage_opt_ok
+
+    def _remove_container_by_name(self, container_name: str) -> None:
+        """Best-effort removal of a container by name after a failed `docker run`.
+
+        When `docker run -d` fails (e.g. daemon not ready, exit 125), Docker may
+        still have created the container object. Since self._container_id never
+        got assigned, cleanup() can't find it — so we remove by name here.
+        """
+        try:
+            subprocess.run(
+                [self._docker_exe, "rm", "-f", container_name],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except Exception as e:
+            logger.debug(
+                "Post-failure cleanup of %s did not complete: %s",
+                container_name, e,
+            )
 
     def cleanup(self):
         """Stop and remove the container. Bind-mount dirs persist if persistent=True."""


### PR DESCRIPTION
## Summary
- Fixes #7439: when `docker run -d` fails in `DockerEnvironment.__init__()`, any container Docker registered before the error is now removed by name.
- Without this, `self._container_id` never gets assigned, so `cleanup()` no-ops and containers pile up in `Created` state (110+ over 3 days on hourly cron sessions).
- The fix wraps the `docker run` call in a try/except for `CalledProcessError` / `TimeoutExpired`, issues `docker rm -f <pre-generated name>`, and re-raises the original error so callers still see the failure.

## Test plan
- [x] New regression tests exercise both the `CalledProcessError` (exit 125) and `TimeoutExpired` paths and assert that `docker rm -f <name>` is invoked with the same name used for `--name` at run time.
- [x] Full `tests/tools/test_docker_environment.py` suite passes in a clean `python:3.11-slim` Docker container (20 tests).
- [ ] Manual repro (stop Docker Desktop, start a session, confirm no leftover container) — deferred to reviewer since it requires a local daemon.