### PR TITLE
[BUG] skill_view() does not track load_count — stats instrumentation missing

### DIFF
--- a/agent/skill_stats.py
+++ b/agent/skill_stats.py
@@ -1,0 +1,75 @@
+"""Skill load statistics tracking.
+
+Records every successful skill_view() call to ~/.hermes/.skills_stats.json
+so that `hermes skills stats` and skills_check.py --watch report real usage
+data instead of always-zero counters.
+"""
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_STATS_LOCK = threading.Lock()
+_STATS_PATH: Optional[Path] = None
+
+
+def _get_stats_path() -> Path:
+    global _STATS_PATH
+    if _STATS_PATH is None:
+        from hermes_constants import get_hermes_home
+
+        _STATS_PATH = get_hermes_home() / ".skills_stats.json"
+    return _STATS_PATH
+
+
+def _record_skill_load(skill_name: str) -> None:
+    """
+    Record a skill load event to the stats file.
+
+    Called after every successful skill_view() call to track which skills
+    are actually being used vs. which are dead weight.
+    """
+    stats_file = _get_stats_path()
+
+    with _STATS_LOCK:
+        try:
+            if stats_file.exists():
+                stats = json.loads(stats_file.read_text(encoding="utf-8"))
+            else:
+                stats = {"skills": {}, "schema_version": 1}
+        except (json.JSONDecodeError, OSError):
+            stats = {"skills": {}, "schema_version": 1}
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        if skill_name not in stats["skills"]:
+            stats["skills"][skill_name] = {
+                "load_count": 0,
+                "last_used": None,
+                "first_used": None,
+            }
+
+        stats["skills"][skill_name]["load_count"] += 1
+        stats["skills"][skill_name]["last_used"] = now
+        if stats["skills"][skill_name]["first_used"] is None:
+            stats["skills"][skill_name]["first_used"] = now
+
+        stats_file.write_text(
+            json.dumps(stats, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+
+def _maybe_record_skill_load(skill_name: str) -> None:
+    """
+    Best-effort skill load recording.
+
+    Silently ignores any exception so that stats tracking can never break
+    the skill_view() tool itself.
+    """
+    try:
+        _record_skill_load(skill_name)
+    except Exception:
+        pass

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1309,6 +1309,13 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
+        # Track load_count for skills_check.py --watch / hermes skills stats
+        try:
+            from agent.skill_stats import _maybe_record_skill_load
+            _maybe_record_skill_load(name)
+        except ImportError:
+            pass  # Non-fatal if stats module unavailable
+
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as e:


### PR DESCRIPTION
## Bug Fix: Instrument skill_view() with load_count tracking

### Problem

Hermes Agent's `skill_view()` function (tools/skills_tool.py:804) has no instrumentation to record when skills are loaded. This means the skills system has no visibility into which skills are actually being used vs. dead weight.

### Solution

Two changes:

1. **New file** `agent/skill_stats.py` — Thread-safe skill load statistics tracker that writes to `~/.hermes/.skills_stats.json`. Records `load_count`, `first_used`, and `last_used` for each skill.

2. **Modified** `tools/skills_tool.py` — `skill_view()` now calls `_maybe_record_skill_load()` on successful execution. The call is best-effort (lazy import + exception swallowing) so it never breaks the tool.

### Files Changed

- `agent/skill_stats.py` (new file)
- `tools/skills_tool.py` (added tracking call)

### Behavior

After this change, skill load events are recorded to `~/.hermes/.skills_stats.json`:

```json
{
  "skills": {
    "axolotl": {
      "load_count": 3,
      "first_used": "2026-04-18T10:00:00+00:00",
      "last_used": "2026-04-18T14:30:00+00:00"
    }
  }
}
```

This enables the `skills_check.py --watch` mechanism and any other stats-based tooling.
