### PR TITLE
fix(gateway): add 'bg' to active-session guard bypass list

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1579,7 +1579,7 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "restart", "queue", "q"):
+            if cmd in ("approve", "deny", "status", "stop", "new", "reset", "background", "bg", "restart", "queue", "q"):
                 logger.debug(
                     "[%s] Command '/%s' bypassing active-session guard for %s",
                     self.name, cmd, session_key,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "johnsonblake1@gmail.com": "blakejohnson",
     "greer.guthrie@gmail.com": "g-guthrie",
     "kennyx102@gmail.com": "bobashopcashier",
+    "mibayy@users.noreply.github.com": "Mibayy",
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",


### PR DESCRIPTION
## Summary

The `/bg` command alias was not included in the active-session bypass list, causing it to be queued as a normal pending user message instead of dispatching immediately during an active session.

`/background` was in the bypass list but its documented alias `/bg` was not.

## Changes

- `gateway/platforms/base.py`: add `"bg"` alongside `"background"` in the active-session guard bypass tuple

## Testing

Manually verified that `/bg <task>` now dispatches immediately during an active session, matching `/background` behavior.

Closes #11770