### PR TITLE
fix(cli): prevent UnicodeEncodeError in doctor on GBK consoles

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -161,8 +161,31 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _make_stdout_unicode_safe() -> None:
+    """Prevent UnicodeEncodeError on consoles with limited encodings (e.g. Windows GBK).
+
+    Doctor prints emoji and box-drawing characters; on Python's default Windows
+    console encoding (GBK on zh-CN, cp1252 on others), encoding fails with
+    UnicodeEncodeError. Reconfigure stdout/stderr to replace unencodable chars
+    with '?' so the command never crashes on the first emoji. See issue #7537.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            encoding = (getattr(stream, "encoding", "") or "").lower()
+            if encoding.replace("-", "") == "utf8":
+                reconfigure(errors="replace")
+            else:
+                reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
+    _make_stdout_unicode_safe()
     should_fix = getattr(args, 'fix', False)
 
     # Doctor runs from the interactive CLI, so CLI-gated tool availability

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -96,6 +96,68 @@ class TestHonchoDoctorConfigDetection:
         assert not doctor._honcho_is_configured_for_doctor()
 
 
+class TestStdoutUnicodeSafety:
+    """Doctor must not crash on consoles with limited encodings (e.g. Windows GBK, #7537)."""
+
+    def test_reconfigures_non_utf8_stream_to_utf8_replace(self, monkeypatch):
+        calls = []
+
+        class FakeStream:
+            encoding = "gbk"
+
+            def reconfigure(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(doctor_mod.sys, "stdout", FakeStream())
+        monkeypatch.setattr(doctor_mod.sys, "stderr", FakeStream())
+
+        doctor_mod._make_stdout_unicode_safe()
+
+        assert calls == [
+            {"encoding": "utf-8", "errors": "replace"},
+            {"encoding": "utf-8", "errors": "replace"},
+        ]
+
+    def test_utf8_stream_only_sets_errors_replace(self, monkeypatch):
+        calls = []
+
+        class FakeStream:
+            encoding = "UTF-8"
+
+            def reconfigure(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(doctor_mod.sys, "stdout", FakeStream())
+        monkeypatch.setattr(doctor_mod.sys, "stderr", FakeStream())
+
+        doctor_mod._make_stdout_unicode_safe()
+
+        assert calls == [{"errors": "replace"}, {"errors": "replace"}]
+
+    def test_stream_without_reconfigure_is_skipped(self, monkeypatch):
+        class FakeStream:
+            encoding = "gbk"
+
+        # No reconfigure attribute — should not raise.
+        monkeypatch.setattr(doctor_mod.sys, "stdout", FakeStream())
+        monkeypatch.setattr(doctor_mod.sys, "stderr", FakeStream())
+
+        doctor_mod._make_stdout_unicode_safe()
+
+    def test_reconfigure_failure_is_swallowed(self, monkeypatch):
+        class FakeStream:
+            encoding = "gbk"
+
+            def reconfigure(self, **kwargs):
+                raise OSError("detached stream")
+
+        monkeypatch.setattr(doctor_mod.sys, "stdout", FakeStream())
+        monkeypatch.setattr(doctor_mod.sys, "stderr", FakeStream())
+
+        # Must not propagate the exception.
+        doctor_mod._make_stdout_unicode_safe()
+
+
 def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
     """Doctor should present CLI-gated tools as available in CLI context."""
     project_root = tmp_path / "project"


### PR DESCRIPTION
## Summary
- `hermes doctor` prints emoji (🩺, 🎉) and box-drawing chars on every run. On Windows consoles whose default encoding isn't UTF-8 (GBK on zh-CN, cp1252 elsewhere), the very first emoji raises `UnicodeEncodeError: 'gbk' codec can't encode character '\U0001fa7a'` and the command aborts before any check runs.
- Fix: at the top of `run_doctor`, reconfigure `sys.stdout`/`sys.stderr` with `errors='replace'` — and switch to UTF-8 when the current encoding can't handle emoji. Unencodable characters become `?` instead of crashing, so diagnostic output still works on legacy Windows consoles.
- Streams without `reconfigure` (e.g. a redirected `StringIO`) and reconfigure failures are silently ignored, so the helper is safe under capture.

Fixes #7537.

## Test plan
- [x] New `TestStdoutUnicodeSafety` unit tests cover: non-UTF-8 stream is reconfigured to `utf-8` + `errors='replace'`; UTF-8 stream only gets `errors='replace'`; streams without `reconfigure` are skipped; `reconfigure` failures are swallowed.
- [x] All 25 tests in `tests/hermes_cli/test_doctor.py` pass (21 existing + 4 new), validated in a Docker container (`python:3.12-slim`).
- [ ] Manual reproduction on a Windows GBK shell (requires a Windows box — not available here).