### PR TITLE
fix(discord): add invoking user to thread after /thread command

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2369,6 +2369,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=auto_archive_duration,
                 reason=reason,
             )
+            # Add the command invoker to the thread so they can see and interact with it
+            # This is required for private threads where the creator isn't auto-added
+            try:
+                if interaction.user:
+                    await thread.add_user(interaction.user)
+            except Exception as add_err:
+                logger.warning("[%s] Failed to add user to thread: %s", self.name, add_err)
             if starter_message:
                 await thread.send(starter_message)
             return {
@@ -2385,6 +2392,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=auto_archive_duration,
                     reason=reason,
                 )
+                # Add the command invoker to the thread (fallback path)
+                try:
+                    if interaction.user:
+                        await thread.add_user(interaction.user)
+                except Exception as add_err:
+                    logger.warning("[%s] Failed to add user to thread (fallback): %s", self.name, add_err)
                 return {
                     "success": True,
                     "thread_id": str(thread.id),


### PR DESCRIPTION
Rebased onto current main. Original PR #5458.

When a user runs /thread, Hermes creates a new Discord thread but doesn't add the invoking user as a member. The user's messages then don't appear in the thread until they manually join. Fix: add the user_id to the thread immediately after creation.