### PR TITLE
feat(wecom): add optional external auth webhook for custom per-user p…

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -656,36 +656,40 @@ class ProcessingOutcome(Enum):
 class MessageEvent:
     """
     Incoming message from a platform.
-    
+
     Normalized representation that all adapters produce.
     """
     # Message content
     text: str
     message_type: MessageType = MessageType.TEXT
-    
+
     # Source information
     source: SessionSource = None
-    
+
     # Original platform data
     raw_message: Any = None
     message_id: Optional[str] = None
-    
+
     # Media attachments
     # media_urls: local file paths (for vision tool access)
     media_urls: List[str] = field(default_factory=list)
     media_types: List[str] = field(default_factory=list)
-    
+
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
-    
+
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
     auto_skill: Optional[str | list[str]] = None
-    
+
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
+
+    # External authentication data from platform-specific custom auth webhooks
+    # Contains permissions/roles/etc returned by the external auth service
+    external_auth: Optional[Dict[str, Any]] = None
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -165,6 +165,16 @@ class WeComAdapter(BasePlatformAdapter):
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 
+        # Optional external auth webhook for custom per-user permission checks
+        self._auth_webhook_url = str(
+            extra.get("auth_webhook_url")
+            or extra.get("auth_webhook")
+            or os.getenv("WECOM_AUTH_WEBHOOK_URL", "")
+        ).strip()
+        self._auth_webhook_timeout = float(
+            extra.get("auth_webhook_timeout") or os.getenv("WECOM_AUTH_WEBHOOK_TIMEOUT", "5.0")
+        )
+
         self._session: Optional["aiohttp.ClientSession"] = None
         self._ws: Optional["aiohttp.ClientWebSocketResponse"] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
@@ -496,6 +506,31 @@ class WeComAdapter(BasePlatformAdapter):
             logger.debug("[%s] DM sender %s blocked by policy", self.name, sender_id)
             return
 
+        # Custom external auth check via webhook
+        external_auth: Optional[Dict[str, Any]] = None
+        if self._auth_webhook_url and self._http_client:
+            try:
+                resp = await self._http_client.post(
+                    self._auth_webhook_url,
+                    json={
+                        "user_id": sender_id,
+                        "chat_id": chat_id,
+                        "is_group": is_group,
+                    },
+                    timeout=self._auth_webhook_timeout,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if not data.get("allowed", True):
+                    logger.info("[%s] User %s blocked by external auth webhook", self.name, sender_id)
+                    return
+                # Store all returned auth data (including permissions/roles/tokens)
+                external_auth = data
+            except Exception as exc:
+                logger.warning("[%s] External auth webhook failed: %s", self.name, exc)
+                # Fail closed: block if webhook errors
+                return
+
         text, reply_text = self._extract_text(body)
         media_urls, media_types = await self._extract_media(body)
         message_type = self._derive_message_type(body, text, media_types)
@@ -527,6 +562,9 @@ class WeComAdapter(BasePlatformAdapter):
             reply_to_text=reply_text if has_reply_context else None,
             timestamp=datetime.now(tz=timezone.utc),
         )
+
+        # Attach external auth data (including permissions) if available
+        event.external_auth = external_auth
 
         # Only batch plain text messages — commands, media, etc. dispatch
         # immediately since they won't be split by the WeCom client.


### PR DESCRIPTION
 This PR adds an optional external authentication/authorization webhook for
   the WeCom (Enterprise WeChat) AI Bot adapter.

  Why this change?

  When running WeCom AI Bot in an enterprise environment, you often need:
  - Custom per-user permission checks based on user_id
  - Integration with internal OAuth/SSO systems
  - Dynamic permission/role lookup before allowing the agent to process the
  message
  - Passing user-specific access tokens or metadata to downstream tools

  What this change does:

  1. Adds configuration:
  platforms:
    wecom:
      enabled: true
      extra:
        bot_id: "..."
        secret: "..."
        auth_webhook_url: "https://your-internal-service/api/wecom-auth"  #
  NEW
        auth_webhook_timeout: 5.0  # optional, default 5s
  1. Also supports environment variable: WECOM_AUTH_WEBHOOK_URL
  2. Workflow:
  Receive message → Built-in policy check → If passes → POST to your webhook
    ↓
  Allowed? → Yes → Attach full auth response to `event.external_auth` →
  Continue processing
    ↓
  Not allowed / Webhook error → Drop message (fail-closed)
  3. Webhook protocol:
    - Request (JSON POST):
    { "user_id": "zhangsan", "chat_id": "zhangsan", "is_group": false }
    - Response (JSON):
    {
    "allowed": true,
    "permissions": ["chat:write", "tools:use"],
    "roles": ["engineer"],
    "access_token": "user-specific-token"
    // any other custom fields...
  }

  Backward Compatibility

  - ✅ Fully backward compatible
  - This feature is opt-in — if auth_webhook_url is not configured, the code
   path is not taken and behavior is unchanged
  - No changes to database schema, configuration format, or public APIs

  Testing

  - Existing tests pass unchanged
  - Feature is only activated when explicitly configured