### PR TITLE
fix(ssh): sync named profiles to remote backends

### DIFF
--- a/tests/tools/test_file_sync_profiles.py
+++ b/tests/tools/test_file_sync_profiles.py
@@ -1,0 +1,75 @@
+"""Tests for syncing profile registry files to remote backends."""
+
+from pathlib import Path
+
+import pytest
+
+from tools.credential_files import clear_credential_files
+from tools.environments.file_sync import iter_sync_files
+
+
+@pytest.fixture(autouse=True)
+def _isolated_hermes_home(monkeypatch, tmp_path):
+    """Isolate HERMES_HOME and wrapper paths for profile sync tests."""
+    import tools.credential_files as credential_files
+
+    clear_credential_files()
+    credential_files._config_files = None
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    yield tmp_path
+
+    clear_credential_files()
+    credential_files._config_files = None
+
+
+def test_iter_sync_files_includes_profile_registry_and_wrappers(tmp_path):
+    default_home = tmp_path / ".hermes"
+    profile_dir = default_home / "profiles" / "pythonguru"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "SOUL.md").write_text("be useful", encoding="utf-8")
+    (profile_dir / "config.yaml").write_text("model: test\n", encoding="utf-8")
+    (default_home / "active_profile").write_text("pythonguru\n", encoding="utf-8")
+
+    wrapper_dir = tmp_path / ".local" / "bin"
+    wrapper_dir.mkdir(parents=True)
+    wrapper_path = wrapper_dir / "pythonguru"
+    wrapper_path.write_text('#!/bin/sh\nexec hermes -p pythonguru "$@"\n', encoding="utf-8")
+
+    files = iter_sync_files("/home/remote/.hermes")
+    remote_map = {remote: host for host, remote in files}
+
+    assert "/home/remote/.hermes/active_profile" in remote_map
+    assert remote_map["/home/remote/.hermes/active_profile"] == str(
+        default_home / "active_profile"
+    )
+    assert "/home/remote/.hermes/profiles/pythonguru/SOUL.md" in remote_map
+    assert remote_map["/home/remote/.hermes/profiles/pythonguru/SOUL.md"] == str(
+        profile_dir / "SOUL.md"
+    )
+    assert "/home/remote/.hermes/profiles/pythonguru/config.yaml" in remote_map
+    assert "/home/remote/.local/bin/pythonguru" in remote_map
+    assert remote_map["/home/remote/.local/bin/pythonguru"] == str(wrapper_path)
+
+
+def test_iter_sync_files_keeps_profile_registry_when_current_home_is_named_profile(
+    monkeypatch, tmp_path
+):
+    default_home = tmp_path / ".hermes"
+    profile_dir = default_home / "profiles" / "pythonguru"
+    skills_dir = profile_dir / "skills"
+    skills_dir.mkdir(parents=True)
+    (profile_dir / "SOUL.md").write_text("named profile", encoding="utf-8")
+    (skills_dir / "skill.md").write_text("# skill", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+    files = iter_sync_files("/srv/hermes/.hermes")
+    remote_paths = {remote for _, remote in files}
+
+    assert "/srv/hermes/.hermes/profiles/pythonguru/SOUL.md" in remote_paths
+    assert "/srv/hermes/.hermes/skills/skill.md" in remote_paths

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -43,10 +43,10 @@ GetFilesFn = Callable[[], list[tuple[str, str]]]  # () -> [(host_path, remote_pa
 def iter_sync_files(container_base: str = "/root/.hermes") -> list[tuple[str, str]]:
     """Enumerate all files that should be synced to a remote environment.
 
-    Combines credentials, skills, and cache into a single flat list of
-    (host_path, remote_path) pairs.  Credential paths are remapped from
-    the hardcoded /root/.hermes to *container_base* because the remote
-    user's home may differ (e.g. /home/daytona, /home/user).
+    Combines credentials, profile registry files, skills, and cache into a
+    single flat list of (host_path, remote_path) pairs. Credential paths are
+    remapped from the hardcoded /root/.hermes to *container_base* because the
+    remote user's home may differ (e.g. /home/daytona, /home/user).
     """
     # Late import: credential_files imports agent modules that create
     # circular dependencies if loaded at file_sync module level.
@@ -62,10 +62,65 @@ def iter_sync_files(container_base: str = "/root/.hermes") -> list[tuple[str, st
             "/root/.hermes", container_base, 1
         )
         files.append((entry["host_path"], remote))
+
+    files.extend(_iter_profile_sync_files(container_base))
+
     for entry in iter_skills_files(container_base=container_base):
         files.append((entry["host_path"], entry["container_path"]))
     for entry in iter_cache_files(container_base=container_base):
         files.append((entry["host_path"], entry["container_path"]))
+    return files
+
+
+def _iter_profile_sync_files(container_base: str) -> list[tuple[str, str]]:
+    """Enumerate named profile metadata/files that remote sandboxes need.
+
+    Remote terminal backends run Hermes under their own ``HOME``, so the
+    local profile registry must be mirrored to the remote ``.hermes`` root.
+    We sync:
+
+    - ``active_profile`` so sticky profile selection matches locally
+    - ``profiles/<name>/...`` file trees so remote ``profile list`` and
+      ``hermes -p <name>`` can resolve named profiles
+    - profile wrapper scripts under ``~/.local/bin`` when they exist locally
+    """
+    from hermes_cli.profiles import (
+        _get_active_profile_path,
+        _get_default_hermes_home,
+        _get_profiles_root,
+        _get_wrapper_dir,
+    )
+
+    files: list[tuple[str, str]] = []
+    remote_root = Path(container_base)
+    remote_home = remote_root.parent
+
+    active_profile_path = _get_active_profile_path()
+    if active_profile_path.is_file():
+        files.append(
+            (str(active_profile_path), str(remote_root / active_profile_path.name))
+        )
+
+    default_home = _get_default_hermes_home()
+    profiles_root = _get_profiles_root()
+    if profiles_root.is_dir():
+        for item in profiles_root.rglob("*"):
+            if item.is_symlink() or not item.is_file():
+                continue
+            rel = item.relative_to(default_home)
+            files.append((str(item), str(remote_root / rel)))
+
+        wrapper_dir = _get_wrapper_dir()
+        for profile_dir in profiles_root.iterdir():
+            if not profile_dir.is_dir():
+                continue
+            wrapper_path = wrapper_dir / profile_dir.name
+            if not wrapper_path.is_file() or wrapper_path.is_symlink():
+                continue
+            files.append(
+                (str(wrapper_path), str(remote_home / ".local" / "bin" / profile_dir.name))
+            )
+
     return files
 
 


### PR DESCRIPTION
## Summary
- sync the local profile registry into remote terminal backends so named profiles exist under the remote  root
- sync  and matching profile wrapper scripts so remote profile selection stays aligned with the local machine
- add focused regression tests for default and named-profile  cases

## Why
Issue #10928 reports that  only creates profiles locally when the terminal backend is SSH, so remote runtime sessions only see the default profile.

The file sync layer already mirrors credentials, skills, and cache into remote backends, but it was not mirroring , , or profile wrapper scripts.

## Testing
- ..                                                                       [100%]
2 passed in 0.04s
- ......................................                                   [100%]
38 passed in 0.56s