### PR TITLE
fix(model-switch): dedupe user_providers against built-in catalog (#7524)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1039,6 +1039,12 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
+            # Skip if already emitted by Sections 1/2/2b under the same slug
+            # (e.g. config.yaml `providers: nous:` overlaps with built-in
+            # "Nous Portal"). Without this, the picker shows both the
+            # curated entry and an empty "nous (0)" duplicate (#7524).
+            if ep_name.lower() in seen_slugs:
+                continue
             display_name = ep_cfg.get("name", "") or ep_name
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
@@ -1066,6 +1072,7 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            seen_slugs.add(ep_name.lower())
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -86,6 +86,34 @@ def test_list_authenticated_providers_dedupes_models_when_default_in_list(monkey
     assert user_prov["models"].count("model-a") == 1, "model-a should not be duplicated"
 
 
+def test_list_authenticated_providers_dedupes_user_providers_against_builtins(monkeypatch):
+    """Regression for #7524: a provider key that also exists in the built-in
+    catalog (Sections 1/2) must not produce a second empty entry from
+    Section 3. Prior to the fix, having ``deepseek:`` in config.yaml
+    ``providers:`` while ``DEEPSEEK_API_KEY`` was set produced both the
+    curated ``DeepSeek`` row and an empty ``deepseek (0)`` duplicate."""
+    # Use deepseek: it's in Section 1 (PROVIDER_TO_MODELS_DEV) with a plain
+    # env-var creds check, so we can reliably simulate it.
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "fake-deepseek-key")
+
+    providers = list_authenticated_providers(
+        current_provider="deepseek",
+        user_providers={"deepseek": {"allowed_models": ["deepseek-chat"]}},
+        custom_providers=[],
+        max_models=50,
+    )
+
+    slugs = [p["slug"] for p in providers]
+    assert len(slugs) == len(set(slugs)), (
+        f"duplicate slugs found: {[s for s in slugs if slugs.count(s) > 1]}"
+    )
+
+    deepseek_rows = [p for p in providers if p["slug"] == "deepseek"]
+    assert len(deepseek_rows) == 1, f"expected one 'deepseek' row, got {len(deepseek_rows)}"
+    # Built-in row wins — user-config row (is_user_defined) must be absent.
+    assert not deepseek_rows[0]["is_user_defined"]
+
+
 def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     """When no models array is provided, should fall back to default_model."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})


### PR DESCRIPTION
## Summary
- `list_authenticated_providers()` Section 3 was the only section not consulting `seen_slugs`, so a `config.yaml` `providers:` entry whose key also exists in `PROVIDER_TO_MODELS_DEV` / `HERMES_OVERLAYS` (e.g. `nous`, `copilot`, `deepseek`, `minimax`, `minimax-cn`) emitted a second row in the `/model` picker showing `0` models.
- Skip `user_providers` entries whose lower-cased key is already in `seen_slugs`, and record the slug after emitting — matching Sections 1, 2, 2b, and 4.

Fixes #7524

## Test plan
- [x] New regression test `test_list_authenticated_providers_dedupes_user_providers_against_builtins` in `tests/hermes_cli/test_user_providers_model_switch.py` — asserts no duplicate slugs and that the built-in row wins when both sources name the same provider.
- [x] Reproduced pre-fix failure (`duplicate slugs found: ['deepseek', 'deepseek']`); passes with fix.
- [x] Existing `test_user_providers_model_switch.py` and `test_overlay_slug_resolution.py` suites still pass (15 / 15) in a disposable `python:3.13-slim` container.