### PR TITLE
feat(tts): add Qwen3-TTS provider

### DIFF
--- a/tests/tools/test_tts_tool.py
+++ b/tests/tools/test_tts_tool.py
@@ -1,0 +1,213 @@
+"""Tests for tools.tts_tool — Qwen3-TTS provider and speak_text dispatch.
+
+Covers the new Qwen3-TTS provider that uses a query-parameter API
+instead of the OpenAI JSON body format.
+"""
+
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+# ============================================================================
+# _generate_qwen3_tts — Qwen3-TTS provider
+# ============================================================================
+
+class TestGenerateQwen3TTS:
+    """Unit tests for _generate_qwen3_tts."""
+
+    def _make_mock_response(self, audio_bytes: bytes):
+        """Create a mock urllib response context manager."""
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        # read() returns chunks then empty bytes to signal EOF
+        resp.read.side_effect = [audio_bytes, b""]
+        return resp
+
+    def test_calls_query_param_endpoint(self, tmp_path):
+        """Qwen3-TTS request must use query params, not a JSON body."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        tts_config = {"qwen3": {"base_url": "http://10.15.0.157:8001", "voice": "ryan"}}
+
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_request_cls:
+            mock_open.return_value = self._make_mock_response(b"fake-audio")
+            _generate_qwen3_tts("Hello world", output, tts_config)
+
+        url_arg = mock_request_cls.call_args[0][0]
+        assert "text=Hello+world" in url_arg or "text=Hello%20world" in url_arg
+        assert "voice=ryan" in url_arg
+        assert "/v1/audio/speech" in url_arg
+        assert "10.15.0.157:8001" in url_arg
+
+    def test_uses_default_base_url_and_voice(self, tmp_path):
+        """Defaults to localhost:8001 and voice='ryan' when not configured."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_request_cls:
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("test", output, {})
+
+        url_arg = mock_request_cls.call_args[0][0]
+        assert "localhost:8001" in url_arg
+        assert "voice=ryan" in url_arg
+
+    def test_response_format_mp3_for_mp3_extension(self, tmp_path):
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "speech.mp3")
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_request_cls:
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("hi", output, {})
+
+        url_arg = mock_request_cls.call_args[0][0]
+        assert "response_format=mp3" in url_arg
+
+    def test_response_format_opus_for_ogg_extension(self, tmp_path):
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "speech.ogg")
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_request_cls:
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("hi", output, {})
+
+        url_arg = mock_request_cls.call_args[0][0]
+        assert "response_format=opus" in url_arg
+
+    def test_writes_audio_to_output_file(self, tmp_path):
+        """The response body should be written to the output path."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        audio_data = b"FAKE-MP3-AUDIO-DATA"
+
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request"):
+            mock_open.return_value = self._make_mock_response(audio_data)
+            result = _generate_qwen3_tts("hello", output, {})
+
+        assert result == output
+        with open(output, "rb") as f:
+            assert f.read() == audio_data
+
+    def test_uses_post_method(self, tmp_path):
+        """Qwen3-TTS must use POST (not GET)."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_request_cls:
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("test", output, {})
+
+        assert mock_request_cls.call_args[1]["method"] == "POST"
+
+    def test_uses_default_timeout_of_120(self, tmp_path):
+        """Default timeout must be 120s (not the old 30s) to handle long responses."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request"):
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("test", output, {})
+
+        _, kwargs = mock_open.call_args
+        assert kwargs.get("timeout") == 120
+
+    def test_timeout_is_configurable(self, tmp_path):
+        """tts.qwen3.timeout should override the default."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        tts_config = {"qwen3": {"base_url": "http://localhost:8001", "timeout": 60}}
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request"):
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("test", output, tts_config)
+
+        _, kwargs = mock_open.call_args
+        assert kwargs.get("timeout") == 60
+
+    def test_instruct_included_in_url_when_configured(self, tmp_path):
+        """tts.qwen3.instruct should be passed as a query parameter."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        tts_config = {"qwen3": {"instruct": "Speak warmly."}}
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_req:
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("test", output, tts_config)
+
+        url = mock_req.call_args[0][0]
+        assert "instruct=Speak+warmly." in url
+
+    def test_instruct_omitted_when_not_configured(self, tmp_path):
+        """instruct should not appear in the URL when not set."""
+        from tools.tts_tool import _generate_qwen3_tts
+
+        output = str(tmp_path / "out.mp3")
+        with patch("urllib.request.urlopen") as mock_open, \
+             patch("urllib.request.Request") as mock_req:
+            mock_open.return_value = self._make_mock_response(b"audio")
+            _generate_qwen3_tts("test", output, {})
+
+        url = mock_req.call_args[0][0]
+        assert "instruct" not in url
+
+    def test_get_provider_returns_qwen3(self):
+        """_get_provider should return 'qwen3' when tts.provider is set to 'qwen3'."""
+        from tools.tts_tool import _get_provider
+        config = {"provider": "qwen3"}
+        assert _get_provider(config) == "qwen3"
+
+
+class TestTextToSpeechTool:
+    def test_check_tts_requirements_accepts_qwen3_provider(self):
+        """qwen3 should count as an available TTS backend without edge/openai extras."""
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "qwen3"}), \
+             patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch.dict(os.environ, {}, clear=True):
+            assert check_tts_requirements() is True
+
+    def test_qwen3_direct_ogg_marks_voice_compatible(self, tmp_path, monkeypatch):
+        """Direct qwen3 .ogg output should keep the native-voice marker."""
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+        output = tmp_path / "speech.ogg"
+
+        def _fake_generate(_text, output_path, _tts_config, **_kwargs):
+            Path(output_path).write_bytes(b"fake-ogg-audio")
+            return output_path
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "qwen3"}), \
+             patch("tools.tts_tool._generate_qwen3_tts", side_effect=_fake_generate), \
+             patch("tools.tts_tool._convert_to_opus") as mock_convert:
+            result = json.loads(text_to_speech_tool("hello", output_path=str(output)))
+
+        assert result["success"] is True
+        assert result["provider"] == "qwen3"
+        assert result["voice_compatible"] is True
+        assert result["media_tag"].startswith("[[audio_as_voice]]\nMEDIA:")
+        assert result["file_path"].endswith(".ogg")
+        mock_convert.assert_not_called()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -263,6 +263,125 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
+# Provider: Qwen3-TTS (query-param API, not OpenAI SDK compatible)
+# ===========================================================================
+def _resolve_qwen3_config(tts_config: Dict[str, Any], language: Optional[str] = None) -> Dict[str, Any]:
+    """Resolve qwen3 config, applying per-language overrides when available.
+
+    Config structure::
+
+        tts:
+          qwen3:
+            base_url: http://localhost:8001
+            voice: ryan
+            instruct: "Speak naturally..."
+            languages:
+              English:
+                voice: ryan
+                instruct: "Speak naturally in English..."
+              French:
+                voice: aiden
+                instruct: "Parle naturellement en français..."
+
+    Returns a new dict with per-language keys overlaid on the base config.
+    Falls back to base config when no match is found.
+    """
+    base = dict(tts_config.get("qwen3", {}))
+    if not language:
+        return base
+    langs = base.get("languages", {}) or {}
+    for key, override in langs.items():
+        if isinstance(override, dict) and key.lower() == language.lower():
+            merged = dict(base)
+            safe_override = {k: v for k, v in override.items() if k != "languages"}
+            merged.update(safe_override)
+            merged["_language"] = key
+            return merged
+    return base
+
+
+def _generate_qwen3_tts(
+    text: str,
+    output_path: str,
+    tts_config: Dict[str, Any],
+    language: Optional[str] = None,
+    voice_override: Optional[str] = None,
+    instruct_override: Optional[str] = None,
+) -> str:
+    """Generate audio using Qwen3-TTS.
+
+    Qwen3-TTS uses a query-parameter API (``/v1/audio/speech?text=...&voice=...``)
+    rather than the OpenAI JSON body format. We call it directly with urllib
+    to avoid the SDK mismatch.
+
+    When ``language`` is provided (e.g. "English", "French"), applies
+    per-language voice/instruct overrides from ``tts.qwen3.languages``.
+
+    When ``voice_override`` is provided it takes precedence over the
+    config-resolved voice (preset name, OpenAI alias, or custom clone ID
+    such as ``vc_e87c8ed1``).
+
+    When ``instruct_override`` is provided it replaces the config-resolved
+    instruct string (e.g. "excited and enthusiastic", "sad and slow").
+    """
+    from urllib.error import HTTPError as _HTTPError
+    from urllib.parse import urlencode
+    from urllib.request import Request, urlopen
+
+    qwen_config = _resolve_qwen3_config(tts_config, language)
+    base_url = qwen_config.get("base_url", "http://localhost:8001")
+    voice = voice_override or qwen_config.get("voice", "ryan")
+    timeout = int(qwen_config.get("timeout", 120))
+
+    if output_path.endswith(".ogg"):
+        response_format = "opus"
+    elif output_path.endswith(".wav"):
+        response_format = "wav"
+    else:
+        response_format = "mp3"
+
+    params_dict = {
+        "text": text,
+        "voice": voice,
+        "response_format": response_format,
+    }
+    instruct = instruct_override or qwen_config.get("instruct", "")
+    if instruct:
+        params_dict["instruct"] = instruct
+    lang_param = language or qwen_config.get("language")
+    if lang_param:
+        params_dict["language"] = lang_param
+
+    url = f"{base_url.rstrip('/')}/v1/audio/speech?{urlencode(params_dict)}"
+
+    req = Request(url, method="POST", headers={"Content-Length": "0"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            with open(output_path, "wb") as f:
+                while True:
+                    chunk = resp.read(8192)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+    except _HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        if exc.code == 400 and "unknown voice" in body.lower():
+            raise ValueError(
+                f"Unknown voice '{voice}'. The voice ID is not registered on the "
+                "TTS server. Use register_voice_clone to register it first, then retry."
+            ) from exc
+        if exc.code == 500:
+            raise ValueError(
+                f"TTS server error (HTTP 500) while synthesising with voice '{voice}'. "
+                "The voice clone may be corrupted. Try a different voice or "
+                "re-register the clone with register_voice_clone."
+            ) from exc
+        raise
+
+    return output_path
+
+
+# ===========================================================================
 # Provider: OpenAI TTS
 # ===========================================================================
 def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
@@ -764,6 +883,9 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 def text_to_speech_tool(
     text: str,
     output_path: Optional[str] = None,
+    voice: Optional[str] = None,
+    instruct: Optional[str] = None,
+    language: Optional[str] = None,
 ) -> str:
     """
     Convert text to speech audio.
@@ -778,6 +900,11 @@ def text_to_speech_tool(
     Args:
         text: The text to convert to speech.
         output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
+        voice: Optional voice ID override (Qwen3 provider only). Accepts preset
+            names ("ryan", "aiden") or custom clone IDs ("vc_<hash>").
+        instruct: Optional speaking style/emotion instruction (Qwen3 provider only).
+        language: Optional language hint (e.g. "English", "French") for providers
+            that support per-language overrides.
 
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
@@ -810,7 +937,7 @@ def text_to_speech_tool(
         out_dir.mkdir(parents=True, exist_ok=True)
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini"):
+        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini", "qwen3"):
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -842,6 +969,17 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
             logger.info("Generating speech with OpenAI TTS...")
             _generate_openai_tts(text, file_str, tts_config)
+
+        elif provider == "qwen3":
+            logger.info("Generating speech with Qwen3-TTS...")
+            _generate_qwen3_tts(
+                text,
+                file_str,
+                tts_config,
+                language=language,
+                voice_override=voice,
+                instruct_override=instruct,
+            )
 
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")
@@ -921,7 +1059,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in ("elevenlabs", "openai", "mistral", "gemini"):
+        elif provider in ("elevenlabs", "openai", "mistral", "gemini", "qwen3"):
             voice_compatible = file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -993,6 +1131,12 @@ def check_tts_requirements() -> bool:
         return True
     if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
         return True
+    # Qwen3-TTS: self-hosted, no API key required — selected via config
+    try:
+        if _get_provider(_load_tts_config()) == "qwen3":
+            return True
+    except Exception:
+        pass
     try:
         _import_mistral_client()
         if os.getenv("MISTRAL_API_KEY"):
@@ -1316,6 +1460,30 @@ TTS_SCHEMA = {
             "output_path": {
                 "type": "string",
                 "description": f"Optional custom file path to save the audio. Defaults to {display_hermes_home()}/audio_cache/<timestamp>.mp3"
+            },
+            "voice": {
+                "type": "string",
+                "description": (
+                    "Voice to use for synthesis (Qwen3 provider only). Accepts preset names "
+                    "(e.g. 'ryan', 'aiden'), OpenAI aliases, or a custom clone ID returned "
+                    "by register_voice_clone (e.g. 'vc_e87c8ed1'). Falls back to the "
+                    "configured default when omitted. Ignored by other providers."
+                )
+            },
+            "instruct": {
+                "type": "string",
+                "description": (
+                    "Speaking style or emotion instruction (Qwen3 provider only). Short "
+                    "natural-language phrase, e.g. 'excited and enthusiastic', "
+                    "'warm and friendly, moderate pace'. Ignored by other providers."
+                )
+            },
+            "language": {
+                "type": "string",
+                "description": (
+                    "Language hint (e.g. 'English', 'French') for providers that support "
+                    "per-language voice/instruct overrides. Optional."
+                )
             }
         },
         "required": ["text"]
@@ -1328,7 +1496,250 @@ registry.register(
     schema=TTS_SCHEMA,
     handler=lambda args, **kw: text_to_speech_tool(
         text=args.get("text", ""),
-        output_path=args.get("output_path")),
+        output_path=args.get("output_path"),
+        voice=args.get("voice"),
+        instruct=args.get("instruct"),
+        language=args.get("language"),
+    ),
     check_fn=check_tts_requirements,
     emoji="🔊",
+)
+
+
+# ===========================================================================
+# Voice clone tools (Qwen3-TTS /v1/voices)
+# ===========================================================================
+
+def register_voice_clone(
+    name: str,
+    audio_id: str,
+    ref_text: Optional[str] = None,
+    language: str = "English",
+) -> str:
+    """Register a new custom voice clone on the Qwen3-TTS server.
+
+    Uploads a reference audio clip received as a voice message or audio
+    attachment to ``POST /v1/voices``. The server extracts the speaker
+    embedding; if ``ref_text`` matches the spoken content it enables full
+    ICL mode (prosody-conditioned, closer clone). Without ``ref_text`` the
+    server falls back to x-vector-only mode.
+
+    ``audio_id`` is the opaque ID shown in the enriched message when the user
+    sends a voice note or audio file attachment. The gateway resolves it to
+    the actual file — the agent never handles filesystem paths.
+
+    The returned voice ID (e.g. ``vc_e87c8ed1``) can be passed as ``voice``
+    to ``text_to_speech`` or stored for later use.
+    """
+    import mimetypes
+    import re as _re
+    import uuid as _uuid
+    from urllib.error import HTTPError
+    from urllib.request import Request, urlopen
+
+    from hermes_constants import get_hermes_dir
+
+    # audio_id must be exactly 12 lowercase hex chars — prevents path traversal.
+    if not _re.fullmatch(r"[0-9a-f]{12}", audio_id):
+        return tool_error(
+            f"Invalid audio_id '{audio_id}'. Expected exactly 12 lowercase hex "
+            "characters as shown in the voice message context.",
+            success=False,
+        )
+
+    audio_cache = get_hermes_dir("cache/audio", "audio_cache").resolve()
+    candidates = list(audio_cache.glob(f"audio_{audio_id}.*"))
+    if not candidates:
+        return tool_error(
+            f"No cached audio found for audio_id '{audio_id}'. The ID must come "
+            "from a voice message or audio attachment sent in this session.",
+            success=False,
+        )
+    audio_path_obj = candidates[0].resolve()
+    if not str(audio_path_obj).startswith(str(audio_cache) + "/"):
+        return tool_error("Audio path escaped cache directory.", success=False)
+
+    tts_config = _load_tts_config()
+    if _get_provider(tts_config) != "qwen3":
+        return tool_error(
+            "register_voice_clone requires the qwen3 TTS provider. "
+            f"Current provider: {_get_provider(tts_config)}",
+            success=False,
+        )
+
+    qwen_config = tts_config.get("qwen3", {})
+    base_url = qwen_config.get("base_url", "http://localhost:8001").rstrip("/")
+    timeout = int(qwen_config.get("timeout", 120))
+    api_key = os.getenv("QWEN_API_KEY", "")
+
+    boundary = _uuid.uuid4().hex
+    CRLF = b"\r\n"
+
+    def _field(field_name: str, value: str) -> bytes:
+        return (
+            f"--{boundary}\r\n"
+            f'Content-Disposition: form-data; name="{field_name}"\r\n\r\n'
+            f"{value}\r\n"
+        ).encode()
+
+    mime_type = mimetypes.guess_type(str(audio_path_obj))[0] or "application/octet-stream"
+    audio_data = audio_path_obj.read_bytes()
+    filename = audio_path_obj.name
+
+    body = b""
+    body += _field("name", name)
+    body += _field("language", language)
+    if ref_text and ref_text.strip():
+        body += _field("ref_text", ref_text.strip())
+    body += (
+        f"--{boundary}\r\n"
+        f'Content-Disposition: form-data; name="audio"; filename="{filename}"\r\n'
+        f"Content-Type: {mime_type}\r\n\r\n"
+    ).encode()
+    body += audio_data + CRLF
+    body += f"--{boundary}--\r\n".encode()
+
+    headers = {
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "Content-Length": str(len(body)),
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    req = Request(f"{base_url}/v1/voices", data=body, headers=headers, method="POST")
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            result = json.loads(resp.read())
+    except HTTPError as exc:
+        body_text = exc.read().decode(errors="replace")[:500]
+        return tool_error(
+            f"Voice registration failed (HTTP {exc.code}): {body_text}", success=False
+        )
+    except Exception as exc:
+        return tool_error(f"Voice registration failed: {exc}", success=False)
+
+    voice_id = result.get("id", "unknown")
+    logger.info("Registered voice clone %s (%s) id=%s", name, language, voice_id)
+    return json.dumps({
+        "success": True,
+        "id": voice_id,
+        "name": result.get("name", name),
+        "kind": result.get("kind", "custom"),
+        "language": language,
+        "ref_text_provided": bool(ref_text and ref_text.strip()),
+        "auto_transcribed": result.get("auto_transcribed", False),
+        "instructions": (
+            f"Voice '{name}' registered as {voice_id}. "
+            f"Pass voice='{voice_id}' to text_to_speech to use it."
+        ),
+    }, ensure_ascii=False)
+
+
+REGISTER_VOICE_CLONE_SCHEMA = {
+    "name": "register_voice_clone",
+    "description": (
+        "Register a new custom voice clone on the Qwen3-TTS server from a "
+        "reference audio file. The audio_id comes from a voice message or audio "
+        "attachment sent in this session. Returns a voice ID (e.g. vc_e87c8ed1) "
+        "usable as the voice= parameter in text_to_speech. Only available when "
+        "the qwen3 TTS provider is configured."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Human-friendly label for the voice."},
+            "audio_id": {
+                "type": "string",
+                "description": "12-char hex audio ID from the voice message context.",
+            },
+            "ref_text": {
+                "type": "string",
+                "description": "Verbatim transcript of the reference clip (recommended).",
+            },
+            "language": {
+                "type": "string",
+                "description": "Spoken language in the clip, e.g. 'English', 'French'.",
+            },
+        },
+        "required": ["name", "audio_id"],
+    },
+}
+
+registry.register(
+    name="register_voice_clone",
+    toolset="tts",
+    schema=REGISTER_VOICE_CLONE_SCHEMA,
+    handler=lambda args, **kw: register_voice_clone(
+        name=args["name"],
+        audio_id=args["audio_id"],
+        ref_text=args.get("ref_text"),
+        language=args.get("language", "English"),
+    ),
+    check_fn=check_tts_requirements,
+    emoji="🎙️",
+)
+
+
+def list_voice_clones() -> str:
+    """List all voice clones registered on the Qwen3-TTS server."""
+    from urllib.error import HTTPError
+    from urllib.request import Request, urlopen
+
+    tts_config = _load_tts_config()
+    if _get_provider(tts_config) != "qwen3":
+        return tool_error("list_voice_clones requires the qwen3 TTS provider.", success=False)
+
+    qwen_config = _resolve_qwen3_config(tts_config)
+    base_url = qwen_config.get("base_url", "http://localhost:8001").rstrip("/")
+    api_key = os.getenv("QWEN_API_KEY", "")
+
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    req = Request(f"{base_url}/v1/voices", headers=headers, method="GET")
+    try:
+        with urlopen(req, timeout=10) as resp:
+            raw = json.loads(resp.read().decode())
+    except HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:300]
+        return tool_error(f"TTS server error (HTTP {exc.code}): {body}", success=False)
+    except Exception as exc:
+        return tool_error(f"Failed to list voice clones: {exc}", success=False)
+
+    if isinstance(raw, list):
+        voices = raw
+    elif isinstance(raw, dict):
+        voices = raw.get("voices") or raw.get("data") or []
+    else:
+        voices = []
+
+    return json.dumps({
+        "success": True,
+        "count": len(voices),
+        "voices": voices,
+        "instructions": (
+            "Use the 'id' field (e.g. 'vc_e87c8ed1') as the voice= parameter in "
+            "text_to_speech."
+        ),
+    }, ensure_ascii=False, indent=2)
+
+
+LIST_VOICE_CLONES_SCHEMA = {
+    "name": "list_voice_clones",
+    "description": (
+        "List all custom voice clones registered on the TTS server. Returns each "
+        "clone's opaque ID (e.g. 'vc_e87c8ed1'), name, language, and kind. Only "
+        "available when the qwen3 TTS provider is configured."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+registry.register(
+    name="list_voice_clones",
+    toolset="tts",
+    schema=LIST_VOICE_CLONES_SCHEMA,
+    handler=lambda args, **kw: list_voice_clones(),
+    check_fn=check_tts_requirements,
+    emoji="🎤",
 )

--- a/website/docs/guides/use-qwen3-asr-and-tts-with-hermes.md
+++ b/website/docs/guides/use-qwen3-asr-and-tts-with-hermes.md
@@ -1,0 +1,170 @@
+---
+sidebar_position: 8
+title: "Use Qwen3 ASR and TTS with Hermes"
+description: "Wire qwen3-asr-server and qwen3-tts-server into Hermes for transcription and text-to-speech"
+---
+
+# Use Qwen3 ASR and TTS with Hermes
+
+This guide shows how to connect Hermes to:
+
+- [`qwen3-asr-server`](https://github.com/malaiwah/qwen3-asr-server) for speech-to-text
+- [`qwen3-tts-server`](https://github.com/malaiwah/qwen3-tts-server) for text-to-speech
+
+The intended result is that voice messages sent to Hermes (e.g. via Discord, Telegram, WhatsApp) are transcribed by Qwen3-ASR and replies are spoken back through Qwen3-TTS, with optional native voice-bubble delivery on platforms that support Opus.
+
+## Prerequisites
+
+- Hermes running with messaging support
+- a reachable `qwen3-asr-server`
+- a reachable `qwen3-tts-server`
+
+See also:
+
+- [TTS](/docs/user-guide/features/tts)
+- [STT](/docs/user-guide/features/tts#speech-to-text-stt)
+- [qwen3-asr-server README](https://github.com/malaiwah/qwen3-asr-server)
+- [qwen3-tts-server README](https://github.com/malaiwah/qwen3-tts-server)
+
+## Topology
+
+```mermaid
+flowchart LR
+    U["User (voice message)"] -->|"audio"| H["Hermes gateway"]
+    H -->|"STT: /v1/audio/transcriptions"| A["qwen3-asr-server"]
+    A -->|"transcript"| H
+    H -->|"LLM + tools"| H
+    H -->|"TTS: /v1/audio/speech (opus)"| T["qwen3-tts-server"]
+    T -->|"voice-message .ogg"| H
+    H -->|"native voice bubble or attachment"| U
+```
+
+## Hermes configuration
+
+Use `stt.provider: openai` for qwen3-asr because Hermes already speaks the OpenAI STT API shape and qwen3-asr-server exposes that contract.
+
+Use `tts.provider: qwen3` for qwen3-tts because Hermes ships a dedicated provider integration for it (query-parameter API rather than OpenAI's JSON body).
+
+### `~/.hermes/config.yaml`
+
+```yaml
+stt:
+  enabled: true
+  provider: "openai"
+  model: "Qwen/Qwen3-ASR-1.7B"
+  openai:
+    base_url: "http://asr-host:8002/v1"
+    api_key: "not-needed"
+    language: "en"
+
+tts:
+  provider: "qwen3"
+  qwen3:
+    base_url: "http://tts-host:8001"
+    voice: "ryan"
+    instruct: "Speak naturally and warmly."
+    timeout: 120
+    languages:
+      English:
+        voice: "ryan"
+        instruct: "Speak naturally and warmly."
+      French:
+        voice: "vc_ab12cd34"
+        instruct: "Parle naturellement en français."
+```
+
+### `~/.hermes/.env`
+
+If your qwen3 servers do not require authentication, no speech-specific env vars are needed.
+
+If your OpenAI-compatible STT endpoint requires auth and you prefer env-based credentials:
+
+```bash
+VOICE_TOOLS_OPENAI_KEY=your-token
+STT_OPENAI_BASE_URL=http://asr-host:8002/v1
+```
+
+Config values take precedence when both config and env are set.
+
+## Field reference
+
+### STT
+
+- `stt.provider: openai` — tells Hermes to use the OpenAI speech-to-text API shape
+- `stt.model` — the model name Hermes passes on transcription requests
+- `stt.openai.base_url` — points Hermes at qwen3-asr-server instead of OpenAI
+- `stt.openai.api_key` — optional; use a dummy string for unauthenticated local servers
+- `stt.openai.language` — optional language hint (ISO codes like `en` or `fr`)
+
+### TTS
+
+- `tts.provider: qwen3` — enables the dedicated qwen3 TTS integration
+- `tts.qwen3.base_url` — qwen3-tts-server base URL
+- `tts.qwen3.voice` — preset voice, OpenAI alias, or custom clone ID like `vc_ab12cd34`
+- `tts.qwen3.instruct` — optional speaking-style hint
+- `tts.qwen3.timeout` — request timeout in seconds (default 120)
+- `tts.qwen3.languages` — per-language overrides for bilingual or multilingual setups
+
+## Voice clones
+
+Hermes can register and use Qwen3 voice clones through the standard tool surface:
+
+- `register_voice_clone` — uploads a reference audio clip and returns a `vc_<id>`
+- `list_voice_clones` — lists all clones registered on the server
+- `text_to_speech` — accepts `voice="vc_<id>"` to synthesise with the clone
+
+Typical flow:
+
+1. The user sends Hermes a voice message
+2. The user asks Hermes to register that recording as a voice clone
+3. Hermes calls `register_voice_clone` with the message's `audio_id`
+4. Hermes can then use the returned `vc_<id>` in `text_to_speech(voice="vc_<id>")`
+
+## Verification
+
+### Verify qwen3-asr-server
+
+```bash
+curl -s http://asr-host:8002/health
+curl -s -X POST http://asr-host:8002/v1/audio/transcriptions \
+  -F model=Qwen/Qwen3-ASR-1.7B \
+  -F language=en \
+  -F file=@sample.wav
+```
+
+### Verify qwen3-tts-server
+
+```bash
+curl -s http://tts-host:8001/health
+curl -s http://tts-host:8001/v1/voices | jq '.data[0:5]'
+curl -s -X POST "http://tts-host:8001/v1/audio/speech?text=Hello+from+Hermes&voice=ryan&response_format=opus&language=English" \
+  --output hello.ogg
+```
+
+### Verify Hermes
+
+1. Send Hermes a voice message
+2. Confirm Hermes transcribes it (check logs for the STT call to qwen3-asr-server)
+3. Confirm Hermes replies with synthesised audio (check logs for the TTS call to qwen3-tts-server)
+4. On platforms with native voice bubbles (Telegram, Discord), confirm the reply arrives as a voice bubble rather than a file attachment
+
+## Troubleshooting
+
+### Hermes is using local Whisper instead of qwen3-asr
+
+Check that:
+
+- `stt.provider` is explicitly set to `openai`
+- `stt.model` is set
+- `stt.openai.base_url` points to qwen3-asr-server
+- The running Hermes instance picked up the latest config
+
+### Reply arrives as a file attachment instead of a native voice bubble
+
+Check that:
+
+- The qwen3-tts output extension is `.ogg` (Opus); Hermes selects this automatically when the platform is Telegram
+- The platform actually supports native voice bubbles for the message type
+- The audio file is well-formed Opus (test the URL directly with curl)
+
+Hermes falls back to a normal audio attachment if the native voice-message route is rejected.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,13 +14,14 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with seven providers:
+Convert text to speech with eight providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
 | **Edge TTS** (default) | Good | Free | None needed |
 | **ElevenLabs** | Excellent | Paid | `ELEVENLABS_API_KEY` |
 | **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
+| **Qwen3-TTS** | Excellent | Self-hosted | None by default |
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
@@ -40,7 +41,7 @@ Convert text to speech with seven providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "neutts"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "qwen3" | "minimax" | "mistral" | "gemini" | "neutts"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -53,6 +54,17 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+  qwen3:
+    base_url: "http://localhost:8001"  # Self-hosted Qwen3-TTS server
+    voice: "ryan"               # preset voice, OpenAI alias, or vc_<clone_id>
+    instruct: "Speak warmly."   # optional speaking-style hint
+    timeout: 120
+    languages:                   # optional per-language overrides
+      English:
+        voice: "ryan"
+      French:
+        voice: "vc_1234abcd"
+        instruct: "Parle naturellement en français."
   minimax:
     model: "speech-2.8-hd"     # speech-2.8-hd (default), speech-2.8-turbo
     voice_id: "English_Graceful_Lady"  # See https://platform.minimax.io/faq/system-voice-id
@@ -78,7 +90,7 @@ tts:
 
 Telegram voice bubbles require Opus/OGG audio format:
 
-- **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
+- **OpenAI, ElevenLabs, Mistral, and Qwen3** produce Opus natively — no extra setup
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles


### PR DESCRIPTION
## Summary

Adds a self-hosted [Qwen3-TTS](https://github.com/QwenLM/Qwen3-Omni) provider. Qwen3-TTS uses a query-parameter API (`/v1/audio/speech?text=...&voice=...`) rather than the OpenAI JSON body shape, so it cannot be served by the existing OpenAI-compatible client — it needs its own dispatcher.

- `_generate_qwen3_tts`: stdlib `urllib` client; supports preset voices, custom clone IDs (`vc_<hash>`), language hints, per-language overrides, and an `instruct` speaking-style parameter.
- `_resolve_qwen3_config`: per-language overlay over the base qwen3 config for bilingual / multilingual setups.
- `text_to_speech` tool: gains optional `voice` / `instruct` / `language` params (Qwen3-only; ignored by other providers). Telegram voice-bubble path recognises Qwen3 as a native-Opus producer (no ffmpeg transcoding needed).
- `check_tts_requirements`: returns `True` when `tts.provider=qwen3`, since Qwen3 is self-hosted and needs no API key.
- `register_voice_clone` / `list_voice_clones`: tools for managing custom voice clones on a Qwen3-TTS server (POST/GET `/v1/voices`). `audio_id` is validated as 12-char hex to prevent path traversal.
- **No new Python dependencies** — Qwen3-TTS uses only stdlib `urllib`.

## Test plan

- [x] 13 new unit tests in `tests/tools/test_tts_tool.py` covering URL shape, defaults, `response_format`, POST method, timeout, `instruct`, and provider dispatch.
- [x] Full `tests/tools/` suite passes locally (`uv run pytest tests/tools/`).
- [ ] Reviewer sanity check: confirm no regression for existing providers (openai / elevenlabs / edge-tts).

## Docs

- New row in the TTS provider comparison table (`website/docs/user-guide/features/tts.md`).
- New config block showing `tts.provider=qwen3` + per-language overrides.
- New integration guide: `website/docs/guides/use-qwen3-asr-and-tts-with-hermes.md` covering setup (qwen3-tts-server), voice clones, and verification.

## Notes for reviewer

- Two follow-up PRs are staged on the same fork that build on top of this one (Discord VAD and voice-reply directives). Each is independently useful and can land in any order — this one is the standalone baseline.