### PR TITLE
fix(weixin): Batch-5 polish — SSRF allowlist, qrcode dep, session retry, macOS SSL, signature alignment

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -28,7 +28,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -535,6 +535,39 @@ async def _download_bytes(
         return await response.read()
 
 
+_WEIXIN_CDN_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "novac2c.cdn.weixin.qq.com",
+        "ilinkai.weixin.qq.com",
+        "wx.qlogo.cn",
+        "thirdwx.qlogo.cn",
+        "res.wx.qq.com",
+        "mmbiz.qpic.cn",
+        "mmbiz.qlogo.cn",
+    }
+)
+
+
+def _assert_weixin_cdn_url(url: str) -> None:
+    """Raise ValueError if *url* does not point at a known WeChat CDN host."""
+    try:
+        parsed = urlparse(url)
+        scheme = parsed.scheme.lower()
+        host = parsed.hostname or ""
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError(f"Unparseable media URL: {url!r}") from exc
+
+    if scheme not in ("http", "https"):
+        raise ValueError(
+            f"Media URL has disallowed scheme {scheme!r}; only http/https are permitted."
+        )
+    if host not in _WEIXIN_CDN_ALLOWLIST:
+        raise ValueError(
+            f"Media URL host {host!r} is not in the WeChat CDN allowlist. "
+            "Refusing to fetch to prevent SSRF."
+        )
+
+
 def _media_reference(item: Dict[str, Any], key: str) -> Dict[str, Any]:
     return (item.get(key) or {}).get("media") or {}
 
@@ -555,6 +588,7 @@ async def _download_and_decrypt_media(
             timeout_seconds=timeout_seconds,
         )
     elif full_url:
+        _assert_weixin_cdn_url(full_url)
         raw = await _download_bytes(session, url=full_url, timeout_seconds=timeout_seconds)
     else:
         raise RuntimeError("media item had neither encrypt_query_param nor full_url")

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -98,6 +98,26 @@ MEDIA_VOICE = 4
 
 _LIVE_ADAPTERS: Dict[str, Any] = {}
 
+
+def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
+    """Return a TCPConnector with a certifi CA bundle, or None if certifi is unavailable.
+
+    Tencent's iLink server (``ilinkai.weixin.qq.com``) is not verifiable against
+    some system CA stores (notably Homebrew's OpenSSL on macOS Apple Silicon).
+    When ``certifi`` is installed, use its Mozilla CA bundle to guarantee
+    verification. Otherwise fall back to aiohttp's default (which honors
+    ``SSL_CERT_FILE`` env var via ``trust_env=True``).
+    """
+    try:
+        import ssl
+        import certifi
+    except ImportError:
+        return None
+    if not AIOHTTP_AVAILABLE:
+        return None
+    ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    return aiohttp.TCPConnector(ssl=ssl_ctx)
+
 ITEM_TEXT = 1
 ITEM_IMAGE = 2
 ITEM_VOICE = 3
@@ -969,7 +989,7 @@ async def qr_login(
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError("aiohttp is required for Weixin QR login")
 
-    async with aiohttp.ClientSession(trust_env=True) as session:
+    async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         try:
             qr_resp = await _api_get(
                 session,
@@ -987,6 +1007,10 @@ async def qr_login(
             logger.error("weixin: QR response missing qrcode")
             return None
 
+        # qrcode_url is the full scannable liteapp URL; qrcode_value is just the hex token
+        # WeChat needs to scan the full URL, not the raw hex string
+        qr_scan_data = qrcode_url if qrcode_url else qrcode_value
+
         print("\n请使用微信扫描以下二维码：")
         if qrcode_url:
             print(qrcode_url)
@@ -994,11 +1018,11 @@ async def qr_login(
             import qrcode
 
             qr = qrcode.QRCode()
-            qr.add_data(qrcode_url or qrcode_value)
+            qr.add_data(qr_scan_data)
             qr.make(fit=True)
             qr.print_ascii(invert=True)
-        except Exception:
-            print("（终端二维码渲染失败，请直接打开上面的二维码链接）")
+        except Exception as _qr_exc:
+            print(f"（终端二维码渲染失败: {_qr_exc}，请直接打开上面的二维码链接）")
 
         deadline = time.time() + timeout_seconds
         current_base_url = ILINK_BASE_URL
@@ -1044,8 +1068,17 @@ async def qr_login(
                     )
                     qrcode_value = str(qr_resp.get("qrcode") or "")
                     qrcode_url = str(qr_resp.get("qrcode_img_content") or "")
+                    qr_scan_data = qrcode_url if qrcode_url else qrcode_value
                     if qrcode_url:
                         print(qrcode_url)
+                    try:
+                        import qrcode as _qrcode
+                        qr = _qrcode.QRCode()
+                        qr.add_data(qr_scan_data)
+                        qr.make(fit=True)
+                        qr.print_ascii(invert=True)
+                    except Exception:
+                        pass
                 except Exception as exc:
                     logger.error("weixin: QR refresh failed: %s", exc)
                     return None
@@ -1169,8 +1202,8 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
-        self._poll_session = aiohttp.ClientSession(trust_env=True)
-        self._send_session = aiohttp.ClientSession(trust_env=True)
+        self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
+        self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
@@ -1964,7 +1997,7 @@ async def send_weixin_direct(
             "context_token_used": bool(context_token),
         }
 
-    async with aiohttp.ClientSession(trust_env=True) as session:
+    async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(
                 enabled=True,

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1685,23 +1685,34 @@ class WeixinAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: str = "",
+        caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> SendResult:
-        return await self.send_document(chat_id, file_path=image_path, caption=caption, metadata=metadata)
+        del reply_to, kwargs
+        return await self.send_document(
+            chat_id=chat_id,
+            file_path=image_path,
+            caption=caption,
+            metadata=metadata,
+        )
 
     async def send_document(
         self,
         chat_id: str,
         file_path: str,
-        caption: str = "",
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> SendResult:
+        del file_name, reply_to, metadata, kwargs
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
-            message_id = await self._send_file(chat_id, file_path, caption)
+            message_id = await self._send_file(chat_id, file_path, caption or "")
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_document failed to=%s: %s", self.name, _safe_id(chat_id), exc)
@@ -1811,7 +1822,6 @@ class WeixinAdapter(BasePlatformAdapter):
             ciphertext=ciphertext,
             upload_url=upload_url,
         )
-
         context_token = self._token_store.get(self._account_id, chat_id)
         # The iLink API expects aes_key as base64(hex_string), not base64(raw_bytes).
         # Sending base64(raw_bytes) causes images to show as grey boxes on the

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -400,7 +400,12 @@ async def _send_message(
     text: str,
     context_token: Optional[str],
     client_id: str,
-) -> None:
+) -> Dict[str, Any]:
+    """Send a text message via iLink sendmessage API.
+
+    Returns the raw API response dict (may contain error codes like
+    ``errcode: -14`` for session expiry that the caller can inspect).
+    """
     if not text or not text.strip():
         raise ValueError("_send_message: text must not be empty")
     message: Dict[str, Any] = {
@@ -413,7 +418,7 @@ async def _send_message(
     }
     if context_token:
         message["context_token"] = context_token
-    await _api_post(
+    return await _api_post(
         session,
         base_url=base_url,
         endpoint=EP_SEND_MESSAGE,
@@ -1452,11 +1457,18 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token: Optional[str],
         client_id: str,
     ) -> None:
-        """Send a single text chunk with per-chunk retry and backoff."""
+        """Send a single text chunk with per-chunk retry and backoff.
+
+        On session-expired errors (errcode -14), automatically retries
+        *without* ``context_token`` — iLink accepts tokenless sends as a
+        degraded fallback, which keeps cron-initiated push messages working
+        even when no user message has refreshed the session recently.
+        """
         last_error: Optional[Exception] = None
+        retried_without_token = False
         for attempt in range(self._send_chunk_retries + 1):
             try:
-                await _send_message(
+                resp = await _send_message(
                     self._send_session,
                     base_url=self._base_url,
                     token=self._token,
@@ -1465,6 +1477,31 @@ class WeixinAdapter(BasePlatformAdapter):
                     context_token=context_token,
                     client_id=client_id,
                 )
+                # Check iLink response for session-expired error
+                if resp and isinstance(resp, dict):
+                    ret = resp.get("ret")
+                    errcode = resp.get("errcode")
+                    if (ret is not None and ret not in (0,)) or (errcode is not None and errcode not in (0,)):
+                        is_session_expired = (
+                            ret == SESSION_EXPIRED_ERRCODE
+                            or errcode == SESSION_EXPIRED_ERRCODE
+                        )
+                        # Session expired — strip token and retry once
+                        if is_session_expired and not retried_without_token and context_token:
+                            retried_without_token = True
+                            context_token = None
+                            self._token_store._cache.pop(
+                                self._token_store._key(self._account_id, chat_id), None
+                            )
+                            logger.warning(
+                                "[%s] session expired for %s; retrying without context_token",
+                                self.name, _safe_id(chat_id),
+                            )
+                            continue
+                        errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
+                        raise RuntimeError(
+                            f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
+                        )
                 return
             except Exception as exc:
                 last_error = exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
-messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
+messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -249,6 +249,10 @@ AUTHOR_MAP = {
     "bernylinville@devopsthink.org": "bernylinville",
     "brian@bde.io": "briandevans",
     "hubin_ll@qq.com": "LLQWQ",
+    "memosr_email@gmail.com": "memosr",
+    "anthhub@163.com": "anthhub",
+    "shenuu@gmail.com": "shenuu",
+    "xiayh17@gmail.com": "xiayh0107",
 }
 
 

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1,6 +1,7 @@
 """Tests for the Weixin platform adapter."""
 
 import asyncio
+import base64
 import json
 import os
 from pathlib import Path
@@ -8,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
+from gateway.platforms.base import SendResult
 from gateway.platforms import weixin
 from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
@@ -357,6 +359,115 @@ class TestWeixinChunkDelivery:
         assert first_try["client_id"] == retry["client_id"]
 
 
+class TestWeixinOutboundMedia:
+    def test_send_image_file_accepts_keyword_image_path(self):
+        adapter = _make_adapter()
+        expected = SendResult(success=True, message_id="msg-1")
+        adapter.send_document = AsyncMock(return_value=expected)
+
+        result = asyncio.run(
+            adapter.send_image_file(
+                chat_id="wxid_test123",
+                image_path="/tmp/demo.png",
+                caption="截图说明",
+                reply_to="reply-1",
+                metadata={"thread_id": "t-1"},
+            )
+        )
+
+        assert result == expected
+        adapter.send_document.assert_awaited_once_with(
+            chat_id="wxid_test123",
+            file_path="/tmp/demo.png",
+            caption="截图说明",
+            metadata={"thread_id": "t-1"},
+        )
+
+    def test_send_document_accepts_keyword_file_path(self):
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._send_session = adapter._session
+        adapter._token = "test-token"
+        adapter._send_file = AsyncMock(return_value="msg-2")
+
+        result = asyncio.run(
+            adapter.send_document(
+                chat_id="wxid_test123",
+                file_path="/tmp/report.pdf",
+                caption="报告请看",
+                file_name="renamed.pdf",
+                reply_to="reply-1",
+                metadata={"thread_id": "t-1"},
+            )
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-2"
+        adapter._send_file.assert_awaited_once_with("wxid_test123", "/tmp/report.pdf", "报告请看")
+
+    def test_send_file_uses_post_for_upload_full_url_and_hex_encoded_aes_key(self, tmp_path):
+        class _UploadResponse:
+            def __init__(self):
+                self.status = 200
+                self.headers = {"x-encrypted-param": "enc-param"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                return b""
+
+            async def text(self):
+                return ""
+
+        class _RecordingSession:
+            def __init__(self):
+                self.post_calls = []
+
+            def post(self, url, **kwargs):
+                self.post_calls.append((url, kwargs))
+                return _UploadResponse()
+
+            def put(self, *_args, **_kwargs):
+                raise AssertionError("upload_full_url branch should use POST")
+
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        adapter = _make_adapter()
+        session = _RecordingSession()
+        adapter._session = session
+        adapter._send_session = session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._cdn_base_url = "https://cdn.example.com/c2c"
+        adapter._token_store.get = lambda account_id, chat_id: None
+
+        aes_key = bytes(range(16))
+        expected_aes_key = base64.b64encode(aes_key.hex().encode("ascii")).decode("ascii")
+
+        with patch("gateway.platforms.weixin._get_upload_url", new=AsyncMock(return_value={"upload_full_url": "https://upload.example.com/media"})), \
+             patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock) as api_post_mock, \
+             patch("gateway.platforms.weixin.secrets.token_hex", return_value="filekey-123"), \
+             patch("gateway.platforms.weixin.secrets.token_bytes", return_value=aes_key):
+            message_id = asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
+
+        assert message_id.startswith("hermes-weixin-")
+        assert len(session.post_calls) == 1
+        upload_url, upload_kwargs = session.post_calls[0]
+        assert upload_url == "https://upload.example.com/media"
+        assert upload_kwargs["headers"] == {"Content-Type": "application/octet-stream"}
+        assert upload_kwargs["data"]
+        assert upload_kwargs["timeout"].total == 120
+        payload = api_post_mock.await_args.kwargs["payload"]
+        media = payload["msg"]["item_list"][0]["image_item"]["media"]
+        assert media["encrypt_query_param"] == "enc-param"
+        assert media["aes_key"] == expected_aes_key
+
+
 class TestWeixinRemoteMediaSafety:
     def test_download_remote_media_blocks_unsafe_urls(self):
         adapter = _make_adapter()
@@ -544,7 +655,7 @@ class TestWeixinSendImageFileParameterName:
 
         assert result.success is True
         send_document_mock.assert_awaited_once_with(
-            "wxid_test123",
+            chat_id="wxid_test123",
             file_path="/tmp/test_image.png",
             caption="Test caption",
             metadata={"thread_id": "thread-123"},
@@ -569,9 +680,9 @@ class TestWeixinSendImageFileParameterName:
 
         assert result.success is True
         send_document_mock.assert_awaited_once_with(
-            "wxid_test123",
+            chat_id="wxid_test123",
             file_path="/tmp/test_image.jpg",
-            caption="",
+            caption=None,
             metadata=None,
         )
 

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -27,3 +27,10 @@ def test_matrix_extra_linux_only_in_all():
         if "matrix" in dep and "linux" in dep
     ]
     assert linux_gated, "expected hermes-agent[matrix] with sys_platform=='linux' marker in [all]"
+
+
+def test_messaging_extra_includes_qrcode_for_weixin_setup():
+    optional_dependencies = _load_optional_dependencies()
+
+    messaging_extra = optional_dependencies["messaging"]
+    assert any(dep.startswith("qrcode") for dep in messaging_extra)

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -16,14 +16,14 @@ This adapter is for **personal WeChat accounts** (微信). If you need enterpris
 
 - A personal WeChat account
 - Python packages: `aiohttp` and `cryptography`
-- The `qrcode` package is optional (for terminal QR rendering during setup)
+- Terminal QR rendering is included when Hermes is installed with the `messaging` extra
 
 Install the required dependencies:
 
 ```bash
 pip install aiohttp cryptography
 # Optional: for terminal QR code display
-pip install qrcode
+pip install hermes-agent[messaging]
 ```
 
 ## Setup
@@ -296,4 +296,4 @@ Only one Weixin gateway instance can use a given token at a time. The adapter ac
 | Voice messages show as text | If WeChat provides a transcription, the adapter uses the text. This is expected behavior |
 | Messages appear duplicated | The adapter deduplicates by message ID. If you see duplicates, check if multiple gateway instances are running |
 | `iLink POST ... HTTP 4xx/5xx` | API error from the iLink service. Check your token validity and network connectivity |
-| Terminal QR code doesn't render | Install `qrcode`: `pip install qrcode`. Alternatively, open the URL printed above the QR |
+| Terminal QR code doesn't render | Reinstall with the messaging extra: `pip install hermes-agent[messaging]`. Alternatively, open the URL printed above the QR |


### PR DESCRIPTION
## Summary
Batch-5 Weixin polish — five contributor PRs salvaged together. Security, packaging, resilience, and platform-compat fixes.

## Included contributor work

◆ **#9222** @memosr — `fix(security): validate WeChat media URLs against CDN allowlist to prevent SSRF`
  Commit `95e15e10`. Adds `_WEIXIN_CDN_ALLOWLIST` frozenset (7 known WeChat CDN hosts) and `_assert_weixin_cdn_url()` validation before any media download via `full_url`. Complements the existing `is_safe_url()` check on `_download_remote_media` — defense in depth. Rejects `file://`, non-WeChat hosts, and unparseable URLs.

◆ **#9504** @anthhub — `fix(packaging): include qrcode in messaging extra`
  Commit `877674e3`. Adds `qrcode>=7.0,<8` to `project.optional-dependencies.messaging` so `hermes-agent[messaging]` can render terminal QR codes for Weixin setup without a follow-up `pip install qrcode`. Adds metadata regression test. Updates weixin docs. Closes #9431.

◆ **#9928** @jinzheng8115 — `fix(weixin): retry send without context_token on iLink session expiry`
  Commit `942086d8`. When `_send_text_chunk` detects an iLink `errcode: -14` (session expired), strips the stale `context_token`, clears it from `ContextTokenStore`, and retries once. Fixes silent drop of cron-initiated pushes (weather reports, digests, etc.) after overnight idle. Also makes `_send_message` return the API response dict so callers can inspect errcode.

◆ **#8730** @shenuu — `fix(weixin): macOS SSL cert, QR data, and refresh rendering`
  Commit `c1b0efbb`. Three fixes:
  1. Use `certifi` CA bundle for SSL verification — Homebrew Python on macOS Apple Silicon can't verify `ilinkai.weixin.qq.com` against the default cert store. Refactored into `_make_ssl_connector()` helper with graceful fallback when certifi is unavailable.
  2. Prefer `qrcode_img_content` (liteapp URL) over `qrcode` (hex token) when encoding the QR ASCII — only the URL is scannable by WeChat.
  3. Re-render QR ASCII on the refresh path, not just print the URL.

◆ **#10342** @xiayh0107 — `Fix Weixin media uploads and refresh lockfile`
  Commit `d8ab47f9`. Aligns `send_document()` signature with `BasePlatformAdapter` — adds `file_name`, `reply_to` params and `**kwargs` for forward-compat. Tightens `send_image_file()` body to use keyword args. Adds regression tests covering keyword-arg acceptance and the `upload_full_url` POST behavior with hex-encoded AES key.

  **Note**: Much of #10342's original scope (the `send_image_file` parameter rename, MEDIA extraction, voice fallback, markdown preservation) was already landed via Batches 1/3. What survived here is the `send_document` base-class alignment + the upload_full_url test, which weren't covered elsewhere.

## Conflict resolutions

Five resolution points (all mechanical, all verified):

1. **`_send_text_chunk()` in weixin.py** — #9928's `resp = await _send_message(self._session, ...)` vs current `await _send_message(self._send_session, ...)`. Kept PR's return capture + HEAD's Batch-4 session name: `resp = await _send_message(self._send_session, ...)`.

2. **SSL connector in `qr_login()` / `connect()` / `send_weixin_direct()`** — #8730's `aiohttp.ClientSession(connector=certifi_ctx)` vs HEAD's `aiohttp.ClientSession(trust_env=True)` (would have silently regressed proxy env var handling). Refactored into a module-level `_make_ssl_connector()` helper used at all 4 ClientSession creation sites with `trust_env=True` preserved:
   ```python
   aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
   ```
   Helper gracefully returns `None` if certifi is unavailable (aiohttp then uses default ctx, still honors `SSL_CERT_FILE` via `trust_env`).

3. **`send_image_file()` body** — #10342 rewrote with keyword args + `del reply_to, kwargs`. Accepted PR's more thorough version.

4. **`send_document()` body** — #10342's `self._session` check vs HEAD's `self._send_session`. Kept HEAD's Batch-4 split + added PR's `del file_name, reply_to, metadata, kwargs`.

5. **Test fixture alignment** — Batch-1's `TestWeixinSendImageFileParameterName` asserted the OLD positional call signature; #10342 changed `send_image_file` to call `send_document(chat_id=chat_id, ...)` with keyword args and caption=None default. Updated tests to match (chat_id as keyword, caption=None when not passed). #10342's `TestWeixinOutboundMedia` mocked only `_session` but code uses `_send_session` after Batch-4 — added `_send_session = session` companion.

## Verification

- **Full targeted suite: 435 passed** across test_weixin + test_qqbot + test_unauthorized_dm_behavior + test_platform_base + test_send_image_file + test_send_retry + cron/test_scheduler + test_send_message_tool + test_url_safety + test_project_metadata.
- Integration sanity (runtime, real imports):
  - `_WEIXIN_CDN_ALLOWLIST` present, contains 7 WeChat CDN hosts
  - `_assert_weixin_cdn_url()` blocks `evil.com`, blocks `file://` scheme, passes legitimate `novac2c.cdn.weixin.qq.com`
  - `_make_ssl_connector()` returns a TCPConnector in async context (graceful None fallback sync-calls tested separately — the helper is only called from async contexts in production)
  - `SESSION_EXPIRED_ERRCODE = -14` present
  - `_send_message` return annotation updated to `Dict[str, Any]`
  - `send_document` signature now matches base class: chat_id, file_path, caption, file_name, reply_to, metadata, **kwargs
- py_compile OK on all changed files.

## AUTHOR_MAP additions
- `memosr_email@gmail.com → memosr`
- `anthhub@163.com → anthhub`
- `shenuu@gmail.com → shenuu`
- `xiayh17@gmail.com → xiayh0107`
- jinzheng8115 auto-resolves via noreply pattern

## On merge
Will rebase-merge to preserve per-commit authorship across 5 contributors, then close #9222, #9504, #9928, #8730, #10342 with credit pointing here.

This closes out the Weixin/QQBot PR queue after Batches 1-5.
