### PR TITLE
fix(compressor): fix context compression Pass 3, make it JSON-safe for tool_call arguments and add test

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -63,6 +63,57 @@ _CHARS_PER_TOKEN = 4
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
 
+def _shrink_json_for_tool_args(
+    value: Any,
+    *,
+    max_string_len: int = 200,
+    max_list_items: int = 20,
+    max_dict_items: int = 40,
+    max_depth: int = 6,
+    _depth: int = 0,
+) -> Any:
+    """Recursively shrink JSON-compatible values while preserving validity."""
+    if _depth >= max_depth:
+        return "[truncated]"
+
+    if isinstance(value, str):
+        if len(value) <= max_string_len:
+            return value
+        return value[:max_string_len] + "...[truncated]"
+
+    if isinstance(value, list):
+        trimmed = value[:max_list_items]
+        return [
+            _shrink_json_for_tool_args(
+                item,
+                max_string_len=max_string_len,
+                max_list_items=max_list_items,
+                max_dict_items=max_dict_items,
+                max_depth=max_depth,
+                _depth=_depth + 1,
+            )
+            for item in trimmed
+        ]
+
+    if isinstance(value, dict):
+        # Keep insertion order for deterministic output.
+        out: Dict[str, Any] = {}
+        for idx, (k, v) in enumerate(value.items()):
+            if idx >= max_dict_items:
+                break
+            out[k] = _shrink_json_for_tool_args(
+                v,
+                max_string_len=max_string_len,
+                max_list_items=max_list_items,
+                max_dict_items=max_dict_items,
+                max_depth=max_depth,
+                _depth=_depth + 1,
+            )
+        return out
+
+    return value
+
+
 def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) -> str:
     """Create an informative 1-line summary of a tool call + result.
 
@@ -345,8 +396,8 @@ class ContextCompressor(ContextEngine):
             [read_file] read config.py from line 1 (3,400 chars)
 
         Also deduplicates identical tool results (e.g. reading the same file
-        5x keeps only the newest full copy) and truncates large tool_call
-        arguments in assistant messages outside the protected tail.
+        5x keeps only the newest full copy) and shrinks old assistant
+        tool_call arguments while preserving valid JSON.
 
         Walks backward from the end, protecting the most recent messages that
         fall within ``protect_tail_tokens`` (when provided) OR the last
@@ -446,9 +497,8 @@ class ContextCompressor(ContextEngine):
                 result[i] = {**msg, "content": summary}
                 pruned += 1
 
-        # Pass 3: Truncate large tool_call arguments in assistant messages
-        # outside the protected tail. write_file with 50KB content, for
-        # example, survives pruning entirely without this.
+        # Pass 3: Shrink large tool_call arguments in assistant messages
+        # outside the protected tail, while keeping arguments as valid JSON.
         for i in range(prune_boundary):
             msg = result[i]
             if msg.get("role") != "assistant" or not msg.get("tool_calls"):
@@ -457,10 +507,27 @@ class ContextCompressor(ContextEngine):
             modified = False
             for tc in msg["tool_calls"]:
                 if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
-                    if len(args) > 500:
-                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
-                        modified = True
+                    fn = tc.get("function") or {}
+                    args = fn.get("arguments", "")
+                    if isinstance(args, str) and len(args) > 500:
+                        try:
+                            parsed = json.loads(args)
+                        except (json.JSONDecodeError, TypeError):
+                            # Preserve pre-existing malformed args verbatim.
+                            new_tcs.append(tc)
+                            continue
+
+                        shrunk = _shrink_json_for_tool_args(parsed)
+                        new_args = json.dumps(shrunk, separators=(",", ":"))
+                        if new_args != args:
+                            tc = {
+                                **tc,
+                                "function": {
+                                    **fn,
+                                    "arguments": new_args,
+                                },
+                            }
+                            modified = True
                 new_tcs.append(tc)
             if modified:
                 result[i] = {**msg, "tool_calls": new_tcs}

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,5 +1,6 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -781,3 +782,55 @@ class TestTokenBudgetTailProtection:
         # Tool at index 2 is outside the protected tail (last 3 = indices 2,3,4)
         # so it might or might not be pruned depending on boundary
         assert isinstance(pruned, int)
+
+    def test_prune_shrinks_tool_call_arguments_as_valid_json(self, budget_compressor):
+        """Regression: shrinking keeps arguments parseable JSON."""
+        c = budget_compressor
+        original_args = json.dumps({
+            "path": "notes.txt",
+            "content": "A" * 2000,
+            "encoding": "utf-8",
+        })
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": original_args},
+                }],
+            },
+            {"role": "tool", "content": "ok" * 800, "tool_call_id": "c1"},
+            {"role": "user", "content": "latest message"},
+        ]
+
+        result, _ = c._prune_old_tool_results(messages, protect_tail_count=1)
+        args_after = result[0]["tool_calls"][0]["function"]["arguments"]
+        parsed_after = json.loads(args_after)
+
+        assert args_after != original_args
+        assert len(args_after) < len(original_args)
+        assert parsed_after["path"] == "notes.txt"
+        assert parsed_after["content"].endswith("...[truncated]")
+
+    def test_prune_does_not_modify_invalid_tool_call_arguments(self, budget_compressor):
+        """Even pre-existing invalid args should be preserved byte-for-byte."""
+        c = budget_compressor
+        invalid_args = '{"path":"broken","content":"unterminated'
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "write_file", "arguments": invalid_args},
+                }],
+            },
+            {"role": "tool", "content": "x" * 1200, "tool_call_id": "c1"},
+            {"role": "user", "content": "recent"},
+        ]
+
+        result, _ = c._prune_old_tool_results(messages, protect_tail_count=1)
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == invalid_args


### PR DESCRIPTION
## What does this PR do?

This PR fixes a context compression bug where Pass 3 could corrupt `tool_calls.function.arguments` by raw string truncation (`args[:200] + "...[truncated]"`), producing invalid JSON and causing downstream `json.loads(arguments)` failures (for example `Unterminated string`).

The fix keeps Pass 3, but makes it JSON-safe:
- Parse `arguments` as JSON before modifying.
- Shrink large payloads structurally (recursive trim of long strings/lists/dicts).
- Re-serialize with `json.dumps(...)` so output stays valid JSON.
- Preserve pre-existing invalid argument strings unchanged (no mutation).

This approach preserves the intent of Pass 3 (reduce oversized args) without violating the tool-call JSON contract.

## Related Issue

Fixes #<!-- add issue id -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/context_compressor.py`:
  - Added `_shrink_json_for_tool_args(...)` recursive helper.
  - Replaced raw-truncate Pass 3 logic with JSON-safe parse/shrink/serialize flow.
  - Preserved invalid pre-existing `arguments` verbatim (skip mutation on parse failure).
  - Updated method docstring to reflect JSON-safe argument shrinking behavior.
- Updated `tests/agent/test_context_compressor.py`:
  - Added regression test ensuring large args are shrunk but remain valid JSON.
  - Added regression test ensuring malformed existing args are not modified.

## How to Test

1. Reproduce old behavior (before fix): run a long session with large tool arguments and compaction; observe JSON parse failures on truncated args.
2. Run tests:
   - `pytest -q tests/agent/test_context_compressor.py`
3. Verify fixed behavior:
   - Large `tool_calls.function.arguments` are reduced in size.
   - `json.loads(arguments)` succeeds for shrunk payloads.
   - Already-invalid argument strings are unchanged after pruning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A (logic + tests change; no UI changes).