### PR TITLE
fix(memory): expose session_title to on_turn_start/sync_turn hooks

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -207,11 +207,15 @@ class MemoryManager:
 
     # -- Sync ----------------------------------------------------------------
 
-    def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        """Sync a completed turn to all providers."""
+    def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
+        """Sync a completed turn to all providers.
+
+        kwargs are forwarded to each provider's sync_turn() — e.g.
+        ``session_title`` lets providers tag writes with the current title.
+        """
         for provider in self._providers:
             try:
-                provider.sync_turn(user_content, assistant_content, session_id=session_id)
+                provider.sync_turn(user_content, assistant_content, session_id=session_id, **kwargs)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' sync_turn failed: %s",

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -111,11 +111,16 @@ class MemoryProvider(ABC):
         that do background prefetching should override this.
         """
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Persist a completed turn to the backend.
 
         Called after each turn. Should be non-blocking — queue for
         background processing if the backend has latency.
+
+        kwargs may include:
+          - session_title (str): Current session title, if one has been set
+            or auto-generated. Providers that scope memories by conversation
+            topic can use this to tag or route writes.
         """
 
     @abstractmethod
@@ -146,8 +151,11 @@ class MemoryProvider(ABC):
 
         Use for turn-counting, scope management, periodic maintenance.
 
-        kwargs may include: remaining_tokens, model, platform, tool_count.
-        Providers use what they need; extras are ignored.
+        kwargs may include: remaining_tokens, model, platform, tool_count,
+        session_title. Providers use what they need; extras are ignored.
+        session_title reflects the title at the start of the turn — it may
+        change later in the same turn (e.g. when auto-titling completes
+        after the first response).
         """
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -234,7 +234,7 @@ class ByteRoverMemoryProvider(MemoryProvider):
         """No-op: prefetch() now runs synchronously at turn start."""
         pass
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Curate the conversation turn in background (non-blocking)."""
         self._turn_count += 1
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -712,7 +712,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Retain conversation turn in background (non-blocking).
 
         Respects retain_every_n_turns for batching.

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -218,7 +218,7 @@ class HolographicMemoryProvider(MemoryProvider):
             logger.debug("Holographic prefetch failed: %s", e)
             return ""
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         # Holographic memory stores explicit facts via tools, not auto-sync.
         # The on_session_end hook handles auto-extraction if configured.
         pass

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -857,7 +857,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
         return chunks
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Record the conversation turn in Honcho (non-blocking).
 
         Messages exceeding the Honcho API limit (default 25k chars) are

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -269,7 +269,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="mem0-prefetch")
         self._prefetch_thread.start()
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Send the turn to Mem0 for server-side fact extraction (non-blocking)."""
         if self._is_breaker_open():
             return

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -408,7 +408,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
         self._prefetch_thread.start()
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Record the conversation turn in OpenViking's session (non-blocking)."""
         if not self._client:
             return

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -624,7 +624,7 @@ class RetainDBMemoryProvider(MemoryProvider):
 
     # ── Turn sync ──────────────────────────────────────────────────────────
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         """Queue turn for async ingest. Returns immediately."""
         if not self._queue or not user_content:
             return

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -560,7 +560,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             logger.debug("Supermemory prefetch failed", exc_info=True)
             return ""
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "", **kwargs) -> None:
         if not self._active or not self._auto_capture or not self._write_enabled or not self._client:
             return
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8679,7 +8679,15 @@ class AIAgent:
         if self._memory_manager:
             try:
                 _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
-                self._memory_manager.on_turn_start(self._user_turn_count, _turn_msg)
+                _turn_kwargs: Dict[str, Any] = {}
+                if self._session_db:
+                    try:
+                        _cur_title = self._session_db.get_session_title(self.session_id)
+                        if _cur_title:
+                            _turn_kwargs["session_title"] = _cur_title
+                    except Exception:
+                        pass
+                self._memory_manager.on_turn_start(self._user_turn_count, _turn_msg, **_turn_kwargs)
             except Exception:
                 pass
 
@@ -11466,7 +11474,15 @@ class AIAgent:
         # injected skill content that bloats / breaks provider queries.
         if self._memory_manager and final_response and original_user_message:
             try:
-                self._memory_manager.sync_all(original_user_message, final_response)
+                _sync_kwargs: Dict[str, Any] = {}
+                if self._session_db:
+                    try:
+                        _cur_title = self._session_db.get_session_title(self.session_id)
+                        if _cur_title:
+                            _sync_kwargs["session_title"] = _cur_title
+                    except Exception:
+                        pass
+                self._memory_manager.sync_all(original_user_message, final_response, **_sync_kwargs)
                 self._memory_manager.queue_prefetch_all(original_user_message)
             except Exception:
                 pass

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -21,9 +21,11 @@ class FakeMemoryProvider(MemoryProvider):
         self._tools = tools or []
         self.initialized = False
         self.synced_turns = []
+        self.sync_turn_kwargs = []
         self.prefetch_queries = []
         self.queued_prefetches = []
         self.turn_starts = []
+        self.turn_start_kwargs = []
         self.session_end_called = False
         self.pre_compress_called = False
         self.memory_writes = []
@@ -52,8 +54,9 @@ class FakeMemoryProvider(MemoryProvider):
     def queue_prefetch(self, query, *, session_id=""):
         self.queued_prefetches.append(query)
 
-    def sync_turn(self, user_content, assistant_content, *, session_id=""):
+    def sync_turn(self, user_content, assistant_content, *, session_id="", **kwargs):
         self.synced_turns.append((user_content, assistant_content))
+        self.sync_turn_kwargs.append(kwargs)
 
     def get_tool_schemas(self):
         return self._tools
@@ -64,8 +67,9 @@ class FakeMemoryProvider(MemoryProvider):
     def shutdown(self):
         self.shutdown_called = True
 
-    def on_turn_start(self, turn_number, message):
+    def on_turn_start(self, turn_number, message, **kwargs):
         self.turn_starts.append((turn_number, message))
+        self.turn_start_kwargs.append(kwargs)
 
     def on_session_end(self, messages):
         self.session_end_called = True
@@ -304,6 +308,24 @@ class TestMemoryManager:
         mgr.add_provider(p)
         mgr.on_turn_start(3, "hello")
         assert p.turn_starts == [(3, "hello")]
+
+    def test_on_turn_start_forwards_session_title(self):
+        """session_title kwarg reaches providers so they can scope by topic."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("p")
+        mgr.add_provider(p)
+        mgr.on_turn_start(1, "hi", session_title="Debugging NVIDIA NIM")
+        assert p.turn_starts == [(1, "hi")]
+        assert p.turn_start_kwargs == [{"session_title": "Debugging NVIDIA NIM"}]
+
+    def test_sync_all_forwards_session_title(self):
+        """session_title kwarg reaches providers via sync_turn."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("p")
+        mgr.add_provider(p)
+        mgr.sync_all("u", "a", session_title="Trip planning")
+        assert p.synced_turns == [("u", "a")]
+        assert p.sync_turn_kwargs == [{"session_title": "Trip planning"}]
 
     def test_on_session_end(self):
         mgr = MemoryManager()


### PR DESCRIPTION
## Summary
- Thread the current session title through `MemoryProvider.on_turn_start` and `sync_turn` as a `session_title` kwarg so providers can observe titles that are auto-generated or `/title`-set after `initialize()`.
- `MemoryManager.sync_all` now forwards arbitrary kwargs to each provider's `sync_turn`; `on_turn_start` already forwarded kwargs, so the fix is wiring the call site in `run_agent.py` to look up the current title on each turn.
- Broaden the `sync_turn` signature on the base class and all bundled plugin providers (hindsight, retaindb, openviking, holographic, honcho, byterover, mem0, supermemory) to accept `**kwargs`, so passing `session_title` doesn't raise `TypeError`.

Fixes #7777.

## Test plan
- [x] `python -m pytest tests/agent/test_memory_provider.py` (62 passed) — includes new regression tests that verify `on_turn_start` and `sync_all` forward `session_title` to providers.
- [x] `python -m py_compile` on every changed file.