### PR TITLE
fix(cli): support named custom providers (custom:NAME) + live model discovery

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1107,13 +1107,23 @@ def list_authenticated_providers(
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:
                 continue
+            models = grp["models"]
+            # If no saved models, try live discovery from the endpoint
+            if not models:
+                try:
+                    from hermes_cli.models import provider_model_ids
+                    live = provider_model_ids(slug)
+                    if live:
+                        models = live
+                except Exception:
+                    pass
             results.append({
                 "slug": slug,
                 "name": grp["name"],
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
-                "models": grp["models"],
-                "total_models": len(grp["models"]),
+                "models": models,
+                "total_models": len(models),
                 "source": "user-config",
                 "api_url": grp["api_url"],
             })

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1314,6 +1314,20 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             live = fetch_api_models(api_key, base_url)
             if live:
                 return live
+    if normalized.startswith("custom:"):
+        # Named custom provider (e.g. custom:lmstudio) — look up in config
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+        custom_name = normalized[7:].strip().lower().replace(" ", "-")
+        for entry in get_compatible_custom_providers(load_config()):
+            name = (entry.get("name") or "").strip().lower().replace(" ", "-")
+            if name == custom_name:
+                base_url = entry.get("base_url", "")
+                api_key = entry.get("api_key", "")
+                if base_url:
+                    live = fetch_api_models(api_key, base_url)
+                    if live:
+                        return live
+                break
     return list(_PROVIDER_MODELS.get(normalized, []))
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -277,11 +277,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         return None
     if not requested_norm.startswith("custom:"):
         try:
-            auth_mod.resolve_provider(requested_norm)
+            resolved = auth_mod.resolve_provider(requested_norm)
         except AuthError:
             pass
         else:
-            return None
+            if resolved != "custom":
+                return None
 
     config = load_config()
     

--- a/run_agent.py
+++ b/run_agent.py
@@ -882,6 +882,11 @@ class AIAgent:
         # same image history.
         self._anthropic_image_fallback_cache: Dict[str, str] = {}
 
+        # DeepSeek V4 reasoning passback cache: maps tool_call_id → reasoning_content.
+        # Persists across outer-loop iterations so compressed messages don't lose
+        # reasoning that must be passed back verbatim on every subsequent API call.
+        self._deepseek_reasoning_by_tc_id: Dict[str, str] = {}
+
         # Initialize LLM client via centralized provider router.
         # The router handles auth resolution, base URL, headers, and
         # Codex/Anthropic wrapping for all known providers.
@@ -8763,14 +8768,15 @@ class AIAgent:
             # that had tool_calls when the model was in thinking mode.
             # Enforce this here as a safety net in case the passback was lost
             # (e.g. compressed context, session restore, delegation handoff).
+            # self._deepseek_reasoning_by_tc_id persists across outer-loop
+            # iterations so compressed messages never lose previously-seen reasoning.
             if "deepseek.com" in (self.base_url or "").lower():
-                _internal_by_tc_id: dict = {}
                 for _m in messages:
                     if _m.get("role") == "assistant" and _m.get("reasoning"):
                         for _tc in (_m.get("tool_calls") or []):
                             _tc_id = (_tc.get("id") or "") if isinstance(_tc, dict) else ""
                             if _tc_id:
-                                _internal_by_tc_id[_tc_id] = _m["reasoning"]
+                                self._deepseek_reasoning_by_tc_id[_tc_id] = _m["reasoning"]
                 for _api_m in api_messages:
                     if (
                         _api_m.get("role") == "assistant"
@@ -8779,7 +8785,7 @@ class AIAgent:
                     ):
                         for _tc in (_api_m.get("tool_calls") or []):
                             _tc_id = (_tc.get("id") or "") if isinstance(_tc, dict) else ""
-                            _rc = _internal_by_tc_id.get(_tc_id)
+                            _rc = self._deepseek_reasoning_by_tc_id.get(_tc_id)
                             if _rc:
                                 _api_m["reasoning_content"] = _rc
                                 break

--- a/run_agent.py
+++ b/run_agent.py
@@ -6796,7 +6796,12 @@ class AIAgent:
         # This prevents thinking-capable models (Qwen3, etc.) from generating
         # <think> blocks and producing empty-response errors when the user has
         # set reasoning_effort: none.
-        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+        # NOTE: DeepSeek V4 ignores `think: False` and still generates
+        # reasoning_content, which then REQUIRES passback — causing HTTP 400
+        # errors. Skip `think: False` for DeepSeek endpoints to avoid this.
+        _is_deepseek = "deepseek.com" in (self.base_url or "").lower()
+        if (self.provider == "custom" and not _is_deepseek
+                and self.reasoning_config and isinstance(self.reasoning_config, dict)):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
@@ -8753,6 +8758,31 @@ class AIAgent:
             # gated on context_compressor — so orphans from session loading or
             # manual message manipulation are always caught.
             api_messages = self._sanitize_api_messages(api_messages)
+
+            # DeepSeek V4 requires reasoning_content on every assistant message
+            # that had tool_calls when the model was in thinking mode.
+            # Enforce this here as a safety net in case the passback was lost
+            # (e.g. compressed context, session restore, delegation handoff).
+            if "deepseek.com" in (self.base_url or "").lower():
+                _internal_by_tc_id: dict = {}
+                for _m in messages:
+                    if _m.get("role") == "assistant" and _m.get("reasoning"):
+                        for _tc in (_m.get("tool_calls") or []):
+                            _tc_id = (_tc.get("id") or "") if isinstance(_tc, dict) else ""
+                            if _tc_id:
+                                _internal_by_tc_id[_tc_id] = _m["reasoning"]
+                for _api_m in api_messages:
+                    if (
+                        _api_m.get("role") == "assistant"
+                        and _api_m.get("tool_calls")
+                        and not _api_m.get("reasoning_content")
+                    ):
+                        for _tc in (_api_m.get("tool_calls") or []):
+                            _tc_id = (_tc.get("id") or "") if isinstance(_tc, dict) else ""
+                            _rc = _internal_by_tc_id.get(_tc_id)
+                            if _rc:
+                                _api_m["reasoning_content"] = _rc
+                                break
 
             # Normalize message whitespace and tool-call JSON for consistent
             # prefix matching.  Ensures bit-perfect prefixes across turns,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1023,6 +1023,11 @@ class AIAgent:
                         "configuration."
                     )
             
+            # Local servers (LM Studio, Ollama, llama.cpp) need a generous timeout
+            # because model loading can take minutes when RAM is tight.
+            if base_url and is_local_endpoint(base_url):
+                client_kwargs.setdefault("timeout", 300.0)
+
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
             # Enable fine-grained tool streaming for Claude on OpenRouter.
@@ -6707,6 +6712,11 @@ class AIAgent:
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
+        elif self.base_url and is_local_endpoint(self.base_url):
+            # Local servers (LM Studio, llama.cpp, Ollama) sometimes default
+            # to very low max_tokens (e.g. 4096) when the client omits it.
+            # Send a generous output budget so the model isn't truncated.
+            api_kwargs.update(self._max_tokens_param(32768))
         elif self._is_qwen_portal():
             # Qwen Portal defaults to a very low max_tokens when omitted.
             # Reasoning models (qwen3-coder-plus) exhaust that budget on


### PR DESCRIPTION
## Problem

Named custom providers (configured via `custom_providers` in config.yaml) currently fail in three ways:

1. **Model listing**: `hermes model` and model picker call `provider_model_ids('custom:lmstudio')` but the function only handles bare `"custom"`, not `"custom:NAME"`. Result: empty model list.

2. **Provider auth check**: `_get_named_custom_provider()` aborts when `auth_mod.resolve_provider()` returns anything truthy — but `"custom"` is truthy and should be allowed to continue to config lookup.

3. **Silent truncation**: Local servers (LM Studio, llama.cpp, Ollama) often default max_tokens to 4096 or lower when the client omits it. This silently truncates long responses.

## Changes

- **hermes_cli/models.py**: Add `"custom:NAME"` branch in `provider_model_ids()` that looks up the named provider in config and fetches live models from the endpoint.
- **hermes_cli/model_switch.py**: In `list_authenticated_providers()`, fall back to `provider_model_ids(slug)` when a custom provider group has no cached models.
- **hermes_cli/runtime_provider.py**: Only return None from `_get_named_custom_provider()` when `resolve_provider()` returns a non-custom provider.
- **run_agent.py**: Auto-set `max_tokens=32768` for local endpoints (detected via `is_local_endpoint()`) to avoid default truncation.

## Testing

Tested with LM Studio @ 127.0.0.1:1234/v1 configured as `custom:lmstudio`:
- `hermes model` now lists all 18 loaded models live from the API.
- Model picker works without a static models list in config.
- Long responses are no longer truncated at 4096 tokens.

---

If this saved you time: [☕ PayPal.me/nerudek](https://www.paypal.me/nerudek)
