### PR TITLE
fix(auth): mirror Nous OAuth credentials to providers.nous on CLI login

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2159,52 +2159,45 @@ def refresh_nous_oauth_from_state(
     )
 
 
-def persist_nous_credentials(
-    creds: Dict[str, Any],
-    *,
-    label: str,
-    source: str,
-):
-    """Persist minted Nous OAuth credentials to both auth-store sections.
+NOUS_DEVICE_CODE_SOURCE = "device_code"
+
+
+def persist_nous_credentials(creds: Dict[str, Any]):
+    """Persist minted Nous OAuth credentials as the singleton provider state
+    and ensure the credential pool is in sync.
 
     Nous credentials are read at runtime from two independent locations:
 
-    - ``credential_pool.nous``: used by the runtime ``pool.select()`` path that
-      services outbound inference requests.
-    - ``providers.nous``: used by ``resolve_nous_runtime_credentials()`` — the
-      singleton-state reader invoked during 401 recovery and dashboard status
-      checks.
+    - ``providers.nous``: singleton state read by
+      ``resolve_nous_runtime_credentials()`` during 401 recovery and by
+      ``_seed_from_singletons()`` during pool load.
+    - ``credential_pool.nous``: used by the runtime ``pool.select()`` path.
 
-    Historically ``hermes auth add nous`` wrote only to the pool while the web
-    dashboard device-code flow wrote to both, so CLI-provisioned profiles
-    failed silently when the recovery path was later consulted.  This helper
-    is the single source of truth for CLI/web device-code persistence: both
-    stores are always written together.
+    Historically ``hermes auth add nous`` wrote a ``manual:device_code`` pool
+    entry only, skipping ``providers.nous``.  When the 24h agent_key TTL
+    expired, the recovery path read the empty singleton state and raised
+    ``AuthError`` silently (``logger.debug`` at INFO level).
 
-    Returns the added :class:`PooledCredential` entry.
+    This helper writes ``providers.nous`` then calls ``load_pool("nous")`` so
+    ``_seed_from_singletons`` materialises the canonical ``device_code`` pool
+    entry from the singleton.  Re-running login upserts the same entry in
+    place; the pool never accumulates duplicate device_code rows.
+
+    Returns the upserted :class:`PooledCredential` entry (or ``None`` if
+    seeding somehow produced no match — shouldn't happen).
     """
-    from agent.credential_pool import (
-        PooledCredential,
-        load_pool,
-        AUTH_TYPE_OAUTH,
-    )
-
-    pool = load_pool("nous")
-    entry = PooledCredential.from_dict("nous", {
-        **creds,
-        "label": label,
-        "auth_type": AUTH_TYPE_OAUTH,
-        "source": source,
-        "base_url": creds.get("inference_base_url"),
-    })
-    pool.add_entry(entry)
+    from agent.credential_pool import load_pool
 
     with _auth_store_lock():
         auth_store = _load_auth_store()
         _save_provider_state(auth_store, "nous", creds)
         _save_auth_store(auth_store)
 
-    return entry
+    pool = load_pool("nous")
+    return next(
+        (e for e in pool.entries() if e.source == NOUS_DEVICE_CODE_SOURCE),
+        None,
+    )
 
 
 def resolve_nous_runtime_credentials(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2159,6 +2159,54 @@ def refresh_nous_oauth_from_state(
     )
 
 
+def persist_nous_credentials(
+    creds: Dict[str, Any],
+    *,
+    label: str,
+    source: str,
+):
+    """Persist minted Nous OAuth credentials to both auth-store sections.
+
+    Nous credentials are read at runtime from two independent locations:
+
+    - ``credential_pool.nous``: used by the runtime ``pool.select()`` path that
+      services outbound inference requests.
+    - ``providers.nous``: used by ``resolve_nous_runtime_credentials()`` — the
+      singleton-state reader invoked during 401 recovery and dashboard status
+      checks.
+
+    Historically ``hermes auth add nous`` wrote only to the pool while the web
+    dashboard device-code flow wrote to both, so CLI-provisioned profiles
+    failed silently when the recovery path was later consulted.  This helper
+    is the single source of truth for CLI/web device-code persistence: both
+    stores are always written together.
+
+    Returns the added :class:`PooledCredential` entry.
+    """
+    from agent.credential_pool import (
+        PooledCredential,
+        load_pool,
+        AUTH_TYPE_OAUTH,
+    )
+
+    pool = load_pool("nous")
+    entry = PooledCredential.from_dict("nous", {
+        **creds,
+        "label": label,
+        "auth_type": AUTH_TYPE_OAUTH,
+        "source": source,
+        "base_url": creds.get("inference_base_url"),
+    })
+    pool.add_entry(entry)
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        _save_provider_state(auth_store, "nous", creds)
+        _save_auth_store(auth_store)
+
+    return entry
+
+
 def resolve_nous_runtime_credentials(
     *,
     min_key_ttl_seconds: int = DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -217,17 +217,11 @@ def auth_add_command(args) -> None:
             ca_bundle=getattr(args, "ca_bundle", None),
             min_key_ttl_seconds=max(60, int(getattr(args, "min_key_ttl_seconds", 5 * 60))),
         )
-        label = (getattr(args, "label", None) or "").strip() or label_from_token(
-            creds.get("access_token", ""),
-            _oauth_default_label(provider, len(pool.entries()) + 1),
+        entry = auth_mod.persist_nous_credentials(creds)
+        shown_label = entry.label if entry is not None else label_from_token(
+            creds.get("access_token", ""), _oauth_default_label(provider, 1),
         )
-        auth_mod.persist_nous_credentials(
-            creds,
-            label=label,
-            source=f"{SOURCE_MANUAL}:device_code",
-        )
-        count = len(load_pool(provider).entries())
-        print(f'Added {provider} OAuth credential #{count}: "{label}"')
+        print(f'Saved {provider} OAuth device-code credentials: "{shown_label}"')
         return
 
     if provider == "openai-codex":

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -221,15 +221,13 @@ def auth_add_command(args) -> None:
             creds.get("access_token", ""),
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
-        entry = PooledCredential.from_dict(provider, {
-            **creds,
-            "label": label,
-            "auth_type": AUTH_TYPE_OAUTH,
-            "source": f"{SOURCE_MANUAL}:device_code",
-            "base_url": creds.get("inference_base_url"),
-        })
-        pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        auth_mod.persist_nous_credentials(
+            creds,
+            label=label,
+            source=f"{SOURCE_MANUAL}:device_code",
+        )
+        count = len(load_pool(provider).entries())
+        print(f'Added {provider} OAuth credential #{count}: "{label}"')
         return
 
     if provider == "openai-codex":

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1444,13 +1444,8 @@ def _nous_poller(session_id: str) -> None:
             auth_state, min_key_ttl_seconds=300, timeout_seconds=15.0,
             force_refresh=False, force_mint=True,
         )
-        from agent.credential_pool import SOURCE_MANUAL
         from hermes_cli.auth import persist_nous_credentials
-        persist_nous_credentials(
-            full_state,
-            label="dashboard device_code",
-            source=f"{SOURCE_MANUAL}:dashboard_device_code",
-        )
+        persist_nous_credentials(full_state)
         with _oauth_sessions_lock:
             sess["status"] = "approved"
         _log.info("oauth/device: nous login completed (session=%s)", session_id)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1444,38 +1444,13 @@ def _nous_poller(session_id: str) -> None:
             auth_state, min_key_ttl_seconds=300, timeout_seconds=15.0,
             force_refresh=False, force_mint=True,
         )
-        # Save into credential pool same as auth_commands.py does
-        from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
-            AUTH_TYPE_OAUTH,
-            SOURCE_MANUAL,
+        from agent.credential_pool import SOURCE_MANUAL
+        from hermes_cli.auth import persist_nous_credentials
+        persist_nous_credentials(
+            full_state,
+            label="dashboard device_code",
+            source=f"{SOURCE_MANUAL}:dashboard_device_code",
         )
-        pool = load_pool("nous")
-        entry = PooledCredential.from_dict("nous", {
-            **full_state,
-            "label": "dashboard device_code",
-            "auth_type": AUTH_TYPE_OAUTH,
-            "source": f"{SOURCE_MANUAL}:dashboard_device_code",
-            "base_url": full_state.get("inference_base_url"),
-        })
-        pool.add_entry(entry)
-        # Also persist to auth store so get_nous_auth_status() sees it
-        # (matches what _login_nous in auth.py does for the CLI flow).
-        try:
-            from hermes_cli.auth import (
-                _load_auth_store, _save_provider_state, _save_auth_store,
-                _auth_store_lock,
-            )
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                _save_provider_state(auth_store, "nous", full_state)
-                _save_auth_store(auth_store)
-        except Exception as store_exc:
-            _log.warning(
-                "oauth/device: credential pool saved but auth store write failed "
-                "(session=%s): %s", session_id, store_exc,
-            )
         with _oauth_sessions_lock:
             sess["status"] = "approved"
         _log.info("oauth/device: nous login completed (session=%s)", session_id)

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -141,10 +141,18 @@ def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     auth_add_command(_Args())
 
     payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+
+    # Pool has exactly one canonical `device_code` entry — not a duplicate
+    # pair of `manual:device_code` + `device_code` (the latter would be
+    # materialised by _seed_from_singletons on every load_pool).
     entries = payload["credential_pool"]["nous"]
-    entry = next(item for item in entries if item["source"] == "manual:device_code")
-    assert entry["label"] == "nous@example.com"
-    assert entry["source"] == "manual:device_code"
+    device_code_entries = [
+        item for item in entries if item["source"] == "device_code"
+    ]
+    assert len(device_code_entries) == 1, entries
+    assert not any(item["source"] == "manual:device_code" for item in entries)
+    entry = device_code_entries[0]
+    assert entry["source"] == "device_code"
     assert entry["agent_key"] == "ak-test"
     assert entry["portal_base_url"] == "https://portal.example.com"
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -148,6 +148,17 @@ def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["agent_key"] == "ak-test"
     assert entry["portal_base_url"] == "https://portal.example.com"
 
+    # `hermes auth add nous` must also populate providers.nous so the
+    # 401-recovery path (resolve_nous_runtime_credentials) can mint a fresh
+    # agent_key when the 24h TTL expires. If this mirror is missing, recovery
+    # raises "Hermes is not logged into Nous Portal" and the agent dies.
+    singleton = payload["providers"]["nous"]
+    assert singleton["access_token"] == token
+    assert singleton["refresh_token"] == "refresh-token"
+    assert singleton["agent_key"] == "ak-test"
+    assert singleton["portal_base_url"] == "https://portal.example.com"
+    assert singleton["inference_base_url"] == "https://inference.example.com/v1"
+
 
 def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -495,7 +495,7 @@ def test_persist_nous_credentials_writes_both_pool_and_providers(tmp_path, monke
     agent failed with "Non-retryable client error". Both stores must stay
     in sync at write time.
     """
-    from hermes_cli.auth import persist_nous_credentials
+    from hermes_cli.auth import persist_nous_credentials, NOUS_DEVICE_CODE_SOURCE
 
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -504,38 +504,35 @@ def test_persist_nous_credentials_writes_both_pool_and_providers(tmp_path, monke
     }))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    creds = _full_state_fixture()
-    entry = persist_nous_credentials(
-        creds, label="test-label", source="manual:device_code",
-    )
+    entry = persist_nous_credentials(_full_state_fixture())
 
     assert entry is not None
     assert entry.provider == "nous"
+    assert entry.source == NOUS_DEVICE_CODE_SOURCE
 
     payload = json.loads((hermes_home / "auth.json").read_text())
 
-    # providers.nous populated with the full state (new behavior)
+    # providers.nous populated with the full state (new behaviour)
     singleton = payload["providers"]["nous"]
     assert singleton["access_token"] == "access-tok"
     assert singleton["refresh_token"] == "refresh-tok"
     assert singleton["agent_key"] == "agent-key-value"
     assert singleton["agent_key_expires_at"] == "2026-04-18T22:00:00+00:00"
 
-    # credential_pool.nous populated with the pool entry
+    # credential_pool.nous has exactly one canonical device_code entry
     pool_entries = payload["credential_pool"]["nous"]
-    pool_entry = next(
-        item for item in pool_entries if item["source"] == "manual:device_code"
-    )
-    assert pool_entry["label"] == "test-label"
+    assert len(pool_entries) == 1, pool_entries
+    pool_entry = pool_entries[0]
+    assert pool_entry["source"] == NOUS_DEVICE_CODE_SOURCE
     assert pool_entry["agent_key"] == "agent-key-value"
-    assert pool_entry["base_url"] == "https://inference.example.com/v1"
+    assert pool_entry["inference_base_url"] == "https://inference.example.com/v1"
 
 
 def test_persist_nous_credentials_allows_recovery_from_401(tmp_path, monkeypatch):
     """End-to-end: after persisting via the helper, resolve_nous_runtime_credentials
     must succeed (not raise "Hermes is not logged into Nous Portal").
 
-    This is the exact path that ran_agent.py's `_try_refresh_nous_client_credentials`
+    This is the exact path that run_agent.py's `_try_refresh_nous_client_credentials`
     calls after a Nous 401 — before the fix it would raise AuthError because
     providers.nous was empty.
     """
@@ -548,11 +545,7 @@ def test_persist_nous_credentials_allows_recovery_from_401(tmp_path, monkeypatch
     }))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    persist_nous_credentials(
-        _full_state_fixture(),
-        label="recovery-test",
-        source="manual:device_code",
-    )
+    persist_nous_credentials(_full_state_fixture())
 
     # Stub the network-touching steps so we don't actually contact the
     # portal — the point of this test is that state lookup succeeds and
@@ -575,9 +568,17 @@ def test_persist_nous_credentials_allows_recovery_from_401(tmp_path, monkeypatch
     assert creds["api_key"] == "new-agent-key"
 
 
-def test_persist_nous_credentials_preserves_existing_providers_entry(tmp_path, monkeypatch):
-    """Calling persist twice must upsert providers.nous (not duplicate or crash)."""
-    from hermes_cli.auth import persist_nous_credentials
+def test_persist_nous_credentials_idempotent_no_duplicate_pool_entries(tmp_path, monkeypatch):
+    """Re-running persist must upsert — not accumulate duplicate device_code rows.
+
+    Regression guard for the review comment on PR #11858: before normalisation,
+    the helper wrote `manual:device_code` while `_seed_from_singletons` wrote
+    `device_code`, so the pool grew a second duplicate entry on every
+    ``load_pool()``. The helper now writes providers.nous and lets seeding
+    materialise the pool entry under the canonical ``device_code`` source, so
+    two persists still leave the pool with exactly one row.
+    """
+    from hermes_cli.auth import persist_nous_credentials, NOUS_DEVICE_CODE_SOURCE
 
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -587,12 +588,12 @@ def test_persist_nous_credentials_preserves_existing_providers_entry(tmp_path, m
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     first = _full_state_fixture()
-    persist_nous_credentials(first, label="first", source="manual:device_code")
+    persist_nous_credentials(first)
 
     second = _full_state_fixture()
     second["access_token"] = "access-second"
     second["agent_key"] = "agent-key-second"
-    persist_nous_credentials(second, label="second", source="manual:device_code")
+    persist_nous_credentials(second)
 
     payload = json.loads((hermes_home / "auth.json").read_text())
 
@@ -600,8 +601,35 @@ def test_persist_nous_credentials_preserves_existing_providers_entry(tmp_path, m
     assert payload["providers"]["nous"]["access_token"] == "access-second"
     assert payload["providers"]["nous"]["agent_key"] == "agent-key-second"
 
-    # credential_pool.nous has both entries (pool = multi-credential)
+    # credential_pool.nous has exactly one entry, carrying the latest agent_key
     pool_entries = payload["credential_pool"]["nous"]
-    labels = [e.get("label") for e in pool_entries]
-    assert "first" in labels
-    assert "second" in labels
+    assert len(pool_entries) == 1, pool_entries
+    assert pool_entries[0]["source"] == NOUS_DEVICE_CODE_SOURCE
+    assert pool_entries[0]["agent_key"] == "agent-key-second"
+    # And no stray `manual:device_code` / `manual:dashboard_device_code` rows
+    assert not any(
+        e["source"].startswith("manual:") for e in pool_entries
+    )
+
+
+def test_persist_nous_credentials_reloads_pool_after_singleton_write(tmp_path, monkeypatch):
+    """The entry returned by the helper must come from a fresh ``load_pool`` so
+    callers observe the canonical seeded state, including any legacy entries
+    that ``_seed_from_singletons`` pruned or upserted.
+    """
+    from hermes_cli.auth import persist_nous_credentials, NOUS_DEVICE_CODE_SOURCE
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1, "providers": {},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    entry = persist_nous_credentials(_full_state_fixture())
+    assert entry is not None
+    assert entry.source == NOUS_DEVICE_CODE_SOURCE
+    # Label derived by _seed_from_singletons via label_from_token; we don't
+    # assert its exact value, just that the helper returned a real entry.
+    assert entry.access_token == "access-tok"
+    assert entry.agent_key == "agent-key-value"

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -456,3 +456,152 @@ class TestLoginNousSkipKeepsCurrent:
         assert "nous" in auth_after.get("providers", {})
 
 
+# =============================================================================
+# persist_nous_credentials: shared helper for CLI + web dashboard login paths
+# =============================================================================
+
+
+def _full_state_fixture() -> dict:
+    """Shape of the dict returned by _nous_device_code_login /
+    refresh_nous_oauth_from_state. Used as helper input."""
+    return {
+        "portal_base_url": "https://portal.example.com",
+        "inference_base_url": "https://inference.example.com/v1",
+        "client_id": "hermes-cli",
+        "scope": "inference:mint_agent_key",
+        "token_type": "Bearer",
+        "access_token": "access-tok",
+        "refresh_token": "refresh-tok",
+        "obtained_at": "2026-04-17T22:00:00+00:00",
+        "expires_at": "2026-04-17T22:15:00+00:00",
+        "expires_in": 900,
+        "agent_key": "agent-key-value",
+        "agent_key_id": "ak-id",
+        "agent_key_expires_at": "2026-04-18T22:00:00+00:00",
+        "agent_key_expires_in": 86400,
+        "agent_key_reused": False,
+        "agent_key_obtained_at": "2026-04-17T22:00:10+00:00",
+        "tls": {"insecure": False, "ca_bundle": None},
+    }
+
+
+def test_persist_nous_credentials_writes_both_pool_and_providers(tmp_path, monkeypatch):
+    """Helper must populate BOTH credential_pool.nous AND providers.nous.
+
+    Regression guard: before this helper existed, `hermes auth add nous`
+    wrote only the pool. After the Nous agent_key's 24h TTL expired, the
+    401-recovery path in run_agent.py called resolve_nous_runtime_credentials
+    which reads providers.nous, found it empty, raised AuthError, and the
+    agent failed with "Non-retryable client error". Both stores must stay
+    in sync at write time.
+    """
+    from hermes_cli.auth import persist_nous_credentials
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1, "providers": {},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    creds = _full_state_fixture()
+    entry = persist_nous_credentials(
+        creds, label="test-label", source="manual:device_code",
+    )
+
+    assert entry is not None
+    assert entry.provider == "nous"
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+
+    # providers.nous populated with the full state (new behavior)
+    singleton = payload["providers"]["nous"]
+    assert singleton["access_token"] == "access-tok"
+    assert singleton["refresh_token"] == "refresh-tok"
+    assert singleton["agent_key"] == "agent-key-value"
+    assert singleton["agent_key_expires_at"] == "2026-04-18T22:00:00+00:00"
+
+    # credential_pool.nous populated with the pool entry
+    pool_entries = payload["credential_pool"]["nous"]
+    pool_entry = next(
+        item for item in pool_entries if item["source"] == "manual:device_code"
+    )
+    assert pool_entry["label"] == "test-label"
+    assert pool_entry["agent_key"] == "agent-key-value"
+    assert pool_entry["base_url"] == "https://inference.example.com/v1"
+
+
+def test_persist_nous_credentials_allows_recovery_from_401(tmp_path, monkeypatch):
+    """End-to-end: after persisting via the helper, resolve_nous_runtime_credentials
+    must succeed (not raise "Hermes is not logged into Nous Portal").
+
+    This is the exact path that ran_agent.py's `_try_refresh_nous_client_credentials`
+    calls after a Nous 401 — before the fix it would raise AuthError because
+    providers.nous was empty.
+    """
+    from hermes_cli.auth import persist_nous_credentials, resolve_nous_runtime_credentials
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1, "providers": {},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    persist_nous_credentials(
+        _full_state_fixture(),
+        label="recovery-test",
+        source="manual:device_code",
+    )
+
+    # Stub the network-touching steps so we don't actually contact the
+    # portal — the point of this test is that state lookup succeeds and
+    # doesn't raise "Hermes is not logged into Nous Portal".
+    def _fake_refresh_access_token(*, client, portal_base_url, client_id, refresh_token):
+        return {
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+            "expires_in": 900,
+            "token_type": "Bearer",
+        }
+
+    def _fake_mint_agent_key(*, client, portal_base_url, access_token, min_ttl_seconds):
+        return _mint_payload(api_key="new-agent-key")
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_access_token", _fake_refresh_access_token)
+    monkeypatch.setattr("hermes_cli.auth._mint_agent_key", _fake_mint_agent_key)
+
+    creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=300, force_mint=True)
+    assert creds["api_key"] == "new-agent-key"
+
+
+def test_persist_nous_credentials_preserves_existing_providers_entry(tmp_path, monkeypatch):
+    """Calling persist twice must upsert providers.nous (not duplicate or crash)."""
+    from hermes_cli.auth import persist_nous_credentials
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1, "providers": {},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    first = _full_state_fixture()
+    persist_nous_credentials(first, label="first", source="manual:device_code")
+
+    second = _full_state_fixture()
+    second["access_token"] = "access-second"
+    second["agent_key"] = "agent-key-second"
+    persist_nous_credentials(second, label="second", source="manual:device_code")
+
+    payload = json.loads((hermes_home / "auth.json").read_text())
+
+    # providers.nous reflects the latest write (singleton semantics)
+    assert payload["providers"]["nous"]["access_token"] == "access-second"
+    assert payload["providers"]["nous"]["agent_key"] == "agent-key-second"
+
+    # credential_pool.nous has both entries (pool = multi-credential)
+    pool_entries = payload["credential_pool"]["nous"]
+    labels = [e.get("label") for e in pool_entries]
+    assert "first" in labels
+    assert "second" in labels


### PR DESCRIPTION
## What does this PR do?

`hermes auth add nous --type oauth` (CLI) only wrote to `credential_pool.nous`, leaving `providers.nous` empty in `auth.json`.  The web dashboard device-code flow wrote to both.  CLI-provisioned Nous profiles therefore couldn't auto-recover from a Nous 401: after the agent_key's 24h TTL expired, `run_agent._try_refresh_nous_client_credentials` called `resolve_nous_runtime_credentials`, which reads `providers.nous`, found it empty, raised `AuthError(\"Hermes is not logged into Nous Portal\")`, and the exception was swallowed as `logger.debug(...)` (suppressed at default INFO level).  The user saw only `Non-retryable client error: 401` with no sign that recovery was even attempted.

This PR introduces `persist_nous_credentials()` in `hermes_cli/auth.py` as the single source of truth for Nous device-code persistence.  Both `auth_commands.auth_add_command` (CLI) and `web_server._nous_poller` (dashboard) now route through it, so the pool and the singleton provider state are always written together.

## Root cause

- `auth_commands.py` (CLI `hermes auth add nous --type oauth`): only `pool.add_entry(entry)` — no `_save_provider_state()`.
- `web_server.py` (dashboard device-code): `pool.add_entry()` **and** `_save_provider_state()` (the comment on the dashboard path even says it's mirroring \"what `_login_nous` does for the CLI flow\" — but the `auth add` CLI path takes a different code path that skipped the mirror).
- `credential_pool._entry_needs_refresh` returns `False` for `\"nous\"` intentionally (to avoid network I/O during pool enumeration), deferring refresh to `resolve_nous_runtime_credentials`.  That deferral is fine — but only if `providers.nous` is populated, which CLI-provisioned profiles weren't.

## Observed symptom (real-world)

Four profiles (CLI-provisioned via `hermes -p <profile> auth add nous --type oauth`) went 401-invisible exactly ~24h after first login.  Fresh mints (re-running `auth add`) restored service for another ~24h, but the underlying asymmetry meant the cycle would repeat nightly.  PRs #6856 and #6869 had addressed adjacent issues (stale pool agent_key detection; providers→pool sync) but both assumed `providers.nous` was populated at write time — this wasn't.

## Changes

- **`hermes_cli/auth.py`**: new `persist_nous_credentials(creds, *, label, source)` helper.  Writes both `credential_pool.nous` (via `pool.add_entry`) and `providers.nous` (via `_save_provider_state`).
- **`hermes_cli/auth_commands.py`**: the nous branch of `auth_add_command` now calls the helper instead of only adding a pool entry.
- **`hermes_cli/web_server.py`**: `_nous_poller` now calls the helper instead of duplicating the pool-then-providers write inline.
- **`hermes_cli/auth.py::_login_nous`**: intentionally untouched — it already wrote `providers.nous` correctly and kept its existing behavior to minimize diff surface.

## Tests

Added in `tests/hermes_cli/test_auth_nous_provider.py`:
- `test_persist_nous_credentials_writes_both_pool_and_providers`
- `test_persist_nous_credentials_allows_recovery_from_401` (end-to-end: helper → `resolve_nous_runtime_credentials` succeeds with stubbed mint)
- `test_persist_nous_credentials_preserves_existing_providers_entry` (idempotency: `providers.nous` upserts, `credential_pool.nous` accumulates)

Updated `tests/hermes_cli/test_auth_commands.py::test_auth_add_nous_oauth_persists_pool_entry` to also assert `providers.nous` is populated after `hermes auth add nous --type oauth`.

All Nous/credential-pool tests pass locally (`pytest tests/hermes_cli/ tests/agent/ -k \"nous or auth or credential_pool\"` → 383 passed, 1 skipped).

## How to test manually

```bash
# Before this PR: providers.nous would be {}; after 24h, agent dies with Non-retryable 401
# After this PR: providers.nous populated, 401-recovery path can mint a fresh agent_key
hermes -p testprofile auth add nous --type oauth
jq '.providers.nous, .credential_pool.nous' ~/.hermes/profiles/testprofile/auth.json
# Both should be populated
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Checklist

- [x] Commit message follows Conventional Commits (`fix(auth):`)
- [x] Searched existing PRs — #6856 and #6869 are adjacent but neither addresses this specific write-side asymmetry
- [x] PR contains only changes related to this fix
- [x] Added tests that would have caught the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)