### PR TITLE
feat(insights): add --friction flag to 'hermes insights' for compound error-pattern analysis

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7410,6 +7410,12 @@ Examples:
     insights_parser.add_argument(
         "--source", help="Filter by platform (cli, telegram, discord, etc.)"
     )
+    insights_parser.add_argument(
+        "--friction",
+        action="store_true",
+        default=False,
+        help="Include session friction analysis — detects recurring error patterns and suggests rules",
+    )
 
     def cmd_insights(args):
         try:
@@ -7420,6 +7426,18 @@ Examples:
             engine = InsightsEngine(db)
             report = engine.generate(days=args.days, source=args.source)
             print(engine.format_terminal(report))
+
+            if getattr(args, "friction", False):
+                print()
+                try:
+                    from agent.friction_analyzer import FrictionAnalyzer
+
+                    friction = FrictionAnalyzer(db=db._conn if hasattr(db, "_conn") else None)
+                    friction_report = friction.analyze(days=args.days)
+                    print(friction.format_report(friction_report))
+                except Exception as fe:
+                    print(f"Friction analysis unavailable: {fe}")
+
             db.close()
         except Exception as e:
             print(f"Error generating insights: {e}")


### PR DESCRIPTION
## Summary

Adds a `--friction` flag to `hermes insights` that appends a session friction analysis to the existing usage report.

## Usage

```bash
hermes insights --friction
hermes insights --days 7 --friction
```

## What it shows

After the standard usage analytics, the friction report surfaces:
- Recurring error patterns (error loops, credential failures, broken infra)
- Memory dropout indicators
- Premature success declarations
- Fix-didn't-work patterns

Plus **auto-generated rule strings** in the same format used in AGENTS.md, so maintainers can paste them directly into agent configuration to prevent recurrence.

## Example output

```
🔍 Session Friction Analysis
──────────────────────────────────────────────────
Sessions scanned: 12 (last 7 days)
Total friction score: 19

📊 Friction by category:
  api_credential_failure (3x, weight=12): Auth/credential error requiring intervention
  error_loop (2x, weight=6): Same error repeated 3+ times before resolution
  infrastructure_broken (1x, weight=3): Tool/script fails due to missing dependency

💡 Generated rules to prevent recurrence:
  • api-credential-failure: Before using any API → verify credentials are valid...
  • infrastructure-broken: Before relying on any tool → verify it exists and works...
  • error-loop: When seeing the same error 3+ times → stop and address root cause...
```

## Notes

- Gracefully degrades if FrictionAnalyzer is unavailable (prints a warning, doesn't crash)
- Reuses the same `--days` window as the main report
- Depends on `agent/friction_analyzer.py` (PR #11877) — can be merged independently, friction section just won't appear until that lands

---

*Submitted by Bartok 🎻 — compound learning surfaces from the command line.*