### PR TITLE
fix(agent): auto-compact context after repeated empty responses (#7180)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8310,6 +8310,7 @@ class AIAgent:
         self._codex_incomplete_retries = 0
         self._thinking_prefill_retries = 0
         self._post_tool_empty_retried = False
+        self._compacted_after_empty = False
         self._last_content_with_tools = None
         self._last_content_tools_all_housekeeping = False
         self._mute_post_response = False
@@ -10997,6 +10998,52 @@ class AIAgent:
                                 f"({self._empty_content_retries}/3)"
                             )
                             continue
+
+                        # ── Exhausted retries — try context compression ──
+                        # Large or noisy context (e.g. a 50K tool output) can
+                        # cause some models to generate nothing.  Attempt one
+                        # compression pass before burning a fallback slot so
+                        # the current model gets a fair shot with a trimmed
+                        # history.  Guarded by _compacted_after_empty so this
+                        # fires at most once per run_conversation turn.
+                        if (
+                            _truly_empty
+                            and self.compression_enabled
+                            and not self._compacted_after_empty
+                            and self.context_compressor is not None
+                            and self.context_compressor.last_prompt_tokens > 0
+                            and getattr(
+                                self.context_compressor,
+                                "_ineffective_compression_count", 0,
+                            ) < 2
+                        ):
+                            self._compacted_after_empty = True
+                            logger.warning(
+                                "Empty response after %d retries — compacting "
+                                "context before fallback (model=%s tokens=%s)",
+                                self._empty_content_retries, self.model,
+                                self.context_compressor.last_prompt_tokens,
+                            )
+                            self._emit_status(
+                                "⟳ Compacting context — model may be choking "
+                                "on noisy history..."
+                            )
+                            try:
+                                messages, active_system_prompt = self._compress_context(
+                                    messages, system_message,
+                                    approx_tokens=self.context_compressor.last_prompt_tokens,
+                                    task_id=effective_task_id,
+                                )
+                                conversation_history = None
+                                self._empty_content_retries = 0
+                                self._session_messages = messages
+                                self._save_session_log(messages)
+                                continue
+                            except Exception as _compact_err:
+                                logger.warning(
+                                    "Post-empty compression failed, falling "
+                                    "through to fallback: %s", _compact_err,
+                                )
 
                         # ── Exhausted retries — try fallback provider ──
                         # Before giving up with "(empty)", attempt to

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2007,6 +2007,99 @@ class TestRunConversation:
         assert result["completed"] is True
         assert result["final_response"] == "(empty)"
 
+    def test_empty_response_triggers_context_compaction_before_fallback(self, agent):
+        """After 3 empty retries, compact context once before invoking fallback.
+
+        Large/noisy context (the "context poison" pattern in #7180) can drive
+        some models to produce nothing.  Compaction gives the current model
+        a chance to recover before a fallback slot is burned.
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        agent.compression_enabled = True
+        agent.context_compressor.last_prompt_tokens = 50_000
+        agent.context_compressor.last_completion_tokens = 0
+        agent.context_compressor._ineffective_compression_count = 0
+
+        empty_resp = _mock_response(content=None, finish_reason="stop")
+        content_resp = _mock_response(
+            content="Recovered after compaction.", finish_reason="stop",
+        )
+        # 4 empty (1 orig + 3 retries), compaction fires, then success
+        agent.client.chat.completions.create.side_effect = [
+            empty_resp, empty_resp, empty_resp, empty_resp, content_resp,
+        ]
+
+        compact_calls = {"count": 0}
+
+        def _mock_compress(messages, system_message, **kwargs):
+            compact_calls["count"] += 1
+            # Return a trimmed copy so the loop proceeds with a new history.
+            return messages[-2:], system_message or "system"
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_compress_context", side_effect=_mock_compress),
+            patch.object(agent, "_try_activate_fallback", return_value=False) as mock_fb,
+        ):
+            result = agent.run_conversation("answer me")
+
+        assert compact_calls["count"] == 1, "Compaction should run exactly once"
+        assert not mock_fb.called, "Fallback should not run when compaction recovers"
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after compaction."
+
+    def test_empty_response_compaction_guard_runs_once_per_turn(self, agent):
+        """Compaction guard prevents repeated compact attempts within one turn.
+
+        If the model keeps returning empty even after compaction, fallback
+        must be invoked — we don't want an infinite compact loop.
+        """
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        agent.compression_enabled = True
+        agent.context_compressor.last_prompt_tokens = 50_000
+        agent.context_compressor.last_completion_tokens = 0
+        agent.context_compressor._ineffective_compression_count = 0
+        agent._fallback_chain = [{"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}]
+        agent._fallback_index = 0
+        agent._fallback_activated = False
+
+        empty_resp = _mock_response(content=None, finish_reason="stop")
+        # 4 empty → compact → 4 more empty → fallback → 4 empty (no more chain)
+        agent.client.chat.completions.create.side_effect = [empty_resp] * 12
+
+        compact_calls = {"count": 0}
+
+        def _mock_compress(messages, system_message, **kwargs):
+            compact_calls["count"] += 1
+            return messages[-2:], system_message or "system"
+
+        def _mock_fallback():
+            if agent._fallback_index >= len(agent._fallback_chain):
+                return False
+            agent._fallback_index += 1
+            agent._fallback_activated = True
+            agent.model = "anthropic/claude-sonnet-4"
+            agent.provider = "openrouter"
+            return True
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_compress_context", side_effect=_mock_compress),
+            patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
+        ):
+            result = agent.run_conversation("answer me")
+
+        assert compact_calls["count"] == 1, (
+            f"Compaction should fire at most once per turn, got {compact_calls['count']}"
+        )
+        assert result["final_response"] == "(empty)"
+
     def test_empty_response_emits_status_for_gateway(self, agent):
         """_emit_status is called during empty retries so gateway users see feedback."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

Addresses the "auto-compact on repeated empties" recommendation from #7180.

When a model (e.g. GLM-4.5-Air via Z.AI) returns empty responses repeatedly — often triggered by large/noisy tool outputs poisoning the context — Hermes now attempts one context-compression pass before burning a fallback provider slot. This gives the current model a fair shot at recovering with a trimmed history.

- Inserted between the existing 3-retry loop and the fallback-chain activation path in `run_agent.py`.
- Guarded by a per-turn flag (`_compacted_after_empty`) so compaction fires at most once per turn.
- Respects the compressor's anti-thrashing state (`_ineffective_compression_count < 2`).
- On failure, falls through to the existing fallback path unchanged — behavior when compression is disabled or the context is tiny is identical to today.

PR #7505 already landed the fallback-activation and user-visible status pieces from the same issue; this is the third remaining recommendation from that analysis.

## Test plan

- [x] `tests/run_agent/test_run_agent.py::TestRunConversation::test_empty_response_triggers_context_compaction_before_fallback` — verifies compaction fires after 3 empty retries, model recovers, fallback is not invoked
- [x] `tests/run_agent/test_run_agent.py::TestRunConversation::test_empty_response_compaction_guard_runs_once_per_turn` — verifies the per-turn guard so compaction doesn't loop; fallback still kicks in if compaction doesn't help
- [x] Existing empty-response tests still pass (no regression to retry, fallback, or status-emission paths)

Refs: #7180
