### PR TITLE
fix(agent): bound project context file reads (aiofiles, timeout, LRU)

### DIFF
--- a/agent/context_file_io.py
+++ b/agent/context_file_io.py
@@ -1,0 +1,153 @@
+"""Bounded context-file reads (aiofiles + wait_for + mtime LRU).
+
+``read_text_sync`` offloads to a worker thread when an asyncio loop is already
+running so gateway threads avoid unbounded ``Path.read_text`` stalls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Final
+
+import aiofiles
+
+logger = logging.getLogger(__name__)
+
+_CACHE_MAX: Final[int] = 64
+_cache: "OrderedDict[tuple[str, int], str]" = OrderedDict()
+_cache_lock = threading.Lock()
+
+# One-off pool for nested "already in asyncio loop" paths (short-lived tasks).
+_nested_pool = ThreadPoolExecutor(1, thread_name_prefix="ctxfileio")
+
+
+def clear_context_file_cache() -> None:
+    """Drop all cached context file bodies (tests / hot reload)."""
+    with _cache_lock:
+        _cache.clear()
+
+
+def _cache_get(key: tuple[str, int]) -> str | None:
+    with _cache_lock:
+        val = _cache.get(key)
+        if val is not None:
+            _cache.move_to_end(key)
+        return val
+
+
+def _cache_put(key: tuple[str, int], text: str) -> None:
+    with _cache_lock:
+        _cache[key] = text
+        _cache.move_to_end(key)
+        while len(_cache) > _CACHE_MAX:
+            _cache.popitem(last=False)
+
+
+async def read_text_async(path: Path, *, timeout_s: float = 10.0, encoding: str = "utf-8") -> str:
+    """Read *path* with aiofiles under an ``asyncio`` timeout."""
+    resolved = path.expanduser()
+    try:
+        resolved = resolved.resolve(strict=False)
+    except OSError as exc:
+        logger.debug("context path resolve failed %s: %s", path, exc)
+        return ""
+
+    if not resolved.is_file():
+        return ""
+
+    try:
+        mtime_ns = await asyncio.wait_for(
+            asyncio.to_thread(lambda: resolved.stat().st_mtime_ns),
+            timeout=min(2.0, timeout_s),
+        )
+    except (OSError, asyncio.TimeoutError) as exc:
+        logger.debug("context file stat failed %s: %s", resolved, exc)
+        return ""
+
+    key = (str(resolved), int(mtime_ns))
+    hit = _cache_get(key)
+    if hit is not None:
+        return hit
+
+    async def _body() -> str:
+        async with aiofiles.open(resolved, mode="r", encoding=encoding) as handle:
+            return await handle.read()
+
+    try:
+        text = await asyncio.wait_for(_body(), timeout=timeout_s)
+    except (asyncio.TimeoutError, OSError, UnicodeDecodeError) as exc:
+        logger.debug("context async read failed %s: %s", resolved, exc)
+        return ""
+
+    _cache_put(key, text)
+    return text
+
+
+def read_text_sync(path: Path, *, timeout_s: float = 10.0, encoding: str = "utf-8") -> str:
+    """Synchronous API used by ``prompt_builder`` (thread-safe, bounded latency)."""
+    resolved = path.expanduser()
+    try:
+        resolved = resolved.resolve(strict=False)
+    except OSError as exc:
+        logger.debug("context path resolve failed %s: %s", path, exc)
+        return ""
+
+    if not resolved.is_file():
+        return ""
+
+    try:
+        mtime_ns = resolved.stat().st_mtime_ns
+    except OSError as exc:
+        logger.debug("context file stat failed %s: %s", resolved, exc)
+        return ""
+
+    key = (str(resolved), int(mtime_ns))
+    hit = _cache_get(key)
+    if hit is not None:
+        return hit
+
+    def _fresh_read() -> str:
+        return asyncio.run(read_text_async(resolved, timeout_s=timeout_s, encoding=encoding))
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        try:
+            return _fresh_read()
+        except RuntimeError:
+            fut = _nested_pool.submit(_fresh_read)
+            try:
+                return fut.result(timeout=timeout_s + 5.0)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("context read fallback failed %s: %s", resolved, exc)
+                return ""
+    else:
+        fut = _nested_pool.submit(_fresh_read)
+        try:
+            return fut.result(timeout=timeout_s + 5.0)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("context read (nested thread) failed %s: %s", resolved, exc)
+            return ""
+
+
+def read_many_sync(paths: list[Path], *, timeout_s: float = 10.0, encoding: str = "utf-8") -> list[str]:
+    """Read several paths in parallel (each call is independently bounded)."""
+    if not paths:
+        return []
+    workers = min(8, len(paths))
+    out: list[str | None] = [None] * len(paths)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futs = {pool.submit(read_text_sync, p, timeout_s=timeout_s, encoding=encoding): i for i, p in enumerate(paths)}
+        for fut in as_completed(futs):
+            idx = futs[fut]
+            try:
+                out[idx] = fut.result()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("parallel context read failed: %s", exc)
+                out[idx] = ""
+    return [x if x is not None else "" for x in out]

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
+from agent.context_file_io import read_many_sync, read_text_sync
 from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
@@ -907,7 +908,7 @@ def load_soul_md() -> Optional[str]:
     if not soul_path.exists():
         return None
     try:
-        content = soul_path.read_text(encoding="utf-8").strip()
+        content = read_text_sync(soul_path, encoding="utf-8").strip()
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
@@ -924,7 +925,7 @@ def _load_hermes_md(cwd_path: Path) -> str:
     if not hermes_md_path:
         return ""
     try:
-        content = hermes_md_path.read_text(encoding="utf-8").strip()
+        content = read_text_sync(hermes_md_path, encoding="utf-8").strip()
         if not content:
             return ""
         content = _strip_yaml_frontmatter(content)
@@ -947,7 +948,7 @@ def _load_agents_md(cwd_path: Path) -> str:
         candidate = cwd_path / name
         if candidate.exists():
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = read_text_sync(candidate, encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
@@ -963,7 +964,7 @@ def _load_claude_md(cwd_path: Path) -> str:
         candidate = cwd_path / name
         if candidate.exists():
             try:
-                content = candidate.read_text(encoding="utf-8").strip()
+                content = read_text_sync(candidate, encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
                     result = f"## {name}\n\n{content}"
@@ -979,7 +980,7 @@ def _load_cursorrules(cwd_path: Path) -> str:
     cursorrules_file = cwd_path / ".cursorrules"
     if cursorrules_file.exists():
         try:
-            content = cursorrules_file.read_text(encoding="utf-8").strip()
+            content = read_text_sync(cursorrules_file, encoding="utf-8").strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
@@ -989,9 +990,10 @@ def _load_cursorrules(cwd_path: Path) -> str:
     cursor_rules_dir = cwd_path / ".cursor" / "rules"
     if cursor_rules_dir.exists() and cursor_rules_dir.is_dir():
         mdc_files = sorted(cursor_rules_dir.glob("*.mdc"))
-        for mdc_file in mdc_files:
+        bodies = read_many_sync(mdc_files, encoding="utf-8")
+        for mdc_file, raw in zip(mdc_files, bodies, strict=True):
             try:
-                content = mdc_file.read_text(encoding="utf-8").strip()
+                content = raw.strip()
                 if content:
                     content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
                     cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [{ name = "Nous Research" }]
 license = { text = "MIT" }
 dependencies = [
   # Core — pinned to known-good ranges to limit supply chain attack surface
+  "aiofiles>=24.1.0,<26",
   "openai>=2.21.0,<3",
   "anthropic>=0.39.0,<1",
   "python-dotenv>=1.2.1,<2",

--- a/tests/agent/test_context_file_io.py
+++ b/tests/agent/test_context_file_io.py
@@ -1,0 +1,60 @@
+"""Tests for agent/context_file_io.py — bounded reads and LRU cache."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agent.context_file_io import clear_context_file_cache, read_many_sync, read_text_async, read_text_sync
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_context_file_cache()
+    yield
+    clear_context_file_cache()
+
+
+def test_read_text_sync_roundtrip(tmp_path: Path):
+    p = tmp_path / "ctx.md"
+    p.write_text("alpha", encoding="utf-8")
+    assert read_text_sync(p) == "alpha"
+    assert read_text_sync(p) == "alpha"
+
+
+def test_read_text_sync_missing(tmp_path: Path):
+    assert read_text_sync(tmp_path / "nope.md") == ""
+
+
+def test_cache_invalidates_on_mtime_change(tmp_path: Path):
+    p = tmp_path / "mut.md"
+    p.write_text("v1", encoding="utf-8")
+    assert read_text_sync(p) == "v1"
+    p.write_text("v2", encoding="utf-8")
+    assert read_text_sync(p) == "v2"
+
+
+def test_read_many_sync_order(tmp_path: Path):
+    a = tmp_path / "a.mdc"
+    b = tmp_path / "b.mdc"
+    a.write_text("A", encoding="utf-8")
+    b.write_text("B", encoding="utf-8")
+    bodies = read_many_sync([a, b])
+    assert bodies == ["A", "B"]
+
+
+@pytest.mark.asyncio
+async def test_read_text_async_roundtrip(tmp_path: Path):
+    p = tmp_path / "async.md"
+    p.write_text("beta", encoding="utf-8")
+    assert await read_text_async(p) == "beta"
+
+
+def test_read_text_sync_from_running_loop_offloads(tmp_path: Path):
+    p = tmp_path / "loop.md"
+    p.write_text("gamma", encoding="utf-8")
+
+    async def _runner():
+        return read_text_sync(p)
+
+    assert asyncio.run(_runner()) == "gamma"


### PR DESCRIPTION
## Summary

Project context files (SOUL.md, HERMES/.hermes.md, AGENTS.md, CLAUDE.md, `.cursorrules`, `.cursor/rules/*.mdc`) were loaded with synchronous `Path.read_text()`, which can block for a long time on high-latency filesystems (e.g. cloud sync folders). That stalls system prompt assembly and hurts responsiveness.

This change introduces a small I/O helper that reads via **aiofiles** under **`asyncio.wait_for` (default 10s)**, adds an **mtime + resolved path LRU cache** (64 entries), and uses **parallel reads** for multiple `.mdc` rule files. When `read_text_sync` is invoked while an asyncio loop is already running, the actual read runs in a dedicated worker thread with its own event loop so the caller’s loop is not used incorrectly with nested `asyncio.run`.

## Changes

- New `agent/context_file_io.py`: `read_text_sync`, `read_text_async`, `read_many_sync`, `clear_context_file_cache`.
- `agent/prompt_builder.py`: context loaders now use the helper instead of `Path.read_text`.
- `pyproject.toml`: add `aiofiles` dependency.
- Tests: `tests/agent/test_context_file_io.py`; existing `tests/agent/test_prompt_builder.py` still passes.

## Test plan

- `pytest tests/agent/test_context_file_io.py tests/agent/test_prompt_builder.py -q -o addopts=`

## Notes / follow-ups

- `watchdog`-based invalidation and a fully async `build_context_files_prompt` API are intentionally out of scope here; can be a follow-up if desired.
- If the project requires an updated lockfile for CI, run `uv lock` (or the repo’s standard lock refresh) in an environment with `uv` installed and push the lockfile update.