### PR TITLE
fix(config): preserve container directory permissions in containers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -226,11 +226,17 @@ def _secure_dir(path):
     caddy, etc.) needs to traverse HERMES_HOME to reach a served subdirectory.
     The execute-only bit on a directory permits cd-through without exposing
     directory listings.
+
+    Skipped in containers unless HERMES_HOME_MODE is explicitly set. Volume
+    mounts often have operator-managed ACLs or shared-reader permissions, and
+    clobbering them on every config load breaks multi-container deployments.
     """
     if is_managed():
         return
+    mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
+    if _is_container() and not mode_str:
+        return
     try:
-        mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
         mode = int(mode_str, 8) if mode_str else 0o700
     except ValueError:
         mode = 0o700

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -59,6 +59,42 @@ class TestEnsureHermesHome:
             ensure_hermes_home()
             assert soul_path.read_text(encoding="utf-8") == "custom soul"
 
+    def test_container_preserves_existing_dir_permissions_without_override(self, tmp_path):
+        for path in (tmp_path, *(tmp_path / name for name in ("cron", "sessions", "logs", "memories"))):
+            path.mkdir(parents=True, exist_ok=True)
+            os.chmod(path, 0o755)
+
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "HERMES_CONTAINER": "1"},
+            clear=False,
+        ):
+            ensure_hermes_home()
+
+        assert (tmp_path.stat().st_mode & 0o777) == 0o755
+        for name in ("cron", "sessions", "logs", "memories"):
+            assert ((tmp_path / name).stat().st_mode & 0o777) == 0o755
+
+    def test_container_honors_home_mode_override(self, tmp_path):
+        for path in (tmp_path, *(tmp_path / name for name in ("cron", "sessions", "logs", "memories"))):
+            path.mkdir(parents=True, exist_ok=True)
+            os.chmod(path, 0o755)
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_HOME": str(tmp_path),
+                "HERMES_CONTAINER": "1",
+                "HERMES_HOME_MODE": "0701",
+            },
+            clear=False,
+        ):
+            ensure_hermes_home()
+
+        assert (tmp_path.stat().st_mode & 0o777) == 0o701
+        for name in ("cron", "sessions", "logs", "memories"):
+            assert ((tmp_path / name).stat().st_mode & 0o777) == 0o701
+
 
 class TestLoadConfigDefaults:
     def test_returns_defaults_when_no_file(self, tmp_path):


### PR DESCRIPTION
## Summary
Preserve existing `HERMES_HOME` directory permissions when Hermes is running inside a container, unless the operator explicitly sets `HERMES_HOME_MODE`.

## Root cause
`load_config()` calls `ensure_hermes_home()` on every config read. On `upstream/main`, `_secure_dir()` still forces `0700` on `HERMES_HOME` and core subdirectories even in container mode, while `_secure_file()` already skips chmod in containers. In shared-volume deployments, that silently strips group and ACL traversal bits from `/opt/data` and breaks sibling containers such as dashboards or web UIs.

## What changed
- Skip `_secure_dir()` in containers by default
- Still honor `HERMES_HOME_MODE` when an operator explicitly sets it
- Add regression tests for container-default preserve behavior and explicit override behavior

## Validation
- `python3 -m pytest -q tests/hermes_cli/test_config.py tests/cron/test_file_permissions.py`
- direct repro: container mode now preserves `0755` by default and applies `0701` when `HERMES_HOME_MODE=0701`

## Notes
Repo-wide `python3 -m pytest -q` was not green in this environment on broad runs outside this change scope, so validation here is targeted to the touched config and permission paths.