### PR TITLE
fix: allow --force to override container detection in gateway install

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2946,14 +2946,22 @@ def gateway_command(args):
             print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
             sys.exit(1)
         elif is_container():
-            print("Service installation is not needed inside a Docker container.")
-            print("The container runtime is your service manager — use Docker restart policies instead:")
-            print()
-            print("  docker run --restart unless-stopped ...   # auto-restart on crash/reboot")
-            print("  docker restart <container>                # manual restart")
-            print()
-            print("To run the gateway: hermes gateway run")
-            sys.exit(0)
+            if force and shutil.which("systemctl") is not None:
+                print_warning("Container environment detected — installing service anyway (--force).")
+                print_info("  Ensure systemd is running inside the container for this to work.")
+                print()
+                systemd_install(force=force, system=system, run_as_user=run_as_user)
+            else:
+                print("Service installation is not needed inside a Docker container.")
+                print("The container runtime is your service manager — use Docker restart policies instead:")
+                print()
+                print("  docker run --restart unless-stopped ...   # auto-restart on crash/reboot")
+                print("  docker restart <container>                # manual restart")
+                print()
+                if force:
+                    print("Hint: --force requires systemctl to be available inside the container.")
+                print("To run the gateway: hermes gateway run")
+                sys.exit(0)
         else:
             print("Service installation not supported on this platform.")
             print("Run manually: hermes gateway run")


### PR DESCRIPTION
## Summary

Fixes #11598

When running inside a Docker/Podman container that has systemd available, `hermes gateway install` is unconditionally blocked — even with `--force`. This PR makes `--force` bypass the container detection and proceed with systemd service installation when `systemctl` is present.

## Changes

- **`hermes_cli/gateway.py`**: In the `install` subcommand handler, when `is_container()` is `True` and `--force` is passed, check for `systemctl` availability and call `systemd_install()` instead of exiting with the Docker restart policy message.
- Without `--force`, behavior is completely unchanged.
- When `--force` is used but `systemctl` is not available, a helpful hint is shown.

## Testing

Manually tested in a systemd-enabled Docker container (Ubuntu 24.04):

```bash
# Without --force: still shows the container message (unchanged behavior)
$ hermes gateway install
Service installation is not needed inside a Docker container.
...

# With --force and systemd available: installs successfully
$ hermes gateway install --force
⚠ Container environment detected — installing service anyway (--force).
  Ensure systemd is running inside the container for this to work.
Installing user systemd service to: ~/.config/systemd/user/hermes-gateway.service
```

## Before / After

| Scenario | Before | After |
|---|---|---|
| Container, no `--force` | Shows Docker message, exits | Shows Docker message, exits (unchanged) |
| Container, `--force`, systemd present | Shows Docker message, exits | Installs systemd service |
| Container, `--force`, no systemd | Shows Docker message, exits | Shows Docker message + hint about systemctl |