### PR TITLE
fix: preserve context when summary generation fails

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -609,9 +609,9 @@ class ContextCompressor(ContextEngine):
                 related to this topic and is more aggressive about compressing
                 everything else.  Inspired by Claude Code's ``/compact``.
 
-        Returns None if all attempts fail — the caller should drop
-        the middle turns without a summary rather than inject a useless
-        placeholder.
+        Returns None if all attempts fail — the caller should preserve
+        the original messages unchanged rather than drop the middle turns
+        or inject a useless placeholder.
         """
         now = time.monotonic()
         if now < self._summary_failure_cooldown_until:
@@ -763,8 +763,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # No provider configured — long cooldown, unlikely to self-resolve
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
             logging.warning("Context compression: no provider available for "
-                            "summary. Middle turns will be dropped without summary "
-                            "for %d seconds.",
+                            "summary. Original messages will be preserved for %d seconds.",
                             _SUMMARY_FAILURE_COOLDOWN_SECONDS)
             return None
         except Exception as e:
@@ -1069,6 +1068,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 everything else.  Inspired by Claude Code's ``/compact``.
         """
         n_messages = len(messages)
+        original_messages = messages
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self.protect_first_n + 3 + 1
         if n_messages <= _min_for_compress:
@@ -1137,8 +1137,15 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     msg["content"] = existing + "\n\n" + _compression_note
             compressed.append(msg)
 
-        # If LLM summary failed, insert a static fallback so the model
-        # knows context was lost rather than silently dropping everything.
+        # If summary generation failed, preserve the original conversation
+        # unchanged instead of deleting the middle turns or mutating the
+        # system prompt with a misleading compaction note.
+        if summary is None:
+            if not self.quiet_mode:
+                logger.warning("Summary generation failed — preserving original messages unchanged")
+            return original_messages
+
+        # Keep an explicit fallback for unexpected empty-string summaries.
         if not summary:
             if not self.quiet_mode:
                 logger.warning("Summary generation failed — inserting static fallback context marker")

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -65,9 +65,11 @@ class TestCompress:
         assert result == msgs
 
     def test_truncation_fallback_no_client(self, compressor):
-        # compressor has client=None, so should use truncation fallback
+        # Mock summary generation so the test does not depend on external
+        # provider auto-detection being configured in the environment.
         msgs = [{"role": "system", "content": "System prompt"}] + self._make_messages(10)
-        result = compressor.compress(msgs)
+        with patch.object(compressor, "_generate_summary", return_value="summary"):
+            result = compressor.compress(msgs)
         assert len(result) < len(msgs)
         # Should keep system message and last N
         assert result[0]["role"] == "system"
@@ -75,9 +77,10 @@ class TestCompress:
 
     def test_compression_increments_count(self, compressor):
         msgs = self._make_messages(10)
-        compressor.compress(msgs)
-        assert compressor.compression_count == 1
-        compressor.compress(msgs)
+        with patch.object(compressor, "_generate_summary", return_value="summary"):
+            compressor.compress(msgs)
+            assert compressor.compression_count == 1
+            compressor.compress(msgs)
         assert compressor.compression_count == 2
 
     def test_protects_first_and_last(self, compressor):
@@ -167,7 +170,8 @@ class TestGenerateSummaryNoneContent:
             {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
             for i in range(10)
         ]
-        result = c.compress(msgs)
+        with patch.object(c, "_generate_summary", return_value="summary"):
+            result = c.compress(msgs)
         assert len(result) < len(msgs)
 
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -93,6 +93,45 @@ class TestCompress:
         assert msgs[-2]["content"] in result[-2]["content"]
 
 
+class TestSummaryFailurePreservesMessages:
+    def test_preserves_all_messages_when_generate_summary_returns_none(self, compressor):
+        msgs = [{"role": "system", "content": "System prompt"}] + [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(10)
+        ]
+
+        with patch.object(compressor, "_generate_summary", return_value=None):
+            result = compressor.compress(msgs)
+
+        assert result == msgs
+        assert result[0]["content"] == "System prompt"
+        assert all(not (m.get("content") or "").startswith(SUMMARY_PREFIX) for m in result)
+        assert compressor.compression_count == 0
+
+    def test_summary_failure_restores_pre_prune_messages(self, compressor):
+        msgs = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "msg 0"},
+            {"role": "assistant", "content": "msg 1"},
+            {"role": "tool", "content": "full tool output"},
+            {"role": "user", "content": "msg 2"},
+            {"role": "assistant", "content": "msg 3"},
+            {"role": "user", "content": "msg 4"},
+        ]
+        pruned_msgs = [m.copy() for m in msgs]
+        pruned_msgs[3]["content"] = "[pruned tool output]"
+
+        with (
+            patch.object(compressor, "_prune_old_tool_results", return_value=(pruned_msgs, 1)),
+            patch.object(compressor, "_generate_summary", return_value=None),
+        ):
+            result = compressor.compress(msgs)
+
+        assert result == msgs
+        assert result[3]["content"] == "full tool output"
+        assert compressor.compression_count == 0
+
+
 class TestGenerateSummaryNoneContent:
     """Regression: content=None (from tool-call-only assistant messages) must not crash."""
 


### PR DESCRIPTION
## Summary
- preserve the original conversation when context summary generation fails with `None`
- stop injecting a misleading fallback marker that implied middle turns were removed without a usable summary
- add regression coverage for both the direct failure path and the pre-prune rollback path

## Root cause
`ContextCompressor.compress()` treated any falsy summary as a signal to continue compression with a static fallback marker. When `_generate_summary()` returned `None`, Hermes still mutated the system prompt, dropped middle turns, and incremented `compression_count` even though no valid summary existed.

## Fix
- return the original messages unchanged when `_generate_summary()` returns `None`
- keep `compression_count` unchanged on this failure path
- align docs/logging with the preserve-on-failure behavior
- add regression tests for summary failure behavior

## Test plan
- `uv run pytest tests/agent/test_context_compressor.py -q -o addopts=`
- `uv run pytest tests/run_agent/test_compression_boundary.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_compressor_fallback_update.py -q -o addopts=`
- `uv run pytest tests/agent/test_compress_focus.py tests/cli/test_compress_focus.py -q -o addopts=`
- `uv run python -m py_compile agent/context_compressor.py tests/agent/test_context_compressor.py`

Closes #11585
