### PR TITLE
fix(feishu): add docstrings to event handlers to clarify no-op behavior

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1960,9 +1960,19 @@ class FeishuAdapter(BasePlatformAdapter):
         self._chat_info_cache.pop(chat_id, None)
 
     def _on_p2p_chat_entered(self, data: Any) -> None:
+        """Handle user entering P2P chat with bot.
+
+        This is a no-op handler to suppress "processor not found" error log spam
+        from the Feishu SDK when the event is received.
+        """
         logger.debug("[Feishu] User entered P2P chat with bot")
 
     def _on_message_recalled(self, data: Any) -> None:
+        """Handle message recalled event.
+
+        This is a no-op handler to suppress "processor not found" error log spam
+        from the Feishu SDK when a message is recalled by a user.
+        """
         logger.debug("[Feishu] Message recalled by user")
 
     def _on_reaction_event(self, event_type: str, data: Any) -> None:


### PR DESCRIPTION
## Summary
Add comprehensive docstrings to  and  event handlers in the Feishu adapter to clarify their purpose as no-op handlers that suppress SDK error log spam.

## Root Cause
The  and  handlers were registered in the Feishu event dispatcher but lacked documentation explaining they are intentionally no-op handlers. This could lead to confusion about why these handlers don't perform any action.

## Fix
Added detailed docstrings to both handlers explaining:
- Their purpose as no-op handlers
- That they exist to suppress "processor not found" error log spam from the Feishu SDK
- The specific events they handle

## Test Plan
- [x] Existing unit tests pass
- [x] No functional changes - only documentation added

Closes NousResearch/hermes-agent#11587