### PR TITLE
fix(profiles): preserve symlinks when cloning and exporting profiles

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -434,7 +434,7 @@ def create_profile(
 
     if clone_all and source_dir:
         # Full copy of source profile
-        shutil.copytree(source_dir, profile_dir)
+        shutil.copytree(source_dir, profile_dir, symlinks=True)
         # Strip runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
@@ -802,6 +802,7 @@ def export_profile(name: str, output_path: str) -> Path:
             shutil.copytree(
                 profile_dir,
                 staged,
+                symlinks=True,
                 ignore=_default_export_ignore(profile_dir),
             )
             result = shutil.make_archive(base, "gztar", tmpdir, "default")
@@ -814,6 +815,7 @@ def export_profile(name: str, output_path: str) -> Path:
         shutil.copytree(
             profile_dir,
             staged,
+            symlinks=True,
             ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
         )
         result = shutil.make_archive(base, "gztar", tmpdir, name)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -171,6 +171,23 @@ class TestCreateProfile:
         assert not (profile_dir / "gateway_state.json").exists()
         assert not (profile_dir / "processes.json").exists()
 
+    def test_clone_all_preserves_recursive_symlink(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        source = default_home / "profiles" / "source"
+        source.mkdir(parents=True)
+        (source / "loop").symlink_to("..", target_is_directory=True)
+
+        profile_dir = create_profile(
+            "dup",
+            clone_from="source",
+            clone_all=True,
+            no_alias=True,
+        )
+
+        assert profile_dir.is_dir()
+        assert (profile_dir / "loop").is_symlink()
+
     def test_clone_config_missing_files_skipped(self, profile_env):
         """Clone config gracefully skips files that don't exist in source."""
         profile_dir = create_profile("coder", clone_config=True, no_alias=True)


### PR DESCRIPTION
## What does this PR do?

`shutil.copytree` is called in three places in `hermes_cli/profiles.py` without `symlinks=True`, so it follows symlinks instead of copying them as-is. A symlink inside `~/.hermes` that points at a parent directory (easy to create by accident - @Opfour hit one while cloning profiles) sends `shutil._copytree` into infinite recursion and `hermes profile create --clone-all` crashes with `RecursionError`. The export paths would crash the same way if a user ever triggered them on such a profile.

Pass `symlinks=True` to all three call sites. `symlinks=True` copies symlinks verbatim rather than walking their target, which is the right semantic when cloning or exporting a user-owned profile tree. The existing `ignore=` callbacks at the export sites are preserved.

## Related Issue

Fixes #11560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py:437` - add `symlinks=True` to the `--clone-all` `shutil.copytree` call (the crash site named in the issue).
- `hermes_cli/profiles.py:802` - add `symlinks=True` to the default-profile export path. Same latent bug.
- `hermes_cli/profiles.py:815` - add `symlinks=True` to the named-profile export path. Same latent bug. Existing `ignore=` callbacks (credential files, `_default_export_ignore`) are untouched and still run.
- `tests/hermes_cli/test_profiles.py` - add `test_clone_all_preserves_recursive_symlink` using the existing `profile_env` fixture. The test creates a source profile with a `loop -> ..` symlink, calls `create_profile(clone_all=True)`, and asserts the call returns, the destination exists, and the symlink survives as a symlink.

## How to Test

1. Reproduce (pre-fix): `mkdir -p /tmp/h/profiles/src && ln -s .. /tmp/h/profiles/src/loop && HERMES_HOME=/tmp/h hermes profile create dup --clone-all --clone-from src --no-alias` -> `RecursionError: maximum recursion depth exceeded` from `shutil._copytree`.
2. Post-fix: same commands succeed. The new `dup/` profile contains the `loop` entry as a symlink (`ls -la` shows `loop -> ..`).
3. Targeted test: `pytest tests/hermes_cli/test_profiles.py -v` - 88 passed including the new regression test.

Demo: https://vhs.charm.sh/vhs-2QQWVciEMvWZk9M4DRyHnF.gif

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_profiles.py -v` and all tests pass (88 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `symlinks=True` works identically on Linux/macOS; on Windows, Python's stdlib `shutil.copytree` falls back per documented behavior.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

---

This contribution was developed with AI assistance (Codex).
