### PR TITLE
feat(gateway): load session_reset.by_type and by_platform from config.yaml

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -479,7 +479,32 @@ def load_gateway_config() -> GatewayConfig:
             # Each key overwrites whatever gateway.json may have set.
             sr = yaml_cfg.get("session_reset")
             if sr and isinstance(sr, dict):
-                gw_data["default_reset_policy"] = sr
+                # Split per-type / per-platform overrides out of the default
+                # policy.  The nested keys map to GatewayConfig.reset_by_type
+                # and reset_by_platform; only the top-level policy fields
+                # belong on default_reset_policy.
+                by_type = sr.get("by_type")
+                by_platform = sr.get("by_platform")
+                gw_data["default_reset_policy"] = {
+                    k: v for k, v in sr.items()
+                    if k not in ("by_type", "by_platform")
+                }
+                if isinstance(by_type, dict):
+                    gw_data["reset_by_type"] = by_type
+                elif by_type is not None:
+                    logger.warning(
+                        "Ignoring invalid session_reset.by_type in config.yaml "
+                        "(expected mapping, got %s)",
+                        type(by_type).__name__,
+                    )
+                if isinstance(by_platform, dict):
+                    gw_data["reset_by_platform"] = by_platform
+                elif by_platform is not None:
+                    logger.warning(
+                        "Ignoring invalid session_reset.by_platform in config.yaml "
+                        "(expected mapping, got %s)",
+                        type(by_platform).__name__,
+                    )
 
             qc = yaml_cfg.get("quick_commands")
             if qc is not None:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -381,6 +381,138 @@ class TestLoadGatewayConfig:
         import os
         assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
 
+    def test_bridges_session_reset_by_platform_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  mode: both\n"
+            "  idle_minutes: 180\n"
+            "  at_hour: 4\n"
+            "  by_platform:\n"
+            "    telegram:\n"
+            "      mode: idle\n"
+            "      idle_minutes: 30\n"
+            "    discord:\n"
+            "      mode: none\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.mode == "both"
+        assert config.default_reset_policy.idle_minutes == 180
+        assert config.default_reset_policy.at_hour == 4
+
+        assert Platform.TELEGRAM in config.reset_by_platform
+        telegram_policy = config.reset_by_platform[Platform.TELEGRAM]
+        assert telegram_policy.mode == "idle"
+        assert telegram_policy.idle_minutes == 30
+
+        assert Platform.DISCORD in config.reset_by_platform
+        assert config.reset_by_platform[Platform.DISCORD].mode == "none"
+
+        # get_reset_policy returns the per-platform override first
+        resolved = config.get_reset_policy(platform=Platform.TELEGRAM)
+        assert resolved.mode == "idle"
+        assert resolved.idle_minutes == 30
+
+    def test_bridges_session_reset_by_type_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  mode: idle\n"
+            "  idle_minutes: 180\n"
+            "  by_type:\n"
+            "    dm:\n"
+            "      mode: idle\n"
+            "      idle_minutes: 60\n"
+            "    group:\n"
+            "      mode: daily\n"
+            "      at_hour: 4\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.idle_minutes == 180
+        assert "dm" in config.reset_by_type
+        assert config.reset_by_type["dm"].idle_minutes == 60
+        assert config.reset_by_type["group"].mode == "daily"
+
+        # get_reset_policy: type override returned when no platform override
+        resolved = config.get_reset_policy(session_type="dm")
+        assert resolved.mode == "idle"
+        assert resolved.idle_minutes == 60
+
+    def test_session_reset_default_only_leaves_overrides_empty(self, tmp_path, monkeypatch):
+        """Legacy-style session_reset with only top-level keys still works."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  mode: both\n"
+            "  idle_minutes: 180\n"
+            "  at_hour: 4\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.mode == "both"
+        assert config.default_reset_policy.idle_minutes == 180
+        assert config.reset_by_type == {}
+        assert config.reset_by_platform == {}
+
+    def test_invalid_session_reset_by_platform_is_ignored(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  mode: idle\n"
+            "  idle_minutes: 180\n"
+            "  by_platform: not-a-mapping\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.idle_minutes == 180
+        assert config.reset_by_platform == {}
+
+    def test_invalid_session_reset_by_type_is_ignored(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "session_reset:\n"
+            "  mode: idle\n"
+            "  idle_minutes: 180\n"
+            "  by_type:\n"
+            "  - not-a-mapping\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.default_reset_policy.idle_minutes == 180
+        assert config.reset_by_type == {}
+
 
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already


### PR DESCRIPTION
## Summary

`GatewayConfig` already supports per-type and per-platform session-reset overrides via `reset_by_type` / `reset_by_platform` (resolution order in `get_reset_policy`: platform > type > default). But the modern `config.yaml` loader stuffed the entire `session_reset` dict into `default_reset_policy`, so the override fields were only reachable via the legacy `gateway.json` fallback — which the loader itself flags as "consider moving settings to config.yaml."

This PR teaches `load_gateway_config` to split `session_reset.by_type` and `session_reset.by_platform` out of the default policy and forward them to `reset_by_type` / `reset_by_platform`. Invalid (non-mapping) values are warned about and ignored, matching the treatment of `quick_commands`.

Configs that set only `mode` / `idle_minutes` / `at_hour` are unaffected.

## Motivation

Multi-channel deployments want different reset policies per channel: Telegram bursts work best with a short idle timeout, long CLI/API sessions need a long one, some channels should never auto-reset. Today the machinery for this is all in place — it just isn't wired up to the documented config file.

Example config.yaml now understood:

```yaml
session_reset:
  mode: both
  idle_minutes: 180
  at_hour: 4
  by_platform:
    telegram:
      mode: idle
      idle_minutes: 30
    discord:
      mode: none
  by_type:
    dm:
      mode: idle
      idle_minutes: 60
    group:
      mode: daily
      at_hour: 4
```

## Test plan

Five new tests in `tests/gateway/test_config.py`:

- `test_bridges_session_reset_by_platform_from_config_yaml` — happy path, multiple platforms, verifies `get_reset_policy(platform=…)` resolves per-platform override
- `test_bridges_session_reset_by_type_from_config_yaml` — happy path, multiple types, verifies `get_reset_policy(session_type=…)` resolves per-type override
- `test_session_reset_default_only_leaves_overrides_empty` — back-compat for configs with only top-level fields
- `test_invalid_session_reset_by_platform_is_ignored` — non-mapping value warned about and ignored
- `test_invalid_session_reset_by_type_is_ignored` — symmetric coverage for `by_type`

Verified locally on Python 3.11:

- `tests/gateway/test_config.py`: 36 passed (31 existing + 5 new)
- All `SessionResetPolicy`-touching tests across the gateway suite: 68 passed
- Wider `tests/gateway/` run: 2992 passed, 4 pre-existing failures unrelated to this change