### PR TITLE
fix(voice): alt+ record_key crashes on startup with ValueError

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7322,7 +7322,7 @@ class HermesCLI:
             _ptt_key = _raw_ptt.lower().replace("ctrl+", "c-").replace("alt+", "a-")
         except Exception:
             _ptt_key = "c-b"
-        _ptt_display = _ptt_key.replace("c-", "Ctrl+").upper()
+        _ptt_display = _ptt_key.replace("c-", "Ctrl+").replace("a-", "Alt+").upper()
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
@@ -8995,11 +8995,15 @@ class HermesCLI:
         try:
             from hermes_cli.config import load_config
             _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _voice_key = _raw_key.lower().replace("ctrl+", "c-").replace("alt+", "a-")
+            _raw_lower = _raw_key.lower()
+            if _raw_lower.startswith("alt+"):
+                _voice_key_parts: tuple[str, ...] = ("escape", _raw_lower[4:])
+            else:
+                _voice_key_parts = (_raw_lower.replace("ctrl+", "c-"),)
         except Exception:
-            _voice_key = "c-b"
+            _voice_key_parts = ("c-b",)
 
-        @kb.add(_voice_key)
+        @kb.add(*_voice_key_parts)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 


### PR DESCRIPTION
## Problem

Setting `voice.record_key: alt+b` (or any `alt+*` key) in `config.yaml` crashes Hermes on startup with:

```
ValueError: Invalid key: a-b
```

The conversion `_raw_key.replace("alt+", "a-")` produces `"a-b"`, but prompt_toolkit does not recognise the `a-` prefix as a valid key name.

Closes #11387

## Root Cause

prompt_toolkit represents Alt+key as a two-key escape sequence — `kb.add("escape", "b")` for Alt+B — not as a single `"a-b"` string. The `a-` prefix is not a valid prompt_toolkit key.

## Fix

Parse `alt+` keys into a `("escape", letter)` tuple and splat into `kb.add(*parts)`. Ctrl+ keys keep their existing `"c-x"` string form unchanged. Also fix the display label so it shows `Alt+B` instead of `A-B`.

## Verification

```python
# Before: ValueError on startup
kb.add("a-b")  # → ValueError: Invalid key: a-b

# After: correct two-step escape sequence
kb.add("escape", "b")  # ✅
```

Tested all key formats against `docker.io/nousresearch/hermes-agent:latest` (v0.8.0):

| Config value | Before | After |
|---|---|---|
| `ctrl+b` | ✅ | ✅ |
| `alt+b` | ❌ crash | ✅ |
| `alt+r` | ❌ crash | ✅ |
| `ctrl+r` | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)