### PR TITLE
fix(gateway): recover stale sessions after interrupt failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3061,12 +3061,24 @@ class GatewayRunner:
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
-            running_agent.interrupt(event.text)
-            if _quick_key in self._pending_messages:
-                self._pending_messages[_quick_key] += "\n" + event.text
+            try:
+                running_agent.interrupt(event.text)
+            except Exception:
+                logger.warning(
+                    "Interrupt failed for session %s; releasing stale running-agent lock "
+                    "and retrying the message as a fresh turn.",
+                    _quick_key[:30],
+                    exc_info=True,
+                )
+                self._running_agents.pop(_quick_key, None)
+                self._running_agents_ts.pop(_quick_key, None)
+                self._busy_ack_ts.pop(_quick_key, None)
             else:
-                self._pending_messages[_quick_key] = event.text
-            return None
+                if _quick_key in self._pending_messages:
+                    self._pending_messages[_quick_key] += "\n" + event.text
+                else:
+                    self._pending_messages[_quick_key] = event.text
+                return None
 
         # Check for commands
         command = event.get_command()

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -37,6 +37,7 @@ def _make_runner():
     runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
     runner._running_agents = {}
     runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._voice_mode = {}
@@ -256,6 +257,35 @@ async def test_recent_telegram_followups_append_in_pending_queue():
     fake_agent.interrupt.assert_not_called()
     adapter = runner.adapters[Platform.TELEGRAM]
     assert adapter._pending_messages[session_key].text == "part one\npart two"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_failure_releases_stale_lock_and_retries_fresh_turn():
+    runner = _make_runner()
+    event = _make_event(text="retry me")
+    session_key = build_session_key(event.source)
+
+    dead_agent = MagicMock()
+    dead_agent.get_activity_summary.return_value = {"seconds_since_activity": 0}
+    dead_agent.interrupt.side_effect = RuntimeError("dead agent")
+    runner._running_agents[session_key] = dead_agent
+    import time as _time
+    runner._running_agents_ts[session_key] = _time.time() - 10
+    runner._busy_ack_ts[session_key] = _time.time()
+
+    async def mock_inner(self_inner, ev, src, qk):
+        assert qk == session_key
+        return "ok"
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        result = await runner._handle_message(event)
+
+    assert result == "ok"
+    dead_agent.interrupt.assert_called_once_with("retry me")
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._running_agents_ts
+    assert session_key not in runner._busy_ack_ts
+    assert session_key not in runner._pending_messages
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- release stale `_running_agents` locks when `interrupt()` fails on a dead active agent
- let the follow-up message continue through the normal fresh-turn path instead of getting trapped in the interrupt loop
- add a regression test covering the dead-agent recovery path in the gateway session race guard suite

## Testing
- ./.venv/bin/python -m pytest -o addopts='' tests/gateway/test_session_race_guard.py -q
- ./.venv/bin/python -m pytest -o addopts='' tests/gateway/test_busy_session_ack.py -q

Fixes #11131