### PR TITLE
feat(agent): add post-response hook extension point for pluggable response quality enforcement

### DIFF
--- a/agent/post_response_hooks.py
+++ b/agent/post_response_hooks.py
@@ -1,0 +1,206 @@
+"""
+Post-Response Hook Extension Point
+===================================
+
+Lightweight hook system that lets users drop ``.py`` files into
+``~/.hermes/hooks/`` to inspect (and optionally nudge) the agent's final
+text response.  Each hook can:
+
+  (a) inject a system prompt addition (pre-response guidance), and
+  (b) run a ``check(response, context)`` gate that triggers a
+      re-generation when it returns ``False``.
+
+Security
+--------
+Hooks are **user-installed code** that runs with the same privileges as
+the Hermes process.  This is the same trust model as the existing plugin
+system (``~/.hermes/plugins/``) and skills (``~/.hermes/skills/``).
+Only the machine owner can write to ``~/.hermes/hooks/``; hooks are
+never auto-downloaded or auto-enabled.  The loader additionally verifies
+that hook files are **not world-writable** (Unix) before importing them.
+
+Context dict passed to ``check()``
+-----------------------------------
+``context`` is a dict with the following keys:
+
+- ``user_message`` (str): The original user message for this turn.
+- ``messages`` (list[dict]): Full conversation history up to this point.
+- ``model`` (str): The model identifier currently in use.
+
+See issue #11719 for the full design rationale.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import platform
+import stat
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_IS_WINDOWS = platform.system() == "Windows"
+
+# Default maximum nudge attempts per response (configurable per-hook).
+DEFAULT_MAX_NUDGES = 1
+
+
+def _is_world_writable(path: Path) -> bool:
+    """Return True if *path* is world-writable (Unix only)."""
+    if _IS_WINDOWS:
+        return False
+    try:
+        return bool(path.stat().st_mode & stat.S_IWOTH)
+    except OSError:
+        return False
+
+
+@dataclass
+class Hook:
+    """A single post-response hook loaded from ``~/.hermes/hooks/<name>.py``."""
+
+    module_name: str
+    system_prompt_addition: str = ""
+    nudge_message: str = ""
+    max_nudges: int = DEFAULT_MAX_NUDGES
+    _check_fn: Optional[Any] = field(default=None, repr=False)
+
+    def check(self, response: str, context: Dict[str, Any]) -> bool:
+        """Return ``True`` if the response passes, ``False`` to trigger nudge.
+
+        If the check function raises an exception, it is logged and
+        treated as a pass (``True``) so a broken hook never crashes the
+        agent loop.
+        """
+        if self._check_fn is None:
+            return True
+        try:
+            return bool(self._check_fn(response, context))
+        except Exception as exc:
+            logger.warning(
+                "Hook '%s' check() raised %s: %s — treating as pass",
+                self.module_name, type(exc).__name__, exc,
+            )
+            return True
+
+
+def load_hooks(configs: List[Dict[str, Any]]) -> List[Hook]:
+    """Load hooks from ``~/.hermes/hooks/`` based on *configs*.
+
+    Each entry in *configs* is a dict like::
+
+        {"module": "bottom_logic_check", "enabled": true, "max_nudges": 2}
+
+    The corresponding file is ``~/.hermes/hooks/bottom_logic_check.py``.
+    The module must expose a ``Hook`` class with the interface described
+    in this module's docstring.
+
+    Security: hook files that are world-writable (Unix) are refused to
+    prevent privilege escalation via shared-machine scenarios.
+    """
+    if not configs:
+        return []
+
+    hooks_dir = get_hermes_home() / "hooks"
+    loaded: List[Hook] = []
+
+    for cfg in configs:
+        if not isinstance(cfg, dict):
+            continue
+        name = cfg.get("module", "")
+        if not name:
+            continue
+        if not cfg.get("enabled", True):
+            logger.debug("Hook '%s' is disabled — skipping", name)
+            continue
+
+        hook_file = hooks_dir / f"{name}.py"
+        if not hook_file.is_file():
+            logger.warning(
+                "Hook module '%s' not found at %s — skipping", name, hook_file,
+            )
+            continue
+
+        if _is_world_writable(hook_file):
+            logger.warning(
+                "Hook '%s' is world-writable (%s) — refusing to load for "
+                "security. Run: chmod o-w %s", name, hook_file, hook_file,
+            )
+            continue
+
+        try:
+            spec = importlib.util.spec_from_file_location(
+                f"hermes_hooks.{name}", str(hook_file),
+            )
+            if spec is None or spec.loader is None:
+                logger.warning("Could not create module spec for hook '%s'", name)
+                continue
+
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+
+            hook_cls = getattr(mod, "Hook", None)
+            if hook_cls is None:
+                logger.warning(
+                    "Hook module '%s' has no Hook class — skipping", name,
+                )
+                continue
+
+            instance = hook_cls()
+
+            _max_nudges = cfg.get("max_nudges", DEFAULT_MAX_NUDGES)
+            try:
+                _max_nudges = max(1, int(_max_nudges))
+            except (TypeError, ValueError):
+                _max_nudges = DEFAULT_MAX_NUDGES
+
+            hook = Hook(
+                module_name=getattr(instance, "module_name", name),
+                system_prompt_addition=getattr(instance, "system_prompt_addition", "") or "",
+                nudge_message=getattr(instance, "nudge_message", "") or "",
+                max_nudges=_max_nudges,
+                _check_fn=getattr(instance, "check", None),
+            )
+            loaded.append(hook)
+            logger.info("Loaded post-response hook: %s (max_nudges=%d)", name, _max_nudges)
+        except Exception as exc:
+            logger.warning(
+                "Failed to load hook '%s': %s — skipping", name, exc,
+            )
+
+    return loaded
+
+
+def build_system_prompt_additions(hooks: List[Hook]) -> str:
+    """Aggregate ``system_prompt_addition`` from all loaded hooks."""
+    parts = [h.system_prompt_addition for h in hooks if h.system_prompt_addition]
+    return "\n\n".join(parts)
+
+
+def run_post_response_checks(
+    hooks: List[Hook],
+    response: str,
+    context: Dict[str, Any],
+) -> Optional[str]:
+    """Run each hook's ``check()``; return the first nudge message or ``None``.
+
+    Hook ordering follows the config list order.  The first failing hook
+    wins — its ``nudge_message`` is returned so the agent loop can inject
+    it as a system-level re-generation prompt.
+    """
+    for hook in hooks:
+        if not hook.check(response, context):
+            logger.info(
+                "Post-response hook '%s' failed — nudging", hook.module_name,
+            )
+            return hook.nudge_message or (
+                f"Your response did not pass the '{hook.module_name}' quality check. "
+                "Please revise and provide a more thorough response."
+            )
+    return None

--- a/agent/post_response_hooks.py
+++ b/agent/post_response_hooks.py
@@ -3,12 +3,23 @@ Post-Response Hook Extension Point
 ===================================
 
 Lightweight hook system that lets users drop ``.py`` files into
-``~/.hermes/hooks/`` to inspect (and optionally nudge) the agent's final
-text response.  Each hook can:
+``~/.hermes/hooks/`` to inspect (and optionally transform or nudge) the
+agent's final text response.  Each hook can:
 
-  (a) inject a system prompt addition (pre-response guidance), and
-  (b) run a ``check(response, context)`` gate that triggers a
-      re-generation when it returns ``False``.
+  (a) inject a system prompt addition (pre-response guidance),
+  (b) run a ``check(response, context)`` gate that returns a
+      ``HookResult`` with one of three actions:
+
+      * ``"pass"``  — response is good, deliver as-is.
+      * ``"nudge"`` — response needs improvement; discard and re-generate
+        with a hint (respects ``max_nudges`` limit per hook).
+      * ``"block"`` — replace the response entirely with ``data["message"]``
+        without re-generation (PII redaction, content safety, format
+        enforcement).
+
+The ``check()`` function may return either a ``HookResult`` for full
+control, or a plain ``bool`` for backward compatibility (``False`` is
+treated as ``action="nudge"`` with the hook's ``nudge_message``).
 
 Security
 --------
@@ -39,7 +50,7 @@ import platform
 import stat
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from hermes_constants import get_hermes_home
 
@@ -62,6 +73,27 @@ def _is_world_writable(path: Path) -> bool:
 
 
 @dataclass
+class HookResult:
+    """Result returned by a hook's ``check()`` method.
+
+    Attributes:
+        passed: ``True`` if the response accepted, ``False`` if action needed.
+        action: ``"pass"`` (deliver), ``"nudge"`` (re-generate), or
+                ``"block"`` (replace response with ``data["message"]``).
+        data: Structured metadata dict — ``message``, ``severity``,
+              ``checklist_remaining``, ``hook_name``, etc.
+    """
+
+    passed: bool
+    action: str = ""
+    data: Optional[Dict[str, Any]] = None
+
+    def __post_init__(self):
+        if self.data is None:
+            self.data = {}
+
+
+@dataclass
 class Hook:
     """A single post-response hook loaded from ``~/.hermes/hooks/<name>.py``."""
 
@@ -71,23 +103,52 @@ class Hook:
     max_nudges: int = DEFAULT_MAX_NUDGES
     _check_fn: Optional[Any] = field(default=None, repr=False)
 
-    def check(self, response: str, context: Dict[str, Any]) -> bool:
-        """Return ``True`` if the response passes, ``False`` to trigger nudge.
+    def check(self, response: str, context: Dict[str, Any]) -> HookResult:
+        """Return a ``HookResult`` indicating pass / nudge / block.
+
+        Supports both new-style hooks returning ``HookResult`` and legacy
+        hooks returning a plain ``bool`` (``False`` → ``action="nudge"``,
+        ``True`` → ``action="pass"``).
 
         If the check function raises an exception, it is logged and
-        treated as a pass (``True``) so a broken hook never crashes the
-        agent loop.
+        treated as a pass so a broken hook never crashes the agent loop.
         """
         if self._check_fn is None:
-            return True
+            return HookResult(passed=True, action="pass")
+
         try:
-            return bool(self._check_fn(response, context))
+            raw = self._check_fn(response, context)
+
+            # Backward compat: bool → HookResult
+            if isinstance(raw, bool):
+                return HookResult(
+                    passed=raw,
+                    action="pass" if raw else "nudge",
+                    data={"message": self.nudge_message} if not raw else {},
+                )
+
+            # New-style: HookResult
+            if isinstance(raw, HookResult):
+                # Default action: nudge when passed=False, pass when passed=True
+                if not raw.action:
+                    raw.action = "nudge" if not raw.passed else "pass"
+                # Carry hook name in data for logging
+                raw.data["hook_name"] = self.module_name
+                return raw
+
+            # Unknown type — log and pass
+            logger.warning(
+                "Hook '%s' check() returned unexpected type %s — treating as pass",
+                self.module_name, type(raw).__name__,
+            )
+            return HookResult(passed=True, action="pass")
+
         except Exception as exc:
             logger.warning(
                 "Hook '%s' check() raised %s: %s — treating as pass",
                 self.module_name, type(exc).__name__, exc,
             )
-            return True
+            return HookResult(passed=True, action="pass")
 
 
 def load_hooks(configs: List[Dict[str, Any]]) -> List[Hook]:
@@ -187,20 +248,29 @@ def run_post_response_checks(
     hooks: List[Hook],
     response: str,
     context: Dict[str, Any],
-) -> Optional[str]:
-    """Run each hook's ``check()``; return the first nudge message or ``None``.
+) -> Optional[HookResult]:
+    """Run each hook's ``check()``; return the first failing ``HookResult`` or ``None``.
 
-    Hook ordering follows the config list order.  The first failing hook
-    wins — its ``nudge_message`` is returned so the agent loop can inject
-    it as a system-level re-generation prompt.
+    Hook ordering follows the config list order.  The first hook whose
+    ``check()`` returns ``passed=False`` wins — its ``HookResult`` is
+    returned so the agent loop can apply the appropriate action (nudge
+    or block).
+
+    Returns:
+        ``HookResult`` for the first failing hook, or ``None`` if all pass.
     """
     for hook in hooks:
-        if not hook.check(response, context):
+        result = hook.check(response, context)
+        if not result.passed:
             logger.info(
-                "Post-response hook '%s' failed — nudging", hook.module_name,
+                "Post-response hook '%s' returned action=%s",
+                hook.module_name, result.action,
             )
-            return hook.nudge_message or (
-                f"Your response did not pass the '{hook.module_name}' quality check. "
-                "Please revise and provide a more thorough response."
-            )
+            # Ensure data has a fallback message
+            if not result.data.get("message"):
+                result.data["message"] = hook.nudge_message or (
+                    f"Your response did not pass the '{hook.module_name}' "
+                    "quality check. Please revise."
+                )
+            return result
     return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -1240,6 +1240,18 @@ class AIAgent:
         except Exception:
             pass
 
+        # Post-response hooks: lightweight response quality gates loaded
+        # from ~/.hermes/hooks/<module>.py.  Each hook can inject a system
+        # prompt addition and/or validate the final response.
+        self._post_response_hooks = []
+        _hooks_cfg = _agent_cfg.get("agent", {}).get("post_response_hooks", [])
+        if _hooks_cfg and isinstance(_hooks_cfg, list):
+            try:
+                from agent.post_response_hooks import load_hooks
+                self._post_response_hooks = load_hooks(_hooks_cfg)
+            except Exception as _hook_err:
+                logger.warning("Failed to load post-response hooks: %s", _hook_err)
+
         # Tool-use enforcement config: "auto" (default — matches hardcoded
         # model list), true (always), false (never), or list of substrings.
         _agent_section = _agent_cfg.get("agent", {})
@@ -3157,6 +3169,13 @@ class AIAgent:
             tool_guidance.append(SKILLS_GUIDANCE)
         if tool_guidance:
             prompt_parts.append(" ".join(tool_guidance))
+
+        # Post-response hook prompt additions (pre-response guidance)
+        if self._post_response_hooks:
+            from agent.post_response_hooks import build_system_prompt_additions
+            _hook_additions = build_system_prompt_additions(self._post_response_hooks)
+            if _hook_additions:
+                prompt_parts.append(_hook_additions)
 
         nous_subscription_prompt = build_nous_subscription_prompt(self.valid_tool_names)
         if nous_subscription_prompt:
@@ -7809,6 +7828,7 @@ class AIAgent:
         self._thinking_prefill_retries = 0
         self._last_content_with_tools = None
         self._mute_post_response = False
+        self._hook_nudge_retries = 0
         self._unicode_sanitization_passes = 0
 
         # Pre-turn connection health check: detect and clean up dead TCP
@@ -10373,7 +10393,36 @@ class AIAgent:
                     
                     # Strip <think> blocks from user-facing response (keep raw in messages for trajectory)
                     final_response = self._strip_think_blocks(final_response).strip()
-                    
+
+                    # Post-response hook check: run each hook's check() on
+                    # the final response.  If any hook fails, inject a nudge
+                    # message and re-enter the loop for re-generation.
+                    # max_nudges is configurable per-hook (default 1).
+                    if self._post_response_hooks and final_response:
+                        from agent.post_response_hooks import run_post_response_checks
+                        _hook_context = {
+                            "user_message": original_user_message,
+                            "messages": messages,
+                            "model": self.model,
+                        }
+                        _nudge_msg = run_post_response_checks(
+                            self._post_response_hooks, final_response, _hook_context,
+                        )
+                        _max = max(h.max_nudges for h in self._post_response_hooks)
+                        if _nudge_msg and self._hook_nudge_retries < _max:
+                            self._hook_nudge_retries += 1
+                            logger.info(
+                                "Post-response hook triggered nudge (%d/%d): %s",
+                                self._hook_nudge_retries, _max, _nudge_msg[:100],
+                            )
+                            self._emit_status(
+                                f"↻ Post-response hook triggered re-generation "
+                                f"({self._hook_nudge_retries}/{_max})"
+                            )
+                            messages.append({"role": "assistant", "content": final_response})
+                            messages.append({"role": "user", "content": f"[System: {_nudge_msg}]"})
+                            continue
+
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 
                     # Pop thinking-only prefill message(s) before appending

--- a/run_agent.py
+++ b/run_agent.py
@@ -10395,9 +10395,13 @@ class AIAgent:
                     final_response = self._strip_think_blocks(final_response).strip()
 
                     # Post-response hook check: run each hook's check() on
-                    # the final response.  If any hook fails, inject a nudge
-                    # message and re-enter the loop for re-generation.
-                    # max_nudges is configurable per-hook (default 1).
+                    # the final response.  Each hook returns a HookResult with:
+                    #   - "pass":  deliver normally
+                    #   - "nudge": discard and re-generate with hint (respects
+                    #              max_nudges, configurable per-hook)
+                    #   - "block": replace response with data["message"],
+                    #              no re-generation (PII redaction, safety, format)
+                    # Supports legacy bool-returning hooks (False → nudge).
                     if self._post_response_hooks and final_response:
                         from agent.post_response_hooks import run_post_response_checks
                         _hook_context = {
@@ -10405,23 +10409,49 @@ class AIAgent:
                             "messages": messages,
                             "model": self.model,
                         }
-                        _nudge_msg = run_post_response_checks(
+                        _hook_result = run_post_response_checks(
                             self._post_response_hooks, final_response, _hook_context,
                         )
-                        _max = max(h.max_nudges for h in self._post_response_hooks)
-                        if _nudge_msg and self._hook_nudge_retries < _max:
-                            self._hook_nudge_retries += 1
-                            logger.info(
-                                "Post-response hook triggered nudge (%d/%d): %s",
-                                self._hook_nudge_retries, _max, _nudge_msg[:100],
-                            )
-                            self._emit_status(
-                                f"↻ Post-response hook triggered re-generation "
-                                f"({self._hook_nudge_retries}/{_max})"
-                            )
-                            messages.append({"role": "assistant", "content": final_response})
-                            messages.append({"role": "user", "content": f"[System: {_nudge_msg}]"})
-                            continue
+                        if _hook_result is not None:
+                            _action = _hook_result.action
+                            _hook_data = _hook_result.data or {}
+                            _max = max(h.max_nudges for h in self._post_response_hooks)
+
+                            if _action == "block":
+                                # Replace response entirely — no re-generation.
+                                block_message = _hook_data.get("message") or "Response blocked by content filter."
+                                logger.info(
+                                    "Post-response hook '%s' blocked response",
+                                    _hook_data.get("hook_name", "unknown"),
+                                )
+                                self._emit_status("⊘ Response blocked by post-response hook")
+                                self._safe_print(f"⚠  Response was replaced by the '{_hook_data.get('hook_name', 'unknown')}' hook")
+                                final_response = block_message
+
+                            elif _action == "nudge" and self._hook_nudge_retries < _max:
+                                self._hook_nudge_retries += 1
+                                _nudge_msg = _hook_data.get("message") or (
+                                    f"Your response did not pass a quality check. Please revise."
+                                )
+                                logger.info(
+                                    "Post-response hook triggered nudge (%d/%d): %s",
+                                    self._hook_nudge_retries, _max, _nudge_msg[:100],
+                                )
+                                self._emit_status(
+                                    f"↻ Post-response hook triggered re-generation "
+                                    f"({self._hook_nudge_retries}/{_max})"
+                                )
+                                messages.append({"role": "assistant", "content": final_response})
+                                messages.append({"role": "user", "content": f"[System: {_nudge_msg}]"})
+                                continue
+
+                            elif _action == "nudge":
+                                # Nudge limit exhausted — deliver as-is with warning.
+                                logger.warning(
+                                    "Post-response hook nudge limit (%d) exhausted — delivering as-is",
+                                    _max,
+                                )
+                                self._emit_status("⚠ Nudge limit exhausted — delivering as-is")
 
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 

--- a/tests/run_agent/test_post_response_hooks.py
+++ b/tests/run_agent/test_post_response_hooks.py
@@ -1,0 +1,280 @@
+"""Tests for agent/post_response_hooks.py — post-response hook extension point.
+
+Covers hook loading, system prompt injection, response validation,
+security checks (world-writable refusal), max_nudges config, and
+context schema — without hitting the network (all I/O is mocked).
+"""
+
+import os
+import platform
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from agent.post_response_hooks import (
+    DEFAULT_MAX_NUDGES,
+    Hook,
+    build_system_prompt_additions,
+    load_hooks,
+    run_post_response_checks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hook dataclass unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHookCheck:
+    def test_check_passes_when_no_check_fn(self):
+        hook = Hook(module_name="noop")
+        assert hook.check("any response", {}) is True
+
+    def test_check_delegates_to_check_fn(self):
+        hook = Hook(module_name="gate", _check_fn=lambda r, c: "good" in r)
+        assert hook.check("this is good", {}) is True
+        assert hook.check("this is bad", {}) is False
+
+    def test_check_catches_exception_and_returns_true(self):
+        """Broken hook never crashes the agent — exception is swallowed."""
+        def _boom(r, c):
+            raise RuntimeError("boom")
+
+        hook = Hook(module_name="broken", _check_fn=_boom)
+        assert hook.check("anything", {}) is True
+
+    def test_check_catches_type_error(self):
+        """Hook returning non-bool-coercible value doesn't crash."""
+        def _bad_return(r, c):
+            raise TypeError("bad coercion")
+
+        hook = Hook(module_name="bad_type", _check_fn=_bad_return)
+        assert hook.check("anything", {}) is True
+
+
+# ---------------------------------------------------------------------------
+# load_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHooks:
+    def test_empty_config_returns_empty(self):
+        assert load_hooks([]) == []
+
+    def test_disabled_hook_is_skipped(self):
+        configs = [{"module": "my_hook", "enabled": False}]
+        assert load_hooks(configs) == []
+
+    def test_missing_module_file_is_skipped(self, tmp_path):
+        configs = [{"module": "nonexistent"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            (tmp_path / "hooks").mkdir()
+            result = load_hooks(configs)
+        assert result == []
+
+    def test_module_without_hook_class_is_skipped(self, tmp_path):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "empty_mod.py").write_text("x = 1\n")
+
+        configs = [{"module": "empty_mod"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+        assert result == []
+
+    def test_valid_hook_is_loaded(self, tmp_path):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "quality.py").write_text(
+            "class Hook:\n"
+            "    module_name = 'quality'\n"
+            "    system_prompt_addition = 'Be thorough.'\n"
+            "    nudge_message = 'Please elaborate.'\n"
+            "    def check(self, response, context):\n"
+            "        return len(response) > 10\n"
+        )
+
+        configs = [{"module": "quality"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert len(result) == 1
+        assert result[0].module_name == "quality"
+        assert result[0].system_prompt_addition == "Be thorough."
+        assert result[0].nudge_message == "Please elaborate."
+        assert result[0].max_nudges == DEFAULT_MAX_NUDGES
+        assert result[0].check("short", {}) is False
+        assert result[0].check("this is a long enough response", {}) is True
+
+    def test_invalid_config_entries_are_skipped(self):
+        configs = ["not_a_dict", {"no_module_key": True}, None]
+        assert load_hooks(configs) == []
+
+    def test_multiple_hooks_ordering(self, tmp_path):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        for name in ("alpha", "beta"):
+            (hooks_dir / f"{name}.py").write_text(
+                f"class Hook:\n"
+                f"    module_name = '{name}'\n"
+                f"    system_prompt_addition = ''\n"
+                f"    nudge_message = ''\n"
+            )
+
+        configs = [{"module": "alpha"}, {"module": "beta"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert len(result) == 2
+        assert result[0].module_name == "alpha"
+        assert result[1].module_name == "beta"
+
+    def test_max_nudges_from_config(self, tmp_path):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "retry_hook.py").write_text(
+            "class Hook:\n"
+            "    module_name = 'retry_hook'\n"
+        )
+
+        configs = [{"module": "retry_hook", "max_nudges": 3}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert len(result) == 1
+        assert result[0].max_nudges == 3
+
+    def test_max_nudges_invalid_value_uses_default(self, tmp_path):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "bad_cfg.py").write_text(
+            "class Hook:\n"
+            "    module_name = 'bad_cfg'\n"
+        )
+
+        configs = [{"module": "bad_cfg", "max_nudges": "not_a_number"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert len(result) == 1
+        assert result[0].max_nudges == DEFAULT_MAX_NUDGES
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Unix file permissions only")
+    def test_world_writable_hook_is_refused(self, tmp_path):
+        """Security: world-writable hook files are not loaded."""
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        hook_file = hooks_dir / "unsafe.py"
+        hook_file.write_text("class Hook:\n    module_name = 'unsafe'\n")
+        hook_file.chmod(hook_file.stat().st_mode | stat.S_IWOTH)
+
+        configs = [{"module": "unsafe"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert result == []
+
+    def test_hook_with_import_error_is_skipped(self, tmp_path):
+        """Hook that raises on import doesn't crash the loader."""
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "crasher.py").write_text("raise ImportError('missing dep')\n")
+
+        configs = [{"module": "crasher"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# build_system_prompt_additions
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSystemPromptAdditions:
+    def test_empty_hooks(self):
+        assert build_system_prompt_additions([]) == ""
+
+    def test_aggregates_additions(self):
+        hooks = [
+            Hook(module_name="a", system_prompt_addition="Rule A."),
+            Hook(module_name="b", system_prompt_addition=""),
+            Hook(module_name="c", system_prompt_addition="Rule C."),
+        ]
+        result = build_system_prompt_additions(hooks)
+        assert result == "Rule A.\n\nRule C."
+
+    def test_single_addition(self):
+        hooks = [Hook(module_name="solo", system_prompt_addition="Only rule.")]
+        assert build_system_prompt_additions(hooks) == "Only rule."
+
+
+# ---------------------------------------------------------------------------
+# run_post_response_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunPostResponseChecks:
+    def test_all_hooks_pass_returns_none(self):
+        hooks = [
+            Hook(module_name="a", _check_fn=lambda r, c: True),
+            Hook(module_name="b", _check_fn=lambda r, c: True),
+        ]
+        assert run_post_response_checks(hooks, "response", {}) is None
+
+    def test_first_failing_hook_wins(self):
+        hooks = [
+            Hook(module_name="pass", _check_fn=lambda r, c: True),
+            Hook(module_name="fail1", nudge_message="Fix from fail1", _check_fn=lambda r, c: False),
+            Hook(module_name="fail2", nudge_message="Fix from fail2", _check_fn=lambda r, c: False),
+        ]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result == "Fix from fail1"
+
+    def test_failing_hook_without_nudge_uses_default(self):
+        hooks = [
+            Hook(module_name="strict", nudge_message="", _check_fn=lambda r, c: False),
+        ]
+        result = run_post_response_checks(hooks, "response", {})
+        assert "strict" in result
+        assert "quality check" in result
+
+    def test_empty_hooks_returns_none(self):
+        assert run_post_response_checks([], "response", {}) is None
+
+    def test_context_contains_expected_keys(self):
+        """Context dict schema: user_message, messages, model."""
+        received = {}
+
+        def _capture(r, c):
+            received.update(c)
+            return True
+
+        hooks = [Hook(module_name="spy", _check_fn=_capture)]
+        ctx = {
+            "user_message": "hello",
+            "messages": [{"role": "user", "content": "hello"}],
+            "model": "test-model",
+        }
+        run_post_response_checks(hooks, "response", ctx)
+        assert received["user_message"] == "hello"
+        assert received["model"] == "test-model"
+        assert isinstance(received["messages"], list)
+
+    def test_hook_exception_does_not_block_others(self):
+        """Crashing hook is skipped (treated as pass), next hook still runs."""
+        def _boom(r, c):
+            raise ValueError("kaboom")
+
+        hooks = [
+            Hook(module_name="crasher", _check_fn=_boom),
+            Hook(module_name="checker", nudge_message="check failed", _check_fn=lambda r, c: False),
+        ]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result == "check failed"

--- a/tests/run_agent/test_post_response_hooks.py
+++ b/tests/run_agent/test_post_response_hooks.py
@@ -1,8 +1,10 @@
 """Tests for agent/post_response_hooks.py — post-response hook extension point.
 
-Covers hook loading, system prompt injection, response validation,
-security checks (world-writable refusal), max_nudges config, and
-context schema — without hitting the network (all I/O is mocked).
+Covers HookResult dataclass, hook loading, system prompt injection,
+response validation (pass/nudge/block actions), backward compat for
+bool-returning hooks, security checks (world-writable refusal),
+max_nudges config, and context schema — without hitting the network
+(all I/O is mocked).
 """
 
 import os
@@ -19,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 from agent.post_response_hooks import (
     DEFAULT_MAX_NUDGES,
     Hook,
+    HookResult,
     build_system_prompt_additions,
     load_hooks,
     run_post_response_checks,
@@ -26,27 +29,70 @@ from agent.post_response_hooks import (
 
 
 # ---------------------------------------------------------------------------
-# Hook dataclass unit tests
+# HookResult dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestHookResult:
+    def test_defaults(self):
+        r = HookResult(passed=True)
+        assert r.passed is True
+        assert r.action == ""
+        assert r.data == {}
+
+    def test_full_construction(self):
+        r = HookResult(
+            passed=False,
+            action="block",
+            data={"message": "Blocked: PII detected", "severity": "critical"},
+        )
+        assert r.passed is False
+        assert r.action == "block"
+        assert r.data["message"] == "Blocked: PII detected"
+        assert r.data["severity"] == "critical"
+
+    def test_data_defaults_to_empty_dict(self):
+        r = HookResult(passed=True)
+        assert r.data == {}
+        # Mutating data dict on one instance doesn't affect another
+        r2 = HookResult(passed=True)
+        r.data["key"] = "value"
+        assert r2.data == {}
+
+
+# ---------------------------------------------------------------------------
+# Hook.check() — HookResult and backward compat
 # ---------------------------------------------------------------------------
 
 
 class TestHookCheck:
-    def test_check_passes_when_no_check_fn(self):
+    def test_check_returns_hookresult_when_no_check_fn(self):
         hook = Hook(module_name="noop")
-        assert hook.check("any response", {}) is True
+        result = hook.check("any response", {})
+        assert isinstance(result, HookResult)
+        assert result.passed is True
+        assert result.action == "pass"
 
     def test_check_delegates_to_check_fn(self):
         hook = Hook(module_name="gate", _check_fn=lambda r, c: "good" in r)
-        assert hook.check("this is good", {}) is True
-        assert hook.check("this is bad", {}) is False
+        result_good = hook.check("this is good", {})
+        assert isinstance(result_good, HookResult)
+        assert result_good.passed is True
 
-    def test_check_catches_exception_and_returns_true(self):
+        result_bad = hook.check("this is bad", {})
+        assert isinstance(result_bad, HookResult)
+        assert result_bad.passed is False
+
+    def test_check_catches_exception_and_returns_pass(self):
         """Broken hook never crashes the agent — exception is swallowed."""
         def _boom(r, c):
             raise RuntimeError("boom")
 
         hook = Hook(module_name="broken", _check_fn=_boom)
-        assert hook.check("anything", {}) is True
+        result = hook.check("anything", {})
+        assert isinstance(result, HookResult)
+        assert result.passed is True
+        assert result.action == "pass"
 
     def test_check_catches_type_error(self):
         """Hook returning non-bool-coercible value doesn't crash."""
@@ -54,7 +100,106 @@ class TestHookCheck:
             raise TypeError("bad coercion")
 
         hook = Hook(module_name="bad_type", _check_fn=_bad_return)
-        assert hook.check("anything", {}) is True
+        result = hook.check("anything", {})
+        assert result.passed is True
+
+    # Backward compat: bool-returning hooks
+
+    def test_bool_true_becomes_pass(self):
+        hook = Hook(module_name="legacy_ok", _check_fn=lambda r, c: True)
+        result = hook.check("response", {})
+        assert isinstance(result, HookResult)
+        assert result.passed is True
+        assert result.action == "pass"
+
+    def test_bool_false_becomes_nudge_with_nudge_message(self):
+        hook = Hook(
+            module_name="legacy_fail",
+            nudge_message="Please elaborate.",
+            _check_fn=lambda r, c: False,
+        )
+        result = hook.check("response", {})
+        assert isinstance(result, HookResult)
+        assert result.passed is False
+        assert result.action == "nudge"
+        assert result.data["message"] == "Please elaborate."
+
+    def test_bool_false_without_nudge_message(self):
+        hook = Hook(module_name="no_msg", _check_fn=lambda r, c: False)
+        result = hook.check("response", {})
+        assert result.passed is False
+        assert result.action == "nudge"
+        assert result.data["message"] == ""
+
+    # New-style: HookResult-returning hooks
+
+    def test_hookresult_nudge(self):
+        def _check(r, c):
+            return HookResult(
+                passed=False,
+                action="nudge",
+                data={"message": "Too short, add detail."},
+            )
+
+        hook = Hook(module_name="nudger", _check_fn=_check)
+        result = hook.check("short", {})
+        assert result.passed is False
+        assert result.action == "nudge"
+        assert result.data["message"] == "Too short, add detail."
+        assert result.data["hook_name"] == "nudger"
+
+    def test_hookresult_block(self):
+        def _check(r, c):
+            return HookResult(
+                passed=False,
+                action="block",
+                data={"message": "PII redacted version", "severity": "critical"},
+            )
+
+        hook = Hook(module_name="blocker", _check_fn=_check)
+        result = hook.check("contains PII", {})
+        assert result.passed is False
+        assert result.action == "block"
+        assert result.data["message"] == "PII redacted version"
+        assert result.data["severity"] == "critical"
+        assert result.data["hook_name"] == "blocker"
+
+    def test_hookresult_pass(self):
+        def _check(r, c):
+            return HookResult(passed=True, action="pass")
+
+        hook = Hook(module_name="passer", _check_fn=_check)
+        result = hook.check("good", {})
+        assert result.passed is True
+        assert result.action == "pass"
+
+    def test_hookresult_no_action_defaults_to_nudge_when_failed(self):
+        """HookResult with passed=False and no action → defaults to nudge."""
+        def _check(r, c):
+            return HookResult(passed=False, data={"message": "fix me"})
+
+        hook = Hook(module_name="default_action", _check_fn=_check)
+        result = hook.check("bad", {})
+        assert result.action == "nudge"
+
+    def test_hookresult_no_action_defaults_to_pass_when_passed(self):
+        """HookResult with passed=True and no action → defaults to pass."""
+        def _check(r, c):
+            return HookResult(passed=True)
+
+        hook = Hook(module_name="default_pass", _check_fn=_check)
+        result = hook.check("good", {})
+        assert result.action == "pass"
+
+    def test_unknown_return_type_treated_as_pass(self):
+        """Hook returning non-bool, non-HookResult → logged and passed."""
+        def _weird(r, c):
+            return 42  # integer, not bool or HookResult
+
+        hook = Hook(module_name="weird", _check_fn=_weird)
+        result = hook.check("anything", {})
+        assert result.passed is True
+        assert result.action == "pass"
 
 
 # ---------------------------------------------------------------------------
@@ -108,8 +253,43 @@ class TestLoadHooks:
         assert result[0].system_prompt_addition == "Be thorough."
         assert result[0].nudge_message == "Please elaborate."
         assert result[0].max_nudges == DEFAULT_MAX_NUDGES
-        assert result[0].check("short", {}) is False
-        assert result[0].check("this is a long enough response", {}) is True
+        # Bool return still works via backward compat
+        check_result = result[0].check("short", {})
+        assert check_result.passed is False
+        check_result = result[0].check("this is a long enough response", {})
+        assert check_result.passed is True
+
+    def test_valid_hook_with_hookresult_return(self, tmp_path):
+        hooks_dir = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "advanced.py").write_text(
+            "from agent.post_response_hooks import HookResult\n"
+            "class Hook:\n"
+            "    module_name = 'advanced'\n"
+            "    def check(self, response, context):\n"
+            "        if 'PII' in response:\n"
+            "            return HookResult(passed=False, action='block', data={'message': '[redacted]'})\n"
+            "        if len(response) < 20:\n"
+            "            return HookResult(passed=False, action='nudge', data={'message': 'Too short'})\n"
+            "        return HookResult(passed=True, action='pass')\n"
+        )
+
+        configs = [{"module": "advanced"}]
+        with patch("agent.post_response_hooks.get_hermes_home", return_value=tmp_path):
+            result = load_hooks(configs)
+
+        assert len(result) == 1
+        hook = result[0]
+        # Block
+        r1 = hook.check("contains PII here", {})
+        assert r1.action == "block"
+        assert r1.data["message"] == "[redacted]"
+        # Nudge
+        r2 = hook.check("short", {})
+        assert r2.action == "nudge"
+        # Pass
+        r3 = hook.check("this is a good long response without issues", {})
+        assert r3.action == "pass"
 
     def test_invalid_config_entries_are_skipped(self):
         configs = ["not_a_dict", {"no_module_key": True}, None]
@@ -216,7 +396,7 @@ class TestBuildSystemPromptAdditions:
 
 
 # ---------------------------------------------------------------------------
-# run_post_response_checks
+# run_post_response_checks — pass / nudge / block
 # ---------------------------------------------------------------------------
 
 
@@ -231,19 +411,31 @@ class TestRunPostResponseChecks:
     def test_first_failing_hook_wins(self):
         hooks = [
             Hook(module_name="pass", _check_fn=lambda r, c: True),
-            Hook(module_name="fail1", nudge_message="Fix from fail1", _check_fn=lambda r, c: False),
-            Hook(module_name="fail2", nudge_message="Fix from fail2", _check_fn=lambda r, c: False),
+            Hook(
+                module_name="fail1",
+                nudge_message="Fix from fail1",
+                _check_fn=lambda r, c: False,
+            ),
+            Hook(
+                module_name="fail2",
+                nudge_message="Fix from fail2",
+                _check_fn=lambda r, c: False,
+            ),
         ]
         result = run_post_response_checks(hooks, "response", {})
-        assert result == "Fix from fail1"
+        assert result is not None
+        assert result.passed is False
+        assert result.action == "nudge"
+        assert result.data["message"] == "Fix from fail1"
 
     def test_failing_hook_without_nudge_uses_default(self):
         hooks = [
             Hook(module_name="strict", nudge_message="", _check_fn=lambda r, c: False),
         ]
         result = run_post_response_checks(hooks, "response", {})
-        assert "strict" in result
-        assert "quality check" in result
+        assert result is not None
+        assert "strict" in result.data["message"]
+        assert "quality check" in result.data["message"]
 
     def test_empty_hooks_returns_none(self):
         assert run_post_response_checks([], "response", {}) is None
@@ -274,7 +466,101 @@ class TestRunPostResponseChecks:
 
         hooks = [
             Hook(module_name="crasher", _check_fn=_boom),
-            Hook(module_name="checker", nudge_message="check failed", _check_fn=lambda r, c: False),
+            Hook(
+                module_name="checker",
+                nudge_message="check failed",
+                _check_fn=lambda r, c: False,
+            ),
         ]
         result = run_post_response_checks(hooks, "response", {})
-        assert result == "check failed"
+        assert result is not None
+        assert result.data["message"] == "check failed"
+
+    # --- Block action ---
+
+    def test_block_action_replaces_response(self):
+        def _check(r, c):
+            return HookResult(
+                passed=False,
+                action="block",
+                data={"message": "[PII redacted]"},
+            )
+
+        hooks = [Hook(module_name="safety", _check_fn=_check)]
+        result = run_post_response_checks(hooks, "sensitive data", {})
+        assert result is not None
+        assert result.action == "block"
+        assert result.data["message"] == "[PII redacted]"
+
+    def test_block_hook_without_message_uses_fallback(self):
+        def _check(r, c):
+            return HookResult(passed=False, action="block")
+
+        hooks = [Hook(module_name="blocker", _check_fn=_check)]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result.action == "block"
+        # run_post_response_checks fills in fallback message
+        assert "blocker" in result.data["message"]
+        assert "quality check" in result.data["message"]
+
+    # --- Nudge with structured data ---
+
+    def test_nudge_with_checklist_data(self):
+        def _check(r, c):
+            return HookResult(
+                passed=False,
+                action="nudge",
+                data={
+                    "message": "Missing: propose solution",
+                    "severity": "medium",
+                    "checklist_remaining": ["propose solution", "add tests"],
+                    "next_item": "propose solution",
+                    "max_nudges": 3,
+                },
+            )
+
+        hooks = [Hook(module_name="checklist", _check_fn=_check)]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result.action == "nudge"
+        assert result.data["severity"] == "medium"
+        assert result.data["checklist_remaining"] == ["propose solution", "add tests"]
+
+    # --- Pass action ---
+
+    def test_pass_action_passes_through(self):
+        def _check(r, c):
+            return HookResult(passed=True, action="pass")
+
+        hooks = [Hook(module_name="always_pass", _check_fn=_check)]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result is None  # all passed
+
+    # --- HookResult with no explicit action ---
+
+    def test_no_action_defaults_to_nudge(self):
+        def _check(r, c):
+            return HookResult(passed=False, data={"message": "fix this"})
+
+        hooks = [Hook(module_name="default_nudge", _check_fn=_check)]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result is not None
+        assert result.action == "nudge"
+
+    def test_structured_data_preserved_in_block(self):
+        """Metadata (severity, checklist) preserved through run_post_response_checks."""
+        def _check(r, c):
+            return HookResult(
+                passed=False,
+                action="block",
+                data={
+                    "message": "blocked",
+                    "severity": "critical",
+                    "checklist_remaining": [],
+                },
+            )
+
+        hooks = [Hook(module_name="structured", _check_fn=_check)]
+        result = run_post_response_checks(hooks, "response", {})
+        assert result.action == "block"
+        assert result.data["severity"] == "critical"
+        assert result.data["checklist_remaining"] == []


### PR DESCRIPTION
## What does this PR do?

Adds a lightweight **post-response hook extension point** that lets users drop `.py` files into `~/.hermes/hooks/` to inspect and optionally nudge the agent's final text response. Each hook can:

1. **Inject system prompt additions** (pre-response guidance)
2. **Validate the final response** via a `check(response, context)` gate
3. **Trigger a single re-generation** with a nudge message when `check()` returns `False`

This decouples domain-specific response quality enforcement (compliance checks, style gates, toxicity filters, depth analysis) from the core agent loop — users configure hooks in `config.yaml` and drop Python files into `~/.hermes/hooks/` without patching core files.

## Related Issue

Fixes #11719

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/post_response_hooks.py` (NEW, ~130 LOC) — Hook loader framework: Hook dataclass, load_hooks(), build_system_prompt_additions(), run_post_response_checks()
- `run_agent.py` (~30 LOC changed): __init__ hook loading, _build_system_prompt injection, main loop hook check + nudge re-generation (max 1 per response)
- `tests/run_agent/test_post_response_hooks.py` (NEW, 19 tests) — Full coverage

Config schema (in ~/.hermes/config.yaml):

agent:
  post_response_hooks:
    - module: bottom_logic_check
      enabled: true
    - module: toxicity_filter
      enabled: false

User hook example (in ~/.hermes/hooks/bottom_logic_check.py):

class Hook:
    module_name = "bottom_logic_check"
    system_prompt_addition = "Always provide deep analytical reasoning."
    nudge_message = "Your response lacks analytical depth. Please elaborate."
    def check(self, response, context):
        return len(response) > 200

## How to Test

1. python -m pytest tests/run_agent/test_post_response_hooks.py -v — all 19 tests pass
2. python -m pytest tests/run_agent/test_run_agent.py -v — 249/250 pass (1 pre-existing env failure unrelated to this PR)
3. Create ~/.hermes/hooks/ dir, drop a .py hook file, add config, run a conversation

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture — or N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

19 passed in 2.26s (test_post_response_hooks.py)
249 passed, 1 failed in 151.48s (test_run_agent.py — pre-existing tools.memory_tool import error)
