### PR TITLE
fix(tools): handle memory(action="read") in dispatcher

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -255,3 +255,31 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+    def test_read_empty(self, store):
+        result = json.loads(memory_tool(action="read", target="memory", store=store))
+        assert result["success"] is True
+        assert result["target"] == "memory"
+        assert result["entries"] == []
+        assert result["entry_count"] == 0
+
+    def test_read_returns_entries_without_mutation(self, store):
+        store.add("memory", "first fact")
+        store.add("memory", "second fact")
+        before = list(store.memory_entries)
+        result = json.loads(memory_tool(action="read", target="memory", store=store))
+        assert result["success"] is True
+        assert result["entries"] == ["first fact", "second fact"]
+        assert result["entry_count"] == 2
+        # Read must not mutate
+        assert store.memory_entries == before
+
+    def test_read_user_target(self, store):
+        store.add("user", "Name: Alice")
+        result = json.loads(memory_tool(action="read", target="user", store=store))
+        assert result["success"] is True
+        assert result["target"] == "user"
+        assert "Name: Alice" in result["entries"]
+
+    def test_read_action_in_schema_enum(self):
+        assert "read" in MEMORY_SCHEMA["parameters"]["properties"]["action"]["enum"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -495,8 +495,16 @@ def memory_tool(
             return tool_error("old_text is required for 'remove' action.", success=False)
         result = store.remove(target, old_text)
 
+    elif action == "read":
+        # Return the current entries without mutation. The docstring advertises
+        # this action and trained LLMs call it at session start to introspect
+        # memory state; without this branch the dispatcher returns an
+        # "Unknown action" error that display._detect_tool_failure renders as
+        # [error] in the REPL even though memory itself is healthy.
+        result = store._success_response(target)
+
     else:
-        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
+        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove, read", success=False)
 
     return json.dumps(result, ensure_ascii=False)
 
@@ -532,7 +540,7 @@ MEMORY_SCHEMA = {
         "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
-        "remove (delete -- old_text identifies it).\n\n"
+        "remove (delete -- old_text identifies it), read (return current entries without changes).\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
     ),
     "parameters": {
@@ -540,7 +548,7 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove"],
+                "enum": ["add", "replace", "remove", "read"],
                 "description": "The action to perform."
             },
             "target": {


### PR DESCRIPTION
## What does this PR do?

The `memory_tool` module docstring advertises a `read` action (line 20: *"Single `memory` tool with action parameter: add, replace, remove, read"*), but the dispatcher in `memory_tool()` only branches on `add`/`replace`/`remove`. A `memory(action="read")` call therefore falls through to the `else:` branch and returns `tool_error("Unknown action 'read'...")`.

Trained LLMs that expect Anthropic's memory-beta semantics (where a `view`/`read`-style action is idiomatic) call `memory(action="read")` at session start to introspect current memory state. Because `agent/display._detect_tool_failure` scans the first 500 chars of a tool result for the substrings `"error"`/`"failed"`, the REPL then renders the call as:

```
  ┊ 🧠 memory    read  0.0s    [error]
```

on every fresh session — even though native memory itself (MEMORY.md / USER.md read-write, system-prompt snapshot, persistence across sessions) is completely healthy. The `0.0s` duration is the tell: it's an immediate dispatcher rejection, not a filesystem operation.

This is a dispatcher gap, not a memory-engine bug.

## Related Issue

No existing issue — this PR is both the bug report and the fix. Happy to split into a separate issue first if preferred.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/memory_tool.py`:
  - Dispatcher: added `elif action == "read":` branch returning `store._success_response(target)` — same response shape as other success paths (`entries`, `usage`, `entry_count`), no mutation.
  - Schema: added `"read"` to `MEMORY_SCHEMA.parameters.properties.action.enum`.
  - Schema description: documented the `read` action in the `ACTIONS:` clause, matching the module docstring.
  - Updated the fallback `Unknown action '{action}'. Use: add, replace, remove` hint to include `read`.
- `tests/tools/test_memory_tool.py`: added four tests in `TestMemoryToolDispatcher`:
  - `test_read_empty` — `read` on a fresh store returns `success=True`, empty entries, `entry_count=0`.
  - `test_read_returns_entries_without_mutation` — after two adds, `read` returns both entries and leaves the store unchanged.
  - `test_read_user_target` — `read` with `target="user"` returns the user profile entries.
  - `test_read_action_in_schema_enum` — schema enum contains `"read"`.

Design choice: `_success_response()` is reused (rather than a new helper) because its response shape is already stable and all three existing actions return it on success. Read is simply "the no-mutation version of the same terminal response."

## How to Test

**Reproduction (on `main` without this patch):**

1. Start `hermes chat` (fresh session, MiniMax-M2.7 or any model that calls `memory(action="read")` for introspection).
2. Ask: *"what do you remember about me?"* — or any prompt that nudges the model to check its own memory.
3. Observe in the scrollback: `🧠 memory read 0.0s [error]` even though `~/.hermes/memories/` is populated and reads/writes via other paths work.
4. Add a `print(action)` or `logger.warning` at the top of `memory_tool()` to confirm `action=="read"` is what falls through to the `else` branch.

**Verification (with this patch):**

1. `pytest tests/tools/test_memory_tool.py -q` — the four new `test_read_*` cases pass alongside the existing dispatcher tests. (I was unable to run pytest locally due to a sandboxed environment that blocks executing arbitrary external repo code; relying on this PR's CI run for validation. Every existing test continues to import the same symbols from `tools.memory_tool` without signature changes.)
2. Manual verification on Linux (Ubuntu 22.04, Python 3.12, Hermes v0.10.0 + this patch applied directly):
   - **Probe A — store**: `❯ remember this: the sky is teal on thursdays` → `🧠 memory +memory: "User fact: the sky is teal on Thursdays"  0.0s` (no `[error]`).
   - **Probe B — same-session recall**: `❯ what color is the sky on thursdays?` → *"Teal."*
   - **Probe C — cross-session recall** (exit, restart `hermes chat`): `❯ what color is the sky on thursdays? also check your memory if needed.` → `🧠 memory read 0.0s` (no `[error]`) → *"According to my memory, the sky is teal on Thursdays."*
   - On-disk: `~/.hermes/memories/MEMORY.md` contains `User fact: the sky is teal on Thursdays`.

## What platforms I tested on

- Linux (Ubuntu 22.04, Python 3.12) — manual REPL verification above.
- Fix is pure Python dispatcher logic with no filesystem, threading, or platform-specific code paths, so cross-platform impact is nil; no Windows/macOS specifics touched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tools): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate covering the `read` dispatcher gap.
- [x] My PR contains **only** changes related to this fix (dispatcher + schema + tests; no unrelated edits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **unable to run locally (sandboxed env blocks external-repo execution); deferring to CI on this PR.** Existing test suite imports are unchanged; the four new tests are scoped to `TestMemoryToolDispatcher`.
- [x] I've added tests for my changes (four new dispatcher tests in `tests/tools/test_memory_tool.py`)
- [x] I've tested on my platform: Ubuntu 22.04 (manual REPL verification)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the tool schema description is the tool's documentation surface, and it now lists `read` in `ACTIONS:`.
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact — N/A (pure dispatcher logic)
- [x] Tool descriptions/schemas updated — yes, `MEMORY_SCHEMA.parameters.properties.action.enum` and the description string both now include `read`.

## Scope

This is a **dispatcher gap only**. Native memory itself (`MemoryStore` read/write, atomic `os.replace` persistence, frozen snapshot injection into the system prompt, `§`-delimited entries) is healthy and untouched. The existing code already contains `_success_response()`, which is the exact primitive a non-mutating `read` needs; this PR just wires it up to the advertised action name.