### PR TITLE
fix(gateway): bypass active-session guard for /btw and /branch

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -267,6 +267,8 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "agents",
         "approve",
         "background",
+        "branch",
+        "btw",
         "commands",
         "deny",
         "help",

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -248,6 +248,38 @@ class TestCommandBypassActiveSession:
             "/queue response was not sent back to the user"
         )
 
+    @pytest.mark.asyncio
+    async def test_btw_bypasses_guard(self):
+        """/btw must bypass so it runs as a parallel side question."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/btw what is this module?"))
+
+        assert sk not in adapter._pending_messages, (
+            "/btw was queued as a pending message instead of being dispatched"
+        )
+        assert any("handled:btw" in r for r in adapter.sent_responses), (
+            "/btw response was not sent back to the user"
+        )
+
+    @pytest.mark.asyncio
+    async def test_branch_bypasses_guard(self):
+        """/branch must bypass so it can fork the session immediately."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/branch experiment"))
+
+        assert sk not in adapter._pending_messages, (
+            "/branch was queued as a pending message instead of being dispatched"
+        )
+        assert any("handled:branch" in r for r in adapter.sent_responses), (
+            "/branch response was not sent back to the user"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tests: non-bypass messages still get queued


### PR DESCRIPTION
## Summary
- Adds `btw` and `branch` to the base adapter's active-session bypass list at `gateway/platforms/base.py:1582`.
- Without this, `/btw` and `/branch` issued during an active run were queued as pending messages instead of running in parallel (`/btw`) or forking the session immediately (`/branch`).

Both command handlers already exist (`_handle_btw_command` at `gateway/run.py:5896`, `_handle_branch_command` at `gateway/run.py:6517`); they were simply never being dispatched while a session was active.

Fixes #7547

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_command_bypass_active_session.py` — 21 passed (includes 2 new regression tests: `test_btw_bypasses_guard`, `test_branch_bypasses_guard`).