### PR TITLE
fix(delegation): detect anthropic compatible direct endpoints

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -627,6 +627,17 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    def test_direct_anthropic_compatible_endpoint_uses_anthropic_messages(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "claude-opus-4-6",
+            "base_url": "https://example.services.ai.azure.com/models/anthropic",
+            "api_key": "foundry-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
     def test_direct_endpoint_falls_back_to_openai_api_key_env(self):
         parent = _make_mock_parent(depth=0)
         cfg = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -906,6 +906,8 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
     if configured_base_url:
+        from hermes_cli.providers import determine_api_mode
+
         api_key = (
             configured_api_key
             or os.getenv("OPENAI_API_KEY", "").strip()
@@ -918,7 +920,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
         base_lower = configured_base_url.lower()
         provider = "custom"
-        api_mode = "chat_completions"
+        api_mode = determine_api_mode(provider, configured_base_url)
         if "chatgpt.com/backend-api/codex" in base_lower:
             provider = "openai-codex"
             api_mode = "codex_responses"


### PR DESCRIPTION
## Summary

Fix subagent delegation when `delegation.base_url` points to an Anthropic-compatible direct endpoint such as Azure AI Foundry.

Previously, direct delegation endpoints defaulted to `chat_completions` unless the URL matched a very narrow `api.anthropic.com` check. That caused Anthropic-compatible endpoints ending in `/anthropic` to be routed with the wrong API mode.

This change reuses the shared `determine_api_mode()` heuristic for direct delegation endpoints, while preserving the existing explicit special cases for Codex and native Anthropic URLs.

## Changes

- use `determine_api_mode()` when resolving `delegation.base_url`
- keep existing Codex/native Anthropic provider overrides intact
- add a regression test covering an Anthropic-compatible Azure-style `/anthropic` endpoint

## Why this matters

Without this fix, delegated child agents can hit the wrong wire protocol against Anthropic-compatible direct endpoints and fail even though the parent configuration is otherwise valid.

## Testing

Passed locally on Windows:

- `py -m pytest tests/tools/test_delegate.py -v -k anthropic_compatible`
- `py -m pytest tests/tools/test_delegate.py -q -n 4`

Results:
- targeted regression test passed
- full `tests/tools/test_delegate.py` file passed (`68 passed`)
