### PR TITLE
fix(classifier): treat Anthropic "out of extra usage" 400 as billing

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -97,6 +97,7 @@ _BILLING_PATTERNS = [
     "exceeded your current quota",
     "account is deactivated",
     "plan does not include",
+    "out of extra usage",
 ]
 
 # Patterns that indicate rate limiting (transient, will resolve)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -708,6 +708,23 @@ class TestAdversarialEdgeCases:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.billing
 
+    def test_400_anthropic_extra_usage_exhausted(self):
+        """Anthropic returns 400 with 'out of extra usage' when the user's
+        extra-usage allowance is depleted. Must classify as billing so the
+        fallback chain engages instead of aborting."""
+        e = MockAPIError(
+            "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+            status_code=400,
+            body={"error": {
+                "type": "invalid_request_error",
+                "message": "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+            }},
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+        assert result.retryable is False
+
     def test_200_with_error_body(self):
         """200 status with error in body — should be unknown, not crash."""
         class WeirdSuccess(Exception):


### PR DESCRIPTION
Anthropic returns HTTP 400 with `"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."` when a user's extra-usage allowance is depleted. This wording is not in `_BILLING_PATTERNS` in `agent/error_classifier.py`, so `classify_api_error` falls through `_classify_400` to the generic format_error path (`retryable=False`, `should_fallback=False`). The agent aborts instead of engaging the configured fallback chain (`fallback_providers` / `fallback_model`).

Fix: add `"out of extra usage"` to `_BILLING_PATTERNS`. Now classified as `FailoverReason.billing` → `should_fallback=True`, matching how other providers' billing-exhaustion messages are handled.

## Repro

Primary Anthropic model with depleted extra usage + Gemini fallback configured:

```
⚠️  API call failed (attempt 1/3): BadRequestError [HTTP 400]
   🔌 Provider: anthropic  Model: claude-opus-4-6
   📝 Error: HTTP 400: You're out of extra usage. Add more at claude.ai/settings/usage and keep going.
❌ Non-retryable client error (HTTP 400). Aborting.
```

After the fix the same error triggers the fallback chain and the agent continues on the fallback provider.

## Test plan

- [x] Added `test_400_anthropic_extra_usage_exhausted` in `tests/agent/test_error_classifier.py` asserting `reason == billing`, `should_fallback is True`, `retryable is False`.
- [x] `pytest tests/agent/test_error_classifier.py` — 98 passed.
- [x] Verified locally: after restarting the gateway with the patch, the same 400 advances to the configured fallback provider instead of aborting.