### PR TITLE
fix(tools): respect configured terminal cwd during init

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -141,6 +141,27 @@ class TestInitSessionFailure:
 
         assert env._snapshot_ready is False
 
+    def test_init_session_bootstraps_into_configured_cwd(self):
+        env = _TestableEnv(cwd="/custom/workspace")
+        calls = []
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            calls.append({"cmd": cmd, "login": login, "timeout": timeout})
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            mock.stdout = iter([])
+            return mock
+
+        env._run_bash = mock_run_bash
+        env._wait_for_process = lambda proc, timeout=120: {"output": f"\n{env._cwd_marker}/custom/workspace{env._cwd_marker}\n", "returncode": 0}
+        env.init_session()
+
+        assert len(calls) == 1
+        assert calls[0]["login"] is True
+        assert "cd /custom/workspace || exit 126" in calls[0]["cmd"]
+        assert env.cwd == "/custom/workspace"
+
     def test_login_flag_when_snapshot_not_ready(self):
         """When _snapshot_ready=False, execute() should pass login=True to _run_bash."""
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -320,6 +320,15 @@ class BaseEnvironment(ABC):
         instead of running with ``bash -l``.
         """
         # Full capture: env vars, functions (filtered), aliases, shell options.
+        # IMPORTANT: cd to the configured cwd before recording pwd. Otherwise the
+        # initial session cwd silently becomes the parent Python process cwd
+        # (e.g. a systemd WorkingDirectory or the shell dir that launched Hermes),
+        # which overrides TERMINAL_CWD / terminal.cwd for local sessions.
+        quoted_cwd = (
+            shlex.quote(self.cwd)
+            if self.cwd != "~" and not self.cwd.startswith("~/")
+            else self.cwd
+        )
         bootstrap = (
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
@@ -327,6 +336,7 @@ class BaseEnvironment(ABC):
             f"echo 'shopt -s expand_aliases' >> {self._snapshot_path}\n"
             f"echo 'set +e' >> {self._snapshot_path}\n"
             f"echo 'set +u' >> {self._snapshot_path}\n"
+            f"cd {quoted_cwd} || exit 126\n"
             f"pwd -P > {self._cwd_file} 2>/dev/null || true\n"
             f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
         )


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
This PR let the terminal commands be executed with the working directory set to `terminal.cwd`.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #11312 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- tools/environments/base.py: cd to the configured cwd before taking pwd snapshot

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure `terminal.cwd` in config.yaml
2. Ask the agent to run terminal command `pwd`
3. Proof -> it prints the configured cwd in config file

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- N/A: I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- N/A: I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- N/A: I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- N/A: I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- N/A: I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

