### PR TITLE
fix(dingtalk): allow config credentials in startup checks

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -66,11 +66,15 @@ _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
 
 
-def check_dingtalk_requirements() -> bool:
-    """Check if DingTalk dependencies are available and configured."""
+def check_dingtalk_requirements(config: Optional[PlatformConfig] = None) -> bool:
+    """Check if DingTalk dependencies are available and credentials exist."""
     if not DINGTALK_STREAM_AVAILABLE or not HTTPX_AVAILABLE:
         return False
-    if not os.getenv("DINGTALK_CLIENT_ID") or not os.getenv("DINGTALK_CLIENT_SECRET"):
+
+    extra = (getattr(config, "extra", None) or {}) if config is not None else {}
+    client_id = extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID")
+    client_secret = extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
+    if not client_id or not client_secret:
         return False
     return True
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2528,8 +2528,8 @@ class GatewayRunner:
 
         elif platform == Platform.DINGTALK:
             from gateway.platforms.dingtalk import DingTalkAdapter, check_dingtalk_requirements
-            if not check_dingtalk_requirements():
-                logger.warning("DingTalk: dingtalk-stream not installed or DINGTALK_CLIENT_ID/SECRET not set")
+            if not check_dingtalk_requirements(config):
+                logger.warning("DingTalk: dingtalk-stream/httpx missing or credentials not configured")
                 return None
             return DingTalkAdapter(config)
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -45,6 +45,51 @@ class TestDingTalkRequirements:
         from gateway.platforms.dingtalk import check_dingtalk_requirements
         assert check_dingtalk_requirements() is True
 
+    def test_returns_true_when_config_extra_has_credentials(self, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        from gateway.platforms.dingtalk import check_dingtalk_requirements
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
+        )
+
+        assert check_dingtalk_requirements(config) is True
+
+    def test_gateway_runner_accepts_config_credentials(self, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+
+        from gateway.config import GatewayConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={})
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
+        )
+        fake_adapter = MagicMock(name="DingTalkAdapterInstance")
+
+        with patch(
+            "gateway.platforms.dingtalk.DingTalkAdapter",
+            return_value=fake_adapter,
+        ) as mock_adapter:
+            adapter = runner._create_adapter(Platform.DINGTALK, config)
+
+        assert adapter is fake_adapter
+        mock_adapter.assert_called_once_with(config)
+
 
 # ---------------------------------------------------------------------------
 # Adapter construction
@@ -680,4 +725,3 @@ class TestIncomingHandlerProcess:
         # Clean up: release the gate so the background task finishes
         processing_gate.set()
         await asyncio.sleep(0.05)
-


### PR DESCRIPTION
## Summary
- let DingTalk startup requirement checks accept credentials from platform config as well as env vars
- pass the platform config into the gateway adapter factory check so config-driven setups are not rejected early
- add focused regression tests for both the helper and the gateway runner path

## Testing
- python3 -m pytest -o addopts='' tests/gateway/test_dingtalk.py -k 'DingTalkRequirements'

Closes #11769