### PR TITLE
fix(browser): persist remote browser_vision screenshots locally

### DIFF
--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -144,6 +145,16 @@ class TestBrowserConsoleToolsetWiring:
 class TestBrowserVisionAnnotate:
     """browser_vision supports annotate parameter."""
 
+    @staticmethod
+    def _png_bytes() -> bytes:
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+            b"\x08\x02\x00\x00\x00\x90wS\xde"
+            b"\x00\x00\x00\x0cIDAT\x08\x99c``\x00\x00\x00\x04\x00\x01"
+            b"\x0b\xe7\x02\x9d\x00\x00\x00\x00IEND\xaeB`\x82"
+        )
+
     def test_schema_has_annotate_param(self):
         from tools.browser_tool import BROWSER_TOOL_SCHEMAS
 
@@ -192,6 +203,94 @@ class TestBrowserVisionAnnotate:
                 args = mock_cmd.call_args[0]
                 cmd_args = args[2] if len(args) > 2 else []
                 assert "--annotate" in cmd_args
+
+    def test_cloud_mode_uses_temp_screenshot_and_copies_to_cache(self, tmp_path):
+        """Cloud backends should not be asked to write to a local Hermes path."""
+        from tools.browser_tool import browser_vision
+
+        remote_png = tmp_path / "remote-browserbase.png"
+        remote_png.write_bytes(self._png_bytes())
+        cache_dir = tmp_path / "cache" / "screenshots"
+
+        provider = MagicMock()
+        provider.provider_name.return_value = "Browserbase"
+
+        llm_response = MagicMock()
+        llm_response.choices = [MagicMock(message=MagicMock(content="The page shows a login form."))]
+
+        observed_args = {}
+
+        def fake_run_browser_command(task_id, command, args, timeout=None):
+            observed_args["task_id"] = task_id
+            observed_args["command"] = command
+            observed_args["args"] = list(args)
+            return {
+                "success": True,
+                "data": {
+                    "path": str(remote_png),
+                    "annotations": [{"index": 1, "label": "Submit"}],
+                },
+            }
+
+        with (
+            patch("tools.browser_tool._get_cloud_provider", return_value=provider),
+            patch("tools.browser_tool._run_browser_command", side_effect=fake_run_browser_command),
+            patch("tools.browser_tool.call_llm", return_value=llm_response),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_constants.get_hermes_dir", return_value=cache_dir),
+            patch("agent.redact.redact_sensitive_text", side_effect=lambda text: text),
+        ):
+            result = json.loads(browser_vision("What is on the page?", annotate=True, task_id="cloud"))
+
+        assert observed_args["task_id"] == "cloud"
+        assert observed_args["command"] == "screenshot"
+        assert observed_args["args"] == ["--annotate", "--full"]
+        assert result["success"] is True
+        assert result["analysis"] == "The page shows a login form."
+        assert result["annotations"] == [{"index": 1, "label": "Submit"}]
+
+        screenshot_path = Path(result["screenshot_path"])
+        assert screenshot_path.parent == cache_dir
+        assert screenshot_path.exists() is True
+        assert screenshot_path.read_bytes() == remote_png.read_bytes()
+
+    def test_local_mode_still_passes_explicit_output_path(self, tmp_path):
+        """Local browser sessions should keep writing directly into Hermes cache."""
+        from tools.browser_tool import browser_vision
+
+        cache_dir = tmp_path / "cache" / "screenshots"
+
+        llm_response = MagicMock()
+        llm_response.choices = [MagicMock(message=MagicMock(content="Looks good."))]
+
+        observed_args = {}
+
+        def fake_run_browser_command(task_id, command, args, timeout=None):
+            observed_args["task_id"] = task_id
+            observed_args["command"] = command
+            observed_args["args"] = list(args)
+            screenshot_path = Path(args[-1])
+            screenshot_path.write_bytes(self._png_bytes())
+            return {"success": True, "data": {}}
+
+        with (
+            patch("tools.browser_tool._get_cloud_provider", return_value=None),
+            patch("tools.browser_tool._run_browser_command", side_effect=fake_run_browser_command),
+            patch("tools.browser_tool.call_llm", return_value=llm_response),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_constants.get_hermes_dir", return_value=cache_dir),
+            patch("agent.redact.redact_sensitive_text", side_effect=lambda text: text),
+        ):
+            result = json.loads(browser_vision("What is on the page?", annotate=False, task_id="local"))
+
+        assert observed_args["task_id"] == "local"
+        assert observed_args["command"] == "screenshot"
+        assert observed_args["args"][0] == "--full"
+        assert observed_args["args"][-1].endswith(".png")
+        assert Path(observed_args["args"][-1]).parent == cache_dir
+        assert result["success"] is True
+        assert result["analysis"] == "Looks good."
+        assert result["screenshot_path"] == observed_args["args"][-1]
 
 
 # ── auto-recording config ────────────────────────────────────────────

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1944,6 +1944,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
     from pathlib import Path
     
     effective_task_id = task_id or "default"
+    cloud_provider = _get_cloud_provider()
     
     # Save screenshot to persistent location so it can be shared with users
     from hermes_constants import get_hermes_dir
@@ -1961,30 +1962,48 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         if annotate:
             screenshot_args.append("--annotate")
         screenshot_args.append("--full")
-        screenshot_args.append(str(screenshot_path))
+        if cloud_provider is None:
+            screenshot_args.append(str(screenshot_path))
         result = _run_browser_command(
             effective_task_id, 
             "screenshot", 
             screenshot_args,
         )
-        
+
         if not result.get("success"):
             error_detail = result.get("error", "Unknown error")
-            _cp = _get_cloud_provider()
-            mode = "local" if _cp is None else f"cloud ({_cp.provider_name()})"
+            mode = "local" if cloud_provider is None else f"cloud ({cloud_provider.provider_name()})"
             return json.dumps({
                 "success": False,
                 "error": f"Failed to take screenshot ({mode} mode): {error_detail}"
             }, ensure_ascii=False)
 
         actual_screenshot_path = result.get("data", {}).get("path")
-        if actual_screenshot_path:
+        if cloud_provider is not None:
+            if not actual_screenshot_path:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        f"Failed to resolve screenshot file in cloud ({cloud_provider.provider_name()}) mode. "
+                        "agent-browser did not return a local temp path."
+                    ),
+                }, ensure_ascii=False)
+            actual_path = Path(actual_screenshot_path)
+            if not actual_path.exists():
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        f"Cloud screenshot file was not created at {actual_path} "
+                        f"({cloud_provider.provider_name()} mode)."
+                    ),
+                }, ensure_ascii=False)
+            shutil.copy2(actual_path, screenshot_path)
+        elif actual_screenshot_path:
             screenshot_path = Path(actual_screenshot_path)
 
         # Check if screenshot file was created
         if not screenshot_path.exists():
-            _cp = _get_cloud_provider()
-            mode = "local" if _cp is None else f"cloud ({_cp.provider_name()})"
+            mode = "local" if cloud_provider is None else f"cloud ({cloud_provider.provider_name()})"
             return json.dumps({
                 "success": False,
                 "error": (


### PR DESCRIPTION
## Summary
- stop passing Hermes-local screenshot output paths to remote cloud browser sessions
- copy the temp screenshot returned by agent-browser back into Hermes' managed cache before vision analysis
- add regression coverage for both cloud screenshot capture and unchanged local-mode behavior

## Root Cause
`browser_vision()` always passed a local `~/.hermes/cache/screenshots/...` path into the screenshot command and then immediately expected that same host path to exist. That works for local Chromium, but remote Browserbase/CDP sessions cannot write into WSL or other host-local filesystem paths.

## Testing
- `python3 -m py_compile /Users/stephenyu/Documents/hermes-agent-wt-11729/tools/browser_tool.py /Users/stephenyu/Documents/hermes-agent-wt-11729/tests/tools/test_browser_console.py`
- `uv run --directory /Users/stephenyu/Documents/hermes-agent-wt-11729 --extra dev pytest -o addopts='' /Users/stephenyu/Documents/hermes-agent-wt-11729/tests/tools/test_browser_console.py -q`

## Platform Tested
- macOS

## Contribution Guide Notes
- keeps the fix scoped to `browser_vision()` and its regression tests
- resolves #11729
