### PR TITLE
fix(kimi): force 0.6 on main chat path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6798,6 +6798,14 @@ class AIAgent:
             "messages": sanitized_messages,
             "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
         }
+        try:
+            from agent.auxiliary_client import _fixed_temperature_for_model
+        except Exception:
+            _fixed_temperature_for_model = None
+        if _fixed_temperature_for_model is not None:
+            fixed_temperature = _fixed_temperature_for_model(self.model)
+            if fixed_temperature is not None:
+                api_kwargs["temperature"] = fixed_temperature
         if self._is_qwen_portal():
             api_kwargs["metadata"] = {
                 "sessionId": self.session_id or "hermes",
@@ -8227,6 +8235,15 @@ class AIAgent:
                     api_messages.insert(sys_offset + idx, pfm.copy())
 
             summary_extra_body = {}
+            try:
+                from agent.auxiliary_client import _fixed_temperature_for_model
+            except Exception:
+                _fixed_temperature_for_model = None
+            _summary_temperature = (
+                _fixed_temperature_for_model(self.model)
+                if _fixed_temperature_for_model is not None
+                else None
+            )
             _is_nous = "nousresearch" in self._base_url_lower
             if self._supports_reasoning_extra_body():
                 if self.reasoning_config is not None:
@@ -8250,6 +8267,8 @@ class AIAgent:
                     "model": self.model,
                     "messages": api_messages,
                 }
+                if _summary_temperature is not None:
+                    summary_kwargs["temperature"] = _summary_temperature
                 if self.max_tokens is not None:
                     summary_kwargs.update(self._max_tokens_param(self.max_tokens))
 
@@ -8315,6 +8334,8 @@ class AIAgent:
                         "model": self.model,
                         "messages": api_messages,
                     }
+                    if _summary_temperature is not None:
+                        summary_kwargs["temperature"] = _summary_temperature
                     if self.max_tokens is not None:
                         summary_kwargs.update(self._max_tokens_param(self.max_tokens))
                     if summary_extra_body:

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -251,6 +251,19 @@ class TestBuildApiKwargsChatCompletionsServiceTier:
         assert "service_tier" not in kwargs
 
 
+class TestBuildApiKwargsKimiFixedTemperature:
+    def test_kimi_for_coding_forces_temperature_on_main_chat_path(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "kimi-coding",
+            base_url="https://api.kimi.com/coding/v1",
+            model="kimi-for-coding",
+        )
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["temperature"] == 0.6
+
+
 class TestBuildApiKwargsAIGateway:
     def test_uses_chat_completions_format(self, monkeypatch):
         agent = _make_agent(monkeypatch, "ai-gateway", base_url="https://ai-gateway.vercel.sh/v1", model="gpt-4o")


### PR DESCRIPTION
Salvage of #11883 onto current main, preserving @helix4u authorship.

## Summary
kimi-for-coding now sends `temperature=0.6` on the main chat-completions path. Previously only the auxiliary client and `flush_memories` forced 0.6, so a normal user turn still returned `HTTP 400: invalid temperature: only 0.6 is allowed for this model`.

## Changes
- `run_agent.py`: apply `_fixed_temperature_for_model()` in `_build_api_kwargs` (covers non-streaming + streaming main paths via `stream_kwargs = {**api_kwargs}`)
- `run_agent.py`: same override applied to the iteration-limit summary and retry-summary paths
- `tests/run_agent/test_provider_parity.py`: regression test asserting `kimi-for-coding` forces `temperature == 0.6`

## Validation
| | Before | After |
|---|---|---|
| `kimi-for-coding` main turn | 400 invalid temperature | temperature=0.6 sent |
| `tests/run_agent/test_provider_parity.py tests/agent/test_auxiliary_client.py` | 133 passed | 134 passed |

Credit: @helix4u (#11883).