### PR TITLE
docs(rl-training): link Atropos, Tinker, and Weights & Biases

### DIFF
--- a/website/docs/user-guide/features/rl-training.md
+++ b/website/docs/user-guide/features/rl-training.md
@@ -12,8 +12,8 @@ Hermes Agent includes an integrated RL (Reinforcement Learning) training pipelin
 
 The RL training system consists of three components:
 
-1. **Atropos** — A trajectory API server that coordinates environment interactions, manages rollout groups, and computes advantages
-2. **Tinker** — A training service that handles model weights, LoRA training, sampling/inference, and optimizer steps
+1. **[Atropos](https://github.com/NousResearch/atropos)** — A trajectory API server that coordinates environment interactions, manages rollout groups, and computes advantages
+2. **[Tinker](https://tinker.computer)** — A training service that handles model weights, LoRA training, sampling/inference, and optimizer steps
 3. **Environments** — Python classes that define tasks, scoring, and reward functions (e.g., GSM8K math problems)
 
 The agent can discover environments, configure training parameters, launch training runs, and monitor metrics — all through a set of `rl_*` tools.
@@ -24,7 +24,7 @@ RL training requires:
 
 - **Python >= 3.11** (Tinker package requirement)
 - **TINKER_API_KEY** — API key for the Tinker training service
-- **WANDB_API_KEY** — API key for Weights & Biases metrics tracking
+- **WANDB_API_KEY** — API key for [Weights & Biases](https://wandb.ai/) metrics tracking
 - The `tinker-atropos` submodule (at `tinker-atropos/` relative to the Hermes root)
 
 ```bash


### PR DESCRIPTION
## Summary

- Closes #7724
- The User Guide RL Training page mentioned `atropos` and Weights & Biases without links, so readers had to search externally and risked landing on the wrong project.
- Add inline links on the first definition of each component (Atropos -> `github.com/NousResearch/atropos`, Tinker -> `tinker.computer`) and on the `WANDB_API_KEY` requirement (-> `wandb.ai`).

## Test plan

- [x] Ran `npm run build` (docusaurus) in a `node:20-alpine` container - build succeeded; only pre-existing unrelated broken link/anchor warnings remain (api-server, profiles, nix-setup, hooks - none in rl-training.md).
- [x] Verified URLs match the existing conventions already used in `docs/developer-guide/environments.md` and `docs/reference/environment-variables.md`.