### PR TITLE
fix(cli): prefer provider model ordering when resolving /model aliases

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -341,8 +341,24 @@ def resolve_alias(
 
     vendor, family = identity
 
-    # Search the provider's catalog from models.dev
-    catalog = list_provider_models(current_provider)
+    # Prefer the provider's curated/live model ordering over raw models.dev key
+    # order. Raw dict insertion order can surface stale versions first, causing
+    # aliases like "sonnet" to resolve to an older family member.
+    try:
+        from hermes_cli.models import provider_model_ids
+        preferred_catalog = provider_model_ids(current_provider)
+    except Exception:
+        preferred_catalog = []
+
+    fallback_catalog = list_provider_models(current_provider)
+    catalog: list[str] = []
+    seen: set[str] = set()
+    for model_id in [*preferred_catalog, *fallback_catalog]:
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        catalog.append(model_id)
+
     if not catalog:
         return None
 

--- a/tests/hermes_cli/test_model_alias_resolution.py
+++ b/tests/hermes_cli/test_model_alias_resolution.py
@@ -1,0 +1,56 @@
+"""Regression tests for short model alias resolution ordering."""
+
+from hermes_cli.model_switch import resolve_alias
+
+
+def test_resolve_alias_prefers_curated_provider_order(monkeypatch):
+    """Curated provider order should win over raw models.dev insertion order."""
+    import hermes_cli.model_switch as ms
+
+    monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+    monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda provider: [
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5-20250929",
+        ],
+    )
+    monkeypatch.setattr(
+        ms,
+        "list_provider_models",
+        lambda provider: [
+            "claude-sonnet-4-0",
+            "claude-sonnet-4-6",
+            "claude-sonnet-4-5-20250929",
+        ],
+    )
+
+    assert resolve_alias("sonnet", "anthropic") == (
+        "anthropic",
+        "claude-sonnet-4-6",
+        "sonnet",
+    )
+
+
+def test_resolve_alias_falls_back_to_models_dev_when_curated_list_misses(monkeypatch):
+    """Models.dev breadth remains available when the curated list lacks a match."""
+    import hermes_cli.model_switch as ms
+
+    monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+    monkeypatch.setattr(ms, "_ensure_direct_aliases", lambda: None)
+    monkeypatch.setattr("hermes_cli.models.provider_model_ids", lambda provider: ["gpt-5.4"])
+    monkeypatch.setattr(
+        ms,
+        "list_provider_models",
+        lambda provider: [
+            "claude-sonnet-4-6",
+            "gpt-5.4",
+        ],
+    )
+
+    assert resolve_alias("sonnet", "anthropic") == (
+        "anthropic",
+        "claude-sonnet-4-6",
+        "sonnet",
+    )


### PR DESCRIPTION
## Summary

Fix `/model` short-alias resolution so aliases like `sonnet`, `opus`, and similar names prefer the provider's intended model ordering instead of depending on raw `models.dev` dictionary insertion order.

Previously, `resolve_alias()` returned the first matching model from `list_provider_models()`. In practice, that could select an older family member when the underlying catalog order happened to list stale versions first.

## What changed

- Updated `hermes_cli/model_switch.py`
- Alias resolution now:
  - prefers the provider's curated/live model order from `provider_model_ids()`
  - falls back to the broader `models.dev` provider catalog only when needed
  - deduplicates the merged candidate list before matching

## Why this matters

This makes short aliases deterministic and better aligned with user expectations. For example, `/model sonnet` should resolve to the provider's preferred current Sonnet model, not whichever matching entry happens to appear first in raw catalog data.

## Tests

Added:
- `tests/hermes_cli/test_model_alias_resolution.py`

Verified:
- curated provider ordering wins over stale raw catalog order
- fallback to `models.dev` still works when the curated list does not contain a matching alias

Targeted test runs:
- `scripts/run_tests.sh tests/hermes_cli/test_model_alias_resolution.py`
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py`

## Risk

Low. The change is narrowly scoped to short-alias resolution in the shared `/model` pipeline and preserves the existing fallback behavior.
