### PR TITLE
feat(gateway): support per-route webhook rate limiting

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -97,7 +97,7 @@ class WebhookAdapter(BasePlatformAdapter):
 
         # Rate limiting: per-route timestamps in a fixed window.
         self._rate_counts: Dict[str, List[float]] = {}
-        self._rate_limit: int = int(config.extra.get("rate_limit", 30))  # per minute
+        self._global_rate_limit: int = int(config.extra.get("rate_limit", 30))  # per minute
 
         # Body size limit (auth-before-body pattern)
         self._max_body_bytes: int = int(
@@ -297,10 +297,12 @@ class WebhookAdapter(BasePlatformAdapter):
             )
 
         # ── Rate limiting ────────────────────────────────────────
+        # ── Rate limiting ────────────────────────────────────────
         now = time.time()
+        route_limit = route_config.get("rate_limit", self._global_rate_limit)
         window = self._rate_counts.setdefault(route_name, [])
         window[:] = [t for t in window if now - t < 60]
-        if len(window) >= self._rate_limit:
+        if len(window) >= route_limit:
             return web.json_response(
                 {"error": "Rate limit exceeded"}, status=429
             )

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -316,7 +316,19 @@ Each route is rate-limited to **30 requests per minute** by default (fixed-windo
 platforms:
   webhook:
     extra:
-      rate_limit: 60  # requests per minute
+      rate_limit: 60  # global default: requests per minute
+```
+
+You can also override this for specific routes:
+
+```yaml
+platforms:
+  webhook:
+    extra:
+      routes:
+        my-route:
+          rate_limit: 5  # route override: requests per minute
+          # ... rest of route config
 ```
 
 Requests exceeding the limit receive a `429 Too Many Requests` response.

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -72,6 +72,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `skills` | No | List of skill names to load for the agent run. |
 | `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
+| `rate_limit` | No | Override the global `rate_limit` for this specific route (requests per minute). |
 
 ### Full example
 


### PR DESCRIPTION
This PR adds support for setting independent rate limits for individual webhook routes in the config.yaml. If a `rate_limit` is defined in the specific route configuration (under `platforms.webhook.extra.routes.<route_name>.rate_limit`), it will override the global platform default (`platforms.webhook.extra.rate_limit`).