### PR TITLE
gateway: handle /start as welcome + command list + home-channel status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3157,6 +3157,9 @@ class GatewayRunner:
         if canonical == "undo":
             return await self._handle_undo_command(event)
         
+        if canonical == "start":
+            return await self._handle_start_command(event)
+
         if canonical == "sethome":
             return await self._handle_set_home_command(event)
 
@@ -5219,6 +5222,67 @@ class GatewayRunner:
         preview = removed_msg[:40] + "..." if len(removed_msg) > 40 else removed_msg
         return f"↩️ Undid {removed_count} message(s).\nRemoved: \"{preview}\""
     
+    async def _handle_start_command(self, event: MessageEvent) -> str:
+        """Handle /start command.
+
+        MD10 deploy fix: Telegram mandates /start as the first message
+        from a new user. Previously this fell through to the
+        "unknown command" notice, which broke the first-contact UX.
+        This handler returns a welcome message, lists the available
+        slash commands, and reports whether a home channel is set.
+        Idempotent and safe to call any time.
+        """
+        source = event.source
+        platform_name = source.platform.value if source.platform else "unknown"
+        env_key = f"{platform_name.upper()}_HOME_CHANNEL"
+
+        # Read home channel from config.yaml (same source /sethome writes to).
+        current_home = None
+        try:
+            import yaml
+            config_path = _hermes_home / "config.yaml"
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+                current_home = user_config.get(env_key)
+        except Exception:
+            current_home = None
+        # Also check the running process environment (if /sethome ran this
+        # session but the file read failed for some reason).
+        if not current_home:
+            current_home = os.environ.get(env_key)
+
+        chat_id = str(source.chat_id) if source.chat_id is not None else None
+
+        lines: list[str] = [
+            "👋 **Hermes Quant — autonomous crypto research**",
+            "",
+            "**Available commands:**",
+            "• `/sethome` — set the current chat as the home channel for cron digests + checkpoint pings.",
+            "• `/status` — show session info + active-hypothesis count.",
+            "• `/help` — list every slash command with descriptions.",
+        ]
+
+        if not current_home:
+            lines.append("")
+            lines.append(
+                "⚠ No home channel set yet. Send `/sethome` in your "
+                "preferred channel to start receiving digests.")
+        elif chat_id and str(current_home) != chat_id:
+            lines.append("")
+            lines.append(
+                f"✅ Bot is active. Home channel is already set "
+                f"(ID `{current_home}`). Cron digests and pings are "
+                f"delivered there. `/sethome` here would reassign it "
+                f"to this chat.")
+        else:
+            lines.append("")
+            lines.append(
+                f"✅ Bot is active. This chat **is** the home channel "
+                f"(ID `{current_home}`).")
+
+        return "\n".join(lines)
+
     async def _handle_set_home_command(self, event: MessageEvent) -> str:
         """Handle /sethome command -- set the current chat as the platform's home channel."""
         source = event.source

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -93,6 +93,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
+    CommandDef("start", "Welcome + available commands + home-channel status", "Session",
+               gateway_only=True),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
 


### PR DESCRIPTION
## What

Register `/start` as a slash command and add a handler. Without this, `/start` falls through to the generic `"unknown command"` notice, which breaks standard Telegram bot first-contact UX (every bot must respond to `/start`).

## Why

Every Telegram bot receives `/start` as the mandatory first message from a new user. hermes-agent already recognizes `/sethome`, `/status`, `/help`, etc. but not `/start` — so first-contact responses feel broken and users are unclear whether the bot is alive. Discovered during a production Hermes-Quant deploy.

## Changes

- `hermes_cli/commands.py`: add one `CommandDef("start", …, "Session", gateway_only=True)` entry to `COMMAND_REGISTRY` so `/start` is recognized everywhere the registry feeds (`GATEWAY_KNOWN_COMMANDS`, help text, Telegram `BotCommands` menu, Slack subcommand mapping, etc.).
- `gateway/run.py`:
  - Dispatch: `if canonical == "start": return await self._handle_start_command(event)` next to the `/sethome` dispatch.
  - New async method `_handle_start_command(self, event: MessageEvent) -> str` that:
    1. Returns a markdown welcome listing `/sethome`, `/status`, `/help`.
    2. Reads the current home channel from `~/.hermes/config.yaml` (same key `/sethome` writes to: `{PLATFORM}_HOME_CHANNEL`); falls back to the process environment.
    3. If no home is set → prompts the user to run `/sethome`.
    4. If a home is set but the user is in a different chat → acknowledges the bot is active and points to the existing home.
    5. If the user is in the home channel → confirms that.

Idempotent; safe to invoke any time.

## Tests

Direct-call smoke covered all three code paths of the handler.

Live Telegram round-trip on a production gateway verified all five scenarios:
- `/start` from the home channel → correct "this chat is home" response.
- `/start` from a different chat → correct "home is already set elsewhere" response.
- `/start` with no home set → correct "run /sethome to receive digests" prompt.
- `/help` still works (unchanged upstream handler).
- `/status` still works (unchanged upstream handler).
- `/sethome` in a different chat correctly reassigns + reverts cleanly.

Import smoke:
- `from hermes_cli.commands import COMMAND_REGISTRY, GATEWAY_KNOWN_COMMANDS; 'start' in GATEWAY_KNOWN_COMMANDS` → `True`
- `import gateway.run` compiles clean (Python 3.11)

## Downstream status

Our production deploy will run on canonical upstream and accept the "unknown command" reply for `/start` until this merges. Documented as a known issue pointing at this PR.

Made with [Cursor](https://cursor.com)