### PR TITLE
fix(router): resolve context length from loaded model in router mode

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -549,8 +549,58 @@ def fetch_endpoint_model_metadata(
                         gen_settings = props.get("default_generation_settings", {})
                         n_ctx = gen_settings.get("n_ctx")
                         model_alias = props.get("model_alias", "")
-                        if n_ctx and model_alias and model_alias in cache:
-                            cache[model_alias]["context_length"] = n_ctx
+                        # Router mode: n_ctx is 0 (dummy value). Query the loaded
+                        # model's port directly via /models to find it.
+                        if not n_ctx:
+                            for model_entry in payload.get("data", []):
+                                if not isinstance(model_entry, dict):
+                                    continue
+                                status = model_entry.get("status", {})
+                                # Router mode uses status.value (not status.state)
+                                if status.get("value") != "loaded":
+                                    continue
+                                model_args = status.get("args", [])
+                                # Extract port from --port argument in loaded model's args
+                                # args can be a list (router mode) or string (single server)
+                                loaded_port = None
+                                if isinstance(model_args, list):
+                                    # Router mode: args is a list like ["--port", "52139"]
+                                    for i, arg in enumerate(model_args):
+                                        if arg == "--port" and i + 1 < len(model_args):
+                                            try:
+                                                loaded_port = int(model_args[i + 1])
+                                            except (ValueError, IndexError):
+                                                pass
+                                            break
+                                elif isinstance(model_args, str):
+                                    # Single server mode: args is a string like "--port 52139"
+                                    for arg in model_args.split():
+                                        if arg.startswith("--port="):
+                                            try:
+                                                loaded_port = int(arg.split("=", 1)[1])
+                                            except (ValueError, IndexError):
+                                                pass
+                                            break
+                                if loaded_port:
+                                    try:
+                                        props_resp2 = requests.get(
+                                            f"http://127.0.0.1:{loaded_port}/props",
+                                            headers=headers, timeout=5,
+                                        )
+                                        if props_resp2.ok:
+                                            props2 = props_resp2.json()
+                                            gen_settings2 = props2.get("default_generation_settings", {})
+                                            n_ctx2 = gen_settings2.get("n_ctx")
+                                            model_alias2 = props2.get("model_alias", "")
+                                            if n_ctx2 and model_alias2 and model_alias2 in cache:
+                                                n_ctx = n_ctx2
+                                                model_alias = model_alias2
+                                                break
+                                    except Exception:
+                                        pass
+                            # Apply the resolved context length
+                            if n_ctx and model_alias and model_alias in cache:
+                                cache[model_alias]["context_length"] = n_ctx
                 except Exception:
                     pass
 


### PR DESCRIPTION
## Problem

In llama.cpp router mode, querying `/props` returns `n_ctx=0` (a dummy value). This breaks context length resolution for models served through the router, causing Hermes to fall through to probe tiers or use incorrect defaults.

## Root Cause

The router's `/models` endpoint exposes loaded model metadata including `status.value: "loaded"` and `status.args` (the model's startup arguments including `--port`). However, the existing code only queries the router's own `/props`, which returns the router's own config (n_ctx=0), not the loaded model's actual context length.

## Fix

When `n_ctx` is 0 (router mode detected), the code now:

1. Scans the `/models` endpoint for the loaded model (`status.value == "loaded"`)
2. Extracts the model's port from `status.args` (router mode exposes args as a list: `["--port", "52139"]`)
3. Queries that port's `/props` directly to get the real `n_ctx`

## Our Use Case

We run a llama-server router with a base model and load the mmproj (multimodal projector) only when needed. The router exposes each loaded model's port via `/models` so we can query its `/props` directly for accurate context length resolution. This fix enables Hermes to correctly detect context length for models loaded dynamically through the router, including vision models where the mmproj is loaded on demand.

## Testing

Verified against live router at `127.0.0.1:8081`:
- **Before:** `qwen3.6-35b-a3b-text: context_length=N/A` (falls through to probe)
- **After:** `qwen3.6-35b-a3b-text: context_length=262144` (correctly resolved from loaded model)
