### PR TITLE
fix(telegram): auto-detect HTML content in send() to prevent MarkdownV2 mangling

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -859,12 +859,22 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=None)
         
         try:
-            # Format and split message if needed
-            formatted = self.format_message(content)
+            # Auto-detect HTML content and choose the appropriate parse mode.
+            # Tools such as v2ex-hot emit pre-formatted HTML; forcing MarkdownV2
+            # on that content mangles tags and causes Telegram API rejections.
+            _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', content))
+
+            if _has_html:
+                formatted = content
+                send_parse_mode = ParseMode.HTML
+            else:
+                formatted = self.format_message(content)
+                send_parse_mode = ParseMode.MARKDOWN_V2
+
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
-            if len(chunks) > 1:
+            if len(chunks) > 1 and send_parse_mode == ParseMode.MARKDOWN_V2:
                 # truncate_message appends a raw " (1/2)" suffix. Escape the
                 # MarkdownV2-special parentheses so Telegram doesn't reject the
                 # chunk and fall back to plain text.
@@ -872,7 +882,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     re.sub(r" \((\d+)/(\d+)\)$", r" \\(\1/\2\\)", chunk)
                     for chunk in chunks
                 ]
-            
+
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
             
@@ -904,16 +914,16 @@ class TelegramAdapter(BasePlatformAdapter):
                             msg = await self._bot.send_message(
                                 chat_id=int(chat_id),
                                 text=chunk,
-                                parse_mode=ParseMode.MARKDOWN_V2,
+                                parse_mode=send_parse_mode,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
-                            # Markdown parsing failed, try plain text
-                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
-                                plain_chunk = _strip_mdv2(chunk)
+                            # Parse mode failed, fall back to plain text
+                            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
+                                logger.warning("[%s] %s parse failed, falling back to plain text: %s", self.name, send_parse_mode, md_error)
+                                plain_chunk = chunk if _has_html else _strip_mdv2(chunk)
                                 msg = await self._bot.send_message(
                                     chat_id=int(chat_id),
                                     text=plain_chunk,


### PR DESCRIPTION
## Problem

The Telegram adapter in `send()` unconditionally pipes all outgoing content through `format_message()` (MarkdownV2 escaping) and sends it with `ParseMode.MARKDOWN_V2`. When a tool — such as **v2ex-hot** — emits pre-formatted **HTML** (e.g. `<b>`, `<a href="…">`, `<i>` tags), the MarkdownV2 formatter escapes angle brackets and special characters, breaking every tag. Telegram then either:

- Rejects the message with a **parse error**, or  
- Falls back to plain text, stripping all formatting.

## Solution

Auto-detect HTML tags in the outgoing content *before* choosing a formatting path:

| Content type | Formatting | Parse mode | Chunk escaping |
|---|---|---|---|
| Contains HTML tags | Passed through as-is | `ParseMode.HTML` | Parenthesis escaping skipped |
| Plain / Markdown | `format_message()` (existing pipeline) | `ParseMode.MARKDOWN_V2` | Parenthesis escaping applied |

Detection uses a lightweight regex (`<[a-zA-Z/][^>]*>`) that matches opening and closing HTML tags.

### Changes to `gateway/platforms/telegram.py`

1. **HTML detection gate** — A `_has_html` flag and `send_parse_mode` variable are set once per `send()` call, before any formatting or chunking.

2. **Conditional formatting** — HTML content skips `format_message()` entirely; Markdown content follows the existing pipeline unchanged.

3. **Conditional chunk escaping** — The MarkdownV2-specific parenthesis escaping for multi-part messages (`(1/2)` → `\(1/2\)`) is guarded behind `send_parse_mode == ParseMode.MARKDOWN_V2` so it does not corrupt HTML chunks.

4. **Dynamic parse mode in `send_message()`** — The hardcoded `ParseMode.MARKDOWN_V2` is replaced with `send_parse_mode`.

5. **Updated error fallback** — The exception handler now:
   - Catches `"html"` in error messages (in addition to `"parse"` and `"markdown"`)
   - Logs the actual parse mode that failed
   - Skips `_strip_mdv2()` for HTML content (which was never MarkdownV2-escaped)

## Test plan

- [x] Verify plain Markdown messages still render with MarkdownV2 formatting
- [x] Verify HTML messages (e.g. `<b>bold</b>`, `<a href="…">link</a>`) render correctly with HTML formatting
- [x] Verify mixed plain-text messages without HTML tags are unaffected
- [x] Verify multi-chunk HTML messages do not get parenthesis-escaped
- [x] Verify parse-error fallback works for both HTML and MarkdownV2 failures