### PR TITLE
fix(wecom): accept aibot hex keys and strip group mentions

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -571,6 +571,9 @@ platform_toolsets:
 #     reply_to_mode: "first"  # off | first | all
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
+#   wecom:
+#     extra:
+#       bot_display_name: "Hermes"  # Strip plain-text group prefixes such as "@Hermes /reset"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1103,6 +1103,9 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "bot_id": wecom_bot_id,
             "secret": wecom_secret,
         })
+        wecom_bot_display_name = os.getenv("WECOM_BOT_DISPLAY_NAME", "")
+        if wecom_bot_display_name:
+            config.platforms[Platform.WECOM].extra["bot_display_name"] = wecom_bot_display_name
         wecom_ws_url = os.getenv("WECOM_WEBSOCKET_URL", "")
         if wecom_ws_url:
             config.platforms[Platform.WECOM].extra["websocket_url"] = wecom_ws_url

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -17,6 +17,7 @@ Configuration in config.yaml:
         extra:
           bot_id: "your-bot-id"          # or WECOM_BOT_ID env var
           secret: "your-secret"          # or WECOM_SECRET env var
+          bot_display_name: "Hermes"     # or WECOM_BOT_DISPLAY_NAME env var
           websocket_url: "wss://openws.work.weixin.qq.com"
           dm_policy: "open"              # open | allowlist | disabled | pairing
           allow_from: ["user_id_1"]
@@ -152,6 +153,11 @@ class WeComAdapter(BasePlatformAdapter):
         extra = config.extra or {}
         self._bot_id = str(extra.get("bot_id") or os.getenv("WECOM_BOT_ID", "")).strip()
         self._secret = str(extra.get("secret") or os.getenv("WECOM_SECRET", "")).strip()
+        self._bot_display_name = str(
+            extra.get("bot_display_name")
+            or extra.get("botDisplayName")
+            or os.getenv("WECOM_BOT_DISPLAY_NAME", "")
+        ).strip()
         self._ws_url = str(
             extra.get("websocket_url")
             or extra.get("websocketUrl")
@@ -497,6 +503,8 @@ class WeComAdapter(BasePlatformAdapter):
             return
 
         text, reply_text = self._extract_text(body)
+        if is_group and text:
+            text = self._strip_bot_mention_prefix(text)
         media_urls, media_types = await self._extract_media(body)
         message_type = self._derive_message_type(body, text, media_types)
         has_reply_context = bool(reply_text and (text or media_urls))
@@ -652,6 +660,15 @@ class WeComAdapter(BasePlatformAdapter):
             reply_text = str(quote_voice.get("content") or "").strip() or None
 
         return "\n".join(part for part in text_parts if part).strip(), reply_text
+
+    def _strip_bot_mention_prefix(self, text: str) -> str:
+        """Strip the plain-text @mention WeCom prepends in group chats."""
+        content = str(text or "").strip()
+        if not content or not self._bot_display_name:
+            return content
+
+        pattern = rf"^\s*[@＠]{re.escape(self._bot_display_name)}(?:[\s\u00a0\u2005]+|$)"
+        return re.sub(pattern, "", content, count=1).lstrip()
 
     async def _extract_media(self, body: Dict[str, Any]) -> Tuple[List[str], List[str]]:
         """Best-effort extraction of inbound media to local cache paths."""
@@ -972,7 +989,10 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
-        key = base64.b64decode(aes_key)
+        if re.fullmatch(r"[0-9a-fA-F]{64}", aes_key):
+            key = bytes.fromhex(aes_key)
+        else:
+            key = base64.b64decode(aes_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -44,6 +44,7 @@ class TestWeComAdapterInit:
             extra={
                 "bot_id": "cfg-bot",
                 "secret": "cfg-secret",
+                "bot_display_name": "Hermes",
                 "websocket_url": "wss://custom.wecom.example/ws",
                 "group_policy": "allowlist",
                 "group_allow_from": ["group-1"],
@@ -53,6 +54,7 @@ class TestWeComAdapterInit:
 
         assert adapter._bot_id == "cfg-bot"
         assert adapter._secret == "cfg-secret"
+        assert adapter._bot_display_name == "Hermes"
         assert adapter._ws_url == "wss://custom.wecom.example/ws"
         assert adapter._group_policy == "allowlist"
         assert adapter._group_allow_from == ["group-1"]
@@ -60,12 +62,14 @@ class TestWeComAdapterInit:
     def test_falls_back_to_env_vars(self, monkeypatch):
         monkeypatch.setenv("WECOM_BOT_ID", "env-bot")
         monkeypatch.setenv("WECOM_SECRET", "env-secret")
+        monkeypatch.setenv("WECOM_BOT_DISPLAY_NAME", "Env Hermes")
         monkeypatch.setenv("WECOM_WEBSOCKET_URL", "wss://env.example/ws")
         from gateway.platforms.wecom import WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
         assert adapter._bot_id == "env-bot"
         assert adapter._secret == "env-secret"
+        assert adapter._bot_display_name == "Env Hermes"
         assert adapter._ws_url == "wss://env.example/ws"
 
 
@@ -211,6 +215,14 @@ class TestExtractText:
         assert text == "spoken text"
         assert reply_text == "quoted"
 
+    def test_strip_bot_mention_prefix_only_for_configured_name(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True, extra={"bot_display_name": "Hermes"}))
+
+        assert adapter._strip_bot_mention_prefix("@Hermes /reset") == "/reset"
+        assert adapter._strip_bot_mention_prefix("@Other /reset") == "@Other /reset"
+
 
 class TestCallbackDispatch:
     @pytest.mark.asyncio
@@ -293,6 +305,21 @@ class TestMediaHelpers:
         encrypted = encryptor.update(padded) + encryptor.finalize()
 
         decrypted = WeComAdapter._decrypt_file_bytes(encrypted, base64.b64encode(key).decode("ascii"))
+
+        assert decrypted == plaintext
+
+    def test_decrypt_file_bytes_accepts_hex_aes_key(self):
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from gateway.platforms.wecom import WeComAdapter
+
+        plaintext = b"wecom-hex-secret"
+        key = os.urandom(32)
+        pad_len = 32 - (len(plaintext) % 32)
+        padded = plaintext + bytes([pad_len]) * pad_len
+        encryptor = Cipher(algorithms.AES(key), modes.CBC(key[:16])).encryptor()
+        encrypted = encryptor.update(padded) + encryptor.finalize()
+
+        decrypted = WeComAdapter._decrypt_file_bytes(encrypted, key.hex())
 
         assert decrypted == plaintext
 
@@ -565,6 +592,34 @@ class TestInboundMessages:
         assert event.reply_to_message_id == "quote:msg-1"
 
     @pytest.mark.asyncio
+    async def test_on_message_strips_group_mention_prefix_for_commands(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True, extra={"bot_display_name": "Hermes"}))
+        adapter._text_batch_delay_seconds = 0  # disable batching for tests
+        adapter.handle_message = AsyncMock()
+        adapter._extract_media = AsyncMock(return_value=([], []))
+
+        payload = {
+            "cmd": "aibot_msg_callback",
+            "headers": {"req_id": "req-1"},
+            "body": {
+                "msgid": "msg-2",
+                "chatid": "group-1",
+                "chattype": "group",
+                "from": {"userid": "user-1"},
+                "msgtype": "text",
+                "text": {"content": "@Hermes /reset"},
+            },
+        }
+
+        await adapter._on_message(payload)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "/reset"
+        assert event.is_command() is True
+
+    @pytest.mark.asyncio
     async def test_on_message_respects_group_policy(self):
         from gateway.platforms.wecom import WeComAdapter
 
@@ -592,4 +647,3 @@ class TestInboundMessages:
 
         await adapter._on_message(payload)
         adapter.handle_message.assert_not_awaited()
-


### PR DESCRIPTION
## Summary
- accept 64-character hex `aeskey` values from the WeCom aibot websocket while preserving the existing base64 callback flow
- strip a configured plain-text `@BotName` prefix from group messages before slash-command detection
- expose `bot_display_name` via config/env wiring and document it in the CLI config example

## Root Cause
WeCom aibot image payloads can deliver `aeskey` as a 64-character hex string, but `_decrypt_file_bytes()` only tried base64 decoding. Group chat messages also arrive with a literal `@DisplayName` prefix and no structured mention metadata, so commands like `@Hermes /reset` never reached the existing slash-command path.

## Testing
- `python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-11447/gateway/platforms/wecom.py /Users/stephenyu/Documents/hermes-agent-wt-11447/gateway/config.py /Users/stephenyu/Documents/hermes-agent-wt-11447/tests/gateway/test_wecom.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-11447 --extra dev pytest -o addopts='' /Users/stephenyu/Documents/hermes-agent-wt-11447/tests/gateway/test_wecom.py -q`

## Platform Tested
- macOS

## Contribution Guide Notes
- updates `cli-config.yaml.example` for the new `platforms.wecom.extra.bot_display_name` knob
- resolves #11447
