### PR TITLE
fix: openai-codex credential rotation — sync guard + 429 token refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -464,8 +464,15 @@ class CredentialPool:
         When the Codex CLI (or another Hermes profile) refreshes its token,
         the pool entry's refresh_token becomes stale.  This method detects that
         by comparing against ~/.codex/auth.json and syncing the fresh pair.
+
+        Only syncs the singleton entry (source="device_code").  Manual entries
+        represent different accounts — syncing them would overwrite their unique
+        tokens with the singleton's token, making the pool a set of identical
+        copies and defeating credential rotation.
         """
         if self.provider != "openai-codex":
+            return entry
+        if entry.source != "device_code":
             return entry
         try:
             cli_tokens = _import_codex_cli_tokens()

--- a/run_agent.py
+++ b/run_agent.py
@@ -9711,6 +9711,20 @@ class AIAgent:
                     )
                     if recovered_with_pool:
                         continue
+                    # On 429 for codex: try re-reading token from auth.json.
+                    # External tools or manual edits may have updated the
+                    # singleton token while this agent was running — rebuild
+                    # the client to pick up the change.
+                    if (
+                        status_code == 429
+                        and self.provider == "openai-codex"
+                        and self.api_mode == "codex_responses"
+                        and not codex_auth_retry_attempted
+                    ):
+                        codex_auth_retry_attempted = True
+                        if self._try_refresh_codex_client_credentials(force=True):
+                            self._vprint(f"{self.log_prefix}🔐 Codex token refreshed after 429 (external change detected). Retrying...", force=True)
+                            continue
                     if (
                         self.api_mode == "codex_responses"
                         and self.provider == "openai-codex"


### PR DESCRIPTION
Two fixes for openai-codex multi-account credential rotation:

**1. credential_pool.py**: `_sync_codex_entry_from_cli` now only syncs the singleton entry (`source="device_code"`). Previously it synced ALL exhausted entries, overwriting manual entries' unique tokens with the singleton token from `~/.codex/auth.json`. This caused the pool to become N copies of the same account, defeating rotation.

**2. run_agent.py**: On HTTP 429 for openai-codex, attempt `_try_refresh_codex_client_credentials` before aborting. This detects token changes made externally (e.g. via hermes-switch) and rebuilds the OpenAI client mid-session, enabling manual credential rotation without restarting the agent.

Fixes #11364