### PR TITLE
fix(ssh): hash ControlMaster socket filename to avoid macOS 104-char limit

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -220,3 +220,42 @@ class TestPersistentSSH:
         assert len(lines) == 1000
         assert lines[0] == "1"
         assert lines[-1] == "1000"
+
+
+# ── _socket_filename unit tests ──────────────────────────────────────────
+
+from tools.environments.ssh import _socket_filename, _SOCKET_PATH_MAX
+
+
+class TestSocketFilename:
+    """Ensure socket filenames stay within OS limits."""
+
+    def test_short_host(self):
+        name = _socket_filename("user", "example.com", 22)
+        assert name.endswith(".sock")
+        assert len(name) <= 30  # plenty of room for control_dir prefix
+
+    def test_ipv6_long_address(self):
+        host = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        name = _socket_filename("deploy", host, 2222)
+        # /tmp/hermes-ssh/ is 17 chars; full path must be < 104
+        full_path = f"/tmp/hermes-ssh/{name}"
+        assert len(full_path) < _SOCKET_PATH_MAX, (
+            f"Socket path too long ({len(full_path)} >= {_SOCKET_PATH_MAX}): {full_path}"
+        )
+
+    def test_very_long_hostname(self):
+        host = "a" * 200 + ".example.com"
+        name = _socket_filename("root", host, 22)
+        full_path = f"/tmp/hermes-ssh/{name}"
+        assert len(full_path) < _SOCKET_PATH_MAX
+
+    def test_deterministic(self):
+        a = _socket_filename("u", "h", 22)
+        b = _socket_filename("u", "h", 22)
+        assert a == b
+
+    def test_different_ports_differ(self):
+        a = _socket_filename("u", "h", 22)
+        b = _socket_filename("u", "h", 2222)
+        assert a != b

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,5 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
+import hashlib
 import logging
 import os
 import shlex
@@ -18,6 +19,23 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# macOS AF_UNIX sun_path limit is 104 bytes; Linux is 108.
+# A raw "user@[::1:2:3:4:5:6]:22.sock" easily exceeds this.
+# We hash the connection identity into a short, fixed-length filename.
+_SOCKET_PATH_MAX = 104  # conservative: use macOS limit everywhere
+
+
+def _socket_filename(user: str, host: str, port: int) -> str:
+    """Return a short, deterministic socket filename for a connection.
+
+    Uses a truncated SHA-256 hex digest so the full path stays under
+    ``_SOCKET_PATH_MAX`` even with a long ``control_dir`` prefix.
+    """
+    identity = f"{user}@{host}:{port}"
+    digest = hashlib.sha256(identity.encode()).hexdigest()[:16]
+    return f"h-{digest}.sock"  # 24 chars total
 
 
 def _ensure_ssh_available() -> None:
@@ -47,7 +65,7 @@ class SSHEnvironment(BaseEnvironment):
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
-        self.control_socket = self.control_dir / f"{user}@{host}:{port}.sock"
+        self.control_socket = self.control_dir / _socket_filename(user, host, port)
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()


### PR DESCRIPTION
## Problem

Closes #11840.

When connecting to hosts with long names — especially IPv6 addresses like `2001:0db8:85a3:0000:0000:8a2e:0370:7334` — the SSH ControlMaster socket path (`/tmp/hermes-ssh/user@host:port.sock`) exceeds the macOS `AF_UNIX` `sun_path` limit of **104 bytes**, causing `ControlMaster` to fail silently.

## Fix

Replace the raw `user@host:port.sock` filename with a truncated SHA-256 hash: `h-<16 hex chars>.sock` (24 chars total). This keeps the full path safely under both macOS (104) and Linux (108) limits while remaining deterministic.

## Tests

Added 5 unit tests in `TestSocketFilename`:
- Short host, IPv6 address, 200+ char hostname → all under limit
- Deterministic output for same inputs
- Different ports produce different filenames