### PR TITLE
fix(prompt): load AGENTS.md from HERMES_HOME

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -942,18 +942,20 @@ def _load_hermes_md(cwd_path: Path) -> str:
 
 
 def _load_agents_md(cwd_path: Path) -> str:
-    """AGENTS.md — top-level only (no recursive walk)."""
-    for name in ["AGENTS.md", "agents.md"]:
-        candidate = cwd_path / name
-        if candidate.exists():
-            try:
-                content = candidate.read_text(encoding="utf-8").strip()
-                if content:
-                    content = _scan_context_content(content, name)
-                    result = f"## {name}\n\n{content}"
-                    return _truncate_content(result, "AGENTS.md")
-            except Exception as e:
-                logger.debug("Could not read %s: %s", candidate, e)
+    """AGENTS.md — HERMES_HOME first, then cwd; no recursive walk."""
+    search_roots = [get_hermes_home(), cwd_path]
+    for root in search_roots:
+        for name in ["AGENTS.md", "agents.md"]:
+            candidate = root / name
+            if candidate.exists():
+                try:
+                    content = candidate.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, name)
+                        result = f"## {name}\n\n{content}"
+                        return _truncate_content(result, "AGENTS.md")
+                except Exception as e:
+                    logger.debug("Could not read %s: %s", candidate, e)
     return ""
 
 
@@ -1008,7 +1010,7 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
 
     Priority (first found wins — only ONE project context type is loaded):
       1. .hermes.md / HERMES.md  (walk to git root)
-      2. AGENTS.md / agents.md   (cwd only)
+      2. AGENTS.md / agents.md   (HERMES_HOME first, then cwd)
       3. CLAUDE.md / claude.md   (cwd only)
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -489,6 +489,16 @@ class TestBuildContextFilesPrompt:
         assert "Ruff for linting" in result
         assert "Project Context" in result
 
+    def test_loads_agents_md_from_hermes_home_before_cwd(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        (hermes_home / "AGENTS.md").write_text("Global gateway instructions.")
+        (tmp_path / "AGENTS.md").write_text("Project cwd instructions.")
+        result = build_context_files_prompt(cwd=str(tmp_path))
+        assert "Global gateway instructions." in result
+        assert "Project cwd instructions." not in result
+
     def test_loads_cursorrules(self, tmp_path):
         (tmp_path / ".cursorrules").write_text("Always use type hints.")
         result = build_context_files_prompt(cwd=str(tmp_path))
@@ -1032,6 +1042,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 


### PR DESCRIPTION
## Summary
- check `HERMES_HOME` for `AGENTS.md` / `agents.md` before falling back to `cwd`
- keep AGENTS lookup top-level only without expanding into recursive discovery
- add a regression test covering gateway-style `HERMES_HOME` precedence over `cwd`

Closes #11763

## Testing
- python3 -m pytest -o addopts= tests/agent/test_prompt_builder.py::TestBuildContextFilesPrompt
- python3 -m pytest -o addopts= tests/agent/test_prompt_builder.py -k "agents or context_files_prompt"
