### PR TITLE
fix(gateway): preserve intraword underscores in plain text markdown stripping

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -158,7 +158,9 @@ class TextBatchAggregator:
 _RE_BOLD = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 _RE_ITALIC_STAR = re.compile(r"\*(.+?)\*", re.DOTALL)
 _RE_BOLD_UNDER = re.compile(r"__(.+?)__", re.DOTALL)
-_RE_ITALIC_UNDER = re.compile(r"_(.+?)_", re.DOTALL)
+# Markdown doesn't allow underscore emphasis inside words like foo_bar_baz.
+# Avoid stripping ordinary underscores from identifiers and file-like text.
+_RE_ITALIC_UNDER = re.compile(r"(?<!\w)_(.+?)_(?!\w)", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")
 _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)

--- a/tests/gateway/test_platform_helpers.py
+++ b/tests/gateway/test_platform_helpers.py
@@ -1,0 +1,11 @@
+"""Tests for shared gateway platform helpers."""
+
+from gateway.platforms.helpers import strip_markdown
+
+
+class TestStripMarkdown:
+    def test_strips_underscore_italic_at_word_boundaries(self):
+        assert strip_markdown("_italic_ text") == "italic text"
+
+    def test_preserves_intraword_underscores(self):
+        assert strip_markdown("foo_bar_baz") == "foo_bar_baz"


### PR DESCRIPTION
## Summary

Fix `gateway.platforms.helpers.strip_markdown()` so underscore-based italic stripping only applies at word boundaries.

Previously, plain-text content like `foo_bar_baz` was treated as Markdown emphasis and collapsed to `foobarbaz`. This affected platform adapters that reuse the shared helper for plain-text delivery, including SMS, BlueBubbles, Feishu, and QQ.

## What changed

- Narrowed `_RE_ITALIC_UNDER` to avoid matching underscores inside words
- Added focused helper tests covering:
  - valid underscore italics: `_italic_ text` -> `italic text`
  - intraword underscores remain unchanged: `foo_bar_baz`

## Why this matters

This is a real user-facing formatting bug in plain-text platform output. It corrupts identifiers, filenames, and other underscore-delimited text even when the content is not Markdown.

## Validation

Ran:
- `scripts/run_tests.sh tests/gateway/test_platform_helpers.py`
- `scripts/run_tests.sh tests/gateway/test_sms.py`
- `scripts/run_tests.sh tests/gateway/test_bluebubbles.py`

Results:
- `test_platform_helpers`: 2 passed
- `test_sms`: 36 passed
- `test_bluebubbles`: 45 passed

Manual smoke:
- `strip_markdown("foo_bar_baz")` -> `foo_bar_baz`
- `strip_markdown("_italic_ text")` -> `italic text`


