### PR TITLE
fix(gateway): re dispatch aliased quick commands to builtin slash handlers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3264,11 +3264,11 @@ class GatewayRunner:
                     target = qcmd.get("target", "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
-                        target_command = target.lstrip("/")
                         user_args = event.get_command_args().strip()
                         event.text = f"{target} {user_args}".strip()
-                        command = target_command
-                        # Fall through to normal command dispatch below
+                        # Re-dispatch so aliased built-ins follow the same
+                        # command path as if the user had typed the target.
+                        return await self._handle_message(event)
                     else:
                         return f"Quick command '/{command}' has no target defined."
                 else:

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -4,6 +4,10 @@ from unittest.mock import MagicMock, patch, AsyncMock
 from rich.text import Text
 import pytest
 
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
 
 # ── CLI tests ──────────────────────────────────────────────────────────────
 
@@ -186,3 +190,38 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_alias_command_re_dispatches_to_builtin_handler(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"shortcut": {"type": "alias", "target": "/help"}}}
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        runner._busy_ack_ts = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._handle_help_command = AsyncMock(side_effect=lambda ev: ev.text)
+        runner._handle_message_with_agent = AsyncMock(return_value="agent")
+        runner.hooks = MagicMock()
+        runner.hooks.emit = AsyncMock()
+
+        event = MessageEvent(
+            text="/shortcut extra args",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                user_id="test_user",
+                user_name="Test User",
+                chat_id="123",
+                chat_type="dm",
+            ),
+        )
+
+        result = await runner._handle_message(event)
+
+        assert result == "/help extra args"
+        runner._handle_help_command.assert_awaited_once()
+        runner._handle_message_with_agent.assert_not_awaited()


### PR DESCRIPTION
##  Problem: Aliased Commands Bypassing Built-in Handlers
In the gateway, quick-command aliases were correctly rewriting `event.text`, but the flow would then fall through to the agent/LLM logic instead of re-evaluating the new command. This meant aliases pointing to built-in slash commands (e.g., `/shortcut` -> `/help`) were effectively broken or leaked as raw text into the conversation.

##  Tactical Fix
- **Re-dispatch Logic:** Updated `gateway/run.py` to recursively call `_handle_message(event)` after an alias rewrite. 
- **CLI Alignment:** This brings gateway alias behavior in line with the existing CLI implementation, ensuring all built-in handlers are available for quick-command targets.
- **Safety-Net:** Prevents rewritten slash commands from reaching the agent loop unnecessarily.

##  Battle Logs (Validation)
- **Regression Test:** Added `test_alias_command_re_dispatches_to_builtin_handler` which verifies that an alias target correctly triggers the `/help` handler.
- **Result:** `5 passed` in `TestGatewayQuickCommands` ✅

##  Files
- `gateway/run.py`
- `tests/cli/test_quick_commands.py`
- `scripts/release.py` 