### PR TITLE
fix(discord): ignore unsupported attachments when typing messages

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2831,27 +2831,35 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_threaded_channel = thread
                     self._threads.mark(thread_id)
 
-        # Determine message type
+        # Determine message type. Unsupported attachments should not lock the
+        # event into TEXT ahead of later valid media, but once we see the
+        # first supported attachment we keep that type even if caching later
+        # fails or the file is oversized.
         msg_type = MessageType.TEXT
         if message.content.startswith("/"):
             msg_type = MessageType.COMMAND
         elif message.attachments:
-            # Check attachment types
             for att in message.attachments:
-                if att.content_type:
-                    if att.content_type.startswith("image/"):
-                        msg_type = MessageType.PHOTO
-                    elif att.content_type.startswith("video/"):
-                        msg_type = MessageType.VIDEO
-                    elif att.content_type.startswith("audio/"):
-                        msg_type = MessageType.AUDIO
-                    else:
-                        doc_ext = ""
-                        if att.filename:
-                            _, doc_ext = os.path.splitext(att.filename)
-                            doc_ext = doc_ext.lower()
-                        if doc_ext in SUPPORTED_DOCUMENT_TYPES:
-                            msg_type = MessageType.DOCUMENT
+                content_type = att.content_type or ""
+                if content_type.startswith("image/"):
+                    msg_type = MessageType.PHOTO
+                    break
+                if content_type.startswith("video/"):
+                    msg_type = MessageType.VIDEO
+                    break
+                if content_type.startswith("audio/"):
+                    msg_type = MessageType.AUDIO
+                    break
+
+                doc_ext = ""
+                if att.filename:
+                    _, doc_ext = os.path.splitext(att.filename)
+                    doc_ext = doc_ext.lower()
+                if not doc_ext and content_type:
+                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    doc_ext = mime_to_ext.get(content_type, "")
+                if doc_ext in SUPPORTED_DOCUMENT_TYPES:
+                    msg_type = MessageType.DOCUMENT
                     break
 
         # When auto-threading kicked in, route responses to the new thread

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -383,3 +383,28 @@ class TestIncomingDocumentHandling:
         assert event.message_type == MessageType.PHOTO
         assert event.media_urls == ["/tmp/cached_image.png"]
         assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_attachment_before_image_still_classifies_as_photo(self, adapter):
+        """Later supported media should decide the final message type."""
+        with patch(
+            "gateway.platforms.discord.cache_image_from_url",
+            new_callable=AsyncMock,
+            return_value="/tmp/cached_image.png",
+        ):
+            msg = make_message([
+                make_attachment(
+                    filename="blob.bin",
+                    content_type="application/octet-stream",
+                ),
+                make_attachment(
+                    filename="photo.png",
+                    content_type="image/png",
+                ),
+            ])
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/cached_image.png"]
+        assert event.media_types == ["image/png"]


### PR DESCRIPTION
## Summary
- keep scanning Discord attachments until the first supported media type is found instead of breaking on the first unsupported content_type
- preserve existing document semantics for oversized or failed downloads while fixing mixed unsupported-plus-image cases
- add a regression test covering an unsupported attachment followed by an image

## Testing
- python3 -m pytest -o addopts='' tests/gateway/test_discord_document_handling.py
- python3 -m pytest -o addopts='' tests/gateway/test_discord_attachment_download.py

Closes #11771