### PR TITLE
fix(compressor): keep truncated tool_call arguments as valid JSON

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -459,7 +459,18 @@ class ContextCompressor(ContextEngine):
                 if isinstance(tc, dict):
                     args = tc.get("function", {}).get("arguments", "")
                     if len(args) > 500:
-                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
+                        # `arguments` is a JSON string. Some providers
+                        # (e.g. Anthropic via LiteLLM) re-parse it when
+                        # rebuilding tool_use blocks, so byte-slicing it
+                        # produces invalid JSON and the next request fails
+                        # with HTTP 400. Replace with a compact sentinel
+                        # object that stays valid JSON.
+                        truncated_payload = json.dumps({
+                            "_truncated": True,
+                            "_original_length": len(args),
+                            "_preview": args[:200],
+                        })
+                        tc = {**tc, "function": {**tc["function"], "arguments": truncated_payload}}
                         modified = True
                 new_tcs.append(tc)
             if modified:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,5 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import json
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -781,3 +783,46 @@ class TestTokenBudgetTailProtection:
         # Tool at index 2 is outside the protected tail (last 3 = indices 2,3,4)
         # so it might or might not be pruned depending on boundary
         assert isinstance(pruned, int)
+
+    def test_pruned_tool_call_args_remain_valid_json(self, budget_compressor):
+        """Truncated tool_call `arguments` must stay parseable JSON.
+
+        Some providers (e.g. Anthropic via LiteLLM) re-parse the arguments
+        string when rebuilding tool_use blocks. If pruning leaves invalid
+        JSON in place, the next API call fails with HTTP 400 and the
+        session gets stuck — replaying the corrupted history on every turn.
+        """
+        c = budget_compressor
+        huge_args = json.dumps({
+            "mode": "replace",
+            "path": "/some/file.ts",
+            "old_string": "placeholder",
+            "new_string": "    const colMatches = sql.matchAll(/(\\w+)\\s+(text|integer)/gi);\n"
+                          + ("  // padding line to exceed 500 chars\n" * 40),
+        })
+        assert len(huge_args) > 500
+        messages = [
+            {"role": "user", "content": "start"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "patch", "arguments": huge_args},
+                }],
+            },
+            {"role": "tool", "content": "ok", "tool_call_id": "c1"},
+            {"role": "user", "content": "recent"},
+            {"role": "assistant", "content": "reply"},
+        ]
+        result, _ = c._prune_old_tool_results(messages, protect_tail_count=2)
+        pruned_msg = next(m for m in result if m.get("tool_calls"))
+        pruned_args = pruned_msg["tool_calls"][0]["function"]["arguments"]
+        # Must be valid JSON — otherwise Anthropic re-parse will explode.
+        parsed = json.loads(pruned_args)
+        assert parsed["_truncated"] is True
+        assert parsed["_original_length"] == len(huge_args)
+        assert isinstance(parsed["_preview"], str) and parsed["_preview"]
+        # Sentinel must actually be smaller than the original.
+        assert len(pruned_args) < len(huge_args)


### PR DESCRIPTION
## Summary

`agent/context_compressor.py` Pass 3 of `_prune_old_tool_results` truncates large tool_call `arguments` strings by byte-slicing to 200 chars and appending the literal sentinel `...[truncated]`. The result is invalid JSON — mid-value, unterminated string.

Some providers (notably Anthropic via LiteLLM) re-parse `function.arguments` when rebuilding `tool_use` blocks. Once a session is compressed with any tool_call whose original args exceeded 500 chars (routine for tools like `patch`), the next API call fails with:

```
HTTP 400: litellm.BadRequestError: AnthropicException -
Failed to parse tool call arguments for tool 'patch' (Anthropic tool invoke).
Error: Unterminated string starting at: line 1 column 35 (char 34).
```

All 3 retries send the same corrupted messages array so they fail identically, and every subsequent user turn replays the poisoned history. The session is permanently stuck and the user sees only a canned error fallback with no way to recover (the corruption is in server-side state).

## Reproduction

Any session that compresses while carrying a >500-char assistant tool_call will produce invalid-JSON `arguments`. On the next turn, the provider adapter (e.g. litellm's Anthropic translator) cannot re-parse the tool_call and rejects the request.

## Fix

Replace the byte slice with a compact JSON-sentinel object that preserves provenance (original length + 200-char preview) while staying parseable:

```json
{"_truncated": true, "_original_length": 1247, "_preview": "..."}
```

## Test plan

- New unit test `test_pruned_tool_call_args_remain_valid_json` asserting pruned arguments parse via `json.loads` and carry the sentinel shape
- All existing `TestTokenBudgetTailProtection` tests still pass

## Observed in production

Caught after a user's agent became unresponsive. A session had 11 prior `patch` tool_calls poisoned by this truncation after compression. Every subsequent inbound message triggered a new 3-retry failure cycle — user received 3 cryptic LiteLLM 400 error strings back-to-back.