### PR TITLE
fix(kimi): cover remaining fixed-temperature bypasses

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -43,6 +43,15 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _effective_temperature_for_model(model: str) -> Optional[float]:
+    """Return a fixed temperature for models with strict sampling contracts."""
+    try:
+        from agent.auxiliary_client import _fixed_temperature_for_model
+    except Exception:
+        return None
+    return _fixed_temperature_for_model(model)
+
+
 
 
 # ============================================================================
@@ -442,12 +451,17 @@ Complete the user's task step by step."""
                 
                 # Make API call
                 try:
-                    response = self.client.chat.completions.create(
-                        model=self.model,
-                        messages=api_messages,
-                        tools=self.tools,
-                        timeout=300.0
-                    )
+                    api_kwargs = {
+                        "model": self.model,
+                        "messages": api_messages,
+                        "tools": self.tools,
+                        "timeout": 300.0,
+                    }
+                    fixed_temperature = _effective_temperature_for_model(self.model)
+                    if fixed_temperature is not None:
+                        api_kwargs["temperature"] = fixed_temperature
+
+                    response = self.client.chat.completions.create(**api_kwargs)
                 except Exception as e:
                     self.logger.error(f"API call failed: {e}")
                     break

--- a/tests/test_mini_swe_runner.py
+++ b/tests/test_mini_swe_runner.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def test_run_task_forces_kimi_fixed_temperature():
+    with patch("openai.OpenAI") as mock_openai:
+        client = MagicMock()
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="done", tool_calls=[]))]
+        )
+        mock_openai.return_value = client
+
+        from mini_swe_runner import MiniSWERunner
+
+        runner = MiniSWERunner(
+            model="kimi-for-coding",
+            base_url="https://api.kimi.com/coding/v1",
+            api_key="test-key",
+            env_type="local",
+            max_iterations=1,
+        )
+        runner._create_env = MagicMock()
+        runner._cleanup_env = MagicMock()
+
+        result = runner.run_task("2+2")
+
+    assert result["completed"] is True
+    assert client.chat.completions.create.call_args.kwargs["temperature"] == 0.6

--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -31,6 +31,29 @@ def test_import_loads_env_from_hermes_home(tmp_path, monkeypatch):
     assert os.getenv("OPENROUTER_API_KEY") == "from-hermes-home"
 
 
+def test_generate_summary_custom_client_forces_kimi_temperature():
+    config = CompressionConfig(
+        summarization_model="kimi-for-coding",
+        temperature=0.3,
+        summary_target_tokens=100,
+        max_retries=1,
+    )
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    compressor.client = MagicMock()
+    compressor.client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
+    )
+
+    metrics = TrajectoryMetrics()
+    result = compressor._generate_summary("tool output", metrics)
+
+    assert result.startswith("[CONTEXT SUMMARY]:")
+    assert compressor.client.chat.completions.create.call_args.kwargs["temperature"] == 0.6
+
+
 # ---------------------------------------------------------------------------
 # CompressionConfig
 # ---------------------------------------------------------------------------

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -11,6 +11,7 @@ each asyncio.run() gets a client bound to the current loop.
 """
 
 import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -113,3 +114,30 @@ class TestSourceLineVerification:
         """_get_async_client method should exist."""
         src = self._read_file()
         assert "def _get_async_client(self)" in src
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_async_custom_client_forces_kimi_temperature():
+    from trajectory_compressor import CompressionConfig, TrajectoryCompressor, TrajectoryMetrics
+
+    config = CompressionConfig(
+        summarization_model="kimi-for-coding",
+        temperature=0.3,
+        summary_target_tokens=100,
+        max_retries=1,
+    )
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    async_client = MagicMock()
+    async_client.chat.completions.create = MagicMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
+    ))
+    compressor._get_async_client = MagicMock(return_value=async_client)
+
+    metrics = TrajectoryMetrics()
+    result = await compressor._generate_summary_async("tool output", metrics)
+
+    assert result.startswith("[CONTEXT SUMMARY]:")
+    assert async_client.chat.completions.create.call_args.kwargs["temperature"] == 0.6

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2,11 +2,13 @@
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
 
 import tools.approval as approval_module
 from tools.approval import (
     _get_approval_mode,
+    _smart_approve,
     approve_session,
     detect_dangerous_command,
     is_approved,
@@ -24,6 +26,21 @@ class TestApprovalModeParsing:
     def test_string_off_still_maps_to_off(self):
         with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "off"}}):
             assert _get_approval_mode() == "off"
+
+
+class TestSmartApproval:
+    def test_smart_approval_uses_call_llm(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="APPROVE"))]
+        )
+        with mock_patch("agent.auxiliary_client.call_llm", return_value=response) as mock_call:
+            result = _smart_approve("python -c \"print('hello')\"", "script execution via -c flag")
+
+        assert result == "approve"
+        mock_call.assert_called_once()
+        assert mock_call.call_args.kwargs["task"] == "approval"
+        assert mock_call.call_args.kwargs["temperature"] == 0
+        assert mock_call.call_args.kwargs["max_tokens"] == 16
 
 
 class TestDetectDangerousRm:
@@ -819,5 +836,4 @@ class TestChmodExecuteCombo:
         cmd = "chmod +x script.sh"
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
-
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -542,12 +542,7 @@ def _smart_approve(command: str, description: str) -> str:
     (openai/codex#13860).
     """
     try:
-        from agent.auxiliary_client import get_text_auxiliary_client, auxiliary_max_tokens_param
-
-        client, model = get_text_auxiliary_client(task="approval")
-        if not client or not model:
-            logger.debug("Smart approvals: no aux client available, escalating")
-            return "escalate"
+        from agent.auxiliary_client import call_llm
 
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
@@ -563,11 +558,11 @@ Rules:
 
 Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
 
-        response = client.chat.completions.create(
-            model=model,
+        response = call_llm(
+            task="approval",
             messages=[{"role": "user", "content": prompt}],
-            **auxiliary_max_tokens_param(16),
             temperature=0,
+            max_tokens=16,
         )
 
         answer = (response.choices[0].message.content or "").strip().upper()

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -54,6 +54,19 @@ _project_env = Path(__file__).parent / ".env"
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 
 
+def _effective_temperature_for_model(model: str, requested_temperature: float) -> float:
+    """Apply fixed model temperature contracts to direct client calls."""
+    try:
+        from agent.auxiliary_client import _fixed_temperature_for_model
+    except Exception:
+        return requested_temperature
+
+    fixed_temperature = _fixed_temperature_for_model(model)
+    if fixed_temperature is not None:
+        return fixed_temperature
+    return requested_temperature
+
+
 @dataclass
 class CompressionConfig:
     """Configuration for trajectory compression."""
@@ -567,6 +580,10 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         for attempt in range(self.config.max_retries):
             try:
                 metrics.summarization_api_calls += 1
+                summary_temperature = _effective_temperature_for_model(
+                    self.config.summarization_model,
+                    self.config.temperature,
+                )
                 
                 if getattr(self, '_use_call_llm', False):
                     from agent.auxiliary_client import call_llm
@@ -574,14 +591,14 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                         provider=self._llm_provider,
                         model=self.config.summarization_model,
                         messages=[{"role": "user", "content": prompt}],
-                        temperature=self.config.temperature,
+                        temperature=summary_temperature,
                         max_tokens=self.config.summary_target_tokens * 2,
                     )
                 else:
                     response = self.client.chat.completions.create(
                         model=self.config.summarization_model,
                         messages=[{"role": "user", "content": prompt}],
-                        temperature=self.config.temperature,
+                        temperature=summary_temperature,
                         max_tokens=self.config.summary_target_tokens * 2,
                     )
                 
@@ -629,6 +646,10 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         for attempt in range(self.config.max_retries):
             try:
                 metrics.summarization_api_calls += 1
+                summary_temperature = _effective_temperature_for_model(
+                    self.config.summarization_model,
+                    self.config.temperature,
+                )
                 
                 if getattr(self, '_use_call_llm', False):
                     from agent.auxiliary_client import async_call_llm
@@ -636,14 +657,14 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                         provider=self._llm_provider,
                         model=self.config.summarization_model,
                         messages=[{"role": "user", "content": prompt}],
-                        temperature=self.config.temperature,
+                        temperature=summary_temperature,
                         max_tokens=self.config.summary_target_tokens * 2,
                     )
                 else:
                     response = await self._get_async_client().chat.completions.create(
                         model=self.config.summarization_model,
                         messages=[{"role": "user", "content": prompt}],
-                        temperature=self.config.temperature,
+                        temperature=summary_temperature,
                         max_tokens=self.config.summary_target_tokens * 2,
                     )
                 


### PR DESCRIPTION
## What does this PR do?

This closes three remaining direct `chat.completions.create()` bypasses that could still violate the Kimi Coding fixed `temperature=0.6` contract.

Current `main` already normalizes the main agent chat path, iteration-limit summary path, auxiliary helper path, and flush-memories path. These three direct-call sites were still outside that normalization layer:

- `tools/approval.py` smart approvals
- `trajectory_compressor.py` raw sync/async custom-endpoint fallback
- `mini_swe_runner.py`

If any of those paths resolved to `kimi-for-coding`, they could still 400 with `invalid temperature: only 0.6 is allowed for this model`.

This patch routes smart approvals through `call_llm()` and applies the same fixed-temperature guard to the remaining direct client calls.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/approval.py` to use `agent.auxiliary_client.call_llm()` for smart approvals instead of calling the auxiliary client directly with `temperature=0`
- Updated `trajectory_compressor.py` to apply the fixed-model temperature contract before the raw sync and async fallback `chat.completions.create()` calls
- Updated `mini_swe_runner.py` to apply the fixed-model temperature contract before its direct chat-completions call
- Added regression coverage in `tests/tools/test_approval.py`, `tests/test_trajectory_compressor.py`, `tests/test_trajectory_compressor_async.py`, and new `tests/test_mini_swe_runner.py`

## How to Test

1. Run the focused regression set:
   `source venv/bin/activate && python -m pytest tests/tools/test_approval.py tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py tests/test_mini_swe_runner.py tests/agent/test_auxiliary_client.py tests/run_agent/test_provider_parity.py -q -n 4`
2. Verify the focused result is `290 passed`
3. Run the full suite:
   `source venv/bin/activate && python -m pytest tests/ -q -n 4`
4. Verify the full-suite baseline result is `77 failed, 12677 passed, 35 skipped in 293.15s`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused regression run:
- `290 passed`

Full suite:
- `77 failed, 12677 passed, 35 skipped in 293.15s`

The failing tests are broad existing baseline failures in unrelated gateway/Discord/delegate/reasoning/backup/TTS areas, not in the Kimi temperature paths touched here.
