### PR TITLE
fix(agent): fall back when rg is blocked for @folder references

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -483,9 +483,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
             text=True,
             timeout=10,
         )
-    except FileNotFoundError:
-        return None
-    except subprocess.TimeoutExpired:
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
     if result.returncode != 0:
         return None

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -121,6 +122,31 @@ def test_expand_file_range_and_folder_listing(sample_repo: Path):
     assert "main.py" in result.message
     assert "helper.py" in result.message
     assert result.injected_tokens > 0
+    assert not result.warnings
+
+
+def test_folder_listing_falls_back_when_rg_is_blocked(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    real_run = subprocess.run
+
+    def blocked_rg(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if isinstance(cmd, list) and cmd and cmd[0] == "rg":
+            raise PermissionError("rg blocked by policy")
+        return real_run(*args, **kwargs)
+
+    with patch("agent.context_references.subprocess.run", side_effect=blocked_rg):
+        result = preprocess_context_references(
+            "Review @folder:src/",
+            cwd=sample_repo,
+            context_length=100_000,
+        )
+
+    assert result.expanded
+    assert "src/" in result.message
+    assert "main.py" in result.message
+    assert "helper.py" in result.message
     assert not result.warnings
 
 


### PR DESCRIPTION
## Summary

Fix `@folder:` context expansion so it still works when `rg` is installed but cannot be executed due to local policy restrictions.

## What changed

- Broadened the `rg` failure handling in `agent/context_references.py` so `@folder:` listing falls back to `os.walk` on `OSError`, not just missing binary / timeout cases.
- Added a regression test that simulates `rg` being blocked with `PermissionError` and verifies folder context is still attached.

## Why

In restricted environments, `rg` may exist on the machine but fail to launch because of AppLocker / endpoint policy. Before this change, `@folder:` expansion degraded into a warning instead of producing the expected folder listing.

## Testing

- `py -m pytest tests/agent/test_context_references.py -q -n 4 -k "folder_listing_falls_back_when_rg_is_blocked or expand_file_range_and_folder_listing"`


