### PR TITLE
fix(session): resolve runtime state DB path for test isolation

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -505,19 +505,19 @@ class SessionStore:
     """
     
     def __init__(self, sessions_dir: Path, config: GatewayConfig,
-                 has_active_processes_fn=None):
+                 has_active_processes_fn=None, db_path: Path = None):
         self.sessions_dir = sessions_dir
         self.config = config
         self._entries: Dict[str, SessionEntry] = {}
         self._loaded = False
         self._lock = threading.Lock()
         self._has_active_processes_fn = has_active_processes_fn
-        
+
         # Initialize SQLite session database
         self._db = None
         try:
             from hermes_state import SessionDB
-            self._db = SessionDB()
+            self._db = SessionDB(db_path=db_path) if db_path else SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
     

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+def _default_db_path() -> Path:
+    """Lazily resolve the default DB path so test fixtures that redirect
+    HERMES_HOME after import take effect."""
+    return get_hermes_home() / "state.db"
 
 SCHEMA_VERSION = 6
 
@@ -136,7 +139,7 @@ class SessionDB:
     _CHECKPOINT_EVERY_N_WRITES = 50
 
     def __init__(self, db_path: Path = None):
-        self.db_path = db_path or DEFAULT_DB_PATH
+        self.db_path = db_path or _default_db_path()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._lock = threading.Lock()

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -25,6 +25,23 @@ from gateway.config import GatewayConfig, Platform, SessionResetPolicy
 from gateway.session import SessionEntry, SessionStore
 
 
+def test_session_store_default_db_uses_runtime_hermes_home(tmp_path, monkeypatch):
+    """SessionStore must honor runtime HERMES_HOME when opening the default DB."""
+    config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
+    fake_home = tmp_path / "alt_hermes_home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(fake_home))
+
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+
+    assert store._db is not None
+    assert store._db.db_path == fake_home / "state.db"
+
+    store._db._conn.close()
+
+
+
 def _make_store(tmp_path, max_age_days: int = 90, has_active_processes_fn=None):
     """Build a SessionStore bypassing SQLite/disk-load side effects."""
     config = GatewayConfig(

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -491,8 +491,8 @@ def session_search(
 def check_session_search_requirements() -> bool:
     """Requires SQLite state database and an auxiliary text model."""
     try:
-        from hermes_state import DEFAULT_DB_PATH
-        return DEFAULT_DB_PATH.parent.exists()
+        from hermes_state import _default_db_path
+        return _default_db_path().parent.exists()
     except ImportError:
         return False
 


### PR DESCRIPTION
## What
- make SessionDB resolve the default state.db path at runtime instead of import time
- allow SessionStore to accept an explicit db_path override
- update session_search requirement check to use runtime DB path resolution
- add a regression test proving SessionStore honors runtime HERMES_HOME

## Why
Some gateway/session tests instantiated a real SessionStore, which opened SessionDB during __init__. Because the default DB path was bound at import time, tests could connect to the developer's real ~/.hermes/state.db and leak phantom telegram/cron sessions into production state.

## How to test
- python -m pytest tests/gateway/test_session_store_prune.py tests/gateway/test_session.py tests/run_agent/test_860_dedup.py -o 'addopts=' -q
- verify the new regression test asserts SessionStore()._db.db_path points at the test HERMES_HOME

## Validation
- targeted regression suite: 89 passed
- full test suite is running in background locally at PR creation time; will update PR if it surfaces a regression

## Platforms
- macOS
- Linux

## Reference
- fixes local test leakage into ~/.hermes/state.db discovered while investigating phantom telegram/cron sessions