### PR TITLE
fix(discord): drop invalid reply references + propagation regression guard

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -873,7 +873,10 @@ class DiscordAdapter(BasePlatformAdapter):
             if reply_to and self._reply_to_mode != "off":
                 try:
                     ref_msg = await channel.fetch_message(int(reply_to))
-                    reference = ref_msg
+                    if hasattr(ref_msg, "to_reference"):
+                        reference = ref_msg.to_reference(fail_if_not_exists=False)
+                    else:
+                        reference = ref_msg
                 except Exception as e:
                     logger.debug("Could not fetch reply-to message: %s", e)
 
@@ -891,14 +894,20 @@ class DiscordAdapter(BasePlatformAdapter):
                     err_text = str(e)
                     if (
                         chunk_reference is not None
-                        and "error code: 50035" in err_text
-                        and "Cannot reply to a system message" in err_text
+                        and (
+                            (
+                                "error code: 50035" in err_text
+                                and "Cannot reply to a system message" in err_text
+                            )
+                            or "error code: 10008" in err_text
+                        )
                     ):
                         logger.warning(
-                            "[%s] Reply target %s is a Discord system message; retrying send without reply reference",
+                            "[%s] Reply target %s rejected the reply reference; retrying send without reply reference",
                             self.name,
                             reply_to,
                         )
+                        reference = None
                         msg = await channel.send(
                             content=chunk,
                             reference=None,

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -105,9 +105,14 @@ def _make_discord_adapter(reply_to_mode: str = "first"):
     config = PlatformConfig(enabled=True, token="test-token", reply_to_mode=reply_to_mode)
     adapter = DiscordAdapter(config)
 
-    # Mock the Discord client and channel
+    # Mock the Discord client and channel.
+    # ref_message.to_reference() → a distinct sentinel: the adapter now wraps
+    # the fetched Message via to_reference(fail_if_not_exists=False) so a
+    # deleted target degrades to "send without reply chip" instead of a 400.
     mock_channel = AsyncMock()
     ref_message = MagicMock()
+    ref_reference = MagicMock(name="MessageReference")
+    ref_message.to_reference = MagicMock(return_value=ref_reference)
     mock_channel.fetch_message = AsyncMock(return_value=ref_message)
 
     sent_msg = MagicMock()
@@ -118,7 +123,9 @@ def _make_discord_adapter(reply_to_mode: str = "first"):
     mock_client.get_channel = MagicMock(return_value=mock_channel)
 
     adapter._client = mock_client
-    return adapter, mock_channel, ref_message
+    # Return the reference sentinel alongside so tests can assert identity.
+    adapter._test_expected_reference = ref_reference
+    return adapter, mock_channel, ref_reference
 
 
 class TestSendWithReplyToMode:

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -48,7 +48,8 @@ from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 async def test_send_retries_without_reference_when_reply_target_is_system_message():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
-    ref_msg = SimpleNamespace(id=99)
+    reference_obj = object()
+    ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
     sent_msg = SimpleNamespace(id=1234)
     send_calls = []
 
@@ -76,5 +77,45 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     assert result.message_id == "1234"
     assert channel.fetch_message.await_count == 1
     assert channel.send.await_count == 2
-    assert send_calls[0]["reference"] is ref_msg
+    ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
+    assert send_calls[0]["reference"] is reference_obj
     assert send_calls[1]["reference"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_retries_without_reference_when_reply_target_is_deleted():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    reference_obj = object()
+    ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
+    sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
+    send_calls = []
+
+    async def fake_send(*, content, reference=None):
+        send_calls.append({"content": content, "reference": reference})
+        if len(send_calls) == 1:
+            raise RuntimeError(
+                "400 Bad Request (error code: 10008): Unknown Message"
+            )
+        return sent_msgs[len(send_calls) - 2]
+
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(return_value=ref_msg),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    long_text = "A" * (adapter.MAX_MESSAGE_LENGTH + 50)
+    result = await adapter.send("555", long_text, reply_to="99")
+
+    assert result.success is True
+    assert result.message_id == "1001"
+    assert channel.fetch_message.await_count == 1
+    assert channel.send.await_count == 3
+    ref_msg.to_reference.assert_called_once_with(fail_if_not_exists=False)
+    assert send_calls[0]["reference"] is reference_obj
+    assert send_calls[1]["reference"] is None
+    assert send_calls[2]["reference"] is None

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -119,3 +119,41 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     assert send_calls[0]["reference"] is reference_obj
     assert send_calls[1]["reference"] is None
     assert send_calls[2]["reference"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_retry_on_unrelated_errors():
+    """Regression guard: errors unrelated to the reply reference (e.g. 50013
+    Missing Permissions) must NOT trigger the no-reference retry path — they
+    should propagate out of the per-chunk loop and surface as a failed
+    SendResult so the caller sees the real problem instead of a silent retry.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    reference_obj = object()
+    ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
+    send_calls = []
+
+    async def fake_send(*, content, reference=None):
+        send_calls.append({"content": content, "reference": reference})
+        raise RuntimeError(
+            "403 Forbidden (error code: 50013): Missing Permissions"
+        )
+
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(return_value=ref_msg),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello", reply_to="99")
+
+    # Outer except in adapter.send() wraps propagated errors as SendResult.
+    assert result.success is False
+    assert "50013" in (result.error or "")
+    # Only the first attempt happens — no reference-retry replay.
+    assert channel.send.await_count == 1
+    assert send_calls[0]["reference"] is reference_obj


### PR DESCRIPTION
Salvage of PR #11348 by @LeonSGP43 onto current main, cherry-picked with authorship preserved.

Closes #11342.

## Summary

When Hermes replies with a reply-reference to a message that gets deleted between `channel.fetch_message()` and `channel.send()`, Discord returns `400 error code 10008 Unknown Message` and the whole chunked response is dropped. The existing retry path only caught `50035` (Cannot reply to a system message).

This PR:

1. Builds the reply reference via `ref_msg.to_reference(fail_if_not_exists=False)` so Discord treats a missing target as "send without reply chip" instead of erroring (proactive fix — avoids the retry entirely).
2. Extends the per-chunk retry path to also catch `10008`, and clears `reference` for all subsequent chunks so we don't replay the reject on every chunk.

## Commits

1. `effd31d7` — **fix(discord): drop invalid reply references** — @LeonSGP43, cherry-picked from #11348
2. `dac2f9ae` — **test(discord): add regression guard for non-reference send errors** — our follow-up: ensures 50013 Missing Permissions (and other unrelated errors) don't silently hit the widened retry path; they must propagate as `SendResult(success=False)`. This was proposed in the issue writeup but missing from the PR.
3. `7cecc2a0` — **test(discord): update reply_mode fixture for new `to_reference()` wrapping** — stale fixture follow-up: `_make_discord_adapter` returned the raw `Message` as the expected reference, but the adapter now passes `ref_msg.to_reference()`. Four chunk-identity tests needed the fixture to yield the MessageReference sentinel instead.

## Test plan

- `pytest tests/gateway/test_discord_send.py tests/gateway/test_discord_reply_mode.py` → 31 passed (3 new + 28 existing)
- `pytest tests/gateway/ -k discord` → 214 passed

## Attribution

Original work by @LeonSGP43 in #11348. Issue originally filed by @malaiwah in #11342 with a thorough root-cause writeup and a suggested test plan — commit `dac2f9ae` implements the one missing piece of that plan.