### PR TITLE
fix(agent): respect proxy env in general client path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -950,6 +950,15 @@ def _validate_proxy_env_urls() -> None:
             ) from exc
 
 
+def _has_proxy_env_configured() -> bool:
+    """Return True when any standard proxy env var is set to a non-empty value."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        if str(os.environ.get(key) or "").strip():
+            return True
+    return False
+
+
 def _validate_base_url(base_url: str) -> None:
     """Reject obviously broken custom endpoint URLs before they reach httpx."""
     from urllib.parse import urlparse

--- a/run_agent.py
+++ b/run_agent.py
@@ -4403,7 +4403,11 @@ class AIAgent:
         return False
 
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
-        from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+        from agent.auxiliary_client import (
+            _has_proxy_env_configured,
+            _validate_base_url,
+            _validate_proxy_env_urls,
+        )
         # Treat client_kwargs as read-only. Callers pass self._client_kwargs (or shallow
         # copies of it) in; any in-place mutation leaks back into the stored dict and is
         # reused on subsequent requests. #10933 hit this by injecting an httpx.Client
@@ -4459,7 +4463,7 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        if "http_client" not in client_kwargs and not _has_proxy_env_configured():
             try:
                 import httpx as _httpx
                 import socket as _socket

--- a/tests/agent/test_proxy_and_url_validation.py
+++ b/tests/agent/test_proxy_and_url_validation.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 import pytest
 
-from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
+from agent.auxiliary_client import (
+    _has_proxy_env_configured,
+    _validate_base_url,
+    _validate_proxy_env_urls,
+)
 
 
 # -- proxy env validation ------------------------------------------------
@@ -29,6 +33,24 @@ def test_proxy_env_accepts_empty(monkeypatch):
     monkeypatch.delenv("https_proxy", raising=False)
     monkeypatch.delenv("all_proxy", raising=False)
     _validate_proxy_env_urls()  # should not raise
+
+
+def test_has_proxy_env_configured_detects_uppercase(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    assert _has_proxy_env_configured() is True
+
+
+def test_has_proxy_env_configured_detects_lowercase(monkeypatch):
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.setenv("http_proxy", "http://127.0.0.1:7897")
+    assert _has_proxy_env_configured() is True
+
+
+def test_has_proxy_env_configured_ignores_empty_values(monkeypatch):
+    for key in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
+                "http_proxy", "https_proxy", "all_proxy"):
+        monkeypatch.setenv(key, "   ")
+    assert _has_proxy_env_configured() is False
 
 
 @pytest.mark.parametrize("key", [

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -23,6 +23,8 @@ from run_agent import AIAgent
 
 def _make_agent():
     return AIAgent(
+        api_key="test-key-value",
+        base_url="https://api.example.com/v1",
         model="test/model",
         quiet_mode=True,
         skip_context_files=True,
@@ -183,4 +185,35 @@ def test_replace_primary_openai_client_survives_repeated_rebuilds():
     assert len({id(c) for c in constructed}) == len(constructed), (
         "Some _create_openai_client calls returned the same object across "
         "a teardown — rebuild is not producing fresh clients"
+    )
+
+
+def test_create_openai_client_skips_custom_transport_when_proxy_env_present(monkeypatch):
+    """Proxy env vars must keep httpx's default proxy-aware transport path.
+
+    Passing a custom ``httpx.HTTPTransport`` bypasses env-proxy auto-detection,
+    which breaks WSL and other proxied setups (#11609). When a proxy env var is
+    configured, `_create_openai_client` should hand the SDK no explicit
+    ``http_client`` so httpx can honor HTTP(S)_PROXY / ALL_PROXY on its own.
+    """
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="proxy_env",
+            shared=False,
+        )
+
+    assert len(constructed) == 1
+    assert constructed[0]._http_client is None, (
+        "Proxy env configured, but _create_openai_client still injected a "
+        "custom http_client. That bypasses httpx env-proxy detection and "
+        "reproduces #11609 on WSL / proxied setups."
     )


### PR DESCRIPTION
## What does this PR do?

Fixes the general agent OpenAI client path so Hermes still honors `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` when those environment variables are configured.

The regression reported in #11609 comes from `_create_openai_client()` always injecting a custom `httpx.HTTPTransport` for TCP keepalive. Once that custom transport is passed in, httpx stops auto-applying env proxy settings, so proxied WSL setups direct-connect and time out.

This PR keeps the keepalive transport for direct connections, but skips that injection when a proxy env var is present so the SDK/httpx default proxy-aware transport path stays intact.

## Related Issue

Fixes #11609

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `_has_proxy_env_configured()` in `agent/auxiliary_client.py`
- skip custom keepalive `httpx.HTTPTransport` injection in `run_agent.py::_create_openai_client()` when proxy env vars are set
- add regression coverage for proxy env detection and for the proxied `_create_openai_client()` path
- make the `_create_openai_client` reuse tests hermetic by giving the test agent explicit dummy credentials instead of depending on local machine provider config

## How to Test

1. `python3 -m pytest -o addopts='' tests/agent/test_proxy_and_url_validation.py tests/run_agent/test_create_openai_client_reuse.py -q`
2. Set `HTTPS_PROXY=http://127.0.0.1:7897` (or another valid local proxy) in a WSL/proxied shell
3. Run a normal Hermes chat flow and confirm the client path no longer direct-connects through a custom transport that bypasses env proxy handling

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local targeted regression tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python3 -m pytest -o addopts='' tests/agent/test_proxy_and_url_validation.py tests/run_agent/test_create_openai_client_reuse.py -q`
- `20 passed in 30.94s`
