### PR TITLE
fix: preserve delivery metadata in gateway threading

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4014,6 +4014,7 @@ class GatewayRunner:
                 session_key=session_key,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                delivery_metadata=getattr(event, "metadata", None),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -5605,7 +5606,9 @@ class GatewayRunner:
                     "audio_path": actual_path,
                     "reply_to": event.message_id,
                 }
-                if event.source.thread_id:
+                if event.metadata is not None:
+                    send_kwargs["metadata"] = event.metadata
+                elif event.source.thread_id:
                     send_kwargs["metadata"] = {"thread_id": event.source.thread_id}
                 await adapter.send_voice(**send_kwargs)
         except Exception as e:
@@ -5636,7 +5639,11 @@ class GatewayRunner:
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
 
-            _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _thread_meta = (
+                event.metadata
+                if event.metadata is not None
+                else ({"thread_id": event.source.thread_id} if event.source.thread_id else None)
+            )
 
             _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
@@ -8119,6 +8126,7 @@ class GatewayRunner:
         session_id: str,
         session_key: str = None,
         event_message_id: Optional[str] = None,
+        delivery_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -8209,8 +8217,10 @@ class GatewayRunner:
             else bool(_plat_streaming)
         )
 
-        if source.thread_id:
-            _thread_metadata: Optional[Dict[str, Any]] = {"thread_id": source.thread_id}
+        if delivery_metadata is not None:
+            _thread_metadata = delivery_metadata
+        elif source.thread_id:
+            _thread_metadata = {"thread_id": source.thread_id}
         else:
             _thread_metadata = None
 
@@ -8362,6 +8372,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        delivery_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -8385,6 +8396,7 @@ class GatewayRunner:
                 session_id=session_id,
                 session_key=session_key,
                 event_message_id=event_message_id,
+                delivery_metadata=delivery_metadata,
             )
 
         from run_agent import AIAgent
@@ -8510,15 +8522,23 @@ class GatewayRunner:
         # Accumulates tool lines into a single message that gets edited.
         #
         # Threading metadata is platform-specific:
+        # - Slack may use explicit delivery_metadata to suppress synthetic
+        #   per-message thread anchors for top-level channel replies
         # - Slack DM threading needs event_message_id fallback (reply thread)
         # - Telegram uses message_thread_id only for forum topics; passing a
         #   normal DM/group message id as thread_id causes send failures
         # - Other platforms should use explicit source.thread_id only
-        if source.platform == Platform.SLACK:
+        _progress_thread_id = None
+        if delivery_metadata is not None:
+            _progress_metadata = delivery_metadata
+            if isinstance(delivery_metadata, dict):
+                _progress_thread_id = delivery_metadata.get("thread_id")
+        elif source.platform == Platform.SLACK:
             _progress_thread_id = source.thread_id or event_message_id
+            _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
         else:
             _progress_thread_id = source.thread_id
-        _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+            _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
         async def send_progress_messages():
             if not progress_queue:
@@ -8679,7 +8699,7 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_thread_metadata = _progress_metadata
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
@@ -8810,7 +8830,7 @@ class GatewayRunner:
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            metadata=_progress_metadata,
                         )
                         if _want_stream_deltas:
                             _stream_delta_cb = _stream_consumer.on_delta
@@ -9751,6 +9771,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    delivery_metadata=getattr(pending_event, "metadata", None) if pending_event is not None else delivery_metadata,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/tests/gateway/test_delivery_metadata_threading.py
+++ b/tests/gateway/test_delivery_metadata_threading.py
@@ -1,0 +1,85 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import run_agent
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _StubAgent:
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = None
+        self.step_callback = None
+        self.stream_delta_callback = None
+        self.interim_assistant_callback = None
+        self.status_callback = None
+        self.reasoning_config = None
+        self.service_tier = None
+        self.request_overrides = None
+        self.background_review_callback = None
+
+    def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "tools": [],
+            "completed": True,
+        }
+
+
+def _make_runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._smart_model_routing = {}
+    runner._session_db = None
+    runner._agent_cache_lock = None
+    runner._agent_cache = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._load_reasoning_config = lambda: {}
+    runner._load_service_tier = lambda: None
+    runner._resolve_session_agent_runtime = lambda **kwargs: ("test/model", {})
+    runner._resolve_turn_agent_config = lambda message, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+    }
+    runner._agent_config_signature = lambda *args, **kwargs: "sig"
+    return runner
+
+
+def test_run_agent_accepts_delivery_metadata_without_unboundlocalerror(monkeypatch):
+    """Regression: explicit delivery_metadata must not leave _progress_thread_id undefined."""
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="channel",
+        user_id="U123",
+    )
+
+    monkeypatch.setattr(run_agent, "AIAgent", _StubAgent)
+
+    result = asyncio.run(
+        runner._run_agent(
+            message="ping",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="session-1",
+            session_key="slack:channel:C123",
+            event_message_id="1712345678.9",
+            delivery_metadata={"thread_id": "1712345678.9"},
+        )
+    )
+
+    assert result["final_response"] == "ok"


### PR DESCRIPTION
## What does this PR do?
- propagate explicit `delivery_metadata` through gateway reply, proxy, streaming, status, media, and interrupt-followup paths
- fix the `_progress_thread_id` UnboundLocalError triggered by Slack delivery metadata
- add a regression test covering the reported Mission Control crash

## Related Issue
- No formal issue; this fixes the live Mission Control Slack-thread crash reported by the user

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- update `gateway/run.py` to carry explicit delivery metadata through `_run_agent` and `_run_agent_via_proxy`
- preserve thread metadata for status updates and stream consumer setup
- preserve delivery metadata on follow-up sends after interrupts
- add `tests/gateway/test_delivery_metadata_threading.py`

## How to Test
1. `python -m pytest tests/gateway/test_delivery_metadata_threading.py tests/gateway/test_slack.py -q`
2. Reproduce a Slack reply path that passes explicit delivery metadata
3. Confirm the agent no longer crashes with `_progress_thread_id` UnboundLocalError

## Checklist
- [x] My PR contains only changes related to this fix
- [x] I've run targeted tests and they pass
- [x] I've added a regression test for the bug
- [x] Cross-platform impact considered; behavior is metadata propagation in gateway code
