### PR TITLE
fix: prevent gateway hang when background process keeps stdout pipe open

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -9,6 +9,7 @@ or a temp file (local).
 import json
 import logging
 import os
+import select
 import shlex
 import subprocess
 import threading
@@ -423,6 +424,11 @@ class BaseEnvironment(ABC):
 
         Shared across all backends — not overridden.
 
+        Uses select() with a short timeout to read stdout instead of a
+        blocking iterator. This prevents the drain thread from hanging
+        forever when a background child process (e.g. a dev server) keeps
+        the pipe open after the parent exits.
+
         Fires the ``activity_callback`` (if set on this instance) every 10s
         while the process is running so the gateway's inactivity timeout
         doesn't kill long-running commands.
@@ -435,11 +441,25 @@ class BaseEnvironment(ABC):
         ``sleep 300``-survives-30-min bug Physikal and I both hit.
         """
         output_chunks: list[str] = []
+        _stop_drain = threading.Event()
 
         def _drain():
+            """Drain stdout using select() so the loop is interruptible."""
             try:
-                for line in proc.stdout:
-                    output_chunks.append(line)
+                fd = proc.stdout.fileno()
+                while not _stop_drain.is_set():
+                    try:
+                        ready, _, _ = select.select([fd], [], [], 0.3)
+                    except (ValueError, OSError):
+                        break
+                    if ready:
+                        try:
+                            data = os.read(fd, 4096)
+                            if not data:
+                                break
+                            output_chunks.append(data.decode("utf-8", errors="replace"))
+                        except OSError:
+                            break
             except UnicodeDecodeError:
                 output_chunks.clear()
                 output_chunks.append(
@@ -548,13 +568,35 @@ class BaseEnvironment(ABC):
                 )
             try:
                 self._kill_process(proc)
+                _stop_drain.set()
                 drain_thread.join(timeout=2)
             except Exception:
                 pass  # cleanup is best-effort
             raise
+        if time.monotonic() > deadline:
+            self._kill_process(proc)
+            _stop_drain.set()
+            drain_thread.join(timeout=2)
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
+            partial = "".join(output_chunks)
+            timeout_msg = f"\n[Command timed out after {timeout}s]"
+            return {
+                "output": partial + timeout_msg
+                if partial
+                else timeout_msg.lstrip(),
+                "returncode": 124,
+            }
+        # Periodic activity touch so the gateway knows we're alive
+        touch_activity_if_due(_activity_state, "terminal command running")
+        time.sleep(0.2)
 
+        # Process exited normally — signal drain thread and close stdout
+        # so the pipe EOF propagates even if background children hold it.
+        _stop_drain.set()
         drain_thread.join(timeout=5)
-
         try:
             proc.stdout.close()
         except Exception:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -519,7 +519,12 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, time.monotonic() - _activity_state["start"],
                         )
                     self._kill_process(proc)
+                    _stop_drain.set()
                     drain_thread.join(timeout=2)
+                    try:
+                        proc.stdout.close()
+                    except Exception:
+                        pass
                     return {
                         "output": "".join(output_chunks) + "\n[Command interrupted]",
                         "returncode": 130,
@@ -532,7 +537,12 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, timeout,
                         )
                     self._kill_process(proc)
+                    _stop_drain.set()
                     drain_thread.join(timeout=2)
+                    try:
+                        proc.stdout.close()
+                    except Exception:
+                        pass
                     partial = "".join(output_chunks)
                     timeout_msg = f"\n[Command timed out after {timeout}s]"
                     return {
@@ -582,29 +592,13 @@ class BaseEnvironment(ABC):
                 self._kill_process(proc)
                 _stop_drain.set()
                 drain_thread.join(timeout=2)
+                try:
+                    proc.stdout.close()
+                except Exception:
+                    pass
             except Exception:
                 pass  # cleanup is best-effort
             raise
-        if time.monotonic() > deadline:
-            self._kill_process(proc)
-            _stop_drain.set()
-            drain_thread.join(timeout=2)
-            try:
-                proc.stdout.close()
-            except Exception:
-                pass
-            partial = "".join(output_chunks)
-            timeout_msg = f"\n[Command timed out after {timeout}s]"
-            return {
-                "output": partial + timeout_msg
-                if partial
-                else timeout_msg.lstrip(),
-                "returncode": 124,
-            }
-        # Periodic activity touch so the gateway knows we're alive
-        touch_activity_if_due(_activity_state, "terminal command running")
-        time.sleep(0.2)
-
         # Process exited normally — signal drain thread and close stdout
         # so the pipe EOF propagates even if background children hold it.
         _stop_drain.set()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -442,14 +442,24 @@ class BaseEnvironment(ABC):
         """
         output_chunks: list[str] = []
         _stop_drain = threading.Event()
+        # Incremental decoder to avoid splitting multibyte characters
+        # across chunk boundaries (copilot review feedback)
+        encoding = getattr(proc.stdout, "encoding", "utf-8") or "utf-8"
+        _decoder_cls = __import__("codecs").getincrementaldecoder(encoding)
+        _decoder = _decoder_cls(errors="replace")
 
         def _drain():
-            """Drain stdout using select() so the loop is interruptible."""
+            """Drain stdout using select() so the loop is interruptible.
+
+            On stop signal, flush any remaining bytes still available in the
+            pipe so output is not lost (copilot review feedback).
+            """
             try:
                 fd = proc.stdout.fileno()
-                while not _stop_drain.is_set():
+                while True:
+                    select_timeout = 0.0 if _stop_drain.is_set() else 0.3
                     try:
-                        ready, _, _ = select.select([fd], [], [], 0.3)
+                        ready, _, _ = select.select([fd], [], [], select_timeout)
                     except (ValueError, OSError):
                         break
                     if ready:
@@ -457,14 +467,16 @@ class BaseEnvironment(ABC):
                             data = os.read(fd, 4096)
                             if not data:
                                 break
-                            output_chunks.append(data.decode("utf-8", errors="replace"))
+                            output_chunks.append(_decoder.decode(data))
                         except OSError:
                             break
-            except UnicodeDecodeError:
-                output_chunks.clear()
-                output_chunks.append(
-                    "[binary output detected — raw bytes not displayable]"
-                )
+                    elif _stop_drain.is_set():
+                        # No more data available after stop signal — done
+                        break
+                # Flush any remaining buffered bytes in the incremental decoder
+                remaining = _decoder.decode(b"", final=True)
+                if remaining:
+                    output_chunks.append(remaining)
             except (ValueError, OSError):
                 pass
 


### PR DESCRIPTION
## Problem

When running a terminal command that starts a background process (e.g. `npx vite &` or `npm run dev &`), the gateway **hangs permanently**. The entire bot becomes unresponsive — no messages, no cron, no API.

### Root Cause

The `_drain` thread in `_wait_for_process` uses `for line in proc.stdout:` to read stdout. This blocks **forever** waiting for EOF. When a background child process inherits the pipe fd and stays alive, the pipe never closes → drain thread blocks → gateway event loop stuck.

## Fix

Replace the blocking iterator with an interruptible `select()` loop:

- Use `select(fd, [], [], 0.3)` to read stdout in 0.3s intervals
- Add `_stop_drain` threading.Event to signal drain thread termination
- Close `proc.stdout` on **all** exit paths (interrupt, timeout, normal)

This guarantees the drain thread exits within ~0.3s even if background children keep the pipe open.

## Changes

- `tools/environments/base.py` — `_wait_for_process` method only
- +35 lines, -3 lines
- No API or behavior changes — only makes an existing timeout actually work

## Verified

Tested with `sleep 9999 &` and a continuous background process — command returns within timeout instead of hanging forever.