### PR TITLE
fix(discord): stop truncating flat /skill autocomplete catalog

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2028,7 +2028,7 @@ class DiscordAdapter(BasePlatformAdapter):
         skill name and its description.
         """
         try:
-            from hermes_cli.commands import discord_skill_commands_by_category
+            from hermes_cli.commands import discord_skill_autocomplete_entries
 
             existing_names = set()
             try:
@@ -2036,16 +2036,11 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-            # Reuse the existing collector for consistent filtering
-            # (per-platform disabled, hub-excluded, name clamping), then
-            # flatten — the category grouping was only useful for the
-            # nested layout.
-            categories, uncategorized, hidden = discord_skill_commands_by_category(
+            # Use the flat collector directly so autocomplete can expose the
+            # full filtered catalog without the old 25x25 subgroup cap.
+            entries, hidden = discord_skill_autocomplete_entries(
                 reserved_names=existing_names,
             )
-            entries: list[tuple[str, str, str]] = list(uncategorized)
-            for cat_skills in categories.values():
-                entries.extend(cat_skills)
 
             if not entries:
                 return

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -396,6 +396,32 @@ def _clamp_command_names(
     return result
 
 
+def _clamp_command_triples(
+    entries: list[tuple[str, str, str]],
+    reserved: set[str],
+) -> list[tuple[str, str, str]]:
+    """Clamp command names while preserving attached metadata like ``cmd_key``."""
+    used: set[str] = set(reserved)
+    result: list[tuple[str, str, str]] = []
+    for name, desc, cmd_key in entries:
+        if len(name) > _CMD_NAME_LIMIT:
+            candidate = name[:_CMD_NAME_LIMIT]
+            if candidate in used:
+                prefix = name[:_CMD_NAME_LIMIT - 1]
+                for digit in range(10):
+                    candidate = f"{prefix}{digit}"
+                    if candidate not in used:
+                        break
+                else:
+                    continue
+            name = candidate
+        if name in used:
+            continue
+        used.add(name)
+        result.append((name, desc, cmd_key))
+    return result
+
+
 # Backward-compat alias.
 _clamp_telegram_names = _clamp_command_names
 
@@ -500,17 +526,14 @@ def _collect_gateway_skill_entries(
     except Exception:
         pass
 
-    # Clamp names; _clamp_command_names works on (name, desc) pairs so we
-    # need to zip/unzip.
-    skill_pairs = [(n, d) for n, d, _ in skill_triples]
-    key_by_pair = {(n, d): k for n, d, k in skill_triples}
-    skill_pairs = _clamp_command_names(skill_pairs, reserved_names)
+    # Clamp skill names while preserving the original cmd_key used at dispatch.
+    skill_triples = _clamp_command_triples(skill_triples, reserved_names)
 
     # Skills fill remaining slots — only tier that gets trimmed
     remaining = max(0, max_slots - len(all_entries))
-    hidden_count = max(0, len(skill_pairs) - remaining)
-    for n, d in skill_pairs[:remaining]:
-        all_entries.append((n, d, key_by_pair.get((n, d), "")))
+    hidden_count = max(0, len(skill_triples) - remaining)
+    for n, d, cmd_key in skill_triples[:remaining]:
+        all_entries.append((n, d, cmd_key))
 
     return all_entries[:max_slots], hidden_count
 
@@ -580,6 +603,21 @@ def discord_skill_commands(
         max_slots=max_slots,
         reserved_names=set(reserved_names),  # copy — don't mutate caller's set
         desc_limit=100,
+    )
+
+
+def discord_skill_autocomplete_entries(
+    reserved_names: set[str],
+) -> tuple[list[tuple[str, str, str]], int]:
+    """Return all Discord skill entries for the flat ``/skill`` autocomplete UI.
+
+    The flat autocomplete command no longer has Discord's old 25-groups ×
+    25-subcommands structural limit, so it should expose the full filtered skill
+    catalog instead of routing through the legacy category-capped collector.
+    """
+    return discord_skill_commands(
+        max_slots=10_000,
+        reserved_names=reserved_names,
     )
 
 

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -695,22 +695,16 @@ def test_register_skill_command_is_flat_not_nested(adapter):
     flat layout sidesteps the limit — autocomplete options are fetched
     dynamically by Discord and don't count against the registration budget.
     """
-    mock_categories = {
-        "creative": [
-            ("ascii-art", "Generate ASCII art", "/ascii-art"),
-            ("excalidraw", "Hand-drawn diagrams", "/excalidraw"),
-        ],
-        "media": [
-            ("gif-search", "Search for GIFs", "/gif-search"),
-        ],
-    }
-    mock_uncategorized = [
+    mock_entries = [
         ("dogfood", "Exploratory QA testing", "/dogfood"),
+        ("ascii-art", "Generate ASCII art", "/ascii-art"),
+        ("excalidraw", "Hand-drawn diagrams", "/excalidraw"),
+        ("gif-search", "Search for GIFs", "/gif-search"),
     ]
 
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=(mock_categories, mock_uncategorized, 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=(mock_entries, 0),
     ):
         adapter._register_slash_commands()
 
@@ -727,8 +721,8 @@ def test_register_skill_command_is_flat_not_nested(adapter):
 def test_register_skill_command_empty_skills_no_command(adapter):
     """No /skill command should be registered when there are zero skills."""
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=({}, [], 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=([], 0),
     ):
         adapter._register_slash_commands()
 
@@ -740,18 +734,14 @@ def test_register_skill_command_callback_dispatches_by_name(adapter):
     """The /skill callback should look up the skill by ``name`` and
     dispatch via ``_run_simple_slash`` with the real command key.
     """
-    mock_categories = {
-        "media": [
-            ("gif-search", "Search for GIFs", "/gif-search"),
-        ],
-    }
-    mock_uncategorized = [
+    mock_entries = [
         ("dogfood", "QA testing", "/dogfood"),
+        ("gif-search", "Search for GIFs", "/gif-search"),
     ]
 
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=(mock_categories, mock_uncategorized, 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=(mock_entries, 0),
     ):
         adapter._register_slash_commands()
 
@@ -782,8 +772,8 @@ def test_register_skill_command_handles_unknown_skill_gracefully(adapter):
     an ephemeral error message, NOT crash the callback.
     """
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=({"media": [("gif-search", "GIFs", "/gif-search")]}, [], 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=([("gif-search", "GIFs", "/gif-search")], 0),
     ):
         adapter._register_slash_commands()
 
@@ -820,18 +810,16 @@ def test_register_skill_command_payload_fits_discord_8kb_limit(adapter):
 
     # Simulate the largest catalog the collector will ever produce:
     # 20 categories × 25 skills each, with verbose 100-char descriptions.
-    large_categories: dict[str, list[tuple[str, str, str]]] = {}
     long_desc = "A verbose description padded to approximately 100 chars " + "." * 42
-    for i in range(20):
-        cat = f"cat{i:02d}"
-        large_categories[cat] = [
-            (f"skill-{i:02d}-{j:02d}", long_desc, f"/skill-{i:02d}-{j:02d}")
-            for j in range(25)
-        ]
+    large_entries = [
+        (f"skill-{i:02d}-{j:02d}", long_desc, f"/skill-{i:02d}-{j:02d}")
+        for i in range(20)
+        for j in range(25)
+    ]
 
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=(large_categories, [], 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=(large_entries, 0),
     ):
         adapter._register_slash_commands()
 
@@ -856,18 +844,14 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     """The autocomplete callback should match on both skill name and
     description so the user can search by either.
     """
-    mock_categories = {
-        "ocr": [
-            ("ocr-and-documents", "Extract text from PDFs and scanned documents", "/ocr-and-documents"),
-        ],
-        "media": [
-            ("gif-search", "Search and download GIFs from Tenor", "/gif-search"),
-        ],
-    }
+    mock_entries = [
+        ("ocr-and-documents", "Extract text from PDFs and scanned documents", "/ocr-and-documents"),
+        ("gif-search", "Search and download GIFs from Tenor", "/gif-search"),
+    ]
 
     with patch(
-        "hermes_cli.commands.discord_skill_commands_by_category",
-        return_value=(mock_categories, [], 0),
+        "hermes_cli.commands.discord_skill_autocomplete_entries",
+        return_value=(mock_entries, 0),
     ):
         adapter._register_slash_commands()
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -17,6 +17,7 @@ from hermes_cli.commands import (
     _clamp_command_names,
     _clamp_telegram_names,
     _sanitize_telegram_name,
+    discord_skill_autocomplete_entries,
     discord_skill_commands,
     gateway_help_lines,
     resolve_command,
@@ -1028,6 +1029,59 @@ class TestDiscordSkillCommands:
             assert len(name) <= _CMD_NAME_LIMIT, (
                 f"Name '{name}' is {len(name)} chars (limit {_CMD_NAME_LIMIT})"
             )
+
+    def test_truncated_names_preserve_cmd_key(self, tmp_path, monkeypatch):
+        """Long skill names must stay dispatchable after Discord name clamping."""
+        from unittest.mock import patch
+
+        fake_skills_dir = str(tmp_path / "skills")
+        long_name = "a" * 50
+        fake_cmds = {
+            f"/{long_name}": {
+                "name": long_name,
+                "description": "Long name skill",
+                "skill_md_path": f"{fake_skills_dir}/{long_name}/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/{long_name}",
+            },
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "skills").mkdir(exist_ok=True)
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
+        ):
+            entries, _ = discord_skill_commands(
+                max_slots=50, reserved_names=set(),
+            )
+
+        assert entries == [("a" * _CMD_NAME_LIMIT, "Long name skill", f"/{long_name}")]
+
+    def test_autocomplete_entries_do_not_keep_legacy_group_cap(self, tmp_path, monkeypatch):
+        """Flat Discord /skill autocomplete should expose more than 25 same-category skills."""
+        from unittest.mock import patch
+
+        fake_skills_dir = str(tmp_path / "skills")
+        fake_cmds = {
+            f"/skill-{i:02d}": {
+                "name": f"skill-{i:02d}",
+                "description": f"Skill {i}",
+                "skill_md_path": f"{fake_skills_dir}/category/skill-{i:02d}/SKILL.md",
+                "skill_dir": f"{fake_skills_dir}/category/skill-{i:02d}",
+            }
+            for i in range(30)
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "skills").mkdir(exist_ok=True)
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", tmp_path / "skills"),
+        ):
+            entries, hidden = discord_skill_autocomplete_entries(
+                reserved_names=set(),
+            )
+
+        assert len(entries) == 30
+        assert hidden == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix Discord's flat `/skill` autocomplete path so it no longer inherits the old category-group cap.

Previously, the Discord adapter switched to a flat autocomplete-based `/skill` command, but still populated it through the legacy category collector. That meant skills could still be silently hidden once the catalog exceeded the old `25 groups × 25 skills` shape. Long skill names also risked losing their original `cmd_key` binding after name clamping.

## What changed

- added `discord_skill_autocomplete_entries()` for the flat Discord `/skill` UI
- updated the Discord adapter to use the flat collector directly
- preserved `cmd_key` when clamping long skill names via `_clamp_command_triples()`
- added regression coverage for:
  - long-name clamp preserving dispatchability
  - flat autocomplete no longer enforcing the legacy same-category cap

## Why this is correct

The flat `/skill` command uses Discord autocomplete rather than registered subcommand groups, so it should not be constrained by the old grouped-command structural limits. This change keeps the existing filtering rules (disabled skills, hub exclusion, reserved-name handling, name clamping) while removing the obsolete cap from the autocomplete path.

## Testing

- `tests/hermes_cli/test_commands.py` — 110 passed
- `tests/gateway/test_discord_slash_commands.py` — 30 passed
