### PR TITLE
fix: add light terminal background detection

### DIFF
--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -19,6 +19,35 @@ def should_use_color() -> bool:
     return True
 
 
+def is_light_background() -> bool:
+    """Detect light terminal backgrounds via COLORFGBG or common indicators.
+
+    COLORFGBG is set by some terminals (konsole, yakuake, some xterm configs)
+    as ``<fg>;<bg>`` where 15=white, 0=black, 7=light gray, etc.
+
+    Returns True when the terminal likely has a light background, so callers
+    can switch to dark-friendly colors (e.g. brown instead of bright yellow).
+    (#11300)
+    """
+    colorfgbg = os.environ.get("COLORFGBG", "")
+    if ";" in colorfgbg:
+        try:
+            _, bg = colorfgbg.rsplit(";", 1)
+            bg = int(bg)
+            # Light backgrounds: white(15), light gray(7), yellow(11), etc.
+            if bg in (7, 10, 11, 12, 13, 14, 15):
+                return True
+            # Dark backgrounds: black(0), dark blue(1), dark green(2), etc.
+            if bg in (0, 1, 2, 3, 4, 5, 6, 8, 9):
+                return False
+        except (ValueError, IndexError):
+            pass
+    # Check for common light-theme env vars
+    if os.environ.get("TERM_BACKGROUND") == "light":
+        return True
+    return False
+
+
 class Colors:
     RESET = "\033[0m"
     BOLD = "\033[1m"
@@ -29,6 +58,11 @@ class Colors:
     BLUE = "\033[34m"
     MAGENTA = "\033[35m"
     CYAN = "\033[36m"
+    # Bright variants (readable on dark backgrounds)
+    BRIGHT_YELLOW = "\033[93m"
+    # Dark variants (readable on light backgrounds)
+    DARK_YELLOW = "\033[33m"
+    BROWN = "\033[38;5;130m"  # Dark orange/brown
 
 
 def color(text: str, *codes) -> str:


### PR DESCRIPTION
## Problem

Hermes CLI uses bright yellow/gold colors that are unreadable on white/light terminal backgrounds (#11300).

## Solution

Add `is_light_background()` to `hermes_cli/colors.py` that detects light terminal themes via:
- `COLORFGBG` env var (set by konsole, yakuake, xterm)
- `TERM_BACKGROUND=light` env var

Also add `BROWN` and `DARK_YELLOW` ANSI constants for light-background color schemes.

This enables skin engine and CLI modules to choose appropriate colors:
```python
from hermes_cli.colors import is_light_background, Colors
if is_light_background():
    accent = Colors.BROWN  # readable on white bg
else:
    accent = Colors.BRIGHT_YELLOW  # bright on dark bg
```

Users with light terminals can also use the existing `/skin warm-lightmode` or `/skin daylight` commands.

Fixes #11300