### PR TITLE
fix(dingtalk): close SDK websocket on disconnect (systemd stop-sigterm hang)

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -154,12 +154,19 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._running = False
         self._mark_disconnected()
 
+        websocket = getattr(self._stream_client, "websocket", None)
+        if websocket is not None:
+            try:
+                await websocket.close()
+            except Exception as e:
+                logger.debug("[%s] websocket close during disconnect failed: %s", self.name, e)
+
         if self._stream_task:
             self._stream_task.cancel()
             try:
-                await self._stream_task
-            except asyncio.CancelledError:
-                pass
+                await asyncio.wait_for(self._stream_task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                logger.debug("[%s] stream task did not exit cleanly during disconnect", self.name)
             self._stream_task = None
 
         if self._http_client:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -70,6 +70,7 @@ AUTHOR_MAP = {
     "27917469+nosleepcassette@users.noreply.github.com": "nosleepcassette",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "109555139+davetist@users.noreply.github.com": "davetist",
+    "Asunfly@users.noreply.github.com": "Asunfly",
     # contributors (manual mapping from git names)
     "ahmedsherif95@gmail.com": "asheriif",
     "dmayhem93@gmail.com": "dmahan93",

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
@@ -229,6 +230,29 @@ class TestSend:
 
 
 class TestConnect:
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_session_websocket(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        websocket = AsyncMock()
+        blocker = asyncio.Event()
+
+        async def _run_forever():
+            try:
+                await blocker.wait()
+            except asyncio.CancelledError:
+                return
+
+        adapter._stream_client = SimpleNamespace(websocket=websocket)
+        adapter._stream_task = asyncio.create_task(_run_forever())
+        adapter._running = True
+
+        await adapter.disconnect()
+
+        websocket.close.assert_awaited_once()
+        assert adapter._stream_task is None
 
     @pytest.mark.asyncio
     async def test_connect_fails_without_sdk(self, monkeypatch):


### PR DESCRIPTION
## Summary

Salvages #10070 (Asunfly — authorship preserved). Fixes a real systemd-level hang: `hermes-gateway.service` can get stuck in `stop-sigterm` and be SIGKILLed on restart when DingTalk is configured, because the adapter's `disconnect()` cancels the stream task but never closes the SDK websocket — it just waits for the remote side to time out.

### Changes (from Asunfly's commit)

- Explicitly `await stream_client.websocket.close()` at the start of `disconnect()` so the SDK's internal recv loop exits promptly.
- Bound the stream task await with `asyncio.wait_for(..., timeout=2.0)` instead of an unbounded `await`, and catch `TimeoutError` so disconnect never hangs.
- Regression test: `test_disconnect_closes_session_websocket` — mocks a websocket on `_stream_client`, kicks a blocked stream task, calls `disconnect()`, asserts `websocket.close` was awaited exactly once and the task reference was cleared.

### Tests

- `tests/gateway/test_dingtalk.py`: **29 passed** (includes the new regression test + the 8 we added in #11471).
- Cherry-pick applied cleanly on top of #11471 — no conflicts with the async `process()` / `_extract_text` changes.

### Authorship

Commit `7099c557` preserves `Asunfly <Asunfly@users.noreply.github.com>` as author. Merge with `--rebase` to keep attribution. Also adds Asunfly to `scripts/release.py` AUTHOR_MAP so the release CI doesn't block on unmapped email.

### Closes

Closes #10070 on merge with credit.
