### PR TITLE
fix(cron): defensive parsing for HERMES_CRON_TIMEOUT env var

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -844,7 +844,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
+        _default_cron_timeout = 600
+        try:
+            _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", _default_cron_timeout))
+        except (ValueError, TypeError):
+            logger.warning(
+                "Job '%s': invalid HERMES_CRON_TIMEOUT=%r; falling back to %s",
+                job_id, os.getenv("HERMES_CRON_TIMEOUT"), _default_cron_timeout,
+            )
+            _cron_timeout = float(_default_cron_timeout)
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)

--- a/tests/cron/test_cron_inactivity_timeout.py
+++ b/tests/cron/test_cron_inactivity_timeout.py
@@ -185,6 +185,28 @@ class TestInactivityTimeout:
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         assert _cron_inactivity_limit is None
 
+    def test_timeout_invalid_env_falls_back_to_default(self, monkeypatch):
+        """Malformed HERMES_CRON_TIMEOUT falls back to 600 instead of crashing."""
+        monkeypatch.setenv("HERMES_CRON_TIMEOUT", "not_a_number")
+        _default = 600
+        try:
+            _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", _default))
+        except (ValueError, TypeError):
+            _cron_timeout = float(_default)
+        assert _cron_timeout == 600.0
+        _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        assert _cron_inactivity_limit == 600.0
+
+    def test_timeout_missing_env_uses_default(self, monkeypatch):
+        """When HERMES_CRON_TIMEOUT is unset, default 600 is used."""
+        monkeypatch.delenv("HERMES_CRON_TIMEOUT", raising=False)
+        _default = 600
+        try:
+            _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", _default))
+        except (ValueError, TypeError):
+            _cron_timeout = float(_default)
+        assert _cron_timeout == 600.0
+
     def test_timeout_error_includes_diagnostics(self):
         """The TimeoutError message should include last activity info."""
         agent = SlowFakeAgent(


### PR DESCRIPTION
Fixes #11319

**Problem:** `run_job()` uses bare `float(os.getenv('HERMES_CRON_TIMEOUT', 600))` which crashes with `ValueError` on malformed env values, bricking all cron execution.

**Fix:** Wrapped in try/except with warning log and fallback to 600s default, consistent with the defensive parsing already used in `_get_script_timeout()` in the same file.

**Tests:** Added tests for invalid and missing env values in `tests/cron/test_cron_inactivity_timeout.py`. All 11 tests pass.