### PR TITLE
fix(wecom): accept urlsafe unpadded inbound aeskey

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -754,6 +754,19 @@ class WeComAdapter(BasePlatformAdapter):
         return base64.b64decode(payload)
 
     @staticmethod
+    def _decode_aes_key(aes_key: str) -> bytes:
+        payload = str(aes_key).strip()
+        if not payload:
+            raise ValueError("aes_key is required")
+        padding = (-len(payload)) % 4
+        if padding:
+            payload += "=" * padding
+        try:
+            return base64.urlsafe_b64decode(payload)
+        except Exception as exc:
+            raise ValueError("Invalid WeCom aes_key encoding") from exc
+
+    @staticmethod
     def _detect_image_ext(data: bytes) -> str:
         if data.startswith(b"\x89PNG\r\n\x1a\n"):
             return ".png"
@@ -972,7 +985,7 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
-        key = base64.b64decode(aes_key)
+        key = WeComAdapter._decode_aes_key(aes_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -296,6 +296,23 @@ class TestMediaHelpers:
 
         assert decrypted == plaintext
 
+    def test_decrypt_file_bytes_accepts_unpadded_urlsafe_aes_key(self):
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+        from gateway.platforms.wecom import WeComAdapter
+
+        plaintext = b"wecom-secret"
+        key = os.urandom(32)
+        pad_len = 32 - (len(plaintext) % 32)
+        padded = plaintext + bytes([pad_len]) * pad_len
+        encryptor = Cipher(algorithms.AES(key), modes.CBC(key[:16])).encryptor()
+        encrypted = encryptor.update(padded) + encryptor.finalize()
+
+        encoded_key = base64.urlsafe_b64encode(key).decode("ascii").rstrip("=")
+
+        decrypted = WeComAdapter._decrypt_file_bytes(encrypted, encoded_key)
+
+        assert decrypted == plaintext
+
     @pytest.mark.asyncio
     async def test_load_outbound_media_rejects_placeholder_path(self):
         from gateway.platforms.wecom import WeComAdapter
@@ -412,7 +429,7 @@ class TestMediaUpload:
             "file",
             {
                 "url": "https://example.com/secret.bin",
-                "aeskey": base64.b64encode(key).decode("ascii"),
+                "aeskey": base64.urlsafe_b64encode(key).decode("ascii").rstrip("="),
             },
         )
 
@@ -592,4 +609,3 @@ class TestInboundMessages:
 
         await adapter._on_message(payload)
         adapter.handle_message.assert_not_awaited()
-


### PR DESCRIPTION
## Summary
- normalize WeCom inbound aeskey values before decrypting downloaded attachments
- accept urlsafe base64 and restore missing padding before decoding
- add regression coverage for unpadded urlsafe keys and cached inbound media decryption

Fixes #11890

## Testing
- python3 -m pytest -o addopts='' tests/gateway/test_wecom.py -k 'decrypt_file_bytes_accepts_unpadded_urlsafe_aes_key or cache_media_decrypts_url_payload_before_writing or decrypt_file_bytes_round_trip'
- python3 -m pytest -o addopts='' tests/gateway/test_wecom.py