### PR TITLE
fix(stt): preprocess .silk voice notes before transcription

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,7 @@ voice = [
   "faster-whisper==1.2.1",
   "sounddevice==0.5.5",
   "numpy==2.4.3",
+  "pilk>=0.2.4,<1",
 ]
 pty = [
   # Kept as a no-op back-compat alias — `ptyprocess` and `pywinpty` are now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ voice = [
   "faster-whisper>=1.0.0,<2",
   "sounddevice>=0.4.6,<1",
   "numpy>=1.24.0,<3",
+  "pilk>=0.2.4,<1",
 ]
 pty = [
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -53,6 +53,14 @@ def sample_ogg(tmp_path):
     ogg_path.write_bytes(b"fake audio data")
     return str(ogg_path)
 
+@pytest.fixture
+def sample_silk(tmp_path):
+    """Create a fake WeChat .silk file for preprocessing tests."""
+    silk_path = tmp_path / "voice.silk"
+    silk_path.write_bytes(b"\x02#!SILK_V3fake")
+    return str(silk_path)
+
+
 
 pytestmark = pytest.mark.usefixtures("disable_lazy_stt_install")
 
@@ -908,6 +916,64 @@ class TestTranscribeAudioDispatch:
             transcribe_audio(sample_ogg, model="large-v3")
 
         assert mock_local.call_args[0][1] == "large-v3"
+
+    def test_converts_silk_before_dispatch(self, sample_silk):
+        with patch("tools.transcription_tools._prepare_audio_for_transcription",
+                   return_value=("/tmp/converted.wav", "/tmp/hermes-silk-123", None),
+                   create=True) as mock_prepare, \
+             patch("tools.transcription_tools._validate_audio_file", return_value=None), \
+             patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "hi"}) as mock_local, \
+             patch("tools.transcription_tools.shutil.rmtree") as mock_rmtree:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_silk)
+
+        assert result["success"] is True
+        mock_prepare.assert_called_once_with(sample_silk)
+        mock_local.assert_called_once_with("/tmp/converted.wav", "base")
+        mock_rmtree.assert_called_once_with("/tmp/hermes-silk-123", ignore_errors=True)
+
+    def test_silk_symlink_is_rejected_before_preprocessing(self, tmp_path):
+        """A Silk symlink must not reach the decoder before path safety validation."""
+        if not hasattr(os, "symlink"):
+            pytest.skip("symlinks are not supported on this platform")
+
+        target = tmp_path / "voice.silk"
+        target.write_bytes(b"\x02#!SILK_V3fake")
+        link = tmp_path / "linked.silk"
+        try:
+            os.symlink(target, link)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        with patch(
+            "tools.transcription_tools._prepare_audio_for_transcription", create=True
+        ) as mock_prepare:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(link))
+
+        assert result["success"] is False
+        assert "symbolic link" in result["error"]
+        mock_prepare.assert_not_called()
+
+    def test_oversized_silk_is_rejected_before_preprocessing(self, tmp_path):
+        """A Silk source over the upload limit must not reach the decoder."""
+        silk_path = tmp_path / "oversized.silk"
+        from tools.transcription_tools import MAX_FILE_SIZE
+        with silk_path.open("wb") as audio_file:
+            audio_file.truncate(MAX_FILE_SIZE + 1)
+
+        with patch(
+            "tools.transcription_tools._prepare_audio_for_transcription", create=True
+        ) as mock_prepare:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(str(silk_path))
+
+        assert result["success"] is False
+        assert "File too large" in result["error"]
+        mock_prepare.assert_not_called()
 
     def test_default_model_used_when_none(self, sample_ogg):
         with patch("tools.transcription_tools._load_stt_config", return_value={}), \

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -42,6 +42,14 @@ def sample_ogg(tmp_path):
     return str(ogg_path)
 
 
+@pytest.fixture
+def sample_silk(tmp_path):
+    """Create a fake WeChat .silk file for preprocessing tests."""
+    silk_path = tmp_path / "voice.silk"
+    silk_path.write_bytes(b"\x02#!SILK_V3fake")
+    return str(silk_path)
+
+
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
     """Ensure no real API keys leak into tests."""
@@ -783,6 +791,24 @@ class TestTranscribeAudioDispatch:
             transcribe_audio(sample_ogg, model="large-v3")
 
         assert mock_local.call_args[0][1] == "large-v3"
+
+    def test_converts_silk_before_dispatch(self, sample_silk):
+        with patch("tools.transcription_tools._prepare_audio_for_transcription",
+                   return_value=("/tmp/converted.wav", "/tmp/hermes-silk-123", None),
+                   create=True) as mock_prepare, \
+             patch("tools.transcription_tools._validate_audio_file", return_value=None), \
+             patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "hi"}) as mock_local, \
+             patch("tools.transcription_tools.shutil.rmtree") as mock_rmtree:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_silk)
+
+        assert result["success"] is True
+        mock_prepare.assert_called_once_with(sample_silk)
+        mock_local.assert_called_once_with("/tmp/converted.wav", "base")
+        mock_rmtree.assert_called_once_with("/tmp/hermes-silk-123", ignore_errors=True)
 
     def test_default_model_used_when_none(self, sample_ogg):
         with patch("tools.transcription_tools._load_stt_config", return_value={}), \

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -79,6 +79,7 @@ def _safe_find_spec(module_name: str) -> bool:
 _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
+_HAS_PILK = _safe_find_spec("pilk")
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -1019,8 +1020,8 @@ def _dispatch_to_plugin_provider(
 # ---------------------------------------------------------------------------
 
 
-def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
-    """Validate the audio file.  Returns an error dict or None if OK."""
+def _validate_audio_source_file(file_path: str) -> Optional[Dict[str, Any]]:
+    """Validate source path safety and size before any decoder is invoked."""
     audio_path = Path(file_path)
 
     if os.path.islink(audio_path):
@@ -1029,24 +1030,66 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
         return {"success": False, "transcript": "", "error": f"Audio file not found: {file_path}"}
     if not audio_path.is_file():
         return {"success": False, "transcript": "", "error": f"Path is not a file: {file_path}"}
+    try:
+        file_size = audio_path.stat().st_size
+    except OSError as exc:
+        return {"success": False, "transcript": "", "error": f"Failed to access file: {exc}"}
+    if file_size > MAX_FILE_SIZE:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"File too large: {file_size / (1024*1024):.1f}MB (max {MAX_FILE_SIZE / (1024*1024):.0f}MB)",
+        }
+    return None
+
+
+def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
+    """Validate a supported, decoder-safe audio file."""
+    source_error = _validate_audio_source_file(file_path)
+    if source_error:
+        return source_error
+
+    audio_path = Path(file_path)
     if audio_path.suffix.lower() not in SUPPORTED_FORMATS:
         return {
             "success": False,
             "transcript": "",
             "error": f"Unsupported format: {audio_path.suffix}. Supported: {', '.join(sorted(SUPPORTED_FORMATS))}",
         }
-    try:
-        file_size = audio_path.stat().st_size
-        if file_size > MAX_FILE_SIZE:
-            return {
-                "success": False,
-                "transcript": "",
-                "error": f"File too large: {file_size / (1024*1024):.1f}MB (max {MAX_FILE_SIZE / (1024*1024):.0f}MB)",
-            }
-    except OSError as e:
-        return {"success": False, "transcript": "", "error": f"Failed to access file: {e}"}
-
     return None
+
+
+def _prepare_audio_for_transcription(
+    file_path: str,
+) -> tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]:
+    """Convert a decoder-safe .silk source to a temporary supported WAV file."""
+    audio_path = Path(file_path)
+    if audio_path.suffix.lower() != ".silk":
+        return file_path, None, None
+    if not _HAS_PILK:
+        return None, None, {
+            "success": False,
+            "transcript": "",
+            "error": "Unsupported format: .silk. Install the optional 'pilk' dependency to enable WeChat voice transcription.",
+        }
+
+    temp_dir = tempfile.mkdtemp(prefix="hermes-silk-")
+    converted_path = os.path.join(temp_dir, f"{audio_path.stem}.wav")
+    try:
+        import pilk
+
+        pilk.silk_to_wav(file_path, converted_path)
+        if not Path(converted_path).is_file() or Path(converted_path).stat().st_size == 0:
+            raise RuntimeError("pilk did not produce a readable WAV file")
+        return converted_path, temp_dir, None
+    except Exception as exc:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        logger.error("Failed to convert .silk audio %s: %s", file_path, exc, exc_info=True)
+        return None, None, {
+            "success": False,
+            "transcript": "",
+            "error": f"Failed to convert .silk audio for transcription: {exc}",
+        }
 
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
@@ -1621,7 +1664,7 @@ def _transcribe_elevenlabs(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
 
@@ -1640,10 +1683,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
           - "error" (str, optional): Error message if success is False
           - "provider" (str, optional): Which provider was used
     """
-    # Validate input
-    error = _validate_audio_file(file_path)
-    if error:
-        return error
+    # `file_path` has already passed source and extension validation.
 
     # Load config and determine provider
     stt_config = _load_stt_config()
@@ -1749,6 +1789,32 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }
+
+
+def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+    """Safely validate, preprocess supported inputs, and dispatch transcription."""
+    source_error = _validate_audio_source_file(file_path)
+    if source_error:
+        return source_error
+
+    prepared_path, cleanup_dir, prep_error = _prepare_audio_for_transcription(file_path)
+    if prep_error:
+        return prep_error
+    if prepared_path is None:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Audio preprocessing did not produce a file for transcription.",
+        }
+
+    try:
+        prepared_error = _validate_audio_file(prepared_path)
+        if prepared_error:
+            return prepared_error
+        return _transcribe_prepared_audio(prepared_path, model)
+    finally:
+        if cleanup_dir:
+            shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -56,6 +56,7 @@ def _safe_find_spec(module_name: str) -> bool:
 _HAS_FASTER_WHISPER = _safe_find_spec("faster_whisper")
 _HAS_OPENAI = _safe_find_spec("openai")
 _HAS_MISTRAL = _safe_find_spec("mistralai")
+_HAS_PILK = _safe_find_spec("pilk")
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -292,6 +293,39 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
         return {"success": False, "transcript": "", "error": f"Failed to access file: {e}"}
 
     return None
+
+
+def _prepare_audio_for_transcription(file_path: str) -> tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]:
+    """Convert pre-processable inputs (for example WeChat .silk) into a supported audio file."""
+    audio_path = Path(file_path)
+    if audio_path.suffix.lower() != ".silk":
+        return file_path, None, None
+
+    if not _HAS_PILK:
+        return None, None, {
+            "success": False,
+            "transcript": "",
+            "error": "Unsupported format: .silk. Install the optional 'pilk' dependency to enable WeChat voice transcription.",
+        }
+
+    temp_dir = tempfile.mkdtemp(prefix="hermes-silk-")
+    converted_path = os.path.join(temp_dir, f"{audio_path.stem}.wav")
+
+    try:
+        import pilk
+
+        pilk.silk_to_wav(file_path, converted_path)
+        if not Path(converted_path).is_file() or Path(converted_path).stat().st_size == 0:
+            raise RuntimeError("pilk did not produce a readable WAV file")
+        return converted_path, temp_dir, None
+    except Exception as e:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        logger.error("Failed to convert .silk audio %s: %s", file_path, e, exc_info=True)
+        return None, None, {
+            "success": False,
+            "transcript": "",
+            "error": f"Failed to convert .silk audio for transcription: {e}",
+        }
 
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
@@ -597,62 +631,71 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
           - "error" (str, optional): Error message if success is False
           - "provider" (str, optional): Which provider was used
     """
-    # Validate input
-    error = _validate_audio_file(file_path)
-    if error:
-        return error
+    prepared_path = file_path
+    cleanup_dir = None
 
-    # Load config and determine provider
-    stt_config = _load_stt_config()
-    if not is_stt_enabled(stt_config):
+    try:
+        prepared_path, cleanup_dir, prep_error = _prepare_audio_for_transcription(file_path)
+        if prep_error:
+            return prep_error
+
+        # Validate input
+        error = _validate_audio_file(prepared_path)
+        if error:
+            return error
+
+        # Load config and determine provider
+        stt_config = _load_stt_config()
+        if not is_stt_enabled(stt_config):
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "STT is disabled in config.yaml (stt.enabled: false).",
+            }
+
+        provider = _get_provider(stt_config)
+
+        if provider == "local":
+            local_cfg = stt_config.get("local", {})
+            model_name = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+            return _transcribe_local(prepared_path, model_name)
+
+        if provider == "local_command":
+            local_cfg = stt_config.get("local", {})
+            model_name = _normalize_local_command_model(
+                model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+            )
+            return _transcribe_local_command(prepared_path, model_name)
+
+        if provider == "groq":
+            model_name = model or DEFAULT_GROQ_STT_MODEL
+            return _transcribe_groq(prepared_path, model_name)
+
+        if provider == "openai":
+            openai_cfg = stt_config.get("openai", {})
+            model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
+            return _transcribe_openai(prepared_path, model_name)
+
+        if provider == "mistral":
+            mistral_cfg = stt_config.get("mistral", {})
+            model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
+            return _transcribe_mistral(prepared_path, model_name)
+
+        # No provider available
         return {
             "success": False,
             "transcript": "",
-            "error": "STT is disabled in config.yaml (stt.enabled: false).",
+            "error": (
+                "No STT provider available. Install faster-whisper for free local "
+                f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
+                "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
+                "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
+                "or OPENAI_API_KEY for the OpenAI Whisper API."
+            ),
         }
-
-    provider = _get_provider(stt_config)
-
-    if provider == "local":
-        local_cfg = stt_config.get("local", {})
-        model_name = _normalize_local_model(
-            model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
-        )
-        return _transcribe_local(file_path, model_name)
-
-    if provider == "local_command":
-        local_cfg = stt_config.get("local", {})
-        model_name = _normalize_local_command_model(
-            model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
-        )
-        return _transcribe_local_command(file_path, model_name)
-
-    if provider == "groq":
-        model_name = model or DEFAULT_GROQ_STT_MODEL
-        return _transcribe_groq(file_path, model_name)
-
-    if provider == "openai":
-        openai_cfg = stt_config.get("openai", {})
-        model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
-        return _transcribe_openai(file_path, model_name)
-
-    if provider == "mistral":
-        mistral_cfg = stt_config.get("mistral", {})
-        model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
-        return _transcribe_mistral(file_path, model_name)
-
-    # No provider available
-    return {
-        "success": False,
-        "transcript": "",
-        "error": (
-            "No STT provider available. Install faster-whisper for free local "
-            f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
-        ),
-    }
+    finally:
+        if cleanup_dir:
+            shutil.rmtree(cleanup_dir, ignore_errors=True)
 
 
 def _resolve_openai_audio_client_config() -> tuple[str, str]:

--- a/uv.lock
+++ b/uv.lock
@@ -1715,6 +1715,7 @@ vertex = [
 voice = [
     { name = "faster-whisper" },
     { name = "numpy" },
+    { name = "pilk" },
     { name = "sounddevice" },
 ]
 web = [
@@ -1810,6 +1811,7 @@ requires-dist = [
     { name = "packaging", specifier = "==26.0" },
     { name = "parallel-web", marker = "extra == 'parallel-web'", specifier = "==0.4.2" },
     { name = "pathspec", specifier = "==1.1.1" },
+    { name = "pilk", marker = "extra == 'voice'", specifier = ">=0.2.4,<1" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
     { name = "psutil", specifier = "==7.2.2" },
@@ -2949,6 +2951,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pilk"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/bb/938dd697b6bc2d851ffec4ffe82ed20078e58bd0ef049e84f4d038d6f991/pilk-0.2.4.tar.gz", hash = "sha256:d4a1bcf93dc6ef5e95e0cfd728ed4ef4d49f9c0476d70816fecbe456cc762e7f", size = 226451, upload-time = "2023-05-26T03:32:34.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/06/80cac61bc7f791bcaae552ba90fb868f7af7503ef1c74e423cc20fca1a53/pilk-0.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:a6692096607e8d77d348aeec00df633788c85b527aa83cbd803ddf508936db7f", size = 127024, upload-time = "2023-05-26T03:32:24.524Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

This PR adds inbound `.silk` voice-note preprocessing to the STT path.

Hermes can receive voice notes from messaging platforms / bridges as Silk-encoded `.silk` files. Before this change, `tools.transcription_tools.transcribe_audio()` validated the file extension before any format-specific preprocessing, so `.silk` inputs failed early with `Unsupported format: .silk` and never reached the configured STT provider.

After this change:
- `.silk` inputs are detected before normal audio-extension validation.
- Hermes converts `.silk` inputs to temporary `.wav` files through optional `pilk` when available.
- The converted `.wav` continues through the existing STT provider dispatch path unchanged.
- Temporary conversion artifacts are cleaned up after transcription.
- Already-supported audio formats keep the existing provider flow.

## Related Issue

N/A — this is a focused compatibility fix for inbound Silk voice-note transcription.

Related / adjacent context:
- Related but distinct from #9971, which is about outbound Weixin TTS voice-bubble delivery (OGG → SILK), not inbound STT preprocessing.
- Complementary to #11686, which concerns inbound Weixin voice media download when a text hint exists. This PR assumes the audio file is already available locally and focuses on how `.silk` inputs enter the STT pipeline.
- Adjacent to #9425 / #11571, which addressed Weixin outbound voice/media delivery behavior rather than STT decoding.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/transcription_tools.py`
  - Adds `.silk` detection before normal supported-format validation.
  - Converts `.silk` inputs to a temporary `.wav` via optional `pilk`.
  - Sends the prepared `.wav` through the existing provider dispatch path.
  - Cleans up temporary conversion output after transcription.
- `tests/tools/test_transcription_tools.py`
  - Adds regression coverage proving `.silk` inputs are converted before provider dispatch.
- `pyproject.toml` / `uv.lock`
  - Adds the optional `pilk` dependency under the `voice` extra so Silk preprocessing is available when voice dependencies are installed.

## How to Test

Focused local verification on the refreshed branch:

1. Run the Silk preprocessing regression:
   ```bash
   python -m pytest tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_converts_silk_before_dispatch -o 'addopts=' -q
   ```
   Expected: `1 passed`

2. Run the affected transcription / managed-media tests:
   ```bash
   python -m pytest tests/tools/test_transcription_tools.py tests/tools/test_managed_media_gateways.py -o 'addopts=' -q
   ```
   Expected: `101 passed`

3. Check Python syntax for the touched transcription files:
   ```bash
   python -m py_compile tools/transcription_tools.py tests/tools/test_transcription_tools.py
   ```
   Expected: no output / exit 0

4. Verify the lockfile is current:
   ```bash
   uv lock --check
   ```
   Expected: exit 0

5. Check diff whitespace:
   ```bash
   git diff --check
   ```
   Expected: no output / exit 0

Manual smoke test when a messaging gateway provides a Silk file:
1. Send a Silk-encoded voice note through a messaging gateway.
2. Confirm Hermes transcribes it instead of returning `Unsupported format: .silk`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not run locally; this PR has targeted verification for the affected STT paths as listed above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / local Hermes development environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A; this is a narrow STT compatibility fix with regression coverage.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A; no config keys added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A; no architecture/workflow contract changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - The implementation uses Python temporary files and the optional Python `pilk` dependency; no platform-specific shell commands are introduced.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A; tool schema is unchanged. The accepted input path behavior now preprocesses `.silk` before dispatch.

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

N/A — no UI changes.

Relevant verification output from the refreshed branch was posted in the PR discussion:

```text
python -m pytest tests/tools/test_transcription_tools.py::TestTranscribeAudioDispatch::test_converts_silk_before_dispatch -o 'addopts=' -q
-> 1 passed

python -m pytest tests/tools/test_transcription_tools.py tests/tools/test_managed_media_gateways.py -o 'addopts=' -q
-> 101 passed

python -m py_compile tools/transcription_tools.py tests/tools/test_transcription_tools.py
-> passed

uv lock --check
-> passed

git diff --check
-> passed
```
