### PR TITLE
feat(whatsapp): add safe service conversation support

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -700,6 +700,16 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
+                if "service_conversations" in whatsapp_cfg:
+                    plat_data = platforms_data.setdefault(Platform.WHATSAPP.value, {})
+                    if not isinstance(plat_data, dict):
+                        plat_data = {}
+                        platforms_data[Platform.WHATSAPP.value] = plat_data
+                    extra = plat_data.setdefault("extra", {})
+                    if not isinstance(extra, dict):
+                        extra = {}
+                        plat_data["extra"] = extra
+                    extra["service_conversations"] = whatsapp_cfg["service_conversations"]
 
             # DingTalk settings → env vars (env vars take precedence)
             dingtalk_cfg = yaml_cfg.get("dingtalk", {})

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -824,6 +824,34 @@ class WhatsAppAdapter(BasePlatformAdapter):
             logger.debug("Could not get WhatsApp chat info for %s: %s", chat_id, e)
         
         return {"name": chat_id, "type": "dm"}
+
+    async def list_recent_chats(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return recent WhatsApp chats discovered by the local bridge."""
+        if not self._running or not self._http_session:
+            return []
+        bridge_exit = await self._check_managed_bridge_exit()
+        if bridge_exit:
+            logger.debug("WhatsApp list_recent_chats aborted: %s", bridge_exit)
+            return []
+
+        try:
+            import aiohttp
+
+            async with self._http_session.get(
+                f"http://127.0.0.1:{self._bridge_port}/chats",
+                params={"limit": max(1, min(int(limit), 200))},
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status != 200:
+                    logger.debug("WhatsApp /chats returned status %s", resp.status)
+                    return []
+                data = await resp.json()
+                if not isinstance(data, list):
+                    return []
+                return [entry for entry in data if isinstance(entry, dict) and entry.get("chatId")]
+        except Exception as e:
+            logger.debug("Could not list WhatsApp chats: %s", e)
+            return []
     
     async def _poll_messages(self) -> None:
         """Poll the bridge for incoming messages."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -277,6 +277,7 @@ from gateway.session import (
     build_session_key,
 )
 from gateway.delivery import DeliveryRouter
+from gateway.whatsapp_service_policy import WhatsAppServiceConversationPolicy
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -606,6 +607,7 @@ class GatewayRunner:
             has_active_processes_fn=lambda key: process_registry.has_active_for_session(key),
         )
         self.delivery_router = DeliveryRouter(self.config)
+        self._whatsapp_service_policy = WhatsAppServiceConversationPolicy.from_gateway_config(self.config)
         self._running = False
         self._shutdown_event = asyncio.Event()
         self._exit_cleanly = False
@@ -2634,6 +2636,21 @@ class GatewayRunner:
 
         return None
 
+    def _is_whatsapp_service_chat_authorized(self, source: SessionSource) -> bool:
+        if source.platform != Platform.WHATSAPP:
+            return False
+        policy = getattr(self, "_whatsapp_service_policy", None)
+        if policy is None:
+            policy = WhatsAppServiceConversationPolicy.from_gateway_config(getattr(self, "config", None))
+            self._whatsapp_service_policy = policy
+        return bool(policy.can_accept_inbound(source.chat_id) or policy.can_accept_inbound(source.user_id))
+
+    def _is_from_whatsapp_service_chat(self, event: MessageEvent) -> bool:
+        source = getattr(event, "source", None)
+        if not source:
+            return False
+        return self._is_whatsapp_service_chat_authorized(source)
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -2656,6 +2673,9 @@ class GatewayRunner:
         user_id = source.user_id
         if not user_id:
             return False
+
+        if self._is_whatsapp_service_chat_authorized(source):
+            return True
 
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
@@ -2816,6 +2836,18 @@ class GatewayRunner:
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
+                adapter = self.adapters.get(source.platform)
+                if (
+                    source.platform == Platform.WHATSAPP
+                    and getattr(self, "_whatsapp_service_policy", None)
+                    and self._whatsapp_service_policy.is_enabled()
+                ):
+                    if adapter:
+                        await adapter.send(
+                            source.chat_id,
+                            "This WhatsApp thread is not approved yet. Ask Tyler to approve this phone number for service conversations."
+                        )
+                    return None
                 platform_name = source.platform.value if source.platform else "unknown"
                 # Rate-limit ALL pairing responses (code or rejection) to
                 # prevent spamming the user with repeated messages when
@@ -3094,6 +3126,8 @@ class GatewayRunner:
 
         # Check for commands
         command = event.get_command()
+        if command and self._is_from_whatsapp_service_chat(event):
+            return "This WhatsApp thread is approved for service conversations only. Commands are disabled here."
         
         # Emit command:* hook for any recognized slash command.
         # GATEWAY_KNOWN_COMMANDS is derived from the central COMMAND_REGISTRY

--- a/gateway/whatsapp_service_policy.py
+++ b/gateway/whatsapp_service_policy.py
@@ -1,0 +1,166 @@
+"""Policy helpers for optional WhatsApp service conversations.
+
+This module is intentionally conservative.  It models explicit approved service
+chats and safe defaults without granting broad autonomy to arbitrary WhatsApp
+contacts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional
+
+from gateway.config import GatewayConfig, Platform
+
+
+_ALLOWED_MODES = {"draft_first", "approved_followup", "paused", "revoked"}
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return bool(value)
+
+
+def _coerce_int(value: Any, default: int, minimum: int = 0) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, parsed)
+
+
+def normalize_whatsapp_chat_id(value: Any) -> Optional[str]:
+    """Normalize phone numbers / JIDs into canonical WhatsApp chat IDs.
+
+    - ``+34600111222`` -> ``34600111222@s.whatsapp.net``
+    - ``34600111222`` -> ``34600111222@s.whatsapp.net``
+    - ``34600111222@s.whatsapp.net`` -> unchanged
+    - ``12345678901234@lid`` -> unchanged
+    - ``12345@g.us`` -> unchanged
+    - human labels (e.g. ``Movistar (dm)``) -> ``None``
+    """
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    normalized = raw.replace(":", "@", 1)
+    if normalized.endswith("@lid") or normalized.endswith("@s.whatsapp.net") or normalized.endswith("@g.us"):
+        return normalized
+
+    digits = "".join(ch for ch in normalized if ch.isdigit())
+    if len(digits) >= 7:
+        return f"{digits}@s.whatsapp.net"
+
+    return None
+
+
+@dataclass
+class WhatsAppServiceConversationConfig:
+    enabled: bool = False
+    default_mode: str = "draft_first"
+    approved_chats: list[str] = field(default_factory=list)
+    allow_agent_initiated_service_chats: bool = False
+    auto_promote_replied_to_chats: bool = False
+    max_new_service_chats_per_day: int = 3
+    require_explicit_approval_for_first_contact: bool = True
+    allow_inbound_media: bool = False
+    allow_outbound_media: bool = False
+    pending_first_contact_ttl_minutes: int = 1440
+    max_auto_sends_per_chat_per_hour: int = 3
+    max_consecutive_agent_sends_without_reply: int = 2
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict[str, Any]]) -> "WhatsAppServiceConversationConfig":
+        data = data or {}
+        mode = str(data.get("default_mode", "draft_first") or "draft_first").strip().lower()
+        if mode not in _ALLOWED_MODES:
+            mode = "draft_first"
+
+        approved = []
+        for candidate in data.get("approved_chats", []) or []:
+            normalized = normalize_whatsapp_chat_id(candidate)
+            if normalized and normalized not in approved:
+                approved.append(normalized)
+
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), False),
+            default_mode=mode,
+            approved_chats=approved,
+            allow_agent_initiated_service_chats=_coerce_bool(data.get("allow_agent_initiated_service_chats"), False),
+            auto_promote_replied_to_chats=_coerce_bool(data.get("auto_promote_replied_to_chats"), False),
+            max_new_service_chats_per_day=_coerce_int(data.get("max_new_service_chats_per_day"), 3, minimum=0),
+            require_explicit_approval_for_first_contact=_coerce_bool(data.get("require_explicit_approval_for_first_contact"), True),
+            allow_inbound_media=_coerce_bool(data.get("allow_inbound_media"), False),
+            allow_outbound_media=_coerce_bool(data.get("allow_outbound_media"), False),
+            pending_first_contact_ttl_minutes=_coerce_int(data.get("pending_first_contact_ttl_minutes"), 1440, minimum=1),
+            max_auto_sends_per_chat_per_hour=_coerce_int(data.get("max_auto_sends_per_chat_per_hour"), 3, minimum=0),
+            max_consecutive_agent_sends_without_reply=_coerce_int(data.get("max_consecutive_agent_sends_without_reply"), 2, minimum=0),
+        )
+
+    @property
+    def approved_chat_set(self) -> set[str]:
+        return set(self.approved_chats)
+
+
+@dataclass
+class WhatsAppServiceConversationPolicy:
+    config: WhatsAppServiceConversationConfig
+
+    @classmethod
+    def disabled(cls) -> "WhatsAppServiceConversationPolicy":
+        return cls(WhatsAppServiceConversationConfig())
+
+    @classmethod
+    def from_gateway_config(cls, gateway_config: Optional[GatewayConfig]) -> "WhatsAppServiceConversationPolicy":
+        if not gateway_config:
+            return cls.disabled()
+        platform_cfg = gateway_config.platforms.get(Platform.WHATSAPP)
+        extra = getattr(platform_cfg, "extra", {}) or {}
+        return cls(WhatsAppServiceConversationConfig.from_dict(extra.get("service_conversations")))
+
+    def normalize_chat_id(self, value: Any) -> Optional[str]:
+        return normalize_whatsapp_chat_id(value)
+
+    def is_enabled(self) -> bool:
+        return self.config.enabled
+
+    def is_approved_chat(self, chat_id: Any) -> bool:
+        normalized = self.normalize_chat_id(chat_id)
+        if not normalized:
+            return False
+        return normalized in self.config.approved_chat_set
+
+    def can_accept_inbound(self, chat_id: Any) -> bool:
+        return self.is_enabled() and self.is_approved_chat(chat_id)
+
+    def requires_first_contact_approval(self) -> bool:
+        return self.config.require_explicit_approval_for_first_contact
+
+    def can_agent_initiate(self) -> bool:
+        return self.is_enabled() and self.config.allow_agent_initiated_service_chats
+
+    def allows_inbound_media(self) -> bool:
+        return self.is_enabled() and self.config.allow_inbound_media
+
+    def allows_outbound_media(self) -> bool:
+        return self.is_enabled() and self.config.allow_outbound_media
+
+    def is_operator_command_allowed(self, from_approved_service_chat: bool) -> bool:
+        # Approved provider/service chats are allowed as conversational inputs only.
+        # They must never inherit trusted-operator command permissions.
+        return not from_approved_service_chat
+
+    def normalize_targets(self, values: Iterable[Any]) -> list[str]:
+        normalized: list[str] = []
+        for value in values:
+            chat_id = self.normalize_chat_id(value)
+            if chat_id and chat_id not in normalized:
+                normalized.append(chat_id)
+        return normalized

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -705,6 +705,20 @@ DEFAULT_CONFIG = {
         # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
+        "service_conversations": {
+            "enabled": False,
+            "default_mode": "draft_first",
+            "approved_chats": [],
+            "allow_agent_initiated_service_chats": False,
+            "auto_promote_replied_to_chats": False,
+            "max_new_service_chats_per_day": 3,
+            "require_explicit_approval_for_first_contact": True,
+            "allow_inbound_media": False,
+            "allow_outbound_media": False,
+            "pending_first_contact_ttl_minutes": 1440,
+            "max_auto_sends_per_chat_per_hour": 3,
+            "max_consecutive_agent_sends_without_reply": 2,
+        },
     },
 
     # Telegram platform settings (gateway mode)

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -120,6 +120,24 @@ const MAX_RECENT_IDS = 50;
 let sock = null;
 let connectionState = 'disconnected';
 
+// Track recently seen chats for discovery.  This is intentionally lightweight
+// and stores metadata only — no message bodies.
+const recentChats = new Map();
+
+function rememberRecentChat(chatId, metadata = {}) {
+  if (!chatId) return;
+  const existing = recentChats.get(chatId) || {};
+  const merged = {
+    chatId,
+    name: metadata.name ?? existing.name ?? chatId.replace(/@.*/, ''),
+    isGroup: metadata.isGroup ?? existing.isGroup ?? chatId.endsWith('@g.us'),
+    lastMessageTimestamp: metadata.lastMessageTimestamp ?? existing.lastMessageTimestamp ?? Math.floor(Date.now() / 1000),
+    unreadCount: metadata.unreadCount ?? existing.unreadCount ?? 0,
+    isBusiness: metadata.isBusiness ?? existing.isBusiness ?? false,
+  };
+  recentChats.set(chatId, merged);
+}
+
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
   const { version } = await fetchLatestBaileysVersion();
@@ -227,8 +245,11 @@ async function startSocket() {
         if (!isSelfChat) continue;
       }
 
-      // Check allowlist for messages from others (resolve LID ↔ phone aliases)
-      if (!msg.key.fromMe && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+      // Check allowlist for messages from others (resolve LID ↔ phone aliases).
+      // DMs are intentionally forwarded even when the sender is unknown so the
+      // Python gateway can apply its own authorization policy (pairing, deny,
+      // or service-conversation approval). Group chats stay bridge-filtered.
+      if (!msg.key.fromMe && isGroup && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
         continue;
       }
 
@@ -352,6 +373,12 @@ async function startSocket() {
         timestamp: msg.messageTimestamp,
       };
 
+      rememberRecentChat(chatId, {
+        name: event.chatName,
+        isGroup,
+        lastMessageTimestamp: Number(msg.messageTimestamp || Math.floor(Date.now() / 1000)),
+      });
+
       messageQueue.push(event);
       if (messageQueue.length > MAX_QUEUE_SIZE) {
         messageQueue.shift();
@@ -383,6 +410,12 @@ app.post('/send', async (req, res) => {
 
   try {
     const sent = await sock.sendMessage(chatId, { text: formatOutgoingMessage(message) });
+
+    rememberRecentChat(chatId, {
+      name: chatId.replace(/@.*/, ''),
+      isGroup: chatId.endsWith('@g.us'),
+      lastMessageTimestamp: Math.floor(Date.now() / 1000),
+    });
 
     // Track sent message ID to prevent echo-back loops
     if (sent?.key?.id) {
@@ -517,11 +550,26 @@ app.post('/typing', async (req, res) => {
 // Chat info
 app.get('/chat/:id', async (req, res) => {
   const chatId = req.params.id;
+
+  const cached = recentChats.get(chatId);
+  if (cached) {
+    return res.json({
+      name: cached.name,
+      isGroup: cached.isGroup,
+      participants: [],
+    });
+  }
+
   const isGroup = chatId.endsWith('@g.us');
 
   if (isGroup && sock) {
     try {
       const metadata = await sock.groupMetadata(chatId);
+      rememberRecentChat(chatId, {
+        name: metadata.subject,
+        isGroup: true,
+        lastMessageTimestamp: Math.floor(Date.now() / 1000),
+      });
       return res.json({
         name: metadata.subject,
         isGroup: true,
@@ -532,11 +580,26 @@ app.get('/chat/:id', async (req, res) => {
     }
   }
 
+  rememberRecentChat(chatId, {
+    name: chatId.replace(/@.*/, ''),
+    isGroup,
+    lastMessageTimestamp: Math.floor(Date.now() / 1000),
+  });
   res.json({
     name: chatId.replace(/@.*/, ''),
     isGroup,
     participants: [],
   });
+});
+
+// Recent chat discovery
+app.get('/chats', (req, res) => {
+  const limitRaw = parseInt(String(req.query.limit || '50'), 10);
+  const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(limitRaw, 200)) : 50;
+  const chats = Array.from(recentChats.values())
+    .sort((a, b) => Number(b.lastMessageTimestamp || 0) - Number(a.lastMessageTimestamp || 0))
+    .slice(0, limit);
+  res.json(chats);
 });
 
 // Health check

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -112,6 +112,69 @@ def test_star_wildcard_in_allowlist_authorizes_any_user(monkeypatch):
     assert runner._is_user_authorized(source) is True
 
 
+def test_whatsapp_service_chat_is_authorized_via_phone_number(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True,
+                extra={
+                    "service_conversations": {
+                        "enabled": True,
+                        "approved_chats": ["+34 600-111-222"],
+                    }
+                },
+            )
+        },
+    )
+    runner, _adapter = _make_runner(Platform.WHATSAPP, config)
+    runner._whatsapp_service_policy = gateway_run.WhatsAppServiceConversationPolicy.from_gateway_config(config)
+
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="34600111222@s.whatsapp.net",
+        chat_id="34600111222@s.whatsapp.net",
+        user_name="Movistar",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+    runner.pairing_store.is_approved.assert_not_called()
+
+
+def test_whatsapp_service_chat_helper_detects_service_chat(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True,
+                extra={
+                    "service_conversations": {
+                        "enabled": True,
+                        "approved_chats": ["+34 600-111-222"],
+                    }
+                },
+            )
+        },
+    )
+    runner, _adapter = _make_runner(Platform.WHATSAPP, config)
+    runner._whatsapp_service_policy = gateway_run.WhatsAppServiceConversationPolicy.from_gateway_config(config)
+
+    event = MessageEvent(
+        text="/status",
+        message_id="m2",
+        source=SessionSource(
+            platform=Platform.WHATSAPP,
+            user_id="34600111222@s.whatsapp.net",
+            chat_id="34600111222@s.whatsapp.net",
+            user_name="Movistar",
+            chat_type="dm",
+        ),
+    )
+
+    assert runner._is_from_whatsapp_service_chat(event) is True
+
+
 def test_star_wildcard_works_for_any_platform(monkeypatch):
     """The * wildcard should work generically, not just for WhatsApp."""
     _clear_auth_env(monkeypatch)
@@ -170,6 +233,39 @@ def test_qq_group_allowlist_does_not_authorize_other_groups(monkeypatch):
     )
 
     assert runner._is_user_authorized(source) is False
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_whatsapp_service_dm_gets_approval_message(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True,
+                extra={
+                    "service_conversations": {
+                        "enabled": True,
+                        "approved_chats": [],
+                    }
+                },
+            )
+        },
+    )
+    runner, adapter = _make_runner(Platform.WHATSAPP, config)
+    runner._whatsapp_service_policy = gateway_run.WhatsAppServiceConversationPolicy.from_gateway_config(config)
+
+    result = await runner._handle_message(
+        _make_event(
+            Platform.WHATSAPP,
+            "34600111222@s.whatsapp.net",
+            "34600111222@s.whatsapp.net",
+        )
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_awaited_once()
+    assert "not approved yet" in adapter.send.await_args.args[1]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_recent_chats.py
+++ b/tests/gateway/test_whatsapp_recent_chats.py
@@ -1,0 +1,72 @@
+"""Tests for WhatsApp recent-chat discovery helpers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.whatsapp import WhatsAppAdapter
+
+
+class _AsyncCM:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _make_adapter():
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter._bridge_port = 3000
+    adapter._http_session = MagicMock()
+    adapter._bridge_process = None
+    adapter._running = True
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_list_recent_chats_returns_bridge_payload():
+    adapter = _make_adapter()
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value=[
+        {"chatId": "34600111222@s.whatsapp.net", "name": "Movistar", "isGroup": False, "lastMessageTimestamp": 1700000000},
+        {"chatId": "12345@g.us", "name": "Family", "isGroup": True, "lastMessageTimestamp": 1690000000},
+    ])
+    adapter._http_session.get.return_value = _AsyncCM(response)
+
+    chats = await adapter.list_recent_chats(limit=10)
+
+    assert chats[0]["chatId"] == "34600111222@s.whatsapp.net"
+    call = adapter._http_session.get.call_args
+    assert call.kwargs["params"] == {"limit": 10}
+
+
+@pytest.mark.asyncio
+async def test_list_recent_chats_returns_empty_on_non_200():
+    adapter = _make_adapter()
+    response = MagicMock(status=503)
+    response.json = AsyncMock(return_value={"error": "nope"})
+    adapter._http_session.get.return_value = _AsyncCM(response)
+
+    chats = await adapter.list_recent_chats()
+
+    assert chats == []
+
+
+@pytest.mark.asyncio
+async def test_list_recent_chats_filters_non_dict_entries():
+    adapter = _make_adapter()
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value=[None, {"name": "missing id"}, {"chatId": "12345@g.us", "name": "Family"}])
+    adapter._http_session.get.return_value = _AsyncCM(response)
+
+    chats = await adapter.list_recent_chats()
+
+    assert chats == [{"chatId": "12345@g.us", "name": "Family"}]

--- a/tests/gateway/test_whatsapp_service_policy.py
+++ b/tests/gateway/test_whatsapp_service_policy.py
@@ -1,0 +1,71 @@
+"""Tests for WhatsApp service-conversation policy defaults and normalization."""
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.whatsapp_service_policy import (
+    WhatsAppServiceConversationConfig,
+    WhatsAppServiceConversationPolicy,
+    normalize_whatsapp_chat_id,
+)
+
+
+def test_normalize_whatsapp_chat_id_for_phone_number():
+    assert normalize_whatsapp_chat_id("+34 600-111-222") == "34600111222@s.whatsapp.net"
+
+
+def test_normalize_whatsapp_chat_id_preserves_jid_forms():
+    assert normalize_whatsapp_chat_id("34600111222@s.whatsapp.net") == "34600111222@s.whatsapp.net"
+    assert normalize_whatsapp_chat_id("12345678901234@lid") == "12345678901234@lid"
+    assert normalize_whatsapp_chat_id("12345@g.us") == "12345@g.us"
+
+
+def test_normalize_whatsapp_chat_id_rejects_human_label():
+    assert normalize_whatsapp_chat_id("Movistar Support (dm)") is None
+
+
+def test_service_conversation_config_defaults_are_conservative():
+    cfg = WhatsAppServiceConversationConfig.from_dict({})
+    assert cfg.enabled is False
+    assert cfg.default_mode == "draft_first"
+    assert cfg.require_explicit_approval_for_first_contact is True
+    assert cfg.allow_inbound_media is False
+    assert cfg.allow_outbound_media is False
+    assert cfg.allow_agent_initiated_service_chats is False
+    assert cfg.max_new_service_chats_per_day == 3
+
+
+def test_service_conversation_config_normalizes_approved_chats():
+    cfg = WhatsAppServiceConversationConfig.from_dict(
+        {
+            "enabled": True,
+            "approved_chats": [
+                "+34 600-111-222",
+                "34600111222@s.whatsapp.net",
+                "Movistar Support (dm)",
+            ],
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.approved_chats == ["34600111222@s.whatsapp.net"]
+
+
+def test_policy_accepts_only_approved_chats_when_enabled():
+    platform_cfg = PlatformConfig(enabled=True, extra={
+        "service_conversations": {
+            "enabled": True,
+            "approved_chats": ["+34 600-111-222"],
+        }
+    })
+    gateway_cfg = GatewayConfig(platforms={Platform.WHATSAPP: platform_cfg})
+    policy = WhatsAppServiceConversationPolicy.from_gateway_config(gateway_cfg)
+
+    assert policy.can_accept_inbound("34600111222@s.whatsapp.net") is True
+    assert policy.can_accept_inbound("+34 600-111-222") is True
+    assert policy.can_accept_inbound("34999999999@s.whatsapp.net") is False
+
+
+def test_policy_disallows_operator_commands_from_provider_chat():
+    policy = WhatsAppServiceConversationPolicy(
+        WhatsAppServiceConversationConfig.from_dict({"enabled": True, "approved_chats": ["+34 600-111-222"]})
+    )
+    assert policy.is_operator_command_allowed(from_approved_service_chat=True) is False
+    assert policy.is_operator_command_allowed(from_approved_service_chat=False) is True

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -19,6 +19,7 @@ from tools.send_message_tool import (
 )
 
 
+
 def _run_async_immediately(coro):
     return asyncio.run(coro)
 
@@ -876,6 +877,34 @@ class TestParseTargetRefDiscord:
         assert chat_id == "123456"
         assert thread_id == "789"
         assert is_explicit is True
+
+
+class TestParseTargetRefWhatsapp:
+    """WhatsApp explicit targets should accept JIDs and phone numbers."""
+
+    def test_whatsapp_jid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "34600111222@s.whatsapp.net")
+        assert chat_id == "34600111222@s.whatsapp.net"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_whatsapp_phone_number_is_normalized(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "+34 600-111-222")
+        assert chat_id == "34600111222@s.whatsapp.net"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_whatsapp_lid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "12345678901234@lid")
+        assert chat_id == "12345678901234@lid"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_whatsapp_human_name_is_not_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "Movistar Support (dm)")
+        assert chat_id is None
+        assert thread_id is None
+        assert is_explicit is False
 
 
 class TestParseTargetRefMatrix:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -316,6 +316,12 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    if platform_name == "whatsapp":
+        from gateway.whatsapp_service_policy import normalize_whatsapp_chat_id
+
+        normalized = normalize_whatsapp_chat_id(target_ref)
+        if normalized:
+            return normalized, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
## Summary
- forward unknown WhatsApp DMs to the gateway so authorization can happen there instead of being dropped in the bridge
- add conservative service-conversation policy helpers for approved provider/support chats
- block slash-command/operator control from approved service chats while allowing normal conversation
- add recent WhatsApp chat discovery plus explicit phone/JID target normalization for send_message

## Test Plan
- [x] `python -m pytest tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_whatsapp_service_policy.py tests/gateway/test_whatsapp_recent_chats.py tests/tools/test_send_message_tool.py -q`

Refs #11751
