### PR TITLE
fix(gateway): remove early return in launchd_restart() for SIGUSR1 path

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1911,8 +1911,7 @@ def launchd_restart():
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
-            return
-        if pid is not None:
+        elif pid is not None:
             try:
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):


### PR DESCRIPTION
## Summary

Fixes #11932

One-line fix: remove the early `return` after SIGUSR1 in `launchd_restart()` and change the second `if pid is not None` to `elif`, so both code paths converge on `_wait_for_gateway_exit()` + `launchctl kickstart -k`.

## Before (buggy)

```python
pid = get_running_pid()
if pid is not None and _request_gateway_self_restart(pid):  # SIGUSR1 path
    print("✓ Service restart requested")
    return                          # ← returns immediately, no kickstart
if pid is not None:                 # SIGTERM path
    terminate_pid(pid, force=False)
    # ... wait + kickstart
subprocess.run(["launchctl", "kickstart", "-k", target])
```

When the gateway PID is an ancestor of the calling process, SIGUSR1 is sent and `launchd_restart()` returns immediately. The gateway exits with code 75, but nobody calls `kickstart`, so launchd does not restart it. The service stays dead until manual `hermes gateway start`.

## After (fixed)

```python
pid = get_running_pid()
if pid is not None and _request_gateway_self_restart(pid):  # SIGUSR1 path
    print("✓ Service restart requested")                   # no return — falls through
elif pid is not None:                 # SIGTERM path (only if SIGUSR1 was NOT sent)
    terminate_pid(pid, force=False)
    # ... wait
subprocess.run(["launchctl", "kickstart", "-k", target])    # always executed
```

Both paths now reach `kickstart -k`, ensuring the gateway is always restarted.

## Impact

- **SIGUSR1 path (ancestor process):** Now correctly waits for exit and kickstarts. Previously broken — gateway died permanently.
- **SIGTERM path (non-ancestor):** Unchanged behavior — already worked correctly.
- **Normal `/update` command:** Unaffected — uses `setsid` to detach from gateway process tree, takes SIGTERM path.
- **Linux:** Unaffected — uses `systemd_restart()`, separate code path.

## Testing

- Syntax verified via `py_compile`.
- Local deployment tested: `hermes update` via agent terminal tool now correctly recovers gateway.
- Existing tests unaffected (launchd is macOS-only, not covered by CI on Linux).

## Related

- Issue: #11932
- Similar fix for Linux (systemd path): PR #9850