### PR TITLE
fix(tests): stop forcing xdist auto by default

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,12 @@ hermes chat -q "Hello"
 ### Run tests
 
 ```bash
-pytest tests/ -v
+scripts/run_tests.sh
 ```
+
+Use `scripts/run_tests.sh` as the canonical entrypoint for full-suite runs.
+It pins a CI-like worker count and hermetic env; bare `pytest` is now safe by
+default but intentionally does not force `-n auto`.
 
 ---
 
@@ -595,7 +599,7 @@ refactor/description   # Code restructuring
 
 ### Before submitting
 
-1. **Run tests**: `pytest tests/ -v`
+1. **Run tests**: `scripts/run_tests.sh`
 2. **Test manually**: Run `hermes` and exercise the code path you changed
 3. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider Windows and macOS
 4. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,4 +133,4 @@ testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
-addopts = "-m 'not integration' -n auto"
+addopts = "-m 'not integration'"

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -4,11 +4,20 @@ from pathlib import Path
 import tomllib
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 def _load_optional_dependencies():
-    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject_path = REPO_ROOT / "pyproject.toml"
     with pyproject_path.open("rb") as handle:
         project = tomllib.load(handle)["project"]
     return project["optional-dependencies"]
+
+
+def _load_pytest_ini_options():
+    pyproject_path = REPO_ROOT / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        return tomllib.load(handle)["tool"]["pytest"]["ini_options"]
 
 
 def test_matrix_extra_linux_only_in_all():
@@ -34,3 +43,16 @@ def test_messaging_extra_includes_qrcode_for_weixin_setup():
 
     messaging_extra = optional_dependencies["messaging"]
     assert any(dep.startswith("qrcode") for dep in messaging_extra)
+
+
+def test_pytest_default_addopts_do_not_force_xdist_auto():
+    """Default `pytest` runs should stay below low macOS file-descriptor limits.
+
+    The canonical parallel entrypoint is scripts/run_tests.sh, which pins an
+    explicit worker count. Keeping `-n auto` out of pyproject addopts avoids
+    EMFILE crashes on low-FD hosts while preserving marker filtering.
+    """
+    addopts = _load_pytest_ini_options()["addopts"]
+
+    assert "-m 'not integration'" in addopts
+    assert "-n auto" not in addopts


### PR DESCRIPTION
## What does this PR do?

Fixes the default local pytest entrypoint so it no longer forces `-n auto` from `pyproject.toml`.

Issue #11645 reports `EMFILE` crashes on low-FD macOS hosts when developers run the repo's default non-integration pytest command. The root cause is that `pyproject.toml` still hardcodes `-n auto`, while the repo already documents `scripts/run_tests.sh` as the canonical CI-like runner and that script pins a bounded worker count.

This PR removes `-n auto` from the default pytest addopts, keeps the existing `not integration` filter, updates CONTRIBUTING to point contributors at `scripts/run_tests.sh`, and adds a regression test so `-n auto` does not silently creep back into the default config.

## Related Issue

Fixes #11645

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- change `pyproject.toml` pytest `addopts` from `-m 'not integration' -n auto` to `-m 'not integration'`
- update `CONTRIBUTING.md` so the documented full-suite command is `scripts/run_tests.sh`
- add a metadata regression test asserting default pytest addopts do not force `-n auto`

## How to Test

1. `./.venv/bin/python -m pytest tests/test_project_metadata.py -q`
2. Confirm the new regression test passes and `pyproject.toml` default addopts are `-m 'not integration'`
3. Run `scripts/run_tests.sh` when you want the bounded CI-like parallel path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local metadata regression test in repo `.venv`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `./.venv/bin/python -m pytest tests/test_project_metadata.py -q`
- `3 passed in 0.10s`
