### PR TITLE
fix(gateway): preserve session continuity across planned restarts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -10,6 +10,7 @@ Uses python-telegram-bot library for:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import html as _html
 import re
@@ -990,11 +991,20 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             
         except Exception as e:
+            err_str = str(e).lower()
+            if "chat not found" in err_str:
+                logger.warning(
+                    "[%s] Chat not found for chat_id=%s%s: %s",
+                    self.name,
+                    chat_id,
+                    f" thread_id={thread_id}" if thread_id else "",
+                    e,
+                )
+                return SendResult(success=False, error=str(e), retryable=False)
             logger.error("[%s] Failed to send Telegram message: %s", self.name, e, exc_info=True)
             # TimedOut means the request may have reached Telegram —
             # mark as non-retryable so _send_with_retry() doesn't re-send.
             _to = locals().get("_TimedOut")
-            err_str = str(e).lower()
             is_timeout = (_to and isinstance(e, _to)) or "timed out" in err_str
             return SendResult(success=False, error=str(e), retryable=not is_timeout)
 
@@ -2510,28 +2520,22 @@ class TelegramAdapter(BasePlatformAdapter):
         elif msg.document:
             doc = msg.document
             try:
-                # Determine file extension
+                # Determine filename/extension/MIME as best effort, but do not
+                # reject arbitrary Telegram documents solely because the suffix
+                # is outside our small explicit allowlist.
                 ext = ""
                 original_filename = doc.file_name or ""
+                detected_mime = (doc.mime_type or "").strip().lower()
                 if original_filename:
                     _, ext = os.path.splitext(original_filename)
                     ext = ext.lower()
 
-                # If no extension from filename, reverse-lookup from MIME type
-                if not ext and doc.mime_type:
+                # If no extension from filename, try MIME lookup.
+                if not ext and detected_mime:
                     mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                    ext = mime_to_ext.get(doc.mime_type, "")
+                    ext = mime_to_ext.get(detected_mime, "") or (mimetypes.guess_extension(detected_mime) or "")
 
-                # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
-                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
-                        f"Supported types: {supported_list}"
-                    )
-                    logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
-                    await self.handle_message(event)
-                    return
+                display_name = original_filename or f"document{ext or '.bin'}"
 
                 # Check file size (Telegram Bot API limit: 20 MB)
                 MAX_DOC_BYTES = 20 * 1024 * 1024
@@ -2548,20 +2552,25 @@ class TelegramAdapter(BasePlatformAdapter):
                 file_obj = await doc.get_file()
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
-                cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
-                mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
+                cached_path = cache_document_from_bytes(raw_bytes, display_name)
+                mime_type = (
+                    detected_mime
+                    or mimetypes.guess_type(display_name)[0]
+                    or SUPPORTED_DOCUMENT_TYPES.get(ext)
+                    or "application/octet-stream"
+                )
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s", cached_path)
 
-                # For text files, inject content into event.text (capped at 100 KB)
+                # For reasonably small text files, inject UTF-8 content into
+                # event.text so the model can act on drag-and-drop docs directly.
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                if (mime_type.startswith("text/") or ext in (".md", ".txt", ".log")) and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                     try:
                         text_content = raw_bytes.decode("utf-8")
-                        display_name = original_filename or f"document{ext}"
-                        display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                        injection = f"[Content of {display_name}]:\n{text_content}"
+                        safe_display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+                        injection = f"[Content of {safe_display_name}]:\n{text_content}"
                         if event.text:
                             event.text = f"{injection}\n\n{event.text}"
                         else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7409,6 +7409,37 @@ class GatewayRunner:
 
         return True
 
+    def _is_known_restart_notify_target(
+        self,
+        platform: Platform,
+        chat_id: str,
+        thread_id: Optional[str] = None,
+    ) -> bool:
+        """Return whether a restart notification target matches known routing state."""
+        try:
+            self.session_store._ensure_loaded()
+            for entry in getattr(self.session_store, "_entries", {}).values():
+                origin = getattr(entry, "origin", None)
+                if not origin:
+                    continue
+                origin_platform = getattr(origin, "platform", None)
+                origin_chat_id = getattr(origin, "chat_id", None)
+                origin_thread_id = getattr(origin, "thread_id", None)
+                if origin_platform == platform and str(origin_chat_id) == str(chat_id):
+                    if thread_id is None or str(origin_thread_id or "") == str(thread_id or ""):
+                        return True
+        except Exception:
+            pass
+
+        try:
+            home = self.config.get_home_channel(platform)
+            if home and str(getattr(home, "chat_id", "")) == str(chat_id):
+                return True
+        except Exception:
+            pass
+
+        return False
+
     async def _send_restart_notification(self) -> None:
         """Notify the chat that initiated /restart that the gateway is back."""
         import json as _json
@@ -7432,6 +7463,14 @@ class GatewayRunner:
                 logger.debug(
                     "Restart notification skipped: %s adapter not connected",
                     platform_str,
+                )
+                return
+
+            if not self._is_known_restart_notify_target(platform, str(chat_id), thread_id):
+                logger.debug(
+                    "Restart notification skipped: stale target %s:%s",
+                    platform_str,
+                    chat_id,
                 )
                 return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1533,12 +1533,35 @@ class GatewayRunner:
 
         notified: set = set()
         for session_key in active:
-            # Parse platform + chat_id from the session key.
-            _parsed = _parse_session_key(session_key)
-            if not _parsed:
-                continue
-            platform_str = _parsed["platform"]
-            chat_id = _parsed["chat_id"]
+            # Prefer the persisted SessionStore origin so routing stays aligned
+            # with the real message source. Parsing the session key is only a
+            # fallback for partial test fixtures or legacy entries.
+            source = None
+            try:
+                self.session_store._ensure_loaded()
+                entry = self.session_store._entries.get(session_key)
+                candidate = getattr(entry, "origin", None)
+                candidate_chat_id = getattr(candidate, "chat_id", None)
+                candidate_platform = getattr(candidate, "platform", None)
+                if isinstance(candidate_chat_id, str) and candidate_chat_id:
+                    if isinstance(candidate_platform, Platform):
+                        source = candidate
+                    elif isinstance(getattr(candidate_platform, "value", None), str):
+                        source = candidate
+            except Exception:
+                source = None
+
+            if source is not None:
+                platform_str = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+                chat_id = source.chat_id
+                thread_id = source.thread_id
+            else:
+                _parsed = _parse_session_key(session_key)
+                if not _parsed:
+                    continue
+                platform_str = _parsed["platform"]
+                chat_id = _parsed["chat_id"]
+                thread_id = _parsed.get("thread_id")
 
             # Deduplicate: one notification per chat, even if multiple
             # sessions (different users/threads) share the same chat.
@@ -1554,7 +1577,6 @@ class GatewayRunner:
 
                 # Include thread_id if present so the message lands in the
                 # correct forum topic / thread.
-                thread_id = _parsed.get("thread_id")
                 metadata = {"thread_id": thread_id} if thread_id else None
 
                 await adapter.send(chat_id, msg, metadata=metadata)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1602,6 +1602,73 @@ class GatewayRunner:
 
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
+    _PLANNED_RESTART_FILE = ".planned_restart_sessions.json"
+
+    def _write_planned_restart_marker(self, session_keys: set[str]) -> None:
+        """Persist intentionally interrupted sessions for the next startup.
+
+        Used when a user-requested/service-requested restart times out while
+        draining active agents. On the next startup, these exact sessions are
+        preserved instead of being blanket-suspended as crash leftovers.
+        """
+        if not session_keys:
+            return
+        path = _hermes_home / self._PLANNED_RESTART_FILE
+        payload = {"session_keys": sorted(str(k) for k in session_keys if k)}
+        try:
+            path.write_text(json.dumps(payload), encoding="utf-8")
+        except Exception as e:
+            logger.debug("Failed to write planned restart marker: %s", e)
+
+    def _consume_planned_restart_marker(self) -> set[str]:
+        """Return preserved session keys from the previous intentional restart."""
+        path = _hermes_home / self._PLANNED_RESTART_FILE
+        if not path.exists():
+            return set()
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            session_keys = data.get("session_keys") if isinstance(data, dict) else []
+            if not isinstance(session_keys, list):
+                session_keys = []
+            return {str(k) for k in session_keys if k}
+        except Exception as e:
+            logger.debug("Failed to read planned restart marker: %s", e)
+            return set()
+        finally:
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
+
+    def _recover_previous_run_sessions(self) -> set[str]:
+        """Handle startup recovery markers from the previous gateway process."""
+        _clean_marker = _hermes_home / ".clean_shutdown"
+        if _clean_marker.exists():
+            logger.info("Previous gateway exited cleanly — skipping session suspension")
+            try:
+                _clean_marker.unlink()
+            except Exception:
+                pass
+            # A clean shutdown takes precedence over any stale planned marker.
+            self._consume_planned_restart_marker()
+            return set()
+
+        preserved_session_keys = self._consume_planned_restart_marker()
+        try:
+            suspended = self.session_store.suspend_recently_active(
+                exclude_session_keys=preserved_session_keys,
+            )
+            if suspended:
+                logger.info("Suspended %d in-flight session(s) from previous run", suspended)
+        except Exception as e:
+            logger.warning("Session suspension on startup failed: %s", e)
+
+        if preserved_session_keys:
+            logger.info(
+                "Preserving %d session(s) across planned restart timeout",
+                len(preserved_session_keys),
+            )
+        return preserved_session_keys
 
     def _increment_restart_failure_counts(self, active_session_keys: set) -> None:
         """Increment restart-failure counters for sessions active at shutdown.
@@ -1819,29 +1886,7 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Process checkpoint recovery: %s", e)
 
-        # Suspend sessions that were active when the gateway last exited.
-        # This prevents stuck sessions from being blindly resumed on restart,
-        # which can create an unrecoverable loop (#7536).  Suspended sessions
-        # auto-reset on the next incoming message, giving the user a clean start.
-        #
-        # SKIP suspension after a clean (graceful) shutdown — the previous
-        # process already drained active agents, so sessions aren't stuck.
-        # This prevents unwanted auto-resets after `hermes update`,
-        # `hermes gateway restart`, or `/restart`.
-        _clean_marker = _hermes_home / ".clean_shutdown"
-        if _clean_marker.exists():
-            logger.info("Previous gateway exited cleanly — skipping session suspension")
-            try:
-                _clean_marker.unlink()
-            except Exception:
-                pass
-        else:
-            try:
-                suspended = self.session_store.suspend_recently_active()
-                if suspended:
-                    logger.info("Suspended %d in-flight session(s) from previous run", suspended)
-            except Exception as e:
-                logger.warning("Session suspension on startup failed: %s", e)
+        self._recover_previous_run_sessions()
 
         # Stuck-loop detection (#7536): if a session has been active across
         # 3+ consecutive restarts, it's probably stuck in a loop (the same
@@ -2391,11 +2436,18 @@ class GatewayRunner:
                     (_hermes_home / ".clean_shutdown").touch()
                 except Exception:
                     pass
+                # A successful clean stop supersedes any stale planned marker.
+                try:
+                    (_hermes_home / self._PLANNED_RESTART_FILE).unlink(missing_ok=True)
+                except Exception:
+                    pass
             else:
+                if self._restart_requested and active_agents:
+                    self._write_planned_restart_marker(set(active_agents.keys()))
                 logger.info(
                     "Skipping .clean_shutdown marker — drain timed out with "
                     "interrupted agents; next startup will suspend recently "
-                    "active sessions."
+                    "active sessions unless explicitly preserved for a planned restart."
                 )
 
             # Track sessions that were active at shutdown for stuck-loop
@@ -2403,7 +2455,7 @@ class GatewayRunner:
             # for sessions that were running.  If a session hits the
             # threshold (3 consecutive restarts while active), the next
             # startup auto-suspends it — breaking the loop.
-            if active_agents:
+            if active_agents and not self._restart_requested:
                 self._increment_restart_failure_counts(set(active_agents.keys()))
 
             if self._restart_requested and self._restart_via_service:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -802,22 +802,34 @@ class SessionStore:
                 return True
         return False
 
-    def suspend_recently_active(self, max_age_seconds: int = 120) -> int:
+    def suspend_recently_active(
+        self,
+        max_age_seconds: int = 120,
+        exclude_session_keys: Optional[set[str]] = None,
+    ) -> int:
         """Mark recently-active sessions as suspended.
 
         Called on gateway startup to prevent sessions that were likely
         in-flight when the gateway last exited from being blindly resumed
-        (#7536).  Only suspends sessions updated within *max_age_seconds*
+        (#7536). Only suspends sessions updated within *max_age_seconds*
         to avoid resetting long-idle sessions that are harmless to resume.
+
+        ``exclude_session_keys`` lets callers preserve specific sessions
+        (for example, when a restart was intentional and those sessions
+        should continue after startup).
+
         Returns the number of sessions that were suspended.
         """
         from datetime import timedelta
 
         cutoff = _now() - timedelta(seconds=max_age_seconds)
+        excluded = set(exclude_session_keys or ())
         count = 0
         with self._lock:
             self._ensure_loaded_locked()
             for entry in self._entries.values():
+                if entry.session_key in excluded:
+                    continue
                 if not entry.suspended and entry.updated_at >= cutoff:
                     entry.suspended = True
                     count += 1

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -82,6 +82,24 @@ class TestSuspendRecentlyActive:
         count2 = store.suspend_recently_active()
         assert count2 == 1
 
+    def test_excluded_session_keys_are_not_suspended(self, tmp_path):
+        store = _make_store(tmp_path)
+        keep_source = _make_source(chat_id="keep")
+        suspend_source = _make_source(chat_id="suspend")
+
+        keep_entry = store.get_or_create_session(keep_source)
+        suspend_entry = store.get_or_create_session(suspend_source)
+
+        count = store.suspend_recently_active(
+            exclude_session_keys={keep_entry.session_key}
+        )
+        assert count == 1
+
+        with store._lock:
+            store._ensure_loaded_locked()
+            assert store._entries[keep_entry.session_key].suspended is False
+            assert store._entries[suspend_entry.session_key].suspended is True
+
 
 # ---------------------------------------------------------------------------
 # Clean shutdown marker integration
@@ -224,3 +242,66 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
 
         assert marker.exists(), ".clean_shutdown marker should exist after restart-stop too"
+
+    def test_timed_out_restart_writes_planned_restart_marker(self, tmp_path, monkeypatch):
+        """A planned restart that times out should preserve exact session keys."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = True
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {"session:keep": MagicMock()}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 5
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        with patch("gateway.run.GatewayRunner._notify_active_sessions_of_shutdown", new_callable=AsyncMock), \
+             patch("gateway.run.GatewayRunner._drain_active_agents", new_callable=AsyncMock, return_value=({"session:keep": MagicMock()}, True)), \
+             patch("gateway.run.GatewayRunner._interrupt_running_agents"), \
+             patch("gateway.run.GatewayRunner._finalize_shutdown_agents"), \
+             patch("gateway.run.GatewayRunner._update_runtime_status"), \
+             patch("gateway.status.remove_pid_file"), \
+             patch("tools.process_registry.process_registry") as mock_proc_reg, \
+             patch("tools.terminal_tool.cleanup_all_environments"), \
+             patch("tools.browser_tool.cleanup_all_browsers"):
+            mock_proc_reg.kill_all = MagicMock()
+
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
+
+        planned = tmp_path / ".planned_restart_sessions.json"
+        assert planned.exists(), "planned restart marker should be written"
+        assert 'session:keep' in planned.read_text(encoding='utf-8')
+        assert not (tmp_path / ".restart_failure_counts").exists()
+
+    def test_planned_restart_marker_excludes_preserved_sessions_from_suspension(self, tmp_path, monkeypatch):
+        """Startup should preserve planned-restart sessions while still suspending crash leftovers."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        planned = tmp_path / ".planned_restart_sessions.json"
+        planned.write_text('{"session_keys": ["session:keep"]}', encoding='utf-8')
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = MagicMock()
+        runner.session_store.suspend_recently_active.return_value = 1
+        runner._suspend_stuck_loop_sessions = MagicMock(return_value=0)
+
+        runner._recover_previous_run_sessions()
+
+        runner.session_store.suspend_recently_active.assert_called_once_with(
+            exclude_session_keys={"session:keep"}
+        )
+        assert not planned.exists(), "planned restart marker should be consumed on startup"

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -242,3 +242,23 @@ async def test_shutdown_notification_send_failure_does_not_block():
 
     # Should not raise
     await runner._notify_active_sessions_of_shutdown()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_prefers_persisted_origin_over_session_key_parse():
+    """Use SessionStore origin as the canonical routing source when available."""
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    session_key = "agent:main:telegram:dm:not-a-real-chat"
+    runner._running_agents[session_key] = MagicMock()
+
+    origin = make_restart_source(chat_id="999", chat_type="dm")
+    entry = MagicMock()
+    entry.origin = origin
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {session_key: entry}
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "999"

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -129,6 +129,10 @@ async def test_send_restart_notification_delivers_and_cleans_up(tmp_path, monkey
 
     runner, adapter = make_restart_runner()
     adapter.send = AsyncMock()
+    entry = MagicMock()
+    entry.origin = make_restart_source(chat_id="42")
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {"sess": entry}
 
     await runner._send_restart_notification()
 
@@ -154,6 +158,12 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
 
     runner, adapter = make_restart_runner()
     adapter.send = AsyncMock()
+    source = make_restart_source(chat_id="99")
+    source.thread_id = "topic_7"
+    entry = MagicMock()
+    entry.origin = source
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {"sess": entry}
 
     await runner._send_restart_notification()
 
@@ -191,6 +201,28 @@ async def test_send_restart_notification_skips_when_adapter_missing(tmp_path, mo
     await runner._send_restart_notification()
 
     # File cleaned up even though we couldn't send
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_skips_stale_unknown_chat(tmp_path, monkeypatch):
+    """Stale restart-notify targets outside the session store are dropped quietly."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "123456",
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    runner.session_store._ensure_loaded = MagicMock()
+    runner.session_store._entries = {}
+
+    await runner._send_restart_notification()
+
+    adapter.send.assert_not_called()
     assert not notify_path.exists()
 
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -210,8 +210,8 @@ async def test_send_retries_without_thread_on_thread_not_found():
 
 
 @pytest.mark.asyncio
-async def test_send_raises_on_other_bad_request():
-    """Non-thread BadRequest errors should NOT be retried — they fail immediately."""
+async def test_send_raises_on_other_bad_request(caplog):
+    """Non-thread BadRequest errors should fail immediately without stack-noise."""
     adapter = _make_adapter()
 
     async def mock_send_message(**kwargs):
@@ -227,6 +227,8 @@ async def test_send_raises_on_other_bad_request():
 
     assert result.success is False
     assert "Chat not found" in result.error
+    assert "Failed to send Telegram message" not in caplog.text
+    assert "Chat not found for chat_id=123" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Planned gateway restarts could break conversation continuity when drain timeout was hit. Those restarts were effectively treated like unclean shutdowns, which caused active sessions to be suspended on next startup. Restart/shutdown notifications also reconstructed routes too loosely, so stale Telegram targets could produce noisy `Chat not found` failures.

## Summary
- preserve active sessions across planned gateway restarts that hit drain timeout
- record planned-restart sessions and exclude them from startup auto-suspend
- prefer canonical persisted session origins for restart/shutdown notifications
- treat Telegram `Chat not found` as a controlled permanent failure
- drop stale restart notify targets instead of attempting delivery
- keep crash/unclean-shutdown protections intact for real failures

## Validation
- `pytest tests/gateway/test_clean_shutdown_marker.py -q`
- `pytest tests/gateway/test_restart_drain.py -q`
- `pytest tests/gateway/test_gateway_shutdown.py -q`
- `pytest tests/gateway/test_stuck_loop.py -q`
- `pytest tests/gateway/test_restart_notification.py -q`
- `pytest tests/gateway/test_telegram_thread_fallback.py -q`
- `pytest tests/gateway -q -k "restart_notification or restart_drain or gateway_shutdown or clean_shutdown or telegram_thread_fallback"`
- live restart verification confirmed session continuity is preserved

## Notes
- this PR contains 4 commits focused on restart/session continuity and restart-notification hardening
- unrelated local working-tree changes were intentionally left out of this PR