### PR TITLE
fix(agent): ignore quoted scratchpad tags in retry detection

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -7,24 +7,39 @@ the file-write logic live here.
 
 import json
 import logging
+import re
 from datetime import datetime
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
+_SCRATCHPAD_OPEN_TAG = "<REASONING_SCRATCHPAD>"
+_SCRATCHPAD_CLOSE_TAG = "</REASONING_SCRATCHPAD>"
+_FENCED_CODE_BLOCK_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_BLOCKQUOTE_RE = re.compile(r"(?m)^[ \t]*>.*(?:\n|$)")
+
 
 def convert_scratchpad_to_think(content: str) -> str:
     """Convert <REASONING_SCRATCHPAD> tags to <think> tags."""
-    if not content or "<REASONING_SCRATCHPAD>" not in content:
+    if not content or _SCRATCHPAD_OPEN_TAG not in content:
         return content
-    return content.replace("<REASONING_SCRATCHPAD>", "<think>").replace("</REASONING_SCRATCHPAD>", "</think>")
+    return content.replace(_SCRATCHPAD_OPEN_TAG, "<think>").replace(_SCRATCHPAD_CLOSE_TAG, "</think>")
+
+
+def _strip_markdown_context_for_scratchpad_check(content: str) -> str:
+    """Remove markdown contexts where scratchpad tags should be treated as literal text."""
+    stripped = _FENCED_CODE_BLOCK_RE.sub("", content)
+    stripped = _INLINE_CODE_RE.sub("", stripped)
+    return _BLOCKQUOTE_RE.sub("", stripped)
 
 
 def has_incomplete_scratchpad(content: str) -> bool:
     """Check if content has an opening <REASONING_SCRATCHPAD> without a closing tag."""
     if not content:
         return False
-    return "<REASONING_SCRATCHPAD>" in content and "</REASONING_SCRATCHPAD>" not in content
+    visible_content = _strip_markdown_context_for_scratchpad_check(content)
+    return visible_content.count(_SCRATCHPAD_OPEN_TAG) > visible_content.count(_SCRATCHPAD_CLOSE_TAG)
 
 
 def save_trajectory(trajectory: List[Dict[str, Any]], model: str,

--- a/tests/agent/test_trajectory.py
+++ b/tests/agent/test_trajectory.py
@@ -1,0 +1,36 @@
+from agent.trajectory import convert_scratchpad_to_think, has_incomplete_scratchpad
+
+
+def test_convert_scratchpad_to_think_rewrites_tags():
+    content = "<REASONING_SCRATCHPAD>think</REASONING_SCRATCHPAD> done"
+    assert convert_scratchpad_to_think(content) == "<think>think</think> done"
+
+
+def test_has_incomplete_scratchpad_detects_real_unclosed_tag():
+    content = "Answering...\n<REASONING_SCRATCHPAD>still thinking"
+    assert has_incomplete_scratchpad(content) is True
+
+
+def test_has_incomplete_scratchpad_ignores_fenced_code_block_mentions():
+    content = """Here is the grep output:
+
+```text
+<REASONING_SCRATCHPAD>
+```
+"""
+    assert has_incomplete_scratchpad(content) is False
+
+
+def test_has_incomplete_scratchpad_ignores_blockquote_mentions():
+    content = "> literal token <REASONING_SCRATCHPAD>\n\nFinal answer."
+    assert has_incomplete_scratchpad(content) is False
+
+
+def test_has_incomplete_scratchpad_ignores_inline_code_mentions():
+    content = "The user literally typed `<REASONING_SCRATCHPAD>` in the prompt."
+    assert has_incomplete_scratchpad(content) is False
+
+
+def test_has_incomplete_scratchpad_still_flags_real_tag_after_quote():
+    content = "> quoted literal <REASONING_SCRATCHPAD>\n\n<REASONING_SCRATCHPAD>real"
+    assert has_incomplete_scratchpad(content) is True


### PR DESCRIPTION
## Summary
- stop `has_incomplete_scratchpad()` from treating quoted or code-form scratchpad tag mentions as an unfinished reasoning block
- strip fenced code blocks, inline code, and blockquotes before checking for unclosed `<REASONING_SCRATCHPAD>` tags
- add focused regression coverage for real incomplete tags plus the false-positive markdown cases

## Root Cause
The retry guard in `agent/trajectory.py` used a plain substring check for `<REASONING_SCRATCHPAD>` without understanding markdown context. That meant grep output, quoted user text, or inline code containing the tag could trigger the incomplete-scratchpad path, causing wasted retries and dropped output.

Closes #11663.

## Validation
- `python3 -m py_compile agent/trajectory.py tests/agent/test_trajectory.py`
- `uv run --extra dev pytest -o addopts='' tests/agent/test_trajectory.py -q`

## Platform Tested
- macOS 15.x (Apple Silicon)

## Contribution Guide Notes
- Reviewed `CONTRIBUTING.md` and checked for existing open PRs before submitting this scoped change.
- Ran the targeted verification commands listed above for this PR. I have not claimed a full repo-wide `pytest tests/ -q` pass unless explicitly noted.
