### PR TITLE
fix(agent): add focus_topic to ContextEngine.compress() ABC

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -26,7 +26,7 @@ Lifecycle:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class ContextEngine(ABC):
@@ -78,6 +78,7 @@ class ContextEngine(ABC):
         self,
         messages: List[Dict[str, Any]],
         current_tokens: int = None,
+        focus_topic: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Compact the message list and return the new message list.
 
@@ -86,6 +87,13 @@ class ContextEngine(ABC):
         context budget. The implementation is free to summarize, build a
         DAG, or do anything else — as long as the returned list is a valid
         OpenAI-format message sequence.
+
+        Args:
+            messages: The full message list.
+            current_tokens: Approximate current token count.
+            focus_topic: Optional focus string for guided compression.
+                When provided, the engine should prioritise preserving
+                information related to this topic.
         """
 
     # -- Optional: pre-flight check ----------------------------------------

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -34,8 +34,9 @@ class StubEngine(ContextEngine):
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         return tokens >= self.threshold_tokens
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None) -> List[Dict[str, Any]]:
+    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None) -> List[Dict[str, Any]]:
         self._compress_called = True
+        self._last_focus_topic = focus_topic
         self.compression_count += 1
         # Trivial: just return as-is
         return messages
@@ -144,6 +145,19 @@ class TestStubEngine:
         assert result == msgs
         assert engine._compress_called
         assert engine.compression_count == 1
+
+    def test_compress_accepts_focus_topic(self):
+        engine = StubEngine()
+        msgs = [{"role": "user", "content": "hello"}]
+        result = engine.compress(msgs, focus_topic="database schema")
+        assert result == msgs
+        assert engine._last_focus_topic == "database schema"
+
+    def test_compress_focus_topic_defaults_to_none(self):
+        engine = StubEngine()
+        msgs = [{"role": "user", "content": "hello"}]
+        engine.compress(msgs)
+        assert engine._last_focus_topic is None
 
     def test_tool_schemas(self):
         engine = StubEngine()

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -22,7 +22,7 @@ class _StubEngine(ContextEngine):
     def should_compress(self, prompt_tokens=None):
         return False
 
-    def compress(self, messages, current_tokens=None):
+    def compress(self, messages, current_tokens=None, focus_topic=None):
         return messages
 
 

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -58,10 +58,11 @@ class LCMEngine(ContextEngine):
     def should_compress(self, prompt_tokens: int = None) -> bool:
         """Return True if compaction should fire this turn."""
 
-    def compress(self, messages: list, current_tokens: int = None) -> list:
+    def compress(self, messages: list, current_tokens: int = None, focus_topic: str = None) -> list:
         """Compact the message list and return a new (possibly shorter) list.
 
         The returned list must be a valid OpenAI-format message sequence.
+        focus_topic: Optional string to prioritise preserving related info.
         """
 ```
 


### PR DESCRIPTION
## Summary

- Add missing `focus_topic: Optional[str] = None` parameter to `ContextEngine.compress()` ABC signature
- `AIAgent._compress_context()` in `run_agent.py` passes `focus_topic=...` to all engines, but the ABC didn't declare it — plugin engines strictly following the ABC signature get `TypeError`
- Update documentation example and test stubs to match the new signature

## Changes

- **`agent/context_engine.py`**: Add `focus_topic: Optional[str] = None` to the abstract `compress()` method, add `Optional` import
- **`website/docs/developer-guide/context-engine-plugin.md`**: Update code example to include `focus_topic` parameter
- **`tests/agent/test_context_engine.py`**: Update `StubEngine.compress()` signature, add tests for focus_topic acceptance and default
- **`tests/run_agent/test_plugin_context_engine_init.py`**: Update `_StubEngine.compress()` signature

## Test plan

- [ ] Existing tests in `tests/agent/test_context_engine.py` pass
- [ ] Existing tests in `tests/agent/test_compress_focus.py` pass
- [ ] New `test_compress_accepts_focus_topic` and `test_compress_focus_topic_defaults_to_none` tests pass
- [ ] Plugin engines implementing `compress(self, messages, current_tokens=None, focus_topic=None)` no longer get TypeError

Closes #11586

🤖 Generated with [Claude Code](https://claude.com/claude-code)