### PR TITLE
fix: list all models from custom_providers models dict in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1103,6 +1103,12 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            # Also include models from the 'models' dict (context_length configs)
+            entry_models = entry.get("models")
+            if isinstance(entry_models, dict):
+                for m_name in entry_models:
+                    if m_name and m_name not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_name)
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:


### PR DESCRIPTION
## Problem

The `/model` command only displays the default `model` field from each
`custom_providers` entry, ignoring additional models defined in the
`models` dict (used for `context_length` overrides).

For example, if a custom provider has 3 models configured in the `models`
dict, only the default one appears in the picker.

## Fix

In `list_authenticated_providers()`, after collecting the default `model`
field, also iterate over the `models` dict keys and include them in the
provider's model list.