### PR TITLE
feat(mcp): support SSE transport alongside Streamable HTTP

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1201,6 +1201,64 @@ class TestHTTPConfig:
         asyncio.run(_test())
 
 
+class TestResolveHttpTransport:
+    """_resolve_http_transport picks between streamable_http and sse."""
+
+    def test_default_is_streamable_http(self):
+        from tools.mcp_tool import MCPServerTask
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/mcp", {}
+        ) == "streamable_http"
+
+    def test_sse_suffix_detected(self):
+        from tools.mcp_tool import MCPServerTask
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/sse", {}
+        ) == "sse"
+
+    def test_sse_suffix_with_trailing_slash(self):
+        from tools.mcp_tool import MCPServerTask
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/sse/", {}
+        ) == "sse"
+
+    def test_sse_suffix_ignored_when_query_or_fragment_present(self):
+        from tools.mcp_tool import MCPServerTask
+        # Query / fragment shouldn't fool the suffix check.
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/sse?token=abc", {}
+        ) == "sse"
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/api#sse", {}
+        ) == "streamable_http"
+
+    def test_explicit_sse_config_overrides_url(self):
+        from tools.mcp_tool import MCPServerTask
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/mcp", {"transport": "sse"}
+        ) == "sse"
+
+    def test_explicit_streamable_http_overrides_url(self):
+        from tools.mcp_tool import MCPServerTask
+        # Even with a /sse URL, explicit streamable_http wins.
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/sse", {"transport": "streamable_http"}
+        ) == "streamable_http"
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/sse", {"transport": "streamable-http"}
+        ) == "streamable_http"
+
+    def test_unknown_transport_falls_through_to_url_detection(self):
+        from tools.mcp_tool import MCPServerTask
+        # Garbage transport string — fall back to URL-based detection.
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/sse", {"transport": "nonsense"}
+        ) == "sse"
+        assert MCPServerTask._resolve_http_transport(
+            "https://example.com/mcp", {"transport": "nonsense"}
+        ) == "streamable_http"
+
+
 # ---------------------------------------------------------------------------
 # Reconnection logic
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -90,6 +90,7 @@ logger = logging.getLogger(__name__)
 
 _MCP_AVAILABLE = False
 _MCP_HTTP_AVAILABLE = False
+_MCP_SSE_AVAILABLE = False
 _MCP_SAMPLING_TYPES = False
 _MCP_NOTIFICATION_TYPES = False
 _MCP_MESSAGE_HANDLER_SUPPORTED = False
@@ -102,6 +103,14 @@ try:
         _MCP_HTTP_AVAILABLE = True
     except ImportError:
         _MCP_HTTP_AVAILABLE = False
+    # SSE transport — used by servers that only speak the older MCP SSE
+    # protocol (e.g. postgres-mcp). Auto-selected when the URL ends in
+    # `/sse`, or explicitly via `transport: sse` in the server config.
+    try:
+        from mcp.client.sse import sse_client
+        _MCP_SSE_AVAILABLE = True
+    except ImportError:
+        _MCP_SSE_AVAILABLE = False
     # Prefer the non-deprecated API (mcp >= 1.24.0); fall back to the
     # deprecated wrapper for older SDK versions.
     try:
@@ -984,8 +993,27 @@ class MCPServerTask:
                 for _pid in new_pids:
                     _stdio_pids.pop(_pid, None)
 
+    @staticmethod
+    def _resolve_http_transport(url: str, config: dict) -> str:
+        """Pick between streamable_http and sse based on config + URL.
+
+        Explicit `transport: sse|streamable_http` in config wins. Otherwise,
+        URLs ending in `/sse` default to SSE (that's how postgres-mcp and
+        other older MCP servers expose themselves). Everything else defaults
+        to streamable_http, which is the current MCP spec transport.
+        """
+        explicit = str(config.get("transport") or "").strip().lower()
+        if explicit in ("sse", "streamable_http", "streamable-http", "streamablehttp"):
+            return "sse" if explicit == "sse" else "streamable_http"
+        # Strip query string / fragment before the suffix check.
+        from urllib.parse import urlsplit
+        path = urlsplit(url).path or ""
+        if path.rstrip("/").endswith("/sse"):
+            return "sse"
+        return "streamable_http"
+
     async def _run_http(self, config: dict):
-        """Run the server using HTTP/StreamableHTTP transport."""
+        """Run the server using HTTP/StreamableHTTP or SSE transport."""
         if not _MCP_HTTP_AVAILABLE:
             raise ImportError(
                 f"MCP server '{self.name}' requires HTTP transport but "
@@ -997,6 +1025,7 @@ class MCPServerTask:
         headers = dict(config.get("headers") or {})
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
         ssl_verify = config.get("ssl_verify", True)
+        transport = self._resolve_http_transport(url, config)
 
         # OAuth 2.1 PKCE: route through the central MCPOAuthManager so the
         # same provider instance is reused across reconnects, pre-flow
@@ -1018,6 +1047,31 @@ class MCPServerTask:
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
             sampling_kwargs["message_handler"] = self._make_message_handler()
+
+        if transport == "sse":
+            if not _MCP_SSE_AVAILABLE:
+                raise ImportError(
+                    f"MCP server '{self.name}' is configured for SSE transport "
+                    "(URL ends in /sse or transport: sse) but mcp.client.sse is "
+                    "not available. Upgrade the mcp package."
+                )
+            # sse_client API: (url, headers, timeout, sse_read_timeout)
+            # It doesn't accept an httpx.Auth directly; header-based auth
+            # (e.g. Bearer token) is the common case and is already covered
+            # by `headers`.
+            _sse_kwargs = {
+                "timeout": float(connect_timeout),
+            }
+            if headers:
+                _sse_kwargs["headers"] = headers
+            async with sse_client(url, **_sse_kwargs) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                    await session.initialize()
+                    self.session = session
+                    await self._discover_tools()
+                    self._ready.set()
+                    await self._shutdown_event.wait()
+            return
 
         if _MCP_NEW_HTTP:
             # New API (mcp >= 1.24.0): build an explicit httpx.AsyncClient


### PR DESCRIPTION
## Summary

The MCP HTTP client currently hardcodes the `streamable_http` transport, which blocks connecting to MCP servers that only expose the older SSE transport (e.g. `postgres-mcp` and many other community servers that haven't migrated). This adds transport selection without changing default behavior:

- **Explicit** `transport: sse` / `transport: streamable_http` in the server config takes precedence.
- **URL heuristic:** if the URL path ends with `/sse`, default to SSE.
- **Otherwise:** default to `streamable_http` (unchanged from today).

This lets users connect to either transport without forcing every remote server to migrate to Streamable HTTP. No changes to stdio servers or to default behavior for existing Streamable HTTP configs.

## Test plan

- [ ] `pytest tests/tools/test_mcp_tool.py -q` (includes new SSE transport tests)
- [ ] Manual: add an SSE-only MCP server (e.g. `postgres-mcp`) and confirm tools are discoverable
- [ ] Manual: confirm existing Streamable HTTP servers continue to work with no config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)