### PR TITLE
fix(agent): respect proxy env vars when transport is injected

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4472,8 +4472,19 @@ class AIAgent:
                 elif hasattr(_socket, "TCP_KEEPALIVE"):
                     # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
                     _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+                _proxy = (
+                    os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+                    or os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy")
+                    or os.environ.get("ALL_PROXY") or os.environ.get("all_proxy")
+                )
+                # httpx's HTTPTransport does not support SOCKS URLs without the
+                # httpx-socks extra; skip rather than raising at client
+                # construction time.  macOS users running Clash/ShadowsocksX
+                # often export ALL_PROXY=socks5://... from their shell setup.
+                if _proxy and _proxy.lower().startswith("socks"):
+                    _proxy = None
                 client_kwargs["http_client"] = _httpx.Client(
-                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                    transport=_httpx.HTTPTransport(socket_options=_sock_opts, proxy=_proxy),
                 )
             except Exception:
                 pass  # Fall through to default transport if socket opts fail


### PR DESCRIPTION
## Summary

Fix a silent proxy bypass in `_create_openai_client`. The custom `HTTPTransport` used for TCP keepalives disables httpx's env-proxy autoconfig — every LLM provider call becomes a direct connection even when `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` is set.

## Root cause

`httpx.Client` only reads proxy env vars when it constructs its **own** transport internally. Once `transport=httpx.HTTPTransport(...)` is passed explicitly — as the keepalive injection does — proxy resolution becomes the caller's responsibility. Nothing in `_create_openai_client` was reading the env, so proxies were silently dropped for every provider call.

## Impact

Users behind a mandatory proxy (corporate network, restricted egress, etc.) see:

- `APIConnectionError: Connection error.`
- `APITimeoutError: Request timed out.`

…while `curl` and stock httpx work in the same shell, and `ps eww $HERMES_PID` shows `HTTPS_PROXY` is present in the agent's process env. Hard to diagnose because every surface-level check passes.

## Reproduction

```python
import os, httpx, socket
os.environ["HTTPS_PROXY"] = "http://127.0.0.1:PORT"

# httpx default — reads env, request goes through proxy
httpx.Client().get("https://chatgpt.com")

# hermes-style — custom transport, env ignored
sock_opts = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
httpx.Client(transport=httpx.HTTPTransport(
    socket_options=sock_opts,
)).get("https://chatgpt.com")
```

The second call bypasses the proxy entirely and fails on any network where direct egress to the endpoint is blocked.

## Fix

Read the standard proxy env vars (`HTTPS_PROXY` > `HTTP_PROXY` > `ALL_PROXY`, both upper and lower case) and pass them to `HTTPTransport(proxy=...)`. When no env var is set, `proxy=None` matches the httpx default — zero behavior change for users without a proxy.

**SOCKS URLs are skipped.** `httpx.HTTPTransport` does not accept `socks5://` / `socks5h://` / `socks4://` URLs without the `httpx-socks` extra, and raising at client construction would regress users whose shell exports `ALL_PROXY=socks5://...` (common on macOS with Clash / ShadowsocksX, where the HTTP proxy env var is already the one that should be picked up). We filter SOCKS URLs out so the keepalive injection still succeeds and the HTTP proxy env var (if any) wins.

## Test plan

- [x] Reproduced on macOS 15.4.1 / Python 3.11 / httpx 0.28.1 with a local HTTP proxy: `HTTPS_PROXY` set in shell + `~/.hermes/.env`, hermes ignored it, chatgpt.com codex endpoint errored out with `APIConnectionError` / `APITimeoutError`
- [x] Applied patch: same env, hermes connects through proxy successfully
- [x] `proxy=None` path (no env vars): behavior unchanged — `HTTPTransport(proxy=None)` is a no-op relative to `HTTPTransport()`
- [x] SOCKS filter checked against `socks5://…`, `socks5h://…`, `socks4://…`, `SOCKS5://…` (all → `None`) and `http://…`, `https://…`, `""`, `None` (all passed through unchanged)
- [x] Ran `pytest tests/run_agent/test_create_openai_client_reuse.py -v` against the patched file — both pre-existing tests pass:
  - `test_second_create_does_not_wrap_closed_transport_from_first`
  - `test_replace_primary_openai_client_survives_repeated_rebuilds`

## Platforms tested

- macOS 15.4.1 (Darwin 24.4.0), Python 3.11.8, httpx 0.28.1, local HTTP proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
