### PR TITLE
fix(wecom): resolve WebSocket zombie sessions and group chat 600039 e…

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -180,6 +180,8 @@ class WeComAdapter(BasePlatformAdapter):
         self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._device_id = uuid.uuid4().hex
+        self._last_chat_req_ids: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -277,7 +279,11 @@ class WeComAdapter(BasePlatformAdapter):
             {
                 "cmd": APP_CMD_SUBSCRIBE,
                 "headers": {"req_id": req_id},
-                "body": {"bot_id": self._bot_id, "secret": self._secret},
+                "body": {
+                    "bot_id": self._bot_id,
+                    "secret": self._secret,
+                    "device_id": self._device_id,
+                },
             }
         )
 
@@ -486,8 +492,10 @@ class WeComAdapter(BasePlatformAdapter):
         if not chat_id:
             logger.debug("[%s] Missing chat id, skipping message", self.name)
             return
+            
+        self._last_chat_req_ids[chat_id] = self._payload_req_id(payload)
 
-        is_group = str(body.get("chattype") or "").lower() == "group"
+        is_group = bool(body.get("chatid"))
         if is_group:
             if not self._is_group_allowed(chat_id, sender_id):
                 logger.debug("[%s] Group %s / sender %s blocked by policy", self.name, chat_id, sender_id)
@@ -1163,19 +1171,15 @@ class WeComAdapter(BasePlatformAdapter):
         self._raise_for_wecom_error(response, "send media message")
         return response
 
-    async def _send_reply_stream(self, reply_req_id: str, content: str) -> Dict[str, Any]:
+    async def _send_reply_markdown(self, reply_req_id: str, content: str) -> Dict[str, Any]:
         response = await self._send_reply_request(
             reply_req_id,
             {
-                "msgtype": "stream",
-                "stream": {
-                    "id": self._new_req_id("stream"),
-                    "finish": True,
-                    "content": content[:self.MAX_MESSAGE_LENGTH],
-                },
+                "msgtype": "markdown",
+                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
             },
         )
-        self._raise_for_wecom_error(response, "send reply stream")
+        self._raise_for_wecom_error(response, "send reply markdown")
         return response
 
     async def _send_reply_media_message(
@@ -1235,6 +1239,9 @@ class WeComAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=prepared["reject_reason"])
 
         reply_req_id = self._reply_req_id_for_message(reply_to)
+        if not reply_req_id and chat_id in getattr(self, '_last_chat_req_ids', {}):
+            reply_req_id = self._last_chat_req_ids[chat_id]
+
         try:
             upload_result = await self._upload_media_bytes(
                 prepared["data"],
@@ -1302,8 +1309,12 @@ class WeComAdapter(BasePlatformAdapter):
 
         try:
             reply_req_id = self._reply_req_id_for_message(reply_to)
+
+            if not reply_req_id and chat_id in getattr(self, '_last_chat_req_ids', {}):
+                reply_req_id = self._last_chat_req_ids[chat_id]
+
             if reply_req_id:
-                response = await self._send_reply_stream(reply_req_id, content)
+                response = await self._send_reply_markdown(reply_req_id, content)
             else:
                 response = await self._send_request(
                     APP_CMD_SEND,


### PR DESCRIPTION
…rrors   #11554

## What does this PR do?

This PR addresses two critical issues with the WeCom AI Bot WebSocket gateway integration, specifically resolving #11554. 

1. **Silent Message Drops on Reconnect:** When the WebSocket reconnects, the WeCom server keeps the previous session alive as a "zombie", routing inbound group messages to the dead connection instead of the new one.
2. **WeCom errcode 600039 in Group Chats:** WeCom AI Bots are restricted from sending proactive messages (`APP_CMD_SEND`) in group chats and must reply to an existing `req_id` (`APP_CMD_RESPONSE`). Additionally, the `stream` message type is unsupported on many WeCom mobile clients, triggering the same 600039 error.

## Changes Made
- **Added `device_id` to `aibot_subscribe`:** Generating and persisting a `device_id` per adapter instance ensures the WeCom server correctly overrides the old zombie session and re-routes messages upon reconnection.
- **Replaced `stream` with `markdown`:** Removed `_send_reply_stream` in favor of `_send_reply_markdown` to ensure message formatting compatibility across all WeCom clients.
- **Implemented `req_id` caching for group fallbacks:** The adapter now tracks the last seen `req_id` for each `chat_id` (`_last_chat_req_ids`). If the bot attempts to send a message to a group without a specific `reply_to` context, it gracefully falls back to sending a reply using the cached `req_id`, bypassing the proactive send restriction.

## Related Issue
Fixes #11554

## Testing
- Verified WebSocket reconnects no longer result in silent message drops.
- Verified bot can successfully send messages to group chats without hitting the `600039: device type not support` error.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

