### PR TITLE
fix(setup): update existing custom provider name/api key by base_url

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1716,10 +1716,17 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None,
     if not isinstance(providers, list):
         providers = []
 
-    # Check if this URL is already saved — update model/context_length if so
+    # Check if this URL is already saved — update mutable fields in-place
+    # (name/api_key/model/context_length) rather than creating duplicates.
     for entry in providers:
         if isinstance(entry, dict) and entry.get("base_url", "").rstrip("/") == base_url.rstrip("/"):
             changed = False
+            if name and entry.get("name") != name:
+                entry["name"] = name
+                changed = True
+            if api_key and entry.get("api_key") != api_key:
+                entry["api_key"] = api_key
+                changed = True
             if model and entry.get("model") != model:
                 entry["model"] = model
                 changed = True

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -13,9 +13,10 @@ This module ties together the foundation layers:
 - ``hermes_cli.providers``        -- canonical provider identity + overlays
 - ``hermes_cli.model_normalize``  -- per-provider name formatting
 
-Provider switching uses the ``--provider`` flag exclusively.
-No colon-based ``provider:model`` syntax — colons are reserved for
-OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
+Provider switching supports both explicit ``--provider`` and inline
+``provider:model`` syntax.  Named custom providers can be selected with
+either ``custom:<name>:<model>`` or the shorthand ``<name>:<model>`` when
+``<name>`` resolves to a configured custom provider.
 """
 
 from __future__ import annotations
@@ -572,17 +573,60 @@ def switch_model(
                         ),
                     )
             else:
-                # --- Step c: On aggregator, convert vendor:model to vendor/model ---
-                # Only convert when there's no slash — a slash means the name
-                # is already in vendor/model format and the colon is a variant
-                # tag (:free, :extended, :fast) that must be preserved.
+                # --- Step c: provider:model syntax (including named custom providers) ---
+                provider_from_colon = False
                 colon_pos = raw_input.find(":")
-                if colon_pos > 0 and "/" not in raw_input and is_aggregator(current_provider):
-                    left = raw_input[:colon_pos].strip().lower()
+                if colon_pos > 0 and "/" not in raw_input:
+                    left = raw_input[:colon_pos].strip()
                     right = raw_input[colon_pos + 1:].strip()
-                    if left and right:
-                        # Colons become slashes for aggregator slugs
-                        new_model = f"{left}/{right}"
+
+                    # Support custom:name:model triple syntax.
+                    # Example: custom:flusions:gpt-5.4 -> provider=custom:flusions model=gpt-5.4
+                    if left.lower() == "custom" and ":" in right:
+                        second_colon = right.find(":")
+                        custom_name = right[:second_colon].strip()
+                        actual_model = right[second_colon + 1:].strip()
+                        if custom_name and actual_model:
+                            pdef = resolve_provider_full(
+                                f"custom:{custom_name}",
+                                user_providers,
+                                custom_providers,
+                            )
+                            if pdef is not None:
+                                target_provider = pdef.id
+                                new_model = actual_model
+                                provider_from_colon = True
+                                logger.debug(
+                                    "Resolved custom triple '%s' -> provider=%s model=%s",
+                                    raw_input, target_provider, new_model,
+                                )
+
+                    # Support shorthand provider:model for any resolvable provider.
+                    # Example: flusions:gpt-5.4, anthropic:claude-sonnet-4.6
+                    if not provider_from_colon and left and right:
+                        pdef = resolve_provider_full(
+                            left,
+                            user_providers,
+                            custom_providers,
+                        )
+                        if pdef is not None:
+                            target_provider = pdef.id
+                            new_model = right
+                            provider_from_colon = True
+                            logger.debug(
+                                "Resolved provider:model '%s' -> provider=%s model=%s",
+                                raw_input, target_provider, new_model,
+                            )
+
+                    # Legacy behavior on aggregators: vendor:model -> vendor/model
+                    # when the left side is not a resolvable provider name.
+                    if (
+                        not provider_from_colon
+                        and left
+                        and right
+                        and is_aggregator(current_provider)
+                    ):
+                        new_model = f"{left.lower()}/{right}"
                         logger.debug(
                             "Converted vendor:model '%s' to aggregator slug '%s'",
                             raw_input, new_model,
@@ -1086,5 +1130,3 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
-
-

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -685,3 +685,47 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+def test_save_custom_provider_updates_existing_entry_fields(monkeypatch, tmp_path):
+    """Existing URL entry should be updated in-place (no duplicate append)."""
+    import yaml
+    from hermes_cli.main import _save_custom_provider
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.dump(
+            {
+                "custom_providers": [
+                    {
+                        "name": "Old Name",
+                        "base_url": "https://www.flusions.com/v1",
+                        "api_key": "old-key",
+                        "model": "gpt-5.4",
+                    }
+                ]
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda: yaml.safe_load(cfg_path.read_text()) or {},
+    )
+    saved = {}
+
+    def _save(cfg):
+        saved.update(cfg)
+
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+
+    _save_custom_provider(
+        "https://www.flusions.com/v1",
+        api_key="new-key",
+        model="gpt-5.4",
+        name="Flusions",
+    )
+    entries = saved.get("custom_providers", [])
+    assert len(entries) == 1
+    assert entries[0]["name"] == "Flusions"
+    assert entries[0]["api_key"] == "new-key"
+    assert entries[0]["model"] == "gpt-5.4"

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -104,6 +104,46 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.api_key == "no-key-required"
 
 
+def test_switch_model_accepts_shorthand_named_custom_provider_syntax(monkeypatch):
+    """`/model flusions:gpt-5.4` should resolve to custom:flusions."""
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested: {
+            "api_key": "flusions-key",
+            "base_url": "https://www.flusions.com/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="flusions:gpt-5.4",
+        current_provider="openrouter",
+        current_model="openai/gpt-5.4",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="or-key",
+        explicit_provider="",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Flusions",
+                "base_url": "https://www.flusions.com/v1",
+                "api_key": "flusions-key",
+                "model": "gpt-5.4",
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:flusions"
+    assert result.provider_label == "Flusions"
+    assert result.new_model == "gpt-5.4"
+    assert result.base_url == "https://www.flusions.com/v1"
+    assert result.api_key == "flusions-key"
+
+
 def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     """Multiple custom_providers entries sharing a name should produce one row
     with all models collected, not N duplicate rows."""


### PR DESCRIPTION
## Summary
- fix _save_custom_provider() so existing custom_providers entries are updated in-place by base_url
- update name and api_key for existing entries (it already updated model/context_length)
- keep dedupe behavior (no duplicate append for same endpoint URL)

## Why
hermes setup currently cannot truly modify an existing custom endpoint entry when the URL is unchanged. It only updates model/context_length, leaving stale name/api_key. This makes endpoint reconfiguration confusing and forces manual config edits.

## Tests
- added regression test for in-place updates of existing entry fields
- ran:
  - python -m pytest -o addopts='' tests/cli/test_cli_provider_resolution.py -k save_custom_provider -q
  - python -m pytest -o addopts='' tests/hermes_cli/test_model_switch_custom_providers.py -q
