### PR TITLE
fix(bedrock): add auxiliary client support and dot preservation for model names

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1469,6 +1469,24 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))
 
+
+    # ── Bedrock (AnthropicBedrock via IAM) ───────────────────────────
+    if provider == "bedrock":
+        try:
+            from agent.anthropic_adapter import build_anthropic_bedrock_client
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            region = (cfg.get("bedrock", {}).get("region") or "").strip() or "us-west-2"
+            bedrock_client = build_anthropic_bedrock_client(region)
+            default_model = model or "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+            logger.debug("resolve_provider_client: bedrock (%s) region=%s", default_model, region)
+            wrapper = AnthropicAuxiliaryClient(bedrock_client, default_model, "bedrock-iam", f"bedrock://{region}", is_oauth=False)
+            return (_to_async_client(wrapper, default_model) if async_mode
+                    else (wrapper, default_model))
+        except Exception as e:
+            logger.warning("resolve_provider_client: bedrock failed: %s", e)
+            return None, None
+
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6468,10 +6468,11 @@ class AIAgent:
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
+        Bedrock keeps dots (e.g. us.anthropic.claude-opus-4-6-v1).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "bedrock", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base


### PR DESCRIPTION
## Problem

The bedrock provider added in #7920 has two edge cases that cause errors:

1. **Auxiliary client does not support bedrock** — `auxiliary_client.py` `resolve_provider_client()` has no bedrock branch, so configuring `auxiliary.provider: bedrock` in config produces a warning and disables LLM-based context compression/summarization.

2. **Model name dots get incorrectly replaced** — `_anthropic_preserve_dots()` whitelist does not include `bedrock`. Bedrock model IDs contain dots (e.g. `us.anthropic.claude-opus-4-6-v1`) which `normalize_model_name()` converts to hyphens, producing invalid model identifiers and HTTP 400 errors.

## Fix

- Add a `bedrock` branch to `resolve_provider_client()` that reuses `build_anthropic_bedrock_client()` with IAM auth
- Add `bedrock` to the `_anthropic_preserve_dots()` provider set
- Update docstring to document bedrock dot preservation

## Testing

Verified on a live Hermes gateway instance running `us.anthropic.claude-opus-4-6-v1` via Bedrock:
- No more HTTP 400 errors
- Auxiliary LLM warning resolved
- Slack + WeChat gateway stable