### PR TITLE
feat(skills): add auto_sync_bundled config to disable bundled skill auto-copy

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -680,6 +680,7 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "auto_sync_bundled": True,  # If False, skip auto-copying new bundled skills on sync
     },
 
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
@@ -779,7 +780,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 18,
+    "_config_version": 19,
 }
 
 # =============================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4954,15 +4954,14 @@ def cmd_update(args):
             if result["copied"]:
                 print(f"  + {len(result['copied'])} new: {', '.join(result['copied'])}")
             if result.get("updated"):
-<<<<<<< HEAD
                 print(
                     f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}"
                 )
-=======
-                print(f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}")
             if result.get("skipped_auto"):
-                print(f"  ⏭ {result['skipped_auto']} new bundled skill(s) skipped (skills.auto_sync_bundled=false)")
->>>>>>> 77dec231 (fix(skills): make reset restore bypass auto-sync suppression)
+                print(
+                    f"  ⏭ {result['skipped_auto']} new bundled skill(s) skipped "
+                    f"(skills.auto_sync_bundled=false)"
+                )
             if result.get("user_modified"):
                 print(f"  ~ {len(result['user_modified'])} user-modified (kept)")
             if result.get("cleaned"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4075,11 +4075,16 @@ def _update_via_zip(args):
             print(
                 f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}"
             )
+        if result.get("skipped_auto"):
+            print(
+                f"  ⏭ {result['skipped_auto']} new bundled skill(s) skipped "
+                f"(skills.auto_sync_bundled=false)"
+            )
         if result.get("user_modified"):
             print(f"  ~ {len(result['user_modified'])} user-modified (kept)")
         if result.get("cleaned"):
             print(f"  − {len(result['cleaned'])} removed from manifest")
-        if not result["copied"] and not result.get("updated"):
+        if not result["copied"] and not result.get("updated") and not result.get("skipped_auto"):
             print("  ✓ Skills are up to date")
     except Exception:
         pass
@@ -4949,14 +4954,20 @@ def cmd_update(args):
             if result["copied"]:
                 print(f"  + {len(result['copied'])} new: {', '.join(result['copied'])}")
             if result.get("updated"):
+<<<<<<< HEAD
                 print(
                     f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}"
                 )
+=======
+                print(f"  ↑ {len(result['updated'])} updated: {', '.join(result['updated'])}")
+            if result.get("skipped_auto"):
+                print(f"  ⏭ {result['skipped_auto']} new bundled skill(s) skipped (skills.auto_sync_bundled=false)")
+>>>>>>> 77dec231 (fix(skills): make reset restore bypass auto-sync suppression)
             if result.get("user_modified"):
                 print(f"  ~ {len(result['user_modified'])} user-modified (kept)")
             if result.get("cleaned"):
                 print(f"  − {len(result['cleaned'])} removed from manifest")
-            if not result["copied"] and not result.get("updated"):
+            if not result["copied"] and not result.get("updated") and not result.get("skipped_auto"):
                 print("  ✓ Skills are up to date")
         except Exception as e:
             logger.debug("Skills sync during update failed: %s", e)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -459,7 +459,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 18
+        assert raw["_config_version"] == 19
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -606,7 +606,7 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 18
+        assert raw["_config_version"] == 19
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True
 
@@ -626,6 +626,6 @@ class TestDiscordChannelPromptsConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 18
+        assert raw["_config_version"] == 19
         assert raw["discord"]["auto_thread"] is True
         assert raw["discord"]["channel_prompts"] == {}

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 18
+        assert DEFAULT_CONFIG["_config_version"] == 19

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -406,7 +406,7 @@ class TestSyncSkills:
         with patch("tools.skills_sync._get_bundled_dir", return_value=tmp_path / "nope"):
             result = sync_skills(quiet=True)
         assert result == {
-            "copied": [], "updated": [], "skipped": 0,
+            "copied": [], "updated": [], "skipped": 0, "skipped_auto": 0,
             "user_modified": [], "cleaned": [], "total_bundled": 0,
         }
 
@@ -652,3 +652,118 @@ class TestResetBundledSkill:
             post_manifest = _read_manifest()
             assert "google-workspace" in post_manifest
         assert (skills_dir / "productivity" / "google-workspace" / "SKILL.md").exists()
+
+
+class TestAutoSyncBundled:
+    """Tests for the auto_sync_bundled config flag."""
+
+    @staticmethod
+    def _setup_bundled(tmp_path):
+        """Create a minimal bundled skills structure."""
+        bundled = tmp_path / "bundled_skills"
+        for name in ("existing-skill", "brand-new-skill"):
+            d = bundled / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}")
+        return bundled
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        import contextlib
+        stack = contextlib.ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", lambda: bundled))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def test_auto_sync_false_skips_new_skills(self, tmp_path):
+        """When auto_sync_bundled=false, new bundled skills should NOT be copied."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        # existing-skill is in manifest + on disk
+        existing = skills_dir / "existing-skill"
+        existing.mkdir(parents=True)
+        (existing / "SKILL.md").write_text("old content")
+        orig_hash = _dir_hash(existing)
+        manifest_file.write_text(f"existing-skill:{orig_hash}\n")
+
+        # Config says auto_sync_bundled=false
+        fake_config = {"skills": {"auto_sync_bundled": False}}
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(fake_config, f)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" not in result["copied"]
+        assert result["skipped_auto"] == 1
+        assert not (skills_dir / "brand-new-skill").exists()
+        # Existing skill still updates normally
+        assert "existing-skill" not in result["copied"]
+
+    def test_auto_sync_true_copies_new_skills(self, tmp_path):
+        """Default (auto_sync_bundled=true) should copy new bundled skills."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        fake_config = {"skills": {"auto_sync_bundled": True}}
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        with open(config_path, "w") as f:
+            yaml.dump(fake_config, f)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" in result["copied"]
+        assert result.get("skipped_auto", 0) == 0
+
+    def test_auto_sync_false_then_reenable_picks_up(self, tmp_path):
+        """After disabling then re-enabling auto_sync_bundled, new skills sync."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+
+        # Phase 1: auto_sync=false → skip new skills
+        with open(config_path, "w") as f:
+            yaml.dump({"skills": {"auto_sync_bundled": False}}, f)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result1 = sync_skills(quiet=True)
+        assert "brand-new-skill" not in result1["copied"]
+        assert not (skills_dir / "brand-new-skill").exists()
+
+        # Phase 2: auto_sync=true → new skills should now be picked up
+        with open(config_path, "w") as f:
+            yaml.dump({"skills": {"auto_sync_bundled": True}}, f)
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result2 = sync_skills(quiet=True)
+        assert "brand-new-skill" in result2["copied"]
+        assert (skills_dir / "brand-new-skill").exists()
+
+    def test_missing_config_defaults_to_true(self, tmp_path):
+        """No config file → auto_sync_bundled defaults to True."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # No config.yaml exists
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" in result["copied"]
+        assert result.get("skipped_auto", 0) == 0

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -601,6 +601,27 @@ class TestResetBundledSkill:
         # SKILL.md should be the bundled content
         assert "GW v2 (upstream)" in (dest / "SKILL.md").read_text()
 
+    def test_reset_restore_works_when_auto_sync_bundled_false(self, tmp_path):
+        """Explicit restore should bypass auto_sync_bundled=false."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+        config_path = tmp_path / "config.yaml"
+
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text("# heavily edited by user\n")
+        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+        config_path.write_text("skills:\n  auto_sync_bundled: false\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = reset_bundled_skill("google-workspace", restore=True)
+
+        assert result["ok"] is True
+        assert result["action"] == "restored"
+        assert "GW v2 (upstream)" in (dest / "SKILL.md").read_text()
+
     def test_reset_nonexistent_skill_errors_gracefully(self, tmp_path):
         """Resetting a skill that's neither bundled nor in the manifest returns a clear error."""
         bundled = self._setup_bundled(tmp_path)
@@ -703,7 +724,25 @@ class TestAutoSyncBundled:
         assert result["skipped_auto"] == 1
         assert not (skills_dir / "brand-new-skill").exists()
         # Existing skill still updates normally
+        assert "existing-skill" in result["updated"]
         assert "existing-skill" not in result["copied"]
+        assert "existing-skill" in (existing / "SKILL.md").read_text()
+
+    def test_auto_sync_false_string_is_parsed_as_false(self, tmp_path):
+        """Quoted string 'false' should still disable auto-sync."""
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("skills:\n  auto_sync_bundled: 'false'\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            with patch("tools.skills_sync.HERMES_HOME", tmp_path):
+                result = sync_skills(quiet=True)
+
+        assert "brand-new-skill" not in result["copied"]
+        assert result["skipped_auto"] == 2
 
     def test_auto_sync_true_copies_new_skills(self, tmp_path):
         """Default (auto_sync_bundled=true) should copy new bundled skills."""

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -180,14 +180,102 @@ def _load_auto_sync_bundled() -> bool:
     """
     try:
         import yaml
-        config_path = HERMES_HOME / "config.yaml"
+        # Derive config path from SKILLS_DIR so tests/profile overrides that patch
+        # SKILLS_DIR automatically isolate config lookup too.
+        config_path = SKILLS_DIR.parent / "config.yaml"
         if config_path.exists():
             with open(config_path, encoding="utf-8") as f:
                 config = yaml.safe_load(f) or {}
-            return config.get("skills", {}).get("auto_sync_bundled", True)
+            skills_cfg = config.get("skills", {})
+            if not isinstance(skills_cfg, dict):
+                return True
+            value = skills_cfg.get("auto_sync_bundled", True)
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in {"0", "false", "no", "off"}:
+                    return False
+                if normalized in {"1", "true", "yes", "on"}:
+                    return True
+            return bool(value)
     except Exception:
         pass
     return True
+
+
+def _sync_one_bundled_skill(name: str, skill_src: Path, quiet: bool = True) -> dict:
+    """Force-sync exactly one bundled skill, bypassing auto_sync_bundled for explicit reset/restore."""
+    SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    manifest = _read_manifest()
+    bundled_dir = _get_bundled_dir()
+    dest = _compute_relative_dest(skill_src, bundled_dir)
+    bundled_hash = _dir_hash(skill_src)
+
+    copied = []
+    updated = []
+    user_modified = []
+    skipped = 0
+
+    if name not in manifest:
+        try:
+            if dest.exists():
+                skipped += 1
+                manifest[name] = bundled_hash
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(skill_src, dest)
+                copied.append(name)
+                manifest[name] = bundled_hash
+                if not quiet:
+                    print(f"  + {name}")
+        except (OSError, IOError) as e:
+            if not quiet:
+                print(f"  ! Failed to copy {name}: {e}")
+    elif dest.exists():
+        origin_hash = manifest.get(name, "")
+        user_hash = _dir_hash(dest)
+
+        if not origin_hash:
+            manifest[name] = user_hash
+            skipped += 1
+        elif user_hash != origin_hash:
+            user_modified.append(name)
+            if not quiet:
+                print(f"  ~ {name} (user-modified, skipping)")
+        elif bundled_hash != origin_hash:
+            try:
+                backup = dest.with_suffix(".bak")
+                shutil.move(str(dest), str(backup))
+                try:
+                    shutil.copytree(skill_src, dest)
+                    manifest[name] = bundled_hash
+                    updated.append(name)
+                    if not quiet:
+                        print(f"  ↑ {name} (updated)")
+                    shutil.rmtree(backup, ignore_errors=True)
+                except (OSError, IOError):
+                    if backup.exists() and not dest.exists():
+                        shutil.move(str(backup), str(dest))
+                    raise
+            except (OSError, IOError) as e:
+                if not quiet:
+                    print(f"  ! Failed to update {name}: {e}")
+        else:
+            skipped += 1
+    else:
+        skipped += 1
+
+    _write_manifest(manifest)
+    return {
+        "copied": copied,
+        "updated": updated,
+        "skipped": skipped,
+        "skipped_auto": 0,
+        "user_modified": user_modified,
+        "cleaned": [],
+        "total_bundled": 1,
+    }
 
 
 def sync_skills(quiet: bool = False) -> dict:
@@ -407,16 +495,37 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
                     "synced": None,
                 }
 
-    # Step 3: run sync to re-baseline (or re-copy if we deleted)
-    synced = sync_skills(quiet=True)
+    # Step 3: force-sync just this skill to re-baseline (or re-copy if we deleted).
+    # Explicit reset/restore should bypass auto_sync_bundled suppression.
+    synced = None
+    if is_bundled:
+        synced = _sync_one_bundled_skill(name, bundled_by_name[name], quiet=True)
 
     if restore and deleted_user_copy:
-        action = "restored"
-        message = f"Restored '{name}' from bundled source."
+        dest = _compute_relative_dest(bundled_by_name[name], bundled_dir)
+        if dest.exists():
+            action = "restored"
+            message = f"Restored '{name}' from bundled source."
+        else:
+            return {
+                "ok": False,
+                "action": "bundled_missing",
+                "message": f"Failed to restore '{name}' from bundled source.",
+                "synced": synced,
+            }
     elif restore:
-        # Nothing on disk to delete, but we re-synced — acts like a fresh install
-        action = "restored"
-        message = f"Restored '{name}' (no prior user copy, re-copied from bundled)."
+        # Nothing on disk to delete, but explicit restore should still ensure the bundled copy exists.
+        dest = _compute_relative_dest(bundled_by_name[name], bundled_dir)
+        if dest.exists():
+            action = "restored"
+            message = f"Restored '{name}' (no prior user copy, re-copied from bundled)."
+        else:
+            return {
+                "ok": False,
+                "action": "bundled_missing",
+                "message": f"Failed to restore '{name}' from bundled source.",
+                "synced": synced,
+            }
     else:
         action = "manifest_cleared"
         message = (

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -173,18 +173,36 @@ def _dir_hash(directory: Path) -> str:
     return hasher.hexdigest()
 
 
+def _load_auto_sync_bundled() -> bool:
+    """Check if auto_sync_bundled is enabled in config.yaml.
+
+    Returns True (default) if config doesn't exist or key is missing.
+    """
+    try:
+        import yaml
+        config_path = HERMES_HOME / "config.yaml"
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                config = yaml.safe_load(f) or {}
+            return config.get("skills", {}).get("auto_sync_bundled", True)
+    except Exception:
+        pass
+    return True
+
+
 def sync_skills(quiet: bool = False) -> dict:
     """
     Sync bundled skills into ~/.hermes/skills/ using the manifest.
 
     Returns:
         dict with keys: copied (list), updated (list), skipped (int),
-                        user_modified (list), cleaned (list), total_bundled (int)
+                        skipped_auto (int), user_modified (list), cleaned (list),
+                        total_bundled (int)
     """
     bundled_dir = _get_bundled_dir()
     if not bundled_dir.exists():
         return {
-            "copied": [], "updated": [], "skipped": 0,
+            "copied": [], "updated": [], "skipped": 0, "skipped_auto": 0,
             "user_modified": [], "cleaned": [], "total_bundled": 0,
         }
 
@@ -198,12 +216,21 @@ def sync_skills(quiet: bool = False) -> dict:
     user_modified = []
     skipped = 0
 
+    auto_sync = _load_auto_sync_bundled()
+    skipped_auto = 0
+
     for skill_name, skill_src in bundled_skills:
         dest = _compute_relative_dest(skill_src, bundled_dir)
         bundled_hash = _dir_hash(skill_src)
 
         if skill_name not in manifest:
             # ── New skill — never offered before ──
+            if not auto_sync:
+                # Auto-sync disabled: skip new skills without adding to manifest,
+                # so they can be picked up later if auto_sync_bundled is re-enabled.
+                skipped += 1
+                skipped_auto += 1
+                continue
             try:
                 if dest.exists():
                     # User already has a skill with the same name — don't overwrite
@@ -295,6 +322,7 @@ def sync_skills(quiet: bool = False) -> dict:
         "copied": copied,
         "updated": updated,
         "skipped": skipped,
+        "skipped_auto": skipped_auto,
         "user_modified": user_modified,
         "cleaned": cleaned,
         "total_bundled": len(bundled_skills),
@@ -407,6 +435,8 @@ if __name__ == "__main__":
         f"{len(result['updated'])} updated",
         f"{result['skipped']} unchanged",
     ]
+    if result.get("skipped_auto"):
+        parts.append(f"{result['skipped_auto']} auto-skilled (auto_sync_bundled=false)")
     if result["user_modified"]:
         parts.append(f"{len(result['user_modified'])} user-modified (kept)")
     if result["cleaned"]:


### PR DESCRIPTION
## What

Add a new config option: `skills.auto_sync_bundled` (default: `true`).

When set to `false`, Hermes will stop automatically copying new bundled skills into the user's `~/.hermes/skills/` directory during sync/update.

This solves the case where users intentionally keep a minimal local skills set and don't want newly added official skills to silently appear after upstream updates.

Existing bundled skills already tracked in the manifest still behave normally:
- unchanged skills stay unchanged
- updated bundled skills still update when the local copy is unmodified
- deleted skills remain respected

## Why

The existing manifest system already respects user deletions, but it cannot prevent newly introduced bundled skills from being auto-installed.

This config flag adds a clean opt-out for that behavior.

## Implementation

- Add `skills.auto_sync_bundled` to config defaults
- Gate the new bundled skill copy path in `tools/skills_sync.py`
- Preserve backward-compatible default behavior (`true`)
- Parse bool-like string values safely (`'false'`, `off`, `0`, etc.)
- Ensure `reset_bundled_skill(..., restore=True)` explicitly bypasses the suppression and still works even when auto-sync is disabled
- Surface `skipped_auto` in CLI update/sync output instead of incorrectly saying "Skills are up to date"

## How to test

### Disable auto-sync for new bundled skills

```yaml
skills:
  auto_sync_bundled: false
```

Then run Hermes update / sync:
- newly introduced bundled skills should NOT be copied
- CLI should report skipped bundled skills

### Re-enable

Set it back to `true` (or remove the key):
- previously skipped bundled skills should be picked up on the next sync

### Explicit reset/restore still works

Even with `auto_sync_bundled: false`, `reset_bundled_skill(..., restore=True)` should still restore the selected bundled skill.

## Tests

Passed:
- `tests/tools/test_skills_sync.py`
- `tests/hermes_cli/test_config.py`
- `tests/tools/test_browser_camofox_state.py`

Key coverage added:
- auto-sync disabled skips new bundled skills
- existing tracked bundled skills still update normally
- quoted string `'false'` is parsed correctly
- explicit restore bypasses auto-sync suppression

## Platforms

- All (Python-only config + sync behavior)
