### PR TITLE
fix: use web.AppKey for api_server adapter to avoid NotAppKeyWarning

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -49,6 +49,12 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+# Typed AppKey for aiohttp application state (avoids NotAppKeyWarning)
+if AIOHTTP_AVAILABLE:
+    _APP_KEY_ADAPTER = web.AppKey("api_server_adapter", Any)
+else:
+    _APP_KEY_ADAPTER = "api_server_adapter"  # type: ignore[misc]
+
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
@@ -243,7 +249,7 @@ if AIOHTTP_AVAILABLE:
     @web.middleware
     async def cors_middleware(request, handler):
         """Add CORS headers for explicitly allowed origins; handle OPTIONS preflight."""
-        adapter = request.app.get("api_server_adapter")
+        adapter = request.app.get(_APP_KEY_ADAPTER)
         origin = request.headers.get("Origin", "")
         cors_headers = None
         if adapter is not None:
@@ -2312,7 +2318,7 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws)
-            self._app["api_server_adapter"] = self
+            self._app[_APP_KEY_ADAPTER] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -216,9 +216,10 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
+    from gateway.platforms.api_server import _APP_KEY_ADAPTER
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
     app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app[_APP_KEY_ADAPTER] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -48,8 +48,9 @@ def _make_adapter(api_key: str = "") -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app with jobs routes registered."""
+    from gateway.platforms.api_server import _APP_KEY_ADAPTER
     app = web.Application(middlewares=[cors_middleware])
-    app["api_server_adapter"] = adapter
+    app[_APP_KEY_ADAPTER] = adapter
     # Register only job routes (plus health for sanity)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/api/jobs", adapter._handle_list_jobs)


### PR DESCRIPTION
## Summary
Fixes the NotAppKeyWarning emitted by aiohttp when using plain string keys for application state in the API server adapter.

## Root Cause
aiohttp deprecated the use of plain string keys for application state and recommends using  instances instead. The warning fires during normal startup and tests.

## Fix
- Introduce a module-level  as a typed  (when aiohttp is available)
- Update all read/write paths to use this typed key instead of the plain string 
- Update test helpers that set the adapter on the app

## Test Plan
- [x] bringing up nodes...
bringing up nodes...

........................................................................ [ 63%]
..........................................                               [100%]
=============================== warnings summary ===============================
tests/gateway/test_api_server.py::TestAdapterInit::test_default_config
tests/gateway/test_api_server.py::TestResponseStore::test_get_missing_returns_none
tests/gateway/test_api_server.py::TestCheckRequirements::test_returns_true_when_aiohttp_available
tests/gateway/test_api_server.py::TestAuth::test_missing_auth_header_returns_401
tests/gateway/test_api_server.py::TestResponseStore::test_update_existing_key
tests/gateway/test_api_server.py::TestAuth::test_no_key_configured_allows_all
  /Volumes/PS3000/GitHub/hermes-agent/tests/conftest.py:296: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop_policy().get_event_loop()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
114 passed, 6 warnings in 3.33s passes (114 tests)
- [x] bringing up nodes...
bringing up nodes...

...................................                                      [100%]
35 passed in 1.17s passes (35 tests)
- [x] No NotAppKeyWarning emitted during test runs

Closes NousResearch/hermes-agent#11635