### PR TITLE
fix(provider): inject required temperature for kimi-for-coding model

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -215,6 +215,12 @@ class IterationBudget:
 # When any of these appear in a batch, we fall back to sequential execution.
 _NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
 
+# Models that require a specific temperature value to avoid HTTP 400 errors.
+# Applied via setdefault so user-supplied temperature (via request_overrides) still wins.
+_MODEL_REQUIRED_TEMPERATURES: Dict[str, float] = {
+    "kimi-for-coding": 0.6,
+}
+
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
     "ha_get_state",
@@ -6897,6 +6903,11 @@ class AIAgent:
 
         if extra_body:
             api_kwargs["extra_body"] = extra_body
+
+        # Per-model required temperature overrides (e.g. kimi-for-coding requires
+        # temperature=0.6; omitting it causes HTTP 400).
+        if self.model in _MODEL_REQUIRED_TEMPERATURES:
+            api_kwargs.setdefault("temperature", _MODEL_REQUIRED_TEMPERATURES[self.model])
 
         # Priority Processing / generic request overrides (e.g. service_tier).
         # Applied last so overrides win over any defaults set above.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -118,6 +118,7 @@ AUTHOR_MAP = {
     "johnsonblake1@gmail.com": "blakejohnson",
     "greer.guthrie@gmail.com": "g-guthrie",
     "kennyx102@gmail.com": "bobashopcashier",
+    "mibayy@users.noreply.github.com": "Mibayy",
     "shokatalishaikh95@gmail.com": "areu01or00",
     "bryan@intertwinesys.com": "bryanyoung",
     "christo.mitov@gmail.com": "christomitov",


### PR DESCRIPTION
## Summary

The `kimi-for-coding` model rejects API requests with HTTP 400 unless `temperature=0.6` is set. Hermes did not set any temperature for this model by default, causing all requests to fail.

## Changes

- `run_agent.py`: add `_MODEL_REQUIRED_TEMPERATURES` dict mapping model names to their required temperatures
- `run_agent.py`: in `_build_api_kwargs`, inject the required temperature via `setdefault` before `request_overrides` so it can still be overridden by the user

## Testing

Requests to `kimi-for-coding` no longer return HTTP 400. The `request_overrides` mechanism still allows users to override the temperature if needed.

Closes #11764