### PR TITLE
fix(api-server): use aiohttp AppKey for adapter state

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,6 +40,11 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+if AIOHTTP_AVAILABLE:
+    API_SERVER_ADAPTER_KEY = web.AppKey("api_server_adapter", object)
+else:
+    API_SERVER_ADAPTER_KEY = "api_server_adapter"
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -243,7 +248,7 @@ if AIOHTTP_AVAILABLE:
     @web.middleware
     async def cors_middleware(request, handler):
         """Add CORS headers for explicitly allowed origins; handle OPTIONS preflight."""
-        adapter = request.app.get("api_server_adapter")
+        adapter = request.app.get(API_SERVER_ADAPTER_KEY)
         origin = request.headers.get("Origin", "")
         cors_headers = None
         if adapter is not None:
@@ -2312,7 +2317,7 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
             self._app = web.Application(middlewares=mws)
-            self._app["api_server_adapter"] = self
+            self._app[API_SERVER_ADAPTER_KEY] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -23,6 +23,7 @@ from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
+    API_SERVER_ADAPTER_KEY,
     APIServerAdapter,
     ResponseStore,
     _CORS_HEADERS,
@@ -218,7 +219,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
     mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
     app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app[API_SERVER_ADAPTER_KEY] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)

--- a/tests/gateway/test_api_server_bind_guard.py
+++ b/tests/gateway/test_api_server_bind_guard.py
@@ -5,9 +5,11 @@ that connect() refuses to start on non-loopback without API_SERVER_KEY.
 """
 
 import socket
+import warnings
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aiohttp.web_app import NotAppKeyWarning
 
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
@@ -130,3 +132,19 @@ class TestConnectBindGuard:
         assert adapter._api_key == "sk-test"
         assert is_network_accessible("0.0.0.0") is True
         # Combined: the guard condition is False (key is set), so it passes
+
+    @pytest.mark.asyncio
+    async def test_connect_does_not_emit_not_app_key_warning(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": 0}))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", NotAppKeyWarning)
+            try:
+                result = await adapter.connect()
+                assert result is True
+            finally:
+                if getattr(adapter, "_site", None) is not None:
+                    await adapter.disconnect()
+
+        not_app_key_warnings = [w for w in caught if issubclass(w.category, NotAppKeyWarning)]
+        assert not not_app_key_warnings

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -18,7 +18,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+from gateway.platforms.api_server import API_SERVER_ADAPTER_KEY, APIServerAdapter, cors_middleware
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +49,7 @@ def _make_adapter(api_key: str = "") -> APIServerAdapter:
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app with jobs routes registered."""
     app = web.Application(middlewares=[cors_middleware])
-    app["api_server_adapter"] = adapter
+    app[API_SERVER_ADAPTER_KEY] = adapter
     # Register only job routes (plus health for sanity)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/api/jobs", adapter._handle_list_jobs)


### PR DESCRIPTION
## Summary
- replace the API server's string-based aiohttp app-state key with a typed `web.AppKey`
- update the API server test helpers to use the same typed key
- add a regression test that verifies `connect()` no longer emits `NotAppKeyWarning`

## Verification
- `source venv/bin/activate && pytest -q tests/gateway/test_api_server_bind_guard.py::TestConnectBindGuard::test_connect_does_not_emit_not_app_key_warning`
- `source venv/bin/activate && pytest -q tests/gateway/test_api_server.py tests/gateway/test_api_server_jobs.py`
- `source venv/bin/activate && pytest -q tests/gateway/test_api_server_bind_guard.py::TestConnectBindGuard::test_refuses_ipv4_wildcard_without_key -W default`

Closes #11635
