### PR TITLE
feat(cli): add `/openmd` command to render LLM response in openmd (markdown viewer)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3663,6 +3663,62 @@ class HermesCLI:
         elif _is_termux_environment():
             _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {_termux_example_image_path(image_path.name)} \"What do you see?\"{_RST}")
 
+    def _handle_openmd_command(self, cmd_original: str):
+        """Handle /openmd [offset] — render an LLM response in openmd."""
+        import shutil
+        import subprocess
+
+        if not shutil.which("openmd"):
+            _cprint(f"  {_DIM}openmd is not installed or not in PATH.{_RST}")
+            _cprint(f"  {_DIM}Install it with: uv tool install openmd{_RST}")
+            return
+
+        # Parse offset (default to 1, meaning the last LLM message)
+        parts = cmd_original.split()
+        offset = 1
+        if len(parts) > 1:
+            try:
+                offset = int(parts[1])
+                if offset < 1:
+                    raise ValueError
+            except ValueError:
+                _cprint(f"  {_DIM}Invalid offset. Usage: /openmd [number]{_RST}")
+                return
+
+        # Extract LLM messages from history
+        llm_messages = [
+            msg.get("content", "")
+            for msg in self.conversation_history
+            if msg.get("role") == "assistant" and msg.get("content")
+        ]
+
+        if not llm_messages:
+            _cprint(f"  {_DIM}(._.) No LLM messages found in history.{_RST}")
+            return
+
+        if offset > len(llm_messages):
+            _cprint(f"  {_DIM}(._.) Only {len(llm_messages)} LLM message(s) available.{_RST}")
+            return
+
+        # Get the target message (offset 1 is the last one)
+        target_content = llm_messages[-offset]
+
+        try:
+            # Launch openmd and pipe the content via stdin.
+            # openmd is non-blocking and detaches its own Qt window,
+            # so we don't need start_new_session=True here.
+            process = subprocess.Popen(
+                ["openmd"],
+                stdin=subprocess.PIPE,
+                text=True
+            )
+            process.stdin.write(target_content)
+            process.stdin.close()
+
+            _cprint(f"  {_DIM}Opened message {offset} ago in openmd.{_RST}")
+        except Exception as e:
+            _cprint(f"\033[1;31mFailed to launch openmd: {e}{_RST}")
+
     def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
 
@@ -5665,6 +5721,8 @@ class HermesCLI:
             self._handle_paste_command()
         elif canonical == "image":
             self._handle_image_command(cmd_original)
+        elif canonical == "openmd":
+            self._handle_openmd_command(cmd_original)
         elif canonical == "reload":
             from hermes_cli.config import reload_env
             count = reload_env()

--- a/cli.py
+++ b/cli.py
@@ -6432,55 +6432,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
 
 
-    def _handle_openmd_command(self, cmd_original: str) -> None:
-        """Handle /openmd [number] — render an assistant response in openmd."""
-        import subprocess
-
-        if not shutil.which("openmd"):
-            _cprint(f"  {_DIM}openmd is not installed or not in PATH.{_RST}")
-            _cprint(f"  {_DIM}Install it with: uv tool install openmd{_RST}")
-            return
-
-        parts = cmd_original.split(maxsplit=1)
-        arg = parts[1].strip() if len(parts) > 1 else ""
-
-        assistant = [m for m in self.conversation_history if m.get("role") == "assistant"]
-        if not assistant:
-            _cprint("  Nothing to open yet.")
-            return
-
-        if arg:
-            try:
-                idx = int(arg) - 1
-            except ValueError:
-                _cprint("  Usage: /openmd [number]")
-                return
-            if idx < 0 or idx >= len(assistant):
-                _cprint(f"  Invalid response number. Use 1-{len(assistant)}.")
-                return
-        else:
-            idx = len(assistant) - 1
-            while idx >= 0 and not _assistant_copy_text(assistant[idx].get("content")):
-                idx -= 1
-            if idx < 0:
-                _cprint("  Nothing to open in assistant responses yet.")
-                return
-
-        text = _assistant_copy_text(assistant[idx].get("content"))
-        if not text:
-            _cprint("  Nothing to open in that assistant response.")
-            return
-
-        try:
-            # openmd is non-blocking and detaches its own Qt window.
-            process = subprocess.Popen(["openmd"], stdin=subprocess.PIPE, text=True)
-            assert process.stdin is not None
-            process.stdin.write(text)
-            process.stdin.close()
-            _cprint(f"  Opened assistant response #{idx + 1} in openmd.")
-        except Exception as e:
-            _cprint(f"\033[1;31mFailed to launch openmd: {e}{_RST}")
-
     def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
 

--- a/cli.py
+++ b/cli.py
@@ -6432,6 +6432,55 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
 
 
+    def _handle_openmd_command(self, cmd_original: str) -> None:
+        """Handle /openmd [number] — render an assistant response in openmd."""
+        import subprocess
+
+        if not shutil.which("openmd"):
+            _cprint(f"  {_DIM}openmd is not installed or not in PATH.{_RST}")
+            _cprint(f"  {_DIM}Install it with: uv tool install openmd{_RST}")
+            return
+
+        parts = cmd_original.split(maxsplit=1)
+        arg = parts[1].strip() if len(parts) > 1 else ""
+
+        assistant = [m for m in self.conversation_history if m.get("role") == "assistant"]
+        if not assistant:
+            _cprint("  Nothing to open yet.")
+            return
+
+        if arg:
+            try:
+                idx = int(arg) - 1
+            except ValueError:
+                _cprint("  Usage: /openmd [number]")
+                return
+            if idx < 0 or idx >= len(assistant):
+                _cprint(f"  Invalid response number. Use 1-{len(assistant)}.")
+                return
+        else:
+            idx = len(assistant) - 1
+            while idx >= 0 and not _assistant_copy_text(assistant[idx].get("content")):
+                idx -= 1
+            if idx < 0:
+                _cprint("  Nothing to open in assistant responses yet.")
+                return
+
+        text = _assistant_copy_text(assistant[idx].get("content"))
+        if not text:
+            _cprint("  Nothing to open in that assistant response.")
+            return
+
+        try:
+            # openmd is non-blocking and detaches its own Qt window.
+            process = subprocess.Popen(["openmd"], stdin=subprocess.PIPE, text=True)
+            assert process.stdin is not None
+            process.stdin.write(text)
+            process.stdin.close()
+            _cprint(f"  Opened assistant response #{idx + 1} in openmd.")
+        except Exception as e:
+            _cprint(f"\033[1;31mFailed to launch openmd: {e}{_RST}")
+
     def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
 
@@ -8781,6 +8830,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_paste_command()
         elif canonical == "image":
             self._handle_image_command(cmd_original)
+        elif canonical == "openmd":
+            self._handle_openmd_command(cmd_original)
         elif canonical == "reload":
             from hermes_cli.config import reload_env
             count = reload_env()

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -397,6 +397,65 @@ class CLICommandsMixin:
         except Exception as e:
             _cprint(f"  Clipboard copy failed: {e}")
 
+    def _handle_openmd_command(self, cmd_original: str) -> None:
+        """Handle /openmd [number] — render an assistant response in openmd."""
+        import shutil
+        import subprocess
+
+        from hermes_cli._subprocess_compat import windows_hide_flags
+        from cli import _DIM, _RST, _assistant_copy_text, _cprint
+
+        if not shutil.which("openmd"):
+            _cprint(f"  {_DIM}openmd is not installed or not in PATH.{_RST}")
+            _cprint(f"  {_DIM}Install it with: uv tool install openmd{_RST}")
+            return
+
+        parts = cmd_original.split(maxsplit=1)
+        arg = parts[1].strip() if len(parts) > 1 else ""
+
+        assistant = [m for m in self.conversation_history if m.get("role") == "assistant"]
+        if not assistant:
+            _cprint("  Nothing to open yet.")
+            return
+
+        if arg:
+            try:
+                idx = int(arg) - 1
+            except ValueError:
+                _cprint("  Usage: /openmd [number]")
+                return
+            if idx < 0 or idx >= len(assistant):
+                _cprint(f"  Invalid response number. Use 1-{len(assistant)}.")
+                return
+        else:
+            idx = len(assistant) - 1
+            while idx >= 0 and not _assistant_copy_text(assistant[idx].get("content")):
+                idx -= 1
+            if idx < 0:
+                _cprint("  Nothing to open in assistant responses yet.")
+                return
+
+        text = _assistant_copy_text(assistant[idx].get("content"))
+        if not text:
+            _cprint("  Nothing to open in that assistant response.")
+            return
+
+        try:
+            # openmd detaches its own Qt window; CREATE_NO_WINDOW avoids a
+            # console flash when spawning the .exe on Windows.
+            process = subprocess.Popen(
+                ["openmd"],
+                stdin=subprocess.PIPE,
+                text=True,
+                creationflags=windows_hide_flags(),
+            )
+            assert process.stdin is not None
+            process.stdin.write(text)
+            process.stdin.close()
+            _cprint(f"  Opened assistant response #{idx + 1} in openmd.")
+        except Exception as e:
+            _cprint(f"\033[1;31mFailed to launch openmd: {e}{_RST}")
+
     def _handle_image_command(self, cmd_original: str):
         """Handle /image <path> — attach a local image file for the next prompt."""
         from cli import _DIM, _IMAGE_EXTENSIONS, _RST, _cprint, _resolve_attachment_path, _split_path_input, _termux_example_image_path

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -163,6 +163,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("image", "Attach a local image file for your next prompt", "Info",
                cli_only=True, args_hint="<path>"),
+    CommandDef("openmd", "Open the last LLM response in openmd (Markdown viewer)", "Info",
+               cli_only=True, args_hint="[offset]"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -245,6 +245,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("image", "Attach a local image file for your next prompt", "Info",
                cli_only=True, args_hint="<path>"),
+    CommandDef("openmd", "Open an assistant response in openmd (Markdown viewer)", "Info",
+               cli_only=True, args_hint="[number]"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",)),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -245,7 +245,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("image", "Attach a local image file for your next prompt", "Info",
                cli_only=True, args_hint="<path>"),
-    CommandDef("openmd", "Open an assistant response in openmd (Markdown viewer)", "Info",
+    CommandDef("openmd", "View a Markdown response in openmd", "Info",
                cli_only=True, args_hint="[number]"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info"),
     CommandDef("version", "Show Hermes Agent version", "Info", aliases=("v",)),

--- a/tests/cli/test_cli_openmd_command.py
+++ b/tests/cli/test_cli_openmd_command.py
@@ -1,0 +1,123 @@
+"""Tests for CLI /openmd command."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli() -> HermesCLI:
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = "sess-openmd-test"
+    cli_obj._pending_input = MagicMock()
+    cli_obj._app = None
+    return cli_obj
+
+
+def test_openmd_pipes_latest_assistant_message():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "first"},
+        {"role": "assistant", "content": "latest"},
+    ]
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+
+    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+        "subprocess.Popen", return_value=mock_proc
+    ) as mock_popen, patch("cli._cprint"):
+        result = cli_obj.process_command("/openmd")
+
+    assert result is True
+    mock_popen.assert_called_once_with(["openmd"], stdin=-1, text=True)
+    mock_proc.stdin.write.assert_called_once_with("latest")
+    mock_proc.stdin.close.assert_called_once()
+
+
+def test_openmd_with_index_uses_requested_assistant_message():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [
+        {"role": "assistant", "content": "one"},
+        {"role": "assistant", "content": "two"},
+    ]
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+
+    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+        "subprocess.Popen", return_value=mock_proc
+    ), patch("cli._cprint"):
+        cli_obj.process_command("/openmd 1")
+
+    mock_proc.stdin.write.assert_called_once_with("one")
+
+
+def test_openmd_strips_reasoning_blocks_before_piping():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [
+        {
+            "role": "assistant",
+            "content": "<REASONING_SCRATCHPAD>internal</REASONING_SCRATCHPAD>\nVisible answer",
+        }
+    ]
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+
+    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+        "subprocess.Popen", return_value=mock_proc
+    ), patch("cli._cprint"):
+        cli_obj.process_command("/openmd")
+
+    mock_proc.stdin.write.assert_called_once_with("Visible answer")
+
+
+def test_openmd_extracts_text_from_multipart_content():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "world"},
+            ],
+        }
+    ]
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+
+    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+        "subprocess.Popen", return_value=mock_proc
+    ), patch("cli._cprint"):
+        cli_obj.process_command("/openmd")
+
+    mock_proc.stdin.write.assert_called_once_with("Hello\nworld")
+
+
+def test_openmd_not_installed_does_not_launch():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "hello"}]
+
+    with patch("cli.shutil.which", return_value=None), patch(
+        "subprocess.Popen"
+    ) as mock_popen, patch("cli._cprint") as mock_print:
+        cli_obj.process_command("/openmd")
+
+    mock_popen.assert_not_called()
+    rendered = " ".join(str(arg) for call in mock_print.call_args_list for arg in call.args)
+    assert "openmd is not installed" in rendered
+
+
+def test_openmd_invalid_index_does_not_launch():
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "only"}]
+
+    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+        "subprocess.Popen"
+    ) as mock_popen, patch("cli._cprint") as mock_print:
+        cli_obj.process_command("/openmd 99")
+
+    mock_popen.assert_not_called()
+    assert any("Invalid response number" in str(call) for call in mock_print.call_args_list)

--- a/tests/cli/test_cli_openmd_command.py
+++ b/tests/cli/test_cli_openmd_command.py
@@ -1,8 +1,10 @@
 """Tests for CLI /openmd command."""
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
+from hermes_cli import _subprocess_compat as subprocess_compat
 
 
 def _make_cli() -> HermesCLI:
@@ -27,13 +29,18 @@ def test_openmd_pipes_latest_assistant_message():
     mock_proc = MagicMock()
     mock_proc.stdin = MagicMock()
 
-    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+    with patch("shutil.which", return_value="/usr/bin/openmd"), patch(
         "subprocess.Popen", return_value=mock_proc
     ) as mock_popen, patch("cli._cprint"):
         result = cli_obj.process_command("/openmd")
 
     assert result is True
-    mock_popen.assert_called_once_with(["openmd"], stdin=-1, text=True)
+    mock_popen.assert_called_once_with(
+        ["openmd"],
+        stdin=subprocess.PIPE,
+        text=True,
+        creationflags=0,
+    )
     mock_proc.stdin.write.assert_called_once_with("latest")
     mock_proc.stdin.close.assert_called_once()
 
@@ -47,7 +54,7 @@ def test_openmd_with_index_uses_requested_assistant_message():
     mock_proc = MagicMock()
     mock_proc.stdin = MagicMock()
 
-    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+    with patch("shutil.which", return_value="/usr/bin/openmd"), patch(
         "subprocess.Popen", return_value=mock_proc
     ), patch("cli._cprint"):
         cli_obj.process_command("/openmd 1")
@@ -66,7 +73,7 @@ def test_openmd_strips_reasoning_blocks_before_piping():
     mock_proc = MagicMock()
     mock_proc.stdin = MagicMock()
 
-    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+    with patch("shutil.which", return_value="/usr/bin/openmd"), patch(
         "subprocess.Popen", return_value=mock_proc
     ), patch("cli._cprint"):
         cli_obj.process_command("/openmd")
@@ -88,7 +95,7 @@ def test_openmd_extracts_text_from_multipart_content():
     mock_proc = MagicMock()
     mock_proc.stdin = MagicMock()
 
-    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+    with patch("shutil.which", return_value="/usr/bin/openmd"), patch(
         "subprocess.Popen", return_value=mock_proc
     ), patch("cli._cprint"):
         cli_obj.process_command("/openmd")
@@ -100,7 +107,7 @@ def test_openmd_not_installed_does_not_launch():
     cli_obj = _make_cli()
     cli_obj.conversation_history = [{"role": "assistant", "content": "hello"}]
 
-    with patch("cli.shutil.which", return_value=None), patch(
+    with patch("shutil.which", return_value=None), patch(
         "subprocess.Popen"
     ) as mock_popen, patch("cli._cprint") as mock_print:
         cli_obj.process_command("/openmd")
@@ -114,10 +121,34 @@ def test_openmd_invalid_index_does_not_launch():
     cli_obj = _make_cli()
     cli_obj.conversation_history = [{"role": "assistant", "content": "only"}]
 
-    with patch("cli.shutil.which", return_value="/usr/bin/openmd"), patch(
+    with patch("shutil.which", return_value="/usr/bin/openmd"), patch(
         "subprocess.Popen"
     ) as mock_popen, patch("cli._cprint") as mock_print:
         cli_obj.process_command("/openmd 99")
 
     mock_popen.assert_not_called()
     assert any("Invalid response number" in str(call) for call in mock_print.call_args_list)
+
+
+def test_openmd_windows_popen_passes_create_no_window():
+    """On Windows, Popen must pass CREATE_NO_WINDOW to avoid a console flash."""
+    cli_obj = _make_cli()
+    cli_obj.conversation_history = [{"role": "assistant", "content": "hello"}]
+    mock_proc = MagicMock()
+    mock_proc.stdin = MagicMock()
+
+    with patch("shutil.which", return_value=r"C:\Tools\openmd.exe"), patch(
+        "subprocess.Popen", return_value=mock_proc
+    ) as mock_popen, patch.object(
+        subprocess_compat, "IS_WINDOWS", True
+    ), patch("cli._cprint"):
+        expected_flags = subprocess_compat.windows_hide_flags()
+        cli_obj.process_command("/openmd")
+
+    mock_popen.assert_called_once()
+    kwargs = mock_popen.call_args.kwargs
+    assert expected_flags == 0x08000000  # CREATE_NO_WINDOW
+    assert kwargs["creationflags"] == expected_flags
+    assert kwargs["stdin"] is subprocess.PIPE
+    assert kwargs["text"] is True
+    mock_proc.stdin.write.assert_called_once_with("hello")

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -118,6 +118,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/platforms` (alias: `/gateway`) | Show gateway/messaging platform status (CLI-only summary view). |
 | `/paste` | Attach a clipboard image |
 | `/copy [number]` | Copy the last assistant response to clipboard (or the Nth-from-last with a number). CLI-only. |
+| `/openmd [number]` | Open the last assistant response in markdown viewer [`openmd`](https://github.com/RufusLin/openmd) (or the Nth-from-last with a number). Optional; requires `openmd` on PATH (`uv tool install openmd`). CLI-only. |
 | `/image <path>` | Attach a local image file for your next prompt. |
 | `/debug` | Upload debug report (system info + logs) and get shareable links. Also available in messaging. |
 | `/profile` | Show active profile name and home directory |
@@ -250,7 +251,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 
 ## Notes
 
-- `/skin`, `/snapshot`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/handoff`, `/billing`, and `/quit` are **CLI-only** commands.
+- `/skin`, `/snapshot`, `/reload`, `/tools`, `/toolsets`, `/browser`, `/config`, `/cron`, `/platforms`, `/paste`, `/image`, `/statusbar`, `/plugins`, `/busy`, `/indicator`, `/redraw`, `/clear`, `/history`, `/save`, `/copy`, `/openmd`, `/handoff`, `/billing`, and `/quit` are **CLI-only** commands.
 - `/skills` is **CLI-only for search/browse/install**; its write-approval review subcommands (`pending`, `approve`, `reject`, `diff`, `approval`) also work on messaging platforms when `skills.write_approval` is on. `/memory` works on **both** surfaces.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, `/platform`, and `/commands` are **messaging-only** commands.


### PR DESCRIPTION
## What does this PR do?

Adds an optional `/openmd` slash command to the CLI. This command pipes the last LLM response (or the Nth-last response via `/openmd N`) to `openmd`, an open source Markdown viewer.

LLMs love markdown, but reading raw markdown with complex tables, Mermaid diagrams, or KaTeX math in the terminal window can be tedious for us humans. The openmd slash command provides a fast, zero-friction bridge from the Hermes Agent CLI to openmd, popping up instantly, rendering the markdown, and closing with an ESC. It's a PySide6 Qt window, completely independent of the Hermes CLI, so no impact on user workflow. The integration is completely optional and degrades gracefully: if the user does not have `openmd` installed, the command simply prints a helpful installation hint (`uv tool install openmd`) and exits. It adds no new dependencies to `pyproject.toml`.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `CommandDef` for `openmd` in `hermes_cli/commands.py`
- Added `_handle_openmd_command` dispatch and implementation in `cli.py`.

## How to Test

1. Start the CLI: `hermes`
2. Ask the agent to generate a complex markdown table or mermaid diagram.
3. Run `/openmd`. If `openmd` is not installed, verify the helpful error message appears.
4. Install the viewer (`uv tool install openmd`) and run `/openmd` again. Verify the Qt window opens instantly with the rendered markdown, and the Hermes CLI remains interactive.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->