### PR TITLE
fix(acp): preserve falsey tool results in step_callback — key-presence check instead of 'or'

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -148,7 +148,7 @@ def make_step_cb(
 
                 if isinstance(tool_info, dict):
                     tool_name = tool_info.get("name") or tool_info.get("function_name")
-                    result = tool_info.get("result") or tool_info.get("output")
+                    result = tool_info.get("result") if "result" in tool_info else tool_info.get("output")
                     function_args = tool_info.get("arguments") or tool_info.get("args")
                 elif isinstance(tool_info, str):
                     tool_name = tool_info


### PR DESCRIPTION
## Problem

`make_step_cb()` uses Python's `or` operator to fall back between result keys:

```python
result = tool_info.get('result') or tool_info.get('output')
```

This treats any **falsey value** (`""`, `0`, `False`, `[]`, `{}`) as missing and falls through to `output`. When a tool legitimately returns an empty string or zero, the result is silently replaced with `None`.

## Fix

```python
result = tool_info.get('result') if 'result' in tool_info else tool_info.get('output')
```

Use explicit key-presence check: if `'result'` key exists in the dict (regardless of value), use it. Only fall back to `'output'` when `'result'` is truly absent.

## Impact

- Tools returning `""` (empty string success) now forward correctly instead of becoming `None`
- Tools returning `0` (e.g. exit codes, counts) no longer lost
- Tools returning `False` (boolean results) preserved correctly
- One-line change, no behavior change for truthy results

## Notes

This is a clean rebase of my earlier PR #10868 onto current main. Single character change — no conflicts.