### PR TITLE
fix(feishu): use utf16_len for message truncation

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1369,7 +1369,8 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        from gateway.platforms.base import utf16_len
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)
         last_response = None
 
         try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "johnsonblake1@gmail.com": "blakejohnson",
     "greer.guthrie@gmail.com": "g-guthrie",
     "kennyx102@gmail.com": "bobashopcashier",
+    "mibayy@users.noreply.github.com": "Mibayy",
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",


### PR DESCRIPTION
## Summary

Feishu's API enforces an 8000 UTF-16 code unit limit on messages, but `FeishuAdapter` was passing Python's `len()` (byte/character count) to `truncate_message`, which undercounts CJK and emoji characters and causes premature truncation.

## Changes

- `gateway/platforms/feishu.py`: import `utf16_len` from `gateway.platforms.base` and pass `len_fn=utf16_len` to `truncate_message`, matching the existing pattern in `telegram.py`

## Testing

Messages with Chinese characters and emoji now split at the correct UTF-16 boundary.

Closes #11589