### PR TITLE
fix(weixin): keep inbound voice audio when text hint exists

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -691,6 +691,10 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Adapter-specific inbound context that should survive normalization without
+    # inventing ad-hoc attributes on the event object.
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -942,6 +942,28 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
     return ""
 
 
+def _extract_voice_context(item_list: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return inbound voice hint metadata from the first voice item."""
+    for item in item_list:
+        if item.get("type") != ITEM_VOICE:
+            continue
+        voice_item = item.get("voice_item") or {}
+        playtime = voice_item.get("playtime")
+        try:
+            duration_ms = int(playtime) if playtime is not None else 0
+        except Exception:
+            duration_ms = 0
+        # Some iLink variants appear to report playtime in seconds instead of
+        # milliseconds. Normalize short plausible voice durations to ms.
+        if 0 < duration_ms <= 120:
+            duration_ms *= 1000
+        return {
+            "text_hint": str(voice_item.get("text") or "").strip(),
+            "duration_ms": duration_ms,
+        }
+    return {"text_hint": "", "duration_ms": 0}
+
+
 def _message_type_from_media(media_types: List[str], text: str) -> MessageType:
     if any(m.startswith("image/") for m in media_types):
         return MessageType.PHOTO
@@ -1324,6 +1346,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)
+        voice_context = _extract_voice_context(item_list)
         media_paths: List[str] = []
         media_types: List[str] = []
 
@@ -1351,6 +1374,12 @@ class WeixinAdapter(BasePlatformAdapter):
             message_id=message_id or None,
             media_urls=media_paths,
             media_types=media_types,
+            metadata={
+                "voice_text_hint": voice_context["text_hint"],
+                "voice_duration_ms": voice_context["duration_ms"],
+            }
+            if voice_context["text_hint"] or voice_context["duration_ms"]
+            else {},
             timestamp=datetime.now(),
         )
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
@@ -1442,7 +1471,7 @@ class WeixinAdapter(BasePlatformAdapter):
     async def _download_voice(self, item: Dict[str, Any]) -> Optional[str]:
         voice_item = item.get("voice_item") or {}
         media = voice_item.get("media") or {}
-        if voice_item.get("text"):
+        if not isinstance(media, dict) or not (media.get("full_url") or media.get("encrypt_query_param")):
             return None
         try:
             data = await _download_and_decrypt_media(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -309,6 +309,96 @@ class TestWeixinSendMessageIntegration:
         )
 
 
+class TestWeixinInboundVoice:
+    @patch("gateway.platforms.weixin._download_and_decrypt_media", new_callable=AsyncMock)
+    def test_download_voice_keeps_audio_even_with_text_hint(self, download_mock):
+        download_mock.return_value = b"fake-silk"
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+
+        path = asyncio.run(
+            adapter._download_voice(
+                {
+                    "voice_item": {
+                        "text": "已有转写",
+                        "media": {
+                            "full_url": "https://cdn.example.com/audio",
+                            "aes_key": "ZmFrZV9rZXk=",
+                        },
+                    }
+                }
+            )
+        )
+
+        assert path is not None
+        download_mock.assert_awaited_once()
+
+    def test_extract_voice_context_normalizes_seconds_to_ms_and_preserves_ms(self):
+        assert weixin._extract_voice_context(
+            [{"type": weixin.ITEM_VOICE, "voice_item": {"text": "短语音", "playtime": 2}}]
+        ) == {"text_hint": "短语音", "duration_ms": 2000}
+
+        assert weixin._extract_voice_context(
+            [{"type": weixin.ITEM_VOICE, "voice_item": {"text": "毫秒值", "playtime": 2400}}]
+        ) == {"text_hint": "毫秒值", "duration_ms": 2400}
+
+    @patch("gateway.platforms.weixin._download_and_decrypt_media", new_callable=AsyncMock)
+    def test_download_voice_returns_none_without_media_reference(self, download_mock):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+
+        path = asyncio.run(
+            adapter._download_voice(
+                {
+                    "voice_item": {
+                        "text": "只有转写没有媒体",
+                        "media": {},
+                    }
+                }
+            )
+        )
+
+        assert path is None
+        download_mock.assert_not_awaited()
+
+    @patch("gateway.platforms.weixin.asyncio.create_task")
+    @patch.object(WeixinAdapter, "_download_voice", new_callable=AsyncMock)
+    def test_process_message_attaches_voice_hint_metadata(self, download_voice_mock, create_task_mock):
+        download_voice_mock.return_value = "/tmp/inbound.silk"
+        create_task_mock.side_effect = lambda coro: coro.close()
+
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter.handle_message = AsyncMock()
+
+        asyncio.run(
+            adapter._process_message(
+                {
+                    "from_user_id": "wxid_peer",
+                    "message_id": "msg-1",
+                    "context_token": "ctx-1",
+                    "item_list": [
+                        {
+                            "type": weixin.ITEM_VOICE,
+                            "voice_item": {
+                                "text": "已有转写",
+                                "playtime": 2,
+                                "media": {"full_url": "https://cdn.example.com/audio"},
+                            },
+                        }
+                    ],
+                }
+            )
+        )
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "已有转写"
+        assert event.media_urls == ["/tmp/inbound.silk"]
+        assert event.media_types == ["audio/silk"]
+        assert event.metadata["voice_text_hint"] == "已有转写"
+        assert event.metadata["voice_duration_ms"] == 2000
+
+
 class TestWeixinChunkDelivery:
     def _connected_adapter(self) -> WeixinAdapter:
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Fixes a Weixin inbound voice handling bug: if `voice_item.text` is already present, Hermes currently skips downloading the actual voice media.

That is too aggressive. Some Weixin / iLink variants provide both:
- a text hint
- a downloadable voice payload

Before this patch, Hermes kept the text hint but dropped the audio entirely. After this patch, Hermes still preserves the text hint, but it also keeps the real voice payload when the media reference is available.

## Related Issue

Fixes #11686

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py`
  - stop treating `voice_item.text` as a reason to skip voice download
  - only skip when there is no usable media reference
  - extract inbound voice hint metadata (`voice_text_hint`, `voice_duration_ms`)
  - normalize short `playtime` values that appear to be in seconds instead of milliseconds
- `gateway/platforms/base.py`
  - add a small `MessageEvent.metadata` dict so adapters can carry normalized inbound metadata without inventing ad-hoc attributes
- `tests/gateway/test_weixin.py`
  - add regressions for:
    - keeping audio even when a text hint exists
    - `playtime` normalization
    - safe no-media fallback
    - attaching normalized voice metadata to the inbound event

## How to Test

1. Run:
   `python -m pytest tests/gateway/test_weixin.py tests/gateway/test_platform_base.py tests/gateway/test_stt_config.py -q`
2. Send a Weixin voice note where the inbound payload contains both `voice_item.text` and downloadable voice media.
3. Confirm Hermes keeps both:
   - `event.text` still contains the hint
   - `event.media_urls` includes the cached voice file

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation run:

```shell
python -m pytest tests/gateway/test_weixin.py tests/gateway/test_platform_base.py tests/gateway/test_stt_config.py -q
127 passed
```
