### PR TITLE
fix(copilot): normalize vendor-prefixed and dash-notation model IDs (#6879)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -374,7 +374,26 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
             return bare
         return _dots_to_hyphens(bare)
 
-    # --- Copilot: strip matching provider prefix, keep dots ---
+    # --- Copilot / Copilot ACP: delegate to the Copilot-specific
+    #     normalizer.  It knows about the alias table (vendor-prefix
+    #     stripping for Anthropic/OpenAI, dash-to-dot repair for Claude)
+    #     and live-catalog lookups.  Without this, vendor-prefixed or
+    #     dash-notation Claude IDs survive to the Copilot API and hit
+    #     HTTP 400 "model_not_supported".  See issue #6879.
+    if provider in {"copilot", "copilot-acp"}:
+        try:
+            from hermes_cli.models import normalize_copilot_model_id
+
+            normalized = normalize_copilot_model_id(name)
+            if normalized:
+                return normalized
+        except Exception:
+            # Fall through to the generic strip-vendor behaviour below
+            # if the Copilot-specific path is unavailable for any reason.
+            pass
+
+    # --- Copilot / Copilot ACP / openai-codex fallback:
+    #     strip matching provider prefix, keep dots ---
     if provider in _STRIP_VENDOR_ONLY_PROVIDERS:
         stripped = _strip_matching_provider_prefix(name, provider)
         if stripped == name and name.startswith("openai/"):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1488,6 +1488,19 @@ _COPILOT_MODEL_ALIASES = {
     "anthropic/claude-sonnet-4.6": "claude-sonnet-4.6",
     "anthropic/claude-sonnet-4.5": "claude-sonnet-4.5",
     "anthropic/claude-haiku-4.5": "claude-haiku-4.5",
+    # Dash-notation fallbacks: Hermes' default Claude IDs elsewhere use
+    # hyphens (anthropic native format), but Copilot's API only accepts
+    # dot-notation.  Accept both so users who configure copilot + a
+    # default hyphenated Claude model don't hit HTTP 400
+    # "model_not_supported".  See issue #6879.
+    "claude-opus-4-6": "claude-opus-4.6",
+    "claude-sonnet-4-6": "claude-sonnet-4.6",
+    "claude-sonnet-4-5": "claude-sonnet-4.5",
+    "claude-haiku-4-5": "claude-haiku-4.5",
+    "anthropic/claude-opus-4-6": "claude-opus-4.6",
+    "anthropic/claude-sonnet-4-6": "claude-sonnet-4.6",
+    "anthropic/claude-sonnet-4-5": "claude-sonnet-4.5",
+    "anthropic/claude-haiku-4-5": "claude-haiku-4.5",
 }
 
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -93,6 +93,59 @@ class TestCopilotDotPreservation:
         assert result == expected
 
 
+# ── Copilot model-name normalization (issue #6879 regression) ──────────
+
+class TestCopilotModelNormalization:
+    """Copilot requires bare dot-notation model IDs.
+
+    Regression coverage for issue #6879 and the broken Copilot branch
+    that previously left vendor-prefixed Anthropic IDs (e.g.
+    ``anthropic/claude-sonnet-4.6``) and dash-notation Claude IDs (e.g.
+    ``claude-sonnet-4-6``) unchanged, causing the Copilot API to reject
+    the request with HTTP 400 "model_not_supported".
+    """
+
+    @pytest.mark.parametrize("model,expected", [
+        # Vendor-prefixed Anthropic IDs — prefix must be stripped.
+        ("anthropic/claude-opus-4.6",   "claude-opus-4.6"),
+        ("anthropic/claude-sonnet-4.6", "claude-sonnet-4.6"),
+        ("anthropic/claude-sonnet-4.5", "claude-sonnet-4.5"),
+        ("anthropic/claude-haiku-4.5",  "claude-haiku-4.5"),
+        # Vendor-prefixed OpenAI IDs — prefix must be stripped.
+        ("openai/gpt-5.4",              "gpt-5.4"),
+        ("openai/gpt-4o",               "gpt-4o"),
+        ("openai/gpt-4o-mini",          "gpt-4o-mini"),
+        # Dash-notation Claude IDs — must be converted to dot-notation.
+        ("claude-opus-4-6",             "claude-opus-4.6"),
+        ("claude-sonnet-4-6",           "claude-sonnet-4.6"),
+        ("claude-sonnet-4-5",           "claude-sonnet-4.5"),
+        ("claude-haiku-4-5",            "claude-haiku-4.5"),
+        # Combined: vendor-prefixed + dash-notation.
+        ("anthropic/claude-opus-4-6",   "claude-opus-4.6"),
+        ("anthropic/claude-sonnet-4-6", "claude-sonnet-4.6"),
+        # Already-canonical inputs pass through unchanged.
+        ("claude-sonnet-4.6",           "claude-sonnet-4.6"),
+        ("gpt-5.4",                     "gpt-5.4"),
+        ("gpt-5-mini",                  "gpt-5-mini"),
+    ])
+    def test_copilot_normalization(self, model, expected):
+        assert normalize_model_for_provider(model, "copilot") == expected
+
+    @pytest.mark.parametrize("model,expected", [
+        ("anthropic/claude-sonnet-4.6", "claude-sonnet-4.6"),
+        ("claude-sonnet-4-6",           "claude-sonnet-4.6"),
+        ("claude-opus-4-6",             "claude-opus-4.6"),
+        ("openai/gpt-5.4",              "gpt-5.4"),
+    ])
+    def test_copilot_acp_normalization(self, model, expected):
+        """Copilot ACP shares the same API expectations as HTTP Copilot."""
+        assert normalize_model_for_provider(model, "copilot-acp") == expected
+
+    def test_openai_codex_still_strips_openai_prefix(self):
+        """Regression: openai-codex must still strip the openai/ prefix."""
+        assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"
+
+
 # ── Aggregator providers (regression) ──────────────────────────────────
 
 class TestAggregatorProviders:


### PR DESCRIPTION
## What this PR does

GitHub Copilot's API rejects any model ID it doesn't recognize with HTTP 400 `model_not_supported`. It only accepts bare dot-notation (`claude-sonnet-4.6`, `gpt-5.4`). Two gaps in Hermes left common config values unhandled and users hit immediate 400s whenever they configured Copilot.

### The symptom

Community user on 0.10.0 after `hermes update`:

> I updated 10 minutes ago and get error with GitHub copilot connection. I changed model and still get error.
> `⚠️ Error code: 400 - {'error': {'message': 'The requested model is not supported.', 'code': 'model_not_supported', ...}}`

### Root cause (two bugs combined)

**Bug 1 — `_COPILOT_MODEL_ALIASES` missed dash-notation.**  Hermes' default Claude IDs elsewhere use hyphens (Anthropic native format). A user with `anthropic/claude-sonnet-4.6` in their config who switches `model.provider` to `copilot` inherits an ID the alias table didn't map.

**Bug 2 — the Copilot branch of `normalize_model_for_provider()` was broken.**  It only stripped the vendor prefix when it matched the target provider (`copilot/`) or was `openai/` (special-cased for openai-codex). Every other vendor prefix — including `anthropic/` — survived to the Copilot API unchanged. The function's docstring doctest claimed `normalize_model_for_provider("anthropic/claude-sonnet-4.6", "copilot")` returns `'claude-sonnet-4.6'`, but it actually returned `'anthropic/claude-sonnet-4.6'`.

### What changed

| File | Change |
|------|--------|
| `hermes_cli/models.py` | Added dash-notation aliases (`claude-{opus,sonnet,haiku}-4-{5,6}` + `anthropic/`-prefixed variants) to `_COPILOT_MODEL_ALIASES` |
| `hermes_cli/model_normalize.py` | Rewired the Copilot / Copilot-ACP branch to delegate to the existing `normalize_copilot_model_id()` — it already does alias lookups, catalog-aware resolution, and vendor-prefix fallback, it was just being bypassed from the generic entry point |
| `tests/hermes_cli/test_model_normalize.py` | New `TestCopilotModelNormalization` class — 20 parameterized cases covering vendor-prefixed, dash-notation, combined, already-canonical, and the openai-codex regression guard |

Because `switch_model()` already calls `normalize_model_for_provider()` (line 685), this single fix propagates to the CLI startup path, the `/model` slash command path, and the gateway load-from-config path.

## Test plan

Targeted tests pass:

```
tests/hermes_cli/test_model_normalize.py            55 passed
tests/hermes_cli/test_model_switch_copilot_api_mode.py   3 passed
tests/hermes_cli/ -k 'copilot or normalize or model_switch'  195 passed
```

E2E verified via `execute_code` with real imports, isolated `HERMES_HOME`, and the full `switch_model()` pipeline. All common user-facing scenarios normalize correctly:

```
config='anthropic/claude-sonnet-4.6'  -> sent to Copilot API='claude-sonnet-4.6'
config='anthropic/claude-opus-4.6'    -> sent to Copilot API='claude-opus-4.6'
config='claude-sonnet-4-6'            -> sent to Copilot API='claude-sonnet-4.6'
config='claude-opus-4-6'              -> sent to Copilot API='claude-opus-4.6'
config='anthropic/claude-sonnet-4-6'  -> sent to Copilot API='claude-sonnet-4.6'
config='openai/gpt-5.4'               -> sent to Copilot API='gpt-5.4'
config='gpt-5.4'                      -> sent to Copilot API='gpt-5.4' (pass-through)
```

Regression guards in place for openai-codex (still strips `openai/`), aggregators (still prepend vendor), and Anthropic native (still hyphenates).

Closes #6879

## Credit

Thanks to @dsr-restyn (#6743) who independently diagnosed the dash-notation half of this bug. Their aliases are folded into this consolidated fix alongside the vendor-prefix stripping repair.