### PR TITLE
fix(gateway): reset archived discord thread sessions

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -643,6 +643,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._handle_message(message)
 
             @self._client.event
+            async def on_thread_update(before, after):
+                if not getattr(after, "archived", False):
+                    return
+                await adapter_self._reset_archived_thread_sessions(after)
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -2109,6 +2115,41 @@ class DiscordAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
         )
         await self.handle_message(event)
+
+    async def _reset_archived_thread_sessions(self, thread: Any) -> int:
+        """Reset any stored sessions that belong to an archived Discord thread."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return 0
+
+        thread_id = str(getattr(thread, "id", "") or "").strip()
+        if not thread_id:
+            return 0
+
+        reset_thread_sessions = getattr(session_store, "reset_thread_sessions", None)
+        if not callable(reset_thread_sessions):
+            return 0
+
+        try:
+            reset_count = reset_thread_sessions(thread_id, platform=Platform.DISCORD)
+        except Exception as e:
+            logger.warning(
+                "[%s] Failed to reset archived Discord thread %s: %s",
+                self.name,
+                thread_id,
+                e,
+                exc_info=True,
+            )
+            return 0
+
+        if reset_count:
+            logger.info(
+                "[%s] Discord thread archived — reset %d session(s) for thread %s",
+                self.name,
+                reset_count,
+                thread_id,
+            )
+        return reset_count
 
     def _resolve_channel_skills(self, channel_id: str, parent_id: str | None = None) -> list[str] | None:
         """Look up auto-skill bindings for a Discord channel/forum thread.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -875,6 +875,33 @@ class SessionStore:
 
         return new_entry
 
+    def reset_thread_sessions(self, thread_id: str, platform: Optional[Platform] = None) -> int:
+        """Reset every session that belongs to a thread.
+
+        This is used by Discord thread lifecycle hooks so archived threads start
+        with a fresh session on their next message.
+        """
+        thread_id = str(thread_id).strip()
+        if not thread_id:
+            return 0
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            session_keys = [
+                entry.session_key
+                for entry in self._entries.values()
+                if entry.origin
+                and entry.origin.thread_id == thread_id
+                and entry.origin.chat_type == "thread"
+                and (platform is None or entry.origin.platform == platform or entry.platform == platform)
+            ]
+
+        reset_count = 0
+        for session_key in session_keys:
+            if self.reset_session(session_key):
+                reset_count += 1
+        return reset_count
+
     def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2295,6 +2295,33 @@ class SessionStore:
 
         return new_entry
 
+    def reset_thread_sessions(self, thread_id: str, platform: Optional[Platform] = None) -> list:
+        """Reset every session that belongs to a thread.
+
+        This is used by Discord thread lifecycle hooks so archived threads start
+        with a fresh session on their next message.
+        """
+        thread_id = str(thread_id).strip()
+        if not thread_id:
+            return 0
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            session_keys = [
+                entry.session_key
+                for entry in self._entries.values()
+                if entry.origin
+                and entry.origin.thread_id == thread_id
+                and entry.origin.chat_type == "thread"
+                and (platform is None or entry.origin.platform == platform or entry.platform == platform)
+            ]
+
+        reset_keys = []
+        for session_key in session_keys:
+            if self.reset_session(session_key):
+                reset_keys.append(session_key)
+        return reset_keys
+
     def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1096,6 +1096,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 )
 
             @self._client.event
+            async def on_raw_thread_update(payload):
+                thread_metadata = payload.data.get("thread_metadata", {})
+                if not thread_metadata.get("archived", False):
+                    return
+                await adapter_self._reset_archived_thread_sessions(payload.thread_id)
+
+            @self._client.event
             async def on_message(message: DiscordMessage):
                 # Block until _resolve_allowed_usernames has swapped
                 # any raw usernames in DISCORD_ALLOWED_USERS for numeric
@@ -6123,6 +6130,59 @@ class DiscordAdapter(BasePlatformAdapter):
                 if resp.status != 200:
                     raise Exception(f"HTTP {resp.status}")
                 return await resp.read()
+
+    async def _reset_archived_thread_sessions(self, thread_id) -> int:
+        """Reset any stored sessions that belong to an archived Discord thread."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return 0
+
+        thread_id = str(thread_id).strip()
+        if not thread_id:
+            return 0
+
+        reset_thread_sessions = getattr(session_store, "reset_thread_sessions", None)
+        if not callable(reset_thread_sessions):
+            return 0
+
+        try:
+            from gateway.config import Platform
+            reset_keys = reset_thread_sessions(thread_id, platform=Platform.DISCORD)
+        except Exception as e:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "[%s] Failed to reset archived Discord thread %s: %s",
+                self.name,
+                thread_id,
+                e,
+                exc_info=True,
+            )
+            return 0
+
+        reset_count = len(reset_keys) if isinstance(reset_keys, list) else (reset_keys if isinstance(reset_keys, int) else 0)
+        
+        if reset_count:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.info(
+                "[%s] Discord thread archived - reset %d session(s) for thread %s",
+                self.name,
+                reset_count,
+                thread_id,
+            )
+            
+            if isinstance(reset_keys, list):
+                try:
+                    from gateway.run import _gateway_runner_ref
+                    runner = _gateway_runner_ref()
+                    if runner and hasattr(runner, "_evict_cached_agent"):
+                        for key in reset_keys:
+                            runner._evict_cached_agent(key)
+                except Exception as ex:
+                    logger.warning("Failed to evict cached agents: %s", ex)
+                    
+        return reset_count
 
     async def _handle_message(self, message: DiscordMessage, role_authorized: bool = False) -> None:
         """Handle incoming Discord messages."""

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 
 
 def _ensure_discord_mock():
@@ -190,4 +190,40 @@ async def test_connect_does_not_wait_for_slash_sync(monkeypatch):
 
     created["bot"].tree.allow_finish.set()
     await asyncio.sleep(0)
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_archived_thread_update_resets_thread_sessions(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None):
+        created["bot"] = FakeBot(intents=intents, proxy=proxy)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    session_store = MagicMock()
+    session_store.reset_thread_sessions.return_value = 2
+    adapter.set_session_store(session_store)
+
+    ok = await adapter.connect()
+    assert ok is True
+    assert "on_thread_update" in created["bot"]._events
+
+    before = SimpleNamespace(id="thread-42", archived=False)
+    after = SimpleNamespace(id="thread-42", archived=True)
+    await created["bot"]._events["on_thread_update"](before, after)
+
+    session_store.reset_thread_sessions.assert_called_once_with("thread-42", platform=Platform.DISCORD)
+
     await adapter.disconnect()

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import PlatformConfig, Platform
 
 
 class _FakeAllowedMentions:
@@ -1076,3 +1076,41 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+@pytest.mark.asyncio
+async def test_archived_thread_update_resets_thread_sessions(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None, allowed_mentions=None, **_):
+        created["bot"] = FakeBot(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+        return created["bot"]
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    session_store = MagicMock()
+    session_store.reset_thread_sessions.return_value = ['key1', 'key2']
+    adapter.set_session_store(session_store)
+
+    ok = await adapter.connect()
+    assert ok is True
+    assert "on_raw_thread_update" in created["bot"]._events
+
+    payload = SimpleNamespace(
+        thread_id="thread-42",
+        data={"thread_metadata": {"archived": True}}
+    )
+    await created["bot"]._events["on_raw_thread_update"](payload)
+
+    session_store.reset_thread_sessions.assert_called_once_with("thread-42", platform=Platform.DISCORD)
+
+    await adapter.disconnect()

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -906,6 +906,59 @@ class TestHasAnySessions:
         assert store.has_any_sessions() is False
 
 
+class TestResetThreadSessions:
+    def test_resets_only_matching_discord_thread_sessions(self, tmp_path):
+        config = GatewayConfig(thread_sessions_per_user=True)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        discord_a = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-1",
+            chat_type="thread",
+            thread_id="thread-42",
+            user_id="alice",
+        )
+        discord_b = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-1",
+            chat_type="thread",
+            thread_id="thread-42",
+            user_id="bob",
+        )
+        discord_other_thread = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-1",
+            chat_type="thread",
+            thread_id="thread-99",
+            user_id="carol",
+        )
+        telegram_thread = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="thread",
+            thread_id="thread-42",
+            user_id="t1",
+        )
+
+        entry_a = store.get_or_create_session(discord_a)
+        entry_b = store.get_or_create_session(discord_b)
+        entry_other = store.get_or_create_session(discord_other_thread)
+        entry_telegram = store.get_or_create_session(telegram_thread)
+
+        original_ids = {
+            entry.session_key: entry.session_id
+            for entry in (entry_a, entry_b, entry_other, entry_telegram)
+        }
+
+        reset_count = store.reset_thread_sessions("thread-42", platform=Platform.DISCORD)
+
+        assert reset_count == 2
+        assert store._entries[entry_a.session_key].session_id != original_ids[entry_a.session_key]
+        assert store._entries[entry_b.session_key].session_id != original_ids[entry_b.session_key]
+        assert store._entries[entry_other.session_key].session_id == original_ids[entry_other.session_key]
+        assert store._entries[entry_telegram.session_key].session_id == original_ids[entry_telegram.session_key]
+
+
 class TestLastPromptTokens:
     """Tests for the last_prompt_tokens field — actual API token tracking."""
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1783,3 +1783,56 @@ class TestGatewayRoutingTable:
         )
         assert entry.session_key not in rows
         restarted._db.close()
+
+
+class TestResetThreadSessions:
+    def test_resets_only_matching_discord_thread_sessions(self, tmp_path):
+        config = GatewayConfig(thread_sessions_per_user=True)
+        store = SessionStore(sessions_dir=tmp_path, config=config)
+
+        discord_a = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-1",
+            chat_type="thread",
+            thread_id="thread-42",
+            user_id="alice",
+        )
+        discord_b = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-1",
+            chat_type="thread",
+            thread_id="thread-42",
+            user_id="bob",
+        )
+        discord_other_thread = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-1",
+            chat_type="thread",
+            thread_id="thread-99",
+            user_id="carol",
+        )
+        telegram_thread = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="thread",
+            thread_id="thread-42",
+            user_id="t1",
+        )
+
+        entry_a = store.get_or_create_session(discord_a)
+        entry_b = store.get_or_create_session(discord_b)
+        entry_other = store.get_or_create_session(discord_other_thread)
+        entry_telegram = store.get_or_create_session(telegram_thread)
+
+        original_ids = {
+            entry.session_key: entry.session_id
+            for entry in (entry_a, entry_b, entry_other, entry_telegram)
+        }
+
+        reset_count = store.reset_thread_sessions("thread-42", platform=Platform.DISCORD)
+
+        assert len(reset_count) == 2
+        assert store._entries[entry_a.session_key].session_id != original_ids[entry_a.session_key]
+        assert store._entries[entry_b.session_key].session_id != original_ids[entry_b.session_key]
+        assert store._entries[entry_other.session_key].session_id == original_ids[entry_other.session_key]
+        assert store._entries[entry_telegram.session_key].session_id == original_ids[entry_telegram.session_key]


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Before this change, Discord archived threads kept the same Hermes thread session, so reopening an archived thread could continue the old conversation context as if the thread had never ended. Now, when Discord archives a thread, Hermes resets the stored thread session, so the next message in that thread starts a fresh conversation instead of inheriting stale state. The implementation reuses the existing session reset path so the behavior stays consistent with the rest of Hermes and does not change how active threads normally work.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

N/A

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added `SessionStore.reset_thread_sessions()` in [gateway/session.py](gateway/session.py) so thread-scoped sessions can be reset together.
- Wired Discord thread archive updates in [gateway/platforms/discord.py](gateway/platforms/discord.py) to call the reset helper when a thread becomes archived.
- Added regression coverage in [tests/gateway/test_session.py](tests/gateway/test_session.py) and [tests/gateway/test_discord_connect.py](tests/gateway/test_discord_connect.py).

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run `pytest tests/gateway/test_session.py tests/gateway/test_discord_connect.py -q`.
2. Confirm the tests pass.
3. Archive a Discord thread, reopen it, and send a new message to confirm Hermes starts a fresh session.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

