### PR TITLE
fix(terminal): cd into configured cwd before capturing session snapshot (#7663)

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -163,6 +163,58 @@ class TestInitSessionFailure:
         assert calls[0]["login"] is True
 
 
+class TestInitSessionBootstrapCwd:
+    """Regression test for issue #7663: the snapshot bootstrap must cd into
+    the configured cwd *before* capturing PWD, otherwise ``_update_cwd``
+    clobbers ``self.cwd`` with the gateway process's startup directory."""
+
+    def _capture_bootstrap(self, env):
+        captured = {}
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            captured["cmd"] = cmd
+            captured["login"] = login
+            mock = MagicMock()
+            mock.poll.return_value = 0
+            mock.returncode = 0
+            mock.stdout = iter([])
+            return mock
+
+        env._run_bash = mock_run_bash
+        env.init_session()
+        return captured
+
+    def test_bootstrap_cds_into_configured_cwd_before_snapshot(self):
+        env = _TestableEnv(cwd="/home/user/.hermes/profiles/fern")
+        captured = self._capture_bootstrap(env)
+
+        cmd = captured["cmd"]
+        cd_line = "cd /home/user/.hermes/profiles/fern 2>/dev/null || true"
+        assert cd_line in cmd
+        # cd must appear before the first pwd capture, otherwise the captured
+        # cwd is the host process's startup dir.
+        assert cmd.index(cd_line) < cmd.index("pwd -P >")
+
+    def test_bootstrap_quotes_cwd_with_spaces(self):
+        env = _TestableEnv(cwd="/home/user/my profiles/fern")
+        captured = self._capture_bootstrap(env)
+
+        assert "cd '/home/user/my profiles/fern' 2>/dev/null || true" in captured["cmd"]
+
+    def test_bootstrap_leaves_tilde_unquoted(self):
+        env = _TestableEnv(cwd="~")
+        captured = self._capture_bootstrap(env)
+
+        assert "cd ~ 2>/dev/null || true" in captured["cmd"]
+        assert "cd '~'" not in captured["cmd"]
+
+    def test_bootstrap_skips_cd_when_cwd_empty(self):
+        env = _TestableEnv(cwd="")
+        captured = self._capture_bootstrap(env)
+
+        assert not captured["cmd"].startswith("cd ")
+
+
 class TestCwdMarker:
     def test_marker_contains_session_id(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -325,6 +325,14 @@ class BaseEnvironment(ABC):
     # Session snapshot (init_session)
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _quote_cwd(cwd: str) -> str:
+        """Shell-quote a cwd, but leave ~ / ~user prefixes unquoted so bash
+        performs tilde expansion."""
+        if cwd == "~" or cwd.startswith("~/"):
+            return cwd
+        return shlex.quote(cwd)
+
     def init_session(self):
         """Capture login shell environment into a snapshot file.
 
@@ -332,8 +340,18 @@ class BaseEnvironment(ABC):
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
         instead of running with ``bash -l``.
         """
+        # cd into the configured cwd FIRST so the snapshot (and the post-bootstrap
+        # ``_update_cwd`` call) reflects the user-configured working directory
+        # rather than whatever directory the host process happens to be in
+        # (e.g. a gateway service's ``WorkingDirectory``).  Silently ignore a
+        # failing cd here — ``_wrap_command`` will surface the error on the
+        # next real command via ``cd ... || exit 126``.
+        cd_line = ""
+        if self.cwd:
+            cd_line = f"cd {self._quote_cwd(self.cwd)} 2>/dev/null || true\n"
         # Full capture: env vars, functions (filtered), aliases, shell options.
         bootstrap = (
+            f"{cd_line}"
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"
@@ -378,9 +396,7 @@ class BaseEnvironment(ABC):
             parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
 
         # cd to working directory — let bash expand ~ natively
-        quoted_cwd = (
-            shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
-        )
+        quoted_cwd = self._quote_cwd(cwd)
         parts.append(f"cd {quoted_cwd} || exit 126")
 
         # Run the actual command


### PR DESCRIPTION
## Summary

- `BaseEnvironment.init_session()` ran the bash bootstrap without first `cd`'ing into `self.cwd`, so the snapshot — and the post-bootstrap `_update_cwd()` call — captured whatever directory the host process started in (e.g. a gateway's systemd `WorkingDirectory`).
- That silently clobbered `self.cwd` back to the gateway's startup dir. As a result, `TERMINAL_CWD` / `terminal.cwd` from profile config were honored by env but ignored by every subsequent command (`pwd` returned `~/.hermes/hermes-agent` instead of the configured profile dir).
- Prepend `cd <quoted_cwd> 2>/dev/null || true` to the bootstrap; share the quoting logic with `_wrap_command` via a new `_quote_cwd` helper so tilde handling stays consistent.

Fixes #7663

## Test plan
- [x] `docker run --rm -v "$PWD":/work -w /work python:3.11-slim bash -c 'pip install -q pytest pytest-xdist pytest-asyncio pytest-timeout requests pyyaml && python -m pytest tests/tools/test_base_environment.py -v -p no:cacheprovider -o addopts=""'` — 19 passed, including new regression tests covering: cd-before-snapshot, spaces quoting, unquoted `~`, empty-cwd skip.