### PR TITLE
chore: add briandevans noreply email to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -250,6 +250,7 @@ AUTHOR_MAP = {
     "1736355688@qq.com": "hedgeho9X",
     "bernylinville@devopsthink.org": "bernylinville",
     "brian@bde.io": "briandevans",
+    "252620095+briandevans@users.noreply.github.com": "briandevans",
     "hubin_ll@qq.com": "LLQWQ",
     "memosr_email@gmail.com": "memosr",
     "anthhub@163.com": "anthhub",


### PR DESCRIPTION
## What does this PR do?

Adds the GitHub noreply form of my email (\`252620095+briandevans@users.noreply.github.com\`) to \`AUTHOR_MAP\` in \`scripts/release.py\`.

\`brian@bde.io\` is already mapped, but commits authored against the noreply form (which is what GitHub-default \`git config user.email\` setups produce) fall through to unmapped in \`contributor_audit\` strict mode. This means any salvage of my work that picks up the noreply authorship would break the release attribution pipeline.

This PR only adds a single entry — no behavior change, no test changes, no other contributors touched. Mirrors the pattern used for kshitijk4poor in #11120 and the batch in #11076.

## Verification

\`\`\`
python -c "
import ast, pathlib
tree = ast.parse(pathlib.Path('scripts/release.py').read_text())
d = next(ast.literal_eval(n.value) for n in ast.walk(tree)
         if isinstance(n, ast.Assign) and any(getattr(t, 'id', None) == 'AUTHOR_MAP' for t in n.targets))
assert d['252620095+briandevans@users.noreply.github.com'] == 'briandevans'
assert d['brian@bde.io'] == 'briandevans'
print(len(d))  # -> 211
"
\`\`\`

No standalone lint command is defined; CI runs \`python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto\` (matches \`.github/workflows/tests.yml\`). No tests reference \`AUTHOR_MAP\`, so no test impact.

## Related Issue

_No specific issue — maintenance change against the release script. The trigger was noticing that the noreply form wasn't mapped while working on salvage-friendly PR hygiene._

## Type of Change

- [x] ♻️ Refactor (no behavior change) — AUTHOR_MAP data change

## Changes Made

- \`scripts/release.py\`: add one entry mapping \`252620095+briandevans@users.noreply.github.com\` → \`briandevans\`.

## How to Test

1. Checkout this branch.
2. Run the verification snippet above.
3. \`python -m py_compile scripts/release.py\` → OK.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (\`chore:\`)
- [x] Searched for existing PRs — none touching this line
- [x] Only changes related to this chore (one line)
- [x] Verified file parses; no test references to AUTHOR_MAP in \`tests/\`

### Documentation & Housekeeping

- [x] No docs changes needed — internal data file only
- [x] No config-key changes
- [x] No architecture/workflow changes
- [x] Cross-platform impact: none
- [x] No tool descriptions/schemas touched