### PR TITLE
feat(feishu): support outbound @ mention in messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -160,6 +160,7 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
+_OUTBOUND_MENTION_RE = re.compile(r"@ou_[a-zA-Z0-9]+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
 # ---------------------------------------------------------------------------
@@ -547,11 +548,24 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 
 
 def _build_markdown_post_payload(content: str) -> str:
-    rows = _build_markdown_post_rows(content)
+    # Split content by @ou_xxx mentions, then interleave at elements with plain text
+    parts: List[Any] = []
+    last_end = 0
+    for match in _OUTBOUND_MENTION_RE.finditer(content):
+        before = content[last_end : match.start()]
+        if before:
+            parts.append([{"tag": "md", "text": before}])
+        user_id = match.group(0)[1:]  # strip leading @
+        parts.append([{"tag": "at", "user_id": user_id}])
+        last_end = match.end()
+    if last_end < len(content):
+        parts.append([{"tag": "md", "text": content[last_end:]}])
+    if not parts:
+        parts.append([{"tag": "md", "text": content}])
     return json.dumps(
         {
             "zh_cn": {
-                "content": rows,
+                "content": parts,
             }
         },
         ensure_ascii=False,
@@ -4290,7 +4304,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if _MARKDOWN_TABLE_RE.search(content):
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
-        if _MARKDOWN_HINT_RE.search(content):
+        if _MARKDOWN_HINT_RE.search(content) or _OUTBOUND_MENTION_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -122,6 +122,7 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
+_OUTBOUND_MENTION_RE = re.compile(r"@ou_[a-zA-Z0-9]+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
 # ---------------------------------------------------------------------------
@@ -432,11 +433,24 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 
 
 def _build_markdown_post_payload(content: str) -> str:
-    rows = _build_markdown_post_rows(content)
+    # Split content by @ou_xxx mentions, then interleave at elements with plain text
+    parts: List[Any] = []
+    last_end = 0
+    for match in _OUTBOUND_MENTION_RE.finditer(content):
+        before = content[last_end : match.start()]
+        if before:
+            parts.append([{"tag": "md", "text": before}])
+        user_id = match.group(0)[1:]  # strip leading @
+        parts.append([{"tag": "at", "user_id": user_id}])
+        last_end = match.end()
+    if last_end < len(content):
+        parts.append([{"tag": "md", "text": content[last_end:]}])
+    if not parts:
+        parts.append([{"tag": "md", "text": content}])
     return json.dumps(
         {
             "zh_cn": {
-                "content": rows,
+                "content": parts,
             }
         },
         ensure_ascii=False,
@@ -3471,7 +3485,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        if _MARKDOWN_HINT_RE.search(content):
+        if _MARKDOWN_HINT_RE.search(content) or _OUTBOUND_MENTION_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)


### PR DESCRIPTION
## Summary

This change enables the bot to send @ mentions to specific users by parsing `@ou_xxx` patterns in the message content and converting them to Feishu's `at` element format in the post payload.

## Problem

Before this change, @ mentions were only parsed on inbound messages. Outbound @ mentions were sent as plain text strings, which Feishu did not recognize as valid mentions — users would see the literal text `@ou_xxx` instead of a highlighted mention.

## Solution

1. **New regex** `_OUTBOUND_MENTION_RE` matches `@ou_xxx` user IDs
2. **Rewritten `_build_markdown_post_payload`** splits content by @ mentions and interleaves `at` elements with plain text segments
3. **Updated `_build_outbound_payload`** uses `post` payload (instead of `text`) when @ mentions are detected, enabling the `at` element format

## Test

```
# Send a message with @ mention
send_message(target='feishu:chat_id', message='@ou_7b52bc1a532ade767e3975a3cb67cf84 please check')

# Result: Feishu now shows a proper @ mention highlight instead of literal text
``"

---

**Author:** Scott1743