### PR TITLE
fix(telegram): prevent surrogate pair splitting in truncate_message

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -33,7 +33,10 @@ def utf16_len(s: str) -> int:
     Ported from nearai/ironclaw#2304 which discovered the same discrepancy in
     Rust's ``chars().count()``.
     """
-    return len(s.encode("utf-16-le")) // 2
+    # Use 'surrogatepass' so lone surrogates (which can appear when JSON
+    # decoders preserve \uD83C\uDFA9-style escape pairs verbatim) are
+    # counted as one UTF-16 code unit each instead of raising.
+    return len(s.encode("utf-16-le", "surrogatepass")) // 2
 
 
 def _prefix_within_utf16_limit(s: str, limit: int) -> str:
@@ -2126,6 +2129,20 @@ class BasePlatformAdapter(ABC):
                     safe_split = max(safe_split, nl_split)
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
+
+            # Ensure split_at does not land between UTF-16 surrogate halves.
+            # Model APIs can deliver astral-plane characters as JSON-escaped
+            # surrogate pairs (\uD83C\uDFA9) which some decoders store as two
+            # separate code units in the Python string.  Slicing between a high
+            # surrogate (U+D800..U+DBFF) and its low surrogate (U+DC00..U+DFFF)
+            # produces a lone surrogate that causes UnicodeEncodeError when the
+            # chunk is later encoded for delivery.
+            if 0 < split_at < len(remaining):
+                ch = remaining[split_at - 1]
+                if '\uD800' <= ch <= '\uDBFF':
+                    # Previous char is a high surrogate — include the low half
+                    # so the pair stays together.
+                    split_at -= 1
 
             chunk_body = remaining[:split_at]
             remaining = remaining[split_at:].lstrip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -582,3 +582,31 @@ class TestTruncateMessageUtf16:
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
 
+    def test_no_lone_surrogates_after_split(self):
+        """Splitting must not produce chunks with isolated UTF-16 surrogates.
+
+        Some JSON decoders store astral-plane characters (emoji, CJK Ext-B) as
+        two separate surrogate code units (\\uD800-\\uDBFF + \\uDC00-\\uDFFF)
+        instead of converting them to a single code point.  If the split lands
+        between the high and low surrogate, the resulting chunk contains a lone
+        surrogate that causes ``UnicodeEncodeError`` on delivery.
+
+        Regression test for GitHub issue #11467.
+        """
+        # Build a string that contains surrogate pairs as separate code units.
+        # 🎩 (U+1F3A9) = surrogate pair D83C DFA9
+        hat_as_surrogates = "\uD83C\uDFA9"
+        # Pad with spaces so the split point naturally falls near the pair.
+        msg = "x" * 95 + " " + hat_as_surrogates + " " + "y" * 200
+        chunks = BasePlatformAdapter.truncate_message(msg, 100, len_fn=utf16_len)
+        for i, chunk in enumerate(chunks):
+            for j, ch in enumerate(chunk):
+                assert not ('\uD800' <= ch <= '\uDBFF' and
+                            (j + 1 >= len(chunk) or not ('\uDC00' <= chunk[j + 1] <= '\uDFFF'))), (
+                    f"Chunk {i} has lone high surrogate at position {j}"
+                )
+                assert not ('\uDC00' <= ch <= '\uDFFF' and
+                            (j == 0 or not ('\uD800' <= chunk[j - 1] <= '\uDBFF'))), (
+                    f"Chunk {i} has lone low surrogate at position {j}"
+                )
+


### PR DESCRIPTION
## Summary

Fixes #11467 — Telegram message splitting can slice UTF-16 surrogate pairs, causing `UnicodeEncodeError` delivery failures.

When model APIs deliver astral-plane characters (emoji like 🎩 `U+1F3A9`) as JSON-escaped surrogate pairs (`\uD83C\uDFA9`), some decoders store them as two separate code units in the Python string. `truncate_message()` could slice between the high and low surrogate, producing a lone surrogate that causes `UnicodeEncodeError: 'utf-16-le' codec can't encode character '\udfa9'` on delivery.

### Changes

- **`utf16_len()`**: use `surrogatepass` error handler so lone surrogates are counted as one UTF-16 code unit each instead of raising
- **`truncate_message()`**: after finding a natural break point (newline/space/backtick adjustment), check that `split_at` does not land between a high surrogate (`U+D800..U+DBFF`) and its low surrogate (`U+DC00..U+DFFF`); if it does, step back by one to keep the pair together

### Files changed

- `gateway/platforms/base.py` — core fix in `utf16_len` and `truncate_message`
- `tests/gateway/test_platform_base.py` — regression test that constructs a string with surrogate-pair code units and verifies no chunk contains a lone surrogate after splitting

## Test plan

- [x] All 77 existing tests in `test_platform_base.py` pass
- [x] New `test_no_lone_surrogates_after_split` validates the fix against the exact scenario from #11467
- [ ] Manual verification: send a long message with emoji (🎩😀🚀) on Telegram that exceeds 4096 UTF-16 code units

🤖 Generated with [Claude Code](https://claude.com/claude-code)