### PR TITLE
fix: cleanly shut down Honcho background workers

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -194,6 +194,9 @@ class HonchoMemoryProvider(MemoryProvider):
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
         self._sync_thread: Optional[threading.Thread] = None
+        self._background_threads: set[threading.Thread] = set()
+        self._background_threads_lock = threading.Lock()
+        self._shutdown_event = threading.Event()
 
         # B1: recall_mode — set during initialize from config
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
@@ -516,6 +519,8 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return ""
+        if self._shutdown_event.is_set():
+            return ""
 
         # B1: tools-only mode — no auto-injection
         if self._recall_mode == "tools":
@@ -574,8 +579,9 @@ class HonchoMemoryProvider(MemoryProvider):
                 except Exception as exc:
                     logger.debug("Honcho first-turn dialectic failed: %s", exc)
 
-            _t = threading.Thread(target=_run_first_turn, daemon=True)
-            _t.start()
+            _t = self._start_background_thread(target=_run_first_turn)
+            if _t is None:
+                return ""
             _t.join(timeout=_first_turn_timeout)
             if not _t.is_alive():
                 first_turn_dialectic = _result_holder[0] if _result_holder else ""
@@ -634,6 +640,8 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        if self._shutdown_event.is_set():
+            return
         if not self._manager or not self._session_key or not query:
             return
 
@@ -662,16 +670,16 @@ class HonchoMemoryProvider(MemoryProvider):
         def _run():
             try:
                 result = self._run_dialectic_depth(query)
-                if result and result.strip():
+                if result and result.strip() and not self._shutdown_event.is_set():
                     with self._prefetch_lock:
                         self._prefetch_result = result
             except Exception as e:
                 logger.debug("Honcho prefetch failed: %s", e)
 
-        self._prefetch_thread = threading.Thread(
-            target=_run, daemon=True, name="honcho-prefetch"
+        self._prefetch_thread = self._start_background_thread(
+            target=_run,
+            name="honcho-prefetch",
         )
-        self._prefetch_thread.start()
 
     # ----- Dialectic depth: multi-pass .chat() with cold/warm prompts -----
 
@@ -865,6 +873,8 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        if self._shutdown_event.is_set():
+            return
         if not self._manager or not self._session_key:
             return
 
@@ -882,17 +892,19 @@ class HonchoMemoryProvider(MemoryProvider):
                 logger.debug("Honcho sync_turn failed: %s", e)
 
         if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=5.0)
-        self._sync_thread = threading.Thread(
-            target=_sync, daemon=True, name="honcho-sync"
+            self._sync_thread.join(timeout=self._join_timeout_seconds())
+        self._sync_thread = self._start_background_thread(
+            target=_sync,
+            name="honcho-sync",
         )
-        self._sync_thread.start()
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in user profile writes as Honcho conclusions."""
         if action != "add" or target != "user" or not content:
             return
         if self._cron_skipped:
+            return
+        if self._shutdown_event.is_set():
             return
         if not self._manager or not self._session_key:
             return
@@ -903,8 +915,7 @@ class HonchoMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Honcho memory mirror failed: %s", e)
 
-        t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
-        t.start()
+        self._start_background_thread(target=_write, name="honcho-memwrite")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
@@ -914,11 +925,40 @@ class HonchoMemoryProvider(MemoryProvider):
             return
         # Wait for pending sync
         if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=10.0)
+            self._sync_thread.join(timeout=self._join_timeout_seconds())
         try:
             self._manager.flush_all()
         except Exception as e:
             logger.debug("Honcho session-end flush failed: %s", e)
+
+    def _join_timeout_seconds(self) -> float:
+        timeout = getattr(self._config, "timeout", None)
+        if timeout:
+            try:
+                return max(5.0, float(timeout) + 2.0)
+            except (TypeError, ValueError):
+                pass
+        return 10.0
+
+    def _start_background_thread(self, *, target, name: str | None = None) -> Optional[threading.Thread]:
+        if self._shutdown_event.is_set():
+            return None
+
+        thread: Optional[threading.Thread] = None
+
+        def _wrapped() -> None:
+            try:
+                target()
+            finally:
+                if thread is not None:
+                    with self._background_threads_lock:
+                        self._background_threads.discard(thread)
+
+        thread = threading.Thread(target=_wrapped, daemon=True, name=name)
+        with self._background_threads_lock:
+            self._background_threads.add(thread)
+        thread.start()
+        return thread
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Return tool schemas, respecting recall_mode.
@@ -1034,13 +1074,25 @@ class HonchoMemoryProvider(MemoryProvider):
             return tool_error(f"Honcho {tool_name} failed: {e}")
 
     def shutdown(self) -> None:
+        self._shutdown_event.set()
+
+        join_timeout = self._join_timeout_seconds()
+
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
-                t.join(timeout=5.0)
-        # Flush any remaining messages
+                t.join(timeout=join_timeout)
+
+        with self._background_threads_lock:
+            background_threads = list(self._background_threads)
+
+        for t in background_threads:
+            if t.is_alive():
+                t.join(timeout=join_timeout)
+
+        # Flush any remaining messages and stop manager-owned workers.
         if self._manager:
             try:
-                self._manager.flush_all()
+                self._manager.shutdown()
             except Exception:
                 pass
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -131,6 +131,9 @@ class HonchoSessionManager:
         # Async write queue — started lazily on first enqueue
         self._async_queue: queue.Queue | None = None
         self._async_thread: threading.Thread | None = None
+        self._shutdown_event = threading.Event()
+        self._background_threads: set[threading.Thread] = set()
+        self._background_threads_lock = threading.Lock()
         if write_frequency == "async":
             self._async_queue = queue.Queue()
             self._async_thread = threading.Thread(
@@ -139,6 +142,36 @@ class HonchoSessionManager:
                 daemon=True,
             )
             self._async_thread.start()
+
+    def _join_timeout_seconds(self) -> float:
+        timeout = getattr(self._config, "timeout", None)
+        if timeout:
+            try:
+                return max(5.0, float(timeout) + 2.0)
+            except (TypeError, ValueError):
+                pass
+        return 10.0
+
+    def _start_background_thread(self, *, name: str, target) -> threading.Thread | None:
+        """Start a tracked Honcho worker thread unless shutdown has begun."""
+        if self._shutdown_event.is_set():
+            return None
+
+        thread: threading.Thread | None = None
+
+        def _wrapped() -> None:
+            try:
+                target()
+            finally:
+                if thread is not None:
+                    with self._background_threads_lock:
+                        self._background_threads.discard(thread)
+
+        thread = threading.Thread(target=_wrapped, name=name, daemon=True)
+        with self._background_threads_lock:
+            self._background_threads.add(thread)
+        thread.start()
+        return thread
 
     @property
     def honcho(self) -> Honcho:
@@ -444,11 +477,22 @@ class HonchoSessionManager:
                     break
 
     def shutdown(self) -> None:
-        """Gracefully shut down the async writer thread."""
+        """Gracefully shut down Honcho background workers."""
+        self._shutdown_event.set()
+
+        join_timeout = self._join_timeout_seconds()
+
+        with self._background_threads_lock:
+            background_threads = list(self._background_threads)
+
+        for thread in background_threads:
+            if thread.is_alive():
+                thread.join(timeout=join_timeout)
+
         if self._async_queue is not None and self._async_thread is not None:
             self.flush_all()
             self._async_queue.put(_ASYNC_SHUTDOWN)
-            self._async_thread.join(timeout=10)
+            self._async_thread.join(timeout=join_timeout)
 
     def delete(self, key: str) -> bool:
         """Delete a session from local cache."""
@@ -567,13 +611,18 @@ class HonchoSessionManager:
             session_key: The session key to query against.
             query: The user's current message, used as the query.
         """
+        if self._shutdown_event.is_set():
+            return
+
         def _run():
             result = self.dialectic_query(session_key, query)
-            if result:
+            if result and not self._shutdown_event.is_set():
                 self.set_dialectic_result(session_key, result)
 
-        t = threading.Thread(target=_run, name="honcho-dialectic-prefetch", daemon=True)
-        t.start()
+        self._start_background_thread(
+            name="honcho-dialectic-prefetch",
+            target=_run,
+        )
 
     def set_dialectic_result(self, session_key: str, result: str) -> None:
         """Store a prefetched dialectic result in a thread-safe way."""
@@ -598,13 +647,18 @@ class HonchoSessionManager:
         Non-blocking. Consumed next turn via pop_context_result(). This avoids
         a synchronous HTTP round-trip blocking every response.
         """
+        if self._shutdown_event.is_set():
+            return
+
         def _run():
             result = self.get_prefetch_context(session_key, user_message)
-            if result:
+            if result and not self._shutdown_event.is_set():
                 self.set_context_result(session_key, result)
 
-        t = threading.Thread(target=_run, name="honcho-context-prefetch", daemon=True)
-        t.start()
+        self._start_background_thread(
+            name="honcho-context-prefetch",
+            target=_run,
+        )
 
     def set_context_result(self, session_key: str, result: dict[str, str]) -> None:
         """Store a prefetched context result in a thread-safe way."""

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch, call
 import pytest
 
 from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho import HonchoMemoryProvider
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
@@ -321,6 +322,39 @@ class TestAsyncWriterThread:
         thread.join(timeout=3)
         assert not thread.is_alive()
 
+    def test_shutdown_joins_prefetch_workers(self):
+        mgr = _make_manager(write_frequency="turn")
+        gate = threading.Event()
+
+        def slow_context(*_args, **_kwargs):
+            gate.wait(timeout=2.0)
+            return {"representation": "ready"}
+
+        def slow_dialectic(*_args, **_kwargs):
+            gate.wait(timeout=2.0)
+            return "done"
+
+        mgr.get_prefetch_context = slow_context
+        mgr.dialectic_query = slow_dialectic
+        mgr._cache["cli:test"] = _make_session()
+
+        mgr.prefetch_context("cli:test", "hello")
+        mgr.prefetch_dialectic("cli:test", "hello")
+
+        deadline = time.time() + 2.0
+        while time.time() < deadline:
+            with mgr._background_threads_lock:
+                if len(mgr._background_threads) >= 2:
+                    break
+            time.sleep(0.01)
+
+        gate.set()
+        mgr.shutdown()
+
+        with mgr._background_threads_lock:
+            tracked = list(mgr._background_threads)
+        assert all(not thread.is_alive() for thread in tracked)
+
 
 # ---------------------------------------------------------------------------
 # async retry on failure
@@ -467,3 +501,14 @@ class TestPrefetchCacheAccessors:
 
         assert mgr.pop_dialectic_result("cli:test") == "Resume with toolset cleanup"
         assert mgr.pop_dialectic_result("cli:test") == ""
+
+
+class TestHonchoProviderShutdown:
+    def test_shutdown_calls_manager_shutdown(self):
+        provider = HonchoMemoryProvider()
+        manager = MagicMock()
+        provider._manager = manager
+
+        provider.shutdown()
+
+        manager.shutdown.assert_called_once_with()


### PR DESCRIPTION
## Bug Description

Hermes could print a valid response and then abort during interpreter teardown in Honcho-enabled CLI runs. This was easiest to reproduce in short-lived one-shot commands like `hermes chat -q ...`.

## Root Cause

Hermes's Honcho integration started several daemon background threads for context prefetch, dialectic prefetch, sync, and async writes. During process shutdown, some of those workers could still be doing HTTP/SSL work while Python was already in `Py_FinalizeEx`, leading to an abort after the response had already been returned.

## Fix

- track Honcho manager-owned background workers and join them during shutdown
- track provider-owned Honcho workers and stop accepting new background work once shutdown begins
- route provider shutdown through `HonchoSessionManager.shutdown()` instead of only `flush_all()`
- add regression coverage for manager/provider shutdown behavior

## How to Verify

1. Run `./venv/bin/python -m hermes_cli.main -p 273 chat -q "Reply with exactly OK"` repeatedly in a Honcho-enabled profile.
2. Confirm the command returns `RC:0` after printing the response instead of intermittently aborting with a coredump.
3. Run the targeted Honcho tests below.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

Commands run:
- `./venv/bin/python -m pytest tests/honcho_plugin/test_async_memory.py tests/honcho_plugin/test_session.py -q`
- `./venv/bin/python -m py_compile plugins/memory/honcho/session.py plugins/memory/honcho/__init__.py tests/honcho_plugin/test_async_memory.py`
- repeated manual one-shot CLI smoke tests on profile 273

## Risk Assessment

Medium — this changes Honcho shutdown/lifecycle behavior, but the blast radius is limited to Hermes's Honcho integration and is covered by targeted regression tests.
