### PR TITLE
fix(agent): honor configured proxy in OpenAI client path (#11609)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4449,6 +4449,24 @@ class AIAgent:
         # the agent hangs until manually killed.  Probes after 30s idle, retry
         # every 10s, give up after 3 → dead peer detected within ~60s.
         #
+        # Proxy interaction (#11609): handing httpx an explicit ``transport=``
+        # makes it skip its own env-proxy mount construction and silently
+        # direct-connect even when HTTPS_PROXY / system proxy is configured.
+        # Re-implementing httpx's proxy resolution (env vars, NO_PROXY with
+        # IPv6 / CIDR / scheme-qualified entries, macOS SystemConfiguration,
+        # Windows registry) by hand is a rabbit hole.  Instead we detect
+        # whether ANY proxy is configured and, if so, skip injection entirely
+        # so the OpenAI SDK can build a default ``httpx.Client`` with
+        # ``trust_env=True`` and let httpx own all proxy semantics.
+        #
+        # Tradeoff: keepalive is NOT preserved on the proxy path.  In
+        # practice our httpx socket on the proxy path is a loopback/LAN
+        # connection to the local proxy process, which rarely dies
+        # mid-stream; the proxy↔provider leg has its own keepalive /
+        # reconnect handling and is owned by the proxy, not us.  Users on
+        # long-lived proxied streams fall back to httpx's read timeout for
+        # dead-peer detection.
+        #
         # Safety against #10933: the ``client_kwargs = dict(client_kwargs)``
         # above means this injection only lands in the local per-call copy,
         # never back into ``self._client_kwargs``.  Each ``_create_openai_client``
@@ -4459,7 +4477,12 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        # When a proxy IS configured, we deliberately leave ``http_client``
+        # out of ``client_kwargs``: the OpenAI SDK will then build its own
+        # default ``httpx.Client`` with ``trust_env=True``, which is how
+        # proxy resolution actually lands.  "http_client is None on the
+        # proxy path" is the intended steady state, not a missing branch.
+        if "http_client" not in client_kwargs and not self._has_proxy_configured():
             try:
                 import httpx as _httpx
                 import socket as _socket
@@ -4472,6 +4495,7 @@ class AIAgent:
                 elif hasattr(_socket, "TCP_KEEPALIVE"):
                     # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
                     _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+
                 client_kwargs["http_client"] = _httpx.Client(
                     transport=_httpx.HTTPTransport(socket_options=_sock_opts),
                 )
@@ -4485,6 +4509,80 @@ class AIAgent:
             self._client_log_context(),
         )
         return client
+
+    @staticmethod
+    def _has_proxy_configured() -> bool:
+        """Return True when any proxy is configured for outbound HTTP traffic.
+
+        Uses ``urllib.request.getproxies()`` — the same function httpx's
+        ``trust_env=True`` path calls internally — so detection aligns
+        exactly with what httpx will actually honor.  That covers the
+        standard env vars (HTTPS_PROXY / HTTP_PROXY / ALL_PROXY), macOS
+        SystemConfiguration, and the Windows registry.
+
+        We deliberately ignore NO_PROXY here: if the user has both
+        HTTPS_PROXY and NO_PROXY set, they clearly intend to use a proxy
+        for some hosts, and the right behavior is to let httpx own the
+        routing decision.  If we injected our keepalive transport and
+        skipped mount construction, NO_PROXY would still be ignored and
+        we'd route *everything* direct (#11609 in reverse).
+        """
+        try:
+            import urllib.request as _urlreq
+            proxies = _urlreq.getproxies()
+        except Exception:
+            return False
+        return any(
+            str(proxies.get(key) or "").strip()
+            for key in ("http", "https", "all")
+        )
+
+    @staticmethod
+    def _iter_client_sockets(http_client: Any):
+        """Yield every live TCP socket owned by an httpx.Client.
+
+        Walks both the default ``_transport`` and all ``_mounts``
+        transports.  When a proxy is configured, the OpenAI SDK's default
+        httpx.Client builds env-proxy mounts via ``trust_env=True``, so
+        socket-level cleanup must visit mounts too or it silently leaks
+        CLOSE-WAIT sockets on proxied setups.
+        """
+        if http_client is None:
+            return
+        transports = []
+        default_t = getattr(http_client, "_transport", None)
+        if default_t is not None:
+            transports.append(default_t)
+        mounts = getattr(http_client, "_mounts", None) or {}
+        for mount_t in mounts.values():
+            if mount_t is not None:
+                transports.append(mount_t)
+        for transport in transports:
+            pool = getattr(transport, "_pool", None)
+            if pool is None:
+                continue
+            # httpx uses httpcore connection pools; connections live in
+            # _connections (list) or _pool (list) depending on version.
+            connections = (
+                getattr(pool, "_connections", None)
+                or getattr(pool, "_pool", None)
+                or []
+            )
+            for conn in list(connections):
+                stream = (
+                    getattr(conn, "_network_stream", None)
+                    or getattr(conn, "_stream", None)
+                )
+                if stream is None:
+                    continue
+                sock = getattr(stream, "_sock", None)
+                if sock is None:
+                    nested = getattr(stream, "stream", None)
+                    if nested is not None:
+                        sock = getattr(nested, "_sock", None)
+                if sock is None:
+                    continue
+                yield sock
 
     @staticmethod
     def _force_close_tcp_sockets(client: Any) -> int:
@@ -4503,35 +4601,7 @@ class AIAgent:
         closed = 0
         try:
             http_client = getattr(client, "_client", None)
-            if http_client is None:
-                return 0
-            transport = getattr(http_client, "_transport", None)
-            if transport is None:
-                return 0
-            pool = getattr(transport, "_pool", None)
-            if pool is None:
-                return 0
-            # httpx uses httpcore connection pools; connections live in
-            # _connections (list) or _pool (list) depending on version.
-            connections = (
-                getattr(pool, "_connections", None)
-                or getattr(pool, "_pool", None)
-                or []
-            )
-            for conn in list(connections):
-                stream = (
-                    getattr(conn, "_network_stream", None)
-                    or getattr(conn, "_stream", None)
-                )
-                if stream is None:
-                    continue
-                sock = getattr(stream, "_sock", None)
-                if sock is None:
-                    sock = getattr(stream, "stream", None)
-                    if sock is not None:
-                        sock = getattr(sock, "_sock", None)
-                if sock is None:
-                    continue
+            for sock in AIAgent._iter_client_sockets(http_client):
                 try:
                     sock.shutdown(_socket.SHUT_RDWR)
                 except OSError:
@@ -4614,39 +4684,14 @@ class AIAgent:
         client = getattr(self, "client", None)
         if client is None:
             return False
+        import socket as _socket
         try:
             http_client = getattr(client, "_client", None)
             if http_client is None:
                 return False
-            transport = getattr(http_client, "_transport", None)
-            if transport is None:
-                return False
-            pool = getattr(transport, "_pool", None)
-            if pool is None:
-                return False
-            connections = (
-                getattr(pool, "_connections", None)
-                or getattr(pool, "_pool", None)
-                or []
-            )
             dead_count = 0
-            for conn in list(connections):
-                # Check for connections that are idle but have closed sockets
-                stream = (
-                    getattr(conn, "_network_stream", None)
-                    or getattr(conn, "_stream", None)
-                )
-                if stream is None:
-                    continue
-                sock = getattr(stream, "_sock", None)
-                if sock is None:
-                    sock = getattr(stream, "stream", None)
-                    if sock is not None:
-                        sock = getattr(sock, "_sock", None)
-                if sock is None:
-                    continue
+            for sock in AIAgent._iter_client_sockets(http_client):
                 # Probe socket health with a non-blocking recv peek
-                import socket as _socket
                 try:
                     sock.setblocking(False)
                     data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -186,3 +186,260 @@ def test_replace_primary_openai_client_survives_repeated_rebuilds():
         "Some _create_openai_client calls returned the same object across "
         "a teardown — rebuild is not producing fresh clients"
     )
+
+
+def _stub_proxies(monkeypatch, proxies):
+    """Force ``urllib.request.getproxies`` to return ``proxies``.
+
+    This is the ONLY source of proxy configuration for _has_proxy_configured
+    and for httpx's trust_env path.  Stubbing it directly (rather than
+    mucking with env vars) makes tests independent of the developer's
+    actual shell and macOS SystemConfiguration — both of which can inject
+    proxies into ``getproxies()`` that the test never intended.
+    """
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "getproxies", lambda: dict(proxies))
+    # Also scrub env so an env-var-reading codepath elsewhere cannot fight
+    # with the stub.  (_has_proxy_configured routes through getproxies,
+    # so this is belt-and-suspenders.)
+    for _var in (
+        "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+        "http_proxy", "https_proxy", "all_proxy", "no_proxy",
+    ):
+        monkeypatch.delenv(_var, raising=False)
+
+
+def _has_keepalive(transport):
+    """Return True when the transport's pool carries ``socket_options``."""
+    if transport is None:
+        return False
+    pool = getattr(transport, "_pool", None)
+    return bool(getattr(pool, "_socket_options", None))
+
+
+def test_create_openai_client_skips_injection_when_https_proxy_set(monkeypatch):
+    """With HTTPS_PROXY configured, _create_openai_client must NOT inject
+    its own http_client.  Letting the OpenAI SDK build a default
+    ``httpx.Client`` (``trust_env=True``) is the only way to honor
+    HTTPS_PROXY / HTTP_PROXY / ALL_PROXY together with NO_PROXY, IPv6
+    literals, and other edge cases that #11609 exposed in the hand-rolled
+    mount rebuild.
+
+    The tradeoff — no keepalive on the proxy path — is accepted: the httpx
+    socket in proxy mode is a loopback/LAN connection to the local proxy
+    process, and httpx's read timeout still fires if that side stalls.
+    """
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    _stub_proxies(monkeypatch, {"https": "http://127.0.0.1:7897"})
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="proxy_env_https",
+            shared=False,
+        )
+
+    assert len(constructed) == 1
+    # Pin the design decision explicitly: when a proxy is configured,
+    # ``http_client`` is deliberately absent from the kwargs so the SDK
+    # builds its own httpx.Client with trust_env=True.  If you see this
+    # test failing because http_client became non-None, DO NOT "fix" it by
+    # restoring an injected transport — that re-opens #11609.
+    assert "http_client" not in constructed[0]._kwargs, (
+        "Proxy configured, but http_client was passed to OpenAI().  "
+        "Delegation contract broken — the SDK's trust_env path can only "
+        "wire up proxy mounts when it owns the httpx.Client."
+    )
+    assert constructed[0]._http_client is None, (
+        "HTTPS_PROXY was set but _create_openai_client still injected an "
+        "http_client.  That hands httpx an explicit transport, which makes "
+        "it skip env-proxy mount construction and silently direct-connect "
+        "— the #11609 bug class."
+    )
+
+
+def test_create_openai_client_skips_injection_for_each_proxy_key(monkeypatch):
+    """Any of the three proxy keys (http / https / all) must trigger
+    delegation — none of them should leave the keepalive transport in
+    place."""
+    agent = _make_agent()
+
+    for key in ("http", "https", "all"):
+        constructed: list = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        _stub_proxies(monkeypatch, {key: "http://127.0.0.1:7897"})
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                {
+                    "api_key": "test-key-value",
+                    "base_url": "https://api.example.com/v1",
+                },
+                reason=f"proxy_{key}",
+                shared=False,
+            )
+
+        assert constructed[0]._http_client is None, (
+            f"proxy key {key!r} did not suppress http_client injection"
+        )
+
+
+def test_create_openai_client_keepalive_direct_path_when_no_proxy(monkeypatch):
+    """Without any proxy configured, the default transport must still carry
+    keepalive.  This is the original #10324 invariant — ensure the
+    detect-and-delegate split doesn't accidentally drop keepalive on direct
+    connections.
+    """
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    _stub_proxies(monkeypatch, {})
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="no_proxy_keepalive",
+            shared=False,
+        )
+
+    hc = constructed[0]._http_client
+    assert hc is not None, "no http_client injected on direct-connect path"
+    assert _has_keepalive(hc._transport), (
+        "direct-connect transport has no socket_options — #10324 regresses"
+    )
+
+
+def test_has_proxy_configured_matches_urllib_getproxies(monkeypatch):
+    """_has_proxy_configured must follow urllib.request.getproxies() — the
+    same function httpx's trust_env path calls internally.  Using the same
+    source means our detection tracks exactly what httpx will honor,
+    including macOS SystemConfiguration and Windows registry entries that
+    env-only detection would miss.
+    """
+    _stub_proxies(monkeypatch, {})
+    assert AIAgent._has_proxy_configured() is False
+
+    _stub_proxies(monkeypatch, {"https": "http://10.0.0.1:8080"})
+    assert AIAgent._has_proxy_configured() is True
+
+    _stub_proxies(monkeypatch, {})
+    assert AIAgent._has_proxy_configured() is False
+
+    # NO_PROXY alone should not trigger — that's a refinement, not a proxy.
+    _stub_proxies(monkeypatch, {"no": "localhost"})
+    assert AIAgent._has_proxy_configured() is False
+
+
+def test_create_openai_client_skips_injection_for_system_proxy(monkeypatch):
+    """When only a system-level proxy is configured (macOS SystemConfig /
+    Windows registry, no env var), we must still delegate to httpx.  This
+    mirrors how httpx's trust_env path resolves proxies and avoids the
+    "detect env only but httpx reads system too" mismatch.
+    """
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    # A "system-only" config is indistinguishable from env at the
+    # getproxies() layer — both surface through the same dict.  We stub
+    # getproxies so the test doesn't depend on the host's System Settings.
+    _stub_proxies(monkeypatch, {"https": "http://10.0.0.1:8080"})
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="system_proxy",
+            shared=False,
+        )
+
+    assert constructed[0]._http_client is None, (
+        "System-level proxy was configured but _create_openai_client still "
+        "injected http_client, which would make httpx skip system-proxy "
+        "mount construction (#11609 regression via the system-proxy path)."
+    )
+
+
+# ─── Socket cleanup must cover proxy mounts (#11609 follow-up) ────────────
+
+
+def _fake_httpx_client_with_mock_sockets(default_sock, mount_sock):
+    """Build an object that shape-matches httpx.Client enough for
+    _iter_client_sockets to walk it.  Both the default transport's pool
+    and a proxy mount's pool expose one fake socket via the connection
+    chain: pool._connections[*]._network_stream._sock.
+    """
+    from types import SimpleNamespace
+
+    def _conn(sock):
+        stream = SimpleNamespace(_sock=sock)
+        return SimpleNamespace(_network_stream=stream)
+
+    def _transport(sock):
+        pool = SimpleNamespace(_connections=[_conn(sock)])
+        return SimpleNamespace(_pool=pool)
+
+    class _URLPattern:
+        def __init__(self, pattern):
+            self._pattern = pattern
+
+    mounts = {_URLPattern("https://"): _transport(mount_sock)}
+    return SimpleNamespace(
+        _transport=_transport(default_sock),
+        _mounts=mounts,
+    )
+
+
+def test_iter_client_sockets_covers_mounts():
+    """#11609 introduced proxy mounts; socket enumeration must walk both
+    the default transport and every mount, else force-close and dead-check
+    sweep the wrong pool on proxied setups.
+    """
+    from unittest.mock import MagicMock
+
+    from run_agent import AIAgent
+
+    default_sock = MagicMock(name="default_sock")
+    mount_sock = MagicMock(name="mount_sock")
+    http_client = _fake_httpx_client_with_mock_sockets(default_sock, mount_sock)
+
+    seen = list(AIAgent._iter_client_sockets(http_client))
+    assert default_sock in seen, "default transport's socket was not yielded"
+    assert mount_sock in seen, (
+        "mount transport's socket was not yielded — #11609 proxy connections "
+        "would leak CLOSE-WAIT past force_close and evade dead-connection "
+        "detection"
+    )
+
+
+def test_force_close_tcp_sockets_closes_mount_sockets():
+    """_force_close_tcp_sockets must force-RST sockets in proxy mounts too.
+    Otherwise proxied deployments accumulate CLOSE-WAIT on the httpx-to-proxy
+    loopback socket whenever the proxy-to-provider side drops.
+    """
+    from unittest.mock import MagicMock
+
+    from run_agent import AIAgent
+
+    default_sock = MagicMock(name="default_sock")
+    mount_sock = MagicMock(name="mount_sock")
+    http_client = _fake_httpx_client_with_mock_sockets(default_sock, mount_sock)
+    fake_openai = MagicMock(_client=http_client)
+
+    closed = AIAgent._force_close_tcp_sockets(fake_openai)
+
+    assert closed == 2, f"expected 2 closed sockets, got {closed}"
+    default_sock.shutdown.assert_called_once()
+    default_sock.close.assert_called_once()
+    mount_sock.shutdown.assert_called_once()
+    mount_sock.close.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Fixes #11609 where `HTTPS_PROXY` / `HTTP_PROXY` / macOS SystemConfiguration proxy / Windows registry proxy were silently ignored after #11277 landed. The custom `httpx.HTTPTransport` injected for TCP keepalives (#10324) made httpx skip env-proxy mount construction, so requests went direct to the destination host regardless of proxy configuration — breaking WSL users, users behind corporate proxies, and users routing outbound traffic through local proxies.

This PR detects any configured proxy via `urllib.request.getproxies()` — the same function httpx's `trust_env=True` path uses internally — and skips the keepalive injection in that case, letting the SDK build a default `httpx.Client` with full `trust_env` proxy support, including system-level proxy configuration on macOS and Windows.

The proxy path intentionally drops the keepalive injection. Re-implementing httpx's proxy resolution (env + NO_PROXY with IPv6 / CIDR / scheme-qualified entries + macOS SystemConfiguration + Windows registry) by hand proved too fragile; the httpx socket in proxy mode is a loopback/LAN hop to the local proxy process, and httpx's read timeout still fires if that side stalls. Keepalive remains applied on the direct-connect path, so #10324 stays addressed there.

Additionally widens `_force_close_tcp_sockets` to walk both `_transport` and `_mounts`. Once the proxied client path activates, live sockets live under mount pools rather than the default transport, so the existing CLOSE-WAIT cleanup would otherwise silently miss them on every client rebuild.

## Related Issue

Fixes #11609

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py`:
  - add `AIAgent._has_proxy_configured()` — detects configured proxy via `urllib.request.getproxies()`, matching httpx `trust_env` semantics
  - gate the keepalive `httpx.Client` injection on `not _has_proxy_configured()` so proxied setups delegate to httpx `trust_env`
  - add `AIAgent._iter_client_sockets()` helper walking both `_transport` and `_mounts`
  - refactor `_force_close_tcp_sockets` and `_cleanup_dead_connections` to use the new iterator
- `tests/run_agent/test_create_openai_client_reuse.py`:
  - 7 new regression tests, alongside the existing client-reuse guards, covering proxy-env / each-proxy-key / direct-path-keepalive / `_has_proxy_configured` / system-proxy / mount iteration / mount force-close
  - hermetic proxy stubbing via `urllib.request.getproxies` to insulate tests from the developer's machine config

## How to Test

Scoped tests that exercise the change:

```
source venv/bin/activate
python -m pytest tests/run_agent/test_create_openai_client_reuse.py -q
```

Expected: 9 passed (no failures, no skips).

End-to-end reproduction:

1. Run hermes-agent from a shell with `HTTPS_PROXY=http://127.0.0.1:<port>` pointing at a local proxy, or with a macOS System Settings → Network proxy configured.
2. Before this PR: requests may bypass the proxy and direct-connect to the destination host, which can surface as connection failures, timeouts, or unexpected routing behavior depending on the network.
3. After this PR: `lsof -i -nP | grep python` shows outbound sockets terminating at the proxy address, not the destination host.

**Note**: `pytest tests/ -q` currently reports pre-existing platform/environment failures on upstream `main` (Discord / Matrix / WSL / file-staleness suites); the scoped regression tests for this change pass cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config change)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `getproxies()` transparently reads env vars on all platforms, macOS SystemConfiguration, and Windows registry; `TCP_KEEPIDLE` / `TCP_KEEPALIVE` platform branch already in place
- [x] I've updated tool descriptions/schemas — N/A