### PR TITLE
fix: preserve dots in Bedrock model IDs (prevent invalid model identifier)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6420,11 +6420,12 @@ class AIAgent:
 
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
+        Bedrock keeps dots (e.g. eu.anthropic.claude-sonnet-4-6).
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "bedrock", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base


### PR DESCRIPTION
## Problem

When using the Bedrock provider with `anthropic_messages` API mode, all API requests fail with:

```
HTTP 400: The provided model identifier is invalid.
```

## Root Cause

`normalize_model_name()` in `anthropic_adapter.py` replaces all dots with hyphens (line 841: `model.replace(".", "-")`). This is correct for native Anthropic model IDs (e.g. `claude-opus-4.6` → `claude-opus-4-6`), but **mangles Bedrock inference profile IDs** which use dots as structural separators:

```
eu.anthropic.claude-sonnet-4-6  →  eu-anthropic-claude-sonnet-4-6  (broken!)
```

The mangled ID is then rejected by the `AnthropicBedrock` SDK.

The `preserve_dots` flag exists and is already used for other providers (Alibaba, MiniMax, ZAI), but Bedrock was missing from the set.

## Fix

Add `"bedrock"` to the `_anthropic_preserve_dots()` provider set in `run_agent.py` so the dot-to-hyphen conversion is skipped for Bedrock model IDs.

## Testing

Before fix:
```
⚠️  API call failed: BadRequestError [HTTP 400]
   🔌 Provider: bedrock  Model: eu.anthropic.claude-sonnet-4-6
   📝 Error: The provided model identifier is invalid.
```

After fix:
```
hermes chat -q "Say hi" → "Shalom!" ✅
```

Verified with both `eu.anthropic.claude-sonnet-4-6` (eu-central-1) and confirmed the `AnthropicBedrock` SDK receives the correct dotted model ID.