### PR TITLE
fix(context): accept focus_topic in ContextEngine ABC

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -78,6 +78,7 @@ class ContextEngine(ABC):
         self,
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
+        focus_topic: str = None,
     ) -> List[Dict[str, Any]]:
         """Compact the message list and return the new message list.
 
@@ -85,7 +86,9 @@ class ContextEngine(ABC):
         list and returns a (possibly shorter) list that fits within the
         context budget. The implementation is free to summarize, build a
         DAG, or do anything else — as long as the returned list is a valid
-        OpenAI-format message sequence.
+        OpenAI-format message sequence. ``focus_topic`` is an optional hint
+        from manual/targeted compression flows to preserve information
+        related to a specific topic.
         """
 
     # -- Optional: pre-flight check ----------------------------------------

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -194,6 +194,7 @@ AUTHOR_MAP = {
     "taeuk178@users.noreply.github.com": "taeuk178",
     "ogzerber@users.noreply.github.com": "ogzerber",
     "cola-runner@users.noreply.github.com": "cola-runner",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "trevmanthony@gmail.com": "trevthefoolish",

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -34,7 +34,12 @@ class StubEngine(ContextEngine):
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         return tokens >= self.threshold_tokens
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None) -> List[Dict[str, Any]]:
+    def compress(
+        self,
+        messages: List[Dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ) -> List[Dict[str, Any]]:
         self._compress_called = True
         self.compression_count += 1
         # Trivial: just return as-is
@@ -144,6 +149,13 @@ class TestStubEngine:
         assert result == msgs
         assert engine._compress_called
         assert engine.compression_count == 1
+
+    def test_compress_accepts_focus_topic(self):
+        engine = StubEngine()
+        msgs = [{"role": "user", "content": "hello"}]
+        result = engine.compress(msgs, focus_topic="auth flow")
+        assert result == msgs
+        assert engine._compress_called
 
     def test_tool_schemas(self):
         engine = StubEngine()

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -22,7 +22,7 @@ class _StubEngine(ContextEngine):
     def should_compress(self, prompt_tokens=None):
         return False
 
-    def compress(self, messages, current_tokens=None):
+    def compress(self, messages, current_tokens=None, focus_topic=None):
         return messages
 
 


### PR DESCRIPTION
## Summary
- add `focus_topic` to the `ContextEngine.compress()` abstract signature so plugin engines match the arguments `AIAgent` already passes during manual or guided compression
- update the plugin and ABC test stubs to implement the new parameter
- add a regression test that verifies a concrete context engine accepts `focus_topic`

Closes #11586

## Testing
- `source venv/bin/activate && python -m pytest tests/agent/test_context_engine.py -q`
- `source venv/bin/activate && python -m pytest tests/run_agent/test_plugin_context_engine_init.py -q`
- `source venv/bin/activate && python -m pytest tests/agent/test_compress_focus.py -q`
- `source venv/bin/activate && python -m pytest tests/ -q`

## Full suite note
The full suite still fails in this environment on existing unrelated issues and missing optional deps (`acp`, `fastapi`), plus current gateway/web/discord/transcription failures. The context-engine-specific coverage above passed locally.
