### PR TITLE
fix: Discord /skill group exceeds 8000-char command size limit

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1967,6 +1967,23 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     cat_group.add_command(cmd)
 
+            # Check serialized size before registering — Discord rejects
+            # command groups that exceed 8000 chars when serialized. (#11321)
+            try:
+                import json as _json
+                _payload = skill_group.to_dict()
+                _size = len(_json.dumps(_payload))
+                if _size > 7500:
+                    logger.warning(
+                        "[%s] /skill group payload %d bytes — skipping registration "
+                        "to avoid Discord 400 error (limit 8000). "
+                        "Reduce built-in skills or disable unused categories.",
+                        self.name, _size,
+                    )
+                    return
+            except Exception:
+                pass
+
             tree.add_command(skill_group)
 
             total = sum(len(v) for v in categories.values()) + len(uncategorized)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -651,8 +651,11 @@ def discord_skill_commands_by_category(
             _names_used.add(discord_name)
 
             desc = info.get("description", "")
-            if len(desc) > 100:
-                desc = desc[:97] + "..."
+            # Truncate to 50 chars — with 75+ skills, longer descriptions
+            # push the serialized /skill group past Discord's 8000-char
+            # command size limit. (#11321)
+            if len(desc) > 50:
+                desc = desc[:47] + "..."
 
             # Determine category from the relative path within SKILLS_DIR.
             # e.g. creative/ascii-art/SKILL.md → parts = ("creative", "ascii-art")


### PR DESCRIPTION
## Problem

With 75+ built-in skills, the `/skill` command group serialization exceeds Discord's 8000-char limit, causing gateway startup to fail with:

```
Failed to upload commands to Discord (HTTP status 400, error code 50035)
Command exceeds maximum size (8000)
```

## Fix (2 files)

1. **`hermes_cli/commands.py`**: Reduce max skill description from 100 → 50 chars. With 75+ skills, shorter descriptions keep the total payload under the limit.

2. **`gateway/platforms/discord.py`**: Add size check before `tree.add_command(skill_group)`. If the serialized payload exceeds 7500 bytes, skip registration and log a warning instead of crashing the gateway.

## Testing

- Gateway with <50 skills: ✅ (no change)
- Gateway with 75+ skills: ✅ (descriptions truncated, size checked)
- Fallback: skips registration with warning instead of crash

Fixes #11321