### PR TITLE
fix: restore think-only empty handling and strengthen memory/search guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -144,21 +144,32 @@ DEFAULT_AGENT_IDENTITY = (
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "
     "tool: user preferences, environment details, tool quirks, and stable conventions. "
-    "Memory is injected into every turn, so keep it compact and focused on facts that "
+    "Memory is injected into future turns, so keep it compact and focused on facts that "
     "will still matter later.\n"
     "Prioritize what reduces future user steering — the most valuable memory is one "
     "that prevents the user from having to correct or remind you again. "
     "User preferences and recurring corrections matter more than procedural task details.\n"
+    "Save memory proactively when the user shares preferences, corrects you, or when you "
+    "discover stable environment facts or conventions that will likely matter again.\n"
     "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO "
     "state to memory; use session_search to recall those from past transcripts. "
-    "If you've discovered a new way to do something, solved a problem that could be "
-    "necessary later, save it as a skill with the skill tool."
+    "If you've discovered a reusable workflow or solved a non-trivial recurring problem, "
+    "save it as a skill with the skill tool."
 )
 
 SESSION_SEARCH_GUIDANCE = (
-    "When the user references something from a past conversation or you suspect "
-    "relevant cross-session context exists, use session_search to recall it before "
-    "asking them to repeat themselves."
+    "When the user references something from a past conversation, says 'last time', "
+    "or you suspect relevant cross-session context exists, use session_search before "
+    "asking them to repeat themselves. Start with recent sessions when the topic is "
+    "unclear, and use keyword search for specific recall. Prefer searching over guessing."
+)
+
+PLANNING_AND_SELF_REVIEW_GUIDANCE = (
+    "Before starting non-trivial work, create a concise plan with the smallest "
+    "useful next steps. While working, keep the plan current if new information "
+    "changes the approach. Before finalizing, self-review the result: confirm the "
+    "requirements were met, verify important outputs with tools when possible, and "
+    "call out any remaining uncertainty or follow-up work."
 )
 
 SKILLS_GUIDANCE = (

--- a/run_agent.py
+++ b/run_agent.py
@@ -80,7 +80,7 @@ from agent.retry_utils import jittered_backoff
 from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
-    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, PLANNING_AND_SELF_REVIEW_GUIDANCE, SKILLS_GUIDANCE,
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
@@ -3371,6 +3371,8 @@ class AIAgent:
             tool_guidance.append(SKILLS_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
+
+        prompt_parts.append(PLANNING_AND_SELF_REVIEW_GUIDANCE)
 
         nous_subscription_prompt = build_nous_subscription_prompt(self.valid_tool_names)
         if nous_subscription_prompt:
@@ -10913,14 +10915,27 @@ class AIAgent:
                         # always populate reasoning fields via OpenRouter,
                         # so the old `not _has_structured` guard blocked
                         # retries for every reasoning model after prefill.
-                        _truly_empty = not self._strip_think_blocks(
+                        _stripped_visible = self._strip_think_blocks(
                             final_response
                         ).strip()
+                        _truly_empty = not _stripped_visible
+                        # Inline think-only content (e.g. "<think>...</think>")
+                        # should not trigger empty-response retries.  Those
+                        # retries are for transport/provider empties and
+                        # structured reasoning prefill exhaustion; retrying
+                        # think-only text burns API calls and regressed
+                        # test_inline_think_blocks_reasoning_only_accepted.
+                        _inline_think_only = bool(final_response.strip()) and _truly_empty
                         _prefill_exhausted = (
                             _has_structured
                             and self._thinking_prefill_retries >= 2
                         )
-                        if _truly_empty and (not _has_structured or _prefill_exhausted) and self._empty_content_retries < 3:
+                        if (
+                            _truly_empty
+                            and not _inline_think_only
+                            and (not _has_structured or _prefill_exhausted)
+                            and self._empty_content_retries < 3
+                        ):
                             self._empty_content_retries += 1
                             logger.warning(
                                 "Empty response (no content or reasoning) — "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -26,6 +26,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    PLANNING_AND_SELF_REVIEW_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -42,12 +43,20 @@ class TestGuidanceConstants:
         assert "durable facts" in MEMORY_GUIDANCE
         assert "Do NOT save task progress" in MEMORY_GUIDANCE
         assert "session_search" in MEMORY_GUIDANCE
+        assert "Save memory proactively" in MEMORY_GUIDANCE
         assert "like a diary" not in MEMORY_GUIDANCE
         assert ">80%" not in MEMORY_GUIDANCE
 
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
+        assert "last time" in SESSION_SEARCH_GUIDANCE
+        assert "Prefer searching over guessing" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_planning_and_self_review_guidance_mentions_plan_and_verify(self):
+        assert "concise plan" in PLANNING_AND_SELF_REVIEW_GUIDANCE
+        assert "self-review" in PLANNING_AND_SELF_REVIEW_GUIDANCE
+        assert "verify important outputs" in PLANNING_AND_SELF_REVIEW_GUIDANCE
 
 
 # =========================================================================

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -20,7 +20,7 @@ import pytest
 import run_agent
 from run_agent import AIAgent
 from agent.error_classifier import FailoverReason
-from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, PLANNING_AND_SELF_REVIEW_GUIDANCE
 
 
 # ---------------------------------------------------------------------------
@@ -667,6 +667,10 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         # Should contain current date info like "Conversation started:"
         assert "Conversation started:" in prompt
+
+    def test_includes_planning_and_self_review_guidance(self, agent):
+        prompt = agent._build_system_prompt()
+        assert PLANNING_AND_SELF_REVIEW_GUIDANCE in prompt
 
     def test_includes_nous_subscription_prompt(self, agent, monkeypatch):
         monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda tool_names: "NOUS SUBSCRIPTION BLOCK")


### PR DESCRIPTION
## Summary
- exclude inline think-only assistant replies from the empty-response retry loop
- keep retries for true empty responses and prefill-exhausted structured outputs
- expand memory guidance with proactive-save criteria and durable-priority language
- expand session-search guidance with last-time cue handling and search-first recall behavior

## Test Plan
- python -m pytest tests/run_agent/test_run_agent.py -q
- python -m pytest tests/agent/test_prompt_builder.py -q