### PR TITLE
fix(gateway): always inject reply context into skill and chat prompts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3241,6 +3241,20 @@ class GatewayRunner:
                                 f"Enable it with: `hermes skills config`"
                             )
                     user_instruction = event.get_command_args().strip()
+                    reply_text = getattr(event, "reply_to_text", None)
+                    reply_id = getattr(event, "reply_to_message_id", None)
+                    if reply_text and reply_id:
+                        cap = 4000
+                        snippet = reply_text[:cap]
+                        if len(reply_text) > cap:
+                            snippet += "…[truncated]"
+                        user_instruction = (
+                            f"This command is a reply to message {reply_id}. "
+                            f"The referent of phrases like 'this skill' or 'that job' is "
+                            f"the replied-to message below, NOT any earlier conversation:\n"
+                            f"---\n{snippet}\n---\n\n"
+                            f"User instruction: {user_instruction}"
+                        )
                     msg = build_skill_invocation_message(
                         cmd_key, user_instruction, task_id=_quick_key
                     )
@@ -3418,14 +3432,15 @@ class GatewayRunner:
                 message_text = f"{context_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
-            reply_snippet = event.reply_to_text[:500]
-            found_in_history = any(
-                reply_snippet[:200] in (msg.get("content") or "")
-                for msg in history
-                if msg.get("role") in ("assistant", "user", "tool")
+            full = event.reply_to_text
+            cap = 4000
+            snippet = full[:cap]
+            if len(full) > cap:
+                snippet += "…[truncated]"
+            message_text = (
+                f"[Replying to message {event.reply_to_message_id}:\n{snippet}\n---]"
+                f"\n\n{message_text}"
             )
-            if not found_in_history:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
             try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ AUTHOR_MAP = {
     "96793918+memosr@users.noreply.github.com": "memosr",
     "milkoor@users.noreply.github.com": "milkoor",
     "xuerui911@gmail.com": "Fatty911",
+    "psikonetik@gmail.com": "el-analista",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",
     "77628552+raulvidis@users.noreply.github.com": "raulvidis",
     "145567217+Aum08Desai@users.noreply.github.com": "Aum08Desai",


### PR DESCRIPTION
## Summary

When a user replied to a previous message in a chat platform (e.g. Telegram), the gateway was suppressing the `[Replying to: ...]` anchor whenever the replied-to text matched anything already in chat history. In practice, replying to the immediately preceding assistant message always skipped the marker, leaving the LLM to pick the referent from recency bias and causing it to act on the wrong subject.

Concrete failure: replying to a `Cronjob Response: Hermes Daily System Audit` message with `/claude_code improve this skill ...` would consistently send the model off to "improve the deep-research skill" (whatever had last been discussed), not the audit skill the user was actually pointing at.

## Changes — `gateway/run.py`

- **Drop the `found_in_history` gate.** Presence in history ≠ being the referent of a reply. The marker is pointer information; always inject it.
- **Widen the snippet** from 500 chars to the full reply body (cap 4000 chars, `…[truncated]` marker appended when over). Telegram's Bot API already provides the complete replied-to `text`/`caption`, so no adapter changes are needed; the runner stays platform-agnostic.
- **For skill slash commands**, inline the replied-to body directly into `user_instruction`. The skill payload (full SKILL.md content) otherwise sits between the top-level marker and the user's ask, separating the anchor from the instruction by thousands of tokens.
- **Explicit disambiguation line** telling the LLM that "this skill" / "that job" phrases refer to the replied-to message, not to earlier turns.

Both code paths (skill-command dispatcher at ~3229 and general inbound prep at ~3418) now use the same 4000-char cap logic. Mild duplication, intentional — the two sites inject at different points in the final prompt for prompt-structure reasons. Could be factored into a helper in a follow-up.

## Test plan

- [x] Syntax check via `python -c "import ast; ast.parse(open('gateway/run.py').read())"`
- [x] Manual end-to-end on Telegram: reply to a `Cronjob Response` message with `/claude_code improve this skill ...` — LLM now correctly anchors on the replied-to audit skill.
- [x] Verified the full reply body lands in the persisted session payload (`sessions/session_*.json`).
- [ ] Reviewers: confirm non-skill reply flow still works (general chat reply should prepend the `[Replying to message N: ...]` block verbatim).