### PR TITLE
docs: Suggest `git-lfs` as a development prerequisite, given it is needed for `tinker-atropos`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 
 | Requirement | Notes |
 |-------------|-------|
-| **Git** | With `--recurse-submodules` support |
+| **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
 | **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -32,7 +32,7 @@ We value contributions in this order:
 
 | Requirement | Notes |
 |-------------|-------|
-| **Git** | With `--recurse-submodules` support |
+| **Git** | With `--recurse-submodules` support, and the `git-lfs` extension installed |
 | **Python 3.11+** | uv will install it if missing |
 | **uv** | Fast Python package manager ([install](https://docs.astral.sh/uv/)) |
 | **Node.js 18+** | Optional — needed for browser tools and WhatsApp bridge |


### PR DESCRIPTION
## What does this PR do?
The "Clone and Install" installation step lists an `uv pip install -e "./tinker-atropos"
` command with a transitive dependency on [BLEUBERI](https://github.com/lilakk/BLEUBERI.git), a submodule which requires Git LFS for checkout.

Updated 2 documentation files to reflect that the developer must have the `git-lfs` extension installed as a prerequisite.


## Type of Change

- [x] 📝 Documentation update

## Changes Made

Files updated:
- CONTRIBUTING.md
- website-docs/.../contributing.md

## How to Test

n/a



