### PR TITLE
fix(config): prevent save_config from leaking ${ENV_VAR} secrets to c…

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2590,19 +2590,22 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return result
 
 
-def _expand_env_vars(obj):
-    """Recursively expand ``${VAR}`` references in config values.
+_ENV_REVERSE_MAP = {}
 
-    Only string values are processed; dict keys, numbers, booleans, and
-    None are left untouched.  Unresolved references (variable not in
-    ``os.environ``) are kept verbatim so callers can detect them.
-    """
+def _expand_env_vars(obj):
+    """Recursively expand ``${VAR}`` references in config values."""
     if isinstance(obj, str):
-        return re.sub(
-            r"\${([^}]+)}",
-            lambda m: os.environ.get(m.group(1), m.group(0)),
-            obj,
-        )
+        def replacer(m):
+            var_name = m.group(1)
+            placeholder = f"${{{var_name}}}"
+            val = os.environ.get(var_name, placeholder)
+            
+            if val != placeholder and val.strip():
+                _ENV_REVERSE_MAP[val] = placeholder
+                
+            return val
+            
+        return re.sub(r"\$\{([^}]+)\}", replacer, obj)
     if isinstance(obj, dict):
         return {k: _expand_env_vars(v) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -2798,6 +2801,21 @@ _COMMENTED_SECTIONS = """
 #     model: google/gemini-2.5-flash
 """
 
+def _collapse_env_vars(obj):
+    """
+    Saves resolved secrets back to their ${ENV_VAR} placeholders before writing to disk.
+    Prevents leaking credentials into config.yaml.
+    """
+    if isinstance(obj, str):
+        for secret_val, placeholder in _ENV_REVERSE_MAP.items():
+            if secret_val in obj:
+                obj = obj.replace(secret_val, placeholder)
+        return obj
+    if isinstance(obj, dict):
+        return {k: _collapse_env_vars(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_collapse_env_vars(item) for item in obj]
+    return obj
 
 def save_config(config: Dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
@@ -2809,7 +2827,8 @@ def save_config(config: Dict[str, Any]):
     ensure_hermes_home()
     config_path = get_config_path()
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-
+    safe_normalized = _collapse_env_vars(normalized)
+    
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.
     parts = []
@@ -2822,7 +2841,7 @@ def save_config(config: Dict[str, Any]):
 
     atomic_yaml_write(
         config_path,
-        normalized,
+        safe_normalized,
         extra_content="".join(parts) if parts else None,
     )
     _secure_file(config_path)


### PR DESCRIPTION
…onfig.yaml   #11551

## What does this PR do?


This PR addresses a critical security footgun (Issue #11551) where `save_config` inadvertently writes resolved plaintext secrets back to `config.yaml`, destroying the original `${ENV_VAR}` references.

When users follow the documentation to move secrets into `~/.hermes/.env` using placeholder syntax (e.g., `api_key: ${TU_ZI_API_KEY}`), any action that persists the config (like `/model <name> --global`) currently collapses and hardcodes the actual secret into the YAML file.

## Changes Made
- Added a runtime `_ENV_REVERSE_MAP` to track injected secrets during `_expand_env_vars`.
- Introduced `_collapse_env_vars` to restore the original `${VAR}` placeholders.
- Modified `save_config` to pipe the configuration dictionary through `_collapse_env_vars` immediately before serializing it to disk via `atomic_yaml_write`.

This ensures the runtime still consumes the expanded secrets naturally, while the on-disk `config.yaml` remains scrubbed and perfectly preserves the user's placeholder references.

## Related Issue
Fixes #11551

## Testing
- Verified that `load_config` successfully expands the environment variables.
- Verified that triggering a `save_config` operation (e.g., changing models globally) patches `config.yaml` while preserving the `${VAR}` syntax instead of leaking the plaintext credentials.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

