### PR TITLE
fix(skills): use frontmatter name in skills index instead of directory name

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -654,7 +654,7 @@ def build_skills_system_prompt(
             ):
                 continue
             skills_by_category.setdefault(category, []).append(
-                (skill_name, entry.get("description", ""))
+                (frontmatter_name, entry.get("description", ""))
             )
         category_descriptions = {
             str(k): str(v)
@@ -679,7 +679,7 @@ def build_skills_system_prompt(
             ):
                 continue
             skills_by_category.setdefault(entry["category"], []).append(
-                (skill_name, entry["description"])
+                (entry["frontmatter_name"], entry["description"])
             )
 
         # Read category-level DESCRIPTION.md files
@@ -722,9 +722,10 @@ def build_skills_system_prompt(
                     continue
                 entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
                 skill_name = entry["skill_name"]
-                if skill_name in seen_skill_names:
+                frontmatter_name = entry["frontmatter_name"]
+                if frontmatter_name in seen_skill_names:
                     continue
-                if entry["frontmatter_name"] in disabled or skill_name in disabled:
+                if frontmatter_name in disabled or skill_name in disabled:
                     continue
                 if not _skill_should_show(
                     extract_skill_conditions(frontmatter),
@@ -732,9 +733,9 @@ def build_skills_system_prompt(
                     available_toolsets,
                 ):
                     continue
-                seen_skill_names.add(skill_name)
+                seen_skill_names.add(frontmatter_name)
                 skills_by_category.setdefault(entry["category"], []).append(
-                    (skill_name, entry["description"])
+                    (frontmatter_name, entry["description"])
                 )
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)


### PR DESCRIPTION
## Problem

`build_skills_system_prompt()` shows skills in the system prompt using their **directory name** (`skill_name`) instead of their declared frontmatter **`name` field** (`frontmatter_name`). Any skill where the directory name differs from its frontmatter name appears under the wrong name in the system prompt, causing LLM routing failures.

Example:
- Directory: `skills/north/review/SKILL.md`
- Frontmatter: `name: north-eval`
- System prompt showed: `review` ❌
- Should show: `north-eval` ✅

Closes #11777

## Root Cause

`_build_snapshot_entry()` correctly stores both `skill_name` (directory) and `frontmatter_name` (declared) in the snapshot entry. But all three code paths that build `skills_by_category` tuples used the wrong variable:

- Line 657 (snapshot/warm path): `(skill_name, ...)`
- Line 682 (cold filesystem scan): `(skill_name, ...)`
- Line 736 (external dirs): `(skill_name, ...)`

## Fix

Switch all three tuple appends to use `frontmatter_name`. Also fix the external-dir dedup set (`seen_skill_names`) to track `frontmatter_name` for consistency — since the local-skill tuples now use `frontmatter_name`, the dedup check against that set must use the same key.

## Reproduction & Verification

Reproduced against `docker.io/nousresearch/hermes-agent:latest` (v0.8.0) with a skill at `skills/north/review/SKILL.md` declaring `name: north-eval`:

**Before fix:**
```xml
<available_skills>
  north:
    - review: Daily portfolio evaluation and rebalancing check
</available_skills>
```

**After fix:**
```xml
<available_skills>
  north:
    - north-eval: Daily portfolio evaluation and rebalancing check
</available_skills>
```

Both cold path (fresh filesystem scan) and warm path (snapshot cache) verified correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)