### PR TITLE
Treat failed skill loads as actual command failures

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -310,7 +310,8 @@ def build_skill_invocation_message(
         user_instruction: Optional text the user typed after the command.
 
     Returns:
-        The formatted message string, or None if the skill wasn't found.
+        The formatted message string, or None if the skill wasn't found or
+        its payload could not be loaded.
     """
     commands = get_skill_commands()
     skill_info = commands.get(cmd_key)
@@ -319,7 +320,12 @@ def build_skill_invocation_message(
 
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
-        return f"[Failed to load skill: {skill_info['name']}]"
+        logger.warning(
+            "Failed to load payload for skill command %s (%s)",
+            cmd_key,
+            skill_info["name"],
+        )
+        return None
 
     loaded_skill, skill_dir, skill_name = loaded
     activation_note = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3233,6 +3233,11 @@ class GatewayRunner:
                     if msg:
                         event.text = msg
                         # Fall through to normal message processing with skill content
+                    else:
+                        return (
+                            f"Failed to load skill `{cmd_key}`. "
+                            "Try reinstalling or re-scanning that skill from the local CLI."
+                        )
                 else:
                     # Not an active skill — check if it's a known-but-disabled or
                     # uninstalled skill and give actionable guidance.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -192,6 +192,7 @@ AUTHOR_MAP = {
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
     "cola-runner@users.noreply.github.com": "cola-runner",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "trevmanthony@gmail.com": "trevthefoolish",

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -259,6 +259,15 @@ Generate some audio.
             msg = build_skill_invocation_message("/nonexistent")
         assert msg is None
 
+    def test_returns_none_when_skill_payload_fails_to_load_after_scan(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = _make_skill(tmp_path, "test-skill")
+            scan_skill_commands()
+            (skill_dir / "SKILL.md").unlink()
+            msg = build_skill_invocation_message("/test-skill")
+
+        assert msg is None
+
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -107,6 +107,23 @@ class TestSlashCommandPrefixMatching:
         unknown = any("Unknown command" in p for p in printed)
         assert not unknown, f"Expected skill prefix to match, got: {printed}"
 
+    def test_skill_load_failure_does_not_queue_placeholder_text(self):
+        cli_obj = _make_cli()
+        fake_skill = {"/broken-skill": {"name": "Broken Skill", "description": "test"}}
+
+        import cli as cli_mod
+
+        with patch.object(cli_mod, "_skill_commands", fake_skill), \
+             patch.object(cli_mod, "build_skill_invocation_message", return_value=None), \
+             patch.object(cli_mod, "ChatConsole") as mock_console:
+            cli_obj.process_command("/broken-skill")
+
+        cli_obj._pending_input.put.assert_not_called()
+        mock_console.return_value.print.assert_called_once()
+        printed = str(mock_console.return_value.print.call_args)
+        assert "Failed to load skill" in printed
+        assert "/broken-skill" in printed
+
     def test_ambiguous_between_builtin_and_skill(self):
         """Ambiguous prefix spanning builtin + skill commands shows suggestions."""
         cli_obj = _make_cli()

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -7,7 +7,7 @@ delegate_task call instead of telling the user the command doesn't exist).
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -164,3 +164,31 @@ async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch)
     # Whatever /reload_mcp returns, it must not be the unknown-command guard.
     if result is not None:
         assert "Unknown command" not in result
+
+
+@pytest.mark.asyncio
+async def test_known_skill_load_failure_returns_guidance_and_skips_agent(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("broken skill should not be forwarded to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    with patch(
+        "agent.skill_commands.get_skill_commands",
+        return_value={"/broken-skill": {"name": "broken-skill"}},
+    ), patch(
+        "agent.skill_commands.build_skill_invocation_message",
+        return_value=None,
+    ):
+        result = await runner._handle_message(_make_event("/broken-skill"))
+
+    assert result is not None
+    assert "Failed to load skill" in result
+    assert "/broken-skill" in result
+    runner._run_agent.assert_not_called()


### PR DESCRIPTION
Closes #11200

## Summary
- return `None` when a cached skill command can no longer load its payload, instead of injecting a bracketed placeholder into the model prompt
- surface known skill load failures to gateway users so broken `/skill` commands do not fall through to the agent as plain text
- add regressions for post-scan skill deletion plus CLI/gateway failure handling

## Testing
- source venv/bin/activate && python -m pytest tests/agent/test_skill_commands.py tests/gateway/test_unknown_command.py tests/cli/test_cli_prefix_matching.py tests/gateway/test_webhook_integration.py -q
- source venv/bin/activate && python -m pytest tests/ -q

Full `tests/ -q` still reflects the current repo baseline in this environment: `73 failed, 12120 passed, 104 skipped, 50 errors`, dominated by existing ACP / FastAPI web / gateway / run_agent failures unrelated to this change.