### PR TITLE
fix(gateway): keep cron alive during reconnect backoff

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1059,22 +1059,14 @@ class GatewayRunner:
                 logger.error("No connected messaging platforms remain. Shutting down gateway cleanly.")
             await self.stop()
         elif not self.adapters and self._failed_platforms:
-            # All platforms are down and queued for background reconnection.
-            # If the error is retryable, exit with failure so systemd Restart=on-failure
-            # can restart the process. Otherwise stay alive and keep retrying in background.
-            if adapter.fatal_error_retryable:
-                self._exit_reason = adapter.fatal_error_message or "All messaging platforms failed with retryable errors"
-                self._exit_with_failure = True
-                logger.error(
-                    "All messaging platforms failed with retryable errors. "
-                    "Shutting down gateway for service restart (systemd will retry)."
-                )
-                await self.stop()
-            else:
-                logger.warning(
-                    "No connected messaging platforms remain, but %d platform(s) queued for reconnection",
-                    len(self._failed_platforms),
-                )
+            # All platforms are down, but at least one is already queued for
+            # background reconnection. Keep the process alive so the reconnect
+            # watcher and embedded cron ticker can continue running.
+            logger.warning(
+                "No connected messaging platforms remain, but %d platform(s) "
+                "queued for reconnection. Gateway staying alive to keep cron running.",
+                len(self._failed_platforms),
+            )
 
     def _request_clean_exit(self, reason: str) -> None:
         self._exit_cleanly = True

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -373,11 +373,11 @@ class TestRuntimeDisconnectQueuing:
         assert Platform.TELEGRAM not in runner._failed_platforms
 
     @pytest.mark.asyncio
-    async def test_retryable_error_exits_for_service_restart_when_all_down(self):
-        """Gateway should exit with failure when all platforms fail with retryable errors.
+    async def test_retryable_error_stays_alive_when_all_down_but_reconnect_queued(self):
+        """Gateway should stay alive when the last adapter is queued for reconnect.
 
-        This lets systemd Restart=on-failure restart the process, which is more
-        reliable than in-process background reconnection after exhausted retries.
+        Keeping the process alive lets the background reconnect watcher recover
+        the platform without interrupting the embedded cron ticker.
         """
         runner = _make_runner()
         runner.stop = AsyncMock()
@@ -388,9 +388,10 @@ class TestRuntimeDisconnectQueuing:
 
         await runner._handle_adapter_fatal_error(adapter)
 
-        # stop() SHOULD be called — gateway exits for systemd restart
-        runner.stop.assert_called_once()
-        assert runner._exit_with_failure is True
+        # stop() should NOT be called — gateway stays alive for background retry
+        runner.stop.assert_not_called()
+        assert runner._exit_with_failure is False
+        assert runner._exit_reason is None
         assert Platform.TELEGRAM in runner._failed_platforms
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_runner_fatal_adapter.py
+++ b/tests/gateway/test_runner_fatal_adapter.py
@@ -68,7 +68,7 @@ async def test_runner_requests_clean_exit_for_nonretryable_startup_conflict(monk
 @pytest.mark.asyncio
 async def test_runner_queues_retryable_runtime_fatal_for_reconnection(monkeypatch, tmp_path):
     """Retryable runtime fatal errors queue the platform for reconnection
-    instead of shutting down the gateway."""
+    instead of shutting down the gateway when reconnect work remains."""
     config = GatewayConfig(
         platforms={
             Platform.WHATSAPP: PlatformConfig(enabled=True, token="token")
@@ -89,8 +89,9 @@ async def test_runner_queues_retryable_runtime_fatal_for_reconnection(monkeypatc
 
     await runner._handle_adapter_fatal_error(adapter)
 
-    # Should shut down with failure — systemd Restart=on-failure will restart
-    runner.stop.assert_awaited_once()
-    assert runner._exit_with_failure is True
+    runner.stop.assert_not_awaited()
+    assert runner._exit_with_failure is False
+    assert runner._exit_reason is None
+    assert Platform.WHATSAPP not in runner.adapters
     assert Platform.WHATSAPP in runner._failed_platforms
     assert runner._failed_platforms[Platform.WHATSAPP]["attempts"] == 0


### PR DESCRIPTION
## What does this PR do?

Keeps the gateway process alive when the last connected platform fails with a retryable fatal error and has already been queued for background reconnection. This preserves the embedded cron ticker while `_platform_reconnect_watcher` handles reconnect backoff.

## Related Issue

Fixes #11614

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- remove the forced shutdown path in `gateway/run.py` when all adapters are down but platforms remain queued for reconnect
- keep the existing reconnect watcher responsible for recovering the failed platform in the background
- update `tests/gateway/test_platform_reconnect.py` to assert the gateway stays alive and preserves the reconnect queue instead of stopping immediately

## How to Test

1. Reproduce the retryable fatal-error path where the final connected platform disconnects and is placed into `_failed_platforms`.
2. Run `./.venv/bin/python -m pytest -o addopts='' tests/gateway/test_platform_reconnect.py -q`.
3. Confirm the reconnect test asserts `runner.stop()` is not called and the gateway remains alive while reconnect backoff continues.

## Notes

The issue already points to `_platform_reconnect_watcher` as the intended recovery path. This patch keeps that behavior active instead of exiting the process and interrupting embedded cron jobs during the reconnect window.
