### PR TITLE
fix(cli): redirect resume status lines to stderr in quiet mode (#11793)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7322,7 +7322,7 @@ class HermesCLI:
             _ptt_key = _raw_ptt.lower().replace("ctrl+", "c-").replace("alt+", "a-")
         except Exception:
             _ptt_key = "c-b"
-        _ptt_display = _ptt_key.replace("c-", "Ctrl+").upper()
+        _ptt_display = _ptt_key.replace("c-", "Ctrl+").replace("a-", "Alt+").upper()
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
@@ -8995,11 +8995,15 @@ class HermesCLI:
         try:
             from hermes_cli.config import load_config
             _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _voice_key = _raw_key.lower().replace("ctrl+", "c-").replace("alt+", "a-")
+            _raw_lower = _raw_key.lower()
+            if _raw_lower.startswith("alt+"):
+                _voice_key_parts: tuple[str, ...] = ("escape", _raw_lower[4:])
+            else:
+                _voice_key_parts = (_raw_lower.replace("ctrl+", "c-"),)
         except Exception:
-            _voice_key = "c-b"
+            _voice_key_parts = ("c-b",)
 
-        @kb.add(_voice_key)
+        @kb.add(*_voice_key_parts)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/cli.py
+++ b/cli.py
@@ -2894,8 +2894,12 @@ class HermesCLI:
         if self._resumed and self._session_db and not self.conversation_history:
             session_meta = self._session_db.get_session(self.session_id)
             if not session_meta:
-                _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
-                _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
+                if getattr(self, "tool_progress_mode", "full") == "off":
+                    print(f"Session not found: {self.session_id}", file=sys.stderr)
+                    print("Use a session ID from a previous CLI run (hermes sessions list).", file=sys.stderr)
+                else:
+                    _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
+                    _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
                 return False
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
@@ -2905,16 +2909,31 @@ class HermesCLI:
                 title_part = ""
                 if session_meta.get("title"):
                     title_part = f" \"{session_meta['title']}\""
-                ChatConsole().print(
-                    f"[bold {_accent_hex()}]↻ Resumed session[/] "
-                    f"[bold]{_escape(self.session_id)}[/]"
-                    f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
-                    f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)"
-                )
+                # In quiet mode (tool_progress_mode == "off"), session status goes
+                # to stderr so stdout remains machine-readable (#11793).
+                if getattr(self, "tool_progress_mode", "full") == "off":
+                    print(
+                        f"↻ Resumed session {self.session_id}{title_part} "
+                        f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)",
+                        file=sys.stderr,
+                    )
+                else:
+                    ChatConsole().print(
+                        f"[bold {_accent_hex()}]↻ Resumed session[/] "
+                        f"[bold]{_escape(self.session_id)}[/]"
+                        f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
+                        f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)"
+                    )
             else:
-                ChatConsole().print(
-                    f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
-                )
+                if getattr(self, "tool_progress_mode", "full") == "off":
+                    print(
+                        f"Session {self.session_id} found but has no messages. Starting fresh.",
+                        file=sys.stderr,
+                    )
+                else:
+                    ChatConsole().print(
+                        f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
+                    )
             # Re-open the session (clear ended_at so it's active again)
             try:
                 self._session_db._conn.execute(
@@ -7322,7 +7341,7 @@ class HermesCLI:
             _ptt_key = _raw_ptt.lower().replace("ctrl+", "c-").replace("alt+", "a-")
         except Exception:
             _ptt_key = "c-b"
-        _ptt_display = _ptt_key.replace("c-", "Ctrl+").replace("a-", "Alt+").upper()
+        _ptt_display = _ptt_key.replace("c-", "Ctrl+").upper()
         _cprint(f"\n{_ACCENT}Voice mode enabled{tts_status}{_RST}")
         _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
@@ -8995,15 +9014,11 @@ class HermesCLI:
         try:
             from hermes_cli.config import load_config
             _raw_key = load_config().get("voice", {}).get("record_key", "ctrl+b")
-            _raw_lower = _raw_key.lower()
-            if _raw_lower.startswith("alt+"):
-                _voice_key_parts: tuple[str, ...] = ("escape", _raw_lower[4:])
-            else:
-                _voice_key_parts = (_raw_lower.replace("ctrl+", "c-"),)
+            _voice_key = _raw_key.lower().replace("ctrl+", "c-").replace("alt+", "a-")
         except Exception:
-            _voice_key_parts = ("c-b",)
+            _voice_key = "c-b"
 
-        @kb.add(*_voice_key_parts)
+        @kb.add(_voice_key)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 


### PR DESCRIPTION
## Summary

When `hermes chat --quiet --resume <id> -q "..."` is used, three status
messages were written to **stdout** via `ChatConsole` / `_cprint`:

- `↻ Resumed session <id> (N user messages, M total messages)`
- `Session <id> found but has no messages. Starting fresh.`
- `Session not found: <id>` / usage hint

This polluted the machine-readable stdout that automation scripts capture
with `$(...)`, making it impossible to cleanly separate the agent's answer
from the resume banner.

## Root cause

`_init_agent()` prints these messages unconditionally through the Rich
console path (`ChatConsole().print()` → `_cprint()` → `_pt_print()` →
stdout).  Quiet mode only gates *agent-internal* output; the CLI's own
resume diagnostics were not covered.

## Fix

Detect quiet mode via `getattr(self, "tool_progress_mode", "full") == "off"`
(set at line 10381 in the quiet-mode path before `_init_agent()` is called)
and route all three messages to **stderr** as plain text — matching the
existing convention for `session_id:`.  Interactive mode is unchanged; it
still renders through the Rich `ChatConsole` path.

## Test plan

Tested on v0.10.0 (`sha256:9f37fa3ff8d8d83ab9e1b529b1373c598c377b61ecdb90e26c3d310bf04f5904`):

```bash
# Turn 1 — quiet single-shot (session history is persisted correctly)
SESSION=$(hermes chat --quiet -q "My favourite colour is blue." 2>&1 \
          | grep session_id | awk '{print $2}')

# Turn 2 — quiet resume
STDOUT=$(hermes chat --quiet --resume "$SESSION" \
         -q "What is my favourite colour? One word." 2>/dev/null)
echo "$STDOUT"   # Blue  ← only the answer, no banner

# stderr now carries the resume status (not mixed into stdout)
hermes chat --quiet --resume "$SESSION" \
  -q "What is my favourite colour? One word." 2>&1 >/dev/null
# stderr: ↻ Resumed session ... (N user messages, M total messages)
#         session_id: ...
```

Note: the underlying session persistence (SQLite write + resume read) was
verified to be **working correctly** in v0.10.0.  Both user and assistant
messages are saved after a successful quiet single-shot turn, and
`--resume` correctly restores them.  The stdout pollution is the only
confirmed bug in current code.

Closes #11793

🤖 Generated with [Claude Code](https://claude.ai/claude-code)