### PR TITLE
BlueBubbles: native iMessage voice memo support + inbound webhook dedup

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -128,6 +128,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
+        # Inbound message guid dedup: BlueBubbles can fire multiple webhook events
+        # for a single iMessage (e.g. a new-message + ~1s-later updated-message for
+        # delivery receipt/edit). Tracking recently-seen guids prevents duplicate
+        # inbound processing. 60s TTL is generous; iMessage guid collisions are
+        # impossible in that window.
+        self._recent_message_guids: Dict[str, float] = {}
+        self._dedup_ttl_seconds: float = 60.0
 
     # ------------------------------------------------------------------
     # API helpers
@@ -805,6 +812,35 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return web.Response(text="ok")
 
         record = self._extract_payload_record(payload) or {}
+
+        # Dedup duplicate webhook events for the same iMessage guid. BlueBubbles
+        # emits more than one webhook per message in some conditions (the classic
+        # case is a new-message event followed ~1s later by an updated-message
+        # event for the same guid, which without this guard would be processed as
+        # two separate inbound turns).
+        msg_guid = self._value(
+            record.get("guid"), payload.get("guid"), record.get("originalGuid")
+        )
+        if msg_guid:
+            import time as _time
+            now = _time.monotonic()
+            # Evict expired entries opportunistically.
+            if self._recent_message_guids:
+                expired = [
+                    g for g, t in self._recent_message_guids.items()
+                    if now - t > self._dedup_ttl_seconds
+                ]
+                for g in expired:
+                    self._recent_message_guids.pop(g, None)
+            if msg_guid in self._recent_message_guids:
+                logger.debug(
+                    "[bluebubbles] dropping duplicate webhook for guid %s (event=%s)",
+                    msg_guid, event_type or "<none>",
+                )
+                from aiohttp import web as _web
+                return _web.Response(text="ok")
+            self._recent_message_guids[msg_guid] = now
+
         is_from_me = bool(
             record.get("isFromMe")
             or record.get("fromMe")

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -528,6 +528,26 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
+        # iMessage voice bubbles require Opus-in-CAF. BlueBubbles' own MP3->CAF
+        # converter currently produces PCM-in-CAF (see BlueBubblesApp/bluebubbles-server#793),
+        # so transcode here via macOS's native afconvert before handing off.
+        import shutil, subprocess
+        afconvert = shutil.which("afconvert") or "/usr/bin/afconvert"
+        if os.path.isfile(afconvert) and not audio_path.lower().endswith(".caf"):
+            caf_path = os.path.splitext(audio_path)[0] + ".caf"
+            try:
+                r = subprocess.run(
+                    [afconvert, "-f", "caff", "-d", "opus@24000", "-c", "1",
+                     audio_path, caf_path],
+                    capture_output=True, timeout=30,
+                )
+                if r.returncode == 0 and os.path.exists(caf_path) and os.path.getsize(caf_path) > 0:
+                    audio_path = caf_path
+                else:
+                    logger.warning("afconvert -> Opus/CAF failed: %s",
+                                   r.stderr.decode("utf-8", errors="ignore")[:200])
+            except Exception as exc:
+                logger.warning("afconvert -> Opus/CAF error: %s", exc)
         return await self._send_attachment(
             chat_id, audio_path, caption=caption, is_audio_message=True
         )

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -468,6 +468,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 }
                 if is_audio_message:
                     data["isAudioMessage"] = "true"
+                    data["method"] = "private-api"
                 res = await self.client.post(
                     self._api_url("/api/v1/message/attachment"),
                     files=files,


### PR DESCRIPTION
## Summary

Three related fixes to the BlueBubbles adapter that together make iMessage voice memos work end-to-end and eliminate duplicate inbound turn processing. Each is a standalone commit so they can be cherry-picked or split during review.

## The three changes

### 1. Route voice memos through the \`private-api\` send path

iMessage only renders an attachment as a voice bubble (waveform + play button) when the underlying IMCore send carries the voice-memo marker. The AppleScript send path in BlueBubbles-server doesn't set this marker -- only the Private API send path does. Setting \`method=\"private-api\"\` in \`_send_attachment\` when \`is_audio_message=True\` fixes this.

Without this change, audio attachments always arrive as generic file attachments even with a correct codec and the \`isAudioMessage\` flag. See the BlueBubbles adapter source (\`packages/server/src/server/api/apple/actions.ts\`): the AppleScript \`sendMessage\` path never forwards \`isAudioMessage\` into the AppleScript itself.

### 2. Transcode audio to Opus-in-CAF before voice send

iMessage's voice-memo renderer specifically requires Opus codec inside a CAF container -- MP3, AAC, and PCM-in-CAF all fall back to generic file rendering. BlueBubbles-server's own \`convertMp3ToCaf\` helper currently produces PCM-in-CAF (tracked in [BlueBubblesApp/bluebubbles-server#793](https://github.com/BlueBubblesApp/bluebubbles-server/pull/793)), and callers shipping any other audio format (AAC, WAV, Opus-in-OGG) never trigger the converter at all.

This pre-converts anything non-.caf to Opus-in-CAF via \`afconvert\`, the native macOS tool. Ships on every macOS version BlueBubbles-server runs on, so no new dependency. On conversion failure, the original path is sent unchanged -- matches today's fallback behavior.

Mirrors the Opus-in-OGG transcode \`tools/tts_tool.py\` already does for Telegram voice messages, just targeting CAF instead of OGG.

### 3. Dedup inbound webhook events by message guid

BlueBubbles fires more than one webhook per iMessage in several conditions:

- A \`new-message\` event followed ~1s later by an \`updated-message\` event for the same guid (delivery receipt / edit / reaction notification).
- Group-chat fanout: when the local user participates in both a DM and a group, a single inbound can trigger webhooks carrying different chat GUIDs (e.g. \`any;-;+phone\` and \`+phone\`) but the same message guid.
- Reconnect / retry paths where BlueBubbles redelivers recent events.

Without dedup, each duplicate webhook produced an independent agent turn -- most visibly: a voice memo landing in the DM *and* a separate text reply landing in the group chat, both triggered by one user send.

This adds a small in-memory LRU (guid -> monotonic timestamp, 60s TTL) that short-circuits the handler if the guid has already been processed. At-least-once delivery is the norm for HTTP webhooks; idempotent handling on the receiver is the right place to solve this rather than trying to suppress duplicates upstream (which would also lose legitimate edit/receipt signal on future \`updated-message\` handling).

## Testing

Verified end-to-end on Apple Silicon macOS 26.3, Hermes v0.10.0 native install, BlueBubbles-server v1.9.9 with Private API helper connected:

1. Send TTS-generated audio via adapter's \`send_voice\` → iMessage renders as a waveform voice bubble with play button on the receiving device.
2. Send user message from phone → one inbound turn, one agent response, even though BlueBubbles fires two webhooks (\`new-message\` + \`updated-message\`) ~1s apart. Debug log shows \`dropping duplicate webhook for guid ...\`.
3. Non-audio attachments (images, videos, documents) unchanged -- still use server-default send method.

## Prerequisites for end users

Voice memos require the BlueBubbles Private API Helper to be connected (\`helper_connected: true\` in \`/api/v1/server/info\`). On Apple Silicon macOS 14+, this means:

1. Boot into 1 True Recovery (hold power button, Options → Continue while holding Left Shift)
2. Startup Security Utility → Reduced Security
3. Recovery Terminal: \`csrutil enable --without debug\`
4. In normal macOS: \`sudo defaults write /Library/Preferences/com.apple.security.libraryvalidation.plist DisableLibraryValidation -bool true\`
5. Quit and reopen BlueBubbles; it will inject the helper dylib into Messages.app

Users without Private API see the same fallback behavior as today (voice send lands as a file attachment), so there's no regression for the non-Private-API path.

## Related

- [BlueBubblesApp/bluebubbles-server#793](https://github.com/BlueBubblesApp/bluebubbles-server/pull/793) -- fixes the PCM-in-CAF codec bug in BB's own converter. This PR is still valuable after #793 merges because it covers callers that ship non-MP3 audio and provides belt-and-suspenders on the codec.