### PR TITLE
fix(session_search): enforce hard timeout to prevent 5+ minute hangs

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -406,6 +406,34 @@ class TestSessionSearch:
         ))
         assert result["success"] is True
 
+    def test_hanging_summarizer_times_out_cleanly(self):
+        """A stuck auxiliary model must not hang session_search forever (#7725)."""
+        import asyncio as _asyncio
+        from unittest.mock import MagicMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "sid_a", "content": "match", "source": "cli",
+             "session_started": 1709500000, "model": "test"},
+        ]
+        mock_db.get_session.return_value = {"parent_session_id": None}
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "hello"},
+        ]
+
+        async def _never_returns(*_a, **_kw):
+            await _asyncio.sleep(3600)
+
+        # Shrink the timeout so the test runs fast but still exercises the
+        # timeout path end-to-end.
+        with _patch("tools.session_search_tool.SUMMARIZATION_TIMEOUT_SECONDS", 0.1), \
+             _patch("tools.session_search_tool.async_call_llm", new=_never_returns):
+            result = json.loads(session_search(query="test", db=mock_db))
+
+        assert result["success"] is False
+        assert "timed out" in result["error"].lower()
+
     def test_current_root_session_excludes_child_lineage(self):
         """Delegation child hits should be excluded when they resolve to the current root session."""
         from unittest.mock import MagicMock

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -25,6 +25,11 @@ from typing import Dict, Any, List, Optional, Union
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 MAX_SESSION_CHARS = 100_000
 MAX_SUMMARY_TOKENS = 10000
+# Hard ceiling on parallel summarization so a slow/stuck auxiliary model
+# can't make the whole tool hang. _run_async has its own timeout only on
+# the gateway path (300s); the CLI path waits forever, so we must bound
+# the coroutine itself here.
+SUMMARIZATION_TIMEOUT_SECONDS = 60
 
 
 def _get_session_search_max_concurrency(default: int = 3) -> int:
@@ -442,9 +447,10 @@ def session_search(
                     exc_info=True,
                 )
 
-        # Summarize all sessions in parallel
+        # Summarize all sessions in parallel, bounded by a hard timeout so
+        # a slow auxiliary model can't make the tool hang indefinitely (#7725).
         async def _summarize_all() -> List[Union[str, Exception]]:
-            """Summarize all sessions with bounded concurrency."""
+            """Summarize all sessions with bounded concurrency and a hard timeout."""
             max_concurrency = min(_get_session_search_max_concurrency(), max(1, len(tasks)))
             semaphore = asyncio.Semaphore(max_concurrency)
 
@@ -456,7 +462,10 @@ def session_search(
                 _bounded_summary(text, meta)
                 for _, _, text, meta in tasks
             ]
-            return await asyncio.gather(*coros, return_exceptions=True)
+            return await asyncio.wait_for(
+                asyncio.gather(*coros, return_exceptions=True),
+                timeout=SUMMARIZATION_TIMEOUT_SECONDS,
+            )
 
         try:
             # Use _run_async() which properly manages event loops across
@@ -467,14 +476,19 @@ def session_search(
             # causing deadlocks in gateway mode (#2681).
             from model_tools import _run_async
             results = _run_async(_summarize_all())
-        except concurrent.futures.TimeoutError:
+        except (asyncio.TimeoutError, concurrent.futures.TimeoutError):
             logging.warning(
-                "Session summarization timed out after 60 seconds",
+                "Session summarization timed out after %d seconds",
+                SUMMARIZATION_TIMEOUT_SECONDS,
                 exc_info=True,
             )
             return json.dumps({
                 "success": False,
-                "error": "Session summarization timed out. Try a more specific query or reduce the limit.",
+                "error": (
+                    f"Session summarization timed out after "
+                    f"{SUMMARIZATION_TIMEOUT_SECONDS}s. Try a more specific "
+                    f"query or reduce the limit."
+                ),
             }, ensure_ascii=False)
 
         summaries = []


### PR DESCRIPTION
## Summary
- Fixes #7725. `session_search` could hang for 5+ minutes (or forever on CLI) because `_run_async` only enforces a timeout on the gateway path (300s), and the existing `concurrent.futures.TimeoutError` handler never fired in CLI/worker-thread paths.
- Wraps the parallel summarization coroutine in `asyncio.wait_for(SUMMARIZATION_TIMEOUT_SECONDS)` (60s) so the hard bound applies in every execution context.
- Catches `asyncio.TimeoutError` alongside `concurrent.futures.TimeoutError` and updates the error message to surface the actual timeout.

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_session_search.py` — 33 passed (includes new `test_hanging_summarizer_times_out_cleanly` regression covering an auxiliary model that never returns).