### PR TITLE
feat: port low-budget handoff flow

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -307,6 +307,16 @@ def load_cli_config() -> Dict[str, Any]:
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         },
+        "checkpoints": {
+            "enabled": True,
+            "max_snapshots": 50,
+            "low_budget_handoff": {
+                "enabled": False,
+                "reserve_iterations": 8,
+                "snapshot_workdirs": True,
+                "write_file": True,
+            },
+        },
     }
     
     # Track whether the config file explicitly set terminal config.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -431,6 +431,12 @@ DEFAULT_CONFIG = {
     "checkpoints": {
         "enabled": True,
         "max_snapshots": 50,  # Max checkpoints to keep per directory
+        "low_budget_handoff": {
+            "enabled": False,        # Stop early and emit a resumable handoff before iteration exhaustion
+            "reserve_iterations": 8, # Remaining turns to preserve for the handoff path
+            "snapshot_workdirs": True,
+            "write_file": True,
+        },
     },
 
     # Maximum characters returned by a single read_file call.  Reads that
@@ -777,7 +783,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 18,
+    "_config_version": 19,
 }
 
 # =============================================================================

--- a/run_agent.py
+++ b/run_agent.py
@@ -1211,6 +1211,9 @@ class AIAgent:
             enabled=checkpoints_enabled,
             max_snapshots=checkpoint_max_snapshots,
         )
+        self._checkpoint_dirs_touched: set[str] = set()
+        self._low_budget_handoff_triggered = False
+        self._low_budget_handoff_artifacts: Dict[str, Any] = {}
         
         # SQLite session store (optional -- provided by CLI or gateway)
         self._session_db = session_db
@@ -1251,6 +1254,23 @@ class AIAgent:
             _agent_cfg = _load_agent_config()
         except Exception:
             _agent_cfg = {}
+
+        checkpoint_cfg = _agent_cfg.get("checkpoints", {})
+        if isinstance(checkpoint_cfg, bool):
+            checkpoint_cfg = {"enabled": checkpoint_cfg}
+        low_budget_cfg = checkpoint_cfg.get("low_budget_handoff", {})
+        if isinstance(low_budget_cfg, bool):
+            low_budget_cfg = {"enabled": low_budget_cfg}
+        self._low_budget_handoff_enabled = bool(low_budget_cfg.get("enabled", False))
+        try:
+            reserve_iterations = int(low_budget_cfg.get("reserve_iterations", 8))
+        except (TypeError, ValueError):
+            reserve_iterations = 8
+        self._low_budget_handoff_reserve = max(1, reserve_iterations)
+        self._low_budget_handoff_snapshot_workdirs = bool(
+            low_budget_cfg.get("snapshot_workdirs", True)
+        )
+        self._low_budget_handoff_write_file = bool(low_budget_cfg.get("write_file", True))
 
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
@@ -7579,6 +7599,7 @@ class AIAgent:
                     file_path = function_args.get("path", "")
                     if file_path:
                         work_dir = self._checkpoint_mgr.get_working_dir_for_path(file_path)
+                        self._remember_checkpoint_dir(work_dir)
                         self._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
                 except Exception:
                     pass
@@ -7589,6 +7610,7 @@ class AIAgent:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
                         cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        self._remember_checkpoint_dir(cwd)
                         self._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )
@@ -7895,6 +7917,7 @@ class AIAgent:
                     file_path = function_args.get("path", "")
                     if file_path:
                         work_dir = self._checkpoint_mgr.get_working_dir_for_path(file_path)
+                        self._remember_checkpoint_dir(work_dir)
                         self._checkpoint_mgr.ensure_checkpoint(
                             work_dir, f"before {function_name}"
                         )
@@ -7907,6 +7930,7 @@ class AIAgent:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
                         cwd = function_args.get("workdir") or os.getenv("TERMINAL_CWD", os.getcwd())
+                        self._remember_checkpoint_dir(cwd)
                         self._checkpoint_mgr.ensure_checkpoint(
                             cwd, f"before terminal: {cmd[:60]}"
                         )
@@ -8183,6 +8207,389 @@ class AIAgent:
 
 
 
+    def _remember_checkpoint_dir(self, working_dir: Optional[str]) -> None:
+        """Track directories touched by mutating tools for later handoff snapshots."""
+        if not working_dir:
+            return
+        try:
+            abs_dir = str(Path(working_dir).expanduser().resolve())
+        except Exception:
+            return
+        if abs_dir in ("/", str(Path.home())):
+            return
+        self._checkpoint_dirs_touched.add(abs_dir)
+
+    def _build_low_budget_resume_prompt(self, original_user_message: str, handoff_path: Optional[str] = None) -> str:
+        """Build a ready-to-paste continuation prompt for a future Hermes session."""
+        prompt_lines = []
+        if handoff_path:
+            prompt_lines.append(f"Resume this task from handoff file: {handoff_path}")
+        else:
+            prompt_lines.append("Resume this task from the latest low-budget handoff summary.")
+
+        clean_request = (original_user_message or "").strip()
+        if clean_request:
+            prompt_lines.extend([
+                "",
+                "Original user request:",
+                clean_request,
+            ])
+
+        prompt_lines.extend([
+            "",
+            "Instructions:",
+            "1. Read the handoff summary first.",
+            "2. Verify current workspace / git state before changing anything.",
+            "3. Continue from the listed Next Steps.",
+            "4. Do not repeat completed work unless verification shows drift.",
+        ])
+        return "\n".join(prompt_lines).strip()
+
+    def _snapshot_low_budget_workdirs(self) -> List[Dict[str, Any]]:
+        """Take fresh snapshots for touched workdirs when emitting a low-budget handoff."""
+        if not (self._checkpoint_mgr.enabled and self._low_budget_handoff_snapshot_workdirs):
+            return []
+
+        dirs = list(self._checkpoint_dirs_touched)
+        if not dirs:
+            fallback_dir = os.getenv("TERMINAL_CWD") or os.getcwd()
+            if fallback_dir:
+                dirs = [fallback_dir]
+
+        # Clear turn-level dedup so the handoff can create a fresh snapshot even if
+        # this turn already checkpointed during earlier file mutations.
+        self._checkpoint_mgr.new_turn()
+
+        records: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+        for working_dir in dirs:
+            try:
+                resolved = str(Path(working_dir).expanduser().resolve())
+            except Exception:
+                continue
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+
+            record: Dict[str, Any] = {"directory": resolved, "checkpointed": False}
+            try:
+                record["checkpointed"] = bool(
+                    self._checkpoint_mgr.ensure_checkpoint(resolved, "low-budget handoff")
+                )
+                checkpoints = self._checkpoint_mgr.list_checkpoints(resolved)
+                if checkpoints:
+                    latest = checkpoints[0]
+                    record["checkpoint"] = latest.get("short_hash") or latest.get("hash")
+                    record["reason"] = latest.get("reason")
+                    record["timestamp"] = latest.get("timestamp")
+            except Exception as exc:
+                record["error"] = str(exc)
+            records.append(record)
+
+        return records
+
+    def _build_low_budget_fallback_handoff(
+        self,
+        api_call_count: int,
+        original_user_message: str,
+        checkpoint_records: List[Dict[str, Any]],
+        error: Optional[str] = None,
+    ) -> str:
+        """Build a deterministic handoff when the model cannot generate one."""
+        relevant_files = [
+            f"- {entry['directory']}"
+            + (f" (checkpoint {entry['checkpoint']})" if entry.get("checkpoint") else "")
+            for entry in checkpoint_records
+            if entry.get("directory")
+        ] or ["- No checkpointable workdir was recorded."]
+
+        blocked = (
+            f"- Automatic handoff summary generation failed: {error}"
+            if error else
+            "- Budget reserve reached; session paused before hard exhaustion."
+        )
+
+        return "\n".join([
+            "## Goal",
+            (original_user_message or "Continue the current task.").strip() or "Continue the current task.",
+            "",
+            "## Constraints & Preferences",
+            "- Resume from existing workspace state; avoid repeating completed work.",
+            "- Verify file / git state before making new changes.",
+            "",
+            "## Progress",
+            "### Done",
+            f"- Reached low-budget reserve at iteration {api_call_count}/{self.max_iterations}.",
+            "### In Progress",
+            "- A continuation handoff is needed before more tool work.",
+            "### Blocked",
+            blocked,
+            "",
+            "## Key Decisions",
+            "- Stop early instead of hitting the hard tool-iteration ceiling.",
+            "",
+            "## Relevant Files",
+            *relevant_files,
+            "",
+            "## Next Steps",
+            "- Read the latest handoff and session transcript.",
+            "- Inspect current workspace / git diff.",
+            "- Continue from the last successful tool results.",
+            "",
+            "## Critical Context",
+            f"- Session ID: {self.session_id}",
+            f"- Model: {self.model}",
+            f"- Iteration budget used: {api_call_count}/{self.max_iterations}",
+            "",
+            "## Resume Prompt",
+            self._build_low_budget_resume_prompt(original_user_message),
+        ]).strip()
+
+    def _should_trigger_low_budget_handoff(self, assistant_message, api_call_count: int) -> bool:
+        """Return True when the session should stop early and emit a resume handoff."""
+        if not self._low_budget_handoff_enabled or self._low_budget_handoff_triggered:
+            return False
+        if not getattr(assistant_message, "tool_calls", None):
+            return False
+        if self.iteration_budget.remaining <= 0:
+            return False
+        if self.iteration_budget.remaining > self._low_budget_handoff_reserve:
+            return False
+
+        housekeeping_tools = frozenset({"memory", "todo", "skill_manage", "session_search"})
+        tool_names = {
+            tc.function.name
+            for tc in assistant_message.tool_calls
+            if getattr(tc, "function", None) is not None
+        }
+        if (
+            tool_names
+            and tool_names.issubset(housekeeping_tools)
+            and getattr(assistant_message, "content", None)
+            and self._has_content_after_think_block(assistant_message.content or "")
+        ):
+            return False
+        return True
+
+    def _handle_low_budget_handoff(
+        self,
+        messages: list,
+        api_call_count: int,
+        original_user_message: str,
+    ) -> str:
+        """Stop early, snapshot state, and emit a resumable handoff before exhaustion."""
+        remaining = self.iteration_budget.remaining
+        if not self.quiet_mode:
+            self._safe_print(
+                f"\n⚠️  Low-budget reserve triggered ({remaining} iteration(s) remaining). "
+                "Creating a resumable handoff instead of continuing tool calls..."
+            )
+
+        checkpoint_records = self._snapshot_low_budget_workdirs()
+        handoff_request = (
+            "You are almost out of tool-calling budget in this Hermes session. "
+            "Do not call any more tools. Create a concise resume handoff for the next session.\n\n"
+            "Use this exact structure:\n\n"
+            "## Goal\n"
+            "[What the user is trying to accomplish]\n\n"
+            "## Constraints & Preferences\n"
+            "[Important constraints, style requirements, user preferences]\n\n"
+            "## Progress\n"
+            "### Done\n"
+            "[Specific work already completed]\n"
+            "### In Progress\n"
+            "[What was underway when budget ran low]\n"
+            "### Blocked\n"
+            "[Anything blocking completion]\n\n"
+            "## Key Decisions\n"
+            "[Important technical decisions and why]\n\n"
+            "## Relevant Files\n"
+            "[Files and directories that matter, with notes]\n\n"
+            "## Next Steps\n"
+            "[Exact next actions for the next session]\n\n"
+            "## Critical Context\n"
+            "[Concrete values, errors, command outputs, or state that must not be lost]\n\n"
+            "## Resume Prompt\n"
+            "[A ready-to-paste prompt telling the next Hermes session how to continue without repeating work]\n\n"
+            "Be concrete. Include file paths, commands, errors, and verification already completed."
+        )
+        messages.append({"role": "user", "content": handoff_request})
+
+        handoff_body = ""
+        handoff_error = None
+
+        try:
+            _needs_sanitize = self._should_sanitize_tool_calls()
+            api_messages = []
+            for msg in messages:
+                api_msg = msg.copy()
+                for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+                    api_msg.pop(internal_field, None)
+                if _needs_sanitize:
+                    self._sanitize_tool_calls_for_strict_api(api_msg)
+                api_messages.append(api_msg)
+
+            effective_system = self._cached_system_prompt or ""
+            if self.ephemeral_system_prompt:
+                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+            if effective_system:
+                api_messages = [{"role": "system", "content": effective_system}] + api_messages
+            if self.prefill_messages:
+                sys_offset = 1 if effective_system else 0
+                for idx, pfm in enumerate(self.prefill_messages):
+                    api_messages.insert(sys_offset + idx, pfm.copy())
+
+            summary_extra_body = {}
+            _is_nous = "nousresearch" in self._base_url_lower
+            if self._supports_reasoning_extra_body():
+                if self.reasoning_config is not None:
+                    summary_extra_body["reasoning"] = self.reasoning_config
+                else:
+                    summary_extra_body["reasoning"] = {
+                        "enabled": True,
+                        "effort": "medium",
+                    }
+            if _is_nous:
+                summary_extra_body["tags"] = ["product=hermes-agent"]
+
+            if self.api_mode == "codex_responses":
+                codex_kwargs = self._build_api_kwargs(api_messages)
+                codex_kwargs.pop("tools", None)
+                summary_response = self._run_codex_stream(codex_kwargs)
+                assistant_message, _ = self._normalize_codex_response(summary_response)
+                handoff_body = (assistant_message.content or "").strip() if assistant_message else ""
+            else:
+                summary_kwargs = {
+                    "model": self.model,
+                    "messages": api_messages,
+                }
+                if self.max_tokens is not None:
+                    summary_kwargs.update(self._max_tokens_param(self.max_tokens))
+
+                provider_preferences = {}
+                if self.providers_allowed:
+                    provider_preferences["only"] = self.providers_allowed
+                if self.providers_ignored:
+                    provider_preferences["ignore"] = self.providers_ignored
+                if self.providers_order:
+                    provider_preferences["order"] = self.providers_order
+                if self.provider_sort:
+                    provider_preferences["sort"] = self.provider_sort
+                if provider_preferences:
+                    summary_extra_body["provider"] = provider_preferences
+                if summary_extra_body:
+                    summary_kwargs["extra_body"] = summary_extra_body
+
+                if self.api_mode == "anthropic_messages":
+                    from agent.anthropic_adapter import build_anthropic_kwargs as _bak, normalize_anthropic_response as _nar
+
+                    _ant_kw = _bak(
+                        model=self.model,
+                        messages=api_messages,
+                        tools=None,
+                        max_tokens=self.max_tokens,
+                        reasoning_config=self.reasoning_config,
+                        is_oauth=self._is_anthropic_oauth,
+                        preserve_dots=self._anthropic_preserve_dots(),
+                    )
+                    summary_response = self._anthropic_messages_create(_ant_kw)
+                    _msg, _ = _nar(summary_response, strip_tool_prefix=self._is_anthropic_oauth)
+                    handoff_body = (_msg.content or "").strip()
+                else:
+                    summary_response = self._ensure_primary_openai_client(
+                        reason="low_budget_handoff"
+                    ).chat.completions.create(**summary_kwargs)
+                    if summary_response.choices and summary_response.choices[0].message.content:
+                        handoff_body = summary_response.choices[0].message.content or ""
+
+            if handoff_body and "<think>" in handoff_body:
+                handoff_body = re.sub(r'<think>.*?</think>\s*', '', handoff_body, flags=re.DOTALL).strip()
+        except Exception as exc:
+            handoff_error = str(exc)
+            logging.warning("Failed to generate low-budget handoff: %s", exc)
+
+        if not handoff_body:
+            handoff_body = self._build_low_budget_fallback_handoff(
+                api_call_count,
+                original_user_message,
+                checkpoint_records,
+                error=handoff_error,
+            )
+
+        artifacts: Dict[str, Any] = {"checkpoints": checkpoint_records}
+        resume_prompt = self._build_low_budget_resume_prompt(original_user_message)
+        if self._low_budget_handoff_write_file:
+            try:
+                handoff_dir = get_hermes_home() / "handoffs"
+                handoff_dir.mkdir(parents=True, exist_ok=True)
+                stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                stem = f"{stamp}_{self.session_id}_budget_handoff"
+                markdown_path = handoff_dir / f"{stem}.md"
+                resume_prompt = self._build_low_budget_resume_prompt(
+                    original_user_message,
+                    handoff_path=str(markdown_path),
+                )
+                markdown_body = handoff_body
+                if "## Resume Prompt" not in markdown_body:
+                    markdown_body = markdown_body.rstrip() + "\n\n## Resume Prompt\n" + resume_prompt
+                markdown_path.write_text(markdown_body.rstrip() + "\n", encoding="utf-8")
+
+                json_path = handoff_dir / f"{stem}.json"
+                atomic_json_write(
+                    json_path,
+                    {
+                        "session_id": self.session_id,
+                        "created_at": datetime.now().isoformat(),
+                        "reason": "low_budget_handoff",
+                        "api_calls_used": api_call_count,
+                        "max_iterations": self.max_iterations,
+                        "remaining_iterations": remaining,
+                        "model": self.model,
+                        "platform": self.platform,
+                        "original_user_message": original_user_message,
+                        "resume_prompt": resume_prompt,
+                        "checkpoints": checkpoint_records,
+                        "handoff_markdown": markdown_body,
+                    },
+                    indent=2,
+                    default=str,
+                )
+                artifacts.update(
+                    {
+                        "markdown_path": str(markdown_path),
+                        "json_path": str(json_path),
+                    }
+                )
+                handoff_body = markdown_body
+            except Exception as exc:
+                logging.warning("Failed to write low-budget handoff artifacts: %s", exc)
+                artifacts["write_error"] = str(exc)
+
+        lines = [
+            f"⚠️ Low-budget handoff triggered at iteration {api_call_count}/{self.max_iterations}.",
+            f"Reserved iterations remaining: {remaining}.",
+        ]
+        if checkpoint_records:
+            lines.append("Checkpointed workdirs:")
+            for entry in checkpoint_records:
+                checkpoint_text = f" [{entry.get('checkpoint')}]" if entry.get("checkpoint") else ""
+                state = "new snapshot" if entry.get("checkpointed") else "existing snapshot"
+                lines.append(f"- {entry.get('directory')}{checkpoint_text} ({state})")
+        if artifacts.get("markdown_path"):
+            lines.extend([
+                f"Handoff markdown: {artifacts['markdown_path']}",
+                f"Handoff metadata: {artifacts.get('json_path')}",
+            ])
+        if resume_prompt:
+            lines.extend(["", "Resume prompt:", resume_prompt])
+        lines.extend(["", handoff_body.strip()])
+
+        final_response = "\n".join(line for line in lines if line is not None).strip()
+        messages.append({"role": "assistant", "content": final_response})
+        self._low_budget_handoff_triggered = True
+        self._low_budget_handoff_artifacts = artifacts
+        return final_response
+
     def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
         """Request a summary when max iterations are reached. Returns the final response text."""
         print(f"⚠️  Reached maximum iterations ({self.max_iterations}). Requesting summary...")
@@ -8414,6 +8821,9 @@ class AIAgent:
         self._last_content_tools_all_housekeeping = False
         self._mute_post_response = False
         self._unicode_sanitization_passes = 0
+        self._checkpoint_dirs_touched.clear()
+        self._low_budget_handoff_triggered = False
+        self._low_budget_handoff_artifacts = {}
 
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.
@@ -10956,6 +11366,14 @@ class AIAgent:
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages
                     self._save_session_log(messages)
+
+                    if self._should_trigger_low_budget_handoff(assistant_message, api_call_count):
+                        final_response = self._handle_low_budget_handoff(
+                            messages,
+                            api_call_count,
+                            original_user_message,
+                        )
+                        break
                     
                     # Continue loop for next response
                     continue
@@ -11334,7 +11752,11 @@ class AIAgent:
             final_response = self._handle_max_iterations(messages, api_call_count)
         
         # Determine if conversation completed successfully
-        completed = final_response is not None and api_call_count < self.max_iterations
+        completed = (
+            final_response is not None
+            and api_call_count < self.max_iterations
+            and not self._low_budget_handoff_triggered
+        )
 
         # Save trajectory if enabled
         self._save_trajectory(messages, user_message, completed)
@@ -11425,6 +11847,8 @@ class AIAgent:
             "partial": False,  # True only when stopped due to invalid tool calls
             "interrupted": interrupted,
             "response_previewed": getattr(self, "_response_was_previewed", False),
+            "budget_handoff": self._low_budget_handoff_triggered,
+            "budget_handoff_artifacts": self._low_budget_handoff_artifacts,
             "model": self.model,
             "provider": self.provider,
             "base_url": self.base_url,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3274,16 +3274,17 @@ class TestLowBudgetHandoff:
     def test_run_conversation_real_write_file_tool_creates_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
         import tools.checkpoint_manager as checkpoint_manager
 
-        handoff_home = tmp_path / "hermes-home"
-        checkpoint_base = tmp_path / "shadow-checkpoints"
-        work_dir = tmp_path / "project"
+        safe_root = self._safe_temp_root()
+        handoff_home = safe_root / "hermes-home"
+        checkpoint_base = safe_root / "shadow-checkpoints"
+        work_dir = safe_root / "project"
         work_dir.mkdir()
         target_file = work_dir / "main.py"
         target_file.write_text("print('seed')\n", encoding="utf-8")
 
         monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
         monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
-        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
 
         agent.tools = _make_tool_defs("write_file")
         agent.valid_tool_names = {"write_file"}
@@ -3367,16 +3368,17 @@ class TestLowBudgetHandoff:
     def test_run_conversation_real_patch_tool_creates_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
         import tools.checkpoint_manager as checkpoint_manager
 
-        handoff_home = tmp_path / "hermes-home"
-        checkpoint_base = tmp_path / "shadow-checkpoints"
-        work_dir = tmp_path / "project"
+        safe_root = self._safe_temp_root()
+        handoff_home = safe_root / "hermes-home"
+        checkpoint_base = safe_root / "shadow-checkpoints"
+        work_dir = safe_root / "project"
         work_dir.mkdir()
         target_file = work_dir / "main.py"
         target_file.write_text("print('seed')\n", encoding="utf-8")
 
         monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
         monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
-        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
 
         agent.tools = _make_tool_defs("patch")
         agent.valid_tool_names = {"patch"}
@@ -3467,9 +3469,10 @@ class TestLowBudgetHandoff:
     def test_run_conversation_real_terminal_tool_creates_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
         import tools.checkpoint_manager as checkpoint_manager
 
-        handoff_home = tmp_path / "hermes-home"
-        checkpoint_base = tmp_path / "shadow-checkpoints"
-        work_dir = tmp_path / "project"
+        safe_root = self._safe_temp_root()
+        handoff_home = safe_root / "hermes-home"
+        checkpoint_base = safe_root / "shadow-checkpoints"
+        work_dir = safe_root / "project"
         work_dir.mkdir()
         target_file = work_dir / "main.py"
         target_file.write_text("print('seed')\n", encoding="utf-8")
@@ -3561,16 +3564,17 @@ class TestLowBudgetHandoff:
     def test_run_conversation_real_multi_tool_same_turn_preserves_order_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
         import tools.checkpoint_manager as checkpoint_manager
 
-        handoff_home = tmp_path / "hermes-home"
-        checkpoint_base = tmp_path / "shadow-checkpoints"
-        work_dir = tmp_path / "project"
+        safe_root = self._safe_temp_root()
+        handoff_home = safe_root / "hermes-home"
+        checkpoint_base = safe_root / "shadow-checkpoints"
+        work_dir = safe_root / "project"
         work_dir.mkdir()
         target_file = work_dir / "main.py"
         target_file.write_text("print('seed')\n", encoding="utf-8")
 
         monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
         monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
-        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe_root))
 
         agent.tools = _make_tool_defs("write_file", "patch")
         agent.valid_tool_names = {"write_file", "patch"}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -9,6 +9,7 @@ import io
 import json
 import logging
 import re
+import tempfile
 import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -3048,6 +3049,630 @@ class TestBudgetPressure:
         """Agent should have budget grace call flags."""
         assert agent._budget_exhausted_injected is False
         assert agent._budget_grace_call is False
+
+
+class TestLowBudgetHandoff:
+    def _safe_temp_root(self) -> Path:
+        return Path(tempfile.mkdtemp(dir="/tmp"))
+
+    def _consume_to_remaining(self, agent, remaining: int, max_total: int = 10):
+        agent.iteration_budget = run_agent.IterationBudget(max_total)
+        while agent.iteration_budget.remaining > remaining:
+            assert agent.iteration_budget.consume() is True
+
+    def test_should_trigger_at_reserve_for_non_housekeeping_tool(self, agent):
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_triggered = False
+        agent._low_budget_handoff_reserve = 2
+        self._consume_to_remaining(agent, remaining=2)
+
+        assistant_message = _mock_assistant_msg(
+            content="",
+            tool_calls=[_mock_tool_call(name="web_search")],
+        )
+
+        assert agent._should_trigger_low_budget_handoff(assistant_message, 8) is True
+
+    def test_skips_housekeeping_tool_when_visible_content_exists(self, agent):
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_triggered = False
+        agent._low_budget_handoff_reserve = 1
+        self._consume_to_remaining(agent, remaining=1)
+
+        assistant_message = _mock_assistant_msg(
+            content="Done saving memory.",
+            tool_calls=[_mock_tool_call(name="memory")],
+        )
+
+        assert agent._should_trigger_low_budget_handoff(assistant_message, 9) is False
+
+    def test_handle_low_budget_handoff_writes_artifacts(self, agent, tmp_path, monkeypatch):
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_records = [
+            {
+                "directory": str(tmp_path / "repo"),
+                "checkpointed": True,
+                "checkpoint": "abc123",
+                "reason": "low-budget handoff",
+            }
+        ]
+        self._consume_to_remaining(agent, remaining=2)
+        agent._cached_system_prompt = "You are helpful."
+        agent.session_id = "sess-budget"
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_write_file = True
+        agent._snapshot_low_budget_workdirs = MagicMock(return_value=checkpoint_records)
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nShip it\n\n## Resume Prompt\nresume me"
+        )
+
+        messages = [{"role": "user", "content": "ship it"}]
+        result = agent._handle_low_budget_handoff(messages, 8, "ship it")
+
+        handoff_dir = handoff_home / "handoffs"
+        markdown_files = sorted(handoff_dir.glob("*_budget_handoff.md"))
+        json_files = sorted(handoff_dir.glob("*_budget_handoff.json"))
+
+        assert len(markdown_files) == 1
+        assert len(json_files) == 1
+        assert agent._low_budget_handoff_triggered is True
+        assert agent._low_budget_handoff_artifacts["markdown_path"] == str(markdown_files[0])
+        assert "Handoff markdown:" in result
+        assert messages[-1]["role"] == "assistant"
+
+        metadata = json.loads(json_files[0].read_text(encoding="utf-8"))
+        assert metadata["reason"] == "low_budget_handoff"
+        assert metadata["original_user_message"] == "ship it"
+        assert metadata["checkpoints"][0]["checkpoint"] == "abc123"
+        assert "## Resume Prompt" in markdown_files[0].read_text(encoding="utf-8")
+
+    def test_handle_low_budget_handoff_falls_back_when_summary_generation_fails(self, agent, tmp_path, monkeypatch):
+        handoff_home = tmp_path / "hermes-home"
+        self._consume_to_remaining(agent, remaining=1)
+        agent._cached_system_prompt = "You are helpful."
+        agent.session_id = "sess-budget"
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_write_file = True
+        agent._snapshot_low_budget_workdirs = MagicMock(return_value=[])
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        agent.client.chat.completions.create.side_effect = Exception("summary api down")
+
+        messages = [{"role": "user", "content": "ship it"}]
+        result = agent._handle_low_budget_handoff(messages, 9, "ship it")
+
+        assert "Automatic handoff summary generation failed: summary api down" in result
+        assert "## Resume Prompt" in result
+        assert agent._low_budget_handoff_triggered is True
+        assert messages[-1]["role"] == "assistant"
+
+    def test_run_conversation_returns_budget_handoff_result(self, agent, tmp_path, monkeypatch):
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_records = [
+            {
+                "directory": str(tmp_path / "repo"),
+                "checkpointed": False,
+                "checkpoint": "seed123",
+                "reason": "low-budget handoff",
+            }
+        ]
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.max_iterations = 2
+        agent.iteration_budget = run_agent.IterationBudget(2)
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_reserve = 1
+        agent._low_budget_handoff_write_file = True
+        agent._interruptible_api_call = MagicMock(
+            return_value=_mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_mock_tool_call(name="web_search", call_id="c1")],
+            )
+        )
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nSearch\n\n## Resume Prompt\nresume"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_save_session_log"),
+            patch.object(agent, "_execute_tool_calls"),
+            patch.object(agent, "_snapshot_low_budget_workdirs", return_value=checkpoint_records),
+        ):
+            result = agent.run_conversation("search for regressions")
+
+        assert result["budget_handoff"] is True
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert result["budget_handoff_artifacts"]["checkpoints"] == checkpoint_records
+        assert result["budget_handoff_artifacts"]["markdown_path"].endswith("_budget_handoff.md")
+        assert "Low-budget handoff triggered" in result["final_response"]
+
+    def test_run_conversation_creates_real_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
+        import tools.checkpoint_manager as checkpoint_manager
+
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_base = tmp_path / "shadow-checkpoints"
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        target_file = work_dir / "main.py"
+        target_file.write_text("print('seed')\n", encoding="utf-8")
+
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
+
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.max_iterations = 2
+        agent.iteration_budget = run_agent.IterationBudget(2)
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_reserve = 1
+        agent._low_budget_handoff_write_file = True
+        agent._low_budget_handoff_snapshot_workdirs = True
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.max_snapshots = 5
+
+        assert agent._checkpoint_mgr.ensure_checkpoint(str(work_dir), "seed baseline") is True
+        agent._checkpoint_mgr.new_turn()
+
+        def fake_execute_tool_calls(*_args, **_kwargs):
+            target_file.write_text("print('changed during tool call')\n", encoding="utf-8")
+            agent._remember_checkpoint_dir(str(work_dir))
+
+        agent._interruptible_api_call = MagicMock(
+            return_value=_mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[_mock_tool_call(name="web_search", call_id="c1")],
+            )
+        )
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nSearch\n\n## Resume Prompt\nresume"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_save_session_log"),
+            patch.object(agent, "_execute_tool_calls", side_effect=fake_execute_tool_calls),
+        ):
+            result = agent.run_conversation("search for regressions")
+
+        checkpoints = agent._checkpoint_mgr.list_checkpoints(str(work_dir))
+        markdown_path = Path(result["budget_handoff_artifacts"]["markdown_path"])
+        json_path = Path(result["budget_handoff_artifacts"]["json_path"])
+        metadata = json.loads(json_path.read_text(encoding="utf-8"))
+
+        assert result["budget_handoff"] is True
+        assert result["completed"] is False
+        assert len(checkpoints) >= 2
+        assert checkpoints[0]["reason"] == "low-budget handoff"
+        assert checkpoints[0]["files_changed"] >= 1
+        assert markdown_path.exists()
+        assert json_path.exists()
+        assert metadata["checkpoints"][0]["directory"] == str(work_dir.resolve())
+        assert metadata["checkpoints"][0]["checkpoint"] == checkpoints[0]["short_hash"]
+        assert "## Resume Prompt" in markdown_path.read_text(encoding="utf-8")
+        assert checkpoint_base.exists()
+
+    def test_run_conversation_real_write_file_tool_creates_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
+        import tools.checkpoint_manager as checkpoint_manager
+
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_base = tmp_path / "shadow-checkpoints"
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        target_file = work_dir / "main.py"
+        target_file.write_text("print('seed')\n", encoding="utf-8")
+
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+
+        agent.tools = _make_tool_defs("write_file")
+        agent.valid_tool_names = {"write_file"}
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.max_iterations = 2
+        agent.iteration_budget = run_agent.IterationBudget(2)
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_reserve = 1
+        agent._low_budget_handoff_write_file = True
+        agent._low_budget_handoff_snapshot_workdirs = True
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.max_snapshots = 5
+
+        assert agent._checkpoint_mgr.ensure_checkpoint(str(work_dir), "seed baseline") is True
+        agent._checkpoint_mgr.new_turn()
+
+        tool_call = _mock_tool_call(
+            name="write_file",
+            arguments=json.dumps({
+                "path": str(target_file),
+                "content": "print('changed by real tool')\n",
+            }),
+            call_id="c1",
+        )
+        agent._interruptible_api_call = MagicMock(
+            return_value=_mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[tool_call],
+            )
+        )
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nUpdate file\n\n## Resume Prompt\nresume"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_save_session_log"),
+            patch("run_agent.handle_function_call", wraps=run_agent.handle_function_call) as wrapped_handle,
+        ):
+            result = agent.run_conversation("update main.py and pause cleanly if budget is low")
+
+        checkpoints = agent._checkpoint_mgr.list_checkpoints(str(work_dir))
+        markdown_path = Path(result["budget_handoff_artifacts"]["markdown_path"])
+        json_path = Path(result["budget_handoff_artifacts"]["json_path"])
+        metadata = json.loads(json_path.read_text(encoding="utf-8"))
+        tool_messages = [msg for msg in result["messages"] if msg.get("role") == "tool"]
+        tool_payload = json.loads(tool_messages[0]["content"])
+
+        assert wrapped_handle.call_count == 1
+        call_args, call_kwargs = wrapped_handle.call_args
+        assert call_args[:2] == (
+            "write_file",
+            {"path": str(target_file), "content": "print('changed by real tool')\n"},
+        )
+        assert call_kwargs["enabled_tools"] == ["write_file"]
+        assert target_file.read_text(encoding="utf-8") == "print('changed by real tool')\n"
+        assert len(tool_messages) == 1
+        assert tool_payload["bytes_written"] > 0
+        assert "error" not in tool_payload
+        assert result["budget_handoff"] is True
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert len(checkpoints) >= 2
+        assert checkpoints[0]["reason"] == "low-budget handoff"
+        assert checkpoints[0]["files_changed"] >= 1
+        assert markdown_path.exists()
+        assert json_path.exists()
+        assert metadata["checkpoints"][0]["directory"] == str(work_dir.resolve())
+        assert metadata["checkpoints"][0]["checkpoint"] == checkpoints[0]["short_hash"]
+        assert "## Resume Prompt" in markdown_path.read_text(encoding="utf-8")
+        assert checkpoint_base.exists()
+
+    def test_run_conversation_real_patch_tool_creates_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
+        import tools.checkpoint_manager as checkpoint_manager
+
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_base = tmp_path / "shadow-checkpoints"
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        target_file = work_dir / "main.py"
+        target_file.write_text("print('seed')\n", encoding="utf-8")
+
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+
+        agent.tools = _make_tool_defs("patch")
+        agent.valid_tool_names = {"patch"}
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.max_iterations = 2
+        agent.iteration_budget = run_agent.IterationBudget(2)
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_reserve = 1
+        agent._low_budget_handoff_write_file = True
+        agent._low_budget_handoff_snapshot_workdirs = True
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.max_snapshots = 5
+
+        assert agent._checkpoint_mgr.ensure_checkpoint(str(work_dir), "seed baseline") is True
+        agent._checkpoint_mgr.new_turn()
+
+        tool_call = _mock_tool_call(
+            name="patch",
+            arguments=json.dumps({
+                "mode": "replace",
+                "path": str(target_file),
+                "old_string": "print('seed')\n",
+                "new_string": "print('patched by real tool')\n",
+            }),
+            call_id="c1",
+        )
+        agent._interruptible_api_call = MagicMock(
+            return_value=_mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[tool_call],
+            )
+        )
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nPatch file\n\n## Resume Prompt\nresume"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_save_session_log"),
+            patch("run_agent.handle_function_call", wraps=run_agent.handle_function_call) as wrapped_handle,
+        ):
+            result = agent.run_conversation("patch main.py and pause cleanly if budget is low")
+
+        checkpoints = agent._checkpoint_mgr.list_checkpoints(str(work_dir))
+        markdown_path = Path(result["budget_handoff_artifacts"]["markdown_path"])
+        json_path = Path(result["budget_handoff_artifacts"]["json_path"])
+        metadata = json.loads(json_path.read_text(encoding="utf-8"))
+        tool_messages = [msg for msg in result["messages"] if msg.get("role") == "tool"]
+        tool_payload = json.loads(tool_messages[0]["content"])
+
+        assert wrapped_handle.call_count == 1
+        call_args, call_kwargs = wrapped_handle.call_args
+        assert call_args[:2] == (
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target_file),
+                "old_string": "print('seed')\n",
+                "new_string": "print('patched by real tool')\n",
+            },
+        )
+        assert call_kwargs["enabled_tools"] == ["patch"]
+        assert target_file.read_text(encoding="utf-8") == "print('patched by real tool')\n"
+        assert len(tool_messages) == 1
+        assert tool_payload["success"] is True
+        assert str(target_file) in tool_payload["files_modified"]
+        assert result["budget_handoff"] is True
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert len(checkpoints) >= 2
+        assert checkpoints[0]["reason"] == "low-budget handoff"
+        assert checkpoints[0]["files_changed"] >= 1
+        assert markdown_path.exists()
+        assert json_path.exists()
+        assert metadata["checkpoints"][0]["directory"] == str(work_dir.resolve())
+        assert metadata["checkpoints"][0]["checkpoint"] == checkpoints[0]["short_hash"]
+        assert "## Resume Prompt" in markdown_path.read_text(encoding="utf-8")
+        assert checkpoint_base.exists()
+
+    def test_run_conversation_real_terminal_tool_creates_checkpoint_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
+        import tools.checkpoint_manager as checkpoint_manager
+
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_base = tmp_path / "shadow-checkpoints"
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        target_file = work_dir / "main.py"
+        target_file.write_text("print('seed')\n", encoding="utf-8")
+
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        agent.tools = _make_tool_defs("terminal")
+        agent.valid_tool_names = {"terminal"}
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.max_iterations = 2
+        agent.iteration_budget = run_agent.IterationBudget(2)
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_reserve = 1
+        agent._low_budget_handoff_write_file = True
+        agent._low_budget_handoff_snapshot_workdirs = True
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.max_snapshots = 5
+
+        assert agent._checkpoint_mgr.ensure_checkpoint(str(work_dir), "seed baseline") is True
+        agent._checkpoint_mgr.new_turn()
+
+        command = 'printf "changed by terminal\\n" > main.py'
+        tool_call = _mock_tool_call(
+            name="terminal",
+            arguments=json.dumps({
+                "command": command,
+                "workdir": str(work_dir),
+                "timeout": 30,
+            }),
+            call_id="c1",
+        )
+        agent._interruptible_api_call = MagicMock(
+            return_value=_mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[tool_call],
+            )
+        )
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nEdit file via terminal\n\n## Resume Prompt\nresume"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_save_session_log"),
+            patch("run_agent.handle_function_call", wraps=run_agent.handle_function_call) as wrapped_handle,
+        ):
+            result = agent.run_conversation("update main.py through terminal and pause cleanly if budget is low")
+
+        checkpoints = agent._checkpoint_mgr.list_checkpoints(str(work_dir))
+        markdown_path = Path(result["budget_handoff_artifacts"]["markdown_path"])
+        json_path = Path(result["budget_handoff_artifacts"]["json_path"])
+        metadata = json.loads(json_path.read_text(encoding="utf-8"))
+        tool_messages = [msg for msg in result["messages"] if msg.get("role") == "tool"]
+        tool_payload = json.loads(tool_messages[0]["content"])
+
+        assert wrapped_handle.call_count == 1
+        call_args, call_kwargs = wrapped_handle.call_args
+        assert call_args[:2] == (
+            "terminal",
+            {"command": command, "workdir": str(work_dir), "timeout": 30},
+        )
+        assert call_kwargs["enabled_tools"] == ["terminal"]
+        assert target_file.read_text(encoding="utf-8") == "changed by terminal\n"
+        assert len(tool_messages) == 1
+        assert tool_payload["exit_code"] == 0
+        assert result["budget_handoff"] is True
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert len(checkpoints) >= 2
+        assert checkpoints[0]["reason"] == "low-budget handoff"
+        assert checkpoints[0]["files_changed"] >= 1
+        assert markdown_path.exists()
+        assert json_path.exists()
+        assert metadata["checkpoints"][0]["directory"] == str(work_dir.resolve())
+        assert metadata["checkpoints"][0]["checkpoint"] == checkpoints[0]["short_hash"]
+        assert "## Resume Prompt" in markdown_path.read_text(encoding="utf-8")
+        assert checkpoint_base.exists()
+
+    def test_run_conversation_real_multi_tool_same_turn_preserves_order_and_handoff_artifacts(self, agent, tmp_path, monkeypatch):
+        import tools.checkpoint_manager as checkpoint_manager
+
+        handoff_home = tmp_path / "hermes-home"
+        checkpoint_base = tmp_path / "shadow-checkpoints"
+        work_dir = tmp_path / "project"
+        work_dir.mkdir()
+        target_file = work_dir / "main.py"
+        target_file.write_text("print('seed')\n", encoding="utf-8")
+
+        monkeypatch.setattr(run_agent, "get_hermes_home", lambda: handoff_home)
+        monkeypatch.setattr(checkpoint_manager, "CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(tmp_path))
+
+        agent.tools = _make_tool_defs("write_file", "patch")
+        agent.valid_tool_names = {"write_file", "patch"}
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.tool_delay = 0
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+        agent.max_iterations = 2
+        agent.iteration_budget = run_agent.IterationBudget(2)
+        agent._low_budget_handoff_enabled = True
+        agent._low_budget_handoff_reserve = 1
+        agent._low_budget_handoff_write_file = True
+        agent._low_budget_handoff_snapshot_workdirs = True
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.max_snapshots = 5
+
+        assert agent._checkpoint_mgr.ensure_checkpoint(str(work_dir), "seed baseline") is True
+        agent._checkpoint_mgr.new_turn()
+
+        write_tool_call = _mock_tool_call(
+            name="write_file",
+            arguments=json.dumps({
+                "path": str(target_file),
+                "content": "print('phase one')\n",
+            }),
+            call_id="c1",
+        )
+        patch_tool_call = _mock_tool_call(
+            name="patch",
+            arguments=json.dumps({
+                "mode": "replace",
+                "path": str(target_file),
+                "old_string": "print('phase one')\n",
+                "new_string": "print('phase two')\n",
+            }),
+            call_id="c2",
+        )
+        agent._interruptible_api_call = MagicMock(
+            return_value=_mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[write_tool_call, patch_tool_call],
+            )
+        )
+        agent._ensure_primary_openai_client = MagicMock(return_value=agent.client)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="## Goal\nApply ordered file mutations\n\n## Resume Prompt\nresume"
+        )
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_save_session_log"),
+            patch("run_agent.handle_function_call", wraps=run_agent.handle_function_call) as wrapped_handle,
+        ):
+            result = agent.run_conversation("update main.py in two ordered steps and pause cleanly if budget is low")
+
+        checkpoints = agent._checkpoint_mgr.list_checkpoints(str(work_dir))
+        markdown_path = Path(result["budget_handoff_artifacts"]["markdown_path"])
+        json_path = Path(result["budget_handoff_artifacts"]["json_path"])
+        metadata = json.loads(json_path.read_text(encoding="utf-8"))
+        tool_messages = [msg for msg in result["messages"] if msg.get("role") == "tool"]
+        write_payload = json.loads(tool_messages[0]["content"])
+        patch_payload = json.loads(tool_messages[1]["content"])
+
+        assert wrapped_handle.call_count == 2
+        first_args, first_kwargs = wrapped_handle.call_args_list[0]
+        second_args, second_kwargs = wrapped_handle.call_args_list[1]
+        assert first_args[:2] == (
+            "write_file",
+            {"path": str(target_file), "content": "print('phase one')\n"},
+        )
+        assert second_args[:2] == (
+            "patch",
+            {
+                "mode": "replace",
+                "path": str(target_file),
+                "old_string": "print('phase one')\n",
+                "new_string": "print('phase two')\n",
+            },
+        )
+        assert set(first_kwargs["enabled_tools"]) == {"write_file", "patch"}
+        assert set(second_kwargs["enabled_tools"]) == {"write_file", "patch"}
+        assert target_file.read_text(encoding="utf-8") == "print('phase two')\n"
+        assert len(tool_messages) == 2
+        assert write_payload["bytes_written"] > 0
+        assert patch_payload["success"] is True
+        assert str(target_file) in patch_payload["files_modified"]
+        assert result["budget_handoff"] is True
+        assert result["completed"] is False
+        assert result["api_calls"] == 1
+        assert len(checkpoints) >= 2
+        assert checkpoints[0]["reason"] == "low-budget handoff"
+        assert checkpoints[0]["files_changed"] >= 1
+        assert markdown_path.exists()
+        assert json_path.exists()
+        assert metadata["checkpoints"][0]["directory"] == str(work_dir.resolve())
+        assert metadata["checkpoints"][0]["checkpoint"] == checkpoints[0]["short_hash"]
+        assert "## Resume Prompt" in markdown_path.read_text(encoding="utf-8")
+        assert checkpoint_base.exists()
 
 
 class TestSafeWriter:


### PR DESCRIPTION
## Summary
- port the low-budget handoff runtime/config path from the backup Hermes fork into the primary maintained Hermes repo
- add the expanded low-budget handoff integration coverage in `tests/run_agent/test_run_agent.py`
- fix the macOS test-path issue by moving the real mutating low-budget tests onto safe `/tmp`-backed workspaces instead of pytest temp dirs under `/private/var`

## Test Plan
- `python -m py_compile run_agent.py hermes_cli/config.py cli.py tests/run_agent/test_run_agent.py`
- `pytest -o addopts='' -q tests/run_agent/test_run_agent.py -k 'LowBudgetHandoff'`
  - result: `10 passed, 261 deselected in 8.25s`

## Notes
- upstream push was not permitted from this machine, so the branch is pushed from the fork
- branch includes:
  - `8d8ef11f feat: port low-budget handoff flow`
  - `45f33470 test: use safe temp roots for low-budget handoff tests`
