### PR TITLE
fix(weixin): Batch-3 salvage — voice fallback, MEDIA extraction, native markdown rendering

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -25,6 +25,7 @@ import struct
 import tempfile
 import time
 import uuid
+import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -65,6 +66,14 @@ from gateway.platforms.base import (
 )
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
+
+try:
+    import pilk
+
+    PILK_AVAILABLE = True
+except ImportError:  # pragma: no cover - optional dependency
+    pilk = None  # type: ignore[assignment]
+    PILK_AVAILABLE = False
 
 ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 WEIXIN_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
@@ -1590,7 +1599,74 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        return await self.send_document(chat_id, audio_path, caption=caption or "", metadata=metadata)
+        if not self._session or not self._token:
+            return SendResult(success=False, error="Not connected")
+
+        temp_paths: List[str] = []
+        try:
+            voice_path = self._prepare_voice_payload(audio_path)
+            if voice_path != audio_path:
+                temp_paths.append(voice_path)
+            message_id = await self._send_file(chat_id, voice_path, caption or "")
+            return SendResult(success=True, message_id=message_id)
+        except Exception as exc:
+            logger.error("[%s] send_voice failed to=%s: %s", self.name, _safe_id(chat_id), exc)
+            return SendResult(success=False, error=str(exc))
+        finally:
+            for path in temp_paths:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+    def _prepare_voice_payload(self, audio_path: str) -> str:
+        path = str(audio_path)
+        if path.endswith(".silk"):
+            return path
+        if not PILK_AVAILABLE:
+            raise RuntimeError(
+                "Weixin native voice requires SILK encoding, but pilk is not installed"
+            )
+
+        wav_path = self._transcode_audio_to_wav(path)
+        try:
+            fd, silk_path = tempfile.mkstemp(suffix='.silk')
+            os.close(fd)
+            pilk.encode(wav_path, silk_path, tencent=True)
+            if not os.path.exists(silk_path) or os.path.getsize(silk_path) <= 0:
+                raise RuntimeError("Generated SILK voice file is empty")
+            return silk_path
+        finally:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+
+    def _transcode_audio_to_wav(self, input_path: str) -> str:
+        fd, wav_path = tempfile.mkstemp(suffix='.wav')
+        os.close(fd)
+        try:
+            result = subprocess.run(
+                [
+                    'ffmpeg', '-y', '-i', input_path,
+                    '-ar', '24000', '-ac', '1', '-f', 'wav', wav_path,
+                ],
+                capture_output=True,
+                timeout=60,
+                check=False,
+            )
+            if result.returncode != 0:
+                stderr = result.stderr.decode('utf-8', errors='ignore')[:400]
+                raise RuntimeError(f"ffmpeg voice conversion failed: {stderr}")
+            if not os.path.exists(wav_path) or os.path.getsize(wav_path) <= 0:
+                raise RuntimeError("ffmpeg produced empty wav for Weixin voice")
+            return wav_path
+        except Exception:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+            raise
 
     async def _download_remote_media(self, url: str) -> str:
         from tools.url_safety import is_safe_url

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -66,14 +66,6 @@ from gateway.platforms.base import (
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
 
-try:
-    import pilk
-
-    PILK_AVAILABLE = True
-except ImportError:  # pragma: no cover - optional dependency
-    pilk = None  # type: ignore[assignment]
-    PILK_AVAILABLE = False
-
 ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 WEIXIN_CDN_BASE_URL = "https://novac2c.cdn.weixin.qq.com/c2c"
 ILINK_APP_ID = "bot"
@@ -1695,11 +1687,6 @@ class WeixinAdapter(BasePlatformAdapter):
             item_kwargs["encode_type"] = 6
             item_kwargs["sample_rate"] = 24000
             item_kwargs["bits_per_sample"] = 16
-            if PILK_AVAILABLE:
-                try:
-                    item_kwargs["playtime"] = pilk.get_duration(path)
-                except Exception as exc:
-                    logger.warning("[%s] failed to read SILK duration for %s: %s", self.name, path, exc)
         media_item = item_builder(**item_kwargs)
 
         last_message_id = None

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1460,8 +1460,44 @@ class WeixinAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
+
+        # Extract MEDIA: tags and bare local file paths before text delivery.
+        media_files, cleaned_content = self.extract_media(content)
+        _, image_cleaned = self.extract_images(cleaned_content)
+        local_files, final_content = self.extract_local_files(image_cleaned)
+
+        _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a"}
+        _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+        _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+
+        async def _deliver_media(path: str, is_voice: bool = False) -> None:
+            ext = Path(path).suffix.lower()
+            if is_voice or ext in _AUDIO_EXTS:
+                await self.send_voice(chat_id=chat_id, audio_path=path, metadata=metadata)
+            elif ext in _VIDEO_EXTS:
+                await self.send_video(chat_id=chat_id, video_path=path, metadata=metadata)
+            elif ext in _IMAGE_EXTS:
+                await self.send_image_file(chat_id=chat_id, image_path=path, metadata=metadata)
+            else:
+                await self.send_document(chat_id=chat_id, file_path=path, metadata=metadata)
+
         try:
-            chunks = [c for c in self._split_text(self.format_message(content)) if c and c.strip()]
+            # Deliver extracted MEDIA: attachments first.
+            for media_path, is_voice in media_files:
+                try:
+                    await _deliver_media(media_path, is_voice)
+                except Exception as exc:
+                    logger.warning("[%s] media delivery failed for %s: %s", self.name, media_path, exc)
+
+            # Deliver bare local file paths.
+            for file_path in local_files:
+                try:
+                    await _deliver_media(file_path, is_voice=False)
+                except Exception as exc:
+                    logger.warning("[%s] local file delivery failed for %s: %s", self.name, file_path, exc)
+
+            # Deliver text content.
+            chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
             for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await self._send_text_chunk(

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -25,7 +25,6 @@ import struct
 import tempfile
 import time
 import uuid
-import subprocess
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -1602,71 +1601,21 @@ class WeixinAdapter(BasePlatformAdapter):
         if not self._session or not self._token:
             return SendResult(success=False, error="Not connected")
 
-        temp_paths: List[str] = []
+        # Native outbound Weixin voice bubbles are not proven-working in the
+        # upstream reference implementation. Prefer a reliable file attachment
+        # fallback so users at least receive playable audio, even for .silk.
+        fallback_caption = caption or "[voice message as attachment]"
         try:
-            voice_path = self._prepare_voice_payload(audio_path)
-            if voice_path != audio_path:
-                temp_paths.append(voice_path)
-            message_id = await self._send_file(chat_id, voice_path, caption or "")
+            message_id = await self._send_file(
+                chat_id,
+                audio_path,
+                fallback_caption,
+                force_file_attachment=True,
+            )
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_voice failed to=%s: %s", self.name, _safe_id(chat_id), exc)
             return SendResult(success=False, error=str(exc))
-        finally:
-            for path in temp_paths:
-                try:
-                    os.unlink(path)
-                except OSError:
-                    pass
-
-    def _prepare_voice_payload(self, audio_path: str) -> str:
-        path = str(audio_path)
-        if path.endswith(".silk"):
-            return path
-        if not PILK_AVAILABLE:
-            raise RuntimeError(
-                "Weixin native voice requires SILK encoding, but pilk is not installed"
-            )
-
-        wav_path = self._transcode_audio_to_wav(path)
-        try:
-            fd, silk_path = tempfile.mkstemp(suffix='.silk')
-            os.close(fd)
-            pilk.encode(wav_path, silk_path, tencent=True)
-            if not os.path.exists(silk_path) or os.path.getsize(silk_path) <= 0:
-                raise RuntimeError("Generated SILK voice file is empty")
-            return silk_path
-        finally:
-            try:
-                os.unlink(wav_path)
-            except OSError:
-                pass
-
-    def _transcode_audio_to_wav(self, input_path: str) -> str:
-        fd, wav_path = tempfile.mkstemp(suffix='.wav')
-        os.close(fd)
-        try:
-            result = subprocess.run(
-                [
-                    'ffmpeg', '-y', '-i', input_path,
-                    '-ar', '24000', '-ac', '1', '-f', 'wav', wav_path,
-                ],
-                capture_output=True,
-                timeout=60,
-                check=False,
-            )
-            if result.returncode != 0:
-                stderr = result.stderr.decode('utf-8', errors='ignore')[:400]
-                raise RuntimeError(f"ffmpeg voice conversion failed: {stderr}")
-            if not os.path.exists(wav_path) or os.path.getsize(wav_path) <= 0:
-                raise RuntimeError("ffmpeg produced empty wav for Weixin voice")
-            return wav_path
-        except Exception:
-            try:
-                os.unlink(wav_path)
-            except OSError:
-                pass
-            raise
 
     async def _download_remote_media(self, url: str) -> str:
         from tools.url_safety import is_safe_url
@@ -1683,10 +1632,16 @@ class WeixinAdapter(BasePlatformAdapter):
             handle.write(data)
             return handle.name
 
-    async def _send_file(self, chat_id: str, path: str, caption: str) -> str:
+    async def _send_file(
+        self,
+        chat_id: str,
+        path: str,
+        caption: str,
+        force_file_attachment: bool = False,
+    ) -> str:
         assert self._session is not None and self._token is not None
         plaintext = Path(path).read_bytes()
-        media_type, item_builder = self._outbound_media_builder(path)
+        media_type, item_builder = self._outbound_media_builder(path, force_file_attachment=force_file_attachment)
         filekey = secrets.token_hex(16)
         aes_key = secrets.token_bytes(16)
         rawsize = len(plaintext)
@@ -1728,14 +1683,24 @@ class WeixinAdapter(BasePlatformAdapter):
         # Sending base64(raw_bytes) causes images to show as grey boxes on the
         # receiver side because the decryption key doesn't match.
         aes_key_for_api = base64.b64encode(aes_key.hex().encode("ascii")).decode("ascii")
-        media_item = item_builder(
-            encrypt_query_param=encrypted_query_param,
-            aes_key_for_api=aes_key_for_api,
-            ciphertext_size=len(ciphertext),
-            plaintext_size=rawsize,
-            filename=Path(path).name,
-            rawfilemd5=rawfilemd5,
-        )
+        item_kwargs = {
+            "encrypt_query_param": encrypted_query_param,
+            "aes_key_for_api": aes_key_for_api,
+            "ciphertext_size": len(ciphertext),
+            "plaintext_size": rawsize,
+            "filename": Path(path).name,
+            "rawfilemd5": rawfilemd5,
+        }
+        if media_type == MEDIA_VOICE and path.endswith(".silk"):
+            item_kwargs["encode_type"] = 6
+            item_kwargs["sample_rate"] = 24000
+            item_kwargs["bits_per_sample"] = 16
+            if PILK_AVAILABLE:
+                try:
+                    item_kwargs["playtime"] = pilk.get_duration(path)
+                except Exception as exc:
+                    logger.warning("[%s] failed to read SILK duration for %s: %s", self.name, path, exc)
+        media_item = item_builder(**item_kwargs)
 
         last_message_id = None
         if caption:
@@ -1771,7 +1736,7 @@ class WeixinAdapter(BasePlatformAdapter):
         )
         return last_message_id
 
-    def _outbound_media_builder(self, path: str):
+    def _outbound_media_builder(self, path: str, force_file_attachment: bool = False):
         mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
         if mime.startswith("image/"):
             return MEDIA_IMAGE, lambda **kw: {
@@ -1799,7 +1764,7 @@ class WeixinAdapter(BasePlatformAdapter):
                     "video_md5": kw.get("rawfilemd5", ""),
                 },
             }
-        if mime.startswith("audio/") or path.endswith(".silk"):
+        if path.endswith(".silk") and not force_file_attachment:
             return MEDIA_VOICE, lambda **kw: {
                 "type": ITEM_VOICE,
                 "voice_item": {
@@ -1808,7 +1773,23 @@ class WeixinAdapter(BasePlatformAdapter):
                         "aes_key": kw["aes_key_for_api"],
                         "encrypt_type": 1,
                     },
+                    "encode_type": kw.get("encode_type"),
+                    "bits_per_sample": kw.get("bits_per_sample"),
+                    "sample_rate": kw.get("sample_rate"),
                     "playtime": kw.get("playtime", 0),
+                },
+            }
+        if mime.startswith("audio/"):
+            return MEDIA_FILE, lambda **kw: {
+                "type": ITEM_FILE,
+                "file_item": {
+                    "media": {
+                        "encrypt_query_param": kw["encrypt_query_param"],
+                        "aes_key": kw["aes_key_for_api"],
+                        "encrypt_type": 1,
+                    },
+                    "file_name": kw["filename"],
+                    "len": str(kw["plaintext_size"]),
                 },
             }
         return MEDIA_FILE, lambda **kw: {

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -623,42 +623,31 @@ def _rewrite_table_block_for_weixin(lines: List[str]) -> str:
 def _normalize_markdown_blocks(content: str) -> str:
     lines = content.splitlines()
     result: List[str] = []
-    i = 0
     in_code_block = False
+    blank_run = 0
 
-    while i < len(lines):
-        line = lines[i].rstrip()
-        fence_match = _FENCE_RE.match(line.strip())
-        if fence_match:
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        if _FENCE_RE.match(line.strip()):
             in_code_block = not in_code_block
             result.append(line)
-            i += 1
+            blank_run = 0
             continue
 
         if in_code_block:
             result.append(line)
-            i += 1
             continue
 
-        if (
-            i + 1 < len(lines)
-            and "|" in lines[i]
-            and _TABLE_RULE_RE.match(lines[i + 1].rstrip())
-        ):
-            table_lines = [lines[i].rstrip(), lines[i + 1].rstrip()]
-            i += 2
-            while i < len(lines) and "|" in lines[i]:
-                table_lines.append(lines[i].rstrip())
-                i += 1
-            result.append(_rewrite_table_block_for_weixin(table_lines))
+        if not line.strip():
+            blank_run += 1
+            if blank_run <= 1:
+                result.append("")
             continue
 
-        result.append(_MARKDOWN_LINK_RE.sub(r"\1 (\2)", _rewrite_headers_for_weixin(line)))
-        i += 1
+        blank_run = 0
+        result.append(line)
 
-    normalized = "\n".join(item.rstrip() for item in result)
-    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
-    return normalized.strip()
+    return "\n".join(result).strip()
 
 
 def _split_markdown_blocks(content: str) -> List[str]:
@@ -704,8 +693,8 @@ def _split_delivery_units_for_weixin(content: str) -> List[str]:
 
     Weixin can render Markdown, but chat readability is better when top-level
     line breaks become separate messages. Keep fenced code blocks intact and
-    attach indented continuation lines to the previous top-level line so
-    transformed tables/lists do not get torn apart.
+    attach indented continuation lines to the previous top-level line so nested
+    list items do not get torn apart.
     """
     units: List[str] = []
 
@@ -747,7 +736,9 @@ def _looks_like_chatty_line_for_weixin(line: str) -> bool:
         return False
     if line.startswith((" ", "\t")):
         return False
-    if stripped.startswith((">", "-", "*", "【")):
+    if stripped.startswith((">", "-", "*", "【", "#", "|")):
+        return False
+    if _TABLE_RULE_RE.match(stripped):
         return False
     if re.match(r"^\*\*[^*]+\*\*$", stripped):
         return False
@@ -757,10 +748,12 @@ def _looks_like_chatty_line_for_weixin(line: str) -> bool:
 
 
 def _looks_like_heading_line_for_weixin(line: str) -> bool:
-    """Return True when a short line behaves like a plain-text heading."""
+    """Return True when a short line behaves like a heading."""
     stripped = line.strip()
     if not stripped:
         return False
+    if _HEADER_RE.match(stripped):
+        return True
     return len(stripped) <= 24 and stripped.endswith((":", "："))
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5811,7 +5811,7 @@ class GatewayRunner:
                         pass
 
                 # Send media files
-                for media_path in (media_files or []):
+                for media_path, _is_voice in (media_files or []):
                     try:
                         await adapter.send_document(
                             chat_id=source.chat_id,
@@ -5989,7 +5989,7 @@ class GatewayRunner:
                 except Exception:
                     pass
 
-            for media_path in (media_files or []):
+            for media_path, _is_voice in (media_files or []):
                 try:
                     await adapter.send_file(chat_id=source.chat_id, file_path=media_path)
                 except Exception:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -238,6 +238,9 @@ AUTHOR_MAP = {
     "dhandhalyabhavik@gmail.com": "v1k22",
     "rucchizhao@zhaochenfeideMacBook-Pro.local": "RucchiZ",
     "lehaolin98@outlook.com": "LehaoLin",
+    "yuewang1@microsoft.com": "imink",
+    "1736355688@qq.com": "hedgeho9X",
+    "bernylinville@devopsthink.org": "bernylinville",
 }
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import PlatformConfig
@@ -580,3 +581,53 @@ class TestWeixinSendImageFileParameterName:
             caption="",
             metadata=None,
         )
+
+
+class TestWeixinVoiceSending:
+    def _connected_adapter(self) -> WeixinAdapter:
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
+        return adapter
+
+    @patch.object(WeixinAdapter, "_send_file", new_callable=AsyncMock)
+    @patch.object(WeixinAdapter, "_prepare_voice_payload")
+    def test_send_voice_uses_silk_payload(self, prepare_mock, send_file_mock, tmp_path):
+        adapter = self._connected_adapter()
+        source = tmp_path / "voice.ogg"
+        silk = tmp_path / "voice.silk"
+        source.write_bytes(b"ogg")
+        silk.write_bytes(b"silk")
+        prepare_mock.return_value = str(silk)
+        send_file_mock.return_value = "msg-1"
+
+        result = asyncio.run(adapter.send_voice("wxid_test123", str(source)))
+
+        assert result.success is True
+        prepare_mock.assert_called_once_with(str(source))
+        send_file_mock.assert_awaited_once_with("wxid_test123", str(silk), "")
+
+    @patch("gateway.platforms.weixin.pilk.encode")
+    @patch.object(WeixinAdapter, "_transcode_audio_to_wav")
+    def test_prepare_voice_payload_transcodes_to_silk(self, transcode_mock, pilk_encode_mock, tmp_path):
+        adapter = _make_adapter()
+        src = tmp_path / "voice.ogg"
+        src.write_bytes(b"ogg")
+        wav = tmp_path / "voice.wav"
+        wav.write_bytes(b"wav")
+        transcode_mock.return_value = str(wav)
+
+        def _fake_encode(infile, outfile, **kwargs):
+            Path(outfile).write_bytes(b"silk-bytes")
+
+        pilk_encode_mock.side_effect = _fake_encode
+
+        silk_path = adapter._prepare_voice_payload(str(src))
+
+        assert silk_path.endswith('.silk')
+        assert Path(silk_path).read_bytes() == b"silk-bytes"
+        pilk_encode_mock.assert_called_once_with(str(wav), silk_path, tencent=True)
+        assert not wav.exists()
+        os.unlink(silk_path)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -501,10 +501,10 @@ class TestWeixinMediaBuilder:
         )
         assert item["video_item"]["video_md5"] == "deadbeef"
 
-    def test_voice_builder_for_audio_files(self):
+    def test_voice_builder_for_audio_files_uses_file_attachment_type(self):
         adapter = _make_adapter()
         media_type, builder = adapter._outbound_media_builder("note.mp3")
-        assert media_type == weixin.MEDIA_VOICE
+        assert media_type == weixin.MEDIA_FILE
 
         item = builder(
             encrypt_query_param="eq",
@@ -514,8 +514,8 @@ class TestWeixinMediaBuilder:
             filename="note.mp3",
             rawfilemd5="abc",
         )
-        assert item["type"] == weixin.ITEM_VOICE
-        assert "voice_item" in item
+        assert item["type"] == weixin.ITEM_FILE
+        assert item["file_item"]["file_name"] == "note.mp3"
 
     def test_voice_builder_for_silk_files(self):
         adapter = _make_adapter()
@@ -593,41 +593,65 @@ class TestWeixinVoiceSending:
         return adapter
 
     @patch.object(WeixinAdapter, "_send_file", new_callable=AsyncMock)
-    @patch.object(WeixinAdapter, "_prepare_voice_payload")
-    def test_send_voice_uses_silk_payload(self, prepare_mock, send_file_mock, tmp_path):
+    def test_send_voice_downgrades_to_document_attachment(self, send_file_mock, tmp_path):
         adapter = self._connected_adapter()
         source = tmp_path / "voice.ogg"
-        silk = tmp_path / "voice.silk"
         source.write_bytes(b"ogg")
-        silk.write_bytes(b"silk")
-        prepare_mock.return_value = str(silk)
         send_file_mock.return_value = "msg-1"
 
         result = asyncio.run(adapter.send_voice("wxid_test123", str(source)))
 
         assert result.success is True
-        prepare_mock.assert_called_once_with(str(source))
-        send_file_mock.assert_awaited_once_with("wxid_test123", str(silk), "")
+        send_file_mock.assert_awaited_once_with(
+            "wxid_test123",
+            str(source),
+            "[voice message as attachment]",
+            force_file_attachment=True,
+        )
 
-    @patch("gateway.platforms.weixin.pilk.encode")
-    @patch.object(WeixinAdapter, "_transcode_audio_to_wav")
-    def test_prepare_voice_payload_transcodes_to_silk(self, transcode_mock, pilk_encode_mock, tmp_path):
+    def test_voice_builder_for_silk_files_can_be_forced_to_file_attachment(self):
         adapter = _make_adapter()
-        src = tmp_path / "voice.ogg"
-        src.write_bytes(b"ogg")
-        wav = tmp_path / "voice.wav"
-        wav.write_bytes(b"wav")
-        transcode_mock.return_value = str(wav)
+        media_type, builder = adapter._outbound_media_builder(
+            "recording.silk",
+            force_file_attachment=True,
+        )
+        assert media_type == weixin.MEDIA_FILE
 
-        def _fake_encode(infile, outfile, **kwargs):
-            Path(outfile).write_bytes(b"silk-bytes")
+        item = builder(
+            encrypt_query_param="eq",
+            aes_key_for_api="fakekey",
+            ciphertext_size=512,
+            plaintext_size=500,
+            filename="recording.silk",
+            rawfilemd5="abc",
+        )
+        assert item["type"] == weixin.ITEM_FILE
+        assert item["file_item"]["file_name"] == "recording.silk"
 
-        pilk_encode_mock.side_effect = _fake_encode
+    @patch.object(weixin, "_api_post", new_callable=AsyncMock)
+    @patch.object(weixin, "_upload_ciphertext", new_callable=AsyncMock)
+    @patch.object(weixin, "_get_upload_url", new_callable=AsyncMock)
+    def test_send_file_sets_voice_playtime_from_silk_duration(
+        self,
+        get_upload_url_mock,
+        upload_ciphertext_mock,
+        api_post_mock,
+        tmp_path,
+    ):
+        adapter = self._connected_adapter()
+        silk = tmp_path / "voice.silk"
+        silk.write_bytes(b"\x02#!SILK_V3\x01\x00")
+        get_upload_url_mock.return_value = {"upload_full_url": "https://cdn.example.com/upload"}
+        upload_ciphertext_mock.return_value = "enc-q"
+        api_post_mock.return_value = {"success": True}
 
-        silk_path = adapter._prepare_voice_payload(str(src))
+        with patch("gateway.platforms.weixin.pilk.get_duration", return_value=1260) as duration_mock:
+            asyncio.run(adapter._send_file("wxid_test123", str(silk), ""))
 
-        assert silk_path.endswith('.silk')
-        assert Path(silk_path).read_bytes() == b"silk-bytes"
-        pilk_encode_mock.assert_called_once_with(str(wav), silk_path, tencent=True)
-        assert not wav.exists()
-        os.unlink(silk_path)
+        duration_mock.assert_called_once_with(str(silk))
+        payload = api_post_mock.await_args.kwargs["payload"]
+        voice_item = payload["msg"]["item_list"][0]["voice_item"]
+        assert voice_item["playtime"] == 1260
+        assert voice_item["encode_type"] == 6
+        assert voice_item["sample_rate"] == 24000
+        assert voice_item["bits_per_sample"] == 16

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -24,17 +24,14 @@ def _make_adapter() -> WeixinAdapter:
 
 
 class TestWeixinFormatting:
-    def test_format_message_preserves_markdown_and_rewrites_headers(self):
+    def test_format_message_preserves_markdown(self):
         adapter = _make_adapter()
 
         content = "# Title\n\n## Plan\n\nUse **bold** and [docs](https://example.com)."
 
-        assert (
-            adapter.format_message(content)
-            == "【Title】\n\n**Plan**\n\nUse **bold** and docs (https://example.com)."
-        )
+        assert adapter.format_message(content) == content
 
-    def test_format_message_rewrites_markdown_tables(self):
+    def test_format_message_preserves_markdown_tables(self):
         adapter = _make_adapter()
 
         content = (
@@ -44,19 +41,14 @@ class TestWeixinFormatting:
             "| Retries | 3 |\n"
         )
 
-        assert adapter.format_message(content) == (
-            "- Setting: Timeout\n"
-            "  Value: 30s\n"
-            "- Setting: Retries\n"
-            "  Value: 3"
-        )
+        assert adapter.format_message(content) == content.strip()
 
     def test_format_message_preserves_fenced_code_blocks(self):
         adapter = _make_adapter()
 
         content = "## Snippet\n\n```python\nprint('hi')\n```"
 
-        assert adapter.format_message(content) == "**Snippet**\n\n```python\nprint('hi')\n```"
+        assert adapter.format_message(content) == content
 
     def test_format_message_returns_empty_string_for_none(self):
         adapter = _make_adapter()
@@ -102,7 +94,7 @@ class TestWeixinChunking:
         content = adapter.format_message("## 结论\n这是正文")
         chunks = adapter._split_text(content)
 
-        assert chunks == ["**结论**\n这是正文"]
+        assert chunks == ["## 结论\n这是正文"]
 
     def test_split_text_keeps_short_reformatted_table_in_single_chunk(self):
         adapter = _make_adapter()
@@ -378,16 +370,13 @@ class TestWeixinRemoteMediaSafety:
 
 
 class TestWeixinMarkdownLinks:
-    """Markdown links should be converted to plaintext since WeChat can't render them."""
+    """Markdown links should be preserved so WeChat can render them natively."""
 
-    def test_format_message_converts_markdown_links_to_plain_text(self):
+    def test_format_message_preserves_markdown_links(self):
         adapter = _make_adapter()
 
         content = "Check [the docs](https://example.com) and [GitHub](https://github.com) for details"
-        assert (
-            adapter.format_message(content)
-            == "Check the docs (https://example.com) and GitHub (https://github.com) for details"
-        )
+        assert adapter.format_message(content) == content
 
     def test_format_message_preserves_links_inside_code_blocks(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -631,7 +631,7 @@ class TestWeixinVoiceSending:
     @patch.object(weixin, "_api_post", new_callable=AsyncMock)
     @patch.object(weixin, "_upload_ciphertext", new_callable=AsyncMock)
     @patch.object(weixin, "_get_upload_url", new_callable=AsyncMock)
-    def test_send_file_sets_voice_playtime_from_silk_duration(
+    def test_send_file_sets_voice_metadata_for_silk_payload(
         self,
         get_upload_url_mock,
         upload_ciphertext_mock,
@@ -645,13 +645,11 @@ class TestWeixinVoiceSending:
         upload_ciphertext_mock.return_value = "enc-q"
         api_post_mock.return_value = {"success": True}
 
-        with patch("gateway.platforms.weixin.pilk.get_duration", return_value=1260) as duration_mock:
-            asyncio.run(adapter._send_file("wxid_test123", str(silk), ""))
+        asyncio.run(adapter._send_file("wxid_test123", str(silk), ""))
 
-        duration_mock.assert_called_once_with(str(silk))
         payload = api_post_mock.await_args.kwargs["payload"]
         voice_item = payload["msg"]["item_list"][0]["voice_item"]
-        assert voice_item["playtime"] == 1260
+        assert voice_item.get("playtime", 0) == 0
         assert voice_item["encode_type"] == 6
         assert voice_item["sample_rate"] == 24000
         assert voice_item["bits_per_sample"] == 16

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -90,7 +90,7 @@ The adapter will restore saved credentials, connect to the iLink API, and begin 
 - **Media support** — images, video, files, and voice messages
 - **AES-128-ECB encrypted CDN** — automatic encryption/decryption for all media transfers
 - **Context token persistence** — disk-backed reply continuity across restarts
-- **Markdown formatting** — headers, tables, and code blocks are reformatted for WeChat readability
+- **Markdown formatting** — preserves Markdown, including headers, tables, and code blocks, so WeChat clients that support Markdown can render it natively
 - **Smart message chunking** — messages stay as a single bubble when under the limit; only oversized payloads split at logical boundaries
 - **Typing indicators** — shows "typing…" status in the WeChat client while the agent processes
 - **SSRF protection** — outbound media URLs are validated before download
@@ -206,12 +206,12 @@ This ensures reply continuity even after gateway restarts.
 
 ## Markdown Formatting
 
-WeChat's personal chat does not natively render full Markdown. The adapter reformats content for better readability:
+WeChat clients connected through the iLink Bot API can render Markdown directly, so the adapter preserves Markdown instead of rewriting it:
 
-- **Headers** (`# Title`) → converted to `【Title】` (level 1) or `**Title**` (level 2+)
-- **Tables** → reformatted as labeled key-value lists (e.g., `- Column: Value`)
-- **Code fences** → preserved as-is (WeChat renders these adequately)
-- **Excessive blank lines** → collapsed to double newlines
+- **Headers** stay as Markdown headings (`#`, `##`, ...)
+- **Tables** stay as Markdown tables
+- **Code fences** stay as fenced code blocks
+- **Excessive blank lines** are collapsed to double newlines outside fenced code blocks
 
 ## Message Chunking
 


### PR DESCRIPTION
## Summary
Batch-3 Weixin behavioral fixes — three independent contributor PRs salvaged together, each with preserved per-commit authorship.

## Included PRs

◆ **#9425** @imink (Patrick Wang) — `fix: route Weixin voice replies to real file attachments`
Current `send_voice()` passes audio through `send_document()` with voice bubble metadata, but WeChat iLink's outbound voice bubble path isn't proven-working for arbitrary audio. PR forces file-attachment fallback for `send_voice()` so users actually receive playable audio. `.silk` files retain native voice metadata (with correct `encode_type=6`, `sample_rate=24000`, `bits_per_sample=16`) when `_send_file` is called directly, but `send_voice()` always takes the attachment path. 3 commits (use SILK encoding → switch to attachment fallback → drop pilk dependency) applied as a sequence; net effect is pilk-free file-attachment delivery with SILK metadata preserved for the direct-`_send_file` path.

Partial fix for #9971 — full voice-bubble TTS (OGG → SILK transcoding) remains open. This ensures audio at least lands as a playable attachment in the meantime.

◆ **#9156** @hedgeho9X (Hedgeho9) — `fix(weixin): extract and deliver MEDIA: attachments in normal send() path`
Current `WeixinAdapter.send()` splits and delivers raw response text without extracting `MEDIA:` tags or bare local file paths — images/docs/voice referenced by the agent in non-streaming replies are silently dropped. PR calls `extract_media()` + `extract_local_files()` before splitting, delivers attachments via the appropriate `send_*_file` method.

Also fixes two live typing bugs in `gateway/run.py` at lines 5814 and 5992: `for media_path in (media_files or [])` was iterating over `List[Tuple[str, bool]]` (the return shape of `extract_media()`) as if it were `List[str]` — passing a tuple as `file_path` to `send_document()`. Fixed to `for media_path, _is_voice in ...`.

Closes #9738 (MEDIA images don't arrive in Weixin chat).

◆ **#10338** @bernylinville (Berny Linville) — `fix(weixin): preserve native markdown rendering`
WeChat iLink clients can render Markdown natively now; the adapter's `format_message()` was rewriting tables → pseudo key-value lists, headings → `【Title】`/`**Title**`, Markdown links → plaintext. That pre-processing is now a regression rather than an enhancement. PR removes the rewrites, updates tests to assert preservation, updates docs.

Closes #10308.
Commit had placeholder author (`Your Name <your-email@example.com>`); rewrote to real identity via GitHub API lookup (`bernylinville@devopsthink.org`).

## Verification
- All cherry-picks applied on current `origin/main` (24342813). One conflict in `test_weixin.py` (Batch-1 added a regression class that collided with #9425's test class addition at file end); resolved by keeping both classes side-by-side.
- `py_compile` OK on 4 touched files (`gateway/platforms/weixin.py`, `gateway/run.py`, `tests/gateway/test_weixin.py`, `scripts/release.py`)
- Full targeted suite: **228 passed** across `test_weixin`, `test_send_image_file`, `test_send_retry`, `test_platform_base`, `test_send_message_tool`
- Manually verified the gateway/run.py tuple-unpacking fix catches a real live bug (on current main those two loops pass a `(path, is_voice)` tuple to `send_document(file_path=...)`)

## AUTHOR_MAP additions
- `yuewang1@microsoft.com → imink`
- `1736355688@qq.com → hedgeho9X`
- `bernylinville@devopsthink.org → bernylinville`

## Deferred from Batch 3
**#10091** (@LLQWQ — split poll/send sessions + reuse live adapter): 234/-133 across 4 files, 695-line diff. Substantial architectural change (splits `aiohttp.ClientSession` into `_poll_session`/`_send_session`, adds `_LIVE_ADAPTERS` registry, modifies `send_weixin_direct()`). Also bundles cron-scheduler changes (multi-target comma-separated `deliver` values) that aren't in the title. Conflicts with #9425 in weixin.py. This deserves its own focused review — proposing to address in Batch 4 alongside the other cron-scheduler PRs (#11317, #9193).

## On merge
Will rebase-merge to preserve per-commit contributor authorship, then close #9425, #9156, #10338 with credit pointing to this PR.
