### PR TITLE
fix(cli): repair broken zsh completion generation

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-)'{{-h,--help}}'[Show help and exit]' \\
-        '(-)'{{-V,--version}}'[Show version and exit]' \\
-        '(-)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
+        "(-h --help)"{{-h,--help}}"[Show help and exit]" \\
+        "(-V --version)"{{-V,--version}}"[Show version and exit]" \\
+        "(-p --profile)"{{-p,--profile}}"[Profile name]:profile:_hermes_profiles" \\
         '1:command:->commands' \\
         '*::arg:->args'
 
@@ -238,7 +238,7 @@ _hermes() {{
     esac
 }}
 
-_hermes "$@"
+compdef _hermes hermes
 """
 
 

--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        "(-h --help)"{{-h,--help}}"[Show help and exit]" \\
-        "(-V --version)"{{-V,--version}}"[Show version and exit]" \\
-        "(-p --profile)"{{-p,--profile}}"[Profile name]:profile:_hermes_profiles" \\
+        '(-)'{{-h,--help}}'[Show help and exit]' \\
+        '(-)'{{-V,--version}}'[Show version and exit]' \\
+        '(-)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 

--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        "(-h --help)"{{-h,--help}}"[Show help and exit]" \\
+        "(-V --version)"{{-V,--version}}"[Show version and exit]" \\
+        "(-p --profile)"{{-p,--profile}}"[Profile name]:profile:_hermes_profiles" \\
         '1:command:->commands' \\
         '*::arg:->args'
 
@@ -238,7 +238,7 @@ _hermes() {{
     esac
 }}
 
-_hermes "$@"
+compdef _hermes hermes
 """
 
 

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -140,6 +140,36 @@ class TestGenerateZsh:
         # gateway has subcommands so a _cmds array must be generated
         assert "gateway_cmds" in out
 
+    def test_registers_compdef_instead_of_invoking_completion_function(self):
+        out = generate_zsh(_make_parser())
+        assert 'compdef _hermes hermes' in out
+        assert '_hermes "$@"' not in out
+
+    def test_uses_valid_zsh_arguments_alias_syntax(self):
+        out = generate_zsh(_make_parser())
+        assert '"(-h --help)"{-h,--help}"[Show help and exit]"' in out
+        assert '"(-V --version)"{-V,--version}"[Show version and exit]"' in out
+        assert '"(-p --profile)"{-p,--profile}"[Profile name]:profile:_hermes_profiles"' in out
+        assert "'(-h --help){-h,--help}[Show help and exit]'" not in out
+
+    def test_valid_zsh_syntax_when_sourced_after_compinit(self):
+        if not shutil.which("zsh"):
+            pytest.skip("zsh not installed")
+        out = generate_zsh(_make_parser())
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".zsh", delete=False) as f:
+            f.write(out)
+            path = f.name
+        try:
+            result = subprocess.run(
+                ["zsh", "-fc", f"autoload -Uz compinit && compinit; source {path}"],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, result.stderr
+            assert result.stderr == ""
+        finally:
+            os.unlink(path)
+
 
 # ---------------------------------------------------------------------------
 # 4. Fish output

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -145,14 +145,28 @@ class TestGenerateZsh:
         assert 'compdef _hermes hermes' in out
         assert '_hermes "$@"' not in out
 
-    def test_uses_valid_zsh_arguments_alias_syntax(self):
+    def test_preserves_valid_zsh_arguments_alias_syntax(self):
         out = generate_zsh(_make_parser())
-        assert '"(-h --help)"{-h,--help}"[Show help and exit]"' in out
-        assert '"(-V --version)"{-V,--version}"[Show version and exit]"' in out
-        assert '"(-p --profile)"{-p,--profile}"[Profile name]:profile:_hermes_profiles"' in out
+        assert "'(-)'{-h,--help}'[Show help and exit]'" in out
+        assert "'(-)'{-V,--version}'[Show version and exit]'" in out
+        assert "'(-)'{-p,--profile}'[Profile name]:profile:_hermes_profiles'" in out
         assert "'(-h --help){-h,--help}[Show help and exit]'" not in out
+        assert '"(-h --help)"{-h,--help}"[Show help and exit]"' not in out
 
-    def test_valid_zsh_syntax_when_sourced_after_compinit(self):
+    def test_valid_zsh_syntax(self):
+        if not shutil.which("zsh"):
+            pytest.skip("zsh not installed")
+        out = generate_zsh(_make_parser())
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".zsh", delete=False) as f:
+            f.write(out)
+            path = f.name
+        try:
+            result = subprocess.run(["zsh", "-n", path], capture_output=True, text=True)
+            assert result.returncode == 0, result.stderr
+        finally:
+            os.unlink(path)
+
+    def test_zsh_eval_style_source_registers_after_compinit(self):
         if not shutil.which("zsh"):
             pytest.skip("zsh not installed")
         out = generate_zsh(_make_parser())
@@ -161,7 +175,11 @@ class TestGenerateZsh:
             path = f.name
         try:
             result = subprocess.run(
-                ["zsh", "-fc", f"autoload -Uz compinit && compinit; source {path}"],
+                [
+                    "zsh",
+                    "-fc",
+                    f"autoload -Uz compinit && compinit -D; source {path}; [[ ${{_comps[hermes]}} == _hermes ]]",
+                ],
                 capture_output=True,
                 text=True,
             )


### PR DESCRIPTION
## Summary

Fixes two reproducible zsh completion bugs in the active generator used by `hermes completion zsh` (`hermes_cli.completion.generate_zsh`).

Small, active-path-only fix for a user-facing zsh regression.

1. the generated script ends with `_hermes "$@"`, which eagerly invokes `_arguments` when sourced and triggers:

   `_arguments:comparguments:327: can only be called from completion function`

2. the generated `_arguments` alias specs use invalid zsh syntax, which triggers errors like:

   `_arguments:comparguments:327: invalid argument: (-h --help){-h,--help}[Show help and exit]`

Intentionally scoped to the active generator path in `hermes_cli/completion.py`.

## Changes

- replace the trailing eager `_hermes "$@"` call with `compdef _hermes hermes`
- emit valid zsh `_arguments` alias specs for:
  - `-h/--help`
  - `-V/--version`
  - `-p/--profile`
- add regression tests covering:
  - no eager invocation at source time
  - valid generated alias syntax
  - successful sourcing after `compinit`

## How to test

```bash
source venv/bin/activate

python -m pytest tests/hermes_cli/test_completion.py -q

python -m pytest tests/hermes_cli/test_completion.py tests/hermes_cli/test_profiles.py -q

python -m hermes_cli.main completion zsh > /tmp/hermes.zsh
zsh -fc 'autoload -Uz compinit && compinit; source /tmp/hermes.zsh'
```

Manual smoke test:
- start a fresh zsh session
- load the generated completion
- verify `hermes config <Tab><Tab>` lists subcommands like `edit`, `set`, `path`, `env-path`, `check`, `migrate`

## Platforms tested

- macOS + zsh

## Notes

I also ran `pytest tests/ -v`; the suite currently has unrelated failures outside this area, so the completion-specific checks above are the relevant verification for this change.

## Related issues

- related to #6122
