### PR TITLE
fix(mattermost): keep threaded replies and progress in-thread

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -998,6 +998,24 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def _event_thread_metadata(self, event: MessageEvent) -> Optional[Dict[str, str]]:
+        """Return threaded delivery metadata for an inbound event.
+
+        Mattermost top-level channel posts need a synthetic thread root using
+        the inbound post id so every outbound send in the turn stays threaded.
+        """
+        thread_id = event.source.thread_id
+        if (
+            not thread_id
+            and self.platform == Platform.MATTERMOST
+            and event.source.chat_type != "dm"
+            and event.message_id
+        ):
+            thread_id = event.message_id
+        if not thread_id:
+            return None
+        return {"thread_id": str(thread_id)}
     
     def set_session_store(self, session_store: Any) -> None:
         """
@@ -1585,7 +1603,7 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
-                    _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                    _thread_meta = self._event_thread_metadata(event)
                     response = await self._message_handler(event)
                     if response:
                         await self._send_with_retry(
@@ -1681,7 +1699,7 @@ class BasePlatformAdapter(ABC):
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
-        _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        _thread_metadata = self._event_thread_metadata(event)
         typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_thread_metadata))
         
         try:
@@ -1917,7 +1935,7 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                _thread_metadata = self._event_thread_metadata(event)
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -48,6 +49,9 @@ _CHANNEL_TYPE_MAP = {
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+_KNOWN_THREAD_TTL_SECONDS = 24 * 60 * 60
+_KNOWN_THREAD_MAX = 500
 
 
 def check_mattermost_requirements() -> bool:
@@ -98,6 +102,53 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # Threads where the bot has already participated. Used to bypass the
+        # @mention gate for follow-up replies in channel threads.
+        self._known_threads: Dict[str, float] = {}
+
+    def _prune_known_threads(self) -> None:
+        now = time.time()
+        expired = [
+            thread_id
+            for thread_id, seen_at in self._known_threads.items()
+            if now - seen_at > _KNOWN_THREAD_TTL_SECONDS
+        ]
+        for thread_id in expired:
+            self._known_threads.pop(thread_id, None)
+
+        if len(self._known_threads) <= _KNOWN_THREAD_MAX:
+            return
+
+        for thread_id, _ in sorted(
+            self._known_threads.items(), key=lambda item: item[1]
+        )[: len(self._known_threads) - _KNOWN_THREAD_MAX]:
+            self._known_threads.pop(thread_id, None)
+
+    def _register_known_thread(self, thread_id: Optional[str]) -> None:
+        if not thread_id:
+            return
+        self._known_threads[str(thread_id)] = time.time()
+        self._prune_known_threads()
+
+    def _is_known_thread(self, thread_id: Optional[str]) -> bool:
+        if not thread_id:
+            return False
+        self._prune_known_threads()
+        return str(thread_id) in self._known_threads
+
+    def _resolve_root_id(
+        self,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        if self._reply_mode != "thread":
+            return None
+        if metadata and metadata.get("thread_id"):
+            return str(metadata["thread_id"])
+        if reply_to:
+            return str(reply_to)
+        return None
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -269,14 +320,16 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            root_id = self._resolve_root_id(reply_to=reply_to, metadata=metadata)
+            if root_id:
+                payload["root_id"] = root_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
                 return SendResult(success=False, error="Failed to create post")
             last_id = data["id"]
+            if root_id:
+                self._register_known_thread(root_id)
 
         return SendResult(success=True, message_id=last_id)
 
@@ -326,7 +379,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
-            chat_id, image_url, caption, reply_to, "image"
+            chat_id, image_url, caption, reply_to, metadata, "image"
         )
 
     async def send_image_file(
@@ -339,7 +392,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
-            chat_id, image_path, caption, reply_to
+            chat_id, image_path, caption, reply_to, metadata=metadata
         )
 
     async def send_document(
@@ -353,7 +406,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
-            chat_id, file_path, caption, reply_to, file_name
+            chat_id, file_path, caption, reply_to, file_name, metadata=metadata
         )
 
     async def send_voice(
@@ -366,7 +419,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
-            chat_id, audio_path, caption, reply_to
+            chat_id, audio_path, caption, reply_to, metadata=metadata
         )
 
     async def send_video(
@@ -379,7 +432,7 @@ class MattermostAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
-            chat_id, video_path, caption, reply_to
+            chat_id, video_path, caption, reply_to, metadata=metadata
         )
 
     def format_message(self, content: str) -> str:
@@ -402,13 +455,14 @@ class MattermostAdapter(BasePlatformAdapter):
         url: str,
         caption: Optional[str],
         reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
         kind: str = "file",
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
             logger.warning("Mattermost: blocked unsafe URL (SSRF protection)")
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         import asyncio
         import aiohttp
@@ -428,7 +482,7 @@ class MattermostAdapter(BasePlatformAdapter):
                             await asyncio.sleep(1.5 * (attempt + 1))
                             continue
                     if resp.status >= 400:
-                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                        return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
                     file_data = await resp.read()
                     ct = resp.content_type or "application/octet-stream"
                     break
@@ -437,27 +491,30 @@ class MattermostAdapter(BasePlatformAdapter):
                     await asyncio.sleep(1.5 * (attempt + 1))
                     continue
                 logger.warning("Mattermost: failed to download %s after %d attempts: %s", url, attempt + 1, exc)
-                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+                return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         if file_data is None:
             logger.warning("Mattermost: download returned no data for %s", url)
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         file_id = await self._upload_file(chat_id, file_data, fname, ct)
         if not file_id:
-            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
+            return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to, metadata=metadata)
 
         payload: Dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        root_id = self._resolve_root_id(reply_to=reply_to, metadata=metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to post with file")
+        if root_id:
+            self._register_known_thread(root_id)
         return SendResult(success=True, message_id=data["id"])
 
     async def _send_local_file(
@@ -467,6 +524,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str],
         reply_to: Optional[str],
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -474,7 +532,7 @@ class MattermostAdapter(BasePlatformAdapter):
         p = Path(file_path)
         if not p.exists():
             return await self.send(
-                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
+                chat_id, f"{caption or ''}\n(file not found: {file_path})", reply_to, metadata=metadata
             )
 
         fname = file_name or p.name
@@ -490,12 +548,15 @@ class MattermostAdapter(BasePlatformAdapter):
             "message": caption or "",
             "file_ids": [file_id],
         }
-        if reply_to and self._reply_mode == "thread":
-            payload["root_id"] = reply_to
+        root_id = self._resolve_root_id(reply_to=reply_to, metadata=metadata)
+        if root_id:
+            payload["root_id"] = root_id
 
         data = await self._api_post("posts", payload)
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to post with file")
+        if root_id:
+            self._register_known_thread(root_id)
         return SendResult(success=True, message_id=data["id"])
 
     # ------------------------------------------------------------------
@@ -613,6 +674,15 @@ class MattermostAdapter(BasePlatformAdapter):
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
 
+        # Thread support:
+        # - replies carry root_id
+        # - top-level channel posts should synthesize a thread root from the
+        #   post id when reply_mode=thread so the whole turn stays in one
+        #   Mattermost thread/session.
+        thread_id = post.get("root_id") or None
+        if not thread_id and channel_type_raw != "D" and self._reply_mode == "thread":
+            thread_id = post_id or None
+
         # Mention-gating for non-DM channels.
         # Config (env vars):
         #   MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
@@ -634,8 +704,9 @@ class MattermostAdapter(BasePlatformAdapter):
                 pattern.lower() in message_text.lower()
                 for pattern in mention_patterns
             )
+            is_known_thread = bool(thread_id and self._is_known_thread(thread_id))
 
-            if require_mention and not is_free_channel and not has_mention:
+            if require_mention and not is_free_channel and not has_mention and not is_known_thread:
                 logger.debug(
                     "Mattermost: skipping non-DM message without @mention (channel=%s)",
                     channel_id,
@@ -652,9 +723,6 @@ class MattermostAdapter(BasePlatformAdapter):
         # Resolve sender info.
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
-
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -451,6 +451,31 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _thread_metadata_for_delivery(
+    platform: "Platform",
+    chat_type: Optional[str],
+    thread_id: Optional[str],
+    event_message_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return delivery metadata for threaded replies.
+
+    Mattermost top-level channel posts need a synthetic thread root derived from
+    the inbound post id so streamed replies, progress updates, and media stay in
+    one thread.
+    """
+    resolved_thread_id = thread_id
+    if (
+        not resolved_thread_id
+        and platform == Platform.MATTERMOST
+        and chat_type != "dm"
+        and event_message_id
+    ):
+        resolved_thread_id = event_message_id
+    if not resolved_thread_id:
+        return None
+    return {"thread_id": resolved_thread_id}
+
+
 def _load_gateway_config() -> dict:
     """Load and parse ~/.hermes/config.yaml, returning {} on any error."""
     try:
@@ -1395,7 +1420,12 @@ class GatewayRunner:
             if not adapter:
                 return True
 
-            thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            thread_meta = _thread_metadata_for_delivery(
+                event.source.platform,
+                event.source.chat_type,
+                event.source.thread_id,
+                event.message_id,
+            )
             if self._queue_during_drain_enabled():
                 self._queue_or_replace_pending_event(session_key, event)
                 message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
@@ -1472,7 +1502,12 @@ class GatewayRunner:
             f"I'll respond to your message shortly."
         )
 
-        thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        thread_meta = _thread_metadata_for_delivery(
+            event.source.platform,
+            event.source.chat_type,
+            event.source.thread_id,
+            event.message_id,
+        )
         try:
             await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
@@ -3410,7 +3445,12 @@ class GatewayRunner:
                 )
                 if any(marker in message_text for marker in _stt_fail_markers):
                     _stt_adapter = self.adapters.get(source.platform)
-                    _stt_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    _stt_meta = _thread_metadata_for_delivery(
+                        source.platform,
+                        source.chat_type,
+                        source.thread_id,
+                        event.message_id,
+                    )
                     if _stt_adapter:
                         try:
                             _stt_msg = (
@@ -3831,7 +3871,11 @@ class GatewayRunner:
                         f"{_compress_token_threshold:,}",
                     )
 
-                    _hyg_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    _hyg_meta = _thread_metadata_for_delivery(
+                        source.platform,
+                        source.chat_type,
+                        source.thread_id,
+                    )
 
                     try:
                         from run_agent import AIAgent
@@ -4861,7 +4905,11 @@ class GatewayRunner:
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
                         return "\n".join(lines)
 
-                    metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                    metadata = _thread_metadata_for_delivery(
+                        source.platform,
+                        source.chat_type,
+                        source.thread_id,
+                    )
                     result = await adapter.send_model_picker(
                         chat_id=source.chat_id,
                         providers=providers,
@@ -5581,8 +5629,14 @@ class GatewayRunner:
                     "audio_path": actual_path,
                     "reply_to": event.message_id,
                 }
-                if event.source.thread_id:
-                    send_kwargs["metadata"] = {"thread_id": event.source.thread_id}
+                _voice_thread_meta = _thread_metadata_for_delivery(
+                    event.source.platform,
+                    event.source.chat_type,
+                    event.source.thread_id,
+                    event.message_id,
+                )
+                if _voice_thread_meta:
+                    send_kwargs["metadata"] = _voice_thread_meta
                 await adapter.send_voice(**send_kwargs)
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
@@ -5612,7 +5666,12 @@ class GatewayRunner:
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
 
-            _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _thread_meta = _thread_metadata_for_delivery(
+                event.source.platform,
+                event.source.chat_type,
+                event.source.thread_id,
+                event.message_id,
+            )
 
             _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
@@ -5768,7 +5827,11 @@ class GatewayRunner:
             logger.warning("No adapter for platform %s in background task %s", source.platform, task_id)
             return
 
-        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        _thread_metadata = _thread_metadata_for_delivery(
+            source.platform,
+            source.chat_type,
+            source.thread_id,
+        )
 
         try:
             user_config = _load_gateway_config()
@@ -5941,7 +6004,11 @@ class GatewayRunner:
             logger.warning("No adapter for platform %s in /btw task %s", source.platform, task_id)
             return
 
-        _thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+        _thread_meta = _thread_metadata_for_delivery(
+            source.platform,
+            source.chat_type,
+            source.thread_id,
+        )
 
         try:
             user_config = _load_gateway_config()
@@ -8490,7 +8557,7 @@ class GatewayRunner:
         # - Telegram uses message_thread_id only for forum topics; passing a
         #   normal DM/group message id as thread_id causes send failures
         # - Other platforms should use explicit source.thread_id only
-        if source.platform == Platform.SLACK:
+        if source.platform in (Platform.SLACK, Platform.MATTERMOST):
             _progress_thread_id = source.thread_id or event_message_id
         else:
             _progress_thread_id = source.thread_id

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -206,6 +206,31 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_prefers_metadata_thread_id(self):
+        """metadata.thread_id should take precedence over reply_to for Mattermost threading."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post457"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="child_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"
@@ -332,6 +357,52 @@ class TestMattermostWebSocketParsing:
         assert not self.adapter.handle_message.called
 
     @pytest.mark.asyncio
+    async def test_thread_id_from_root_id(self):
+        """Post with root_id should have thread_id set."""
+        post_data = {
+            "id": "post_threaded",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Thread reply",
+            "root_id": "root_post_123",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "root_post_123"
+
+    @pytest.mark.asyncio
+    async def test_top_level_channel_post_uses_post_id_as_synthetic_thread(self):
+        """Top-level channel posts should synthesize a thread root when reply_mode=thread."""
+        self.adapter._reply_mode = "thread"
+        post_data = {
+            "id": "post_top_level",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "@bot_user_id Hello there",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.thread_id == "post_top_level"
+
+    @pytest.mark.asyncio
     async def test_channel_type_mapping(self):
         """channel_type 'D' should map to 'dm'."""
         post_data = {
@@ -355,13 +426,16 @@ class TestMattermostWebSocketParsing:
         assert msg_event.source.chat_type == "dm"
 
     @pytest.mark.asyncio
-    async def test_thread_id_from_root_id(self):
-        """Post with root_id should have thread_id set."""
+    async def test_known_thread_bypasses_mention_gate(self):
+        """Replies in a known Mattermost thread should not require a fresh @mention."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._register_known_thread("root_post_123")
+
         post_data = {
-            "id": "post_reply",
+            "id": "post_followup",
             "user_id": "user_123",
             "channel_id": "chan_456",
-            "message": "@bot_user_id Thread reply",
+            "message": "follow-up without mention",
             "root_id": "root_post_123",
         }
         event = {
@@ -376,6 +450,7 @@ class TestMattermostWebSocketParsing:
         await self.adapter._handle_ws_event(event)
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "follow-up without mention"
         assert msg_event.source.thread_id == "root_post_123"
 
     @pytest.mark.asyncio
@@ -532,6 +607,48 @@ class TestMattermostFileUpload:
 
         assert result.success is True
         assert result.message_id == "post_with_file"
+
+    @pytest.mark.asyncio
+    @patch("tools.url_safety.is_safe_url", return_value=True)
+    async def test_send_image_uses_metadata_thread_id_for_root(self, _mock_safe):
+        """File uploads must honor metadata.thread_id so threaded delivery stays intact."""
+        self.adapter._reply_mode = "thread"
+
+        mock_dl_resp = AsyncMock()
+        mock_dl_resp.status = 200
+        mock_dl_resp.read = AsyncMock(return_value=b"\x89PNG\x00fake-image-data")
+        mock_dl_resp.content_type = "image/png"
+        mock_dl_resp.__aenter__ = AsyncMock(return_value=mock_dl_resp)
+        mock_dl_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_upload_resp = AsyncMock()
+        mock_upload_resp.status = 200
+        mock_upload_resp.json = AsyncMock(return_value={"file_infos": [{"id": "file_abc123"}]})
+        mock_upload_resp.text = AsyncMock(return_value="")
+        mock_upload_resp.__aenter__ = AsyncMock(return_value=mock_upload_resp)
+        mock_upload_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_post_resp = AsyncMock()
+        mock_post_resp.status = 200
+        mock_post_resp.json = AsyncMock(return_value={"id": "post_with_file"})
+        mock_post_resp.text = AsyncMock(return_value="")
+        mock_post_resp.__aenter__ = AsyncMock(return_value=mock_post_resp)
+        mock_post_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.get = MagicMock(return_value=mock_dl_resp)
+        self.adapter._session.post = MagicMock(side_effect=[mock_upload_resp, mock_post_resp])
+
+        result = await self.adapter.send_image(
+            "channel_1",
+            "https://img.example.com/cat.png",
+            caption="A cat",
+            reply_to="child_post",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args_list[-1][1]["json"]
+        assert payload["root_id"] == "root_post"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost_thread_delivery.py
+++ b/tests/gateway/test_mattermost_thread_delivery.py
@@ -1,0 +1,42 @@
+import pytest
+
+from gateway.config import Platform
+from gateway.run import _thread_metadata_for_delivery
+
+
+class TestMattermostThreadMetadataForDelivery:
+    def test_preserves_explicit_thread_id(self):
+        metadata = _thread_metadata_for_delivery(
+            Platform.MATTERMOST,
+            "channel",
+            "root_post_123",
+            "new_post_456",
+        )
+        assert metadata == {"thread_id": "root_post_123"}
+
+    def test_synthesizes_thread_id_from_top_level_channel_post(self):
+        metadata = _thread_metadata_for_delivery(
+            Platform.MATTERMOST,
+            "channel",
+            None,
+            "post_top_level_123",
+        )
+        assert metadata == {"thread_id": "post_top_level_123"}
+
+    def test_does_not_synthesize_for_mattermost_dm(self):
+        metadata = _thread_metadata_for_delivery(
+            Platform.MATTERMOST,
+            "dm",
+            None,
+            "post_dm_123",
+        )
+        assert metadata is None
+
+    def test_does_not_synthesize_for_other_platforms(self):
+        metadata = _thread_metadata_for_delivery(
+            Platform.TELEGRAM,
+            "channel",
+            None,
+            "post_top_level_123",
+        )
+        assert metadata is None


### PR DESCRIPTION
## Summary
- preserve Mattermost thread follow-ups by tracking known threads and preferring `metadata.thread_id` over child post ids
- synthesize a Mattermost thread root from the inbound top-level post id so streamed replies, progress updates, and post-stream media stay in the same thread
- add regression coverage for adapter threading and gateway thread-metadata delivery

## Root cause
Mattermost top-level channel posts arrive without `source.thread_id`. The adapter already knew how to thread replies when given a root id, but several gateway delivery paths only propagated `source.thread_id`. That meant fresh top-level Mattermost turns lost thread context during streaming, progress, and media delivery and leaked back into the main channel.

## Test plan
- `pytest tests/gateway/test_mattermost_thread_delivery.py -q`
- `pytest tests/gateway/test_mattermost.py -q`
- `pytest tests/gateway/test_stream_consumer.py -q`
- `python -m py_compile gateway/run.py gateway/platforms/base.py gateway/platforms/mattermost.py`

Closes #4221
