### PR TITLE
fix(kimi): force 0.6 on main chat path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6798,6 +6798,14 @@ class AIAgent:
             "messages": sanitized_messages,
             "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
         }
+        try:
+            from agent.auxiliary_client import _fixed_temperature_for_model
+        except Exception:
+            _fixed_temperature_for_model = None
+        if _fixed_temperature_for_model is not None:
+            fixed_temperature = _fixed_temperature_for_model(self.model)
+            if fixed_temperature is not None:
+                api_kwargs["temperature"] = fixed_temperature
         if self._is_qwen_portal():
             api_kwargs["metadata"] = {
                 "sessionId": self.session_id or "hermes",
@@ -8227,6 +8235,15 @@ class AIAgent:
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
             summary_extra_body = {}
+            try:
+                from agent.auxiliary_client import _fixed_temperature_for_model
+            except Exception:
+                _fixed_temperature_for_model = None
+            _summary_temperature = (
+                _fixed_temperature_for_model(self.model)
+                if _fixed_temperature_for_model is not None
+                else None
+            )
             _is_nous = "nousresearch" in self._base_url_lower
             if self._supports_reasoning_extra_body():
                 if self.reasoning_config is not None:
@@ -8250,6 +8267,8 @@ class AIAgent:
                     "model": self.model,
                     "messages": api_messages,
                 }
+                if _summary_temperature is not None:
+                    summary_kwargs["temperature"] = _summary_temperature
                 if self.max_tokens is not None:
                     summary_kwargs.update(self._max_tokens_param(self.max_tokens))
 
@@ -8315,6 +8334,8 @@ class AIAgent:
                         "model": self.model,
                         "messages": api_messages,
                     }
+                    if _summary_temperature is not None:
+                        summary_kwargs["temperature"] = _summary_temperature
                     if self.max_tokens is not None:
                         summary_kwargs.update(self._max_tokens_param(self.max_tokens))
                     if summary_extra_body:

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -251,6 +251,19 @@ class TestBuildApiKwargsChatCompletionsServiceTier:
         assert "service_tier" not in kwargs
 
 
+class TestBuildApiKwargsKimiFixedTemperature:
+    def test_kimi_for_coding_forces_temperature_on_main_chat_path(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "kimi-coding",
+            base_url="https://api.kimi.com/coding/v1",
+            model="kimi-for-coding",
+        )
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["temperature"] == 0.6
+
+
 class TestBuildApiKwargsAIGateway:
     def test_uses_chat_completions_format(self, monkeypatch):
         agent = _make_agent(monkeypatch, "ai-gateway", base_url="https://ai-gateway.vercel.sh/v1", model="gpt-4o")


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining `kimi-for-coding` temperature hole on the main chat-completions path.

Hermes already forced `temperature=0.6` for Kimi in auxiliary calls and `flush_memories`, but a normal user turn still built its main `chat.completions.create(...)` payload without the fixed-temperature override. That left `kimi-for-coding` able to fail with `HTTP 400: invalid temperature: only 0.6 is allowed for this model` even on builds that already included the earlier Kimi fixes.

This patch applies the same fixed-temperature contract to the shared main request builder in `run_agent.py`, and also covers the iteration-limit summary path so the same bug does not survive there.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Apply `_fixed_temperature_for_model()` in the main chat-completions request builder in `run_agent.py`
- Apply the same Kimi temperature override to the iteration-limit summary and retry-summary requests in `run_agent.py`
- Add a regression test in `tests/run_agent/test_provider_parity.py` that asserts the main `kimi-coding` + `kimi-for-coding` path sends `temperature == 0.6`

## How to Test

1. Configure Hermes to use `provider: kimi-coding` and `model: kimi-for-coding`
2. Send a simple prompt like `hi` through the normal main agent path
3. Confirm Hermes no longer returns `HTTP 400: invalid temperature: only 0.6 is allowed for this model`

Focused test run:

```bash
source venv/bin/activate && python -m pytest tests/run_agent/test_provider_parity.py tests/agent/test_auxiliary_client.py -q -n 4
```

Result: `134 passed`

Full suite run on this branch:

```bash
source venv/bin/activate && python -m pytest tests/ -q -n 4
```

Result: `81 failed, 12551 passed, 35 skipped in 330.36s`

Those full-suite failures are existing unrelated baseline failures in areas like gateway approvals, Discord, delegate, send_message, backup, TTS Mistral, and CLI reasoning tests. They are not in the Kimi paths touched here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live repro before the fix was a plain main-agent turn returning:

```text
Non-retryable client error: Error code: 400 - {'error': {'message': 'invalid temperature: only 0.6 is allowed for this model', 'type': 'invalid_request_error'}}
```
