### PR TITLE
fix(cli): hide cron sessions by default in sessions list and browse

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13862,9 +13862,10 @@ def main():
             print(f"Error: Could not open session database: {e}")
             return
 
-        # Hide third-party tool sessions by default, but honour explicit --source
+        # Hide background/internal session sources by default, but honour explicit --source.
+        # `action` was already initialized at the start of cmd_sessions().
         _source = getattr(args, "source", None)
-        _exclude = None if _source else ["tool"]
+        _exclude = None if _source else ["tool", "cron"]
 
         if action == "list":
             from hermes_state import workspace_key as _ws_key
@@ -14490,9 +14491,11 @@ def main():
         elif action == "browse":
             limit = getattr(args, "limit", 500) or 500
             source = getattr(args, "source", None)
-            _browse_exclude = None if source else ["tool"]
+            _browse_exclude = None if source else ["tool", "cron"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
             )
             db.close()
             if not sessions:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7822,9 +7822,9 @@ Examples:
 
         action = args.sessions_action
 
-        # Hide third-party tool sessions by default, but honour explicit --source
+        # Hide background/internal session sources by default, but honour explicit --source
         _source = getattr(args, "source", None)
-        _exclude = None if _source else ["tool"]
+        _exclude = None if _source else ["tool", "cron"]
 
         if action == "list":
             sessions = db.list_sessions_rich(
@@ -7932,9 +7932,11 @@ Examples:
         elif action == "browse":
             limit = getattr(args, "limit", 50) or 50
             source = getattr(args, "source", None)
-            _browse_exclude = None if source else ["tool"]
+            _browse_exclude = None if source else ["tool", "cron"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
             )
             db.close()
             if not sessions:

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -10,7 +10,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 
-from hermes_cli.main import _session_browse_picker
+from hermes_cli.main import _session_browse_picker, main as hermes_main
 
 
 # ─── Sample session data ──────────────────────────────────────────────────────
@@ -441,6 +441,72 @@ class TestCmdSessionsBrowse:
                 result = _session_browse_picker(sessions)
 
         assert result == "s1"
+
+    def test_browse_hides_cron_and_tool_sessions_by_default(self, monkeypatch):
+        """Browse should exclude cron/tool sources unless the user explicitly asks for one."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "browse"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool", "cron"],
+            limit=500,
+        )
+        mock_db.close.assert_called_once()
+
+    def test_browse_source_filter_disables_default_exclusions(self, monkeypatch):
+        """Explicit --source should bypass default source exclusions."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "browse", "--source", "cron"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source="cron",
+            exclude_sources=None,
+            limit=500,
+        )
+        mock_db.close.assert_called_once()
+
+    def test_list_hides_cron_and_tool_sessions_by_default(self, monkeypatch):
+        """List should exclude cron/tool sources unless the user explicitly asks for one."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "list"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool", "cron"],
+            limit=20,
+        )
+
+    def test_list_source_filter_disables_default_exclusions(self, monkeypatch):
+        """Explicit --source should bypass list default source exclusions too."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "list", "--source", "cron"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source="cron",
+            exclude_sources=None,
+            limit=20,
+        )
 
 
 # ─── Edge cases ──────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch, call
 
 import pytest
 
-from hermes_cli.main import _session_browse_picker
+from hermes_cli.main import _session_browse_picker, main as hermes_main
 
 
 # ─── Sample session data ──────────────────────────────────────────────────────
@@ -442,6 +442,72 @@ class TestCmdSessionsBrowse:
                 result = _session_browse_picker(sessions)
 
         assert result == "s1"
+
+    def test_browse_hides_cron_and_tool_sessions_by_default(self, monkeypatch):
+        """Browse should exclude cron/tool sources unless the user explicitly asks for one."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "browse"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool", "cron"],
+            limit=50,
+        )
+        mock_db.close.assert_called_once()
+
+    def test_browse_source_filter_disables_default_exclusions(self, monkeypatch):
+        """Explicit --source should bypass default source exclusions."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "browse", "--source", "cron"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source="cron",
+            exclude_sources=None,
+            limit=50,
+        )
+        mock_db.close.assert_called_once()
+
+    def test_list_hides_cron_and_tool_sessions_by_default(self, monkeypatch):
+        """List should exclude cron/tool sources unless the user explicitly asks for one."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "list"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool", "cron"],
+            limit=20,
+        )
+
+    def test_list_source_filter_disables_default_exclusions(self, monkeypatch):
+        """Explicit --source should bypass list default source exclusions too."""
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: mock_db)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "list", "--source", "cron"])
+
+        hermes_main()
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source="cron",
+            exclude_sources=None,
+            limit=20,
+        )
 
 
 # ─── Edge cases ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- hide `cron` sessions by default in `hermes sessions list`
- hide `cron` sessions by default in `hermes sessions browse`
- preserve `--source cron` as an explicit opt-in for inspecting cron sessions
- add regression coverage for both default filtering and explicit source behavior

## Why
Frequent cron jobs create many background sessions that clutter the default interactive session views. This change keeps manual session navigation focused on user-facing sessions while preserving explicit access to cron sessions when requested.

## Behavior before
- `hermes sessions list` hid `tool` sessions by default, but still showed `cron`
- `hermes sessions browse` hid `tool` sessions by default, but still showed `cron`

## Behavior after
- `hermes sessions list` hides both `tool` and `cron` by default
- `hermes sessions browse` hides both `tool` and `cron` by default
- `hermes sessions list --source cron` still shows cron sessions
- `hermes sessions browse --source cron` still shows cron sessions

## How to test
- `source venv/bin/activate && pytest tests/hermes_cli/test_session_browse.py -q`
- Start Hermes locally and compare:
  - `hermes sessions list`
  - `hermes sessions list --source cron`
  - `hermes sessions browse`
  - `hermes sessions browse --source cron`

## Platforms tested
- Linux (local Hermes development environment on omarchy)

## Notes
- This PR is intentionally scoped to the CLI session listing / browsing behavior only.
