### PR TITLE
fix(memory): plumb per-turn user_id + user_name to providers (#7781)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -272,7 +272,15 @@ class MemoryManager:
         """Notify all providers of a new turn.
 
         kwargs may include: remaining_tokens, model, platform, tool_count.
+
+        Per-turn ``user_id`` and ``user_name`` are auto-injected from gateway
+        session context variables when the caller hasn't already supplied
+        them. In multi-user sessions (``group_sessions_per_user: false``) a
+        single session receives turns from different users, so providers
+        need per-turn identity to attribute memories correctly — not just
+        the identity captured at ``initialize()``.
         """
+        kwargs = self._inject_session_identity(kwargs)
         for provider in self._providers:
             try:
                 provider.on_turn_start(turn_number, message, **kwargs)
@@ -281,6 +289,29 @@ class MemoryManager:
                     "Memory provider '%s' on_turn_start failed: %s",
                     provider.name, e,
                 )
+
+    @staticmethod
+    def _inject_session_identity(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Fill in ``user_id`` / ``user_name`` from gateway session context vars.
+
+        Only fills values the caller didn't explicitly pass. Empty session
+        context values are skipped so CLI/cron (which don't set these vars)
+        don't clobber explicit caller-provided kwargs.
+        """
+        try:
+            from gateway.session_context import get_session_env
+        except Exception:
+            return kwargs
+        for key, var_name in (
+            ("user_id", "HERMES_SESSION_USER_ID"),
+            ("user_name", "HERMES_SESSION_USER_NAME"),
+        ):
+            if kwargs.get(key):
+                continue
+            value = get_session_env(var_name, "")
+            if value:
+                kwargs[key] = value
+        return kwargs
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Notify all providers of session end."""
@@ -358,11 +389,15 @@ class MemoryManager:
 
         Automatically injects ``hermes_home`` into *kwargs* so that every
         provider can resolve profile-scoped storage paths without importing
-        ``get_hermes_home()`` themselves.
+        ``get_hermes_home()`` themselves. Also auto-injects ``user_id`` /
+        ``user_name`` from gateway session context vars when not already
+        provided, so providers can do attribution in single-user sessions
+        without the caller having to plumb ``user_name`` manually.
         """
         if "hermes_home" not in kwargs:
             from hermes_constants import get_hermes_home
             kwargs["hermes_home"] = str(get_hermes_home())
+        kwargs = self._inject_session_identity(kwargs)
         for provider in self._providers:
             try:
                 provider.initialize(session_id=session_id, **kwargs)

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -78,6 +78,10 @@ class MemoryProvider(ABC):
           - agent_workspace (str): Shared workspace name (e.g. "hermes").
           - parent_session_id (str): For subagents, the parent's session_id.
           - user_id (str): Platform user identifier (gateway sessions).
+          - user_name (str): Platform user display name (gateway sessions).
+            Note: in multi-user sessions (``group_sessions_per_user: false``)
+            this is only the user who opened the session. Use the values
+            passed to ``on_turn_start`` for per-turn attribution.
         """
 
     def system_prompt_block(self) -> str:
@@ -146,8 +150,12 @@ class MemoryProvider(ABC):
 
         Use for turn-counting, scope management, periodic maintenance.
 
-        kwargs may include: remaining_tokens, model, platform, tool_count.
-        Providers use what they need; extras are ignored.
+        kwargs may include: remaining_tokens, model, platform, tool_count,
+        user_id, user_name. ``user_id`` / ``user_name`` identify the user
+        who sent *this turn's* message — critical for attribution in
+        multi-user sessions (``group_sessions_per_user: false``) where one
+        session receives turns from different users. Providers use what
+        they need; extras are ignored.
         """
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -334,3 +334,153 @@ class TestAIAgentUserIdPropagation:
             agent = object.__new__(AIAgent)
             agent._user_id = None
             assert agent._user_id is None
+
+
+# ---------------------------------------------------------------------------
+# Per-turn identity auto-injection from gateway session contextvars
+# ---------------------------------------------------------------------------
+
+
+class _TurnRecordingProvider(RecordingProvider):
+    """Records per-turn kwargs in addition to init kwargs."""
+
+    def __init__(self, name="turn-recording"):
+        super().__init__(name=name)
+        self._turn_kwargs = None
+        self._turn_number = None
+        self._turn_message = None
+
+    def on_turn_start(self, turn_number, message, **kwargs):
+        self._turn_number = turn_number
+        self._turn_message = message
+        self._turn_kwargs = dict(kwargs)
+
+
+@pytest.fixture
+def _reset_session_contextvars():
+    """Reset gateway session contextvars between tests."""
+    from gateway.session_context import _VAR_MAP, _UNSET
+    yield
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+
+
+class TestPerTurnIdentityInjection:
+    """In multi-user sessions (group_sessions_per_user=false), providers need
+    per-turn user_id/user_name to attribute memories to the right user. The
+    manager auto-injects these from gateway session contextvars.
+    """
+
+    def test_on_turn_start_injects_user_id_from_contextvar(
+        self, _reset_session_contextvars
+    ):
+        from gateway.session_context import set_session_vars
+
+        mgr = MemoryManager()
+        p = _TurnRecordingProvider()
+        mgr.add_provider(p)
+
+        set_session_vars(user_id="discord_user_42", user_name="alice")
+        mgr.on_turn_start(turn_number=1, message="hello")
+
+        assert p._turn_kwargs.get("user_id") == "discord_user_42"
+        assert p._turn_kwargs.get("user_name") == "alice"
+        assert p._turn_number == 1
+        assert p._turn_message == "hello"
+
+    def test_on_turn_start_caller_kwargs_take_precedence(
+        self, _reset_session_contextvars
+    ):
+        """Explicit caller-provided kwargs must win over contextvar values."""
+        from gateway.session_context import set_session_vars
+
+        mgr = MemoryManager()
+        p = _TurnRecordingProvider()
+        mgr.add_provider(p)
+
+        set_session_vars(user_id="discord_user_42", user_name="alice")
+        mgr.on_turn_start(
+            turn_number=1,
+            message="hello",
+            user_id="explicit-override",
+            user_name="bob",
+        )
+
+        assert p._turn_kwargs["user_id"] == "explicit-override"
+        assert p._turn_kwargs["user_name"] == "bob"
+
+    def test_on_turn_start_no_contextvar_leaves_kwargs_empty(
+        self, _reset_session_contextvars, monkeypatch
+    ):
+        """CLI (no gateway contextvars, no env) should not synthesize values."""
+        monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
+
+        mgr = MemoryManager()
+        p = _TurnRecordingProvider()
+        mgr.add_provider(p)
+
+        mgr.on_turn_start(turn_number=1, message="hello")
+
+        assert "user_id" not in p._turn_kwargs
+        assert "user_name" not in p._turn_kwargs
+
+    def test_on_turn_start_tracks_user_switch_mid_session(
+        self, _reset_session_contextvars
+    ):
+        """Bug #7781: in a shared thread, sequential turns from different
+        users must each report their own identity — initialize() only sees
+        the session opener, so per-turn propagation is the only correct path.
+        """
+        from gateway.session_context import set_session_vars
+
+        mgr = MemoryManager()
+        p = _TurnRecordingProvider()
+        mgr.add_provider(p)
+
+        set_session_vars(user_id="user_alice", user_name="alice")
+        mgr.on_turn_start(turn_number=1, message="hi from alice")
+        alice_turn = p._turn_kwargs
+
+        set_session_vars(user_id="user_bob", user_name="bob")
+        mgr.on_turn_start(turn_number=2, message="hi from bob")
+        bob_turn = p._turn_kwargs
+
+        assert alice_turn["user_id"] == "user_alice"
+        assert alice_turn["user_name"] == "alice"
+        assert bob_turn["user_id"] == "user_bob"
+        assert bob_turn["user_name"] == "bob"
+
+    def test_initialize_all_injects_user_name_from_contextvar(
+        self, _reset_session_contextvars
+    ):
+        """user_name was never plumbed through explicitly; ensure it now
+        reaches initialize() so single-user sessions can attribute correctly."""
+        from gateway.session_context import set_session_vars
+
+        mgr = MemoryManager()
+        p = RecordingProvider()
+        mgr.add_provider(p)
+
+        set_session_vars(user_id="user_99", user_name="charlie")
+        mgr.initialize_all(session_id="sess-x", platform="telegram")
+
+        assert p._init_kwargs.get("user_name") == "charlie"
+        # user_id is injected too (covers the path where the agent didn't
+        # explicitly pass it) — caller-provided values still win.
+        assert p._init_kwargs.get("user_id") == "user_99"
+
+    def test_initialize_all_caller_user_id_wins(self, _reset_session_contextvars):
+        from gateway.session_context import set_session_vars
+
+        mgr = MemoryManager()
+        p = RecordingProvider()
+        mgr.add_provider(p)
+
+        set_session_vars(user_id="from_context", user_name="ctx_name")
+        mgr.initialize_all(
+            session_id="sess-x", platform="telegram", user_id="from_caller"
+        )
+
+        assert p._init_kwargs["user_id"] == "from_caller"
+        assert p._init_kwargs["user_name"] == "ctx_name"


### PR DESCRIPTION
## Summary
- **Bug:** In multi-user sessions (`group_sessions_per_user: false`), the `MemoryProvider.on_turn_start` hook received no identity, so providers saw only the user who opened the session — not the one who actually sent the current turn. Additionally, `user_name` was never plumbed anywhere, blocking correct attribution even in single-user sessions.
- **Fix:** `MemoryManager` now auto-injects `user_id` / `user_name` into both `on_turn_start` and `initialize_all` kwargs from the gateway session contextvars (`HERMES_SESSION_USER_ID`, `HERMES_SESSION_USER_NAME`). Explicit caller-provided values still win.
- **Compatibility:** `on_turn_start` already accepted `**kwargs`, so every existing provider (honcho, supermemory, mem0, hindsight, …) keeps compiling unchanged — they can opt in to per-turn attribution by reading `kwargs.get("user_id")` / `kwargs.get("user_name")`. No plugin signature changes.
- **Scope:** Agent ↔ gateway coupling is limited to the same lazy `from gateway.session_context import get_session_env` pattern already used in `agent/prompt_builder.py` and `agent/skill_utils.py`.

Closes #7781

## Test plan
- [x] New `TestPerTurnIdentityInjection` in `tests/agent/test_memory_user_id.py` covers:
  - per-turn `user_id` / `user_name` auto-injected from contextvars
  - caller-provided kwargs take precedence over contextvars
  - CLI path (no contextvars set) leaves kwargs untouched
  - user switch mid-session — each turn reports its own identity (the #7781 repro)
  - `initialize_all` auto-injects `user_name` while still honoring explicit `user_id`
- [x] All existing `tests/agent/test_memory_provider.py` (60 tests) + `test_memory_user_id.py` (prior suites) pass unchanged.
- [x] Validation run in Docker (`python:3.11-slim` + pytest + xdist), matching CI's `-n auto` shape.