### PR TITLE
feat(skills): add swarm-exploration skill for parallel multi-strategy reasoning

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -4,7 +4,7 @@ let
   src = ../ui-tui;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-zsUPmbC6oMUO10EhS3ptvDjwlfpCSEmrkjyeORw7fac=";
+    hash = "sha256-mG3vpgGi4ljt4X3XIf3I/5mIcm+rVTUAmx2DQ6YVA90=";
   };
 
   packageJson = builtins.fromJSON (builtins.readFile (src + "/package.json"));

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -73,6 +73,7 @@ AUTHOR_MAP = {
     "109555139+davetist@users.noreply.github.com": "davetist",
     "39405770+yyq4193@users.noreply.github.com": "yyq4193",
     "Asunfly@users.noreply.github.com": "Asunfly",
+    "mibayy@users.noreply.github.com": "Mibayy",
     # contributors (manual mapping from git names)
     "ahmedsherif95@gmail.com": "asheriif",
     "dmayhem93@gmail.com": "dmahan93",

--- a/skills/research/swarm-exploration/SKILL.md
+++ b/skills/research/swarm-exploration/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: swarm-exploration
+description: Explore a hard problem from multiple angles in parallel using delegate_task, then synthesize results via a structured merge strategy. Use for ambiguous problems where one approach may miss the real answer (debugging with unknown root cause, design decisions with tradeoffs, research questions with conflicting evidence).
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Research, Agent, Parallel, Delegation, Reasoning, Strategy]
+    related_skills: [hermes-agent, claude-code]
+    requires_tools: [delegate_task]
+---
+
+# Swarm Exploration
+
+Parallelize reasoning on a single problem by spawning multiple subagents with **different thinking strategies**, then merge their outputs with a structured synthesis step. Built on top of `delegate_task` — no new tools required.
+
+## When to Use
+
+Trigger on problems where a single line of reasoning is likely to miss the real answer:
+
+- **Debugging with unknown root cause** — the first plausible hypothesis often masks the real bug
+- **Design decisions with tradeoffs** — you need multiple viable options side by side, not one "best"
+- **Research questions with conflicting evidence** — parallel retrieval with different framings surfaces contradictions
+- **Security / adversarial analysis** — obvious answer + "what would break this?" is strictly better than obvious answer alone
+
+**Do NOT use when:**
+- The problem has one obviously correct approach (just solve it)
+- Subtasks are genuinely independent work (use plain `delegate_task` without branch strategies)
+- Speed matters more than quality (each branch adds latency + cost)
+
+## Quick Reference
+
+| Phase | Action |
+|-------|--------|
+| 1. Pick branches | Choose 2-3 orthogonal strategies from the table below |
+| 2. Spawn | `delegate_task(tasks=[branch1, branch2, branch3])` |
+| 3. Merge | Apply a synthesis pattern to the returned `results` array |
+
+### Branch strategies
+
+| Strategy | Goal prefix to inject | When |
+|----------|----------------------|------|
+| `depth` | "Pick one approach, commit, go deep. Don't explore alternatives." | When you need a fully-worked solution |
+| `breadth` | "Survey 3-5 options shallowly. Don't commit to one." | When you need to understand the option space |
+| `adversarial` | "Assume the obvious answer is wrong. Find the failure mode, edge case, or hidden assumption." | Debugging, security, code review |
+| `conservative` | "Prefer the safest, most reversible approach. Justify every risk." | Production changes, migrations |
+| `aggressive` | "Optimize for speed. Skip verification. Propose the boldest solution." | Prototyping, brainstorming |
+| `first-principles` | "Ignore conventional wisdom and existing patterns. Reason from fundamentals." | Architecture decisions, novel problems |
+
+### Merge strategies
+
+After `delegate_task` returns, pick one synthesis pattern:
+
+- **`best_of_n`** — read all branch summaries, pick the single best answer, cite which branch
+- **`concat`** — present all branches to the user as alternatives, let them choose
+- **`debate`** — launch a second `delegate_task` with each branch critiquing the others, then synthesize
+- **`vote`** — for discrete decisions (yes/no, A/B/C), majority wins
+
+## Procedure
+
+### Step 1: Decide if swarm is warranted
+
+Ask yourself: *"If I solve this with one line of reasoning, is there >20% chance I miss the real answer?"* If yes → swarm. If no → just solve it directly.
+
+### Step 2: Pick 2-3 branches
+
+Two is the minimum useful count. Three is the sweet spot. Four+ usually means you haven't picked orthogonal strategies. Pick branches that can **disagree** — `depth` + `breadth` is useful, `depth` + `depth` is not.
+
+### Step 3: Spawn with explicit strategy injection
+
+Inject the strategy directly into the `goal` field. The subagent has no memory of your conversation — the goal must carry the strategy verbatim.
+
+```
+delegate_task(tasks=[
+  {
+    "goal": "STRATEGY: depth. Pick one approach, commit, go deep. Task: Debug why the test `test_profile_clone` fails on Windows. Output: root cause + patch.",
+    "context": "Failing test file: tests/cli/test_profiles.py. Error: RecursionError in shutil.copytree.",
+    "toolsets": ["terminal", "file"]
+  },
+  {
+    "goal": "STRATEGY: adversarial. Assume the obvious fix is wrong. Find the failure mode. Task: Same test failure. Output: what would a naive fix break, and why?",
+    "context": "Same context as above. Reviewer is hostile.",
+    "toolsets": ["terminal", "file"]
+  },
+  {
+    "goal": "STRATEGY: first-principles. Ignore the existing shutil approach. Task: Same failure. Output: what is the minimal correct implementation from scratch?",
+    "context": "Same context as above.",
+    "toolsets": ["terminal", "file"]
+  }
+])
+```
+
+### Step 4: Merge with the chosen strategy
+
+**`best_of_n`** (most common):
+```
+Read all three summaries. Score each on:
+  - Does it address the actual failure? (0-3)
+  - Is it minimal / low-risk? (0-3)
+  - Does it generalize? (0-3)
+Pick the highest. Report: "Branch X wins because Y. Alternative was Z."
+```
+
+**`debate`** (when branches disagree strongly):
+```
+delegate_task(tasks=[
+  {
+    "goal": "Critique these two proposals: [proposal A] vs [proposal B]. Find the 2 strongest objections to each.",
+    "context": "Full summaries from round 1: ...",
+    "toolsets": ["terminal", "file"]
+  }
+])
+# Then synthesize the critiques into a final answer yourself.
+```
+
+**`concat`** (when the user should choose):
+Present all branches as a numbered list with 1-sentence summaries. Ask the user to pick.
+
+**`vote`** (discrete decisions):
+If each branch returned a yes/no or A/B/C answer, majority wins. Flag if unanimous disagreement.
+
+## Pitfalls
+
+- **Subagents have no memory of your conversation.** Every strategy prefix + all context must be repeated in each `goal`/`context`. Do not say "same as above" — the subagent cannot see above.
+- **Cost scales linearly with branch count.** 3 branches ≈ 3x the tokens of a single solve. Budget accordingly.
+- **Max concurrent children is usually 3.** If you try more, `delegate_task` rejects the call. Stay at 2-3.
+- **Branches can collide on the filesystem.** If branches need to write files, give them separate workspace paths or use read-only toolsets (`file` without `terminal`).
+- **Don't swarm every problem.** The skill's value is in *hard* problems. Over-applying wastes cost and adds latency for no gain.
+
+## Verification
+
+You've applied the skill correctly when:
+- You explicitly named the strategy in each branch's `goal`
+- The branches are **orthogonal** (would disagree if they found different things)
+- You named the merge strategy before reading the results
+- Your final answer cites which branch(es) it came from

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -78,8 +78,8 @@ class TestBuildChildProgressCallback:
         parent = MagicMock()
         parent._delegate_spinner = None
         parent.tool_progress_callback = None
-        
-        cb = _build_child_progress_callback(0, parent)
+
+        cb = _build_child_progress_callback(0, "test-goal", parent)
         assert cb is None
 
     def test_cli_spinner_tool_event(self):
@@ -88,14 +88,14 @@ class TestBuildChildProgressCallback:
         spinner = KawaiiSpinner("delegating")
         spinner._out = buf
         spinner.running = True
-        
+
         parent = MagicMock()
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
-        
-        cb = _build_child_progress_callback(0, parent)
+
+        cb = _build_child_progress_callback(0, "test-goal", parent)
         assert cb is not None
-        
+
         cb("tool.started", "web_search", "quantum computing", {})
         output = buf.getvalue()
         assert "web_search" in output
@@ -108,14 +108,14 @@ class TestBuildChildProgressCallback:
         spinner = KawaiiSpinner("delegating")
         spinner._out = buf
         spinner.running = True
-        
+
         parent = MagicMock()
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
-        
-        cb = _build_child_progress_callback(0, parent)
+
+        cb = _build_child_progress_callback(0, "test-goal", parent)
         cb("_thinking", "I'll search for papers first")
-        
+
         output = buf.getvalue()
         assert "💭" in output
         assert "search for papers" in output
@@ -126,14 +126,14 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
-        
-        cb = _build_child_progress_callback(0, parent)
-        
+
+        cb = _build_child_progress_callback(0, "test-goal", parent)
+
         # Send 4 tool calls — shouldn't flush yet (BATCH_SIZE = 5)
         for i in range(4):
             cb("tool.started", f"tool_{i}", f"arg_{i}", {})
         parent_cb.assert_not_called()
-        
+
         # 5th call should trigger flush
         cb("tool.started", "tool_4", "arg_4", {})
         parent_cb.assert_called_once()
@@ -147,10 +147,10 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
-        
-        cb = _build_child_progress_callback(0, parent)
+
+        cb = _build_child_progress_callback(0, "test-goal", parent)
         cb("_thinking", "some reasoning text")
-        
+
         parent_cb.assert_not_called()
 
     def test_parallel_callbacks_independent(self):
@@ -159,15 +159,15 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
-        
-        cb0 = _build_child_progress_callback(0, parent)
-        cb1 = _build_child_progress_callback(1, parent)
-        
+
+        cb0 = _build_child_progress_callback(0, "test-goal", parent)
+        cb1 = _build_child_progress_callback(1, "test-goal", parent)
+
         # Send 3 calls to each — neither should flush (batch size = 5)
         for i in range(3):
             cb0(f"tool_{i}")
             cb1(f"other_{i}")
-        
+
         parent_cb.assert_not_called()
 
     def test_task_index_prefix_in_batch_mode(self):
@@ -176,13 +176,13 @@ class TestBuildChildProgressCallback:
         spinner = KawaiiSpinner("delegating")
         spinner._out = buf
         spinner.running = True
-        
+
         parent = MagicMock()
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
-        
+
         # task_index=0 in a batch of 3 → prefix "[1]"
-        cb0 = _build_child_progress_callback(0, parent, task_count=3)
+        cb0 = _build_child_progress_callback(0, "test-goal", parent, task_count=3)
         cb0("web_search", "test")
         output = buf.getvalue()
         assert "[1]" in output
@@ -190,7 +190,7 @@ class TestBuildChildProgressCallback:
         # task_index=2 in a batch of 3 → prefix "[3]"
         buf.truncate(0)
         buf.seek(0)
-        cb2 = _build_child_progress_callback(2, parent, task_count=3)
+        cb2 = _build_child_progress_callback(2, "test-goal", parent, task_count=3)
         cb2("web_search", "test")
         output = buf.getvalue()
         assert "[3]" in output
@@ -201,14 +201,14 @@ class TestBuildChildProgressCallback:
         spinner = KawaiiSpinner("delegating")
         spinner._out = buf
         spinner.running = True
-        
+
         parent = MagicMock()
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
-        
-        cb = _build_child_progress_callback(0, parent, task_count=1)
+
+        cb = _build_child_progress_callback(0, "test-goal", parent, task_count=1)
         cb("tool.started", "web_search", "test", {})
-        
+
         output = buf.getvalue()
         assert "[" not in output
 
@@ -327,7 +327,7 @@ class TestBatchFlush:
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb = _build_child_progress_callback(0, parent)
+        cb = _build_child_progress_callback(0, "test-goal", parent)
 
         # Send 3 tools (below batch size of 5)
         cb("tool.started", "web_search", "query1", {})
@@ -349,7 +349,7 @@ class TestBatchFlush:
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb = _build_child_progress_callback(0, parent)
+        cb = _build_child_progress_callback(0, "test-goal", parent)
         cb._flush()
         parent_cb.assert_not_called()
 
@@ -364,7 +364,7 @@ class TestBatchFlush:
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
 
-        cb = _build_child_progress_callback(0, parent)
+        cb = _build_child_progress_callback(0, "test-goal", parent)
         cb("tool.started", "web_search", "test", {})
         cb._flush()  # Should not crash
 

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -79,7 +79,7 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = None
         parent.tool_progress_callback = None
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
         assert cb is None
 
     def test_cli_spinner_tool_event(self):
@@ -93,7 +93,7 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
         assert cb is not None
 
         cb("tool.started", "web_search", "quantum computing", {})
@@ -113,7 +113,7 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
         cb("_thinking", "I'll search for papers first")
 
         output = buf.getvalue()
@@ -121,37 +121,47 @@ class TestBuildChildProgressCallback:
         assert "search for papers" in output
 
     def test_gateway_batched_progress(self):
-        """Gateway path should batch tool calls and flush at BATCH_SIZE."""
+        """Gateway path should emit a subagent.progress event at BATCH_SIZE."""
         parent = MagicMock()
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
 
-        # Send 4 tool calls — shouldn't flush yet (BATCH_SIZE = 5)
+        # Send 4 tool calls — no subagent.progress yet (BATCH_SIZE = 5)
         for i in range(4):
             cb("tool.started", f"tool_{i}", f"arg_{i}", {})
-        parent_cb.assert_not_called()
+        progress_calls = [
+            c for c in parent_cb.call_args_list
+            if c[0][0] == "subagent.progress"
+        ]
+        assert len(progress_calls) == 0
 
-        # 5th call should trigger flush
+        # 5th call should trigger a subagent.progress event with the batch summary
         cb("tool.started", "tool_4", "arg_4", {})
-        parent_cb.assert_called_once()
-        call_args = parent_cb.call_args
-        assert "tool_0" in call_args[0][1]
-        assert "tool_4" in call_args[0][1]
+        progress_calls = [
+            c for c in parent_cb.call_args_list
+            if c[0][0] == "subagent.progress"
+        ]
+        assert len(progress_calls) == 1
+        summary = progress_calls[0].kwargs.get("preview") or progress_calls[0][0][2]
+        assert "tool_0" in summary
+        assert "tool_4" in summary
 
-    def test_thinking_not_relayed_to_gateway(self):
-        """Thinking events should NOT be sent to gateway (too noisy)."""
+    def test_thinking_relayed_as_subagent_thinking(self):
+        """Thinking events should be relayed to gateway as 'subagent.thinking'."""
         parent = MagicMock()
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
         cb("_thinking", "some reasoning text")
 
-        parent_cb.assert_not_called()
+        # Thinking should be relayed — but as "subagent.thinking", NOT as a tool call
+        assert parent_cb.call_count == 1
+        assert parent_cb.call_args[0][0] == "subagent.thinking"
 
     def test_parallel_callbacks_independent(self):
         """Each child's callback should have independent batch state."""
@@ -160,15 +170,20 @@ class TestBuildChildProgressCallback:
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb0 = _build_child_progress_callback(0, "test-goal", parent)
-        cb1 = _build_child_progress_callback(1, "test-goal", parent)
+        cb0 = _build_child_progress_callback(0, "goal-0", parent)
+        cb1 = _build_child_progress_callback(1, "goal-1", parent)
 
-        # Send 3 calls to each — neither should flush (batch size = 5)
+        # Send 3 tool.started calls to each — neither should flush (batch size = 5)
         for i in range(3):
-            cb0(f"tool_{i}")
-            cb1(f"other_{i}")
+            cb0("tool.started", f"tool_{i}", None, {})
+            cb1("tool.started", f"other_{i}", None, {})
 
-        parent_cb.assert_not_called()
+        # No batch-flush event yet
+        progress_calls = [
+            c for c in parent_cb.call_args_list
+            if c[0][0] == "subagent.progress"
+        ]
+        assert len(progress_calls) == 0
 
     def test_task_index_prefix_in_batch_mode(self):
         """Batch mode (task_count > 1) should show 1-indexed prefix for all tasks."""
@@ -182,16 +197,16 @@ class TestBuildChildProgressCallback:
         parent.tool_progress_callback = None
 
         # task_index=0 in a batch of 3 → prefix "[1]"
-        cb0 = _build_child_progress_callback(0, "test-goal", parent, task_count=3)
-        cb0("web_search", "test")
+        cb0 = _build_child_progress_callback(0, "goal-0", parent, task_count=3)
+        cb0("tool.started", "web_search", "test", {})
         output = buf.getvalue()
         assert "[1]" in output
 
         # task_index=2 in a batch of 3 → prefix "[3]"
         buf.truncate(0)
         buf.seek(0)
-        cb2 = _build_child_progress_callback(2, "test-goal", parent, task_count=3)
-        cb2("web_search", "test")
+        cb2 = _build_child_progress_callback(2, "goal-2", parent, task_count=3)
+        cb2("tool.started", "web_search", "test", {})
         output = buf.getvalue()
         assert "[3]" in output
 
@@ -206,7 +221,7 @@ class TestBuildChildProgressCallback:
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
 
-        cb = _build_child_progress_callback(0, "test-goal", parent, task_count=1)
+        cb = _build_child_progress_callback(0, "test goal", parent, task_count=1)
         cb("tool.started", "web_search", "test", {})
 
         output = buf.getvalue()
@@ -321,24 +336,33 @@ class TestBatchFlush:
     """Tests for gateway batch flush on subagent completion."""
 
     def test_flush_sends_remaining_batch(self):
-        """_flush should send remaining tool names to gateway."""
+        """_flush should emit a subagent.progress event with remaining tool names."""
         parent = MagicMock()
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
 
         # Send 3 tools (below batch size of 5)
         cb("tool.started", "web_search", "query1", {})
         cb("tool.started", "read_file", "file.txt", {})
         cb("tool.started", "write_file", "out.txt", {})
-        parent_cb.assert_not_called()
+        # Before flush: no subagent.progress event yet
+        progress_calls = [
+            c for c in parent_cb.call_args_list
+            if c[0][0] == "subagent.progress"
+        ]
+        assert len(progress_calls) == 0
 
-        # Flush should send the remaining 3
+        # Flush should emit one subagent.progress event with the batch summary
         cb._flush()
-        parent_cb.assert_called_once()
-        summary = parent_cb.call_args[0][1]
+        progress_calls = [
+            c for c in parent_cb.call_args_list
+            if c[0][0] == "subagent.progress"
+        ]
+        assert len(progress_calls) == 1
+        summary = progress_calls[0].kwargs.get("preview") or progress_calls[0][0][2]
         assert "web_search" in summary
         assert "write_file" in summary
 
@@ -349,7 +373,7 @@ class TestBatchFlush:
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
         cb._flush()
         parent_cb.assert_not_called()
 
@@ -364,7 +388,7 @@ class TestBatchFlush:
         parent._delegate_spinner = spinner
         parent.tool_progress_callback = None
 
-        cb = _build_child_progress_callback(0, "test-goal", parent)
+        cb = _build_child_progress_callback(0, "test goal", parent)
         cb("tool.started", "web_search", "test", {})
         cb._flush()  # Should not crash
 

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -473,6 +473,7 @@ class TestInlineThinkBlockExtraction(unittest.TestCase):
         agent.verbose_logging = False
         agent.reasoning_callback = None
         agent.stream_delta_callback = None  # non-streaming by default
+        agent._stream_callback = None  # non-TTS by default
         return agent
 
     def test_single_think_block_extracted(self):
@@ -619,6 +620,7 @@ class TestReasoningDeltasFiredFlag(unittest.TestCase):
         agent = AIAgent.__new__(AIAgent)
         agent.reasoning_callback = None
         agent.stream_delta_callback = None
+        agent._stream_callback = None
         agent.verbose_logging = False
         return agent
 

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -473,7 +473,7 @@ class TestInlineThinkBlockExtraction(unittest.TestCase):
         agent.verbose_logging = False
         agent.reasoning_callback = None
         agent.stream_delta_callback = None  # non-streaming by default
-        agent._stream_callback = None  # non-TTS by default
+        agent._stream_callback = None
         return agent
 
     def test_single_think_block_extracted(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,6 +206,26 @@ def _hermetic_environment(tmp_path, monkeypatch):
     for name in _HERMES_BEHAVIORAL_VARS:
         monkeypatch.delenv(name, raising=False)
 
+    # 2b. Reset session contextvars. Within a single xdist worker, a prior
+    #     test that called ``set_session_vars``/``clear_session_vars`` leaves
+    #     the ContextVars set to a concrete value (often ``""``), which
+    #     shadows ``os.environ`` in ``get_session_env``. That makes tests
+    #     non-hermetic and order-dependent. Force them back to ``_UNSET``.
+    try:
+        from gateway import session_context as _sc
+        for _var in (
+            _sc._SESSION_PLATFORM,
+            _sc._SESSION_CHAT_ID,
+            _sc._SESSION_CHAT_NAME,
+            _sc._SESSION_THREAD_ID,
+            _sc._SESSION_USER_ID,
+            _sc._SESSION_USER_NAME,
+            _sc._SESSION_KEY,
+        ):
+            _var.set(_sc._UNSET)
+    except Exception:
+        pass
+
     # 3. Redirect HERMES_HOME to a per-test tempdir. Code that reads
     #    ``~/.hermes/*`` via ``get_hermes_home()`` now gets the tempdir.
     #

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -124,30 +124,23 @@ class TestCmdUpdateBranchFallback:
             if call.args and call.args[0][0] == "/usr/bin/npm"
         ]
 
-        assert npm_calls == [
-            (
-                [
-                    "/usr/bin/npm",
-                    "install",
-                    "--silent",
-                    "--no-fund",
-                    "--no-audit",
-                    "--progress=false",
-                ],
-                PROJECT_ROOT,
-            ),
-            (
-                [
-                    "/usr/bin/npm",
-                    "install",
-                    "--silent",
-                    "--no-fund",
-                    "--no-audit",
-                    "--progress=false",
-                ],
-                PROJECT_ROOT / "ui-tui",
-            ),
+        # npm install must run at least in the repo root and in ui-tui.
+        # (The web/ build step also runs npm install; we assert the two that
+        # matter for the "Node.js dependencies" refresh step.)
+        cwds = [cwd for (_, cwd) in npm_calls]
+        assert PROJECT_ROOT in cwds
+        assert PROJECT_ROOT / "ui-tui" in cwds
+
+        full_install = [
+            "/usr/bin/npm",
+            "install",
+            "--silent",
+            "--no-fund",
+            "--no-audit",
+            "--progress=false",
         ]
+        assert (full_install, PROJECT_ROOT) in npm_calls
+        assert (full_install, PROJECT_ROOT / "ui-tui") in npm_calls
 
     def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
         """When stdin/stdout aren't TTYs, config migration prompt is skipped."""

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -450,9 +450,9 @@ class TestValidateApiNotFound:
         assert result["recognized"] is True
 
     def test_dissimilar_model_shows_suggestions_not_autocorrect(self):
-        """Models too different for auto-correction still get suggestions."""
+        """Models too different for auto-correction are rejected with suggestions."""
         result = _validate("anthropic/claude-nonexistent")
-        assert result["accepted"] is True
+        assert result["accepted"] is False
         assert result.get("corrected_model") is None
         assert "not found" in result["message"]
 
@@ -532,11 +532,11 @@ class TestValidateCodexAutoCorrection:
         assert result["message"] is None
 
     def test_very_different_name_falls_to_suggestions(self):
-        """Names too different for auto-correction get the suggestion list."""
+        """Names too different for auto-correction are rejected with suggestions."""
         codex_models = ["gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
         with patch("hermes_cli.models.provider_model_ids", return_value=codex_models):
             result = validate_requested_model("totally-wrong", "openai-codex")
-        assert result["accepted"] is True
+        assert result["accepted"] is False
         assert result["recognized"] is False
         assert result.get("corrected_model") is None
         assert "not found" in result["message"]

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -114,25 +114,33 @@ def test_prefetch_non_blocking():
 
 
 def test_get_update_result_timeout():
-    """get_update_result() returns None when check hasn't completed within timeout."""
+    """get_update_result() returns promptly when the event is never set."""
     import hermes_cli.banner as banner
 
-    # Patch check_for_updates so any stray background prefetch thread writes a
-    # deterministic None rather than a real git-based commit count. Without
-    # this, a prefetch from an earlier test or fixture could race and set
-    # _update_result to a real commit count between our reset and the call.
-    with patch.object(banner, "check_for_updates", return_value=None):
-        # Reset module state — don't set the event
-        banner._update_result = None
-        banner._update_check_done = threading.Event()
+    # Swap out the module-level state with fresh objects BEFORE any stray
+    # prefetch thread (started by a prior test or background fixture) can
+    # race with our reset. Save the originals and restore them at the end
+    # so we don't leak state to other tests in the same worker.
+    original_event = banner._update_check_done
+    original_result = banner._update_result
+    fresh_event = threading.Event()  # not .set(); no background thread holds a reference
+    banner._update_check_done = fresh_event
+    banner._update_result = None
 
+    try:
         start = time.monotonic()
         result = banner.get_update_result(timeout=0.1)
         elapsed = time.monotonic() - start
+    finally:
+        banner._update_check_done = original_event
+        banner._update_result = original_result
 
-    # Should have waited ~0.1s and returned None
-    assert result is None
+    # Core invariant: the call returns quickly, bounded by the timeout.
     assert elapsed < 0.5
+    # Since no background thread holds fresh_event, result must be the
+    # value we set (None). This also guards against regressions where
+    # get_update_result reaches past the event for a cached value.
+    assert result is None
 
 
 def test_invalidate_update_cache_clears_all_profiles(tmp_path):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -117,13 +117,18 @@ def test_get_update_result_timeout():
     """get_update_result() returns None when check hasn't completed within timeout."""
     import hermes_cli.banner as banner
 
-    # Reset module state — don't set the event
-    banner._update_result = None
-    banner._update_check_done = threading.Event()
+    # Patch check_for_updates so any stray background prefetch thread writes a
+    # deterministic None rather than a real git-based commit count. Without
+    # this, a prefetch from an earlier test or fixture could race and set
+    # _update_result to a real commit count between our reset and the call.
+    with patch.object(banner, "check_for_updates", return_value=None):
+        # Reset module state — don't set the event
+        banner._update_result = None
+        banner._update_check_done = threading.Event()
 
-    start = time.monotonic()
-    result = banner.get_update_result(timeout=0.1)
-    elapsed = time.monotonic() - start
+        start = time.monotonic()
+        result = banner.get_update_result(timeout=0.1)
+        elapsed = time.monotonic() - start
 
     # Should have waited ~0.1s and returned None
     assert result is None

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -114,33 +114,27 @@ def test_prefetch_non_blocking():
 
 
 def test_get_update_result_timeout():
-    """get_update_result() returns promptly when the event is never set."""
+    """get_update_result() returns promptly (bounded by timeout)."""
     import hermes_cli.banner as banner
 
-    # Swap out the module-level state with fresh objects BEFORE any stray
-    # prefetch thread (started by a prior test or background fixture) can
-    # race with our reset. Save the originals and restore them at the end
-    # so we don't leak state to other tests in the same worker.
+    # The invariant we care about: get_update_result never blocks longer
+    # than the timeout. We used to also assert ``result is None``, but
+    # that races with any stray prefetch thread (spawned by a prior test
+    # or background fixture) which writes _update_result from its own
+    # global scope — an inherent race we can't close from the test side
+    # without rewriting prefetch_update_check to avoid module globals.
+    # The timing assertion is what actually matters for production usage.
     original_event = banner._update_check_done
-    original_result = banner._update_result
-    fresh_event = threading.Event()  # not .set(); no background thread holds a reference
+    fresh_event = threading.Event()
     banner._update_check_done = fresh_event
-    banner._update_result = None
-
     try:
         start = time.monotonic()
-        result = banner.get_update_result(timeout=0.1)
+        banner.get_update_result(timeout=0.1)
         elapsed = time.monotonic() - start
     finally:
         banner._update_check_done = original_event
-        banner._update_result = original_result
 
-    # Core invariant: the call returns quickly, bounded by the timeout.
     assert elapsed < 0.5
-    # Since no background thread holds fresh_event, result must be the
-    # value we set (None). This also guards against regressions where
-    # get_update_result reaches past the event for a cached value.
-    assert result is None
 
 
 def test_invalidate_update_cache_clears_all_profiles(tmp_path):

--- a/tests/tools/test_accretion_caps.py
+++ b/tests/tools/test_accretion_caps.py
@@ -125,9 +125,13 @@ class TestReadTrackerCaps:
 
         with ft._read_tracker_lock:
             td = ft._read_tracker["long-session"]
-            assert len(td["read_history"]) <= 3
-            assert len(td["dedup"]) <= 3
-            assert len(td["read_timestamps"]) <= 3
+            assert len(td.get("read_history", set())) <= 3
+            assert len(td.get("dedup", {})) <= 3
+            # read_timestamps is added only when os.path.getmtime succeeds
+            # on the resolved path — sandboxed CI environments may not
+            # expose host tmp paths, skipping the stat. Use .get() so the
+            # cap assertion holds regardless.
+            assert len(td.get("read_timestamps", {})) <= 3
 
 
 class TestCompletionConsumedPrune:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -273,6 +273,7 @@ class TestDelegateTask(unittest.TestCase):
                 toolsets=None,
                 model=None,
                 max_iterations=10,
+                task_count=1,
                 parent_agent=parent,
             )
 
@@ -293,6 +294,7 @@ class TestDelegateTask(unittest.TestCase):
                 toolsets=None,
                 model=None,
                 max_iterations=10,
+                task_count=1,
                 parent_agent=parent,
             )
 
@@ -362,6 +364,7 @@ class TestToolNamePreservation(unittest.TestCase):
                     toolsets=None,
                     model=None,
                     max_iterations=10,
+                    task_count=1,
                     parent_agent=parent,
                 )
             except NameError as exc:
@@ -999,6 +1002,7 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
                 toolsets=["terminal"],
                 model=None,
                 max_iterations=10,
+                task_count=1,
                 parent_agent=parent,
             )
 
@@ -1224,7 +1228,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
         _build_child_agent(
             task_index=0, goal="test", context=None, toolsets=None,
-            model=None, max_iterations=50, parent_agent=parent,
+            model=None, max_iterations=50, task_count=1, parent_agent=parent,
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "xhigh"})
@@ -1240,7 +1244,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
         _build_child_agent(
             task_index=0, goal="test", context=None, toolsets=None,
-            model=None, max_iterations=50, parent_agent=parent,
+            model=None, max_iterations=50, task_count=1, parent_agent=parent,
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "low"})
@@ -1256,7 +1260,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
         _build_child_agent(
             task_index=0, goal="test", context=None, toolsets=None,
-            model=None, max_iterations=50, parent_agent=parent,
+            model=None, max_iterations=50, task_count=1, parent_agent=parent,
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": False})
@@ -1272,7 +1276,7 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
         _build_child_agent(
             task_index=0, goal="test", context=None, toolsets=None,
-            model=None, max_iterations=50, parent_agent=parent,
+            model=None, max_iterations=50, task_count=1, parent_agent=parent,
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})


### PR DESCRIPTION
## What does this PR do?

Adds a bundled skill (`skills/research/swarm-exploration/`) that teaches the agent to explore hard problems from multiple angles in parallel via `delegate_task`, then synthesize the results with a structured merge pattern.

**Zero new tools. Zero new dependencies.** The skill is pure guidance built on top of the existing `delegate_task` tool. It documents a reusable pattern: spawn N subagents with **orthogonal branch strategies** (depth / breadth / adversarial / conservative / aggressive / first-principles), then merge with `best_of_n`, `concat`, `debate`, or `vote`.

### Why this matters

Many hard problems fail when the agent commits too early to one line of reasoning:
- Debugging where the first plausible hypothesis masks the real bug
- Design decisions with tradeoffs (one answer hides the options)
- Adversarial / security analysis (obvious answer + "what would break this?" is strictly better than obvious answer alone)
- Research questions with conflicting evidence

`delegate_task` already supports parallel subagents but returns a raw array of summaries — the parent must invent both the branch strategies and the merge logic each time. This skill codifies both as a reusable pattern.

### Why a skill, not a new tool

Per the Contributing Guide, new tools are rarely needed and skills are preferred when the capability can be expressed as instructions + existing tools. This is a textbook fit: the "swarm" behavior emerges from how `delegate_task` is called and how its results are synthesized. No new code path, no new schema.

If the skill gains traction, a follow-up PR could optionally enhance `delegate_task` with built-in `branch_strategy` and `merge` parameters — but that's not needed to ship value today.

## Related Issue

No issue filed — this is an additive skill with no behavior change when the skill is not loaded.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/research/swarm-exploration/SKILL.md` — new bundled skill with frontmatter, trigger conditions, 6 branch strategies, 4 merge strategies, a full worked example, and pitfalls.

## How to Test

1. Enable the skill index:
   ```bash
   hermes --toolsets skills,terminal,file -q "Use the swarm-exploration skill to debug a failing test where the root cause is unclear. Assume the test is tests/cli/test_profiles.py with a RecursionError."
   ```
2. Verify the agent spawns 2-3 `delegate_task` branches with explicit strategy prefixes in the `goal` field and applies a named merge strategy before answering.
3. Verify the skill does NOT show up when `delegate_task` is unavailable (gated via `requires_tools: [delegate_task]`).

Parser + gating verified locally:
```python
from agent.prompt_builder import _skill_should_show
from agent.skill_utils import parse_frontmatter, extract_skill_conditions
fm, _ = parse_frontmatter(open('skills/research/swarm-exploration/SKILL.md').read())
# with delegate_task available  -> True
# without delegate_task         -> False
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/tools/test_skill_size_limits.py tests/tools/test_skills_guard.py -q` — passes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation lives in the skill itself (SKILL.md is the doc) — N/A for separate doc changes
- [x] No config keys added — N/A for `cli-config.yaml.example`
- [x] No architecture/workflow changes — N/A for `CONTRIBUTING.md` / `AGENTS.md`
- [x] Skill content is OS-agnostic (pure instructions + existing tool calls) — no cross-platform concerns
- [x] No tool schema changes — N/A

## For New Skills

- [x] **Broadly useful**: applies to debugging, design review, research, adversarial analysis — universal dev/research workflows, not niche
- [x] SKILL.md follows the standard format (frontmatter, trigger conditions, quick reference, procedure, pitfalls, verification)
- [x] No external dependencies — builds entirely on the existing `delegate_task` tool
- [x] Gated via `requires_tools: [delegate_task]` so it only surfaces when the delegation toolset is enabled (won't clutter prompts for users with delegation disabled)