### PR TITLE
fix(gateway): preserve per-session model override across /new

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3982,9 +3982,9 @@ class GatewayRunner:
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 
-        # Clear any session-scoped model override so the next agent picks up
-        # the configured default instead of the previously switched model.
-        self._session_model_overrides.pop(session_key, None)
+        # Keep any session-scoped model override across /new. Resetting the
+        # conversation should clear history, not silently revert the chat back
+        # to the profile default model/provider.
 
         # Fire plugin on_session_finalize hook (session boundary)
         try:

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -1,4 +1,4 @@
-"""Tests that /new (and its /reset alias) clears the session-scoped model override."""
+"""Tests that /new (and its /reset alias) preserves the session-scoped model override."""
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -66,23 +66,24 @@ def _make_runner():
 
 
 @pytest.mark.asyncio
-async def test_new_command_clears_session_model_override():
-    """/new must remove the session-scoped model override for that session."""
+async def test_new_command_preserves_session_model_override():
+    """/new must keep the session-scoped model override for that session."""
     runner = _make_runner()
     session_key = build_session_key(_make_source())
 
     # Simulate a prior /model switch stored as a session override
-    runner._session_model_overrides[session_key] = {
+    override = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
+    runner._session_model_overrides[session_key] = dict(override)
 
     await runner._handle_reset_command(_make_event("/new"))
 
-    assert session_key not in runner._session_model_overrides
+    assert runner._session_model_overrides[session_key] == override
 
 
 @pytest.mark.asyncio
@@ -99,28 +100,30 @@ async def test_new_command_no_override_is_noop():
 
 
 @pytest.mark.asyncio
-async def test_new_command_only_clears_own_session():
-    """/new must only clear the override for the session that triggered it."""
+async def test_new_command_preserves_own_override_without_touching_others():
+    """/new must keep the triggering session's override and leave other sessions alone."""
     runner = _make_runner()
     session_key = build_session_key(_make_source())
     other_key = "other_session_key"
 
-    runner._session_model_overrides[session_key] = {
+    own_override = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
-    runner._session_model_overrides[other_key] = {
+    other_override = {
         "model": "claude-sonnet-4-6",
         "provider": "anthropic",
-        "api_key": "sk-ant-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "anthropic",
     }
+    runner._session_model_overrides[session_key] = dict(own_override)
+    runner._session_model_overrides[other_key] = dict(other_override)
 
     await runner._handle_reset_command(_make_event("/new"))
 
-    assert session_key not in runner._session_model_overrides
-    assert other_key in runner._session_model_overrides
+    assert runner._session_model_overrides[session_key] == own_override
+    assert runner._session_model_overrides[other_key] == other_override


### PR DESCRIPTION
## Bug Description

After switching models in a chat session, sending `/new` reset the conversation history but also cleared the session-scoped model override. As a result, the next turn silently fell back to the default configured model, which caused the assistant to identify as the wrong model/provider.

## Root Cause

`GatewayRunner._handle_reset_command()` explicitly removed `self._session_model_overrides[session_key]` during `/new` / `/reset`. That made session reset behave like a model reset, even though users expect `/new` to start a fresh conversation while keeping the model they already selected for the current chat.

## Fix

- preserve the per-session model override across `/new`
- update the gateway regression tests to reflect the intended behavior
- verify that the current session keeps its override and other sessions remain unaffected

## How to Verify

1. Switch to a non-default model in a Telegram chat.
2. Send `/new`.
3. Send another message in the same chat.
4. Confirm the assistant still uses the selected model instead of reverting to the default one.

## Test Plan

- [x] Added regression test for this bug
- [x] Targeted tests pass: `python -m pytest tests/gateway/test_session_model_reset.py -q`
- [ ] Manual verification of the fix

## Risk Assessment

Low — this only changes `/new` semantics for session-scoped model overrides in the gateway. It does not affect global model configuration or unrelated session reset behavior.
