### PR TITLE
fix(auxiliary): keep auto text routing on active main provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1196,10 +1196,11 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
     """Full auto-detection chain.
 
     Priority:
-      1. If the user's main provider is NOT an aggregator (OpenRouter / Nous),
-         use their main provider + main model directly.  This ensures users on
-         Alibaba, DeepSeek, ZAI, etc. get auxiliary tasks handled by the same
-         provider they already have credentials for — no OpenRouter key needed.
+      1. If the user already has an active main provider + main model, use that
+         provider/model directly for text-side auxiliary tasks. This keeps side
+         work aligned with the model the user actually selected instead of
+         silently hopping to a different provider/model just because another key
+         happens to be present in the environment.
       2. OpenRouter → Nous → custom → Codex → API-key providers (original chain).
     """
     global auxiliary_is_nous, _stale_base_url_warned
@@ -1230,12 +1231,10 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             )
             _stale_base_url_warned = True
 
-    # ── Step 1: non-aggregator main provider → use main model directly ──
+    # ── Step 1: main provider → use main model directly ─────────────────
     main_provider = runtime_provider or _read_main_provider()
     main_model = runtime_model or _read_main_model()
-    if (main_provider and main_model
-            and main_provider not in _AGGREGATOR_PROVIDERS
-            and main_provider not in ("auto", "")):
+    if main_provider and main_model and main_provider not in ("auto", ""):
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -332,6 +332,37 @@ class TestExpiredCodexFallback:
             # OpenRouter is 1st in chain, should win
             mock_openai.assert_called()
 
+    def test_aggregator_main_provider_uses_main_model_before_fallback_chain(self):
+        """Auto auxiliary should follow the active main provider/model first, even for aggregators."""
+        mock_client = MagicMock()
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(mock_client, "xiaomi/mimo-v2-pro")) as mock_rpc, \
+             patch("agent.auxiliary_client._try_openrouter", side_effect=AssertionError("fallback chain should not run")), \
+             patch("agent.auxiliary_client._read_main_provider", return_value="nous"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="xiaomi/mimo-v2-pro"):
+            client, model = _resolve_auto()
+
+        assert client is mock_client
+        assert model == "xiaomi/mimo-v2-pro"
+        mock_rpc.assert_called_once_with("nous", "xiaomi/mimo-v2-pro", explicit_base_url=None, explicit_api_key=None, api_mode=None)
+
+    def test_openrouter_env_does_not_hijack_nous_main_provider(self, monkeypatch):
+        """A stray OPENROUTER_API_KEY should not override a Nous main model for auxiliary auto."""
+        mock_client = MagicMock()
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        with patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(mock_client, "xiaomi/mimo-v2-pro")) as mock_rpc, \
+             patch("agent.auxiliary_client._try_openrouter", side_effect=AssertionError("openrouter should not win before main provider")), \
+             patch("agent.auxiliary_client._read_main_provider", return_value="nous"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="xiaomi/mimo-v2-pro"):
+            client, model = _resolve_auto()
+
+        assert client is mock_client
+        assert model == "xiaomi/mimo-v2-pro"
+        mock_rpc.assert_called_once_with("nous", "xiaomi/mimo-v2-pro", explicit_base_url=None, explicit_api_key=None, api_mode=None)
+
     def test_expired_codex_custom_endpoint_wins(self, tmp_path, monkeypatch):
         """With expired Codex + custom endpoint (Ollama), custom should win (3rd in chain)."""
         import base64


### PR DESCRIPTION
## What does this PR do?

Keeps text-side auxiliary auto-routing on the user's active main provider/model before falling through to the generic provider chain. This stops hidden Gemini Flash usage from appearing just because an unrelated provider key is present, and it keeps aggregator-backed mains like Nous + MiMo from silently drifting onto provider default auxiliary models.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/auxiliary_client.py` so `_resolve_auto()` uses the active main provider/model first for text auxiliary work, including aggregator-backed mains like `nous` and `openrouter`
- Preserved the existing generic fallback chain for cases where that direct main-provider route is unavailable
- Added focused regression tests in `tests/agent/test_auxiliary_client.py` covering aggregator-main routing and stray `OPENROUTER_API_KEY` hijacking

## How to Test

1. Configure Hermes with a main model on `nous`, such as `xiaomi/mimo-v2-pro`
2. Leave text auxiliary tasks on `auto`, and set an unrelated `OPENROUTER_API_KEY` in the environment
3. Verify auxiliary text tasks follow the active main provider/model instead of drifting to Gemini Flash through the generic fallback chain

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 / WSL2-style Linux environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression run:

`source venv/bin/activate && python -m pytest tests/agent/test_auxiliary_client.py -q`

Passed: `55 passed in 4.85s`

Full suite:

`source venv/bin/activate && python -m pytest tests/ -q -n 4`

Result: `55 failed, 12410 passed, 35 skipped in 347.46s (0:05:47)`

The failures appear to be broad pre-existing red in gateway/browser/tirith areas and do not touch `agent/auxiliary_client.py` or the new auxiliary-client regression tests for this change.
