### PR TITLE
fix: remove misleading model.max_tokens suggestion from thinking-exhausted error

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9255,8 +9255,7 @@ class AIAgent:
                                 "and had none left for the actual response.\n\n"
                                 "To fix this:\n"
                                 "→ Lower reasoning effort: `/thinkon low` or `/thinkon minimal`\n"
-                                "→ Increase the output token limit: "
-                                "set `model.max_tokens` in config.yaml"
+                                "→ Or switch to a larger/non-reasoning model with `/model`"
                             )
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)


### PR DESCRIPTION
## Summary

The \"Thinking Budget Exhausted\" user-facing error message advised users to
\`set \`model.max_tokens\` in config.yaml\` — but that config key is intentionally
not wired through to the API call. Users followed the advice, saw no change,
and filed bugs. We just closed 12 of them.

## Why the suggestion was wrong

We omit \`max_tokens\` by default so the inference server uses its full output
budget. Researched defaults when \`max_tokens\` is omitted:

- **llama.cpp / llama-server**: \`n_predict = -1\` (infinity). Generates until
  EOS, stop sequence, or context exhaustion. Source: \`common/common.h\`, \`tools/server/README.md\`.
- **vLLM chat**: defaults to \`max_model_len - prompt_len\` (remaining context).
- **OpenAI chat**: dynamic default = remaining context.
- **OpenRouter**: uses the model's documented max output for credit
  pre-authorization — a real quirk handled per-provider in \`run_agent.py:6719\`
  (Claude path), not via user config.
- **Qwen Portal**: low default, already overridden to 65536 internally.

Wiring \`model.max_tokens\` through to every API call would regress all of these
(cap llama.cpp users currently unlimited, truncate reasoning models' thinking
blocks at whatever the user guessed in config). The per-provider surgical
workarounds are the right place for caps.

## What this PR changes

One-line edit to the \`_exhaust_response\` user-facing message at \`run_agent.py:~9258\`.

Before:
\`\`\`
→ Lower reasoning effort: \`/thinkon low\` or \`/thinkon minimal\`
→ Increase the output token limit: set \`model.max_tokens\` in config.yaml
\`\`\`

After:
\`\`\`
→ Lower reasoning effort: \`/thinkon low\` or \`/thinkon minimal\`
→ Or switch to a larger/non-reasoning model with \`/model\`
\`\`\`

Lowering reasoning effort is the canonical fix; \`/model\` is an actionable
fallback. No more pointing users at a config knob that doesn't do anything.

## Closed in this sweep

Issues: #4404, #6955, #10917
PRs: #5001, #6080, #6446, #6707, #7075, #8804, #10924, #11173, #11268

Full reasoning in the close comment on #4404.

## Test plan

- \`py_compile run_agent.py\` — passes
- Unit tests in the area aren't affected (message is a string literal)
- The \`_exhaust_error\` (internal/log) string still mentions \"max_tokens\"
  generically — that's fine since it's advice on the server-side knob, not
  a specific broken Hermes config key