### PR TITLE
fix(sanitizer): dedup duplicate tool_call ids before API call

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3594,6 +3594,86 @@ class AIAgent:
             filtered.append(msg)
         messages = filtered
 
+        # --- Dedup duplicate tool_call ids across the payload ---------------
+        # Strict providers (Mistral, Fireworks, Anthropic) count tool_calls
+        # and tool results as a multiset and reject payloads where the counts
+        # disagree: "Not the same number of function calls and responses".
+        # Weaker models such as mistral-small-latest sometimes regenerate the
+        # same short tool_call_id twice when prompted to re-run an identical
+        # tool invocation, which the existing set-based orphan logic below
+        # does not catch (both ids look paired).  Rename later occurrences to
+        # a unique id and rewrite the contiguous tool results that follow the
+        # assistant so each (call, result) pair stays linked positionally.
+        from collections import deque
+        seen_ids: set = set()
+        rename_count = 0
+        deduped: List[Dict[str, Any]] = []
+        i = 0
+        while i < len(messages):
+            msg = messages[i]
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                # Queue of replacement ids per original id, in the order the
+                # tool_calls appear. A value of None means "keep original".
+                renames_by_id: Dict[str, deque] = {}
+                new_tool_calls = []
+                for tc in msg["tool_calls"]:
+                    old_id = AIAgent._get_tool_call_id_static(tc)
+                    if not old_id:
+                        new_tool_calls.append(tc)
+                        continue
+                    if old_id in seen_ids:
+                        new_id = f"{old_id}_dedup_{rename_count}"
+                        rename_count += 1
+                        seen_ids.add(new_id)
+                        renames_by_id.setdefault(old_id, deque()).append(new_id)
+                        if isinstance(tc, dict):
+                            new_tc = {**tc, "id": new_id}
+                            if "call_id" in tc:
+                                new_tc["call_id"] = new_id
+                        else:
+                            _fn = getattr(tc, "function", None)
+                            new_tc = {
+                                "id": new_id,
+                                "type": getattr(tc, "type", "function"),
+                                "function": {
+                                    "name": getattr(_fn, "name", "") if _fn else "",
+                                    "arguments": getattr(_fn, "arguments", "{}") if _fn else "{}",
+                                },
+                            }
+                        new_tool_calls.append(new_tc)
+                    else:
+                        seen_ids.add(old_id)
+                        renames_by_id.setdefault(old_id, deque()).append(None)
+                        new_tool_calls.append(tc)
+                deduped.append({**msg, "tool_calls": new_tool_calls})
+                # Walk the contiguous tool results that belong to this
+                # assistant.  Rename each one positionally — the Nth result
+                # with id X corresponds to the Nth tool_call with id X.
+                j = i + 1
+                while j < len(messages) and messages[j].get("role") == "tool":
+                    tmsg = messages[j]
+                    tcid = tmsg.get("tool_call_id")
+                    pending = renames_by_id.get(tcid)
+                    if pending:
+                        replacement = pending.popleft()
+                        if replacement is not None:
+                            deduped.append({**tmsg, "tool_call_id": replacement})
+                        else:
+                            deduped.append(tmsg)
+                    else:
+                        deduped.append(tmsg)
+                    j += 1
+                i = j
+            else:
+                deduped.append(msg)
+                i += 1
+        if rename_count > 0:
+            logger.info(
+                "Pre-call sanitizer: renamed %d duplicate tool_call id(s)",
+                rename_count,
+            )
+        messages = deduped
+
         surviving_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "assistant":

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -108,6 +108,108 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         assert out[1]["tool_call_id"] == "c6"
 
+    def test_duplicate_tool_call_id_across_turns_renamed(self):
+        """Mistral-small occasionally regenerates the same short tool_call_id
+        when prompted to re-run an identical invocation. Before this fix,
+        set-based orphan detection silently accepted the duplicate and the
+        provider rejected the payload with HTTP 400 ("Not the same number of
+        function calls and responses"). The sanitizer now renames the later
+        occurrence so each call/result pair stays unique."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup1")]},
+            tool_result("dup1", "first result"),
+            {"role": "assistant", "tool_calls": [assistant_dict_call("dup1")]},
+            tool_result("dup1", "second result"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert len(out) == 4
+        # Collect all tool_call ids in order
+        call_ids_in_order = [
+            tc["id"] for m in out if m.get("role") == "assistant"
+            for tc in m.get("tool_calls") or []
+        ]
+        # Must all be unique (no duplicates)
+        assert len(call_ids_in_order) == len(set(call_ids_in_order))
+        # First id preserved, second renamed
+        assert call_ids_in_order[0] == "dup1"
+        assert call_ids_in_order[1] != "dup1"
+        assert call_ids_in_order[1].startswith("dup1_dedup_")
+        # Tool results renamed in lockstep
+        result_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+        assert result_ids[0] == "dup1"
+        assert result_ids[1] == call_ids_in_order[1]
+        # Contents preserved (no mixing)
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert tool_msgs[0]["content"] == "first result"
+        assert tool_msgs[1]["content"] == "second result"
+
+    def test_duplicate_id_without_matching_result_gets_stub(self):
+        """Reproduces the dump seen in the wild: duplicate assistant tool_call
+        with the second one missing its matching result (because the loop was
+        interrupted). Dedup should rename the second occurrence AND the stub
+        injector should add a result for the renamed id."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("X")]},
+            tool_result("X"),
+            {"role": "assistant", "tool_calls": [assistant_dict_call("X")]},
+            {"role": "user", "content": "nudge"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Count must balance: as many tool_call ids as tool results
+        call_ids = [
+            tc["id"] for m in out if m.get("role") == "assistant"
+            for tc in m.get("tool_calls") or []
+        ]
+        result_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+        assert len(call_ids) == len(result_ids)
+        assert set(call_ids) == set(result_ids)
+        # All ids unique
+        assert len(call_ids) == len(set(call_ids))
+
+    def test_duplicate_ids_in_same_assistant_message_renamed(self):
+        """Edge case: a single assistant turn emits the same id twice. Each
+        call still needs its own unique result slot."""
+        msgs = [
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("Y"),
+                assistant_dict_call("Y"),
+            ]},
+            tool_result("Y"),
+            tool_result("Y"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        call_ids = [
+            tc["id"] for m in out if m.get("role") == "assistant"
+            for tc in m.get("tool_calls") or []
+        ]
+        result_ids = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+        assert len(call_ids) == 2
+        assert len(result_ids) == 2
+        assert len(set(call_ids)) == 2  # unique after rename
+        assert set(call_ids) == set(result_ids)
+
+    def test_sdk_object_duplicate_renamed_to_dict(self):
+        """SDK-object tool_calls with duplicate ids must also be deduped."""
+        tc1 = types.SimpleNamespace(id="Z", type="function",
+            function=types.SimpleNamespace(name="execute_code", arguments='{"code":"a"}'))
+        tc2 = types.SimpleNamespace(id="Z", type="function",
+            function=types.SimpleNamespace(name="execute_code", arguments='{"code":"b"}'))
+        msgs = [
+            {"role": "assistant", "tool_calls": [tc1]},
+            tool_result("Z"),
+            {"role": "assistant", "tool_calls": [tc2]},
+            tool_result("Z"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        call_ids = [
+            tc["id"] if isinstance(tc, dict) else getattr(tc, "id", None)
+            for m in out if m.get("role") == "assistant"
+            for tc in m.get("tool_calls") or []
+        ]
+        assert len(set(call_ids)) == 2
+        assert call_ids[0] == "Z"
+        assert call_ids[1] != "Z"
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls


### PR DESCRIPTION
## Summary

Strict providers — Mistral, Fireworks, Anthropic — count tool_calls and tool results as a multiset and reject payloads where the counts disagree:

```
HTTP 400: Not the same number of function calls and responses
(type: invalid_request_message_order, code: 3230)
```

Small open models such as `mistral-small-latest` regenerate the **exact same short `tool_call_id`** (a 9-char nanoid) when prompted to re-run an identical tool invocation in a later turn. The existing set-based orphan detection in `_sanitize_api_messages` treats the duplicate as paired (both ids show up in `surviving_call_ids` and `result_call_ids`), so the malformed payload passes through and every subsequent call on the session fails until the session is manually reset.

## Reproduction

Observed in a long Telegram conversation on `mistral-small-latest`. An in-the-wild anonymized request-dump shows:

- `[63]` assistant `tool_calls=[{id: "b9mgIC84m"}]`
- `[64]` tool `tool_call_id=b9mgIC84m` ← paired, fine
- `[65]` assistant `tool_calls=[{id: "b9mgIC84m"}]` ← duplicate id, same args
- `[66]` user (nudge/new message)

Payload totals: 27 tool_calls, 26 results. Mistral rejects with 3230. Set-based sanitizer sees 26 unique ids on both sides — no orphan, no action. Every retry on the same session reproduces the error until the session is reset.

## Fix

Add a dedup pass at the start of `_sanitize_api_messages`:

1. Walk messages in order. For each assistant with `tool_calls`, compare each id against a running `seen_ids` set.
2. Rename repeats to `<id>_dedup_<N>` (creating a new dict copy so callers are not mutated; SDK-object tool_calls are converted to the dict schema we emit elsewhere).
3. Track per-id rename queues so that when the contiguous tool-result messages follow, the Nth result with id X maps to the Nth tool_call with id X (preserves pairing even when a single assistant turn emits a duplicate id).
4. Any imbalance after rename falls through to the existing stub-injection branch.

The rename is deterministic (no randomness) so KV-cache prefixes remain stable across turns — matches the reasoning in `_deterministic_call_id`.

## Test plan

- [x] 4 new unit tests in `tests/run_agent/test_agent_guardrails.py::TestSanitizeApiMessages`:
  - `test_duplicate_tool_call_id_across_turns_renamed` — the reported failure.
  - `test_duplicate_id_without_matching_result_gets_stub` — the nudge/interruption variant from the wild dump.
  - `test_duplicate_ids_in_same_assistant_message_renamed` — intra-turn edge case.
  - `test_sdk_object_duplicate_renamed_to_dict` — SDK-object tool_calls.
- [x] All 33 existing `TestSanitizeApiMessages` / `TestCapDelegateTaskCalls` / `TestDeduplicateToolCalls` tests still pass locally.
- [x] Deployed to a production Pi running the gateway against Mistral; previously-blocked session no longer fails with 3230 on subsequent turns.

## Risk

Low. The dedup pass is a pure rewrite of an in-memory list — no network, no mutation of the caller's list (new dicts created on rename). When no duplicates are found (the common case), the pass is a no-op walk and the rest of the function behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)