### PR TITLE
fix(memory): strip UTF-8 BOM from MEMORY.md on load

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -416,7 +416,7 @@ class MemoryStore:
         if not path.exists():
             return []
         try:
-            raw = path.read_text(encoding="utf-8")
+            raw = path.read_text(encoding="utf-8-sig")
         except (OSError, IOError):
             return []
 


### PR DESCRIPTION
## Problem

`MemoryStore._read_file()` uses `encoding="utf-8"` which does not strip the UTF-8 BOM (`\ufeff`). Files written by Windows Notepad or any BOM-emitting editor silently inject the invisible character into the first memory entry, which then pollutes the system prompt.

Closes #10878

## Fix

One-line change in `tools/memory_tool.py`: `encoding="utf-8"` → `encoding="utf-8-sig"`.

Python's `utf-8-sig` codec auto-strips a leading BOM when present and is otherwise identical to `utf-8` — no behaviour change for files that don't have one.

## Verification

```python
# File written with BOM (as Windows Notepad does)
p.write_bytes(b'\xef\xbb\xbfUser prefers dark mode')

# Before fix
raw = p.read_text(encoding="utf-8")
# raw[0] == '\ufeff'  ← BOM present, enters system prompt

# After fix
raw = p.read_text(encoding="utf-8-sig")
# raw == 'User prefers dark mode'  ← BOM stripped ✅
```

Tested against `docker.io/nousresearch/hermes-agent:latest` (v0.8.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)