### PR TITLE
fix(doctor): detect OPENAI_BASE_URL vs config.yaml base_url conflict (asymmetric routing)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -367,6 +367,65 @@ def run_doctor(args):
             pass
 
     # =========================================================================
+    # Check: Provider endpoint configuration (OPENAI_BASE_URL conflicts)
+    # =========================================================================
+    print()
+    print(color("◆ Provider Endpoint Configuration", Colors.CYAN, Colors.BOLD))
+
+    # Check for OPENAI_BASE_URL vs config.yaml base_url conflict (#5161)
+    env_base_url = os.environ.get("OPENAI_BASE_URL", "").rstrip("/")
+    config_base_url = ""
+    try:
+        config_path = HERMES_HOME / "config.yaml"
+        if config_path.exists():
+            with open(config_path) as f:
+                raw_config = yaml.safe_load(f) or {}
+            config_base_url = (raw_config.get("model", {}).get("base_url") or "").rstrip("/")
+    except Exception:
+        pass
+
+    if env_base_url and config_base_url:
+        if env_base_url != config_base_url:
+            check_warn(
+                "OPENAI_BASE_URL conflicts with config.yaml base_url",
+                f"(env: {env_base_url[:40]}... vs config: {config_base_url[:40]}...)"
+            )
+            check_info("Auxiliary clients (compression, vision, subagents) may route to wrong endpoint")
+            check_info(f"Fix: comment out OPENAI_BASE_URL in {_DHH}/.env or align endpoints")
+            if should_fix:
+                # Comment out OPENAI_BASE_URL in .env
+                env_file = HERMES_HOME / ".env"
+                if env_file.exists():
+                    try:
+                        content = env_file.read_text()
+                        lines = content.splitlines()
+                        new_lines = []
+                        modified = False
+                        for line in lines:
+                            stripped = line.strip()
+                            if stripped.startswith("OPENAI_BASE_URL="):
+                                new_lines.append(f"# {line}  # commented by hermes doctor --fix")
+                                modified = True
+                            else:
+                                new_lines.append(line)
+                        if modified:
+                            env_file.write_text("\n".join(new_lines) + "\n")
+                            check_ok(f"Commented out OPENAI_BASE_URL in {_DHH}/.env")
+                            fixed_count += 1
+                    except Exception as e:
+                        check_warn(f"Could not fix .env: {e}")
+            else:
+                issues.append(f"OPENAI_BASE_URL in .env conflicts with base_url in config.yaml — run 'hermes doctor --fix'")
+        else:
+            check_ok("OPENAI_BASE_URL matches config.yaml base_url")
+    elif env_base_url and not config_base_url:
+        check_ok(f"OPENAI_BASE_URL set (custom endpoint: {env_base_url[:50]}...)")
+    elif config_base_url:
+        check_ok(f"base_url configured in config.yaml")
+    else:
+        check_ok("Using provider defaults (no custom endpoint)")
+
+    # =========================================================================
     # Check: Auth providers
     # =========================================================================
     print()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -88,6 +88,36 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _normalize_base_url(url: str) -> str:
+    """Normalize a base URL for comparison.
+
+    Handles:
+      - Trailing slashes
+      - Default ports (:443 for https, :80 for http)
+      - Case normalization for scheme/host
+
+    This prevents false-positive conflict warnings when URLs are semantically
+    identical but differ in representation (e.g., https://api.example.com:443/
+    vs https://api.example.com).
+    """
+    import re
+    if not url:
+        return ""
+    url = url.strip().rstrip("/")
+    # Normalize scheme and host to lowercase (path case is preserved)
+    if "://" in url:
+        scheme_host, _, path = url.partition("/")
+        if "/" in path:
+            # Has path after host
+            url = scheme_host.lower() + "/" + path
+        else:
+            url = url.lower()
+    # Remove default ports
+    url = re.sub(r"^(https://[^/:]+):443(/|$)", r"\1\2", url)
+    url = re.sub(r"^(http://[^/:]+):80(/|$)", r"\1\2", url)
+    return url
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -373,22 +403,26 @@ def run_doctor(args):
     print(color("◆ Provider Endpoint Configuration", Colors.CYAN, Colors.BOLD))
 
     # Check for OPENAI_BASE_URL vs config.yaml base_url conflict (#5161)
-    env_base_url = os.environ.get("OPENAI_BASE_URL", "").rstrip("/")
+    env_base_url_raw = os.environ.get("OPENAI_BASE_URL", "")
+    env_base_url = _normalize_base_url(env_base_url_raw)
     config_base_url = ""
+    config_base_url_raw = ""
     try:
         config_path = HERMES_HOME / "config.yaml"
         if config_path.exists():
             with open(config_path) as f:
                 raw_config = yaml.safe_load(f) or {}
-            config_base_url = (raw_config.get("model", {}).get("base_url") or "").rstrip("/")
+            config_base_url_raw = raw_config.get("model", {}).get("base_url") or ""
+            config_base_url = _normalize_base_url(config_base_url_raw)
     except Exception:
         pass
 
     if env_base_url and config_base_url:
         if env_base_url != config_base_url:
+            # Show raw values in output so users can see what they configured
             check_warn(
                 "OPENAI_BASE_URL conflicts with config.yaml base_url",
-                f"(env: {env_base_url[:40]}... vs config: {config_base_url[:40]}...)"
+                f"(env: {env_base_url_raw[:40]}... vs config: {config_base_url_raw[:40]}...)"
             )
             check_info("Auxiliary clients (compression, vision, subagents) may route to wrong endpoint")
             check_info(f"Fix: comment out OPENAI_BASE_URL in {_DHH}/.env or align endpoints")


### PR DESCRIPTION
Rebased cleanly onto main. Original PR #5193.

## Problem

When switching providers via `hermes model`, `config.yaml` gets the new `base_url` but any pre-existing `OPENAI_BASE_URL` in `.env` remains. This causes **asymmetric routing**: main inference uses `config.yaml` correctly, while auxiliary clients (compression, vision, delegation) fall back to `OPENAI_BASE_URL` — silently routing to the wrong endpoint.

## Fix

Adds a new check in `hermes doctor` that detects when both are set and point to different endpoints. Issues a `WARN` with clear remediation instructions.

URL normalization handles: trailing slashes, default ports (:443/:80), scheme/host casing.

Supersedes #5193.