### PR TITLE
fix: preserve None content on tool-call-only assistant messages (#11906)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1013,7 +1013,11 @@ def convert_messages_to_anthropic(
 
     for m in messages:
         role = m.get("role", "user")
-        content = m.get("content", "")
+        content = m.get("content")
+        # Normalize empty string to None — proxies may convert "" to
+        # {"type": "text", "text": ""} which Anthropic rejects (HTTP 400).
+        if content is not None and isinstance(content, str) and not content.strip():
+            content = None
 
         if role == "system":
             if isinstance(content, list):

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -313,7 +313,7 @@ class HermesAgentLoop:
                 # Build the assistant message dict for conversation history
                 msg_dict: Dict[str, Any] = {
                     "role": "assistant",
-                    "content": assistant_msg.content or "",
+                    "content": assistant_msg.content,
                     "tool_calls": [_tc_to_dict(tc) for tc in assistant_msg.tool_calls],
                 }
 
@@ -490,7 +490,7 @@ class HermesAgentLoop:
                 # No tool calls -- model is done
                 msg_dict = {
                     "role": "assistant",
-                    "content": assistant_msg.content or "",
+                    "content": assistant_msg.content,
                 }
                 if reasoning:
                     msg_dict["reasoning_content"] = reasoning

--- a/run_agent.py
+++ b/run_agent.py
@@ -6993,7 +6993,7 @@ class AIAgent:
         # reasoning fields are present (some models/providers embed thinking
         # directly in the content rather than returning separate API fields).
         if not reasoning_text:
-            content = assistant_message.content or ""
+            content = assistant_message.content or ""  # safe for regex; not stored
             think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
             if think_blocks:
                 combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
@@ -7019,8 +7019,12 @@ class AIAgent:
 
         # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
         # can return invalid surrogate code points that crash json.dumps() on persist.
-        _raw_content = assistant_message.content or ""
-        _san_content = _sanitize_surrogates(_raw_content)
+        _raw_content = assistant_message.content
+        # Normalize empty string content to None — prevents downstream proxies
+        # from generating empty text blocks that Anthropic rejects (#11906).
+        if isinstance(_raw_content, str) and not _raw_content.strip():
+            _raw_content = None
+        _san_content = _sanitize_surrogates(_raw_content) if _raw_content is not None else None
         if reasoning_text:
             reasoning_text = _sanitize_surrogates(reasoning_text)
 
@@ -7188,6 +7192,11 @@ class AIAgent:
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
+                # Normalize empty assistant content to None (#11906)
+                if (api_msg.get("role") == "assistant"
+                        and isinstance(api_msg.get("content"), str)
+                        and not api_msg["content"].strip()):
+                    api_msg["content"] = None
                 if msg.get("role") == "assistant":
                     reasoning = msg.get("reasoning")
                     if reasoning:
@@ -8795,6 +8804,14 @@ class AIAgent:
             api_messages = []
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
+
+                # Normalize empty assistant content to None to prevent
+                # OpenAI-compatible proxies from generating empty text blocks
+                # that Anthropic rejects with HTTP 400 (#11906).
+                if (api_msg.get("role") == "assistant"
+                        and isinstance(api_msg.get("content"), str)
+                        and not api_msg["content"].strip()):
+                    api_msg["content"] = None
 
                 # Inject ephemeral context into the current turn's user message.
                 # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/tests/environments/test_agent_loop_none_content.py
+++ b/tests/environments/test_agent_loop_none_content.py
@@ -1,0 +1,84 @@
+"""Tests that assistant messages with content=None preserve None instead of
+normalizing to empty string ''.
+
+Anthropic-compatible proxies reject empty string content with HTTP 400:
+'text content blocks must be non-empty'.  Tool-call-only responses from the
+model return content=None, which must stay None in the conversation history.
+
+Fixes: #11906
+"""
+
+import types
+import unittest
+
+
+def _make_assistant_msg(content, tool_calls=None, reasoning_content=None):
+    """Create a minimal mock assistant message object."""
+    return types.SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls or [],
+        reasoning_content=reasoning_content,
+    )
+
+
+class TestAgentLoopNoneContent(unittest.TestCase):
+    """agent_loop.py must not convert content=None to '' in message dicts."""
+
+    def test_tool_call_message_preserves_none_content(self):
+        """The assistant message dict built for tool-call turns must keep content=None."""
+        from environments.agent_loop import HermesAgentLoop
+        import inspect
+        source = inspect.getsource(HermesAgentLoop.run)
+
+        # Find lines with content or "" normalization, excluding the read-only
+        # fallback parser check (which just tests string membership).
+        lines = [
+            line.strip() for line in source.splitlines()
+            if 'assistant_msg.content or ""' in line
+            and "<tool_call>" not in line
+        ]
+        self.assertEqual(
+            len(lines), 0,
+            f"Found message-dict normalization of None to '': {lines}",
+        )
+
+class TestBuildAssistantMessageNoneContent(unittest.TestCase):
+    """run_agent.py _build_assistant_message must preserve content=None."""
+
+    def _make_agent(self):
+        from run_agent import AIAgent
+        agent = AIAgent.__new__(AIAgent)
+        agent.verbose_logging = False
+        agent.reasoning_callback = None
+        agent.stream_delta_callback = None
+        agent._stream_callback = None
+        return agent
+
+    def test_none_content_stays_none(self):
+        """_build_assistant_message should keep content=None, not convert to ''."""
+        agent = self._make_agent()
+        msg = _make_assistant_msg(content=None)
+        result = agent._build_assistant_message(msg, finish_reason="stop")
+
+        self.assertIsNone(
+            result["content"],
+            f"content should be None, got {result['content']!r}",
+        )
+
+    def test_string_content_preserved(self):
+        """_build_assistant_message should preserve string content."""
+        agent = self._make_agent()
+        msg = _make_assistant_msg(content="Hello")
+        result = agent._build_assistant_message(msg, finish_reason="stop")
+        self.assertEqual(result["content"], "Hello")
+
+    def test_empty_string_content_normalized_to_none(self):
+        """_build_assistant_message should normalize empty string to None (#11906)."""
+        agent = self._make_agent()
+        msg = _make_assistant_msg(content="")
+        result = agent._build_assistant_message(msg, finish_reason="stop")
+        self.assertIsNone(result["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1066,7 +1066,8 @@ class TestBuildAssistantMessage:
     def test_empty_content(self, agent):
         msg = _mock_assistant_msg(content=None)
         result = agent._build_assistant_message(msg, "stop")
-        assert result["content"] == ""
+        # None content should stay None, not be converted to "" (#11906)
+        assert result["content"] is None
 
     def test_tool_call_extra_content_preserved(self, agent):
         """Gemini thinking models attach extra_content with thought_signature

--- a/tests/test_empty_assistant_content.py
+++ b/tests/test_empty_assistant_content.py
@@ -1,0 +1,162 @@
+"""Tests for #11906: Empty assistant content normalization.
+
+Ensures that empty/whitespace-only assistant message content is normalized
+to None so that downstream proxies don't generate empty text blocks that
+Anthropic rejects with HTTP 400.
+"""
+
+import json
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class TestBuildAssistantMessageEmptyContent:
+    """Test _build_assistant_message normalizes empty content to None."""
+
+    def _make_agent(self):
+        """Create a minimal AIAgent-like object for testing."""
+        from run_agent import AIAgent
+        agent = AIAgent.__new__(AIAgent)
+        agent.verbose_logging = False
+        agent.reasoning_callback = None
+        agent.stream_delta_callback = None
+        agent._stream_callback = None
+        agent._skill_nudge_interval = 0
+        return agent
+
+    def test_none_content_preserved(self):
+        agent = self._make_agent()
+        msg = SimpleNamespace(
+            content=None,
+            tool_calls=[SimpleNamespace(
+                id="call_1",
+                function=SimpleNamespace(name="test", arguments="{}"),
+                type="function",
+            )],
+        )
+        # Mock reasoning extraction
+        with patch.object(agent, '_extract_reasoning', return_value=None):
+            result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] is None
+
+    def test_empty_string_content_normalized_to_none(self):
+        agent = self._make_agent()
+        msg = SimpleNamespace(
+            content="",
+            tool_calls=[SimpleNamespace(
+                id="call_1",
+                function=SimpleNamespace(name="test", arguments="{}"),
+                type="function",
+            )],
+        )
+        with patch.object(agent, '_extract_reasoning', return_value=None):
+            result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] is None
+
+    def test_whitespace_content_normalized_to_none(self):
+        agent = self._make_agent()
+        msg = SimpleNamespace(
+            content="   \n  ",
+            tool_calls=None,
+        )
+        with patch.object(agent, '_extract_reasoning', return_value=None):
+            result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] is None
+
+    def test_real_content_preserved(self):
+        agent = self._make_agent()
+        msg = SimpleNamespace(
+            content="Hello, world!",
+            tool_calls=None,
+        )
+        with patch.object(agent, '_extract_reasoning', return_value=None):
+            result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "Hello, world!"
+
+
+class TestAnthropicAdapterEmptyContent:
+    """Test that the Anthropic adapter handles empty content correctly."""
+
+    def test_empty_content_assistant_with_tool_calls(self):
+        """Assistant message with tool_calls and empty content should not produce empty text blocks."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+
+        assert len(result) == 1
+        assistant_msg = result[0]
+        # Should have tool_use block but no empty text block
+        for block in assistant_msg["content"]:
+            if block.get("type") == "text":
+                assert block["text"] != "", "Empty text block should not be present"
+
+    def test_none_content_assistant_with_tool_calls(self):
+        """Assistant message with tool_calls and None content should not produce empty text blocks."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+
+        assert len(result) == 1
+        assistant_msg = result[0]
+        # Should have tool_use block but no empty text block
+        for block in assistant_msg["content"]:
+            if block.get("type") == "text":
+                assert block["text"] != "", "Empty text block should not be present"
+
+    def test_real_content_assistant_preserved(self):
+        """Assistant message with actual content should preserve it."""
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "I'll help you with that.",
+            }
+        ]
+        system, result = convert_messages_to_anthropic(messages)
+
+        assert len(result) == 1
+        assistant_msg = result[0]
+        text_blocks = [b for b in assistant_msg["content"] if b.get("type") == "text"]
+        assert any(b["text"] == "I'll help you with that." for b in text_blocks)
+
+
+class TestStreamingEmptyContent:
+    """Test that streaming correctly handles empty content."""
+
+    def test_empty_content_parts_yield_none(self):
+        """When no content deltas arrive (tool-call-only), content should be None."""
+        content_parts = []
+        full_content = "".join(content_parts) or None
+        assert full_content is None
+
+    def test_whitespace_only_content_parts(self):
+        """Whitespace-only streamed content should still be preserved (it's valid content)."""
+        content_parts = ["  "]
+        full_content = "".join(content_parts) or None
+        assert full_content == "  "  # Whitespace IS valid streamed content


### PR DESCRIPTION
## Problem
Empty assistant content (None) gets normalized to empty string `''`, which causes HTTP 400 on Anthropic-compatible proxies ('text content blocks must be non-empty'). This happens when the model returns a tool-call-only response.

## Fix
Three-layer normalization to prevent empty text blocks:
1. **`run_agent.py` (storage)**: Normalize empty string to None when storing assistant messages
2. **`run_agent.py` (API prep)**: Strip empty assistant content before sending to API (2 locations)
3. **`anthropic_adapter.py`**: Normalize in Anthropic message conversion as defensive guard

## Tests
- New test files covering empty content round-trips and Anthropic adapter behavior

Fixes #11906