### PR TITLE
fix(mcp): bump initial connect retries 3→6 for slow upstream warmups

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -255,7 +255,14 @@ class TestMCPInitialConnectionRetry:
                 call_count += 1
                 raise ConnectionError("DNS resolution failed")
 
-            with patch.object(MCPServerTask, '_run_stdio', fake_run_stdio):
+            async def _fast_sleep(_seconds, *args, **kwargs):
+                # Skip backoff delays so the test finishes fast.  With the
+                # real 6-retry backoff the cumulative wait is 63s, which
+                # exceeds the conftest 30s per-test timeout.
+                return
+
+            with patch.object(MCPServerTask, '_run_stdio', fake_run_stdio), \
+                 patch("tools.mcp_tool.asyncio.sleep", _fast_sleep):
                 task = asyncio.ensure_future(server.run({"command": "fake"}))
                 await server._ready.wait()
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -650,9 +650,13 @@ class TestMCPServerTask:
         from tools.mcp_tool import MCPServerTask
 
         async def _test():
-            server = MCPServerTask("bad")
-            with pytest.raises(ValueError, match="no 'command'"):
-                await server.start({"args": []})
+            # Patch backoff sleep so the retry loop finishes fast — the
+            # validation ValueError gets retried _MAX_INITIAL_CONNECT_RETRIES
+            # times (same as any other startup error) before re-raising.
+            with patch("tools.mcp_tool.asyncio.sleep", new_callable=AsyncMock):
+                server = MCPServerTask("bad")
+                with pytest.raises(ValueError, match="no 'command'"):
+                    await server.start({"args": []})
 
         asyncio.run(_test())
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -163,7 +163,14 @@ if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
 _DEFAULT_TOOL_TIMEOUT = 120      # seconds for tool calls
 _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
-_MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
+# Retries for the very first connection attempt.  With exponential backoff
+# starting at 1s (capped by _MAX_BACKOFF_SECONDS), 6 attempts give a
+# cumulative wait of up to 63s (1+2+4+8+16+32) before giving up — enough to
+# cover transient DNS / reverse-proxy warmup on a freshly-booted VM.
+# Previously 3 (cumulative 7s), which repeatedly lost the race to exe.dev
+# integration DNS propagation on VM restart and left MCP servers "down for
+# the whole session" until a second manual restart.
+_MAX_INITIAL_CONNECT_RETRIES = 6
 _MAX_BACKOFF_SECONDS = 60
 
 # Environment variables that are safe to pass to stdio subprocesses


### PR DESCRIPTION
## Summary

On environments where the MCP server's upstream target is still warming up at agent boot time (e.g. cloud VMs where a reverse-proxy route takes up to ~30s to become ready), the initial MCP connection attempt can receive a transient error (e.g. a 405 from a placeholder route). With the current `_MAX_INITIAL_CONNECT_RETRIES = 3` and exponential backoff starting at 1s, the cumulative retry window is `1+2+4 = 7s` — short enough that the warmup window usually isn't covered. The MCP task gives up, sets `_error`, and the server stays down for the entire session since there's no lazy reconnect. Recovery requires manually restarting the agent after the window passes.

Bumps `_MAX_INITIAL_CONNECT_RETRIES` to **6**. With the existing `_MAX_BACKOFF_SECONDS = 60` cap, the retry sequence is `1+2+4+8+16+32 = 63s` cumulative, which comfortably covers ~30s warmups. Genuine (permanent) connect failures take longer to surface, but only on startup; steady-state behavior is unchanged.

Two tests (`test_mcp_tool.py`, `test_mcp_stability.py`) relied on the 7s fast-fail path to stay under their 30s per-test timeout. They're patched to stub `asyncio.sleep` so the retry loop completes instantly.

## Test plan

- [ ] `pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_stability.py -q`
- [ ] Manual: start agent against an MCP server whose upstream is slow to come up; confirm it reconnects within 60s instead of erroring out

🤖 Generated with [Claude Code](https://claude.com/claude-code)