### PR TITLE
fix(http): pass HTTPS_PROXY explicitly to httpx HTTPTransport

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4472,8 +4472,24 @@ class AIAgent:
                 elif hasattr(_socket, "TCP_KEEPALIVE"):
                     # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
                     _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+                # httpx HTTPTransport with custom args does not honor
+                # HTTPS_PROXY/HTTP_PROXY env vars (trust_env is bypassed
+                # when the transport is user-constructed). Pass proxy
+                # explicitly so SDK clients reach hosts that require a
+                # local forward proxy (e.g. chatgpt.com from networks
+                # where it is unreachable directly).
+                import os as _os
+                _proxy_url = (
+                    _os.environ.get("HTTPS_PROXY")
+                    or _os.environ.get("https_proxy")
+                    or _os.environ.get("HTTP_PROXY")
+                    or _os.environ.get("http_proxy")
+                )
+                _transport_kwargs = {"socket_options": _sock_opts}
+                if _proxy_url:
+                    _transport_kwargs["proxy"] = _proxy_url
                 client_kwargs["http_client"] = _httpx.Client(
-                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                    transport=_httpx.HTTPTransport(**_transport_kwargs),
                 )
             except Exception:
                 pass  # Fall through to default transport if socket opts fail


### PR DESCRIPTION
## Summary

When the OpenAI client's `http_client` is constructed with a custom `httpx.HTTPTransport` (currently done in `run_agent.py:_ensure_primary_openai_client` to enable TCP keepalive `socket_options`), httpx **does not honor `HTTPS_PROXY` / `HTTP_PROXY` env vars** even though `trust_env=True` is the documented default. As a result, OpenAI SDK requests bypass the configured forward proxy and time out on hosts that are only reachable via that proxy.

Other Hermes traffic paths — Lark/Feishu websocket, DeepSeek, Kimi, Xiaomi MiMo — go through fine because they use httpx's default env-aware client and never construct a custom transport.

## Repro

```python
import os, httpx, socket
os.environ['HTTPS_PROXY'] = 'http://127.0.0.1:PORT'  # any working forward proxy
sock_opts = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]

# Current behavior — proxy is silently ignored
c = httpx.Client(transport=httpx.HTTPTransport(socket_options=sock_opts))
c.get('https://example-blocked-host/', timeout=10)   # ConnectTimeout

# With explicit proxy=
c2 = httpx.Client(transport=httpx.HTTPTransport(
    socket_options=sock_opts, proxy='http://127.0.0.1:PORT'))
c2.get('https://example-blocked-host/', timeout=10)  # 200/4xx in <1s
```

End-user symptom (gateway log):
```
APITimeoutError | Provider: <provider>  Model: <model>
Endpoint: https://<host>/...
Error: Request timed out.  Elapsed: 121.25s
```

## Fix

Read `HTTPS_PROXY` / `HTTP_PROXY` (and lowercase variants) from env and pass to `HTTPTransport` explicitly when present. No-op when no proxy env is set.

## Test plan

- [x] Repro confirmed locally with httpx 0.28
- [x] OpenAI-compatible provider routed through a forward HTTP proxy via env-injected `HTTPS_PROXY` — request succeeds in ~2s instead of timing out
- [x] Existing direct paths unaffected — they don't touch this code path
- [x] Lark/Feishu websocket unaffected (separate Lark SDK transport)

## Notes

- Affects any user behind a forward HTTP proxy — corporate egress proxies, VPS tunnels, captive networks, etc.
- httpx behavior here is somewhat surprising (`trust_env=True` is the default, but it does not apply once a custom transport is constructed). Considered upstream-reportable to httpx but not blocking for this fix.