### PR TITLE
fix(gateway): handle missing systemd unit on start

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1104,6 +1104,18 @@ def systemd_start(system: bool = False):
     system = _select_systemd_scope(system)
     if system:
         _require_root_for_system_service("start")
+    unit_path = get_systemd_unit_path(system=system)
+    if not unit_path.exists():
+        scope_flag = " --system" if system else ""
+        scope_label = _service_scope_label(system)
+        print(f"✗ Hermes gateway {scope_label} service is not installed.")
+        print()
+        print("Install it first:")
+        print(f"  {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print()
+        print("Or run the gateway without a background service:")
+        print("  hermes gateway run")
+        sys.exit(1)
     refresh_systemd_unit_if_needed(system=system)
     _run_systemctl(["start", get_service_name()], system=system, check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service started")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -59,6 +59,30 @@ class TestSystemdServiceRefresh:
             ["systemctl", "--user", "start", gateway_cli.get_service_name()],
         ]
 
+    def test_systemd_start_missing_unit_prints_install_guidance(self, tmp_path, monkeypatch, capsys):
+        import pytest
+
+        unit_path = tmp_path / "hermes-gateway.service"
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_cli.systemd_start()
+
+        output = capsys.readouterr().out
+        assert exc_info.value.code == 1
+        assert "service is not installed" in output
+        assert "hermes gateway install" in output
+        assert "hermes gateway run" in output
+        assert calls == []
+
     def test_systemd_restart_refreshes_outdated_unit(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- detect when the systemd gateway unit has not been installed before running hermes gateway start
- print install/manual-run guidance instead of surfacing a raw CalledProcessError
- add regression coverage for the missing-unit start path

## Test
- venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q