### PR TITLE
feat(dingtalk): QR-code device-flow authorization for setup wizard

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1038,6 +1038,25 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if webhook_secret:
             config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
 
+    # DingTalk
+    dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")
+    dingtalk_client_secret = os.getenv("DINGTALK_CLIENT_SECRET")
+    if dingtalk_client_id and dingtalk_client_secret:
+        if Platform.DINGTALK not in config.platforms:
+            config.platforms[Platform.DINGTALK] = PlatformConfig()
+        config.platforms[Platform.DINGTALK].enabled = True
+        config.platforms[Platform.DINGTALK].extra.update({
+            "client_id": dingtalk_client_id,
+            "client_secret": dingtalk_client_secret,
+        })
+        dingtalk_home = os.getenv("DINGTALK_HOME_CHANNEL")
+        if dingtalk_home:
+            config.platforms[Platform.DINGTALK].home_channel = HomeChannel(
+                platform=Platform.DINGTALK,
+                chat_id=dingtalk_home,
+                name=os.getenv("DINGTALK_HOME_CHANNEL_NAME", "Home"),
+            )
+
     # Feishu / Lark
     feishu_app_id = os.getenv("FEISHU_APP_ID")
     feishu_app_secret = os.getenv("FEISHU_APP_SECRET")

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -238,6 +238,8 @@ def dingtalk_qr_auth() -> Optional[Tuple[str, str]]:
 
     print()
     print_info("  Initializing DingTalk device authorization...")
+    print_info("  Note: the scan page is branded 'OpenClaw' — DingTalk's")
+    print_info("        ecosystem onboarding bridge. Safe to use.")
 
     try:
         reg = begin_registration()

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -1,0 +1,292 @@
+"""
+DingTalk Device Flow authorization.
+
+Implements the same 3-step registration flow as dingtalk-openclaw-connector:
+  1. POST /app/registration/init   → get nonce
+  2. POST /app/registration/begin  → get device_code + verification_uri_complete
+  3. POST /app/registration/poll   → poll until SUCCESS → get client_id + client_secret
+
+The verification_uri_complete is rendered as a QR code in the terminal so the
+user can scan it with DingTalk to authorize, yielding AppKey + AppSecret
+automatically.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import time
+import logging
+from typing import Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration ──────────────────────────────────────────────────────────
+
+REGISTRATION_BASE_URL = os.environ.get(
+    "DINGTALK_REGISTRATION_BASE_URL", "https://oapi.dingtalk.com"
+).rstrip("/")
+
+REGISTRATION_SOURCE = os.environ.get("DINGTALK_REGISTRATION_SOURCE", "openClaw")
+
+
+# ── API helpers ────────────────────────────────────────────────────────────
+
+class RegistrationError(Exception):
+    """Raised when a DingTalk registration API call fails."""
+
+
+def _api_post(path: str, payload: dict) -> dict:
+    """POST to the registration API and return the parsed JSON body."""
+    url = f"{REGISTRATION_BASE_URL}{path}"
+    try:
+        resp = requests.post(url, json=payload, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:
+        raise RegistrationError(f"Network error calling {url}: {exc}") from exc
+
+    errcode = data.get("errcode", -1)
+    if errcode != 0:
+        errmsg = data.get("errmsg", "unknown error")
+        raise RegistrationError(f"API error [{path}]: {errmsg} (errcode={errcode})")
+    return data
+
+
+# ── Core flow ──────────────────────────────────────────────────────────────
+
+def begin_registration() -> dict:
+    """Start a device-flow registration.
+
+    Returns a dict with keys:
+        device_code, verification_uri_complete, expires_in, interval
+    """
+    # Step 1: init → nonce
+    init_data = _api_post("/app/registration/init", {"source": REGISTRATION_SOURCE})
+    nonce = str(init_data.get("nonce", "")).strip()
+    if not nonce:
+        raise RegistrationError("init response missing nonce")
+
+    # Step 2: begin → device_code, verification_uri_complete
+    begin_data = _api_post("/app/registration/begin", {"nonce": nonce})
+    device_code = str(begin_data.get("device_code", "")).strip()
+    verification_uri_complete = str(begin_data.get("verification_uri_complete", "")).strip()
+    if not device_code:
+        raise RegistrationError("begin response missing device_code")
+    if not verification_uri_complete:
+        raise RegistrationError("begin response missing verification_uri_complete")
+
+    return {
+        "device_code": device_code,
+        "verification_uri_complete": verification_uri_complete,
+        "expires_in": int(begin_data.get("expires_in", 7200)),
+        "interval": max(int(begin_data.get("interval", 3)), 2),
+    }
+
+
+def poll_registration(device_code: str) -> dict:
+    """Poll the registration status once.
+
+    Returns a dict with keys:  status, client_id?, client_secret?, fail_reason?
+    """
+    data = _api_post("/app/registration/poll", {"device_code": device_code})
+    status_raw = str(data.get("status", "")).strip().upper()
+    if status_raw not in ("WAITING", "SUCCESS", "FAIL", "EXPIRED"):
+        status_raw = "UNKNOWN"
+    return {
+        "status": status_raw,
+        "client_id": str(data.get("client_id", "")).strip() or None,
+        "client_secret": str(data.get("client_secret", "")).strip() or None,
+        "fail_reason": str(data.get("fail_reason", "")).strip() or None,
+    }
+
+
+def wait_for_registration_success(
+    device_code: str,
+    interval: int = 3,
+    expires_in: int = 7200,
+    on_waiting: Optional[callable] = None,
+) -> Tuple[str, str]:
+    """Block until the registration succeeds or times out.
+
+    Returns (client_id, client_secret).
+    """
+    deadline = time.monotonic() + expires_in
+    retry_window = 120  # 2 minutes for transient errors
+    retry_start = 0.0
+
+    while time.monotonic() < deadline:
+        time.sleep(interval)
+        try:
+            result = poll_registration(device_code)
+        except RegistrationError:
+            if retry_start == 0:
+                retry_start = time.monotonic()
+            if time.monotonic() - retry_start < retry_window:
+                continue
+            raise
+
+        status = result["status"]
+        if status == "WAITING":
+            retry_start = 0
+            if on_waiting:
+                on_waiting()
+            continue
+        if status == "SUCCESS":
+            cid = result["client_id"]
+            csecret = result["client_secret"]
+            if not cid or not csecret:
+                raise RegistrationError("authorization succeeded but credentials are missing")
+            return cid, csecret
+        # FAIL / EXPIRED / UNKNOWN
+        if retry_start == 0:
+            retry_start = time.monotonic()
+        if time.monotonic() - retry_start < retry_window:
+            continue
+        reason = result.get("fail_reason") or status
+        raise RegistrationError(f"authorization failed: {reason}")
+
+    raise RegistrationError("authorization timed out, please retry")
+
+
+# ── QR code rendering ─────────────────────────────────────────────────────
+
+def _ensure_qrcode_installed() -> bool:
+    """Try to import qrcode; if missing, auto-install it via pip/uv."""
+    try:
+        import qrcode  # noqa: F401
+        return True
+    except ImportError:
+        pass
+
+    import subprocess
+
+    # Try uv first (Hermes convention), then pip
+    for cmd in (
+        [sys.executable, "-m", "uv", "pip", "install", "qrcode"],
+        [sys.executable, "-m", "pip", "install", "-q", "qrcode"],
+    ):
+        try:
+            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            import qrcode  # noqa: F401,F811
+            return True
+        except (subprocess.CalledProcessError, ImportError, FileNotFoundError):
+            continue
+    return False
+
+
+def render_qr_to_terminal(url: str) -> bool:
+    """Render *url* as a compact QR code in the terminal.
+
+    Returns True if the QR code was printed, False if the library is missing.
+    """
+    try:
+        import qrcode
+    except ImportError:
+        return False
+
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=1,
+        border=1,
+    )
+    qr.add_data(url)
+    qr.make(fit=True)
+
+    # Use half-block characters for compact rendering (2 rows per character)
+    matrix = qr.get_matrix()
+    rows = len(matrix)
+    lines: list[str] = []
+
+    TOP_HALF = "\u2580"      # ▀
+    BOTTOM_HALF = "\u2584"   # ▄
+    FULL_BLOCK = "\u2588"    # █
+    EMPTY = " "
+
+    for r in range(0, rows, 2):
+        line_chars: list[str] = []
+        for c in range(len(matrix[r])):
+            top = matrix[r][c]
+            bottom = matrix[r + 1][c] if r + 1 < rows else False
+            if top and bottom:
+                line_chars.append(FULL_BLOCK)
+            elif top:
+                line_chars.append(TOP_HALF)
+            elif bottom:
+                line_chars.append(BOTTOM_HALF)
+            else:
+                line_chars.append(EMPTY)
+        lines.append("    " + "".join(line_chars))
+
+    print("\n".join(lines))
+    return True
+
+
+# ── High-level entry point for the setup wizard ───────────────────────────
+
+def dingtalk_qr_auth() -> Optional[Tuple[str, str]]:
+    """Run the interactive QR-code device-flow authorization.
+
+    Returns (client_id, client_secret) on success, or None if the user
+    cancelled or the flow failed.
+    """
+    from hermes_cli.setup import print_info, print_success, print_warning, print_error
+
+    print()
+    print_info("  Initializing DingTalk device authorization...")
+
+    try:
+        reg = begin_registration()
+    except RegistrationError as exc:
+        print_error(f"  Authorization init failed: {exc}")
+        return None
+
+    url = reg["verification_uri_complete"]
+
+    # Ensure qrcode library is available (auto-install if missing)
+    if not _ensure_qrcode_installed():
+        print_warning("  qrcode library install failed, will show link only.")
+
+    print()
+    print_info("  Please scan the QR code below with DingTalk to authorize:")
+    print()
+
+    if not render_qr_to_terminal(url):
+        print_warning(f"  QR code render failed, please open the link below to authorize:")
+
+    print()
+    print_info(f"  Or open this link manually: {url}")
+    print()
+    print_info("  Waiting for QR scan authorization... (timeout: 2 hours)")
+
+    dot_count = 0
+
+    def _on_waiting():
+        nonlocal dot_count
+        dot_count += 1
+        if dot_count % 10 == 0:
+            sys.stdout.write(".")
+            sys.stdout.flush()
+
+    try:
+        client_id, client_secret = wait_for_registration_success(
+            device_code=reg["device_code"],
+            interval=reg["interval"],
+            expires_in=reg["expires_in"],
+            on_waiting=_on_waiting,
+        )
+    except RegistrationError as exc:
+        print()
+        print_error(f"  Authorization failed: {exc}")
+        return None
+
+    print()
+    print_success("  QR scan authorization successful!")
+    print_success(f"  Client ID:     {client_id}")
+    print_success(f"  Client Secret: {client_secret[:8]}{'*' * (len(client_secret) - 8)}")
+
+    return client_id, client_secret

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2211,9 +2211,62 @@ def _setup_sms():
 
 
 def _setup_dingtalk():
-    """Configure DingTalk via the standard platform setup."""
+    """Configure DingTalk — QR scan (recommended) or manual credential entry."""
+    from hermes_cli.setup import (
+        prompt_choice, prompt_yes_no, print_info, print_success, print_warning,
+    )
+
     dingtalk_platform = next(p for p in _PLATFORMS if p["key"] == "dingtalk")
-    _setup_standard_platform(dingtalk_platform)
+    emoji = dingtalk_platform["emoji"]
+    label = dingtalk_platform["label"]
+
+    print()
+    print(color(f"  ─── {emoji} {label} Setup ───", Colors.CYAN))
+
+    existing = get_env_value("DINGTALK_CLIENT_ID")
+    if existing:
+        print()
+        print_success(f"{label} is already configured (Client ID: {existing}).")
+        if not prompt_yes_no(f"  Reconfigure {label}?", False):
+            return
+
+    print()
+    method = prompt_choice(
+        "  Choose setup method",
+        [
+            "QR Code Scan (Recommended, auto-obtain Client ID and Client Secret)",
+            "Manual Input (Client ID and Client Secret)",
+        ],
+        default=0,
+    )
+
+    if method == 0:
+        # ── QR-code device-flow authorization ──
+        try:
+            from hermes_cli.dingtalk_auth import dingtalk_qr_auth
+        except ImportError as exc:
+            print_warning(f"  QR auth module failed to load ({exc}), falling back to manual input.")
+            _setup_standard_platform(dingtalk_platform)
+            return
+
+        result = dingtalk_qr_auth()
+        if result is None:
+            print_warning("  QR auth incomplete, falling back to manual input.")
+            _setup_standard_platform(dingtalk_platform)
+            return
+
+        client_id, client_secret = result
+        save_env_value("DINGTALK_CLIENT_ID", client_id)
+        save_env_value("DINGTALK_CLIENT_SECRET", client_secret)
+        save_env_value("DINGTALK_ALLOW_ALL_USERS", "true")
+        print()
+        print_success(f"{emoji} {label} configured via QR scan!")
+    else:
+        # ── Manual entry ──
+        _setup_standard_platform(dingtalk_platform)
+        # Also enable allow-all by default for convenience
+        if get_env_value("DINGTALK_CLIENT_ID"):
+            save_env_value("DINGTALK_ALLOW_ALL_USERS", "true")
 
 
 def _setup_wecom():
@@ -2749,6 +2802,8 @@ def gateway_setup():
             _setup_signal()
         elif platform["key"] == "weixin":
             _setup_weixin()
+        elif platform["key"] == "dingtalk":
+            _setup_dingtalk()
         elif platform["key"] == "feishu":
             _setup_feishu()
         else:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -85,6 +85,7 @@ AUTHOR_MAP = {
     "lovre.pesut@gmail.com": "rovle",
     "kevinskysunny@gmail.com": "kevinskysunny",
     "xiewenxuan462@gmail.com": "yule975",
+    "yiweimeng.dlut@hotmail.com": "meng93",
     "hakanerten02@hotmail.com": "teyrebaz33",
     "ruzzgarcn@gmail.com": "Ruzzgar",
     "alireza78.crypto@gmail.com": "alireza78a",

--- a/tests/hermes_cli/test_dingtalk_auth.py
+++ b/tests/hermes_cli/test_dingtalk_auth.py
@@ -1,0 +1,217 @@
+"""Unit tests for hermes_cli/dingtalk_auth.py (QR device-flow registration)."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# API layer — _api_post + error mapping
+# ---------------------------------------------------------------------------
+
+
+class TestApiPost:
+
+    def test_raises_on_network_error(self):
+        import requests
+        from hermes_cli.dingtalk_auth import _api_post, RegistrationError
+
+        with patch("hermes_cli.dingtalk_auth.requests.post",
+                   side_effect=requests.ConnectionError("nope")):
+            with pytest.raises(RegistrationError, match="Network error"):
+                _api_post("/app/registration/init", {"source": "hermes"})
+
+    def test_raises_on_nonzero_errcode(self):
+        from hermes_cli.dingtalk_auth import _api_post, RegistrationError
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"errcode": 42, "errmsg": "boom"}
+
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
+            with pytest.raises(RegistrationError, match=r"boom \(errcode=42\)"):
+                _api_post("/app/registration/init", {"source": "hermes"})
+
+    def test_returns_data_on_success(self):
+        from hermes_cli.dingtalk_auth import _api_post
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"errcode": 0, "nonce": "abc"}
+
+        with patch("hermes_cli.dingtalk_auth.requests.post", return_value=mock_resp):
+            result = _api_post("/app/registration/init", {"source": "hermes"})
+            assert result["nonce"] == "abc"
+
+
+# ---------------------------------------------------------------------------
+# begin_registration — 2-step nonce → device_code chain
+# ---------------------------------------------------------------------------
+
+
+class TestBeginRegistration:
+
+    def test_chains_init_then_begin(self):
+        from hermes_cli.dingtalk_auth import begin_registration
+
+        responses = [
+            {"errcode": 0, "nonce": "nonce123"},
+            {
+                "errcode": 0,
+                "device_code": "dev-xyz",
+                "verification_uri_complete": "https://open-dev.dingtalk.com/openapp/registration/openClaw?user_code=ABCD",
+                "expires_in": 7200,
+                "interval": 2,
+            },
+        ]
+        with patch("hermes_cli.dingtalk_auth._api_post", side_effect=responses):
+            result = begin_registration()
+
+        assert result["device_code"] == "dev-xyz"
+        assert "verification_uri_complete" in result
+        assert result["interval"] == 2
+        assert result["expires_in"] == 7200
+
+    def test_missing_nonce_raises(self):
+        from hermes_cli.dingtalk_auth import begin_registration, RegistrationError
+
+        with patch("hermes_cli.dingtalk_auth._api_post",
+                   return_value={"errcode": 0, "nonce": ""}):
+            with pytest.raises(RegistrationError, match="missing nonce"):
+                begin_registration()
+
+    def test_missing_device_code_raises(self):
+        from hermes_cli.dingtalk_auth import begin_registration, RegistrationError
+
+        responses = [
+            {"errcode": 0, "nonce": "n1"},
+            {"errcode": 0, "verification_uri_complete": "http://x"},  # no device_code
+        ]
+        with patch("hermes_cli.dingtalk_auth._api_post", side_effect=responses):
+            with pytest.raises(RegistrationError, match="missing device_code"):
+                begin_registration()
+
+    def test_missing_verification_uri_raises(self):
+        from hermes_cli.dingtalk_auth import begin_registration, RegistrationError
+
+        responses = [
+            {"errcode": 0, "nonce": "n1"},
+            {"errcode": 0, "device_code": "dev"},  # no verification_uri_complete
+        ]
+        with patch("hermes_cli.dingtalk_auth._api_post", side_effect=responses):
+            with pytest.raises(RegistrationError,
+                               match="missing verification_uri_complete"):
+                begin_registration()
+
+
+# ---------------------------------------------------------------------------
+# wait_for_registration_success — polling loop
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForSuccess:
+
+    def test_returns_credentials_on_success(self):
+        from hermes_cli.dingtalk_auth import wait_for_registration_success
+
+        responses = [
+            {"status": "WAITING"},
+            {"status": "WAITING"},
+            {"status": "SUCCESS", "client_id": "cid-1", "client_secret": "sec-1"},
+        ]
+        with patch("hermes_cli.dingtalk_auth.poll_registration", side_effect=responses), \
+             patch("hermes_cli.dingtalk_auth.time.sleep"):
+            cid, secret = wait_for_registration_success(
+                device_code="dev", interval=0, expires_in=60
+            )
+            assert cid == "cid-1"
+            assert secret == "sec-1"
+
+    def test_success_without_credentials_raises(self):
+        from hermes_cli.dingtalk_auth import wait_for_registration_success, RegistrationError
+
+        with patch("hermes_cli.dingtalk_auth.poll_registration",
+                   return_value={"status": "SUCCESS", "client_id": "", "client_secret": ""}), \
+             patch("hermes_cli.dingtalk_auth.time.sleep"):
+            with pytest.raises(RegistrationError, match="credentials are missing"):
+                wait_for_registration_success(
+                    device_code="dev", interval=0, expires_in=60
+                )
+
+    def test_invokes_waiting_callback(self):
+        from hermes_cli.dingtalk_auth import wait_for_registration_success
+
+        callback = MagicMock()
+        responses = [
+            {"status": "WAITING"},
+            {"status": "WAITING"},
+            {"status": "SUCCESS", "client_id": "cid", "client_secret": "sec"},
+        ]
+        with patch("hermes_cli.dingtalk_auth.poll_registration", side_effect=responses), \
+             patch("hermes_cli.dingtalk_auth.time.sleep"):
+            wait_for_registration_success(
+                device_code="dev", interval=0, expires_in=60, on_waiting=callback
+            )
+        assert callback.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# QR rendering — terminal output
+# ---------------------------------------------------------------------------
+
+
+class TestRenderQR:
+
+    def test_returns_false_when_qrcode_missing(self, monkeypatch):
+        from hermes_cli import dingtalk_auth
+
+        # Simulate qrcode import failure
+        monkeypatch.setitem(sys.modules, "qrcode", None)
+        assert dingtalk_auth.render_qr_to_terminal("https://example.com") is False
+
+    def test_prints_when_qrcode_available(self, capsys):
+        """End-to-end: render a real QR and verify SOMETHING got printed."""
+        try:
+            import qrcode  # noqa: F401
+        except ImportError:
+            pytest.skip("qrcode library not available")
+
+        from hermes_cli.dingtalk_auth import render_qr_to_terminal
+        result = render_qr_to_terminal("https://example.com/test")
+        captured = capsys.readouterr()
+        assert result is True
+        assert len(captured.out) > 100  # rendered matrix is non-trivial
+
+
+# ---------------------------------------------------------------------------
+# Configuration — env var overrides
+# ---------------------------------------------------------------------------
+
+
+class TestConfigOverrides:
+
+    def test_base_url_default(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_REGISTRATION_BASE_URL", raising=False)
+        # Force module reload to pick up current env
+        import importlib
+        import hermes_cli.dingtalk_auth as mod
+        importlib.reload(mod)
+        assert mod.REGISTRATION_BASE_URL == "https://oapi.dingtalk.com"
+
+    def test_base_url_override_via_env(self, monkeypatch):
+        monkeypatch.setenv("DINGTALK_REGISTRATION_BASE_URL",
+                           "https://test.example.com/")
+        import importlib
+        import hermes_cli.dingtalk_auth as mod
+        importlib.reload(mod)
+        # Trailing slash stripped
+        assert mod.REGISTRATION_BASE_URL == "https://test.example.com"
+
+    def test_source_default(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_REGISTRATION_SOURCE", raising=False)
+        import importlib
+        import hermes_cli.dingtalk_auth as mod
+        importlib.reload(mod)
+        assert mod.REGISTRATION_SOURCE == "openClaw"


### PR DESCRIPTION
## Summary

Salvages #8345 (meng93 — authorship preserved) + 15 new regression tests + an OpenClaw branding disclosure.

Adds QR-code device-flow authorization to `hermes gateway setup` for DingTalk, eliminating the manual developer-console workflow. Users scan a QR with the DingTalk mobile app and Client ID / Client Secret are returned automatically.

### Why this path

Per design discussion with @teknium1:

- **Tested `source="hermes"` live (option B)**: DingTalk's `/app/registration/begin` accepts any source at the API layer but the returned `verification_uri_complete` is **hardcoded** to `https://open-dev.dingtalk.com/openapp/registration/openClaw?user_code=...`. Confirmed against the real endpoint — we cannot use our own source string until DingTalk-Real-AI registers a Hermes template server-side. Issue #482 on their repo (filed today asking about Hermes support) has no official response yet.
- **Going with openClaw identity for now (option C)**: Takes the onboarding win. Nous will follow up with Alibaba/DingTalk-Real-AI via a direct channel to register a Hermes-specific `source` so we can eventually swap the token. The disclosure below makes the interim UX honest with users.

### What's in

**meng93's commit (0bbb6f0a)** — cherry-picked with authorship preserved:
- `hermes_cli/dingtalk_auth.py` (new, 292 lines) — three-step device flow (`init → begin → poll`) + compact half-block QR renderer + auto-install of `qrcode` pip dep.
- `hermes_cli/gateway.py` — rewrites `_setup_dingtalk()` to offer QR scan (default) or manual credential entry, plus dispatch wiring in `gateway_setup()`.
- `gateway/config.py` — env-var → `PlatformConfig` bridge for `DINGTALK_CLIENT_ID`, `DINGTALK_CLIENT_SECRET`, and optional `DINGTALK_HOME_CHANNEL` (matches the pattern used by other platforms).

Intentionally **dropped** from meng93's PR:
- `gateway/platforms/dingtalk.py` SDK-compat fixes — already on main via #11471. Resolved the cherry-pick conflict by keeping current main's version.

**My follow-up (b7ba8652)**:
- 15 regression tests in `tests/hermes_cli/test_dingtalk_auth.py` covering `_api_post` error paths, `begin_registration` chaining + missing-field errors, polling loop success/failure/callback, QR renderer fallback, and env-var config overrides.
- One-line disclosure in `dingtalk_qr_auth()`:
  ```
  Note: the scan page is branded 'OpenClaw' — DingTalk's
        ecosystem onboarding bridge. Safe to use.
  ```
- Added `meng93` to `scripts/release.py` AUTHOR_MAP.

### Tests

- `tests/hermes_cli/test_dingtalk_auth.py` — **15 passed** (new)
- `tests/hermes_cli/test_dingtalk_auth.py + test_dingtalk.py + test_config.py` — **85 passed** combined
- **E2E against real `oapi.dingtalk.com`** — loaded module from worktree, called `begin_registration()` live, got a real `device_code` + `verification_uri_complete` back. Didn't complete the QR scan (requires a human + DingTalk mobile app) but the full protocol up to QR display works.

### Authorship

Commit `0bbb6f0a` preserves `meng93 <yiweimeng.dlut@hotmail.com>` as author. Merge with `--rebase` to keep attribution.

PRs #9610 and #10004 ship word-for-word identical `dingtalk_auth.py` code — they're copies of meng93's earlier submission (meng93: Apr 12, audanye-sudo: Apr 14, PeterGuy326: Apr 15). On merge they'll be closed with credit to all three, with primary credit to meng93 as the original author.

### Follow-ups (post-merge)

1. **@teknium1 to reach out** to DingTalk-Real-AI via their Alibaba contact to register `hermes` as a sanctioned `source` token.
2. When sanctioned, flip `REGISTRATION_SOURCE` default from `openClaw` → `hermes` and remove the disclosure. The `DINGTALK_REGISTRATION_SOURCE` env var already exists as an escape hatch.

### Closes

Closes #8345, #9610, #10004 on merge.
