### PR TITLE
fix(file): block Win32 reserved device reads on native NT

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -86,6 +86,27 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("device file", result["error"])
 
+    @patch("tools.file_tools.os.name", "nt")
+    def test_nt_reserved_device_detection(self):
+        for dev in ("CON", "con", r"\\.\CON", r"\\.\NUL", r"C:\Windows\system32\con"):
+            self.assertTrue(_is_blocked_device(dev), f"{dev} should be blocked on NT")
+
+    @patch("tools.file_tools.os.name", "nt")
+    def test_nt_com_lpt_reserved(self):
+        self.assertTrue(_is_blocked_device("COM1"))
+        self.assertTrue(_is_blocked_device(r"C:\COM3.txt"))
+
+    @patch("tools.file_tools.os.name", "nt")
+    def test_nt_normal_file_not_blocked(self):
+        self.assertFalse(_is_blocked_device(r"C:\Users\me\readme.txt"))
+
+    @patch("tools.file_tools.os.name", "nt")
+    def test_read_file_tool_rejects_nt_reserved(self):
+        """Reserved NT device paths are rejected before resolve()/I/O."""
+        result = json.loads(read_file_tool("CON", task_id="nt_dev_test"))
+        self.assertIn("error", result)
+        self.assertIn("device file", result["error"])
+
 
 # ---------------------------------------------------------------------------
 # Character-count limits

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -70,6 +70,37 @@ _BLOCKED_DEVICE_PATHS = frozenset({
     "/dev/fd/0", "/dev/fd/1", "/dev/fd/2",
 })
 
+# Windows reserved device names (native ``os.name == "nt"``). WSL sessions
+# report as POSIX and continue to use the ``/dev/*`` rules above.
+_WIN_NT_RESERVED_DEVICE_STEMS: frozenset[str] = frozenset(
+    {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
+
+def _is_nt_reserved_device_path(normalized: str) -> bool:
+    """Return True when *normalized* targets a classic Win32 reserved device.
+
+    Only active on native Windows (``os.name == "nt"``). Hermes users on WSL2
+    keep POSIX semantics; this guard closes the gap for Windows-native runs
+    where paths like ``CON`` or ``COM1`` map to console/serial devices.
+    """
+    if os.name != "nt":
+        return False
+    p = os.path.normcase(os.path.normpath(normalized))
+    p = p.replace("/", "\\")
+    if p.startswith("\\\\.\\") or p.startswith("\\\\?\\"):
+        inner = p[4:]
+        head = inner.split("\\", 1)[0]
+        stem = os.path.splitext(head)[0].upper()
+        if stem in _WIN_NT_RESERVED_DEVICE_STEMS:
+            return True
+        return head.upper() in _WIN_NT_RESERVED_DEVICE_STEMS
+    base = os.path.basename(p)
+    stem = os.path.splitext(base)[0].upper()
+    return stem in _WIN_NT_RESERVED_DEVICE_STEMS
+
 
 def _is_blocked_device(filepath: str) -> bool:
     """Return True if the path would hang the process (infinite output or blocking input).
@@ -81,6 +112,8 @@ def _is_blocked_device(filepath: str) -> bool:
     """
     normalized = os.path.expanduser(filepath)
     if normalized in _BLOCKED_DEVICE_PATHS:
+        return True
+    if _is_nt_reserved_device_path(normalized):
         return True
     # /proc/self/fd/0-2 and /proc/<pid>/fd/0-2 are Linux aliases for stdio
     if normalized.startswith("/proc/") and normalized.endswith(


### PR DESCRIPTION
## Summary

Harden `read_file_tool`'s pre-I/O device guard for **native Windows** (`os.name == "nt"`). Paths such as `CON`, `NUL`, `COM1`–`COM9`, `LPT1`–`LPT9`, and the `\\.\` / `\\?\` device namespace can map to the console or serial devices and may block or behave unlike normal files. The existing blocklist covers Linux `/dev/*` and `/proc/.../fd/{0,1,2}`; this change closes the gap for **Windows-native Python** runs.

## Why this is orthogonal to WSL2

Hermes users on **WSL2** continue to see `os.name == "posix"` and keep the existing `/dev/*` rules unchanged. This patch only applies when the interpreter is a **native NT** process, so it complements the WSL-oriented workflow rather than replacing it.

## Changes

- Add `_WIN_NT_RESERVED_DEVICE_STEMS` and `_is_nt_reserved_device_path()` in `tools/file_tools.py`.
- Call it from `_is_blocked_device()` after `os.path.expanduser()` and alongside the POSIX `/dev` set.
- Extend `tests/tools/test_file_read_guards.py` with `patch("tools.file_tools.os.name", "nt")` so CI on non-Windows still exercises the NT branch.

## Testing

`python -m pytest tests/tools/test_file_read_guards.py -q -o addopts=`

## Note

Noticed this while setting up uv on Windows WSL2, then double-checked that the same read guard should apply when running Hermes under native Windows without the Linux `/dev` namespace.