### PR TITLE
fix(gateway): replay queued messages after restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -330,6 +330,7 @@ logger = logging.getLogger(__name__)
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+_PENDING_RESTART_EVENTS_FILE = ".gateway_restart_pending.json"
 
 
 def _resolve_runtime_agent_kwargs() -> dict:
@@ -1078,6 +1079,129 @@ class GatewayRunner:
 
     def _queue_during_drain_enabled(self) -> bool:
         return self._restart_requested and self._busy_input_mode == "queue"
+
+    def _pending_restart_events_path(self) -> Path:
+        return _hermes_home / _PENDING_RESTART_EVENTS_FILE
+
+    @staticmethod
+    def _serialize_pending_event(event: MessageEvent) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "text": event.text,
+            "message_type": event.message_type.value,
+            "source": event.source.to_dict() if event.source else None,
+            "message_id": event.message_id,
+            "media_urls": list(event.media_urls or []),
+            "media_types": list(event.media_types or []),
+            "reply_to_message_id": event.reply_to_message_id,
+            "reply_to_text": event.reply_to_text,
+            "auto_skill": event.auto_skill,
+            "channel_prompt": event.channel_prompt,
+            "internal": bool(event.internal),
+        }
+        if getattr(event, "timestamp", None):
+            try:
+                payload["timestamp"] = event.timestamp.isoformat()
+            except Exception:
+                pass
+        return payload
+
+    @staticmethod
+    def _deserialize_pending_event(payload: Dict[str, Any]) -> MessageEvent:
+        source_payload = payload.get("source") or {}
+        source = SessionSource.from_dict(source_payload) if source_payload else None
+        timestamp = None
+        raw_ts = payload.get("timestamp")
+        if raw_ts:
+            try:
+                timestamp = datetime.fromisoformat(raw_ts)
+            except Exception:
+                timestamp = None
+        return MessageEvent(
+            text=payload.get("text") or "",
+            message_type=MessageType(payload.get("message_type") or MessageType.TEXT.value),
+            source=source,
+            message_id=payload.get("message_id"),
+            media_urls=list(payload.get("media_urls") or []),
+            media_types=list(payload.get("media_types") or []),
+            reply_to_message_id=payload.get("reply_to_message_id"),
+            reply_to_text=payload.get("reply_to_text"),
+            auto_skill=payload.get("auto_skill"),
+            channel_prompt=payload.get("channel_prompt"),
+            internal=bool(payload.get("internal", False)),
+            timestamp=timestamp or datetime.now(),
+        )
+
+    def _persist_pending_restart_events(self) -> int:
+        path = self._pending_restart_events_path()
+        events: List[Dict[str, Any]] = []
+        for _platform, adapter in list(getattr(self, "adapters", {}).items()):
+            pending_messages = getattr(adapter, "_pending_messages", {}) or {}
+            for pending_event in list(pending_messages.values()):
+                if not isinstance(pending_event, MessageEvent) or not pending_event.source:
+                    continue
+                events.append(self._serialize_pending_event(pending_event))
+
+        if not events:
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            return 0
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps({"events": events}, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp_path.replace(path)
+        logger.info("Persisted %d queued gateway event(s) for restart replay", len(events))
+        return len(events)
+
+    async def _replay_persisted_pending_restart_events(self) -> int:
+        path = self._pending_restart_events_path()
+        if not path.exists():
+            return 0
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning("Could not read pending restart events checkpoint: %s", e)
+            return 0
+
+        raw_events = payload.get("events") or []
+        replayed = 0
+        remaining: List[Dict[str, Any]] = []
+
+        for item in raw_events:
+            try:
+                event = self._deserialize_pending_event(item)
+            except Exception as e:
+                logger.warning("Skipping invalid pending restart event: %s", e)
+                continue
+
+            adapter = self.adapters.get(event.source.platform) if event.source else None
+            if not adapter:
+                remaining.append(item)
+                continue
+
+            try:
+                await adapter.handle_message(event)
+                replayed += 1
+            except Exception as e:
+                logger.warning("Failed replaying queued gateway event: %s", e)
+                remaining.append(item)
+
+        if remaining:
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_path.write_text(json.dumps({"events": remaining}, ensure_ascii=False, indent=2), encoding="utf-8")
+            tmp_path.replace(path)
+        else:
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+        if replayed:
+            logger.info("Replayed %d queued gateway event(s) after restart", replayed)
+        return replayed
 
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
@@ -2017,6 +2141,10 @@ class GatewayRunner:
         # Notify the chat that initiated /restart that the gateway is back.
         await self._send_restart_notification()
 
+        # Replay any queued follow-up messages persisted by the previous
+        # gateway instance during a graceful restart.
+        await self._replay_persisted_pending_restart_events()
+
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
             from tools.process_registry import process_registry
@@ -2329,6 +2457,12 @@ class GatewayRunner:
                     await self._launch_detached_restart_command()
                 except Exception as e:
                     logger.error("Failed to launch detached gateway restart: %s", e)
+
+            if self._restart_requested and self._queue_during_drain_enabled():
+                try:
+                    self._persist_pending_restart_events()
+                except Exception as e:
+                    logger.warning("Failed to persist queued gateway events for restart: %s", e)
 
             self._finalize_shutdown_agents(active_agents)
 

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,6 +1,8 @@
 import asyncio
+import json
 import shutil
 import subprocess
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -242,3 +244,68 @@ async def test_shutdown_notification_send_failure_does_not_block():
 
     # Should not raise
     await runner._notify_active_sessions_of_shutdown()
+
+
+def test_persist_pending_restart_events_writes_checkpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    runner._persist_pending_restart_events = gateway_run.GatewayRunner._persist_pending_restart_events.__get__(runner, gateway_run.GatewayRunner)
+
+    event = MessageEvent(
+        text="continue openviking fix",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(chat_id="555"),
+        message_id="msg-555",
+    )
+    session_key = build_session_key(event.source)
+    adapter._pending_messages[session_key] = event
+
+    saved = runner._persist_pending_restart_events()
+
+    assert saved == 1
+    checkpoint = tmp_path / ".gateway_restart_pending.json"
+    payload = json.loads(checkpoint.read_text())
+    assert len(payload["events"]) == 1
+    assert payload["events"][0]["text"] == "continue openviking fix"
+    assert payload["events"][0]["source"]["chat_id"] == "555"
+
+
+@pytest.mark.asyncio
+async def test_replay_pending_restart_events_requeues_messages_and_clears_checkpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    runner._replay_persisted_pending_restart_events = gateway_run.GatewayRunner._replay_persisted_pending_restart_events.__get__(runner, gateway_run.GatewayRunner)
+
+    seen = []
+
+    async def fake_handle_message(event):
+        seen.append(event)
+
+    adapter.handle_message = fake_handle_message
+
+    checkpoint = tmp_path / ".gateway_restart_pending.json"
+    checkpoint.write_text(json.dumps({
+        "events": [
+            {
+                "text": "resume queued task",
+                "message_type": "text",
+                "source": make_restart_source(chat_id="777").to_dict(),
+                "message_id": "queued-777",
+                "media_urls": [],
+                "media_types": [],
+                "reply_to_message_id": None,
+                "reply_to_text": None,
+                "auto_skill": None,
+                "channel_prompt": None,
+                "internal": False,
+            }
+        ]
+    }))
+
+    replayed = await runner._replay_persisted_pending_restart_events()
+
+    assert replayed == 1
+    assert len(seen) == 1
+    assert seen[0].text == "resume queued task"
+    assert seen[0].source.chat_id == "777"
+    assert not checkpoint.exists()


### PR DESCRIPTION
## Summary
- persist queued follow-up gateway events during graceful restart drain in queue mode
- replay those queued events after the gateway reconnects
- add focused regression tests for checkpoint persistence/replay

## What changed
- add a checkpoint file for queued restart events: `.gateway_restart_pending.json`
- serialize queued `MessageEvent`s before adapter teardown during graceful restart
- replay saved events through normal adapter `handle_message()` processing after startup
- keep unreplayed entries in the checkpoint when a platform is still unavailable
- add regression tests covering checkpoint write + replay behavior

## Why
Before this change, `busy_input_mode=queue` improved drain-time UX but queued follow-up messages still lived only in RAM. A graceful restart could acknowledge a queued follow-up and then lose it during process replacement.

## Tests
- `pytest -q tests/gateway/test_restart_drain.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_clean_shutdown_marker.py`
- `python3 -m py_compile gateway/run.py tests/gateway/test_restart_drain.py`
