### PR TITLE
fix: preserve ${ENV_VAR} placeholders in config.yaml during migration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2628,6 +2628,53 @@ def _expand_env_vars(obj):
     return obj
 
 
+_ENV_PLACEHOLDER_RE = re.compile(r"\$\{[^}]+\}")
+
+
+def _collect_env_placeholders(obj, _prefix=""):
+    """Walk *obj* and return a dict mapping dotted key paths to original strings
+    for every value that contains a ``${…}`` placeholder.
+
+    Only string leaves are inspected; lists use ``[i]`` indices in the path.
+    """
+    out: dict[str, str] = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            path = f"{_prefix}.{k}" if _prefix else k
+            out.update(_collect_env_placeholders(v, path))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            out.update(_collect_env_placeholders(v, f"{_prefix}[{i}]"))
+    elif isinstance(obj, str) and _ENV_PLACEHOLDER_RE.search(obj):
+        out[_prefix] = obj
+    return out
+
+
+def _restore_env_placeholders(obj, placeholders, _prefix=""):
+    """Return a copy of *obj* with values listed in *placeholders* replaced by
+    their original ``${…}`` template strings.
+
+    Mutates nothing — returns new dicts/lists as needed.
+    """
+    if isinstance(obj, dict):
+        new = {}
+        for k, v in obj.items():
+            path = f"{_prefix}.{k}" if _prefix else k
+            if path in placeholders and isinstance(v, str):
+                new[k] = placeholders[path]
+            else:
+                new[k] = _restore_env_placeholders(v, placeholders, path)
+        return new
+    if isinstance(obj, list):
+        return [
+            placeholders.get(f"{_prefix}[{i}]", None)
+            if isinstance(v, str) and f"{_prefix}[{i}]" in placeholders
+            else _restore_env_placeholders(v, placeholders, f"{_prefix}[{i}]")
+            for i, v in enumerate(obj)
+        ]
+    return obj
+
+
 def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     """Move stale root-level provider/base_url into model section.
 
@@ -2827,6 +2874,12 @@ def save_config(config: Dict[str, Any]):
     ensure_hermes_home()
     config_path = get_config_path()
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+
+    # Restore ${…} placeholders so expanded secrets are never written to disk.
+    raw = read_raw_config()
+    placeholders = _collect_env_placeholders(raw)
+    if placeholders:
+        normalized = _restore_env_placeholders(normalized, placeholders)
 
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -2,7 +2,15 @@
 
 import os
 import pytest
-from hermes_cli.config import _expand_env_vars, load_config
+import yaml
+from hermes_cli.config import (
+    _expand_env_vars,
+    _collect_env_placeholders,
+    _restore_env_placeholders,
+    load_config,
+    save_config,
+    read_raw_config,
+)
 from unittest.mock import patch as mock_patch
 
 
@@ -130,3 +138,129 @@ class TestLoadCliConfigExpansion:
         config = load_cli_config()
 
         assert config["auxiliary"]["vision"]["api_key"] == "${UNSET_CLI_VAR_ABC}"
+
+
+class TestCollectEnvPlaceholders:
+    def test_flat_dict(self):
+        raw = {"api_key": "${SECRET}", "name": "literal"}
+        result = _collect_env_placeholders(raw)
+        assert result == {"api_key": "${SECRET}"}
+
+    def test_nested_dict(self):
+        raw = {"providers": {"my-llm": {"api_key": "${MY_KEY}", "api": "http://x"}}}
+        result = _collect_env_placeholders(raw)
+        assert result == {"providers.my-llm.api_key": "${MY_KEY}"}
+
+    def test_list_items(self):
+        raw = {"keys": ["${A}", "literal"]}
+        result = _collect_env_placeholders(raw)
+        assert result == {"keys[0]": "${A}"}
+
+    def test_no_placeholders(self):
+        assert _collect_env_placeholders({"x": "plain", "n": 42}) == {}
+
+    def test_multiple_placeholders_in_one_string(self):
+        raw = {"url": "https://${HOST}:${PORT}/api"}
+        result = _collect_env_placeholders(raw)
+        assert result == {"url": "https://${HOST}:${PORT}/api"}
+
+
+class TestRestoreEnvPlaceholders:
+    def test_restores_nested(self):
+        placeholders = {"providers.my-llm.api_key": "${MY_KEY}"}
+        expanded = {"providers": {"my-llm": {"api_key": "actual-secret", "api": "http://x"}}}
+        result = _restore_env_placeholders(expanded, placeholders)
+        assert result["providers"]["my-llm"]["api_key"] == "${MY_KEY}"
+        assert result["providers"]["my-llm"]["api"] == "http://x"
+
+    def test_no_placeholders_passthrough(self):
+        data = {"a": "b", "c": 1}
+        assert _restore_env_placeholders(data, {}) == data
+
+    def test_list_restore(self):
+        placeholders = {"keys[0]": "${A}"}
+        expanded = {"keys": ["expanded-a", "literal"]}
+        result = _restore_env_placeholders(expanded, placeholders)
+        assert result["keys"] == ["${A}", "literal"]
+
+
+class TestSaveConfigPreservesPlaceholders:
+    """Round-trip: config with ${…} placeholders survives save_config()."""
+
+    def test_migration_round_trip(self, tmp_path, monkeypatch):
+        """api_key placeholder must survive load_config → save_config cycle."""
+        config_yaml = (
+            "providers:\n"
+            "  my-llm:\n"
+            "    api: http://localhost:8080\n"
+            "    api_key: ${MY_SECRET_KEY}\n"
+            "model:\n"
+            "  default: gpt-4\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("MY_SECRET_KEY", "sk-real-secret-value")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+        monkeypatch.setattr("hermes_cli.config.ensure_hermes_home", lambda: None)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+
+        # Simulate what migrate_config does: load → modify → save
+        config = load_config()
+        assert config["providers"]["my-llm"]["api_key"] == "sk-real-secret-value"
+
+        save_config(config)
+
+        # Re-read the raw file — placeholder must be preserved
+        raw = yaml.safe_load(config_file.read_text())
+        assert raw["providers"]["my-llm"]["api_key"] == "${MY_SECRET_KEY}"
+        assert "sk-real-secret-value" not in config_file.read_text()
+
+    def test_non_placeholder_values_written_normally(self, tmp_path, monkeypatch):
+        """Literal api_key values (no ${…}) should be written as-is."""
+        config_yaml = (
+            "providers:\n"
+            "  my-llm:\n"
+            "    api: http://localhost:8080\n"
+            "    api_key: sk-literal-key\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+        monkeypatch.setattr("hermes_cli.config.ensure_hermes_home", lambda: None)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+
+        config = load_config()
+        save_config(config)
+
+        raw = yaml.safe_load(config_file.read_text())
+        assert raw["providers"]["my-llm"]["api_key"] == "sk-literal-key"
+
+    def test_multiple_placeholders_preserved(self, tmp_path, monkeypatch):
+        """Multiple placeholders across different keys all survive."""
+        config_yaml = (
+            "providers:\n"
+            "  openai:\n"
+            "    api_key: ${OPENAI_KEY}\n"
+            "  anthropic:\n"
+            "    api_key: ${ANTHROPIC_KEY}\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("OPENAI_KEY", "sk-openai-123")
+        monkeypatch.setenv("ANTHROPIC_KEY", "sk-ant-456")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+        monkeypatch.setattr("hermes_cli.config.ensure_hermes_home", lambda: None)
+        monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+
+        config = load_config()
+        save_config(config)
+
+        raw = yaml.safe_load(config_file.read_text())
+        assert raw["providers"]["openai"]["api_key"] == "${OPENAI_KEY}"
+        assert raw["providers"]["anthropic"]["api_key"] == "${ANTHROPIC_KEY}"
+        file_text = config_file.read_text()
+        assert "sk-openai-123" not in file_text
+        assert "sk-ant-456" not in file_text


### PR DESCRIPTION
Fixes #11864

**Problem:** `migrate_config()` calls `load_config()` which expands `${ENV_VAR}` placeholders via `_expand_env_vars()`, then `save_config()` writes the expanded (literal secret) values back to `config.yaml`, leaking secrets to disk.

**Fix:** `save_config()` now reads the raw config file to collect all `${...}` placeholder paths before writing, and restores them after migration so secrets are never written as plaintext.

**New functions in `hermes_cli/config.py`:**
- `_collect_env_placeholders(obj)` — walks a config dict, returns `{dotted.path: "${TEMPLATE}"}` for all placeholder values
- `_restore_env_placeholders(obj, placeholders)` — replaces expanded values back with their original `${...}` templates

**Tests:** 11 new tests covering placeholder collection, restoration, and full round-trip through `load_config()` → `save_config()` confirming placeholders survive and secrets never appear in the written file.