### PR TITLE
feat(provider): auto-wire native TTS / image / vision / video / music for multi-modal providers

### DIFF
--- a/hermes_cli/provider_native_tools.py
+++ b/hermes_cli/provider_native_tools.py
@@ -1,0 +1,130 @@
+"""Setup-time defaults for chat providers that also serve TTS / image / vision / video / music."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, Set, Tuple
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Tool categories that get config defaults written at setup time.
+# Vision is runtime-only (no config persistence) so it is not listed here.
+_CONFIG_CATEGORIES = ("tts", "image_gen", "video_gen", "music_gen")
+
+# Existing config values considered "not explicitly set by the user".
+_OVERRIDABLE = {"", "edge", "auto", "fal"}
+
+
+def _api_host(config):
+    url = (config.get("model") or {}).get("base_url", "")
+    try:
+        return urlparse(url).hostname or ""
+    except Exception:
+        return ""
+
+
+def _is_native_provider(config):
+    return "minimax" in _api_host(config)
+
+
+def _provider_label(config):
+    model = config.get("model") or {}
+    if isinstance(model, dict):
+        return str(model.get("provider") or "").strip().lower()
+    return ""
+
+
+def _safe_load_config():
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _category_display(cat):
+    if cat == "tts":
+        return "Text-to-speech"
+    return cat.replace("_gen", " generation").replace("_", " ").capitalize()
+
+
+def active_provider_api_root(config):
+    """API root derived from ``model.base_url``, stripping ``/anthropic``."""
+    model = config.get("model")
+    if not isinstance(model, dict):
+        return ""
+    base = str(model.get("base_url") or "").strip().rstrip("/")
+    if not base:
+        return ""
+    return base[: -len("/anthropic")] if base.endswith("/anthropic") else base
+
+
+def native_api_url(subpath, config=None):
+    """Full URL for a native API subpath, or ``""`` if not a native provider."""
+    cfg = config if config is not None else _safe_load_config()
+    if not _is_native_provider(cfg):
+        return ""
+    root = active_provider_api_root(cfg).rstrip("/")
+    return f"{root}{subpath}" if root else ""
+
+
+def native_credential(config=None):
+    """API key matching the active provider's region, or ``""``."""
+    import os
+    cfg = config if config is not None else _safe_load_config()
+    host = _api_host(cfg)
+    if "minimaxi.com" in host:
+        return (os.environ.get("MINIMAX_CN_API_KEY", "").strip()
+                or os.environ.get("MINIMAX_API_KEY", "").strip())
+    return (os.environ.get("MINIMAX_API_KEY", "").strip()
+            or os.environ.get("MINIMAX_CN_API_KEY", "").strip())
+
+
+def get_native_tools(config):
+    """Tool categories served natively by the active provider, or ``()``."""
+    if not _is_native_provider(config):
+        return ()
+    return _CONFIG_CATEGORIES + ("vision",)
+
+
+def provider_has_native_tool(tool, config):
+    if tool not in get_native_tools(config):
+        return False
+    try:
+        from tools.tool_backend_helpers import prefers_gateway
+        if prefers_gateway(tool):
+            return False
+    except Exception:
+        pass
+    return True
+
+
+def apply_provider_native_tool_defaults(config):
+    """Wire config defaults for providers that serve tools natively."""
+    if not _is_native_provider(config):
+        return set()
+    label = _provider_label(config)
+    if not label:
+        return set()
+    changed = set()
+    for cat in _CONFIG_CATEGORIES:
+        cfg = config.setdefault(cat, {})
+        if isinstance(cfg, dict) and str(cfg.get("provider") or "").strip().lower() in _OVERRIDABLE:
+            cfg["provider"] = label
+            changed.add(cat)
+    if changed:
+        aux = config.get("auxiliary") if isinstance(config.get("auxiliary"), dict) else {}
+        vis = aux.get("vision") if isinstance(aux.get("vision"), dict) else {}
+        if str(vis.get("provider") or "").strip().lower() in _OVERRIDABLE:
+            changed.add("vision")
+    return changed
+
+
+def describe_changes(changed, config):
+    """Bullet-list summary used by the setup wizard."""
+    items = sorted(changed)
+    if not items:
+        return "No changes \u2014 existing tool choices were preserved."
+    return "\n".join(f"  \u2022 {_category_display(k)}" for k in items)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -21,6 +21,11 @@ from pathlib import Path
 from typing import Optional, Dict, Any
 
 from hermes_cli.nous_subscription import get_nous_subscription_features
+from hermes_cli.provider_native_tools import (
+    apply_provider_native_tool_defaults,
+    describe_changes as describe_native_tool_changes,
+    get_native_tools as _provider_native_tools,
+)
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from hermes_constants import get_optional_skills_dir
 
@@ -835,9 +840,25 @@ def setup_model_provider(config: dict, *, quick: bool = False):
 
 
     # Tool Gateway prompt is already shown by _model_flow_nous() above.
+
+    # Wire tool defaults for chat providers that serve TTS / image / vision
+    # natively on the same credential.  Self-gates on the active provider's
+    # base_url; a no-op for providers not in the registry.
+    native_changes = apply_provider_native_tool_defaults(config)
+    if native_changes:
+        print()
+        print_success(
+            "The same credential also unlocks the following — wired automatically:"
+        )
+        print(describe_native_tool_changes(native_changes, config))
+
     save_config(config)
 
-    if not quick and selected_provider != "nous":
+    if (
+        not quick
+        and selected_provider != "nous"
+        and "tts" not in _provider_native_tools(config)
+    ):
         _setup_tts_provider(config)
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -54,6 +54,8 @@ CONFIGURABLE_TOOLSETS = [
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),
+    ("video_gen",       "🎬 Video Generation",          "video_generate"),
+    ("music_gen",       "🎵 Music Generation",          "music_generate"),
     ("moa",             "🧠 Mixture of Agents",         "mixture_of_agents"),
     ("tts",             "🔊 Text-to-Speech",            "text_to_speech"),
     ("skills",          "📚 Skills",                    "list, view, manage"),

--- a/tests/hermes_cli/test_provider_native_tools.py
+++ b/tests/hermes_cli/test_provider_native_tools.py
@@ -1,0 +1,187 @@
+"""Tests for hermes_cli/provider_native_tools.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.provider_native_tools import (
+    active_provider_api_root,
+    apply_provider_native_tool_defaults,
+    describe_changes,
+    native_api_url,
+    get_native_tools,
+    provider_has_native_tool,
+)
+
+_INTL = "https://api.minimax.io/anthropic"
+_INTL_UW = "https://api-uw.minimax.io/anthropic"
+_CN = "https://api.minimaxi.com/anthropic"
+_CN_APAC = "https://api-apac.minimaxi.com/anthropic"
+
+
+def _cfg(base_url, provider="minimax"):
+    return {"model": {"base_url": base_url, "provider": provider}}
+
+
+class TestApiHost:
+    def test_intl_detected(self):
+        assert get_native_tools(_cfg(_INTL)) != ()
+
+    def test_intl_uw_detected(self):
+        assert get_native_tools(_cfg(_INTL_UW)) != ()
+
+    def test_cn_detected(self):
+        assert get_native_tools(_cfg(_CN)) != ()
+
+    def test_cn_apac_detected(self):
+        assert get_native_tools(_cfg(_CN_APAC)) != ()
+
+    def test_non_native(self):
+        assert get_native_tools(_cfg("https://api.openai.com/v1")) == ()
+
+    def test_unset(self):
+        assert get_native_tools({}) == ()
+        assert get_native_tools({"model": {}}) == ()
+
+
+class TestApiRoot:
+    def test_strips_anthropic_suffix(self):
+        assert active_provider_api_root(_cfg(_INTL)) == "https://api.minimax.io"
+
+    def test_strips_trailing_slash(self):
+        assert active_provider_api_root(
+            _cfg("https://api.minimax.io/anthropic/")
+        ) == "https://api.minimax.io"
+
+    def test_cn_endpoint(self):
+        assert active_provider_api_root(_cfg(_CN)) == "https://api.minimaxi.com"
+
+    def test_no_anthropic_suffix(self):
+        cfg = _cfg("https://api.openai.com/v1")
+        assert active_provider_api_root(cfg) == "https://api.openai.com/v1"
+
+    def test_unset(self):
+        assert active_provider_api_root({}) == ""
+
+
+class TestNativeTools:
+    @pytest.mark.parametrize("tool", ["tts", "image_gen", "vision", "video_gen", "music_gen"])
+    def test_all_categories_present(self, tool):
+        assert provider_has_native_tool(tool, _cfg(_INTL)) is True
+
+    def test_unknown_tool(self):
+        assert provider_has_native_tool("search", _cfg(_INTL)) is False
+
+    def test_non_native_provider(self):
+        assert provider_has_native_tool("tts", _cfg("https://api.openai.com/v1")) is False
+
+
+class TestApplyDefaults:
+    def test_noop_for_non_native(self):
+        config = _cfg("https://api.openai.com/v1")
+        assert apply_provider_native_tool_defaults(config) == set()
+
+    def test_noop_for_empty(self):
+        assert apply_provider_native_tool_defaults({}) == set()
+
+    def test_writes_all_config_slots(self):
+        config = _cfg(_INTL)
+        changed = apply_provider_native_tool_defaults(config)
+        assert changed == {"tts", "image_gen", "vision", "video_gen", "music_gen"}
+        assert config["tts"]["provider"] == "minimax"
+        assert config["image_gen"]["provider"] == "minimax"
+        assert config["video_gen"]["provider"] == "minimax"
+        assert config["music_gen"]["provider"] == "minimax"
+
+    def test_explicit_tts_preserved(self):
+        config = {**_cfg(_INTL), "tts": {"provider": "elevenlabs"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" not in changed
+        assert config["tts"]["provider"] == "elevenlabs"
+
+    def test_edge_default_overridden(self):
+        config = {**_cfg(_INTL), "tts": {"provider": "edge"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+
+    def test_fal_default_overridden(self):
+        config = {**_cfg(_INTL), "image_gen": {"provider": "fal"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" in changed
+
+    def test_explicit_image_preserved(self):
+        config = {**_cfg(_INTL), "image_gen": {"provider": "stability"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "image_gen" not in changed
+
+    def test_explicit_video_preserved(self):
+        config = {**_cfg(_INTL), "video_gen": {"provider": "runway"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "video_gen" not in changed
+
+    def test_explicit_music_preserved(self):
+        config = {**_cfg(_INTL), "music_gen": {"provider": "suno"}}
+        changed = apply_provider_native_tool_defaults(config)
+        assert "music_gen" not in changed
+
+    def test_explicit_vision_preserved(self):
+        config = {
+            **_cfg(_INTL),
+            "auxiliary": {"vision": {"provider": "openrouter"}},
+        }
+        changed = apply_provider_native_tool_defaults(config)
+        assert "vision" not in changed
+
+    def test_idempotent(self):
+        config = _cfg(_INTL)
+        first = apply_provider_native_tool_defaults(config)
+        assert len(first) == 5
+        second = apply_provider_native_tool_defaults(config)
+        assert second == set()
+
+    def test_cn_provider(self):
+        config = _cfg(_CN, provider="minimax-cn")
+        changed = apply_provider_native_tool_defaults(config)
+        assert "tts" in changed
+        assert config["tts"]["provider"] == "minimax-cn"
+
+    def test_other_auxiliary_keys_preserved(self):
+        config = {
+            **_cfg(_INTL),
+            "auxiliary": {"compression": {"provider": "openai"}},
+        }
+        apply_provider_native_tool_defaults(config)
+        assert config["auxiliary"]["compression"]["provider"] == "openai"
+
+
+class TestDescribeChanges:
+    def test_empty(self):
+        assert "No changes" in describe_changes(set(), _cfg(_INTL))
+
+    def test_all_five(self):
+        out = describe_changes(
+            {"tts", "image_gen", "vision", "video_gen", "music_gen"},
+            _cfg(_INTL),
+        )
+        assert out.count("\u2022") == 5
+
+    def test_contains_category_labels(self):
+        out = describe_changes({"image_gen", "video_gen"}, _cfg(_INTL))
+        assert "Image generation" in out
+        assert "Video generation" in out
+
+
+class TestNativeApiUrl:
+    def test_derives_url(self):
+        assert native_api_url("/v1/t2a_v2", _cfg(_INTL)) == "https://api.minimax.io/v1/t2a_v2"
+
+    def test_cn_host(self):
+        assert native_api_url("/v1/t2a_v2", _cfg(_CN, provider="minimax-cn")) == "https://api.minimaxi.com/v1/t2a_v2"
+
+    def test_non_native_empty(self):
+        assert native_api_url("/v1/t2a_v2", _cfg("https://api.openai.com/v1")) == ""
+
+    def test_unset_empty(self):
+        assert native_api_url("/v1/t2a_v2", {}) == ""
+
+

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -617,6 +617,16 @@ def image_generate_tool(
         "generation_time": 0,
     }
 
+    # Provider-native dispatch.
+    try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        if provider_has_native_tool("image_gen", _safe_load_config()):
+            result = _native_image_generate(prompt, aspect_ratio, num_images or 1, output_format or "png")
+            if result is not None:
+                return result
+    except Exception as _exc:
+        logger.debug("provider-native image dispatch skipped: %s", _exc)
+
     start_time = datetime.datetime.now()
 
     try:
@@ -740,6 +750,12 @@ def check_fal_api_key() -> bool:
 def check_image_generation_requirements() -> bool:
     """True if FAL credentials and fal_client SDK are both available."""
     try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        if provider_has_native_tool("image_gen", _safe_load_config()):
+            return True
+    except Exception:
+        pass
+    try:
         if not check_fal_api_key():
             return False
         import fal_client  # noqa: F401 — SDK presence check
@@ -813,6 +829,76 @@ IMAGE_GENERATE_SCHEMA = {
         "required": ["prompt"],
     },
 }
+
+
+# ─── Provider-native image generation ─────────────────────────────────────
+
+_RATIO_ALIAS = {"landscape": "16:9", "portrait": "9:16", "square": "1:1"}
+_VALID_RATIOS = {"1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3", "21:9"}
+
+
+def _native_image_generate(prompt, aspect_ratio, num_images, output_format):
+    """Generate via the native provider's image API, or return None."""
+    import ssl
+    import urllib.error
+    import urllib.request
+    from hermes_cli.provider_native_tools import native_api_url, native_credential
+
+    url = native_api_url("/v1/image_generation")
+    key = native_credential()
+    if not url or not key:
+        return None
+
+    ratio = _RATIO_ALIAS.get((aspect_ratio or "").lower(), aspect_ratio)
+    if ratio not in _VALID_RATIOS:
+        ratio = "16:9"
+
+    payload = {
+        "model": "image-01",
+        "prompt": (prompt or "").strip(),
+        "aspect_ratio": ratio,
+        "n": max(1, min(4, int(num_images or 1))),
+        "response_format": "url",
+    }
+    try:
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            method="POST",
+            headers={"Authorization": f"Bearer {key}",
+                     "Content-Type": "application/json"},
+        )
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, timeout=120, context=ctx) as resp:
+            body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False, "error": f"image API HTTP {exc.code}"})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+                           "error": f"image API error {base.get('status_code')}: "
+                                    f"{base.get('status_msg', '')}"})
+
+    data = body.get("data") or {}
+    urls = []
+    if isinstance(data, dict):
+        for k in ("image_urls", "urls"):
+            v = data.get(k)
+            if isinstance(v, list):
+                urls = [u for u in v if isinstance(u, str) and u.startswith("http")]
+                break
+    if not urls:
+        return json.dumps({"success": False, "error": "image API returned no URL(s)"})
+
+    return json.dumps({
+        "success": True,
+        "image": urls[0],
+        "model": "image-01",
+        "aspect_ratio": ratio,
+    }, ensure_ascii=False)
 
 
 def _handle_image_generate(args, **kw):

--- a/tools/music_generation_tool.py
+++ b/tools/music_generation_tool.py
@@ -1,0 +1,196 @@
+"""Music generation tool — generates songs with lyrics and style prompt via the native provider."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_MUSIC_VALID_FORMATS = {"mp3", "wav", "pcm"}
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _post_json(url: str, payload: Dict[str, Any], key: str,
+               *, timeout: int = 180) -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _music_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/music", "music_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "music_cache"
+
+
+def _music_model_for_key(key: str) -> str:
+    """``sk-cp-`` (Token Plan) → ``music-2.6``; others → ``music-2.6-free``."""
+    return "music-2.6" if key.startswith("sk-cp-") else "music-2.6-free"
+
+
+# ─── Core ─────────────────────────────────────────────────────────────────
+
+
+def music_generate_tool(
+    prompt: str,
+    lyrics: str,
+    output_format: str = "mp3",
+    sample_rate: int = 44100,
+    bitrate: int = 256000,
+) -> str:
+    try:
+        from hermes_cli.provider_native_tools import native_api_url
+    except Exception:
+        return json.dumps({"success": False,
+                           "error": "no music backend available"})
+
+    from hermes_cli.provider_native_tools import native_credential
+    url = native_api_url("/v1/music_generation")
+    key = native_credential()
+    if not url or not key:
+        return json.dumps({"success": False,
+                           "error": "no music backend configured"})
+
+    fmt = (output_format or "mp3").lower()
+    if fmt not in _MUSIC_VALID_FORMATS:
+        fmt = "mp3"
+
+    model = _music_model_for_key(key)
+    payload = {
+        "model": model,
+        "prompt": (prompt or "").strip(),
+        "lyrics": (lyrics or "").strip(),
+        "audio_setting": {
+            "sample_rate": sample_rate,
+            "bitrate": bitrate,
+            "format": fmt,
+        },
+        "output_format": "hex",
+        "stream": False,
+    }
+
+    try:
+        body = _post_json(url, payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+                           "error": f"music API HTTP {exc.code}"})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+                           "error": f"music API error {base.get('status_code')}: "
+                                    f"{base.get('status_msg', '')}"})
+
+    data = body.get("data") or {}
+    audio_hex = data.get("audio") if isinstance(data, dict) else None
+    if not isinstance(audio_hex, str) or not audio_hex:
+        return json.dumps({"success": False,
+                           "error": "music API returned no audio"})
+
+    try:
+        audio_bytes = bytes.fromhex(audio_hex)
+    except ValueError as exc:
+        return json.dumps({"success": False,
+                           "error": f"invalid hex audio: {exc}"})
+
+    out_dir = _music_cache_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"music_{ts}.{fmt}"
+    try:
+        path.write_bytes(audio_bytes)
+    except OSError as exc:
+        return json.dumps({"success": False, "error": f"write failed: {exc}"})
+
+    return json.dumps({
+        "success": True,
+        "model": model,
+        "path": str(path),
+        "format": fmt,
+        "bytes": len(audio_bytes),
+    }, ensure_ascii=False)
+
+
+# ─── Check & registration ─────────────────────────────────────────────────
+
+
+def check_music_generation_requirements() -> bool:
+    try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        return provider_has_native_tool("music_gen", _safe_load_config())
+    except Exception:
+        return False
+
+
+MUSIC_GENERATE_SCHEMA = {
+    "name": "music_generate",
+    "description": (
+        "Generate a song from a style/mood prompt and lyrics. "
+        "Supports structure tags like [Intro], [Verse], [Chorus], [Bridge], [Outro]."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Style and mood description (10-300 chars).",
+            },
+            "lyrics": {
+                "type": "string",
+                "description": "Song lyrics with optional structure tags (10-600 chars).",
+            },
+            "output_format": {
+                "type": "string",
+                "enum": ["mp3", "wav", "pcm"],
+                "description": "Audio output format (default mp3).",
+            },
+        },
+        "required": ["prompt", "lyrics"],
+    },
+}
+
+
+def _handle_music_generate(args: Dict[str, Any], **kw: Any) -> str:
+    prompt = args.get("prompt", "")
+    lyrics = args.get("lyrics", "")
+    if not prompt or not lyrics:
+        return json.dumps({"success": False,
+                           "error": "both prompt and lyrics are required"})
+    return music_generate_tool(
+        prompt=prompt,
+        lyrics=lyrics,
+        output_format=args.get("output_format", "mp3"),
+    )
+
+
+registry.register(
+    name="music_generate",
+    toolset="music_gen",
+    schema=MUSIC_GENERATE_SCHEMA,
+    handler=_handle_music_generate,
+    check_fn=check_music_generation_requirements,
+    emoji="\U0001f3b5",
+)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -398,7 +398,18 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     """
     import requests
 
-    api_key = os.getenv("MINIMAX_API_KEY", "")
+    # Derive URL + key from the active provider when available (handles CN
+    # region automatically); fall back to env var + default URL.
+    derived_base = ""
+    api_key = ""
+    try:
+        from hermes_cli.provider_native_tools import native_api_url, native_credential
+        derived_base = native_api_url("/v1/t2a_v2")
+        api_key = native_credential()
+    except Exception:
+        pass
+    if not api_key:
+        api_key = os.getenv("MINIMAX_API_KEY", "")
     if not api_key:
         raise ValueError("MINIMAX_API_KEY not set. Get one at https://platform.minimax.io/")
 
@@ -408,7 +419,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     speed = mm_config.get("speed", tts_config.get("speed", 1))
     vol = mm_config.get("vol", 1)
     pitch = mm_config.get("pitch", 0)
-    base_url = mm_config.get("base_url", DEFAULT_MINIMAX_BASE_URL)
+    base_url = mm_config.get("base_url") or derived_base or DEFAULT_MINIMAX_BASE_URL
 
     # Determine audio format from output extension
     if output_path.endswith(".wav"):

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -1,0 +1,272 @@
+"""Video generation tool — generates short video clips via the native provider."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import ssl
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_VIDEO_MODEL = "MiniMax-Hailuo-2.3"
+_VIDEO_VALID_RESOLUTIONS = {"768P", "1080P"}
+_VIDEO_VALID_DURATIONS = {6, 10}
+_VIDEO_POLL_SECONDS = 15
+_VIDEO_POLL_MAX = 40  # 40 × 15s = 10 min ceiling
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _post_json(url: str, payload: Dict[str, Any], key: str,
+               *, timeout: int = 120) -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        method="POST",
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _get_json(url: str, key: str, *, timeout: int = 60) -> Dict[str, Any]:
+    req = urllib.request.Request(
+        url, method="GET",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        return json.loads(resp.read().decode("utf-8", errors="replace"))
+
+
+def _download(url: str, output_path: Path, *, timeout: int = 300) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(url, timeout=timeout, context=ctx) as resp:
+        with open(output_path, "wb") as fh:
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                fh.write(chunk)
+
+
+def _video_cache_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_dir
+        return Path(get_hermes_dir("cache/videos", "video_cache"))
+    except Exception:
+        return Path.home() / ".hermes" / "video_cache"
+
+
+def _coerce_image_source(src: str) -> Optional[str]:
+    """Normalise a local path / URL / data-URI for first_frame_image."""
+    import base64
+    import mimetypes
+
+    src = (src or "").strip()
+    if not src:
+        return None
+    if src.startswith(("data:", "http://", "https://")):
+        return src
+    if src.startswith("file://"):
+        src = src[len("file://"):]
+    path = Path(src).expanduser()
+    if not path.is_file():
+        return None
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime or not mime.startswith("image/"):
+        return None
+    data = base64.b64encode(path.read_bytes()).decode()
+    return f"data:{mime};base64,{data}"
+
+
+# ─── Core ─────────────────────────────────────────────────────────────────
+
+
+def video_generate_tool(
+    prompt: str,
+    duration: Optional[int] = None,
+    resolution: Optional[str] = None,
+    first_frame_image: Optional[str] = None,
+) -> str:
+    try:
+        from hermes_cli.provider_native_tools import native_api_url
+    except Exception:
+        return json.dumps({"success": False,
+                           "error": "no video backend available"})
+
+    from hermes_cli.provider_native_tools import native_credential
+    url = native_api_url("/v1/video_generation")
+    key = native_credential()
+    if not url or not key:
+        return json.dumps({"success": False,
+                           "error": "no video backend configured"})
+
+    payload: Dict[str, Any] = {
+        "model": _VIDEO_MODEL,
+        "prompt": (prompt or "").strip(),
+    }
+    if duration in _VIDEO_VALID_DURATIONS:
+        payload["duration"] = duration
+    if resolution and resolution.upper() in _VIDEO_VALID_RESOLUTIONS:
+        payload["resolution"] = resolution.upper()
+    if first_frame_image:
+        coerced = _coerce_image_source(first_frame_image)
+        if coerced:
+            payload["first_frame_image"] = coerced
+
+    # 1. Submit task.
+    try:
+        body = _post_json(url, payload, key)
+    except urllib.error.HTTPError as exc:
+        return json.dumps({"success": False,
+                           "error": f"video API HTTP {exc.code}"})
+    except (urllib.error.URLError, json.JSONDecodeError) as exc:
+        return json.dumps({"success": False, "error": str(exc)})
+
+    base = body.get("base_resp") or {}
+    if isinstance(base, dict) and base.get("status_code") not in (0, None):
+        return json.dumps({"success": False,
+                           "error": f"video API error {base.get('status_code')}: "
+                                    f"{base.get('status_msg', '')}"})
+
+    task_id = body.get("task_id")
+    if not task_id:
+        return json.dumps({"success": False,
+                           "error": "video API returned no task_id"})
+
+    # 2. Poll until terminal status.
+    api_root = url.rsplit("/v1/", 1)[0]
+    file_id: Optional[str] = None
+    last_status = ""
+    for _ in range(_VIDEO_POLL_MAX):
+        time.sleep(_VIDEO_POLL_SECONDS)
+        try:
+            status_body = _get_json(
+                f"{api_root}/v1/query/video_generation?task_id={task_id}", key)
+        except Exception:
+            continue
+        last_status = str(status_body.get("status") or "")
+        if last_status == "Success":
+            file_id = status_body.get("file_id")
+            break
+        if last_status == "Fail":
+            return json.dumps({"success": False,
+                               "error": f"video generation failed (task {task_id})",
+                               "task_id": task_id})
+
+    if not file_id:
+        return json.dumps({"success": False,
+                           "error": f"video generation timed out after "
+                                    f"{_VIDEO_POLL_SECONDS * _VIDEO_POLL_MAX}s "
+                                    f"(last status: {last_status or 'unknown'})",
+                           "task_id": task_id})
+
+    # 3. Resolve download URL.
+    try:
+        file_body = _get_json(
+            f"{api_root}/v1/files/retrieve?file_id={file_id}", key)
+    except Exception as exc:
+        return json.dumps({"success": False,
+                           "error": f"file retrieve failed: {exc}"})
+    download_url = (file_body.get("file") or {}).get("download_url")
+    if not download_url:
+        return json.dumps({"success": False,
+                           "error": f"no download_url for file_id {file_id}"})
+
+    # 4. Save locally.
+    out_dir = _video_cache_dir()
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    path = out_dir / f"video_{ts}.mp4"
+    try:
+        _download(download_url, path)
+    except Exception as exc:
+        return json.dumps({"success": False,
+                           "error": f"video download failed: {exc}",
+                           "url": download_url, "task_id": task_id})
+
+    return json.dumps({
+        "success": True,
+        "model": _VIDEO_MODEL,
+        "task_id": task_id,
+        "path": str(path),
+        "url": download_url,
+    }, ensure_ascii=False)
+
+
+# ─── Check & registration ─────────────────────────────────────────────────
+
+
+def check_video_generation_requirements() -> bool:
+    try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        return provider_has_native_tool("video_gen", _safe_load_config())
+    except Exception:
+        return False
+
+
+VIDEO_GENERATE_SCHEMA = {
+    "name": "video_generate",
+    "description": (
+        "Generate a short video clip from a text description. "
+        "Optionally provide a first-frame image for image-to-video."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Scene description for the video.",
+            },
+            "duration": {
+                "type": "integer",
+                "enum": [6, 10],
+                "description": "Video length in seconds (default 6).",
+            },
+            "resolution": {
+                "type": "string",
+                "enum": ["768P", "1080P"],
+                "description": "Output resolution (default 768P).",
+            },
+            "first_frame_image": {
+                "type": "string",
+                "description": "Local path, URL, or data URI of the first frame image.",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _handle_video_generate(args: Dict[str, Any], **kw: Any) -> str:
+    prompt = args.get("prompt", "")
+    if not prompt or not isinstance(prompt, str):
+        return json.dumps({"success": False, "error": "prompt is required"})
+    return video_generate_tool(
+        prompt=prompt,
+        duration=args.get("duration"),
+        resolution=args.get("resolution"),
+        first_frame_image=args.get("first_frame_image"),
+    )
+
+
+registry.register(
+    name="video_generate",
+    toolset="video_gen",
+    schema=VIDEO_GENERATE_SCHEMA,
+    handler=_handle_video_generate,
+    check_fn=check_video_generation_requirements,
+    emoji="\U0001f3ac",
+)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -465,7 +465,15 @@ async def vision_analyze_tool(
 
         logger.info("Analyzing image: %s", image_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
-        
+
+        # Try provider-native VLM when available and vision is not pinned.
+        try:
+            native_result = _native_vision_analyze(image_url, user_prompt)
+            if native_result is not None:
+                return native_result
+        except Exception as _exc:
+            logger.debug("provider-native vision dispatch skipped: %s", _exc)
+
         # Determine if this is a local file path or a remote URL
         # Strip file:// scheme so file URIs resolve as local paths.
         resolved_url = image_url
@@ -681,6 +689,12 @@ async def vision_analyze_tool(
 def check_vision_requirements() -> bool:
     """Check if the configured runtime vision path can resolve a client."""
     try:
+        from hermes_cli.provider_native_tools import provider_has_native_tool, _safe_load_config
+        if provider_has_native_tool("vision", _safe_load_config()):
+            return True
+    except Exception:
+        pass
+    try:
         from agent.auxiliary_client import resolve_vision_provider_client
 
         _provider, client, _model = resolve_vision_provider_client()
@@ -776,6 +790,77 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
     )
     model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
     return vision_analyze_tool(image_url, full_prompt, model)
+
+
+# ─── Provider-native VLM ──────────────────────────────────────────────────
+
+_VLM_SUPPORTED_MIME = {"image/jpeg", "image/png", "image/webp"}
+
+
+def _native_vision_analyze(image_source, user_prompt):
+    """Dispatch to the native provider's VLM, or return None to fall through."""
+    import base64 as _b64
+    import mimetypes
+    import ssl
+    import urllib.error
+    import urllib.request
+    from hermes_cli.provider_native_tools import native_api_url, native_credential
+
+    try:
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _vis_provider = (_cfg.get("auxiliary") or {}).get("vision", {}).get("provider", "")
+        if str(_vis_provider).strip().lower() not in ("", "auto", "main"):
+            return None
+    except Exception:
+        pass
+
+    url = native_api_url("/v1/coding_plan/vlm")
+    key = native_credential()
+    if not url or not key:
+        return None
+
+    src = (image_source or "").strip()
+    if not src:
+        return None
+    if not src.startswith(("data:", "http://", "https://")):
+        if src.startswith("file://"):
+            src = src[len("file://"):]
+        path = Path(os.path.expanduser(src))
+        if not path.is_file():
+            return None
+        mime, _ = mimetypes.guess_type(str(path))
+        if not mime or mime not in _VLM_SUPPORTED_MIME:
+            return None
+        data = _b64.b64encode(path.read_bytes()).decode()
+        src = f"data:{mime};base64,{data}"
+
+    payload = json.dumps({"prompt": user_prompt, "image_url": src},
+                         ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=payload, method="POST",
+        headers={"Authorization": f"Bearer {key}",
+                 "Content-Type": "application/json"},
+    )
+    try:
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(req, timeout=60, context=ctx) as resp:
+            body = json.loads(resp.read().decode("utf-8", errors="replace"))
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return None
+
+    base_resp = body.get("base_resp") or {}
+    if isinstance(base_resp, dict) and base_resp.get("status_code") not in (0, None):
+        return json.dumps({
+            "success": False,
+            "error": f"VLM error {base_resp.get('status_code')}: "
+                     f"{base_resp.get('status_msg', '')}",
+        }, ensure_ascii=False)
+
+    content = body.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return json.dumps({"success": True, "analysis": content}, ensure_ascii=False)
 
 
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,8 +35,9 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
-    # Vision + image generation
+    # Vision + image / video / music generation
     "vision_analyze", "image_generate",
+    "video_generate", "music_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -90,7 +91,19 @@ TOOLSETS = {
         "tools": ["image_generate"],
         "includes": []
     },
-    
+
+    "video_gen": {
+        "description": "Creative generation tools (short video clips)",
+        "tools": ["video_generate"],
+        "includes": []
+    },
+
+    "music_gen": {
+        "description": "Creative generation tools (songs with lyrics + style)",
+        "tools": ["music_generate"],
+        "includes": []
+    },
+
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
@@ -251,8 +264,9 @@ TOOLSETS = {
             "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
-            # Vision + image generation
+            # Vision + image / video / music generation
             "vision_analyze", "image_generate",
+            "video_generate", "music_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation


### PR DESCRIPTION
## Summary

Auto-detect multi-modal chat providers from `model.base_url` and wire all native capabilities (TTS, image, vision, video, music) as default tool backends — zero manual configuration.

- URL-based detection (single `"minimax" in hostname` check), no external dependency
- Setup hook mirrors `apply_nous_provider_defaults`: data-driven, only overrides built-in defaults, never touches explicit user config
- Respects Tool Gateway `use_gateway` flag — if user opts into gateway for a tool, native dispatch yields
- Request handlers in individual tool files (same pattern as `_generate_minimax_tts`)
- Region-aware credential selection: CN endpoints prefer `MINIMAX_CN_API_KEY`
- MiniMax is the first provider. Adding another: one line in `_is_native_provider` + per-tool handlers

## Files Changed

| File | Changes |
|------|---------|
| `hermes_cli/provider_native_tools.py` | **new (+120)** — setup defaults, `native_api_url`, `native_credential`, gateway-aware `provider_has_native_tool` |
| `tools/video_generation_tool.py` | **new** — `video_generate` tool. Async poll flow (submit → poll → file retrieve → download) |
| `tools/music_generation_tool.py` | **new** — `music_generate` tool. Sync call + hex audio decode. `sk-cp-` key → premium model |
| `tests/hermes_cli/test_provider_native_tools.py` | **new (38 tests)** |
| `hermes_cli/setup.py` | **+15** — call `apply_provider_native_tool_defaults`; skip TTS selector when provider owns TTS |
| `tools/image_generation_tool.py` | **+80** — `_native_image_generate` handler, dispatch before FAL path |
| `tools/vision_tools.py` | **+80** — `_native_vision_analyze` VLM handler, dispatch before auxiliary-client path |
| `tools/tts_tool.py` | **+10** — derive URL + key via `native_api_url` / `native_credential` for CN auto-routing |
| `toolsets.py` | **+16** — `video_gen` / `music_gen` toolset definitions |
| `hermes_cli/tools_config.py` | **+2** — `video_gen` / `music_gen` in `CONFIGURABLE_TOOLSETS` |

## Test Plan

```
python -m pytest tests/hermes_cli/test_provider_native_tools.py -q
# 38 passed
```

Live end-to-end with Token Plan key on both `api.minimax.io` and `api.minimaxi.com`: all 5 capabilities verified.

Zero new pip dependencies (stdlib only). Zero behaviour change for providers not matched by `_is_native_provider`.