### PR TITLE
fix(openviking): improve explicit fallback recall

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -29,7 +29,7 @@ All config via environment variables in `.env`:
 | `OPENVIKING_ENDPOINT` | `http://127.0.0.1:1933` | Server URL |
 | `OPENVIKING_API_KEY` | (none) | API key (optional) |
 | `OPENVIKING_ACCOUNT` | `default` | Tenant account for API requests |
-| `OPENVIKING_USER` | `hermes` | Tenant user for API requests |
+| `OPENVIKING_USER` | `default` | Tenant user for API requests |
 | `OPENVIKING_AGENT` | `hermes` | Tenant agent for API requests |
 
 ## Behavior notes

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -28,6 +28,14 @@ All config via environment variables in `.env`:
 |---------|---------|-------------|
 | `OPENVIKING_ENDPOINT` | `http://127.0.0.1:1933` | Server URL |
 | `OPENVIKING_API_KEY` | (none) | API key (optional) |
+| `OPENVIKING_ACCOUNT` | `default` | Tenant account for API requests |
+| `OPENVIKING_USER` | `hermes` | Tenant user for API requests |
+| `OPENVIKING_AGENT` | `hermes` | Tenant agent for API requests |
+
+## Behavior notes
+
+- File reads via `viking_read` fall back to full-content reads for file URIs because OpenViking overview/abstract endpoints are directory-oriented and can return 500 on file paths.
+- Explicit Hermes memory writes also store a deterministic fallback resource under `viking://resources/hermes_explicit_memories/...` so important notes remain durable even if session extraction is degraded.
 
 ## Tools
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -11,8 +11,8 @@ Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
   OPENVIKING_ACCOUNT   — Tenant account (default: default)
-  OPENVIKING_USER      — Tenant user (default: default)
-  OPENVIKING_AGENT   — Tenant agent (default: hermes)
+  OPENVIKING_USER      — Tenant user (default: hermes)
+  OPENVIKING_AGENT     — Tenant agent (default: hermes)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -28,7 +28,11 @@ import atexit
 import json
 import logging
 import os
+import re
 import threading
+import time
+import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -38,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
+_EXPLICIT_MEMORY_ROOT = "viking://resources/hermes_explicit_memories"
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +90,7 @@ class _VikingClient:
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
         self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
-        self._user = user or os.environ.get("OPENVIKING_USER", "default")
+        self._user = user or os.environ.get("OPENVIKING_USER", "hermes")
         self._agent = agent or os.environ.get("OPENVIKING_AGENT", "hermes")
         self._httpx = _get_httpx()
         if self._httpx is None:
@@ -259,9 +264,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._client: Optional[_VikingClient] = None
         self._endpoint = ""
         self._api_key = ""
+        self._account = "default"
+        self._user = "hermes"
+        self._agent = "hermes"
         self._session_id = ""
         self._turn_count = 0
         self._sync_thread: Optional[threading.Thread] = None
+        self._memwrite_thread: Optional[threading.Thread] = None
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
@@ -285,7 +294,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
             {
                 "key": "api_key",
-                "description": "OpenViking API key (leave blank for local dev mode)",
+                "description": "OpenViking API key",
                 "secret": True,
                 "env_var": "OPENVIKING_API_KEY",
             },
@@ -297,8 +306,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
             {
                 "key": "user",
-                "description": "OpenViking user ID within the account ([default], used when local mode, OPENVIKING_API_KEY is empty)",
-                "default": "default",
+                "description": "OpenViking user ID within the account ([hermes], used when local mode, OPENVIKING_API_KEY is empty)",
+                "default": "hermes",
                 "env_var": "OPENVIKING_USER",
             },
             {
@@ -309,23 +318,145 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
         ]
 
+    def _ensure_session(self) -> bool:
+        if not self._client or not self._session_id:
+            return False
+        try:
+            self._client.get(
+                f"/api/v1/sessions/{self._session_id}",
+                params={"auto_create": "true"},
+            )
+            return True
+        except Exception as e:
+            logger.warning("OpenViking session ensure failed for %s: %s", self._session_id, e)
+            return False
+
+    def _build_client(self) -> _VikingClient:
+        return _VikingClient(
+            self._endpoint,
+            self._api_key,
+            account=self._account,
+            user=self._user,
+            agent=self._agent,
+        )
+
+    @staticmethod
+    def _slugify(value: str) -> str:
+        slug = re.sub(r"[^a-zA-Z0-9_-]+", "_", value or "memory").strip("_")
+        return slug[:64] or "memory"
+
+    def _fallback_roots_on_disk(self) -> List[Path]:
+        base = Path.home() / ".openviking" / "data" / "viking"
+        roots = []
+        account = getattr(self, "_account", "default") or "default"
+        for candidate in dict.fromkeys([account, "default", "root"]):
+            root = base / candidate / "resources" / "hermes_explicit_memories"
+            if root.exists():
+                roots.append(root)
+        return roots
+
+    def _search_explicit_fallback(self, query: str, *, limit: int = 5) -> List[Dict[str, Any]]:
+        needle = (query or "").strip().lower()
+        if not needle:
+            return []
+
+        matches = []
+        for root in self._fallback_roots_on_disk():
+            for path in root.rglob("*.md"):
+                if path.name in {".abstract.md", ".overview.md"}:
+                    continue
+                try:
+                    content = path.read_text(errors="ignore")
+                except Exception:
+                    continue
+                lower = content.lower()
+                if needle not in lower:
+                    continue
+                idx = lower.index(needle)
+                start = max(0, idx - 120)
+                end = min(len(content), idx + 220)
+                snippet = content[start:end].replace("\n", " ").strip()
+                rel = path.relative_to(root.parent).as_posix()
+                score = 1.0 if needle in path.name.lower() else 0.97
+                matches.append({
+                    "uri": f"viking://resources/{rel}",
+                    "type": "resource",
+                    "score": score,
+                    "abstract": snippet[:280],
+                    "_mtime": path.stat().st_mtime,
+                })
+
+        matches.sort(key=lambda item: (item["score"], item["_mtime"]), reverse=True)
+        return [{k: v for k, v in item.items() if k != "_mtime"} for item in matches[:limit]]
+
+    def _store_explicit_memory_resource(self, target: str, content: str) -> Optional[str]:
+        if not self._client or not content:
+            return None
+
+        try:
+            note = (
+                "# Hermes explicit memory\n\n"
+                f"Target: {target}\n"
+                f"Session: {self._session_id or 'n/a'}\n"
+                f"Recorded at ms: {int(time.time() * 1000)}\n\n"
+                f"Content: {content}\n"
+            ).encode("utf-8")
+            headers = self._client._headers().copy()
+            headers.pop("Content-Type", None)
+            upload = self._client._httpx.post(
+                self._client._url("/api/v1/resources/temp_upload"),
+                headers=headers,
+                files={"file": ("explicit-memory.md", note, "text/markdown")},
+                data={"telemetry": "false"},
+                timeout=_TIMEOUT,
+            )
+            upload.raise_for_status()
+            temp_file_id = upload.json().get("result", {}).get("temp_file_id")
+            if not temp_file_id:
+                return None
+
+            uri = (
+                f"{_EXPLICIT_MEMORY_ROOT}/"
+                f"{self._slugify(target)}_{int(time.time() * 1000)}_{uuid.uuid4().hex[:8]}"
+            )
+            resp = self._client.post(
+                "/api/v1/resources",
+                {
+                    "temp_file_id": temp_file_id,
+                    "to": uri,
+                    "reason": "Hermes explicit memory fallback",
+                    "wait": False,
+                },
+            )
+            return resp.get("result", {}).get("root_uri", uri)
+        except Exception as e:
+            logger.debug("OpenViking explicit memory fallback failed: %s", e)
+            return None
+
+    def _is_directory_uri(self, uri: str) -> bool:
+        try:
+            resp = self._client.get("/api/v1/fs/stat", params={"uri": uri})
+            result = resp.get("result", {})
+            return bool(result.get("isDir"))
+        except Exception:
+            return uri.endswith("/")
+
     def initialize(self, session_id: str, **kwargs) -> None:
         self._endpoint = os.environ.get("OPENVIKING_ENDPOINT", _DEFAULT_ENDPOINT)
         self._api_key = os.environ.get("OPENVIKING_API_KEY", "")
         self._account = os.environ.get("OPENVIKING_ACCOUNT", "default")
-        self._user = os.environ.get("OPENVIKING_USER", "default")
+        self._user = os.environ.get("OPENVIKING_USER", "hermes")
         self._agent = os.environ.get("OPENVIKING_AGENT", "hermes")
         self._session_id = session_id
         self._turn_count = 0
 
         try:
-            self._client = _VikingClient(
-                self._endpoint, self._api_key,
-                account=self._account, user=self._user, agent=self._agent,
-            )
+            self._client = self._build_client()
             if not self._client.health():
                 logger.warning("OpenViking server at %s is not reachable", self._endpoint)
                 self._client = None
+            else:
+                self._ensure_session()
         except ImportError:
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
@@ -379,10 +510,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _run():
             try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
+                client = self._build_client()
                 resp = client.post("/api/v1/search/find", {
                     "query": query,
                     "top_k": 5,
@@ -397,6 +525,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
                         score = item.get("score", 0)
                         if abstract:
                             parts.append(f"- [{score:.2f}] {abstract} ({uri})")
+                for item in self._search_explicit_fallback(query, limit=3):
+                    parts.append(
+                        f"- [{item['score']:.2f}] {item.get('abstract', '')} ({item['uri']})"
+                    )
                 if parts:
                     with self._prefetch_lock:
                         self._prefetch_result = "\n".join(parts)
@@ -417,11 +549,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _sync():
             try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
+                client = self._build_client()
                 sid = self._session_id
+                client.get(f"/api/v1/sessions/{sid}", params={"auto_create": "true"})
 
                 # Add user message
                 client.post(f"/api/v1/sessions/{sid}/messages", {
@@ -459,11 +589,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # the count hasn't been incremented yet.
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=10.0)
+        if self._memwrite_thread and self._memwrite_thread.is_alive():
+            self._memwrite_thread.join(timeout=10.0)
 
         if self._turn_count == 0:
             return
 
         try:
+            if not self._ensure_session():
+                return
             self._client.post(f"/api/v1/sessions/{self._session_id}/commit")
             logger.info("OpenViking session %s committed (%d turns)", self._session_id, self._turn_count)
         except Exception as e:
@@ -476,9 +610,10 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         def _write():
             try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
+                client = self._build_client()
+                client.get(
+                    f"/api/v1/sessions/{self._session_id}",
+                    params={"auto_create": "true"},
                 )
                 # Add as a user message with memory context so the commit
                 # picks it up as an explicit memory during extraction
@@ -490,9 +625,18 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 })
             except Exception as e:
                 logger.debug("OpenViking memory mirror failed: %s", e)
+            finally:
+                uri = self._store_explicit_memory_resource(target, content)
+                if uri:
+                    logger.info("OpenViking explicit memory fallback stored at %s", uri)
 
-        t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
-        t.start()
+        if self._memwrite_thread and self._memwrite_thread.is_alive():
+            self._memwrite_thread.join(timeout=5.0)
+
+        self._memwrite_thread = threading.Thread(
+            target=_write, daemon=True, name="openviking-memwrite"
+        )
+        self._memwrite_thread.start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [SEARCH_SCHEMA, READ_SCHEMA, BROWSE_SCHEMA, REMEMBER_SCHEMA, ADD_RESOURCE_SCHEMA]
@@ -518,7 +662,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     def shutdown(self) -> None:
         # Wait for background threads to finish
-        for t in (self._sync_thread, self._prefetch_thread):
+        for t in (self._sync_thread, self._memwrite_thread, self._prefetch_thread):
             if t and t.is_alive():
                 t.join(timeout=5.0)
         # Clear atexit reference so it doesn't double-commit
@@ -564,10 +708,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         scored_entries.sort(key=lambda x: x[0], reverse=True)
         formatted = [entry for _, entry in scored_entries]
+        seen = {entry["uri"] for entry in formatted}
+        for item in self._search_explicit_fallback(query, limit=args.get("limit") or 5):
+            if item["uri"] in seen:
+                continue
+            formatted.append(item)
+            seen.add(item["uri"])
+        formatted.sort(key=lambda entry: entry.get("score", 0), reverse=True)
 
         return json.dumps({
             "results": formatted,
-            "total": result.get("total", len(formatted)),
+            "total": max(result.get("total", 0), len(formatted)),
         }, ensure_ascii=False)
 
     def _tool_read(self, args: dict) -> str:
@@ -576,6 +727,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return tool_error("uri is required")
 
         level = args.get("level", "overview")
+        if level != "full" and not self._is_directory_uri(uri):
+            level = "full"
         # Map our level names to OpenViking GET endpoints
         if level == "abstract":
             resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
@@ -634,16 +787,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if category:
             text = f"[Remember — {category}] {content}"
 
+        if not self._ensure_session():
+            return tool_error("OpenViking session unavailable")
+
         self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
             "role": "user",
             "parts": [
                 {"type": "text", "text": text},
             ],
         })
+        self._client.post(f"/api/v1/sessions/{self._session_id}/commit")
+        fallback_uri = self._store_explicit_memory_resource(category or "memory", content)
 
         return json.dumps({
             "status": "stored",
             "message": "Memory recorded. Will be extracted and indexed on session commit.",
+            "fallback_uri": fallback_uri,
         })
 
     def _tool_add_resource(self, args: dict) -> str:
@@ -651,11 +810,31 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not url:
             return tool_error("url is required")
 
-        payload: Dict[str, Any] = {"path": url}
-        if args.get("reason"):
-            payload["reason"] = args["reason"]
+        if os.path.exists(url):
+            headers = self._client._headers().copy()
+            headers.pop("Content-Type", None)
+            with open(url, "rb") as f:
+                upload = self._client._httpx.post(
+                    self._client._url("/api/v1/resources/temp_upload"),
+                    headers=headers,
+                    files={"file": (os.path.basename(url), f, "application/octet-stream")},
+                    data={"telemetry": "false"},
+                    timeout=_TIMEOUT,
+                )
+            upload.raise_for_status()
+            temp_file_id = upload.json().get("result", {}).get("temp_file_id")
+            if not temp_file_id:
+                return tool_error("OpenViking temp upload failed")
 
-        resp = self._client.post("/api/v1/resources", payload)
+            payload: Dict[str, Any] = {"temp_file_id": temp_file_id, "wait": False}
+            if args.get("reason"):
+                payload["reason"] = args["reason"]
+            resp = self._client.post("/api/v1/resources", payload)
+        else:
+            payload = {"path": url}
+            if args.get("reason"):
+                payload["reason"] = args["reason"]
+            resp = self._client.post("/api/v1/resources", payload)
         result = resp.get("result", {})
 
         return json.dumps({

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -11,7 +11,7 @@ Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
   OPENVIKING_ACCOUNT   — Tenant account (default: default)
-  OPENVIKING_USER      — Tenant user (default: hermes)
+  OPENVIKING_USER      — Tenant user (default: default)
   OPENVIKING_AGENT     — Tenant agent (default: hermes)
 
 Capabilities:
@@ -90,7 +90,7 @@ class _VikingClient:
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
         self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
-        self._user = user or os.environ.get("OPENVIKING_USER", "hermes")
+        self._user = user or os.environ.get("OPENVIKING_USER", "default")
         self._agent = agent or os.environ.get("OPENVIKING_AGENT", "hermes")
         self._httpx = _get_httpx()
         if self._httpx is None:
@@ -265,7 +265,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._endpoint = ""
         self._api_key = ""
         self._account = "default"
-        self._user = "hermes"
+        self._user = "default"
         self._agent = "hermes"
         self._session_id = ""
         self._turn_count = 0
@@ -306,8 +306,8 @@ class OpenVikingMemoryProvider(MemoryProvider):
             },
             {
                 "key": "user",
-                "description": "OpenViking user ID within the account ([hermes], used when local mode, OPENVIKING_API_KEY is empty)",
-                "default": "hermes",
+                "description": "OpenViking user ID within the account ([default], used when local mode, OPENVIKING_API_KEY is empty)",
+                "default": "default",
                 "env_var": "OPENVIKING_USER",
             },
             {
@@ -445,7 +445,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._endpoint = os.environ.get("OPENVIKING_ENDPOINT", _DEFAULT_ENDPOINT)
         self._api_key = os.environ.get("OPENVIKING_API_KEY", "")
         self._account = os.environ.get("OPENVIKING_ACCOUNT", "default")
-        self._user = os.environ.get("OPENVIKING_USER", "hermes")
+        self._user = os.environ.get("OPENVIKING_USER", "default")
         self._agent = os.environ.get("OPENVIKING_AGENT", "hermes")
         self._session_id = session_id
         self._turn_count = 0

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -77,7 +77,7 @@ class _FakePrefetchClient:
         return {"result": {"memories": [], "resources": []}}
 
 
-def test_viking_client_defaults_use_hermes_user(monkeypatch):
+def test_viking_client_defaults_use_default_user(monkeypatch):
     monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
     monkeypatch.delenv("OPENVIKING_USER", raising=False)
     monkeypatch.delenv("OPENVIKING_AGENT", raising=False)
@@ -85,8 +85,17 @@ def test_viking_client_defaults_use_hermes_user(monkeypatch):
     client = _VikingClient("http://127.0.0.1:1933", api_key="dev")
 
     assert client._headers()["X-OpenViking-Account"] == "default"
-    assert client._headers()["X-OpenViking-User"] == "hermes"
+    assert client._headers()["X-OpenViking-User"] == "default"
     assert client._headers()["X-OpenViking-Agent"] == "hermes"
+
+
+
+def test_provider_initial_defaults_use_default_user():
+    provider = OpenVikingMemoryProvider()
+
+    assert provider._account == "default"
+    assert provider._user == "default"
+    assert provider._agent == "hermes"
 
 
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,7 +1,93 @@
 import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
-from plugins.memory.openviking import OpenVikingMemoryProvider
+from plugins.memory.openviking import OpenVikingMemoryProvider, _VikingClient
+
+
+class _FakeFileReadClient:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, path, **kwargs):
+        self.calls.append((path, kwargs))
+        if path == "/api/v1/fs/stat":
+            return {"result": {"isDir": False}}
+        if path == "/api/v1/content/read":
+            return {"result": "file body"}
+        raise AssertionError(f"Unexpected GET call: {path}")
+
+
+class _FakeUploadResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttpx:
+    def __init__(self):
+        self.calls = []
+
+    def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _FakeUploadResponse({"result": {"temp_file_id": "temp-123"}})
+
+
+class _FakeResourceClient:
+    def __init__(self):
+        self._httpx = _FakeHttpx()
+        self.post_calls = []
+
+    def _headers(self):
+        return {
+            "Content-Type": "application/json",
+            "X-OpenViking-Account": "default",
+            "X-OpenViking-User": "hermes",
+            "X-OpenViking-Agent": "hermes",
+            "X-API-Key": "dev",
+        }
+
+    def _url(self, path):
+        return f"http://127.0.0.1:1933{path}"
+
+    def post(self, path, payload=None, **kwargs):
+        self.post_calls.append((path, payload, kwargs))
+        if path == "/api/v1/resources":
+            return {"result": {"root_uri": "viking://resources/test-upload"}}
+        raise AssertionError(f"Unexpected POST call: {path}")
+
+
+class _FakeRememberClient:
+    def __init__(self):
+        self.post_calls = []
+
+    def post(self, path, payload=None, **kwargs):
+        self.post_calls.append((path, payload, kwargs))
+        return {"result": {}}
+
+
+class _FakePrefetchClient:
+    def post(self, path, payload=None, **kwargs):
+        assert path == "/api/v1/search/find"
+        return {"result": {"memories": [], "resources": []}}
+
+
+def test_viking_client_defaults_use_hermes_user(monkeypatch):
+    monkeypatch.delenv("OPENVIKING_ACCOUNT", raising=False)
+    monkeypatch.delenv("OPENVIKING_USER", raising=False)
+    monkeypatch.delenv("OPENVIKING_AGENT", raising=False)
+
+    client = _VikingClient("http://127.0.0.1:1933", api_key="dev")
+
+    assert client._headers()["X-OpenViking-Account"] == "default"
+    assert client._headers()["X-OpenViking-User"] == "hermes"
+    assert client._headers()["X-OpenViking-Agent"] == "hermes"
+
 
 
 def test_tool_search_sorts_by_raw_score_across_buckets():
@@ -33,6 +119,7 @@ def test_tool_search_sorts_by_raw_score_across_buckets():
     assert result["total"] == 3
 
 
+
 def test_tool_search_sorts_missing_raw_score_after_negative_scores():
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()
@@ -60,3 +147,74 @@ def test_tool_search_sorts_missing_raw_score_after_negative_scores():
     ]
     assert [entry["score"] for entry in result["results"]] == [0.1, 0.0, -0.25]
     assert result["total"] == 3
+
+
+
+def test_tool_read_uses_full_for_file_uri():
+    provider = OpenVikingMemoryProvider()
+    provider._client = _FakeFileReadClient()
+
+    payload = json.loads(
+        provider._tool_read(
+            {"uri": "viking://user/hermes/memories/profile.md", "level": "overview"}
+        )
+    )
+
+    assert payload["level"] == "full"
+    assert payload["content"] == "file body"
+
+
+
+def test_tool_add_resource_uploads_local_file_via_temp_upload(tmp_path):
+    provider = OpenVikingMemoryProvider()
+    provider._client = _FakeResourceClient()
+
+    test_file = tmp_path / "resource.md"
+    test_file.write_text("hello")
+
+    payload = json.loads(provider._tool_add_resource({"url": str(test_file), "reason": "unit-test"}))
+
+    upload_url, upload_kwargs = provider._client._httpx.calls[0]
+    assert upload_url.endswith("/api/v1/resources/temp_upload")
+    assert "file" in upload_kwargs["files"]
+    assert payload["status"] == "added"
+    assert payload["root_uri"] == "viking://resources/test-upload"
+    assert provider._client.post_calls[0][1]["temp_file_id"] == "temp-123"
+
+
+
+def test_tool_remember_commits_and_returns_fallback_uri(monkeypatch):
+    provider = OpenVikingMemoryProvider()
+    provider._client = _FakeRememberClient()
+    provider._session_id = "sess-123"
+    provider._ensure_session = MagicMock(return_value=True)
+    provider._store_explicit_memory_resource = MagicMock(return_value="viking://resources/hermes_explicit_memories/case_1")
+
+    payload = json.loads(provider._tool_remember({"content": "remember me", "category": "case"}))
+
+    assert provider._client.post_calls[0][0] == "/api/v1/sessions/sess-123/messages"
+    assert provider._client.post_calls[1][0] == "/api/v1/sessions/sess-123/commit"
+    assert payload["fallback_uri"] == "viking://resources/hermes_explicit_memories/case_1"
+
+
+
+def test_queue_prefetch_includes_explicit_fallback_hits():
+    provider = OpenVikingMemoryProvider()
+    provider._client = object()
+    provider._build_client = MagicMock(return_value=_FakePrefetchClient())
+    provider._search_explicit_fallback = MagicMock(return_value=[
+        {
+            "uri": "viking://resources/hermes_explicit_memories/test-note.md",
+            "score": 0.97,
+            "abstract": "important fallback note",
+        }
+    ])
+
+    provider.queue_prefetch("openviking restart")
+    if provider._prefetch_thread and provider._prefetch_thread.is_alive():
+        provider._prefetch_thread.join(timeout=3)
+
+    result = provider.prefetch("openviking restart")
+
+    assert "important fallback note" in result
+    assert "viking://resources/hermes_explicit_memories/test-note.md" in result


### PR DESCRIPTION
## Summary
- make deterministic explicit-memory fallback more operationally useful in the Hermes OpenViking provider
- keep fallback memories visible through provider search/prefetch paths
- add focused regression coverage for fallback recall behavior

## What changed
- extend the provider's explicit fallback search/retrieval flow
- ensure prefetch can surface explicit fallback hits, not just semantic search hits
- keep local-file upload / fallback behavior documented in the provider README
- add regression tests for:
  - default tenant/user/agent behavior
  - file reads forced to full mode
  - local resource upload via temp upload
  - explicit remember fallback URI
  - prefetch including explicit fallback hits

## Why
The OpenViking session-backed path is still inconsistent in local runtime verification, so Hermes needs the deterministic fallback path to be not only durable, but also recallable during normal use.

## Tests
- `pytest -q tests/plugins/memory/test_openviking_provider.py`
- `python3 -m py_compile plugins/memory/openviking/__init__.py tests/plugins/memory/test_openviking_provider.py`
