### PR TITLE
fix(discord): add watchdog for bot task to auto-reconnect after sleep/wake

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -652,8 +652,18 @@ class DiscordAdapter(BasePlatformAdapter):
             # Register slash commands
             self._register_slash_commands()
 
+            # Register lifecycle event handlers for reconnection awareness
+            @self._client.event
+            async def on_disconnect():
+                logger.warning("[%s] WebSocket disconnected — discord.py will attempt to reconnect", adapter_self.name)
+
+            @self._client.event
+            async def on_resumed():
+                logger.info("[%s] WebSocket session resumed successfully", adapter_self.name)
+
             # Start the bot in background
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))
+            self._bot_task.add_done_callback(self._on_bot_task_done)
 
             # Wait for ready
             await asyncio.wait_for(self._ready_event.wait(), timeout=30)
@@ -672,6 +682,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        # Suppress the done callback — this is an intentional shutdown
+        if self._bot_task and not self._bot_task.done():
+            self._bot_task.remove_done_callback(self._on_bot_task_done)
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:
@@ -700,6 +713,25 @@ class DiscordAdapter(BasePlatformAdapter):
         self._release_platform_lock()
 
         logger.info("[%s] Disconnected", self.name)
+
+    def _on_bot_task_done(self, task: asyncio.Task) -> None:
+        """Handle unexpected bot task exit (e.g. after sleep/wake network loss).
+
+        discord.py's Client.start() normally runs forever with built-in reconnect.
+        If it exits, the WebSocket loop has given up — trigger the fatal error
+        handler so the gateway reconnect watcher can spin up a fresh adapter.
+        """
+        if not self._running:
+            return  # intentional shutdown, nothing to do
+
+        exc = task.exception() if not task.cancelled() else None
+        reason = str(exc) if exc else "task exited cleanly (unexpected)"
+        logger.error(
+            "[%s] Bot task died unexpectedly: %s — triggering reconnection",
+            self.name, reason,
+        )
+        self._set_fatal_error("bot_task_died", reason, retryable=True)
+        asyncio.ensure_future(self._notify_fatal_error())
 
     async def _run_post_connect_initialization(self) -> None:
         """Finish non-critical startup work after Discord is connected."""


### PR DESCRIPTION
## Problem

When running the gateway on a laptop, sleep/wake cycles (or network changes like proxy becoming unavailable) can cause discord.py's internal WebSocket reconnect loop to exhaust its retries. Once `Client.start()` exits, the `_bot_task` dies silently — no code path detects this, so the bot stays permanently offline until the entire gateway is manually restarted.

**Evidence from gateway logs:**
```
20:31-20:46  discord.py retries with escalating backoff: 1s → 372s
21:46        backoff reaches 686s (11+ min between attempts)
00:22        still retrying at 609s intervals
09:30        Client.start() finally exits — bot goes gray permanently
```

In the proxy scenario, `Client.start()` exits immediately with `ClientProxyConnectionError` when the local proxy (e.g. `127.0.0.1:7890`) is unavailable after wake.

## Root Cause

`_bot_task` (line 656) has no `add_done_callback` — when the task finishes unexpectedly, nobody triggers the gateway's reconnect watcher (`_platform_reconnect_watcher`), which would otherwise spin up a fresh adapter.

## Fix

1. **`add_done_callback` on `_bot_task`** — detects unexpected exit, calls `_set_fatal_error(..., retryable=True)` + `_notify_fatal_error()` to queue the platform for background reconnection via the existing exponential backoff watcher (30s → 60s → ... → 300s cap, 20 max attempts).

2. **Suppress callback during `disconnect()`** — `remove_done_callback` prevents false alarms on intentional shutdown.

3. **`on_disconnect` / `on_resumed` event handlers** — log discord.py's internal reconnection state for observability.

## Changes

- `gateway/platforms/discord.py` — 32 lines added, 0 removed

Similar pattern to #8208 which fixed the same class of bug (silent task death) for the interrupt monitor task.