### PR TITLE
test(matrix): make encrypted upload coverage independent of optional mautrix deps

### DIFF
--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1229,6 +1229,7 @@ class TestMatrixUploadAndSend:
         """Encrypted rooms should use 'file' key with crypto metadata."""
         adapter = _make_adapter()
         adapter._encryption = True
+        fake_mautrix_mods = _make_fake_mautrix()
         mock_client = MagicMock()
         mock_client.crypto = object()
         mock_client.state_store = MagicMock()
@@ -1237,9 +1238,10 @@ class TestMatrixUploadAndSend:
         mock_client.send_message_event = AsyncMock(return_value="$event")
         adapter._client = mock_client
 
-        result = await adapter._upload_and_send(
-            "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
-        )
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            result = await adapter._upload_and_send(
+                "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
+            )
 
         assert result.success is True
         # Should have uploaded ciphertext, not plaintext


### PR DESCRIPTION
## Summary
- make the Matrix encrypted-upload regression test independent of optional local `mautrix` E2EE installs
- inject the existing fake `mautrix.crypto.attachments.encrypt_attachment` module for the encrypted upload case
- keep the test validating ciphertext upload plus `file` payload semantics on non-Linux dev machines

## Why
`tests/gateway/test_matrix.py::TestMatrixUploadAndSend::test_upload_encrypted_room_uses_file_payload` currently fails on macOS and other environments where Matrix encryption deps are intentionally absent from `.[all,dev]`. That turns a packaging difference into a false-red test failure instead of exercising the adapter logic.

This patch keeps the test meaningful without weakening production behavior: it still verifies the encrypted-room branch, but it no longer depends on host-specific optional deps being installed.

## Testing
- `python3 -m pytest -o addopts= tests/gateway/test_matrix.py::TestMatrixUploadAndSend::test_upload_encrypted_room_uses_file_payload -q`
- `python3 -m pytest -o addopts= tests/gateway/test_matrix.py::TestMatrixUploadAndSend -q`
- `python3 -m pytest -o addopts= tests/gateway/test_matrix.py -q`

Closes #11679
