### PR TITLE
fix(acp): accept wrapped prompt payloads

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -70,6 +70,18 @@ except Exception:
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 
 
+def _normalize_prompt_blocks(prompt: Any) -> list[Any]:
+    """Accept ACP prompt payloads passed either as raw block lists or wrappers."""
+    if prompt is None:
+        return []
+    if isinstance(prompt, (list, tuple)):
+        return list(prompt)
+    prompt_blocks = getattr(prompt, "prompt", None)
+    if prompt_blocks is not None:
+        return _normalize_prompt_blocks(prompt_blocks)
+    return [prompt]
+
+
 def _extract_text(
     prompt: list[
         TextContentBlock
@@ -81,7 +93,7 @@ def _extract_text(
 ) -> str:
     """Extract plain text from ACP content blocks."""
     parts: list[str] = []
-    for block in prompt:
+    for block in _normalize_prompt_blocks(prompt):
         if isinstance(block, TextContentBlock):
             parts.append(block.text)
         elif hasattr(block, "text"):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -306,6 +306,34 @@ class TestPrompt:
         state.agent.run_conversation.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_prompt_accepts_wrapped_prompt_payload(self, agent):
+        """ACP clients may pass a wrapper object instead of a raw block list."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "Hello from wrapper payload",
+            "messages": [],
+        })
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        wrapped_prompt = SimpleNamespace(
+            prompt=[TextContentBlock(type="text", text="hello from wrapper")]
+        )
+        resp = await agent.prompt(prompt=wrapped_prompt, session_id=new_resp.session_id)
+
+        assert isinstance(resp, PromptResponse)
+        assert resp.stop_reason == "end_turn"
+        state.agent.run_conversation.assert_called_once_with(
+            user_message="hello from wrapper",
+            conversation_history=state.history,
+            task_id=new_resp.session_id,
+        )
+
+    @pytest.mark.asyncio
     async def test_prompt_updates_history(self, agent):
         """After a prompt, session history should be updated."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## What does this PR do?

Fixes `#11732`: some ACP clients can call the adapter with a request-like wrapper object instead of passing the raw prompt block list directly. The current ACP adapter assumes `prompt` is always iterable, so `_extract_text()` crashes with `TypeError: 'types.SimpleNamespace' object is not iterable` before Hermes ever reaches the model.

This PR keeps the fix narrow to the ACP boundary:
- accept prompt payloads passed either as the normal block list or as a wrapper object exposing `.prompt`
- keep the existing text extraction behavior once the block list is normalized
- add a regression test that exercises `agent.prompt(prompt=SimpleNamespace(prompt=[...]))`

## Related Issue

Fixes #11732

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`: normalize ACP prompt payloads that arrive as wrapper objects with a `.prompt` attribute before iterating blocks in `_extract_text()`
- `tests/acp/test_server.py`: add a regression test proving wrapped prompt payloads no longer crash and still call `run_conversation()` with the extracted text

## How to Test

1. Reproduce the old failing shape by calling the ACP adapter with a wrapped payload, e.g. `prompt=SimpleNamespace(prompt=[TextContentBlock(type="text", text="hello")])`
2. Confirm the ACP adapter no longer raises `TypeError` and instead forwards `hello` into `run_conversation()`
3. Run:
   `pytest -o addopts='' tests/acp/test_server.py -q`
4. Run:
   `pytest -o addopts='' tests/acp -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (local dev environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run:
- `pytest -o addopts='' tests/acp/test_server.py -q` → `42 passed`
- `pytest -o addopts='' tests/acp -q` → `128 passed`
