### PR TITLE
fix(memory): honor config.yaml limits in registry-dispatched memory calls (#11665)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -708,7 +708,10 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        # Match production layout: MEMORY.md lives under HERMES_HOME/memories/.
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         subagent = type("SubAgent", (), {"_memory_store": None})()
 
@@ -734,7 +737,9 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         resolved = _resolve_memory_store_from_kwargs({})
         assert resolved is not None
@@ -756,7 +761,9 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         resolved = _resolve_memory_store_from_kwargs({})
         assert resolved is not None
@@ -778,10 +785,19 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        # Do NOT pre-create hermes_home/memories: when memory is disabled,
+        # the resolver must short-circuit before touching the filesystem.
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: hermes_home / "memories",
+        )
 
         resolved = _resolve_memory_store_from_kwargs({})
         assert resolved is None
+        # Defensive assertion: resolving a disabled config must NOT have
+        # created the memories/ subdir as a side effect (Copilot review).
+        assert not (hermes_home / "memories").exists(), (
+            "resolver with memory disabled should have no filesystem side effects"
+        )
 
     def test_default_store_is_singleton(self, tmp_path, monkeypatch):
         """The default store is cached — two resolutions return the same
@@ -798,7 +814,9 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         first = _resolve_memory_store_from_kwargs({})
         second = _resolve_memory_store_from_kwargs({})
@@ -828,7 +846,10 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        # Match production layout: get_memory_dir() -> HERMES_HOME/memories.
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         # Dispatch via the registry with NO store kwarg and NO parent_agent
         # — mirrors handle_function_call's path.
@@ -840,7 +861,10 @@ class TestRegistryDispatchStoreResolution:
         # On unpatched code this fails with "Memory is not available".
         assert result.get("success") is True, f"dispatch returned: {result}"
 
-        # The entry should have been persisted under the tmp HERMES_HOME.
-        memory_md = hermes_home / "MEMORY.md"
-        assert memory_md.exists(), "dispatch did not persist to config-driven hermes_home"
+        # The entry should be persisted at the production path:
+        # HERMES_HOME/memories/MEMORY.md — not HERMES_HOME/MEMORY.md.
+        memory_md = memories_dir / "MEMORY.md"
+        assert memory_md.exists(), (
+            f"dispatch did not persist to {memory_md} (production layout)"
+        )
         assert "routed via registry dispatch" in memory_md.read_text(encoding="utf-8")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -636,3 +636,211 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Registry dispatch store resolution — regression for #11665
+# =========================================================================
+
+class TestRegistryDispatchStoreResolution:
+    """The ``memory`` tool is also reachable through ``registry.dispatch``
+    (handle_function_call path) and ``_resolve_memory_store_from_kwargs``.
+
+    Prior to #11665 that path passed ``store=None`` unconditionally, so
+    ``config.yaml``'s ``memory.memory_char_limit`` / ``memory.user_char_limit``
+    values were invisible to every dispatch site that wasn't the main
+    agent loop (code_execution sandbox, RL environments, reward verifiers,
+    and any plugin that forwarded a dispatch without an explicit store).
+
+    The resolver now walks the fallback chain:
+        explicit ``store=`` → ``parent_agent._memory_store`` → config-
+        driven module-level singleton built from ``hermes_cli.config``.
+    """
+
+    def _reset_default(self):
+        # Best-effort cache reset — absent on pre-fix revisions, which
+        # lets this helper run on either checkout so the behavioral
+        # regression test below can still exercise both branches.
+        try:
+            from tools.memory_tool import _reset_default_store_for_tests
+        except ImportError:
+            return
+        _reset_default_store_for_tests()
+
+    def test_explicit_store_kwarg_wins(self, tmp_path, monkeypatch):
+        """When a caller passes ``store=`` explicitly (main agent loop,
+        unit tests), the resolver returns it unchanged — never falls
+        through to ``parent_agent`` or the default singleton."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        explicit = MemoryStore(memory_char_limit=111, user_char_limit=222)
+        decoy = MemoryStore(memory_char_limit=333, user_char_limit=444)
+        decoy_agent = type("FakeAgent", (), {"_memory_store": decoy})()
+
+        resolved = _resolve_memory_store_from_kwargs(
+            {"store": explicit, "parent_agent": decoy_agent}
+        )
+        assert resolved is explicit
+
+    def test_parent_agent_store_used_when_no_explicit_store(self, tmp_path, monkeypatch):
+        """Plugin dispatches (``hermes_cli/plugins.py`` plumbs
+        ``parent_agent`` through ``registry.dispatch``) should use the
+        parent agent's memory store so plugin-triggered memory calls
+        honor the user's configured limits."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        parent_store = MemoryStore(memory_char_limit=555, user_char_limit=666)
+        agent = type("FakeAgent", (), {"_memory_store": parent_store})()
+
+        resolved = _resolve_memory_store_from_kwargs({"parent_agent": agent})
+        assert resolved is parent_store
+
+    def test_parent_agent_without_store_falls_through(self, tmp_path, monkeypatch):
+        """A subagent has ``_memory_store = None``; the resolver must keep
+        walking the chain rather than returning the None store."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 4242\n"
+            "  user_char_limit: 3131\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        subagent = type("SubAgent", (), {"_memory_store": None})()
+
+        resolved = _resolve_memory_store_from_kwargs({"parent_agent": subagent})
+        assert resolved is not None
+        # Resolver fell through to the config-driven default.
+        assert resolved.memory_char_limit == 4242
+        assert resolved.user_char_limit == 3131
+
+    def test_default_store_uses_config_yaml_values(self, tmp_path, monkeypatch):
+        """Registry dispatch with no store and no parent_agent builds the
+        default MemoryStore from ``config.yaml`` memory limits — this is
+        the regression #11665 reports."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 9999\n"
+            "  user_char_limit: 8888\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        resolved = _resolve_memory_store_from_kwargs({})
+        assert resolved is not None
+        assert resolved.memory_char_limit == 9999
+        assert resolved.user_char_limit == 8888
+
+    def test_default_store_respects_user_profile_only(self, tmp_path, monkeypatch):
+        """``user_profile_enabled: true`` alone is enough to activate the
+        default store — mirrors the main-loop gate in run_agent.py."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: false\n"
+            "  user_profile_enabled: true\n"
+            "  user_char_limit: 7777\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        resolved = _resolve_memory_store_from_kwargs({})
+        assert resolved is not None
+        assert resolved.user_char_limit == 7777
+
+    def test_default_store_returns_none_when_memory_disabled(self, tmp_path, monkeypatch):
+        """When both memory and user-profile are disabled in config, the
+        resolver returns ``None`` so ``memory_tool`` reports the normal
+        ``"Memory is not available"`` error instead of silently writing
+        to an on-disk file the user opted out of."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: false\n"
+            "  user_profile_enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        resolved = _resolve_memory_store_from_kwargs({})
+        assert resolved is None
+
+    def test_default_store_is_singleton(self, tmp_path, monkeypatch):
+        """The default store is cached — two resolutions return the same
+        instance so repeated dispatches don't re-read config or the on-
+        disk files on every call."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 1234\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        first = _resolve_memory_store_from_kwargs({})
+        second = _resolve_memory_store_from_kwargs({})
+        assert first is second
+        assert first.memory_char_limit == 1234
+
+    def test_registry_dispatch_uses_config_memory_limit(self, tmp_path, monkeypatch):
+        """End-to-end: ``registry.dispatch("memory", ...)`` with no store
+        and no parent_agent must succeed and write through to the
+        config-driven MemoryStore — not silently return ``"Memory is not
+        available"``.
+
+        This is the exact path #11665 describes as broken. On pre-fix
+        code the registry handler passed ``store=None`` and the dispatch
+        returned ``success: false`` with ``"not available"``.  Deliberately
+        written to avoid importing the private resolver helper so the
+        behavioral regression is visible even on a pre-fix checkout."""
+        from tools.registry import registry
+        self._reset_default()
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 9999\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        # Dispatch via the registry with NO store kwarg and NO parent_agent
+        # — mirrors handle_function_call's path.
+        raw = registry.dispatch(
+            "memory",
+            {"action": "add", "target": "memory", "content": "routed via registry dispatch"},
+        )
+        result = json.loads(raw)
+        # On unpatched code this fails with "Memory is not available".
+        assert result.get("success") is True, f"dispatch returned: {result}"
+
+        # The entry should have been persisted under the tmp HERMES_HOME.
+        memory_md = hermes_home / "MEMORY.md"
+        assert memory_md.exists(), "dispatch did not persist to config-driven hermes_home"
+        assert "routed via registry dispatch" in memory_md.read_text(encoding="utf-8")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -327,7 +327,10 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        # Match production layout: MEMORY.md lives under HERMES_HOME/memories/.
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         subagent = type("SubAgent", (), {"_memory_store": None})()
 
@@ -353,7 +356,9 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         resolved = _resolve_memory_store_from_kwargs({})
         assert resolved is not None
@@ -375,7 +380,9 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         resolved = _resolve_memory_store_from_kwargs({})
         assert resolved is not None
@@ -397,10 +404,19 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        # Do NOT pre-create hermes_home/memories: when memory is disabled,
+        # the resolver must short-circuit before touching the filesystem.
+        monkeypatch.setattr(
+            "tools.memory_tool.get_memory_dir", lambda: hermes_home / "memories",
+        )
 
         resolved = _resolve_memory_store_from_kwargs({})
         assert resolved is None
+        # Defensive assertion: resolving a disabled config must NOT have
+        # created the memories/ subdir as a side effect (Copilot review).
+        assert not (hermes_home / "memories").exists(), (
+            "resolver with memory disabled should have no filesystem side effects"
+        )
 
     def test_default_store_is_singleton(self, tmp_path, monkeypatch):
         """The default store is cached — two resolutions return the same
@@ -417,7 +433,9 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         first = _resolve_memory_store_from_kwargs({})
         second = _resolve_memory_store_from_kwargs({})
@@ -447,7 +465,10 @@ class TestRegistryDispatchStoreResolution:
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+        # Match production layout: get_memory_dir() -> HERMES_HOME/memories.
+        memories_dir = hermes_home / "memories"
+        memories_dir.mkdir()
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: memories_dir)
 
         # Dispatch via the registry with NO store kwarg and NO parent_agent
         # — mirrors handle_function_call's path.
@@ -459,7 +480,10 @@ class TestRegistryDispatchStoreResolution:
         # On unpatched code this fails with "Memory is not available".
         assert result.get("success") is True, f"dispatch returned: {result}"
 
-        # The entry should have been persisted under the tmp HERMES_HOME.
-        memory_md = hermes_home / "MEMORY.md"
-        assert memory_md.exists(), "dispatch did not persist to config-driven hermes_home"
+        # The entry should be persisted at the production path:
+        # HERMES_HOME/memories/MEMORY.md — not HERMES_HOME/MEMORY.md.
+        memory_md = memories_dir / "MEMORY.md"
+        assert memory_md.exists(), (
+            f"dispatch did not persist to {memory_md} (production layout)"
+        )
         assert "routed via registry dispatch" in memory_md.read_text(encoding="utf-8")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -255,3 +255,211 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+
+# =========================================================================
+# Registry dispatch store resolution — regression for #11665
+# =========================================================================
+
+class TestRegistryDispatchStoreResolution:
+    """The ``memory`` tool is also reachable through ``registry.dispatch``
+    (handle_function_call path) and ``_resolve_memory_store_from_kwargs``.
+
+    Prior to #11665 that path passed ``store=None`` unconditionally, so
+    ``config.yaml``'s ``memory.memory_char_limit`` / ``memory.user_char_limit``
+    values were invisible to every dispatch site that wasn't the main
+    agent loop (code_execution sandbox, RL environments, reward verifiers,
+    and any plugin that forwarded a dispatch without an explicit store).
+
+    The resolver now walks the fallback chain:
+        explicit ``store=`` → ``parent_agent._memory_store`` → config-
+        driven module-level singleton built from ``hermes_cli.config``.
+    """
+
+    def _reset_default(self):
+        # Best-effort cache reset — absent on pre-fix revisions, which
+        # lets this helper run on either checkout so the behavioral
+        # regression test below can still exercise both branches.
+        try:
+            from tools.memory_tool import _reset_default_store_for_tests
+        except ImportError:
+            return
+        _reset_default_store_for_tests()
+
+    def test_explicit_store_kwarg_wins(self, tmp_path, monkeypatch):
+        """When a caller passes ``store=`` explicitly (main agent loop,
+        unit tests), the resolver returns it unchanged — never falls
+        through to ``parent_agent`` or the default singleton."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        explicit = MemoryStore(memory_char_limit=111, user_char_limit=222)
+        decoy = MemoryStore(memory_char_limit=333, user_char_limit=444)
+        decoy_agent = type("FakeAgent", (), {"_memory_store": decoy})()
+
+        resolved = _resolve_memory_store_from_kwargs(
+            {"store": explicit, "parent_agent": decoy_agent}
+        )
+        assert resolved is explicit
+
+    def test_parent_agent_store_used_when_no_explicit_store(self, tmp_path, monkeypatch):
+        """Plugin dispatches (``hermes_cli/plugins.py`` plumbs
+        ``parent_agent`` through ``registry.dispatch``) should use the
+        parent agent's memory store so plugin-triggered memory calls
+        honor the user's configured limits."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        parent_store = MemoryStore(memory_char_limit=555, user_char_limit=666)
+        agent = type("FakeAgent", (), {"_memory_store": parent_store})()
+
+        resolved = _resolve_memory_store_from_kwargs({"parent_agent": agent})
+        assert resolved is parent_store
+
+    def test_parent_agent_without_store_falls_through(self, tmp_path, monkeypatch):
+        """A subagent has ``_memory_store = None``; the resolver must keep
+        walking the chain rather than returning the None store."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 4242\n"
+            "  user_char_limit: 3131\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        subagent = type("SubAgent", (), {"_memory_store": None})()
+
+        resolved = _resolve_memory_store_from_kwargs({"parent_agent": subagent})
+        assert resolved is not None
+        # Resolver fell through to the config-driven default.
+        assert resolved.memory_char_limit == 4242
+        assert resolved.user_char_limit == 3131
+
+    def test_default_store_uses_config_yaml_values(self, tmp_path, monkeypatch):
+        """Registry dispatch with no store and no parent_agent builds the
+        default MemoryStore from ``config.yaml`` memory limits — this is
+        the regression #11665 reports."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 9999\n"
+            "  user_char_limit: 8888\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        resolved = _resolve_memory_store_from_kwargs({})
+        assert resolved is not None
+        assert resolved.memory_char_limit == 9999
+        assert resolved.user_char_limit == 8888
+
+    def test_default_store_respects_user_profile_only(self, tmp_path, monkeypatch):
+        """``user_profile_enabled: true`` alone is enough to activate the
+        default store — mirrors the main-loop gate in run_agent.py."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: false\n"
+            "  user_profile_enabled: true\n"
+            "  user_char_limit: 7777\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        resolved = _resolve_memory_store_from_kwargs({})
+        assert resolved is not None
+        assert resolved.user_char_limit == 7777
+
+    def test_default_store_returns_none_when_memory_disabled(self, tmp_path, monkeypatch):
+        """When both memory and user-profile are disabled in config, the
+        resolver returns ``None`` so ``memory_tool`` reports the normal
+        ``"Memory is not available"`` error instead of silently writing
+        to an on-disk file the user opted out of."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: false\n"
+            "  user_profile_enabled: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        resolved = _resolve_memory_store_from_kwargs({})
+        assert resolved is None
+
+    def test_default_store_is_singleton(self, tmp_path, monkeypatch):
+        """The default store is cached — two resolutions return the same
+        instance so repeated dispatches don't re-read config or the on-
+        disk files on every call."""
+        from tools.memory_tool import _resolve_memory_store_from_kwargs
+        self._reset_default()
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 1234\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        first = _resolve_memory_store_from_kwargs({})
+        second = _resolve_memory_store_from_kwargs({})
+        assert first is second
+        assert first.memory_char_limit == 1234
+
+    def test_registry_dispatch_uses_config_memory_limit(self, tmp_path, monkeypatch):
+        """End-to-end: ``registry.dispatch("memory", ...)`` with no store
+        and no parent_agent must succeed and write through to the
+        config-driven MemoryStore — not silently return ``"Memory is not
+        available"``.
+
+        This is the exact path #11665 describes as broken. On pre-fix
+        code the registry handler passed ``store=None`` and the dispatch
+        returned ``success: false`` with ``"not available"``.  Deliberately
+        written to avoid importing the private resolver helper so the
+        behavioral regression is visible even on a pre-fix checkout."""
+        from tools.registry import registry
+        self._reset_default()
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "memory:\n"
+            "  memory_enabled: true\n"
+            "  memory_char_limit: 9999\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: hermes_home)
+
+        # Dispatch via the registry with NO store kwarg and NO parent_agent
+        # — mirrors handle_function_call's path.
+        raw = registry.dispatch(
+            "memory",
+            {"action": "add", "target": "memory", "content": "routed via registry dispatch"},
+        )
+        result = json.loads(raw)
+        # On unpatched code this fails with "Memory is not available".
+        assert result.get("success") is True, f"dispatch returned: {result}"
+
+        # The entry should have been persisted under the tmp HERMES_HOME.
+        memory_md = hermes_home / "MEMORY.md"
+        assert memory_md.exists(), "dispatch did not persist to config-driven hermes_home"
+        assert "routed via registry dispatch" in memory_md.read_text(encoding="utf-8")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -704,6 +704,93 @@ MEMORY_SCHEMA = {
 # --- Registry ---
 from tools.registry import registry, tool_error
 
+# Module-level config-driven MemoryStore used as a last-resort fallback when
+# memory is dispatched via the registry without an explicit ``store`` kwarg
+# and no ``parent_agent`` is in the dispatch context (e.g. code_execution
+# sandboxes, RL training environments, or reward verifiers that call
+# ``handle_function_call("memory", ...)``).  Built lazily from
+# ``hermes_cli.config.load_config()`` so ``config.yaml`` values
+# (``memory.memory_char_limit``, ``memory.user_char_limit``) are honored in
+# every dispatch path, not just the main ``AIAgent.__init__`` code path.
+# Regression for #11665.
+import threading as _threading
+
+_default_store_lock = _threading.Lock()
+_default_store: Optional["MemoryStore"] = None
+
+
+def _resolve_memory_store_from_kwargs(kw: dict) -> Optional["MemoryStore"]:
+    """Resolve the MemoryStore to use for a registry-dispatched memory call.
+
+    Fallback chain:
+      1. Explicit ``store=`` kwarg (main agent loop special-case + tests).
+      2. ``kw["parent_agent"]._memory_store`` (CLI plugin dispatch —
+         ``hermes_cli/plugins.py`` plumbs ``parent_agent`` into kwargs).
+      3. A process-wide config-driven singleton, built from the current
+         ``config.yaml`` memory section.
+
+    The singleton is cached on first use and reused across calls so
+    repeated dispatches don't re-read ``config.yaml`` or re-read the on-
+    disk MEMORY.md / USER.md.  If memory is disabled in config, returns
+    ``None`` and the caller's ``memory_tool`` guard reports the usual
+    ``"Memory is not available"`` error.
+    """
+    explicit = kw.get("store")
+    if explicit is not None:
+        return explicit
+
+    parent = kw.get("parent_agent")
+    if parent is not None:
+        parent_store = getattr(parent, "_memory_store", None)
+        if parent_store is not None:
+            return parent_store
+
+    # Last resort: build (or reuse) a config-driven default store.
+    global _default_store
+    if _default_store is not None:
+        return _default_store
+
+    with _default_store_lock:
+        if _default_store is not None:
+            return _default_store
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+            mem_cfg = cfg.get("memory", {}) or {}
+            if not (
+                mem_cfg.get("memory_enabled", False)
+                or mem_cfg.get("user_profile_enabled", False)
+            ):
+                return None
+            store = MemoryStore(
+                memory_char_limit=int(mem_cfg.get("memory_char_limit", 2200)),
+                user_char_limit=int(mem_cfg.get("user_char_limit", 1375)),
+            )
+            try:
+                store.load_from_disk()
+            except Exception:
+                # Disk load is best-effort; a freshly-constructed store
+                # still enforces the configured limits for new entries.
+                logger.debug("Default MemoryStore load_from_disk failed", exc_info=True)
+            _default_store = store
+            return _default_store
+        except Exception:
+            logger.debug("Failed to build default MemoryStore from config", exc_info=True)
+            return None
+
+
+def _reset_default_store_for_tests() -> None:
+    """Reset the module-level default MemoryStore cache.
+
+    Intended for tests that mutate ``config.yaml`` / ``HERMES_HOME`` and
+    need the next ``_resolve_memory_store_from_kwargs`` call to rebuild
+    the singleton with the new values.  Not part of the public API.
+    """
+    global _default_store
+    with _default_store_lock:
+        _default_store = None
+
+
 registry.register(
     name="memory",
     toolset="memory",
@@ -713,7 +800,7 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
-        store=kw.get("store")),
+        store=_resolve_memory_store_from_kwargs(kw)),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -754,14 +754,22 @@ def _resolve_memory_store_from_kwargs(kw: dict) -> Optional["MemoryStore"]:
         if _default_store is not None:
             return _default_store
         try:
-            from hermes_cli.config import load_config
-            cfg = load_config() or {}
-            mem_cfg = cfg.get("memory", {}) or {}
+            # Use read_raw_config() rather than load_config(): the latter
+            # calls ensure_hermes_home(), which creates ~/.hermes subdirs
+            # and seeds SOUL.md.  A registry dispatch must not have
+            # filesystem side effects when memory is ultimately disabled —
+            # only touch disk once we know memory is actually active.
+            from hermes_cli.config import read_raw_config, DEFAULT_CONFIG
+            raw = read_raw_config() or {}
+            raw_mem = raw.get("memory") if isinstance(raw.get("memory"), dict) else {}
+            default_mem = DEFAULT_CONFIG.get("memory", {})
+            mem_cfg = {**default_mem, **raw_mem}
             if not (
                 mem_cfg.get("memory_enabled", False)
                 or mem_cfg.get("user_profile_enabled", False)
             ):
                 return None
+            # Memory is enabled; now it's safe to allocate + load from disk.
             store = MemoryStore(
                 memory_char_limit=int(mem_cfg.get("memory_char_limit", 2200)),
                 user_char_limit=int(mem_cfg.get("user_char_limit", 1375)),

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -565,6 +565,93 @@ MEMORY_SCHEMA = {
 # --- Registry ---
 from tools.registry import registry, tool_error
 
+# Module-level config-driven MemoryStore used as a last-resort fallback when
+# memory is dispatched via the registry without an explicit ``store`` kwarg
+# and no ``parent_agent`` is in the dispatch context (e.g. code_execution
+# sandboxes, RL training environments, or reward verifiers that call
+# ``handle_function_call("memory", ...)``).  Built lazily from
+# ``hermes_cli.config.load_config()`` so ``config.yaml`` values
+# (``memory.memory_char_limit``, ``memory.user_char_limit``) are honored in
+# every dispatch path, not just the main ``AIAgent.__init__`` code path.
+# Regression for #11665.
+import threading as _threading
+
+_default_store_lock = _threading.Lock()
+_default_store: Optional["MemoryStore"] = None
+
+
+def _resolve_memory_store_from_kwargs(kw: dict) -> Optional["MemoryStore"]:
+    """Resolve the MemoryStore to use for a registry-dispatched memory call.
+
+    Fallback chain:
+      1. Explicit ``store=`` kwarg (main agent loop special-case + tests).
+      2. ``kw["parent_agent"]._memory_store`` (CLI plugin dispatch —
+         ``hermes_cli/plugins.py`` plumbs ``parent_agent`` into kwargs).
+      3. A process-wide config-driven singleton, built from the current
+         ``config.yaml`` memory section.
+
+    The singleton is cached on first use and reused across calls so
+    repeated dispatches don't re-read ``config.yaml`` or re-read the on-
+    disk MEMORY.md / USER.md.  If memory is disabled in config, returns
+    ``None`` and the caller's ``memory_tool`` guard reports the usual
+    ``"Memory is not available"`` error.
+    """
+    explicit = kw.get("store")
+    if explicit is not None:
+        return explicit
+
+    parent = kw.get("parent_agent")
+    if parent is not None:
+        parent_store = getattr(parent, "_memory_store", None)
+        if parent_store is not None:
+            return parent_store
+
+    # Last resort: build (or reuse) a config-driven default store.
+    global _default_store
+    if _default_store is not None:
+        return _default_store
+
+    with _default_store_lock:
+        if _default_store is not None:
+            return _default_store
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+            mem_cfg = cfg.get("memory", {}) or {}
+            if not (
+                mem_cfg.get("memory_enabled", False)
+                or mem_cfg.get("user_profile_enabled", False)
+            ):
+                return None
+            store = MemoryStore(
+                memory_char_limit=int(mem_cfg.get("memory_char_limit", 2200)),
+                user_char_limit=int(mem_cfg.get("user_char_limit", 1375)),
+            )
+            try:
+                store.load_from_disk()
+            except Exception:
+                # Disk load is best-effort; a freshly-constructed store
+                # still enforces the configured limits for new entries.
+                logger.debug("Default MemoryStore load_from_disk failed", exc_info=True)
+            _default_store = store
+            return _default_store
+        except Exception:
+            logger.debug("Failed to build default MemoryStore from config", exc_info=True)
+            return None
+
+
+def _reset_default_store_for_tests() -> None:
+    """Reset the module-level default MemoryStore cache.
+
+    Intended for tests that mutate ``config.yaml`` / ``HERMES_HOME`` and
+    need the next ``_resolve_memory_store_from_kwargs`` call to rebuild
+    the singleton with the new values.  Not part of the public API.
+    """
+    global _default_store
+    with _default_store_lock:
+        _default_store = None
+
+
 registry.register(
     name="memory",
     toolset="memory",
@@ -574,7 +661,7 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
-        store=kw.get("store")),
+        store=_resolve_memory_store_from_kwargs(kw)),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -615,14 +615,22 @@ def _resolve_memory_store_from_kwargs(kw: dict) -> Optional["MemoryStore"]:
         if _default_store is not None:
             return _default_store
         try:
-            from hermes_cli.config import load_config
-            cfg = load_config() or {}
-            mem_cfg = cfg.get("memory", {}) or {}
+            # Use read_raw_config() rather than load_config(): the latter
+            # calls ensure_hermes_home(), which creates ~/.hermes subdirs
+            # and seeds SOUL.md.  A registry dispatch must not have
+            # filesystem side effects when memory is ultimately disabled —
+            # only touch disk once we know memory is actually active.
+            from hermes_cli.config import read_raw_config, DEFAULT_CONFIG
+            raw = read_raw_config() or {}
+            raw_mem = raw.get("memory") if isinstance(raw.get("memory"), dict) else {}
+            default_mem = DEFAULT_CONFIG.get("memory", {})
+            mem_cfg = {**default_mem, **raw_mem}
             if not (
                 mem_cfg.get("memory_enabled", False)
                 or mem_cfg.get("user_profile_enabled", False)
             ):
                 return None
+            # Memory is enabled; now it's safe to allocate + load from disk.
             store = MemoryStore(
                 memory_char_limit=int(mem_cfg.get("memory_char_limit", 2200)),
                 user_char_limit=int(mem_cfg.get("user_char_limit", 1375)),


### PR DESCRIPTION
## What does this PR do?

Fixes #11665.

The ``memory`` tool is reachable through two code paths, and until now only one of them respected ``config.yaml``:

- **Path A** — ``AIAgent._invoke_tool`` / the main agent loop passes ``store=self._memory_store``, which ``AIAgent.__init__`` (``run_agent.py:1219``) builds with the user's configured ``memory.memory_char_limit`` / ``memory.user_char_limit``. ✅
- **Path B** — anything that routes through ``model_tools.handle_function_call`` → ``tools.registry.registry.dispatch("memory", ...)``. The registry handler lambda reads ``store=kw.get("store")``, and **nothing** passes ``store=`` through that path. ❌

Code paths affected by Path B:

- ``tools/code_execution_tool.py`` (execute_code sandboxes that call tools back via JSON-RPC)
- ``environments/agent_loop.py`` (RL training loop)
- ``environments/tool_context.py`` (reward / verifier helpers)
- ``hermes_cli/plugins.py`` (plugin dispatch — already plumbs ``parent_agent`` but the handler wasn't using it)

On pre-fix code, dispatches via Path B silently errored with ``"Memory is not available"`` (the reporter's description of "hardcoded defaults" maps to the same underlying symptom — config.yaml values were invisible to that path). Any ``memory_char_limit: 3000`` or ``user_char_limit: …`` override a user set in ``config.yaml`` was ignored in every dispatch site that wasn't the main ``AIAgent`` loop.

## Root cause

``tools/memory_tool.py:572`` — the registry handler:

```python
handler=lambda args, **kw: memory_tool(
    ...
    store=kw.get("store")),
```

`store` is never populated by ``handle_function_call`` or ``registry.dispatch``, so the tool always received ``None`` and short-circuited at the ``if store is None`` guard (``tools/memory_tool.py:475``).

## Smallest safe fix

Extend the registry handler with ``_resolve_memory_store_from_kwargs`` — a fallback chain:

1. Explicit ``store=`` kwarg — main agent loop + tests, unchanged.
2. ``kw[\"parent_agent\"]._memory_store`` — ``hermes_cli/plugins.py`` already plumbs ``parent_agent`` into dispatch kwargs, so plugin-initiated memory calls now reuse the live agent's store.
3. A process-wide config-driven ``MemoryStore`` singleton built lazily from ``hermes_cli.config.load_config()``. Cached so repeated dispatches don't re-read ``config.yaml`` or the on-disk MEMORY.md / USER.md files.
4. If both ``memory_enabled`` and ``user_profile_enabled`` are ``false`` in config, returns ``None`` — preserves the ``"Memory is not available"`` error for users who opted out.

Also exports ``_reset_default_store_for_tests`` so tests that mutate ``HERMES_HOME`` can force the next dispatch to rebuild the singleton. No public API change.

## Precedence / compat truth table

| caller / state | store used |
| --- | --- |
| explicit ``store=`` kwarg passed | that store (unchanged — main agent loop path) |
| plugin dispatch with ``parent_agent``, parent has store | parent's store (new) |
| plugin dispatch with ``parent_agent``, parent store is ``None`` (subagent) | falls through to config default (new) |
| no store, no parent_agent, ``memory_enabled: true`` in config | config-driven singleton (new) |
| no store, no parent_agent, ``memory_enabled: false`` AND ``user_profile_enabled: false`` | ``None`` → "not available" error (unchanged) |

The main agent loop still uses ``self._memory_store`` directly in all three special-case sites (``_invoke_tool``, main tool-calling loop, ``flush_memories``), so there is no behavior change for users on the normal CLI path. The fallback chain only activates when the registry handler lambda fires.

## Narrow scope — why only the registry handler

I intentionally did **not** touch ``handle_function_call``, ``registry.dispatch``, or any of the caller sites that invoke them. Adding ``store=`` to those signatures would ripple through RL training, sandbox RPC, plugin context, and the public plugin API. The fallback-chain approach scoped inside ``memory_tool.py`` is local, is reversible, and keeps the single source of truth on ``config.yaml``.

## How to test

1. Run the focused suite:
   ```
   source venv/bin/activate
   python -m pytest tests/tools/test_memory_tool.py -q
   ```
   → **41 passed** (33 existing + 8 new).

2. Confirm the new behavioral test catches the bug on origin/main:
   ```
   git stash push tools/memory_tool.py
   python -m pytest tests/tools/test_memory_tool.py::TestRegistryDispatchStoreResolution::test_registry_dispatch_uses_config_memory_limit -v
   ```
   → fails with
   ```
   AssertionError: dispatch returned: {'error': 'Memory is not available...', 'success': False}
   ```
   Restore with ``git stash pop``.

3. CI-aligned broad suite:
   ```
   python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
   ```
   → 12389 passed, 39 skipped, 7 pre-existing baseline failures (``tests/gateway/test_matrix.py``, ``tests/gateway/test_approve_deny_commands.py`` ×2, ``tests/hermes_cli/test_gateway_wsl.py`` ×2, ``tests/tools/test_file_staleness.py`` ×2). Each reproduces on clean ``origin/main`` with identical assertions — none are in the touched code path.

Tested on: macOS 15 (Darwin 25.5.0), Python 3.11.15.

## Related Issue

Fixes #11665

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``tools/memory_tool.py``: add ``_resolve_memory_store_from_kwargs`` + ``_reset_default_store_for_tests`` + module-level lazy singleton; swap the registry handler to use the resolver.
- ``tests/tools/test_memory_tool.py``: add ``TestRegistryDispatchStoreResolution`` — 8 tests covering the full truth table (explicit store wins, parent_agent fallback, subagent-with-None falls through, config-driven default, user_profile-only activation, memory-disabled returns None, singleton identity, end-to-end registry dispatch).

## Adjacent surfaces checked

- ``run_agent.py`` special-case branches at lines 7411 and 7894 — unchanged; they still pass ``store=self._memory_store``.
- ``run_agent.py:1219`` ``AIAgent.__init__`` MemoryStore construction — unchanged.
- ``tools/delegate_tool.py:366`` (subagent ``skip_memory=True``) — the new behavior is safe: subagents still don't get a store (``parent_agent._memory_store`` is ``None`` on them); the resolver falls through to the config-driven default, but the subagent's own ``skip_memory=True`` keeps it from dispatching memory in the first place.
- ``hermes_cli/plugins.py:291`` plugin dispatch with ``parent_agent`` — now transparently uses parent's store.
- ``tools/code_execution_tool.py`` sandbox dispatch — now works with config-driven defaults.
- ``environments/agent_loop.py`` and ``environments/tool_context.py`` — now work with config-driven defaults.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (``fix(scope):``)
- [x] Searched for existing PRs — none on #11665
- [x] Only changes related to this fix
- [x] Ran the CI-aligned test command and classified failures baseline-vs-change
- [x] Added tests for my changes (8 new; 1 fails behaviorally on ``origin/main`` without the fix, the rest pin the fallback chain)
- [x] Tested on macOS 15 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] No docs changes needed — internal dispatch detail, no public API surface
- [x] No config-key changes — existing ``memory.memory_char_limit`` / ``memory.user_char_limit`` keys are unchanged
- [x] No architecture/workflow changes
- [x] Cross-platform impact: none — pure Python, no filesystem/process/encoding changes
- [x] No tool descriptions/schemas touched

## Notes for reviewers

- No standalone lint command is defined; CI runs ``python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`` (matches ``.github/workflows/tests.yml``).
- No ``hermes_cli/**`` changes — the Nix workflow should not trigger.