### PR TITLE
fix(acp): use session cwd for project context discovery

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -322,6 +322,10 @@ class SessionManager:
         if state is None:
             return None
         state.cwd = cwd
+        if getattr(state, "agent", None) is not None:
+            setattr(state.agent, "working_dir", cwd)
+            if hasattr(state.agent, "_cached_system_prompt"):
+                state.agent._cached_system_prompt = None
         _register_task_cwd(session_id, cwd)
         self._persist(state)
         return state
@@ -568,6 +572,7 @@ class SessionManager:
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,
+            "working_dir": cwd,
             "session_id": session_id,
             "model": model or default_model,
         }

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -211,6 +211,10 @@ class SessionManager:
         if state is None:
             return None
         state.cwd = cwd
+        if getattr(state, "agent", None) is not None:
+            setattr(state.agent, "working_dir", cwd)
+            if hasattr(state.agent, "_cached_system_prompt"):
+                state.agent._cached_system_prompt = None
         _register_task_cwd(session_id, cwd)
         self._persist(state)
         return state
@@ -448,6 +452,7 @@ class SessionManager:
             "platform": "acp",
             "enabled_toolsets": ["hermes-acp"],
             "quiet_mode": True,
+            "working_dir": cwd,
             "session_id": session_id,
             "model": model or default_model,
         }

--- a/run_agent.py
+++ b/run_agent.py
@@ -899,6 +899,7 @@ class AIAgent:
         provider_sort: str = None,
         provider_require_parameters: bool = False,
         provider_data_collection: str = None,
+        working_dir: str = None,
         session_id: str = None,
         tool_progress_callback: callable = None,
         tool_start_callback: callable = None,
@@ -958,6 +959,7 @@ class AIAgent:
             providers_ignored (List[str]): OpenRouter providers to ignore (optional)
             providers_order (List[str]): OpenRouter providers to try in order (optional)
             provider_sort (str): Sort providers by price/throughput/latency (optional)
+            working_dir (str): Explicit workspace directory for project context discovery.
             session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
@@ -997,6 +999,7 @@ class AIAgent:
         self._chat_type = chat_type
         self._thread_id = thread_id
         self._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+        self.working_dir = working_dir
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
         # instead of going directly to stdout where patch_stdout's StdoutProxy
@@ -2006,7 +2009,7 @@ class AIAgent:
                 logger.debug("Context engine on_session_start: %s", _ce_err)
 
         self._subdirectory_hints = SubdirectoryHintTracker(
-            working_dir=os.getenv("TERMINAL_CWD") or None,
+            working_dir=self.working_dir or os.getenv("TERMINAL_CWD") or None,
         )
         self._user_turn_count = 0
 
@@ -4825,11 +4828,11 @@ class AIAgent:
             prompt_parts.append(skills_prompt)
 
         if not self.skip_context_files:
-            # Use TERMINAL_CWD for context file discovery when set (gateway
-            # mode).  The gateway process runs from the hermes-agent install
-            # dir, so os.getcwd() would pick up the repo's AGENTS.md and
-            # other dev files — inflating token usage by ~10k for no benefit.
-            _context_cwd = os.getenv("TERMINAL_CWD") or None
+            # Prefer an explicit session working_dir when one is bound (ACP),
+            # otherwise fall back to TERMINAL_CWD for gateway mode.  Without
+            # this, ACP tools run in the editor workspace while context-file
+            # discovery still follows the process cwd.
+            _context_cwd = self.working_dir or os.getenv("TERMINAL_CWD") or None
             context_files_prompt = build_context_files_prompt(
                 cwd=_context_cwd, skip_soul=_soul_loaded)
             if context_files_prompt:

--- a/run_agent.py
+++ b/run_agent.py
@@ -576,6 +576,7 @@ class AIAgent:
         provider_sort: str = None,
         provider_require_parameters: bool = False,
         provider_data_collection: str = None,
+        working_dir: str = None,
         session_id: str = None,
         tool_progress_callback: callable = None,
         tool_start_callback: callable = None,
@@ -631,6 +632,7 @@ class AIAgent:
             providers_ignored (List[str]): OpenRouter providers to ignore (optional)
             providers_order (List[str]): OpenRouter providers to try in order (optional)
             provider_sort (str): Sort providers by price/throughput/latency (optional)
+            working_dir (str): Explicit workspace directory for project context discovery.
             session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
@@ -665,6 +667,7 @@ class AIAgent:
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
         self._user_id = user_id  # Platform user identifier (gateway sessions)
         self._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
+        self.working_dir = working_dir
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
         # instead of going directly to stdout where patch_stdout's StdoutProxy
@@ -1533,7 +1536,7 @@ class AIAgent:
                 logger.debug("Context engine on_session_start: %s", _ce_err)
 
         self._subdirectory_hints = SubdirectoryHintTracker(
-            working_dir=os.getenv("TERMINAL_CWD") or None,
+            working_dir=self.working_dir or os.getenv("TERMINAL_CWD") or None,
         )
         self._user_turn_count = 0
 
@@ -3468,11 +3471,11 @@ class AIAgent:
             prompt_parts.append(skills_prompt)
 
         if not self.skip_context_files:
-            # Use TERMINAL_CWD for context file discovery when set (gateway
-            # mode).  The gateway process runs from the hermes-agent install
-            # dir, so os.getcwd() would pick up the repo's AGENTS.md and
-            # other dev files — inflating token usage by ~10k for no benefit.
-            _context_cwd = os.getenv("TERMINAL_CWD") or None
+            # Prefer an explicit session working_dir when one is bound (ACP),
+            # otherwise fall back to TERMINAL_CWD for gateway mode.  Without
+            # this, ACP tools run in the editor workspace while context-file
+            # discovery still follows the process cwd.
+            _context_cwd = self.working_dir or os.getenv("TERMINAL_CWD") or None
             context_files_prompt = build_context_files_prompt(
                 cwd=_context_cwd, skip_soul=_soul_loaded)
             if context_files_prompt:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -386,6 +386,7 @@ AUTHOR_MAP = {
     "lrawnsley@users.noreply.github.com": "lrawnsley",
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "cola-runner@users.noreply.github.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -193,6 +193,7 @@ AUTHOR_MAP = {
     "lrawnsley@users.noreply.github.com": "lrawnsley",
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "cola-runner@users.noreply.github.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -332,6 +332,17 @@ class TestPersistence:
         mc = json.loads(row["model_config"])
         assert mc["cwd"] == "/new"
 
+    def test_update_cwd_refreshes_agent_working_dir_and_prompt_cache(self, manager):
+        state = manager.create_session(cwd="/old")
+        state.agent.working_dir = "/old"
+        state.agent._cached_system_prompt = "cached"
+
+        updated = manager.update_cwd(state.session_id, "/new")
+
+        assert updated is not None
+        assert updated.agent.working_dir == "/new"
+        assert updated.agent._cached_system_prompt is None
+
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""
         db = manager._get_db()

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -237,6 +237,17 @@ class TestPersistence:
         mc = json.loads(row["model_config"])
         assert mc["cwd"] == "/new"
 
+    def test_update_cwd_refreshes_agent_working_dir_and_prompt_cache(self, manager):
+        state = manager.create_session(cwd="/old")
+        state.agent.working_dir = "/old"
+        state.agent._cached_system_prompt = "cached"
+
+        updated = manager.update_cwd(state.session_id, "/new")
+
+        assert updated is not None
+        assert updated.agent.working_dir == "/new"
+        assert updated.agent._cached_system_prompt is None
+
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""
         db = manager._get_db()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -888,6 +888,42 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert "NOUS SUBSCRIPTION BLOCK" in prompt
 
+    def test_prefers_explicit_working_dir_for_context_files(self, monkeypatch):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.build_context_files_prompt", return_value="CTX") as mock_context,
+        ):
+            monkeypatch.setenv("TERMINAL_CWD", "/env/workspace")
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_memory=True,
+                working_dir="/acp/workspace",
+            )
+
+            prompt = agent._build_system_prompt()
+
+        assert "CTX" in prompt
+        assert mock_context.call_args.kwargs["cwd"] == "/acp/workspace"
+
+    def test_initializes_subdirectory_hints_from_explicit_working_dir(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                working_dir="/acp/workspace",
+            )
+
+        assert agent._subdirectory_hints.working_dir == Path("/acp/workspace").resolve()
+
     def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
         tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
         toolset_map = {

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -673,6 +673,42 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert "NOUS SUBSCRIPTION BLOCK" in prompt
 
+    def test_prefers_explicit_working_dir_for_context_files(self, monkeypatch):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.build_context_files_prompt", return_value="CTX") as mock_context,
+        ):
+            monkeypatch.setenv("TERMINAL_CWD", "/env/workspace")
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_memory=True,
+                working_dir="/acp/workspace",
+            )
+
+            prompt = agent._build_system_prompt()
+
+        assert "CTX" in prompt
+        assert mock_context.call_args.kwargs["cwd"] == "/acp/workspace"
+
+    def test_initializes_subdirectory_hints_from_explicit_working_dir(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                working_dir="/acp/workspace",
+            )
+
+        assert agent._subdirectory_hints.working_dir == Path("/acp/workspace").resolve()
+
     def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
         tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
         toolset_map = {


### PR DESCRIPTION
## Summary
- pass the ACP session cwd into AIAgent so project context discovery uses the same workspace as ACP tool execution
- invalidate the cached system prompt when an ACP session changes cwd so context files are rebuilt from the new workspace
- initialize ACP subdirectory hint tracking from the explicit session cwd and add regression coverage for both the agent and session manager paths

Closes #11515

## Testing
- `source venv/bin/activate && python -m pytest tests/run_agent/test_run_agent.py -q -k 'TestBuildSystemPrompt'`
- `source venv/bin/activate && python -m pytest tests/acp/test_session.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

## Full suite note
The full suite still fails in this environment on existing unrelated tests and missing optional deps (`acp`, `fastapi`), plus current gateway/Discord/transcription failures. The ACP and run_agent coverage for this change passed locally.
