### PR TITLE
fix(qqbot): correct Authorization header format in send_message REST path

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1274,7 +1274,7 @@ async def _send_qqbot(pconfig, chat_id, message):
 
             # Step 2: Send message via REST
             headers = {
-                "Authorization": f"QQBotAccessToken {access_token}",
+                "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"


### PR DESCRIPTION
## Summary
1-line fix — `tools/send_message_tool.py`'s direct-REST QQBot path used `Authorization: QQBotAccessToken {token}`. QQ's API rejects that format with 401. The correct format is `QQBot {token}`, which the gateway adapter at `gateway/platforms/qqbot.py` already uses in all 5 header sites (lines 341, 551, 579, 1068, 1467). This call site was the outlier.

Impact: any `send_message` call targeting QQBot via the direct REST path (no gateway running) was silently returning `401 Unauthorized`.

## Credit
Salvaged from @Quon's #10257 — that PR had broader issues in its media-upload logic and was closed after a detailed review, but the Authorization header typo it surfaced is a genuine live bug. Credit to @Quon.
