### PR TITLE
fix: clear input buffer before opening /model picker to prevent residue

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8564,11 +8564,16 @@ class HermesCLI:
                 # Handle /model directly on the UI thread so interactive pickers
                 # can safely use prompt_toolkit terminal handoff helpers.
                 if self._should_handle_model_command_inline(text, has_images=has_images):
+                    # Clear the buffer BEFORE process_command so that the
+                    # model picker's _capture_modal_input_snapshot() saves
+                    # an empty string instead of "/model".  Without this,
+                    # _restore_modal_input_snapshot() puts "/model" back
+                    # into the input field when the picker closes.
+                    event.app.current_buffer.reset(append_to_history=True)
                     if not self.process_command(text):
                         self._should_exit = True
                         if event.app.is_running:
                             event.app.exit()
-                    event.app.current_buffer.reset(append_to_history=True)
                     return
 
                 # Snapshot and clear attached images


### PR DESCRIPTION
## Problem

When the user types `/model` and presses Enter, the input field retains `/model` after the picker closes (whether a model is selected or the picker is cancelled).

## Root Cause

In the accept handler, `process_command()` was called before `buffer.reset()`. The model picker's `_capture_modal_input_snapshot()` (invoked inside `process_command`) saved the current buffer content — which still contained `/model`. When the picker closed, `_restore_modal_input_snapshot()` restored that text back into the input field.

## Fix

Move `buffer.reset(append_to_history=True)` before `process_command()` so the snapshot captures an empty buffer instead.