### PR TITLE
fix(cli): route voice reply behavior by input origin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -38,6 +38,8 @@ import time
 import uuid
 import textwrap
 from collections import deque
+from dataclasses import dataclass
+from enum import Enum
 from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
@@ -89,6 +91,30 @@ except Exception:
     pass
 import threading
 import queue
+
+
+class _CLIInputOrigin(str, Enum):
+    TEXT = "text"
+    VOICE = "voice"
+
+
+@dataclass(frozen=True)
+class _CLIQueuedInput:
+    """Structured queue payload for turns that carry origin metadata."""
+
+    text: str
+    images: tuple[Path, ...] = ()
+    origin: _CLIInputOrigin = _CLIInputOrigin.TEXT
+
+
+def _normalize_cli_queued_input(payload):
+    """Normalize structured and legacy CLI queue payloads at one boundary."""
+    if isinstance(payload, _CLIQueuedInput):
+        return payload.text, list(payload.images), payload.origin
+    if isinstance(payload, tuple):
+        text, images = payload
+        return text, images, _CLIInputOrigin.TEXT
+    return payload, [], _CLIInputOrigin.TEXT
 
 def CanonicalUsage(*args, **kwargs):
     from agent.usage_pricing import CanonicalUsage as _CanonicalUsage
@@ -11298,7 +11324,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._attached_images.clear()
                 if hasattr(self, '_app') and self._app:
                     self._app.invalidate()
-                self._pending_input.put(transcript)
+                self._pending_input.put(
+                    _CLIQueuedInput(transcript, origin=_CLIInputOrigin.VOICE)
+                )
                 submitted = True
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -11425,6 +11453,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
         return True
+
+    def _get_voice_message_reply_mode(self) -> str:
+        """Return normalized CLI voice reply mode from config."""
+        try:
+            from hermes_cli.config import load_config
+
+            voice_config = load_config().get("voice", {})
+            reply_mode = str(voice_config.get("message_reply_mode", "all")).strip().lower()
+            if reply_mode in ("voice_only", "all"):
+                return reply_mode
+        except Exception:
+            pass
+        return "all"
+
+    def _should_speak_voice_response(self, input_origin: _CLIInputOrigin | str) -> bool:
+        """Return whether TTS output is enabled for this input origin."""
+        try:
+            origin = _CLIInputOrigin(input_origin)
+        except (TypeError, ValueError):
+            origin = _CLIInputOrigin.TEXT
+        return self._voice_tts and (
+            origin == _CLIInputOrigin.VOICE
+            or self._get_voice_message_reply_mode() == "all"
+        )
 
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
@@ -12073,7 +12125,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def chat(
+        self,
+        message,
+        images: list = None,
+        input_origin: _CLIInputOrigin | str = _CLIInputOrigin.TEXT,
+    ) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -12088,6 +12145,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
+            input_origin: Where the turn came from ("text" or "voice")
             
         Returns:
             The agent's response, or None on error
@@ -12095,6 +12153,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Single-query and direct chat callers do not go through run(), so
         # register secure secret capture here as well.
         set_secret_capture_callback(self._secret_capture_callback)
+
+        try:
+            input_origin = _CLIInputOrigin(input_origin)
+        except (TypeError, ValueError):
+            input_origin = _CLIInputOrigin.TEXT
 
         # Reset the per-turn interrupt flag. Any subsequent path that
         # discovers an interrupt (below, after run_conversation) will flip
@@ -12235,7 +12298,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             stream_callback = None
             stop_event = None
 
-            if self._voice_tts:
+            should_speak_response = self._should_speak_voice_response(input_origin)
+
+            if should_speak_response:
                 try:
                     from tools.tts_tool import (
                         _load_tts_config as _load_tts_cfg,
@@ -12288,7 +12353,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # model responds concisely. The prefix is API-call-local only —
             # run_conversation persists the original clean user message.
             _voice_prefix = ""
-            if self._voice_mode and isinstance(message, str):
+            if (
+                self._voice_mode
+                and input_origin == _CLIInputOrigin.VOICE
+                and isinstance(message, str)
+            ):
                 _voice_prefix = (
                     "[Voice input — respond concisely and conversationally, "
                     "2-3 sentences max. No code blocks or markdown.] "
@@ -12710,9 +12779,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         f"response may be incomplete{_RST}"
                     )
 
-            # Speak response aloud if voice TTS is enabled
-            # Skip batch TTS when streaming TTS already handled it
-            if self._voice_tts and response and not use_streaming_tts:
+            # Speak response aloud only when this turn qualifies for voice output.
+            # Skip batch TTS when streaming TTS already handled it.
+            if should_speak_response and response and not use_streaming_tts:
                 self._voice_speak_response_async(response)
 
 
@@ -15191,10 +15260,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     # post-resize transient suppression should end here.
                     self._status_bar_suppressed_after_resize = False
 
-                    # Unpack image payload: (text, [Path, ...]) or plain str
-                    submit_images = []
-                    if isinstance(user_input, tuple):
-                        user_input, submit_images = user_input
+                    # Normalize plain strings, legacy (text, images) tuples, and
+                    # structured turns carrying input-origin metadata.
+                    user_input, submit_images, input_origin = _normalize_cli_queued_input(
+                        user_input
+                    )
 
                     if isinstance(user_input, str):
                         user_input = _strip_leaked_bracketed_paste_wrappers(user_input)
@@ -15277,7 +15347,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            input_origin=input_origin,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/cli.py
+++ b/cli.py
@@ -7033,10 +7033,12 @@ class HermesCLI:
 
             if result.get("success") and result.get("transcript", "").strip():
                 transcript = result["transcript"].strip()
-                self._attached_images.clear()
+                attached_images = getattr(self, '_attached_images', None)
+                if attached_images is not None:
+                    attached_images.clear()
                 if hasattr(self, '_app') and self._app:
                     self._app.invalidate()
-                self._pending_input.put(transcript)
+                self._pending_input.put((transcript, [], "voice"))
                 submitted = True
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -7158,6 +7160,19 @@ class HermesCLI:
         else:
             _cprint(f"Unknown voice subcommand: {subcommand}")
             _cprint("Usage: /voice [on|off|tts|status]")
+
+    def _get_voice_message_reply_mode(self) -> str:
+        """Return normalized CLI voice reply mode from config."""
+        try:
+            from hermes_cli.config import load_config
+
+            voice_config = load_config().get("voice", {})
+            reply_mode = str(voice_config.get("message_reply_mode", "all")).strip().lower()
+            if reply_mode in ("voice_only", "all"):
+                return reply_mode
+        except Exception:
+            pass
+        return "all"
 
     def _enable_voice_mode(self):
         """Enable voice mode after checking requirements."""
@@ -7688,7 +7703,15 @@ class HermesCLI:
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def _clear_current_input(self) -> None:
+        if getattr(self, "_app", None):
+            try:
+                self._app.current_buffer.text = ""
+            except Exception:
+                pass
+
+
+    def chat(self, message, images: list = None, input_origin: str = "text") -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -7703,6 +7726,7 @@ class HermesCLI:
         Args:
             message: The user's message (str or multimodal content list)
             images: Optional list of Path objects for attached images
+            input_origin: Where the turn came from ("text" or "voice")
             
         Returns:
             The agent's response, or None on error
@@ -7795,7 +7819,12 @@ class HermesCLI:
             stream_callback = None
             stop_event = None
 
-            if self._voice_tts:
+            voice_reply_mode = self._get_voice_message_reply_mode()
+            should_speak_response = self._voice_tts and (
+                input_origin == "voice" or voice_reply_mode == "all"
+            )
+
+            if should_speak_response:
                 try:
                     from tools.tts_tool import (
                         _load_tts_config as _load_tts_cfg,
@@ -7846,7 +7875,7 @@ class HermesCLI:
             # model responds concisely. The prefix is API-call-local only —
             # run_conversation persists the original clean user message.
             _voice_prefix = ""
-            if self._voice_mode and isinstance(message, str):
+            if self._voice_mode and input_origin == "voice" and isinstance(message, str):
                 _voice_prefix = (
                     "[Voice input — respond concisely and conversationally, "
                     "2-3 sentences max. No code blocks or markdown.] "
@@ -8106,9 +8135,9 @@ class HermesCLI:
                         f"response may be incomplete{_RST}"
                     )
 
-            # Speak response aloud if voice TTS is enabled
-            # Skip batch TTS when streaming TTS already handled it
-            if self._voice_tts and response and not use_streaming_tts:
+            # Speak response aloud only when this turn qualifies for voice output.
+            # Skip batch TTS when streaming TTS already handled it.
+            if should_speak_response and response and not use_streaming_tts:
                 threading.Thread(
                     target=self._voice_speak_response,
                     args=(response,),
@@ -9819,10 +9848,16 @@ class HermesCLI:
                     if not user_input:
                         continue
 
-                    # Unpack image payload: (text, [Path, ...]) or plain str
+                    # Unpack queued payload: plain str, (text, [Path, ...]), or
+                    # (text, [Path, ...], input_origin) where input_origin is
+                    # "text" or "voice".
                     submit_images = []
+                    input_origin = "text"
                     if isinstance(user_input, tuple):
-                        user_input, submit_images = user_input
+                        if len(user_input) == 3:
+                            user_input, submit_images, input_origin = user_input
+                        else:
+                            user_input, submit_images = user_input
                     
                     # Check for commands — but detect dragged/pasted file paths first.
                     # See _detect_file_drop() for details.
@@ -9905,7 +9940,11 @@ class HermesCLI:
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            input_origin=input_origin,
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2152,6 +2152,7 @@ DEFAULT_CONFIG = {
         "max_recording_seconds": 120,
         "auto_tts": False,
         "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
+        "message_reply_mode": "all",
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
     },

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -620,6 +620,7 @@ DEFAULT_CONFIG = {
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,
+        "message_reply_mode": "all",
         "silence_threshold": 200,     # RMS below this = silence (0-32767)
         "silence_duration": 3.0,      # Seconds of silence before auto-stop
     },

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -325,6 +325,95 @@ class TestSingleQueryState:
         assert hasattr(cli, "_interrupt_queue")
         assert hasattr(cli, "_pending_input")
 
+    def test_voice_reply_policy_covers_text_voice_and_tts_disabled(self):
+        from cli import _CLIInputOrigin
+
+        cli = _make_cli()
+        cli._voice_tts = True
+        cli._get_voice_message_reply_mode = lambda: "voice_only"
+        assert cli._should_speak_voice_response(_CLIInputOrigin.TEXT) is False
+        assert cli._should_speak_voice_response(_CLIInputOrigin.VOICE) is True
+
+        cli._get_voice_message_reply_mode = lambda: "all"
+        assert cli._should_speak_voice_response(_CLIInputOrigin.TEXT) is True
+
+        cli._voice_tts = False
+        assert cli._should_speak_voice_response(_CLIInputOrigin.VOICE) is False
+
+    def test_invalid_voice_reply_mode_falls_back_to_all(self):
+        cli = _make_cli()
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"message_reply_mode": "invalid"}},
+        ):
+            assert cli._get_voice_message_reply_mode() == "all"
+
+    @staticmethod
+    def _make_voice_routing_cli():
+        cli = _make_cli()
+        captured = {}
+
+        def fake_run_conversation(**kwargs):
+            captured.update(kwargs)
+            return {
+                "final_response": "Spoken reply",
+                "messages": [{"role": "assistant", "content": "Spoken reply"}],
+                "completed": True,
+            }
+
+        cli._voice_tts = True
+        cli._voice_mode = True
+        cli._get_voice_message_reply_mode = lambda: "voice_only"
+        cli._ensure_runtime_credentials = lambda: True
+        cli._resolve_turn_agent_config = lambda message: {
+            "signature": "sig",
+            "model": None,
+            "runtime": None,
+            "label": "test",
+        }
+        cli._active_agent_route_signature = "sig"
+        cli._reset_stream_state = lambda: None
+        cli._flush_stream = lambda: None
+        cli._invalidate = lambda *args, **kwargs: None
+        cli._voice_speak_response_async = MagicMock()
+        cli.agent = SimpleNamespace(
+            run_conversation=fake_run_conversation,
+            interrupt=lambda _msg=None: None,
+            _active_children=[],
+            _interrupt_requested=False,
+        )
+
+        return cli, captured
+
+    def test_voice_origin_gets_voice_prompt_and_spoken_reply(self):
+        cli, captured = self._make_voice_routing_cli()
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai"}), patch(
+            "tools.tts_tool._get_provider", return_value="openai"
+        ):
+            response = cli.chat("Hello there", input_origin="voice")
+
+        assert response == "Spoken reply"
+        assert captured["user_message"].startswith("[Voice input — respond concisely")
+        assert captured["persist_user_message"] == "Hello there"
+        cli._voice_speak_response_async.assert_called_once_with("Spoken reply")
+
+    def test_typed_origin_stays_plain_and_silent_in_voice_only_mode(self):
+        cli, captured = self._make_voice_routing_cli()
+
+        with patch("tools.tts_tool._load_tts_config") as load_tts_config, patch(
+            "tools.tts_tool._get_provider"
+        ) as get_tts_provider:
+            response = cli.chat("Hello there", input_origin="text")
+
+        assert response == "Spoken reply"
+        assert captured["user_message"] == "Hello there"
+        assert captured["persist_user_message"] is None
+        load_tts_config.assert_not_called()
+        get_tts_provider.assert_not_called()
+        cli._voice_speak_response_async.assert_not_called()
+
 
 class TestHistoryDisplay:
     def test_history_numbers_only_visible_messages_and_summarizes_tools(self, capsys):

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -3,6 +3,7 @@ that only manifest at runtime (not in mocked unit tests)."""
 
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -158,6 +159,48 @@ class TestSingleQueryState:
         assert cli._voice_tts_done.is_set()
         assert hasattr(cli, "_interrupt_queue")
         assert hasattr(cli, "_pending_input")
+
+    def test_chat_accepts_voice_input_origin_without_name_error(self):
+        cli = _make_cli()
+        captured = {}
+
+        def fake_run_conversation(**kwargs):
+            captured.update(kwargs)
+            return {
+                "final_response": "",
+                "messages": [{"role": "user", "content": kwargs["persist_user_message"]}],
+                "completed": True,
+            }
+
+        cli._voice_tts = True
+        cli._voice_mode = True
+        cli._get_voice_message_reply_mode = lambda: "voice_only"
+        cli._ensure_runtime_credentials = lambda: True
+        cli._resolve_turn_agent_config = lambda message: {
+            "signature": "sig",
+            "model": None,
+            "runtime": None,
+            "label": "test",
+        }
+        cli._active_agent_route_signature = "sig"
+        cli._reset_stream_state = lambda: None
+        cli._flush_stream = lambda: None
+        cli._invalidate = lambda *args, **kwargs: None
+        cli.agent = SimpleNamespace(
+            run_conversation=fake_run_conversation,
+            interrupt=lambda _msg=None: None,
+            _active_children=[],
+            _interrupt_requested=False,
+        )
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai"}), patch(
+            "tools.tts_tool._get_provider", return_value="openai"
+        ):
+            response = cli.chat("Hello there", input_origin="voice")
+
+        assert response == ""
+        assert captured["user_message"].startswith("[Voice input — respond concisely")
+        assert captured["persist_user_message"] == "Hello there"
 
 
 class TestHistoryDisplay:

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -1079,7 +1079,11 @@ class TestVoiceSubmission:
                         cli._voice_stop_and_transcribe()
 
         assert cli._attached_images == []
-        assert cli._pending_input.get_nowait() == "hello"
+        from cli import _CLIInputOrigin, _CLIQueuedInput
+
+        assert cli._pending_input.get_nowait() == _CLIQueuedInput(
+            "hello", origin=_CLIInputOrigin.VOICE
+        )
 
 
 # ═════════════════════════════════════════════════════════════════════════
@@ -1087,29 +1091,41 @@ class TestVoiceSubmission:
 # ═════════════════════════════════════════════════════════════════════════
 
 class TestQueueRouting:
-    """Test that (text, images) tuples are correctly unpacked and routed."""
+    """Test production normalization of structured and legacy queue payloads."""
 
     def test_plain_string_stays_string(self):
         """Regular text input has no images."""
-        user_input = "hello world"
-        submit_images = []
-        if isinstance(user_input, tuple):
-            user_input, submit_images = user_input
+        from cli import _CLIInputOrigin, _normalize_cli_queued_input
+
+        user_input, submit_images, origin = _normalize_cli_queued_input("hello world")
         assert user_input == "hello world"
         assert submit_images == []
+        assert origin == _CLIInputOrigin.TEXT
 
     def test_tuple_unpacks_text_and_images(self, tmp_path):
         """(text, images) tuple is correctly split."""
         img = tmp_path / "test.png"
         img.write_bytes(FAKE_PNG)
-        user_input = ("describe this", [img])
+        from cli import _CLIInputOrigin, _normalize_cli_queued_input
 
-        submit_images = []
-        if isinstance(user_input, tuple):
-            user_input, submit_images = user_input
+        user_input, submit_images, origin = _normalize_cli_queued_input(
+            ("describe this", [img])
+        )
         assert user_input == "describe this"
         assert len(submit_images) == 1
         assert submit_images[0] == img
+        assert origin == _CLIInputOrigin.TEXT
+
+    def test_structured_voice_input_preserves_origin(self):
+        from cli import _CLIInputOrigin, _CLIQueuedInput, _normalize_cli_queued_input
+
+        user_input, submit_images, origin = _normalize_cli_queued_input(
+            _CLIQueuedInput("hello", origin=_CLIInputOrigin.VOICE)
+        )
+
+        assert user_input == "hello"
+        assert submit_images == []
+        assert origin == _CLIInputOrigin.VOICE
 
     def test_empty_text_with_images(self, tmp_path):
         """Images without text — text should be empty string."""

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -303,14 +303,14 @@ class TestVoiceMessagePrefix:
     """Voice mode should inject instruction via user message prefix,
     not by modifying the system prompt (which breaks prompt cache)."""
 
-    def test_prefix_added_when_voice_mode_active(self):
-        """When voice mode is active and message is str, agent_message
-        should have the voice instruction prefix."""
+    def test_prefix_added_only_for_voice_origin(self):
+        """Only STT-originated prompts should get the voice instruction prefix."""
         voice_mode = True
+        input_origin = "voice"
         message = "What's the weather like?"
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -320,13 +320,30 @@ class TestVoiceMessagePrefix:
         assert agent_message.startswith("[Voice input")
         assert "What's the weather like?" in agent_message
 
-    def test_no_prefix_when_voice_mode_inactive(self):
-        """When voice mode is off, message passes through unchanged."""
-        voice_mode = False
+    def test_no_prefix_for_typed_input_while_voice_mode_active(self):
+        """Typed prompts should remain plain text even when voice mode is on."""
+        voice_mode = True
+        input_origin = "text"
         message = "What's the weather like?"
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
+            agent_message = (
+                "[Voice input — respond concisely and conversationally, "
+                "2-3 sentences max. No code blocks or markdown.] "
+                + message
+            )
+
+        assert agent_message == message
+
+    def test_no_prefix_when_voice_mode_inactive(self):
+        """When voice mode is off, message passes through unchanged."""
+        voice_mode = False
+        input_origin = "voice"
+        message = "What's the weather like?"
+
+        agent_message = message
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -338,10 +355,11 @@ class TestVoiceMessagePrefix:
     def test_no_prefix_for_multimodal_content(self):
         """When message is a list (multimodal), no prefix is added."""
         voice_mode = True
+        input_origin = "voice"
         message = [{"type": "text", "text": "describe this"}, {"type": "image_url"}]
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -354,13 +372,14 @@ class TestVoiceMessagePrefix:
         """conversation_history should contain the original message,
         not the prefixed version."""
         voice_mode = True
+        input_origin = "voice"
         message = "Hello there"
         conversation_history = []
 
         conversation_history.append({"role": "user", "content": message})
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -1101,7 +1120,7 @@ class TestVoiceStopAndTranscribeReal:
         recorder.stop.return_value = "/tmp/test.wav"
         cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
         cli._voice_stop_and_transcribe()
-        assert cli._pending_input.get_nowait() == "hello world"
+        assert cli._pending_input.get_nowait() == ("hello world", [], "voice")
 
     @patch("cli._cprint")
     @patch("cli.os.unlink")

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -302,14 +302,14 @@ class TestVoiceMessagePrefix:
     """Voice mode should inject instruction via user message prefix,
     not by modifying the system prompt (which breaks prompt cache)."""
 
-    def test_prefix_added_when_voice_mode_active(self):
-        """When voice mode is active and message is str, agent_message
-        should have the voice instruction prefix."""
+    def test_prefix_added_only_for_voice_origin(self):
+        """Only STT-originated prompts should get the voice instruction prefix."""
         voice_mode = True
+        input_origin = "voice"
         message = "What's the weather like?"
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -319,13 +319,30 @@ class TestVoiceMessagePrefix:
         assert agent_message.startswith("[Voice input")
         assert "What's the weather like?" in agent_message
 
-    def test_no_prefix_when_voice_mode_inactive(self):
-        """When voice mode is off, message passes through unchanged."""
-        voice_mode = False
+    def test_no_prefix_for_typed_input_while_voice_mode_active(self):
+        """Typed prompts should remain plain text even when voice mode is on."""
+        voice_mode = True
+        input_origin = "text"
         message = "What's the weather like?"
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
+            agent_message = (
+                "[Voice input — respond concisely and conversationally, "
+                "2-3 sentences max. No code blocks or markdown.] "
+                + message
+            )
+
+        assert agent_message == message
+
+    def test_no_prefix_when_voice_mode_inactive(self):
+        """When voice mode is off, message passes through unchanged."""
+        voice_mode = False
+        input_origin = "voice"
+        message = "What's the weather like?"
+
+        agent_message = message
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -337,10 +354,11 @@ class TestVoiceMessagePrefix:
     def test_no_prefix_for_multimodal_content(self):
         """When message is a list (multimodal), no prefix is added."""
         voice_mode = True
+        input_origin = "voice"
         message = [{"type": "text", "text": "describe this"}, {"type": "image_url"}]
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -353,13 +371,14 @@ class TestVoiceMessagePrefix:
         """conversation_history should contain the original message,
         not the prefixed version."""
         voice_mode = True
+        input_origin = "voice"
         message = "Hello there"
         conversation_history = []
 
         conversation_history.append({"role": "user", "content": message})
 
         agent_message = message
-        if voice_mode and isinstance(message, str):
+        if voice_mode and input_origin == "voice" and isinstance(message, str):
             agent_message = (
                 "[Voice input — respond concisely and conversationally, "
                 "2-3 sentences max. No code blocks or markdown.] "
@@ -1184,7 +1203,11 @@ class TestVoiceStopAndTranscribeReal:
         recorder.stop.return_value = "/tmp/test.wav"
         cli = _make_voice_cli(_voice_recording=True, _voice_recorder=recorder)
         cli._voice_stop_and_transcribe()
-        assert cli._pending_input.get_nowait() == "hello world"
+        from cli import _CLIInputOrigin, _CLIQueuedInput
+
+        assert cli._pending_input.get_nowait() == _CLIQueuedInput(
+            "hello world", origin=_CLIInputOrigin.VOICE
+        )
 
     @patch("cli._cprint")
     @patch("cli.os.unlink")

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1576,11 +1576,12 @@ voice:
   max_recording_seconds: 120    # Hard stop for long recordings
   auto_tts: false               # Enable spoken replies automatically when /voice on
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
+  message_reply_mode: "all"     # "all" speaks typed + voice turns; "voice_only" speaks voice turns only
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
 ```
 
-Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. With `message_reply_mode: "voice_only"`, typed turns remain text-only while replies to microphone input are spoken; the default `"all"` preserves spoken replies for both input types. See [Voice Mode](/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
 
 ## Streaming
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -142,6 +142,12 @@ Then use these commands inside the CLI:
 
 This loop continues until you press **Ctrl+B** during recording (exits continuous mode) or 3 consecutive recordings detect no speech.
 
+By default, enabling TTS speaks replies to both microphone and typed input. Set
+`voice.message_reply_mode: "voice_only"` in `~/.hermes/config.yaml` to keep
+typed turns text-only while still speaking replies to microphone input. Accepted
+values are `"all"` (the default) and `"voice_only"`; the setting has no effect
+while TTS is disabled.
+
 :::tip
 The record key is configurable via `voice.record_key` in `~/.hermes/config.yaml` (default: `ctrl+b`).
 :::


### PR DESCRIPTION
## Bug Description

The classic CLI voice path did not distinguish typed turns from STT-originated turns while voice mode was enabled. Typed prompts could therefore inherit the concise voice-only prompt and spoken-output behavior, and the old routing attempt lacked a complete input-origin path.

## Related Issue

Fixes #65827

## Current-Main Validation

The bug remains present on current upstream `main` (`7b5ba2054721dde998ed47fd4a0f031955278e99`):

- `_voice_stop_and_transcribe()` queues STT output as an unmarked string.
- The CLI process loop understands only strings and legacy `(text, images)` tuples.
- `chat()` gates its voice prefix and both streaming/batch TTS only on global voice/TTS state.

Newer gateway message-type routing and provider-level streaming TTS do not carry origin metadata into the classic CLI, so they do not supersede this fix.

## Fix

- Add a typed `_CLIQueuedInput` payload and `_CLIInputOrigin` enum.
- Normalize structured turns and legacy string/`(text, images)` queue payloads at one process-loop boundary.
- Mark successful STT transcripts as voice-originated.
- Thread the normalized origin into `chat()`.
- Centralize spoken-output policy so both streaming and batch TTS obey `voice.message_reply_mode`.
- Apply the concise voice prompt only to actual voice-origin turns while preserving the clean transcript through `persist_user_message`.
- Preserve current-main `_voice_speak_response_async()` completion signaling, beep configuration, transcription-failure recording retention, terminal-input recovery, and legacy image queue handling.

## Teknium1 Feedback Addressed

- Updated `tests/tools/test_clipboard.py` for the structured STT queue payload.
- Added production-path assertions proving `voice_only` microphone turns are spoken and typed turns remain unprefixed, do not initialize streaming TTS, and do not invoke batch TTS.
- Added queue-normalization and reply-policy coverage.
- Documented `voice.message_reply_mode`, accepted values (`all`, `voice_only`), default behavior, CLI scope, and TTS-disabled behavior in both CLI configuration and voice-mode documentation.
- Removed the unrelated dead `_clear_current_input` helper from the old patch.

## Test Plan

- [x] Current-main negative control confirms the new routing tests fail before the patch.
- [x] `250 passed` across `tests/cli/test_cli_init.py`, `tests/tools/test_voice_cli_integration.py`, and `tests/tools/test_clipboard.py`.
- [x] `117 passed` across `tests/tools/test_voice_mode.py` and `tests/hermes_cli/test_voice_wrapper.py`.
- [x] Ruff passed on all changed Python files.
- [x] Python compile checks passed.
- [x] `git diff --check` passed.
- [x] Rebased onto current upstream `main`; conflicts resolved semantically.

A repository-wide test run was also attempted. The full suite has unrelated baseline/environment failures and did not complete within ten minutes; no failure implicated these changed paths.

## Risk Assessment

Low-to-moderate and localized to classic CLI queue normalization and voice-output policy. Legacy string and `(text, images)` payloads remain supported, the default `message_reply_mode: all` preserves existing spoken-output behavior, and newer async TTS completion handling remains intact.