### PR TITLE
docs(cli): add `skills reset` subcommand to CLI reference

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -563,6 +563,7 @@ Subcommands:
 | `update` | Reinstall hub skills with upstream changes when available. |
 | `audit` | Re-scan installed hub skills. |
 | `uninstall` | Remove a hub-installed skill. |
+| `reset` | Un-stick a bundled skill flagged as `user_modified` by clearing its manifest entry. With `--restore`, also replaces the user copy with the bundled version. |
 | `publish` | Publish a skill to a registry. |
 | `snapshot` | Export/import skill configurations. |
 | `tap` | Manage custom skill sources. |
@@ -582,6 +583,8 @@ hermes skills install skills-sh/anthropics/skills/pdf --force
 hermes skills check
 hermes skills update
 hermes skills config
+hermes skills reset google-workspace
+hermes skills reset google-workspace --restore --yes
 ```
 
 Notes:


### PR DESCRIPTION
## Summary

PR #11468 added `hermes skills reset <name>` (with `--restore` and `--yes` flags) and updated `website/docs/user-guide/features/skills.md`, but the CLI reference at `website/docs/reference/cli-commands.md` was not updated.

This adds:
- `reset` row to the `hermes skills` subcommands table with a description covering both non-destructive (manifest clear) and `--restore` (full re-copy) modes
- Two usage examples (`reset` and `reset --restore --yes`)

Closes #11543