### PR TITLE
docs: align contributing node version with package engines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 | **Git** | With `--recurse-submodules` support |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
-| **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |
+| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 
 ### Clone and install
 

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -35,7 +35,7 @@ We value contributions in this order:
 | **Git** | With `--recurse-submodules` support |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
-| **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |
+| **Node.js 20+** | Optional — needed for browser tools and WhatsApp bridge (matches root `package.json` engines) |
 
 ### Clone and Install
 


### PR DESCRIPTION
## Summary
- update the contributor prerequisites in `CONTRIBUTING.md` from Node.js 18+ to Node.js 20+
- mirror the same fix in `website/docs/developer-guide/contributing.md`
- note that the docs now match the root `package.json` engine requirement

## Verification
- compared `CONTRIBUTING.md` and `website/docs/developer-guide/contributing.md` against `package.json` (`"engines": { "node": ">=20.0.0" }`)
- searched the repo to confirm the contributing docs no longer mention `Node.js 18+`

Closes #11684
