### PR TITLE
fix(gateway): claim PID file immediately after old process exits on --replace

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10064,6 +10064,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 except (ProcessLookupError, PermissionError, OSError):
                     pass
             remove_pid_file()
+            # Claim the PID file immediately so any concurrent --replace
+            # invocation sees this process rather than an empty file and
+            # skips the termination step, preventing duplicate instances.
+            from gateway.status import write_pid_file as _write_pid_now
+            _write_pid_now()
             # Also release all scoped locks left by the old process.
             # Stopped (Ctrl+Z) processes don't release locks on exit,
             # leaving stale lock files that block the new gateway from starting.


### PR DESCRIPTION
Fixes #11718

## Problem

When two `--replace` invocations overlap (e.g. launchd auto-restart racing a manual restart), the second process reads an **empty** PID file after the first has called `remove_pid_file()`. It finds no existing PID, skips termination, and both instances end up running simultaneously — causing repeated Telegram polling conflicts:

```
Conflict: terminated by other getUpdates request; make sure that only one bot instance is running
```

## Fix

Write the new process PID to the file right after `remove_pid_file()`, before continuing initialization. Any concurrent `--replace` invocation will then see the current process PID and correctly terminate it instead of finding an empty file and proceeding unchecked.

```python
remove_pid_file()
# Claim the PID file immediately so any concurrent --replace
# invocation sees this process rather than an empty file and
# skips the termination step, preventing duplicate instances.
from gateway.status import write_pid_file as _write_pid_now
_write_pid_now()
```