### PR TITLE
fix(gateway): prevent --replace race condition causing multiple instances

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10338,8 +10338,25 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     
     # Write PID file so CLI can detect gateway is running
     import atexit
-    from gateway.status import write_pid_file, remove_pid_file
-    write_pid_file()
+    from gateway.status import write_pid_file, remove_pid_file, get_running_pid
+    # Defensive re-check: another --replace racer may have started
+    # while we were initializing. If so, yield and exit.
+    _current_pid = get_running_pid()
+    if _current_pid is not None and _current_pid != os.getpid():
+        logger.error(
+            "Another gateway instance (PID %d) started during our startup. "
+            "Exiting to avoid double-running.", _current_pid
+        )
+        await runner.stop()
+        return False
+    try:
+        write_pid_file()
+    except FileExistsError:
+        logger.error(
+            "PID file race lost to another gateway instance. Exiting."
+        )
+        await runner.stop()
+        return False
     atexit.register(remove_pid_file)
     
     # Start background cron ticker so scheduled jobs fire automatically.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10189,6 +10189,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 except (ProcessLookupError, PermissionError, OSError):
                     pass
             remove_pid_file()
+            # remove_pid_file() is a no-op when the PID doesn't match.
+            # Force-unlink to cover the old-process-crashed case.
+            try:
+                (get_hermes_home() / "gateway.pid").unlink(missing_ok=True)
+            except Exception:
+                pass
             # Clean up any takeover marker the old process didn't consume
             # (e.g. SIGKILL'd before its shutdown handler could read it).
             try:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -225,8 +225,28 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
 
 
 def write_pid_file() -> None:
-    """Write the current process PID and metadata to the gateway PID file."""
-    _write_json_file(_get_pid_path(), _build_pid_record())
+    """Write the current process PID and metadata to the gateway PID file.
+
+    Uses atomic O_CREAT | O_EXCL creation so that concurrent --replace
+    invocations race: exactly one process wins and the rest get
+    FileExistsError.
+    """
+    path = _get_pid_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record = json.dumps(_build_pid_record())
+    try:
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        raise  # Let caller decide: another gateway is racing us
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(record)
+    except Exception:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def write_runtime_status(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -260,6 +260,7 @@ AUTHOR_MAP = {
     "anthhub@163.com": "anthhub",
     "shenuu@gmail.com": "shenuu",
     "xiayh17@gmail.com": "xiayh0107",
+    "zhujianxyz@gmail.com": "opriz",
     "asurla@nvidia.com": "anniesurla",
     "limkuan24@gmail.com": "WideLee",
     "aviralarora002@gmail.com": "AviArora02-commits",


### PR DESCRIPTION
## Summary

Fixes #11718.

When starting the gateway with `--replace`, concurrent invocations could leave multiple instances running simultaneously. This triggered Telegram (and other platform) polling conflicts, causing the bot to become unresponsive.

## Root Cause

`write_pid_file()` in `gateway/status.py` used a plain file overwrite. Two racing `--replace` processes could both proceed through the termination-wait logic, then the second process would silently overwrite the first process's PID record, leaving both instances alive.

## Changes

- **`gateway/status.py`**: `write_pid_file()` now uses atomic `O_CREAT | O_EXCL` file creation. If the PID file already exists, it raises `FileExistsError`, ensuring exactly one process wins the race.
- **`gateway/run.py`**: Before writing the PID file, performs a defensive re-check via `get_running_pid()`. Also catches `FileExistsError` from `write_pid_file()`. In both cases, stops the runner and returns `False` so the process exits cleanly (non-zero exit code for systemd auto-restart compatibility).

## Reproduction

Run two `gateway --replace` invocations concurrently (e.g. via systemd restart overlap or manual double-start):

```bash
# Terminal 1
hermes gateway run --replace &

# Terminal 2 (within ~1s)
hermes gateway run --replace &
```

Before the fix: both processes write to `gateway.pid` and start polling Telegram, causing:
```
Conflict: terminated by other getUpdates request; make sure that only one bot instance is running
```

After the fix: the second process detects the race, logs an error, and exits before starting any platform adapters.

## Test Plan

### Existing tests
```bash
pytest tests/gateway/test_status.py -q                    # 14 passed
pytest tests/gateway/test_runner_startup_failures.py -q   # included in 75 passed
pytest tests/hermes_cli/test_update_gateway_restart.py -q # 34 passed
pytest tests/gateway/test_telegram_conflict.py -q         # 6 passed
```

### Concurrent race simulation
A standalone script was used to verify the atomicity under real OS-level concurrency:

```python
import multiprocessing
import os
import tempfile
from pathlib import Path
from gateway import status

def racer(pid_file, queue):
    status._get_pid_path = lambda: Path(pid_file)
    try:
        status.write_pid_file()
        queue.put(("ok", os.getpid()))
    except FileExistsError:
        queue.put(("race_lost", os.getpid()))

pid_file = Path(tempfile.mkdtemp()) / "gateway.pid"
q = multiprocessing.Queue()
p1 = multiprocessing.Process(target=racer, args=(str(pid_file), q))
p2 = multiprocessing.Process(target=racer, args=(str(pid_file), q))
p1.start(); p2.start()
p1.join(); p2.join()

results = [q.get() for _ in range(2)]
assert len([r for r in results if r[0] == "ok"]) == 1
assert len([r for r in results if r[0] == "race_lost"]) == 1
```

Result: **exactly 1 process succeeds, the other receives `FileExistsError`**.

## Backwards Compatibility

- `write_pid_file()` signature unchanged; callers that don't handle `FileExistsError` will see the exception propagate (which is the desired behavior for race detection).
- `remove_pid_file()` already guards against deleting another process's PID file, so old-process atexit handlers won't clobber the new PID record.