### PR TITLE
fix(dingtalk): get_connected_platforms + fire-and-forget processing + null-toolsets guard

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -312,7 +312,7 @@ class GatewayConfig:
                 config.extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID")
             ) and (
                 config.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
-            ):                                                                                                                                                                                    
+            ):
                 connected.append(platform)
         
         return connected

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -307,6 +307,14 @@ class GatewayConfig:
             # QQBot uses extra dict for app credentials
             elif platform == Platform.QQBOT and config.extra.get("app_id") and config.extra.get("client_secret"):
                 connected.append(platform)
+            # DingTalk uses client_id/client_secret from config.extra or env vars
+            elif platform == Platform.DINGTALK and (
+                config.extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID")
+            ) and (
+                config.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
+            ):                                                                                                                                                                                    
+                connected.append(platform)
+        
         return connected
     
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -483,13 +483,39 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
         """Called by dingtalk-stream when a message arrives.
 
         dingtalk-stream >= 0.24 passes a CallbackMessage whose `.data` contains
-        the chatbot payload. Convert it to ChatbotMessage and await the adapter
-        handler directly on the main event loop.
+        the chatbot payload. Convert it to ChatbotMessage via
+        ``ChatbotMessage.from_dict()``.
+
+        Message processing is dispatched as a background task so that this
+        method returns the ACK immediately — blocking here would prevent the
+        SDK from sending heartbeats, eventually causing a disconnect.
         """
         try:
-            chatbot_msg = ChatbotMessage.from_dict(callback_message.data)
+            data = callback_message.data
+            chatbot_msg = ChatbotMessage.from_dict(data)
+
+            # Ensure session_webhook is populated even if the SDK's
+            # from_dict() did not map it (field name mismatch across
+            # SDK versions).
+            if not getattr(chatbot_msg, "session_webhook", None):
+                webhook = (
+                    data.get("sessionWebhook")
+                    or data.get("session_webhook")
+                    or ""
+                )
+                if webhook:
+                    chatbot_msg.session_webhook = webhook
+
+            # Fire-and-forget: return ACK immediately, process in background.
+            asyncio.create_task(self._safe_on_message(chatbot_msg))
+        except Exception:
+            logger.exception("[DingTalk] Error preparing incoming message")
+
+        return dingtalk_stream.AckMessage.STATUS_OK, "OK"
+
+    async def _safe_on_message(self, chatbot_msg: "ChatbotMessage") -> None:
+        """Wrapper that catches exceptions from _on_message."""
+        try:
             await self._adapter._on_message(chatbot_msg)
         except Exception:
             logger.exception("[DingTalk] Error processing incoming message")
-
-        return dingtalk_stream.AckMessage.STATUS_OK, "OK"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -512,7 +512,7 @@ def _get_platform_tools(
     """Resolve which individual toolset names are enabled for a platform."""
     from toolsets import resolve_toolset
 
-    platform_toolsets = config.get("platform_toolsets", {})
+    platform_toolsets = config.get("platform_toolsets") or {}
     toolset_names = platform_toolsets.get(platform)
 
     if toolset_names is None or not isinstance(toolset_names, list):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -70,6 +70,7 @@ AUTHOR_MAP = {
     "27917469+nosleepcassette@users.noreply.github.com": "nosleepcassette",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "109555139+davetist@users.noreply.github.com": "davetist",
+    "39405770+yyq4193@users.noreply.github.com": "yyq4193",
     "Asunfly@users.noreply.github.com": "Asunfly",
     # contributors (manual mapping from git names)
     "ahmedsherif95@gmail.com": "asheriif",
@@ -181,6 +182,7 @@ AUTHOR_MAP = {
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
     "kagura.chen28@gmail.com": "kagura-agent",
+    "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
     "karamusti912@gmail.com": "MustafaKara7",
     "kira@ariaki.me": "kira-ariaki",

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -71,6 +71,51 @@ class TestGetConnectedPlatforms:
         config = GatewayConfig()
         assert config.get_connected_platforms() == []
 
+    def test_dingtalk_recognised_via_extras(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(
+                    enabled=True,
+                    extra={"client_id": "cid", "client_secret": "sec"},
+                ),
+            },
+        )
+        assert Platform.DINGTALK in config.get_connected_platforms()
+
+    def test_dingtalk_recognised_via_env_vars(self, monkeypatch):
+        """DingTalk configured via env vars (no extras) should still be
+        recognised as connected — covers the case where _apply_env_overrides
+        hasn't populated extras yet."""
+        monkeypatch.setenv("DINGTALK_CLIENT_ID", "env_cid")
+        monkeypatch.setenv("DINGTALK_CLIENT_SECRET", "env_sec")
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(enabled=True, extra={}),
+            },
+        )
+        assert Platform.DINGTALK in config.get_connected_platforms()
+
+    def test_dingtalk_missing_creds_not_connected(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(enabled=True, extra={}),
+            },
+        )
+        assert Platform.DINGTALK not in config.get_connected_platforms()
+
+    def test_dingtalk_disabled_not_connected(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DINGTALK: PlatformConfig(
+                    enabled=False,
+                    extra={"client_id": "cid", "client_secret": "sec"},
+                ),
+            },
+        )
+        assert Platform.DINGTALK not in config.get_connected_platforms()
+
 
 class TestSessionResetPolicy:
     def test_roundtrip(self):

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -575,3 +575,109 @@ class TestShouldProcessMessage:
         # Different group still blocked
         assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp2") is False
 
+
+# ---------------------------------------------------------------------------
+# _IncomingHandler.process — session_webhook extraction & fire-and-forget
+# ---------------------------------------------------------------------------
+
+
+class TestIncomingHandlerProcess:
+    """Verify that _IncomingHandler.process correctly converts callback data
+    and dispatches message processing as a background task (fire-and-forget)
+    so the SDK ACK is returned immediately."""
+
+    @pytest.mark.asyncio
+    async def test_process_extracts_session_webhook(self):
+        """session_webhook must be populated from callback data."""
+        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._on_message = AsyncMock()
+        handler = _IncomingHandler(adapter, asyncio.get_running_loop())
+
+        callback = MagicMock()
+        callback.data = {
+            "msgtype": "text",
+            "text": {"content": "hello"},
+            "senderId": "user1",
+            "conversationId": "conv1",
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?session=abc",
+            "msgId": "msg-001",
+        }
+
+        result = await handler.process(callback)
+        # Should return ACK immediately (STATUS_OK = 200)
+        assert result[0] == 200
+
+        # Let the background task run
+        await asyncio.sleep(0.05)
+
+        # _on_message should have been called with a ChatbotMessage
+        adapter._on_message.assert_called_once()
+        chatbot_msg = adapter._on_message.call_args[0][0]
+        assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=abc"
+
+    @pytest.mark.asyncio
+    async def test_process_fallback_session_webhook_when_from_dict_misses_it(self):
+        """If ChatbotMessage.from_dict does not map sessionWebhook (e.g. SDK
+        version mismatch), the handler should fall back to extracting it
+        directly from the raw data dict."""
+        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._on_message = AsyncMock()
+        handler = _IncomingHandler(adapter, asyncio.get_running_loop())
+
+        callback = MagicMock()
+        # Use a key that from_dict might not recognise in some SDK versions
+        callback.data = {
+            "msgtype": "text",
+            "text": {"content": "hi"},
+            "senderId": "user2",
+            "conversationId": "conv2",
+            "session_webhook": "https://oapi.dingtalk.com/robot/sendBySession?session=def",
+            "msgId": "msg-002",
+        }
+
+        await handler.process(callback)
+        await asyncio.sleep(0.05)
+
+        adapter._on_message.assert_called_once()
+        chatbot_msg = adapter._on_message.call_args[0][0]
+        assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=def"
+
+    @pytest.mark.asyncio
+    async def test_process_returns_ack_immediately(self):
+        """process() must not block on _on_message — it should return
+        the ACK tuple before the message is fully processed."""
+        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+
+        processing_started = asyncio.Event()
+        processing_gate = asyncio.Event()
+
+        async def slow_on_message(msg):
+            processing_started.set()
+            await processing_gate.wait()  # Block until we release
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._on_message = slow_on_message
+        handler = _IncomingHandler(adapter, asyncio.get_running_loop())
+
+        callback = MagicMock()
+        callback.data = {
+            "msgtype": "text",
+            "text": {"content": "test"},
+            "senderId": "u",
+            "conversationId": "c",
+            "sessionWebhook": "https://oapi.dingtalk.com/x",
+            "msgId": "m",
+        }
+
+        # process() should return immediately even though _on_message blocks
+        result = await handler.process(callback)
+        assert result[0] == 200
+
+        # Clean up: release the gate so the background task finishes
+        processing_gate.set()
+        await asyncio.sleep(0.05)
+

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -40,6 +40,19 @@ def test_get_platform_tools_preserves_explicit_empty_selection():
     assert enabled == set()
 
 
+def test_get_platform_tools_handles_null_platform_toolsets():
+    """YAML `platform_toolsets:` with no value parses as None — the old
+    ``config.get("platform_toolsets", {})`` pattern would then crash with
+    ``NoneType has no attribute 'get'`` on the next line. Guard against that.
+    """
+    config = {"platform_toolsets": None}
+
+    enabled = _get_platform_tools(config, "cli")
+
+    # Falls through to defaults instead of raising
+    assert enabled
+
+
 def test_platform_toolset_summary_uses_explicit_platform_list():
     config = {}
 


### PR DESCRIPTION
## Summary

Three DingTalk follow-up fixes in one PR — all from external contributors, all cherry-picked with authorship preserved:

1. **#11500 @youngDoo** — `GatewayConfig.get_connected_platforms()` was missing a DingTalk branch entirely. A DingTalk-configured gateway (via YAML `extra:` or env vars) never appeared in the connected-platforms list, so status displays and iteration callers silently omitted it.

2. **#11518 @kagura-agent** — `_IncomingHandler.process()` currently awaits `_on_message` directly, which blocks the SDK's recv loop for the full duration of agent processing. For a chat agent responding in 10-30s, this breaks the SDK's heartbeat deadline and causes WebSocket disconnects. Fix: dispatch via `asyncio.create_task()` so ACK returns immediately. Also adds a defensive `session_webhook` fallback (raw dict lookup for both `sessionWebhook` and `session_webhook` keys) in case a future SDK revision changes the field name. Resolves issue #11463 (@sgjeff's "No session_webhook available" report).

3. **#9003 @yyq4193** (one-liner cherry-picked with `Co-authored-by` trailer) — `hermes_cli/tools_config.py` was calling `config.get("platform_toolsets", {})`, which returns `None` when the YAML key is explicitly null (common with `platform_toolsets:` and no value below). The next line's `.get(platform)` then crashed with AttributeError. Changed to `config.get(...) or {}`.

The rest of #9003 is redundant with #11471 that landed earlier today (webhook regex, async `start()`, async `process()`, `CallbackMessage → ChatbotMessage`) and includes one security regression (`https?://` allowing plain HTTP on the webhook allowlist) that I deliberately did not carry over. The tools_config.py one-liner is the only net-new legitimate change from #9003 and I'm landing it here with credit.

### Commits (all authorship preserved)

```
726bea34  Teknium (Co-authored-by: yyq4193)
          test(dingtalk): cover get_connected_platforms + null platform_toolsets
973e0128  kagura-agent
          fix(dingtalk): fire-and-forget message processing & session_webhook fallback
0d2a845f  youngDoo
          gateway cant add DingTalk platform
```

Merge with `--rebase` to preserve per-commit authorship.

### What I cleaned up

- **gateway/config.py**: stripped ~140 trailing whitespace characters on the new DingTalk branch line from @youngDoo's diff.
- Resolved a cherry-pick conflict in `tests/gateway/test_dingtalk.py` — kagura-agent's branch predated the group-gating test classes we merged earlier today via #11564, and both sides appended new test classes at EOF. Kept both.

### What I deliberately dropped from #9003

- `r'^https?://(api|oapi)\.dingtalk\.com/'` — this would re-allow plain HTTP on the webhook URL allowlist. Current main enforces `^https://` only and this is the right security posture. **Rejected as a regression.**
- Pre-#11471 SDK compat changes (`async start()`, `async process()`, `CallbackMessage → ChatbotMessage`, webhook regex `oapi` accept) — already on main.
- `logger.debug → logger.info` for inbound messages — debatable noise; every received message would land in `agent.log` at INFO. Not carrying over.

### Tests

- `tests/gateway/test_dingtalk.py` — 50 passed (includes kagura-agent's 3 new `TestIncomingHandlerProcess` tests + our earlier regression tests)
- `tests/gateway/test_config.py` — 28 passed (includes 4 new `TestGetConnectedPlatforms::test_dingtalk_*` tests I added)
- `tests/hermes_cli/test_tools_config.py` — 31 passed (includes `test_get_platform_tools_handles_null_platform_toolsets` regression test)
- Combined: **109 passed**

### Closes

Closes #11500, #11518, #9003 on merge. Should also resolve #11463 (pending @sgjeff pulling latest main).
