### PR TITLE
fix(anthropic-adapter): cap qwen3.6-plus output at 65K for DashScope anthropic endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -88,6 +88,8 @@ _ANTHROPIC_OUTPUT_LIMITS = {
     "claude-3-haiku":      4_096,
     # Third-party Anthropic-compatible providers
     "minimax":            131_072,
+    # Alibaba DashScope via /apps/anthropic — output capped at 65K
+    "qwen3-6-plus":        65_536,
 }
 
 # For any model not in the table, assume the highest current limit.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1169,6 +1169,11 @@ class TestGetAnthropicMaxOutput:
         # claude-3-5-sonnet (8192) should win over a hypothetical shorter match
         assert _get_anthropic_max_output("claude-3-5-sonnet-20241022") == 8_192
 
+    def test_qwen3_6_plus_dashscope(self):
+        """qwen3.6-plus via Alibaba DashScope /apps/anthropic is capped at 65K output."""
+        from agent.anthropic_adapter import _get_anthropic_max_output
+        assert _get_anthropic_max_output("qwen3.6-plus") == 65_536
+
 
 # ---------------------------------------------------------------------------
 # _to_plain_data hardening


### PR DESCRIPTION
## Summary

Adds `qwen3.6-plus` to `_ANTHROPIC_OUTPUT_LIMITS` in `agent/anthropic_adapter.py` with a 65,536 output token cap, matching the limit Alibaba DashScope enforces on its `/apps/anthropic` endpoint.

Without this entry, Hermes sends requests with output budgets higher than the provider allows, which the API rejects.

## Evidence

Per [Alibaba Cloud — OpenCode Coding Plan](https://www.alibabacloud.com/help/en/model-studio/opencode-coding-plan) docs, the following sibling models on the same `https://coding-intl.dashscope.aliyuncs.com/apps/anthropic/v1` endpoint are all capped at 65,536 output tokens:

- `qwen3.5-plus`: 65,536
- `qwen3-coder-plus`: 65,536
- `qwen3-coder-next`: 65,536

`qwen3.6-plus` is newer and not yet listed in the published docs, but empirically exhibits the same 65K cap on this endpoint.

## Test plan

- [x] Added `test_qwen3_6_plus_dashscope` to `tests/agent/test_anthropic_adapter.py::TestGetAnthropicMaxOutput`
- [x] Test passes locally:
  ```
  $ ./venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py::TestGetAnthropicMaxOutput::test_qwen3_6_plus_dashscope -v
  ============================== 1 passed in 1.26s ===============================
  ```
- [x] Verified in production: running qwen3.6-plus through the DashScope anthropic endpoint for several weeks with the capped value; without the cap, requests were being rejected by the provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)