### PR TITLE
fix(feishu): drop non-approval card callbacks instead of replying "Unknown command /card" (#11600)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1794,8 +1794,9 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send an interactive card with approval buttons.
 
         The buttons carry ``hermes_action`` in their value dict so that
-        ``_handle_card_action_event`` can intercept them and call
-        ``resolve_gateway_approval()`` to unblock the waiting agent thread.
+        ``_on_card_action_trigger`` routes them to
+        ``_handle_approval_card_action`` / ``_resolve_approval`` and
+        unblocks the waiting agent thread.
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
@@ -2357,11 +2358,21 @@ class FeishuAdapter(BasePlatformAdapter):
     def _on_card_action_trigger(self, data: Any) -> Any:
         """Handle card-action callback from the Feishu SDK (synchronous).
 
-        For approval actions: parses the event once, returns the resolved card
-        inline (the only reliable way to sync all clients), and schedules a
+        For Hermes-generated approval cards (payloads that carry
+        ``hermes_action``): parse the event once, return the resolved card
+        inline (the only reliable way to sync all clients), and schedule a
         lightweight async method to actually unblock the agent.
 
-        For other card actions: delegates to ``_handle_card_action_event``.
+        For any other card callback: log at debug level and drop.  Hermes
+        does not register a handler for unrecognized card actions and never
+        has — the previous ``/card <tag> …`` synthesis routed those events
+        into the generic slash-command dispatcher, which always produced a
+        user-visible ``Unknown command /card`` reply because the command
+        was never defined in ``hermes_cli/commands.py``
+        (``GATEWAY_KNOWN_COMMANDS`` does not contain ``card``).  See
+        issue #11600.  Silently dropping is strictly better UX: approval
+        cards keep working exactly as before, and non-Hermes cards no
+        longer trigger a fake-command reply to the user.
         """
         loop = self._loop
         if not self._loop_accepts_callbacks(loop):
@@ -2504,7 +2515,30 @@ class FeishuAdapter(BasePlatformAdapter):
         return False
 
     async def _handle_card_action_event(self, data: Any) -> None:
-        """Route Feishu interactive card button clicks as synthetic COMMAND events."""
+        """Log-and-drop handler for non-approval Feishu card callbacks.
+
+        Feishu sends every interactive-card interaction through the
+        ``card.action.trigger`` event.  Hermes-generated approval cards
+        carry a ``hermes_action`` key in the button value and are handled
+        by ``_handle_approval_card_action``; everything else lands here.
+
+        Earlier versions of this adapter synthesized a
+        ``/card <tag> <value>`` slash command and pushed it through the
+        gateway command dispatcher.  That produced a user-visible
+        ``Unknown command /card`` reply on every click because Hermes has
+        never registered a ``card`` command in
+        ``hermes_cli/commands.py`` (and therefore ``GATEWAY_KNOWN_COMMANDS``
+        does not contain it).  It also meant that malformed approval
+        callbacks — callbacks that should have been rejected — instead
+        reached the user as an error message unrelated to approvals.
+        See issue #11600.
+
+        Since there is no registered consumer for non-approval card
+        events anywhere in the codebase, the correct behaviour is to log
+        the event at debug level and return.  The processed-token cache
+        is still maintained so repeated SDK deliveries of the same
+        callback don't re-log.
+        """
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
         if token and self._is_card_action_duplicate(token):
@@ -2515,43 +2549,24 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = str(getattr(context, "open_chat_id", "") or "")
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        if not chat_id or not open_id:
-            logger.debug("[Feishu] Card action missing chat_id or operator open_id, dropping")
-            return
 
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
 
-        synthetic_text = f"/card {action_tag}"
-        if action_value:
-            try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
-            except Exception:
-                pass
-
-        sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
-        sender_profile = await self._resolve_sender_profile(sender_id)
-        chat_info = await self.get_chat_info(chat_id)
-        source = self.build_source(
-            chat_id=chat_id,
-            chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
-            user_id=sender_profile["user_id"],
-            user_name=sender_profile["user_name"],
-            thread_id=None,
-            user_id_alt=sender_profile["user_id_alt"],
+        # Compact, privacy-preserving log line — no message forwarded, no
+        # synthesized slash command.  Only the action_tag and value-key
+        # list are logged; full value payloads may contain user-visible
+        # strings that shouldn't hit INFO-level logs.
+        try:
+            value_keys = sorted(action_value.keys()) if isinstance(action_value, dict) else []
+        except Exception:
+            value_keys = []
+        logger.debug(
+            "[Feishu] Dropping non-approval card action tag=%r from %s in %s (value keys: %s)",
+            action_tag, open_id or "?", chat_id or "?", value_keys,
         )
-        synthetic_event = MessageEvent(
-            text=synthetic_text,
-            message_type=MessageType.COMMAND,
-            source=source,
-            raw_message=data,
-            message_id=token or str(uuid.uuid4()),
-            timestamp=datetime.now(),
-        )
-        logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
-        await self._handle_message_with_guards(synthetic_event)
+        return
 
     # =========================================================================
     # Per-chat serialization and typing indicator

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1454,8 +1454,9 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send an interactive card with approval buttons.
 
         The buttons carry ``hermes_action`` in their value dict so that
-        ``_handle_card_action_event`` can intercept them and call
-        ``resolve_gateway_approval()`` to unblock the waiting agent thread.
+        ``_on_card_action_trigger`` routes them to
+        ``_handle_approval_card_action`` / ``_resolve_approval`` and
+        unblocks the waiting agent thread.
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
@@ -2000,11 +2001,21 @@ class FeishuAdapter(BasePlatformAdapter):
     def _on_card_action_trigger(self, data: Any) -> Any:
         """Handle card-action callback from the Feishu SDK (synchronous).
 
-        For approval actions: parses the event once, returns the resolved card
-        inline (the only reliable way to sync all clients), and schedules a
+        For Hermes-generated approval cards (payloads that carry
+        ``hermes_action``): parse the event once, return the resolved card
+        inline (the only reliable way to sync all clients), and schedule a
         lightweight async method to actually unblock the agent.
 
-        For other card actions: delegates to ``_handle_card_action_event``.
+        For any other card callback: log at debug level and drop.  Hermes
+        does not register a handler for unrecognized card actions and never
+        has — the previous ``/card <tag> …`` synthesis routed those events
+        into the generic slash-command dispatcher, which always produced a
+        user-visible ``Unknown command /card`` reply because the command
+        was never defined in ``hermes_cli/commands.py``
+        (``GATEWAY_KNOWN_COMMANDS`` does not contain ``card``).  See
+        issue #11600.  Silently dropping is strictly better UX: approval
+        cards keep working exactly as before, and non-Hermes cards no
+        longer trigger a fake-command reply to the user.
         """
         loop = self._loop
         if not self._loop_accepts_callbacks(loop):
@@ -2146,7 +2157,30 @@ class FeishuAdapter(BasePlatformAdapter):
         return False
 
     async def _handle_card_action_event(self, data: Any) -> None:
-        """Route Feishu interactive card button clicks as synthetic COMMAND events."""
+        """Log-and-drop handler for non-approval Feishu card callbacks.
+
+        Feishu sends every interactive-card interaction through the
+        ``card.action.trigger`` event.  Hermes-generated approval cards
+        carry a ``hermes_action`` key in the button value and are handled
+        by ``_handle_approval_card_action``; everything else lands here.
+
+        Earlier versions of this adapter synthesized a
+        ``/card <tag> <value>`` slash command and pushed it through the
+        gateway command dispatcher.  That produced a user-visible
+        ``Unknown command /card`` reply on every click because Hermes has
+        never registered a ``card`` command in
+        ``hermes_cli/commands.py`` (and therefore ``GATEWAY_KNOWN_COMMANDS``
+        does not contain it).  It also meant that malformed approval
+        callbacks — callbacks that should have been rejected — instead
+        reached the user as an error message unrelated to approvals.
+        See issue #11600.
+
+        Since there is no registered consumer for non-approval card
+        events anywhere in the codebase, the correct behaviour is to log
+        the event at debug level and return.  The processed-token cache
+        is still maintained so repeated SDK deliveries of the same
+        callback don't re-log.
+        """
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
         if token and self._is_card_action_duplicate(token):
@@ -2157,43 +2191,24 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = str(getattr(context, "open_chat_id", "") or "")
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        if not chat_id or not open_id:
-            logger.debug("[Feishu] Card action missing chat_id or operator open_id, dropping")
-            return
 
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
 
-        synthetic_text = f"/card {action_tag}"
-        if action_value:
-            try:
-                synthetic_text += f" {json.dumps(action_value, ensure_ascii=False)}"
-            except Exception:
-                pass
-
-        sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
-        sender_profile = await self._resolve_sender_profile(sender_id)
-        chat_info = await self.get_chat_info(chat_id)
-        source = self.build_source(
-            chat_id=chat_id,
-            chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
-            user_id=sender_profile["user_id"],
-            user_name=sender_profile["user_name"],
-            thread_id=None,
-            user_id_alt=sender_profile["user_id_alt"],
+        # Compact, privacy-preserving log line — no message forwarded, no
+        # synthesized slash command.  Only the action_tag and value-key
+        # list are logged; full value payloads may contain user-visible
+        # strings that shouldn't hit INFO-level logs.
+        try:
+            value_keys = sorted(action_value.keys()) if isinstance(action_value, dict) else []
+        except Exception:
+            value_keys = []
+        logger.debug(
+            "[Feishu] Dropping non-approval card action tag=%r from %s in %s (value keys: %s)",
+            action_tag, open_id or "?", chat_id or "?", value_keys,
         )
-        synthetic_event = MessageEvent(
-            text=synthetic_text,
-            message_type=MessageType.COMMAND,
-            source=source,
-            raw_message=data,
-            message_id=token or str(uuid.uuid4()),
-            timestamp=datetime.now(),
-        )
-        logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
-        await self._handle_message_with_guards(synthetic_event)
+        return
 
     # =========================================================================
     # Per-chat serialization and typing indicator

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -282,14 +282,18 @@ class TestResolveApproval:
         mock_resolve.assert_not_called()
 
 # ===========================================================================
-# _handle_card_action_event — non-approval card actions
+# _handle_card_action_event — non-approval card actions (regression #11600)
 # ===========================================================================
 
 class TestNonApprovalCardAction:
-    """Non-approval card actions should still route as synthetic commands."""
+    """Non-approval card callbacks must NOT be synthesized into ``/card``
+    slash-commands.  Hermes has never registered a ``card`` command in
+    ``hermes_cli/commands.py``, so the previous synthesis always produced a
+    user-visible ``"Unknown command /card"`` reply — see issue #11600."""
 
     @pytest.mark.asyncio
-    async def test_routes_as_synthetic_command(self):
+    async def test_non_approval_callback_does_not_synthesize_command(self):
+        """Non-approval card action: nothing routed to the agent pipeline."""
         adapter = _make_adapter()
 
         data = _make_card_action_data(
@@ -300,16 +304,120 @@ class TestNonApprovalCardAction:
         with (
             patch.object(
                 adapter, "_resolve_sender_profile", new_callable=AsyncMock,
-                return_value={"user_id": "ou_u", "user_name": "Dave", "user_id_alt": None},
-            ),
-            patch.object(adapter, "get_chat_info", new_callable=AsyncMock, return_value={"name": "Test Chat"}),
-            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+            ) as mock_resolve_sender,
+            patch.object(
+                adapter, "get_chat_info", new_callable=AsyncMock,
+            ) as mock_chat_info,
+            patch.object(
+                adapter, "_handle_message_with_guards", new_callable=AsyncMock,
+            ) as mock_handle,
         ):
             await adapter._handle_card_action_event(data)
 
-        mock_handle.assert_called_once()
-        event = mock_handle.call_args[0][0]
-        assert "/card button" in event.text
+        mock_handle.assert_not_called()
+        # We also don't round-trip through Feishu chat-info / sender-profile
+        # lookups for a dropped callback — avoid wasted API calls.
+        mock_resolve_sender.assert_not_called()
+        mock_chat_info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_token_still_deduped(self):
+        """Dedup cache still recognizes repeat SDK deliveries so we don't
+        log the same drop twice in a row."""
+        adapter = _make_adapter()
+        data = _make_card_action_data(
+            action_value={"custom_action": "dup"},
+            token="tok_dup",
+        )
+
+        with patch.object(
+            adapter, "_handle_message_with_guards", new_callable=AsyncMock,
+        ) as mock_handle:
+            await adapter._handle_card_action_event(data)
+            await adapter._handle_card_action_event(data)
+
+        # Neither call should synthesize a command.
+        mock_handle.assert_not_called()
+        # Token cache populated on first call, short-circuits second call.
+        assert "tok_dup" in adapter._card_action_tokens
+
+    @pytest.mark.asyncio
+    async def test_non_dict_action_value_is_safe(self):
+        """A Feishu SDK variant / malformed payload that delivers
+        ``action.value`` as a non-dict (e.g. JSON-encoded string) must not
+        crash the adapter or synthesize a command."""
+        adapter = _make_adapter()
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                token="tok_str",
+                context=SimpleNamespace(open_chat_id="oc_12345"),
+                operator=SimpleNamespace(open_id="ou_user1"),
+                action=SimpleNamespace(tag="button", value="not-a-dict"),
+            ),
+        )
+
+        with patch.object(
+            adapter, "_handle_message_with_guards", new_callable=AsyncMock,
+        ) as mock_handle:
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_chat_id_is_safe(self):
+        """Drop path must also handle truncated payloads (no chat_id /
+        no operator) without crashing."""
+        adapter = _make_adapter()
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                token="tok_partial",
+                context=SimpleNamespace(open_chat_id=""),
+                operator=SimpleNamespace(open_id=""),
+                action=SimpleNamespace(tag="button", value={"x": 1}),
+            ),
+        )
+
+        with patch.object(
+            adapter, "_handle_message_with_guards", new_callable=AsyncMock,
+        ) as mock_handle:
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_not_called()
+
+    def test_non_approval_trigger_does_not_reach_approval_handler(
+        self, _patch_callback_card_types,
+    ):
+        """End-to-end: the sync dispatcher must pass non-approval events
+        through ``_handle_card_action_event`` (which drops them), NOT
+        ``_handle_approval_card_action`` (which would try to resolve a
+        non-existent approval)."""
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data({"some_other": "value"})
+
+        def _close_coro(_loop, coro):
+            # Close the scheduled coro so pytest doesn't emit
+            # ``coroutine was never awaited`` warnings; the test only
+            # cares that _submit_on_loop was called, not that the drop
+            # path actually ran.
+            coro.close()
+
+        with (
+            patch.object(
+                adapter, "_handle_approval_card_action",
+            ) as mock_approval_handler,
+            patch.object(
+                adapter, "_submit_on_loop", side_effect=_close_coro,
+            ) as mock_submit,
+        ):
+            adapter._on_card_action_trigger(data)
+
+        mock_approval_handler.assert_not_called()
+        # The drop path is still scheduled on the adapter loop (so the
+        # dedup cache etc. run on the adapter's own event loop), but the
+        # important invariant is that it's not the approval handler.
+        mock_submit.assert_called_once()
 
 
 # ===========================================================================

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -243,15 +243,13 @@ Grant the `application:bot.basic_info:read` scope to display peer bot names; wit
 
 ## Interactive Card Actions
 
-When users click buttons or interact with interactive cards sent by the bot, the adapter routes these as synthetic `/card` command events:
+The adapter handles one kind of interactive card callback:
 
-- Button clicks become: `/card button {"key": "value", ...}`
-- The action's `value` payload from the card definition is included as JSON.
-- Card actions are deduplicated with a 15-minute window to prevent double processing.
+- **Command-approval cards.** When the agent needs to run a dangerous command, it sends an interactive card with Allow Once / Session / Always / Deny buttons. Each button carries a `hermes_action` field in its `value` payload; on click, the adapter resolves the pending approval inline and returns an updated "resolved" card as the Feishu callback response so every client re-renders the same resolution state.
 
-Card action events are dispatched with `MessageType.COMMAND`, so they flow through the normal command processing pipeline.
+All other interactive-card callbacks (custom buttons in cards Hermes didn't produce, card types that Feishu reports under `card.action.trigger` without an approval payload, etc.) are dropped at DEBUG log level. Hermes does not register a command handler for generic card actions — routing them through the slash-command pipeline produced user-visible `Unknown command /card` replies, so the adapter now silently drops them instead (see issue #11600).
 
-This is also how **command approval** works — when the agent needs to run a dangerous command, it sends an interactive card with Allow Once / Session / Always / Deny buttons. The user clicks a button, and the card action callback delivers the approval decision back to the agent.
+Card action callbacks are deduplicated with a 15-minute window to prevent double processing of repeat SDK deliveries.
 
 ### Required Feishu App Configuration
 

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -217,15 +217,13 @@ If none of these are set, the adapter will attempt to auto-discover the bot name
 
 ## Interactive Card Actions
 
-When users click buttons or interact with interactive cards sent by the bot, the adapter routes these as synthetic `/card` command events:
+The adapter handles one kind of interactive card callback:
 
-- Button clicks become: `/card button {"key": "value", ...}`
-- The action's `value` payload from the card definition is included as JSON.
-- Card actions are deduplicated with a 15-minute window to prevent double processing.
+- **Command-approval cards.** When the agent needs to run a dangerous command, it sends an interactive card with Allow Once / Session / Always / Deny buttons. Each button carries a `hermes_action` field in its `value` payload; on click, the adapter resolves the pending approval inline and returns an updated "resolved" card as the Feishu callback response so every client re-renders the same resolution state.
 
-Card action events are dispatched with `MessageType.COMMAND`, so they flow through the normal command processing pipeline.
+All other interactive-card callbacks (custom buttons in cards Hermes didn't produce, card types that Feishu reports under `card.action.trigger` without an approval payload, etc.) are dropped at DEBUG log level. Hermes does not register a command handler for generic card actions — routing them through the slash-command pipeline produced user-visible `Unknown command /card` replies, so the adapter now silently drops them instead (see issue #11600).
 
-This is also how **command approval** works — when the agent needs to run a dangerous command, it sends an interactive card with Allow Once / Session / Always / Deny buttons. The user clicks a button, and the card action callback delivers the approval decision back to the agent.
+Card action callbacks are deduplicated with a 15-minute window to prevent double processing of repeat SDK deliveries.
 
 ### Required Feishu App Configuration
 


### PR DESCRIPTION
## What does this PR do?

Fixes #11600.

The Feishu adapter has a dead-end code path: every `card.action.trigger` callback whose payload does not carry a `hermes_action` key is converted into a synthetic `/card <tag> <value>` `MessageType.COMMAND` event and pushed through the gateway slash-command dispatcher. Because Hermes has never registered a `card` command, the dispatcher falls through to the `Unrecognized slash command` branch at `gateway/run.py:3319` and replies to the user with:

> `Unknown command /card. Type /commands to see what's available, or resend without the leading slash to send as a regular message.`

That reply fires on every click in any interactive card that isn't one of Hermes's own approval cards — and, critically, it also fires when a *real* approval callback's payload shape doesn't quite match `_handle_approval_card_action`'s expectations (SDK version drift, proxy wrappers, etc.), which is the exact release-level symptom #11600 reports on v0.9.0. The user then gets a misleading "Unknown command" reply that has nothing to do with approvals, while the pending approval silently fails to resolve.

## Root cause

`gateway/platforms/feishu.py:2168` synthesises `/card <tag>`:

```python
synthetic_text = f"/card {action_tag}"
...
synthetic_event = MessageEvent(
    text=synthetic_text,
    message_type=MessageType.COMMAND,
    ...
)
await self._handle_message_with_guards(synthetic_event)
```

Grep for `card` handler registration:

```
$ python -c "from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS; print('card' in GATEWAY_KNOWN_COMMANDS)"
False
```

…and `hermes_cli/commands.py` / `COMMAND_REGISTRY` do not define one. The `/card` synthesis was documented at `website/docs/user-guide/messaging/feishu.md:220-228` as a generic extension point but was never wired up to anything. The feature landed with the original Feishu integration in ca4907df (#3817) and has been unreachable since.

## Smallest safe fix

- `_handle_card_action_event` becomes a log-and-drop handler. It still walks the SDK event shape to maintain the 15-minute dedup token cache (so repeat SDK deliveries don't re-log) and emits a compact DEBUG line with the `action_tag` and the *keys* of the value dict (never the raw value — user-typed payloads must not land at INFO). No synthetic command, no `_handle_message_with_guards` call.
- **Approval branch is completely unchanged.** Hermes-generated cards still carry `hermes_action` in their button value and route through `_on_card_action_trigger` → `_handle_approval_card_action` → `_resolve_approval` exactly as before. See the green/red resolved-card tests in `TestCardActionCallbackResponse`, all unchanged.
- Updated `website/docs/user-guide/messaging/feishu.md` to describe the actual behaviour (approval cards work, unrecognized card callbacks are dropped) instead of the aspirational `/card` claim.

## Compat / behaviour truth table

| Card callback shape | Before | After |
| --- | --- | --- |
| Approval (`hermes_action` present) | Resolves approval inline | **Unchanged** |
| Non-approval, dict value, no `hermes_action` | `/card <tag>` command → user sees `Unknown command /card` | Dropped with DEBUG log |
| Non-approval, non-dict `action.value` (SDK variant / JSON-string) | `/card <tag>` command (same noise) | Dropped with DEBUG log |
| Repeat SDK delivery of same token | Deduped | Still deduped |
| Missing `chat_id` / `operator` | Already dropped | Still dropped |

No user-facing behaviour is silently lost — the only removed path was one that produced a misleading error reply.

## Narrow scope — why only the log-drop

I deliberately did not:

- Introduce a new `MessageType.CARD_ACTION` event type. That's a feature, not a fix. If plugin extensibility for Feishu card events is desired later, it can be added as an additive follow-up without re-introducing the misleading `/card` reply.
- Try to repair why some approval-card clicks fail to resolve at all (the other half of #11600's first symptom). That depends on SDK event shape behaviour that this repo can't observe without a trace from the reporter — it belongs in its own investigation. Dropping the `/card` synthesis at least means that when an approval path fails, the user stops seeing a wrong-looking "Unknown command" reply, so the separable bug becomes *observably* separate in production.
- Extend the GATEWAY_KNOWN_COMMANDS allow-list to include `card`. Making the dispatcher *not complain* about an unimplemented command would hide a real design gap.

## Pre-emptive reviewer Q&A

**Q: Could anyone depend on the `/card` synthesis?**
No registered command handles it; no plugin hook consumes it. The behaviour was exclusively "user sees `Unknown command /card`". External dependency on that is implausible.

**Q: Should the drop log at INFO?**
No. These callbacks fire on every user click on any non-Hermes card in a shared chat. INFO-level logging would be noisy for anything larger than a demo deployment. DEBUG is reachable via `HERMES_LOG_LEVEL=DEBUG` for anyone actually debugging Feishu card flows.

**Q: Why log value *keys* but not the full value?**
Feishu cards can embed user-typed strings in the `value` payload. Keys are bounded metadata (card authors control them); full values can be arbitrary text including PII. Keys-only preserves debuggability without routing user content through INFO/DEBUG logs.

**Q: What happens to the `P2CardActionTriggerResponse` return value now that non-approval callbacks don't schedule agent work?**
Unchanged. `_on_card_action_trigger` still returns `P2CardActionTriggerResponse()` for non-approval callbacks — Feishu's SDK requires *some* response to the callback so the button doesn't spin forever. We just don't push an agent event onto the loop.

**Q: Dedup cache behaviour?**
Still maintained. The first callback for a given token logs its drop; subsequent deliveries of the same token short-circuit via the existing `_is_card_action_duplicate` check. Covered by `test_duplicate_token_still_deduped`.

**Q: Security?**
The drop path is strictly less privileged than the synthesise-command path: we now *don't* forward user-controlled `action_tag` / `action_value` strings into the agent pipeline as a command. That removes a small but real injection surface: a card author could have crafted an `action.value` whose JSON serialization contains slash-command tokens, and every click would have sent that as a `/card …` command under a Hermes-user-looking `MessageEvent`. The new drop path never constructs a `MessageEvent` at all, so the agent pipeline never sees card-supplied strings.

## Regression coverage

`tests/gateway/test_feishu_approval_buttons.py` — the pre-existing `test_routes_as_synthetic_command` (which pinned the broken behaviour) is replaced with `test_non_approval_callback_does_not_synthesize_command` (same code path, inverted assertion). Plus 4 new tests:

- `test_non_approval_callback_does_not_synthesize_command` — no `MessageEvent` emitted, no chat-info / sender-profile lookups wasted.
- `test_duplicate_token_still_deduped` — processed-token cache still recognises repeat SDK deliveries.
- `test_non_dict_action_value_is_safe` — SDK variant / malformed payload (`action.value` as a string) doesn't crash.
- `test_missing_chat_id_is_safe` — truncated payloads still handled.
- `test_non_approval_trigger_does_not_reach_approval_handler` — pins the routing invariant end-to-end through `_on_card_action_trigger`.

**On unpatched `origin/main`, 3 of these tests fail with the expected `"_handle_message_with_guards should not have been called. Called 1 times"` / similar assertion errors**, confirming they catch the regression. The remaining two pin behaviour preserved by the fix.

## How to test

1. Focused suite:
   ```
   source venv/bin/activate
   python -m pytest tests/gateway/test_feishu_approval_buttons.py -q
   ```
   → **22 passed** (17 existing + 5 new).

2. Verify the tests catch the bug on origin/main:
   ```
   git stash push gateway/platforms/feishu.py
   python -m pytest tests/gateway/test_feishu_approval_buttons.py::TestNonApprovalCardAction -v
   ```
   → 3 fail with `_handle_message_with_guards was called 1 times`. Restore with `git stash pop`.

3. CI-aligned broad suite:
   ```
   python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
   ```
   → 12385 passed, 39 skipped, 7 pre-existing baseline failures (`tests/gateway/test_matrix.py`, `tests/gateway/test_approve_deny_commands.py` ×2, `tests/hermes_cli/test_gateway_wsl.py` ×2, `tests/tools/test_file_staleness.py` ×2). All 7 reproduce on clean `origin/main` with identical assertions — none in the touched code path.

Tested on: macOS 15 (Darwin 25.5.0), Python 3.11.15.

## Related Issue

Fixes #11600

Related / adjacent (not fixed here): #9585, #10073, #9533, #10256, #10412, #10301, #10801 — several of these may have been partially masked by the same `/card` noise. After this lands, the signal-to-noise on future Feishu approval reports should improve because the dispatcher can no longer conflate approval failures with unknown-command replies.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: rewrite `_handle_card_action_event` as log-and-drop; update `_on_card_action_trigger` docstring; update `send_exec_approval` docstring to reference the actual handler chain.
- `tests/gateway/test_feishu_approval_buttons.py`: replace `test_routes_as_synthetic_command` with `test_non_approval_callback_does_not_synthesize_command`, add 4 additional regression tests.
- `website/docs/user-guide/messaging/feishu.md`: rewrite the "Interactive Card Actions" section to describe actual behaviour.

## Adjacent surfaces checked

- `_handle_approval_card_action` / `_resolve_approval` / `send_exec_approval` — unchanged; approval resolution path verified by the (untouched) `TestResolveApproval` and `TestCardActionCallbackResponse` suites.
- `_is_card_action_duplicate` / dedup token cache — unchanged; new test pins it still works.
- `_on_card_action_trigger` — only docstring + one added clarifying comment; routing logic byte-for-byte unchanged.
- `GATEWAY_KNOWN_COMMANDS` / `hermes_cli/commands.py` — confirmed `card` is not registered anywhere (see "Root cause" above).
- Other gateway platforms (`matrix.py`, `slack.py`, etc.) — none synthesize `/card`; no cross-platform impact.
- Plugin hooks — grepped `hooks.emit` / `invoke_hook` for any `card:*` event names; none exist.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] Searched for existing PRs — none on #11600
- [x] Only changes related to this fix
- [x] Ran the CI-aligned test command and classified failures baseline-vs-change
- [x] Added tests for my changes (5 new; 3 fail on `origin/main` without the fix, 2 pin preserved behaviour)
- [x] Tested on macOS 15 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] Updated `website/docs/user-guide/messaging/feishu.md` to describe actual behaviour
- [x] No config-key changes
- [x] No architecture/workflow changes
- [x] Cross-platform impact: none — only touches the Feishu adapter
- [x] No tool descriptions/schemas touched

## Notes for reviewers

- No standalone lint command is defined; CI runs `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` (matches `.github/workflows/tests.yml`).
- No `hermes_cli/**` changes — the Nix workflow should not trigger.