### PR TITLE
fix(gateway): honor legacy terminal env_type config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -115,6 +115,12 @@ if _config_path.exists():
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
         if _terminal_cfg and isinstance(_terminal_cfg, dict):
+            # Backward-compat: older configs used terminal.env_type.
+            # Keep honoring it when terminal.backend is absent so gateway
+            # sessions match the CLI's backend resolution semantics.
+            if "backend" not in _terminal_cfg and "env_type" in _terminal_cfg:
+                _terminal_cfg = dict(_terminal_cfg)
+                _terminal_cfg["backend"] = _terminal_cfg["env_type"]
             _terminal_env_map = {
                 "backend": "TERMINAL_ENV",
                 "cwd": "TERMINAL_CWD",

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -9,8 +9,10 @@ the semantics by reimplementing the relevant config bridge snippet and
 asserting the expected env var outcomes.
 """
 
-import os
 import json
+import importlib
+import os
+import sys
 import pytest
 
 
@@ -205,3 +207,35 @@ class TestNestedTerminalCwdPlaceholderSkip:
         assert result["TERMINAL_ENV"] == "docker"
         assert result["TERMINAL_TIMEOUT"] == "300"
         assert result["TERMINAL_CWD"] == "/from/env"
+
+
+class TestGatewayRunLegacyEnvTypeBridge:
+    """gateway.run should honor legacy terminal.env_type configs."""
+
+    def _reload_gateway_run(self, monkeypatch, hermes_home):
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        sys.modules.pop("gateway.run", None)
+        import gateway.run as gateway_run
+        return importlib.reload(gateway_run)
+
+    def test_terminal_env_type_bridges_to_terminal_env(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "terminal:\n  env_type: docker\n",
+            encoding="utf-8",
+        )
+
+        self._reload_gateway_run(monkeypatch, tmp_path)
+
+        assert os.environ["TERMINAL_ENV"] == "docker"
+
+    def test_backend_still_wins_over_legacy_env_type(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "terminal:\n  backend: modal\n  env_type: docker\n",
+            encoding="utf-8",
+        )
+
+        self._reload_gateway_run(monkeypatch, tmp_path)
+
+        assert os.environ["TERMINAL_ENV"] == "modal"


### PR DESCRIPTION
## Summary

Fix the gateway config bridge so it still honors legacy `terminal.env_type`
when `terminal.backend` is not present.

This keeps gateway startup behavior aligned with the CLI's existing backward-
compat handling and prevents older configs from silently falling back to the
local terminal backend.

## Changes

- treat `terminal.env_type` as a fallback source for `TERMINAL_ENV`
- keep `terminal.backend` as the explicit winner when both keys are present
- add regression coverage for:
  - legacy `env_type` bridging
  - `backend` precedence over `env_type`

## Why this matters

Older configs can still contain:


## terminal:
  env_type: docker
  
## Testing
Passed:
tests/gateway/test_config_cwd_bridge.py
tests/gateway/test_verbose_command.py

Also checked:
tests/hermes_cli/test_gateway.py
