### PR TITLE
fix(cli): auto-select daylight skin on light terminal backgrounds

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -112,6 +112,7 @@ Activate with ``/skin <name>`` in the CLI or ``display.skin: <name>`` in config.
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -647,6 +648,33 @@ _active_skin: Optional[SkinConfig] = None
 _active_skin_name: str = "default"
 
 
+def _looks_like_light_terminal() -> bool:
+    """Best-effort detection for light terminal backgrounds."""
+    explicit = os.getenv("HERMES_LIGHT_TERMINAL", "").strip().lower()
+    if explicit in {"1", "true", "yes", "on"}:
+        return True
+    if explicit in {"0", "false", "no", "off"}:
+        return False
+
+    term_bg = os.getenv("TERM_BACKGROUND", "").strip().lower()
+    if term_bg in {"light", "lightmode"}:
+        return True
+    if term_bg in {"dark", "darkmode"}:
+        return False
+
+    colorfgbg = os.getenv("COLORFGBG", "").strip()
+    if colorfgbg:
+        parts = [p for p in colorfgbg.split(";") if p]
+        if parts:
+            try:
+                # In many terminals the last field represents background.
+                bg = int(parts[-1])
+                return bg in {7, 15}
+            except ValueError:
+                return False
+    return False
+
+
 def _skins_dir() -> Path:
     """User skins directory."""
     return get_hermes_home() / "skins"
@@ -768,9 +796,15 @@ def init_skin_from_config(config: dict) -> None:
     display = config.get("display") or {}
     if not isinstance(display, dict):
         display = {}
-    skin_name = display.get("skin", "default")
-    if isinstance(skin_name, str) and skin_name.strip():
-        set_active_skin(skin_name.strip())
+    configured_skin = display.get("skin", "")
+    if isinstance(configured_skin, str) and configured_skin.strip():
+        set_active_skin(configured_skin.strip())
+        return
+
+    # No explicit skin configured: prefer a light-safe built-in skin when the
+    # terminal appears to use a bright background.
+    if _looks_like_light_terminal():
+        set_active_skin("daylight")
     else:
         set_active_skin("default")
 

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -104,6 +104,7 @@ Activate with ``/skin <name>`` in the CLI or ``display.skin: <name>`` in config.
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -590,6 +591,33 @@ _active_skin: Optional[SkinConfig] = None
 _active_skin_name: str = "default"
 
 
+def _looks_like_light_terminal() -> bool:
+    """Best-effort detection for light terminal backgrounds."""
+    explicit = os.getenv("HERMES_LIGHT_TERMINAL", "").strip().lower()
+    if explicit in {"1", "true", "yes", "on"}:
+        return True
+    if explicit in {"0", "false", "no", "off"}:
+        return False
+
+    term_bg = os.getenv("TERM_BACKGROUND", "").strip().lower()
+    if term_bg in {"light", "lightmode"}:
+        return True
+    if term_bg in {"dark", "darkmode"}:
+        return False
+
+    colorfgbg = os.getenv("COLORFGBG", "").strip()
+    if colorfgbg:
+        parts = [p for p in colorfgbg.split(";") if p]
+        if parts:
+            try:
+                # In many terminals the last field represents background.
+                bg = int(parts[-1])
+                return bg in {7, 15}
+            except ValueError:
+                return False
+    return False
+
+
 def _skins_dir() -> Path:
     """User skins directory."""
     return get_hermes_home() / "skins"
@@ -711,9 +739,15 @@ def init_skin_from_config(config: dict) -> None:
     display = config.get("display") or {}
     if not isinstance(display, dict):
         display = {}
-    skin_name = display.get("skin", "default")
-    if isinstance(skin_name, str) and skin_name.strip():
-        set_active_skin(skin_name.strip())
+    configured_skin = display.get("skin", "")
+    if isinstance(configured_skin, str) and configured_skin.strip():
+        set_active_skin(configured_skin.strip())
+        return
+
+    # No explicit skin configured: prefer a light-safe built-in skin when the
+    # terminal appears to use a bright background.
+    if _looks_like_light_terminal():
+        set_active_skin("daylight")
     else:
         set_active_skin("default")
 

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -152,6 +152,20 @@ class TestSkinManagement:
         init_skin_from_config({})
         assert get_active_skin_name() == "default"
 
+    def test_init_skin_from_empty_config_uses_daylight_on_light_terminal_env(self, monkeypatch):
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+
+        monkeypatch.setenv("TERM_BACKGROUND", "light")
+        init_skin_from_config({})
+        assert get_active_skin_name() == "daylight"
+
+    def test_init_skin_explicit_default_ignores_light_terminal_auto_detection(self, monkeypatch):
+        from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name
+
+        monkeypatch.setenv("TERM_BACKGROUND", "light")
+        init_skin_from_config({"display": {"skin": "default"}})
+        assert get_active_skin_name() == "default"
+
     def test_init_skin_from_null_display(self):
         """display: null should fall back to default, not crash."""
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin_name


### PR DESCRIPTION
## What does this PR do?
This PR improves CLI readability on light terminal themes by auto-selecting a light-safe skin when no explicit skin is configured.
Previously, Hermes defaulted to the gold-heavy `default` skin, which can be hard to read on white/light backgrounds. With this change, startup now uses a best-effort light terminal detection and falls back to the built-in `daylight` skin automatically.
Explicit user settings are preserved: if `display.skin` is set, Hermes continues using that exact skin with no auto override.
## Related Issue
Fixes #11300
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
- Updated `hermes_cli/skin_engine.py`:
  - Added `_looks_like_light_terminal()` helper
  - Updated `init_skin_from_config()` to:
    - respect explicit `display.skin`
    - otherwise default to `daylight` on light terminals, `default` otherwise
- Added regression tests in `tests/hermes_cli/test_skin_engine.py`:
  - light terminal env selects `daylight`
  - explicit `display.skin` still takes precedence
## How to Test
1. Ensure no explicit skin is set in config (`display.skin` unset).
2. Run with a light terminal hint, e.g.:
   - `TERM_BACKGROUND=light` (or `HERMES_LIGHT_TERMINAL=1`)
3. Start Hermes CLI and verify active skin is `daylight`.
4. Set `display.skin: default` and verify auto-detection does not override it.
## Screenshots / Logs
N/A (startup behavior + test coverage)