### PR TITLE
docs(docker): fix gateway port binding for external/container access

### DIFF
--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -36,12 +36,18 @@ docker run -d \
   --restart unless-stopped \
   -v ~/.hermes:/opt/data \
   -p 8642:8642 \
+  -e API_SERVER_ENABLED=true \
+  -e API_SERVER_HOST=0.0.0.0 \
+  -e API_SERVER_KEY=your_api_key_here \
+  -e API_SERVER_CORS_ORIGINS='*' \
   nousresearch/hermes-agent gateway run
 ```
 
 Port 8642 exposes the gateway's [OpenAI-compatible API server](./api-server.md) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
 
 Opening any port on an internet facing machine is a security risk. You should not do it unless you understand the risks.
+
+To expose the API server externally (to the host or other containers), you must override the default binding (127.0.0.1) with `API_SERVER_HOST=0.0.0.0` and provide a valid `API_SERVER_KEY` (minimum 8 characters). Generate a secure key with: `openssl rand -hex 32`.
 
 ## Running the dashboard
 
@@ -128,13 +134,17 @@ services:
       - "8642:8642"
     volumes:
       - ~/.hermes:/opt/data
+    environment:
+      - API_SERVER_ENABLED=true
+      - API_SERVER_HOST=0.0.0.0
+      - API_SERVER_KEY=${API_SERVER_KEY}
+      - API_SERVER_CORS_ORIGINS=*
+      # Uncomment to forward additional env vars:
+      # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      # - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
     networks:
       - hermes-net
-    # Uncomment to forward specific env vars instead of using .env file:
-    # environment:
-    #   - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-    #   - OPENAI_API_KEY=${OPENAI_API_KEY}
-    #   - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
     deploy:
       resources:
         limits:

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -155,7 +155,7 @@ services:
     image: nousresearch/hermes-agent:latest
     container_name: hermes-dashboard
     restart: unless-stopped
-    command: dashboard --host 0.0.0.0
+    command: dashboard --host 0.0.0.0 --insecure
     ports:
       - "9119:9119"
     volumes:


### PR DESCRIPTION
The gateway listens on 127.0.0.1:8642 by default when API_SERVER_ENABLED=true, making it unreachable from outside the container even when -p 8642:8642 is used. Add required environment variables to enable external access:
- API_SERVER_ENABLED=true
- API_SERVER_HOST=0.0.0.0
- API_SERVER_KEY=<secret> (min 8 chars, use openssl rand -hex 32)
- API_SERVER_CORS_ORIGINS=*

## What does this PR do?

Fix Docker documentation to include the required environment variables to make the API server accessible from outside the container or from other containers in a Docker Compose setup.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

<!-- N/A - this is a documentation fix without a reported issue -->

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `website/docs/user-guide/docker.md`: Updated "Running in gateway mode" section to add required environment variables
- `website/docs/user-guide/docker.md`: Updated "Docker Compose example" section to add required environment variables

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. N/A - this is a documentation change

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the `CONTRIBUTING.md`
- [x] My commit messages follow `Conventional Commits` (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for `pull requests` to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the `CONTRIBUTING.md#cross-platform-compatibility` — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see `CONTRIBUTING.md#should-the-skill-be-bundled`
- [ ] SKILL.md follows the `CONTRIBUTING.md#skillmd-format` (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->