### PR TITLE
fix(profiles): pass symlinks=True to copytree to prevent RecursionError

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -433,8 +433,12 @@ def create_profile(
             )
 
     if clone_all and source_dir:
-        # Full copy of source profile
-        shutil.copytree(source_dir, profile_dir)
+        # Full copy of source profile.  symlinks=True prevents RecursionError
+        # when the source tree contains recursive or self-referential symlinks
+        # (e.g. a skills directory that links back to its parent).  With the
+        # default symlinks=False, copytree follows every symlink and can enter
+        # an infinite loop on circular ones (issue #11560).
+        shutil.copytree(source_dir, profile_dir, symlinks=True)
         # Strip runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "johnsonblake1@gmail.com": "blakejohnson",
     "greer.guthrie@gmail.com": "g-guthrie",
     "kennyx102@gmail.com": "bobashopcashier",
+    "mibayy@users.noreply.github.com": "Mibayy",
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",


### PR DESCRIPTION
## Summary

`hermes profile create <name> --clone-all` raises `RecursionError` when the profile directory contains a symlink pointing to a parent directory. `shutil.copytree` follows symlinks by default, causing infinite recursion.

## Changes

- `hermes_cli/profiles.py`: add `symlinks=True` to the `shutil.copytree` call so symlinks are copied as symlinks rather than followed

## Testing

Profile creation with a directory containing a circular symlink no longer crashes.

Closes #11560