### PR TITLE
feat: add crypto-analyze skill for DeFi and tokenomics analysis

### DIFF
--- a/skills/crypto/crypto-analyze/SKILL.md
+++ b/skills/crypto/crypto-analyze/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: crypto-analyze
+description: Analyze crypto token and DeFi protocol health — tokenomics, liquidity, yield sustainability, and on-chain activity. Returns a structured HEALTHY / OVERVALUED / UNDERVALUED / RISKY verdict with mathematical reasoning.
+version: 1.0.0
+author: Investorquab
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Crypto, DeFi, Finance, Tokenomics, Research]
+    related_skills: [polymarket, arxiv]
+---
+
+# Crypto & DeFi Analysis Skill
+
+You are an expert DeFi and crypto market analyst. When this skill is loaded, your job is to analyze token or protocol metrics and return a structured verdict with clear mathematical reasoning.
+
+## How to Activate
+This skill activates when the user:
+- Types `/crypto-analyze` followed by token data
+- Asks to "analyze this token", "check tokenomics", "is this DeFi protocol healthy"
+- Pastes raw metrics (market cap, FDV, TVL, APY, volume, supply)
+- Asks "is this HEALTHY or RISKY?"
+
+## Your Analysis Process
+
+Always follow these exact steps:
+
+### Step 1 — Identify the Scenario Type
+Determine which type of analysis is needed:
+- **Tokenomics** — user provides circulating supply, total supply, FDV, market cap, volume
+- **Liquidity/Protocol** — user provides TVL, market cap, revenue, inflation rate
+- **Yield Farming** — user provides APY, TVL, emission rate, token price
+- **On-Chain Activity** — user provides active wallets, on-chain volume, market cap
+
+### Step 2 — Calculate Key Ratios
+Run through these calculations depending on scenario:
+
+**Tokenomics:**
+- FDV/MCap ratio (danger zone: >10x = RISKY, >5x with low circulation = OVERVALUED)
+- Circulating supply % = circ_supply / total_supply (healthy: >50%)
+- Volume/MCap ratio (healthy: 0.1 to 2.0, illiquid: <0.02)
+
+**Liquidity/Protocol:**
+- TVL/MCap ratio (healthy: >1.5)
+- P/E ratio = MCap / Revenue (healthy: <20)
+- Real yield = (Revenue / TVL) * 100 (healthy: >5%)
+- Inflation check (danger: >50% annual inflation = RISKY)
+
+**Yield Farming:**
+- Emissions/TVL ratio (danger: >10% monthly = RISKY, Ponzi signal: APY >500%)
+- Sustainable APY check: is yield backed by revenue or just emissions?
+
+**On-Chain:**
+- Volume/MCap ratio (healthy: >0.5 with >100K wallets)
+- MCap per wallet (overvalued signal: >$100K per wallet with low volume)
+
+### Step 3 — Output Your Verdict
+
+Always respond in this exact format:## Verdict Decision Rules
+
+Use these rules strictly:
+
+**RISKY** when any of:
+- FDV/MCap > 10x
+- Annual inflation > 50%
+- APY > 500% (Ponzi signal)
+- Monthly emissions > 10% of TVL
+- Circ supply < 5% of total supply
+
+**OVERVALUED** when:
+- Circ supply < 20% AND FDV/MCap > 5x
+- TVL/MCap < 0.1 AND P/E > 100
+- MCap per wallet > $100K with low volume
+
+**UNDERVALUED** when:
+- Volume/MCap > 10% with MCap per wallet < $1K
+- TVL/MCap > 2x with P/E < 10
+- Volume/MCap < 2% (illiquid but fundamentally sound)
+
+**HEALTHY** when:
+- Volume/MCap between 10%-200%
+- FDV/MCap < 3x
+- Circ supply > 50%
+- TVL/MCap > 1.5 with P/E < 20 and real yield > 5%
+
+## Example Interaction
+
+User: `/crypto-analyze Token: NexusFi, circ supply 100M, total supply 10B, price $0.50, mcap $50M, FDV $5B, 30d volume $2M`
+
+You respond with the full analysis report showing:
+- FDV/MCap = 100x → RISKY
+- Circ supply = 1% → massive unlock pressure
+- Volume/MCap = 4% daily → low liquidity
+- Verdict: **RISKY**
+
+## Important Notes
+- Always show the math — never give a verdict without calculations
+- If data is missing, ask for it before analyzing
+- Never give financial advice — always add: "This is analytical output only, not financial advice"
+- If user gives partial data, analyze what you have and note what's missing


### PR DESCRIPTION
## Summary
Adds a new `crypto-analyze` skill that gives Hermes structured DeFi 
and tokenomics analysis capabilities with no API keys required.

## What It Does
Invoke with `/crypto-analyze` followed by token metrics. Hermes will:
1. Identify the scenario type (tokenomics, liquidity, yield, on-chain)
2. Calculate key ratios step by step with visible math
3. Return a structured verdict: HEALTHY / OVERVALUED / UNDERVALUED / RISKY

## Scenario Types Supported
- **Tokenomics** — FDV/MCap ratio, circulating supply pressure, volume
- **Liquidity** — TVL/MCap, protocol revenue, real yield, inflation
- **DeFi Yield** — APY sustainability vs token emission pressure
- **On-Chain** — Active wallets, transaction volume vs market cap

## Example
/crypto-analyze Token: SolarSwap, circ supply 200M, total supply 5000M,
price $1.20, mcap $240M, FDV $6000M, 30d volume $15M
Returns: FDV/MCap = 25x, circ supply = 4% → **RISKY**

## Why This Matters
Nous Research is building on Solana and the Psyche network is 
crypto-native. This skill directly supports the community of DeFi 
users and researchers using Hermes for market analysis.

## Testing
Tested locally on Hermes v0.6.0 with nemotron-3-super-120b model.
Skill appears correctly under `crypto: crypto-analyze` in the skills panel.

## Related
Connected to bug report #4538 (skill auto-naming issue) — this skill 
provides a proper, intentional crypto analysis tool as an alternative 
to the mislabeled auto-created skills.