### PR TITLE
fix: preserve local Codex/Anthropic reliability fixes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -163,6 +163,33 @@ _CODEX_AUX_MODEL = "gpt-5.2-codex"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
+def _codex_default_headers(token: str) -> dict:
+    """Build the headers required by the Codex backend.
+
+    chatgpt.com/backend-api requires both chatgpt-account-id (extracted from
+    the JWT) and an originator header, in addition to the Bearer token.
+    Without these the backend can return 401 auth parsing errors.
+    """
+    import base64
+    import json as _json
+    import platform
+
+    try:
+        parts = token.split(".")
+        payload = _json.loads(base64.b64decode(parts[1] + "==").decode())
+        account_id = payload["https://api.openai.com/auth"]["chatgpt_account_id"]
+    except Exception:
+        account_id = ""
+
+    ua = f"codex_cli_rs/0.0.0 ({platform.system()} {platform.release()}; {platform.machine()})"
+    return {
+        "chatgpt-account-id": account_id,
+        "originator": "codex_cli_rs",
+        "User-Agent": ua,
+        "OpenAI-Beta": "responses=experimental",
+    }
+
+
 def _to_openai_base_url(base_url: str) -> str:
     """Normalize an Anthropic-style base URL to OpenAI-compatible format.
 
@@ -1015,7 +1042,11 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
             return None, None
         base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
-    real_client = OpenAI(api_key=codex_token, base_url=base_url)
+    real_client = OpenAI(
+        api_key=codex_token,
+        base_url=base_url,
+        default_headers=_codex_default_headers(codex_token),
+    )
     return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
 
@@ -1475,7 +1506,11 @@ def resolve_provider_client(
                                "but no Codex OAuth token found (run: hermes model)")
                 return None, None
             final_model = _normalize_resolved_model(model or _CODEX_AUX_MODEL, provider)
-            raw_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL)
+            raw_client = OpenAI(
+                api_key=codex_token,
+                base_url=_CODEX_AUX_BASE_URL,
+                default_headers=_codex_default_headers(codex_token),
+            )
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
         client, default = _try_codex()
@@ -1516,9 +1551,30 @@ def resolve_provider_client(
             client = _wrap_if_needed(client, final_model, custom_base)
             return (_to_async_client(client, final_model) if async_mode
                     else (client, final_model))
-        # Try custom first, then codex, then API-key providers
-        for try_fn in (_try_custom_endpoint, _try_codex,
-                       _resolve_api_key_provider):
+        # Respect OPENAI_BASE_URL directly when it points at a non-Codex
+        # OpenAI-compatible endpoint. This avoids accidentally falling through
+        # to the Codex backend when the primary/fallback runtime is meant to
+        # use a normal OpenAI-compatible server.
+        _env_base = os.getenv("OPENAI_BASE_URL", "").strip().rstrip("/")
+        if _env_base and "chatgpt.com" not in _env_base.lower():
+            _env_key = os.getenv("OPENAI_API_KEY", "").strip() or "no-key-required"
+            final_model = _normalize_resolved_model(
+                model or _read_main_model() or "gpt-4o-mini",
+                provider,
+            )
+            client = OpenAI(api_key=_env_key, base_url=_env_base)
+            logger.debug(
+                "resolve_provider_client: custom via OPENAI_BASE_URL (%s)",
+                _env_base,
+            )
+            client = _wrap_if_needed(client, final_model, _env_base)
+            return (_to_async_client(client, final_model) if async_mode
+                    else (client, final_model))
+
+        # Try custom endpoint resolver, then API-key providers.
+        # Do not fall through to _try_codex here, or custom/main fallback can
+        # bleed into the Codex backend unexpectedly.
+        for try_fn in (_try_custom_endpoint, _resolve_api_key_provider):
             client, default = try_fn()
             if client is not None:
                 final_model = _normalize_resolved_model(model or default, provider)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -156,10 +156,9 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
 # Codex fallback: uses the Responses API (the only endpoint the Codex
 # OAuth token can access) with a fast model for auxiliary tasks.
-# ChatGPT-backed Codex accounts currently reject gpt-5.3-codex for these
-# auxiliary flows, while gpt-5.2-codex remains broadly available and supports
-# vision via Responses.
-_CODEX_AUX_MODEL = "gpt-5.2-codex"
+# On this ChatGPT-backed Codex account, gpt-5.3-codex works for auxiliary
+# flows while gpt-5.2-codex is rejected.
+_CODEX_AUX_MODEL = "gpt-5.3-codex"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -129,6 +129,10 @@ def check_for_updates() -> Optional[int]:
     Does a ``git fetch`` at most once every 6 hours (cached to
     ``~/.hermes/.update_check``).  Returns the number of commits behind,
     or ``None`` if the check fails or isn't applicable.
+
+    Fresh cache entries are only reused when they match the current local
+    ``HEAD`` and ``origin/main`` refs. This prevents stale "commits behind"
+    reports after manual git updates or branch switches.
     """
     hermes_home = get_hermes_home()
     repo_dir = hermes_home / "hermes-agent"
@@ -140,13 +144,23 @@ def check_for_updates() -> Optional[int]:
     if not (repo_dir / ".git").exists():
         return None
 
+    def _current_refs() -> tuple[Optional[str], Optional[str]]:
+        return (_git_short_hash(repo_dir, "HEAD"), _git_short_hash(repo_dir, "origin/main"))
+
     # Read cache
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
             if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
-                return cached.get("behind")
+                current_head, current_upstream = _current_refs()
+                if (
+                    current_head
+                    and current_upstream
+                    and cached.get("head") == current_head
+                    and cached.get("upstream") == current_upstream
+                ):
+                    return cached.get("behind")
     except Exception:
         pass
 
@@ -174,9 +188,16 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         behind = None
 
+    current_head, current_upstream = _current_refs()
+
     # Write cache
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(json.dumps({
+            "ts": now,
+            "behind": behind,
+            "head": current_head,
+            "upstream": current_upstream,
+        }))
     except Exception:
         pass
 

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -178,6 +178,20 @@ def _dots_to_hyphens(model_name: str) -> str:
     return model_name.replace(".", "-")
 
 
+_ANTHROPIC_SHORTHAND_ALIASES: dict[str, str] = {
+    # Common marketing shorthand users type into config/CLI.
+    # Anthropic's direct API rejects these unless they resolve to the
+    # current native model id.
+    "claude-sonnet-4": "claude-sonnet-4-6",
+    "claude-opus-4": "claude-opus-4-7",
+}
+
+
+def _repair_anthropic_shorthand(model_name: str) -> str:
+    """Map common Anthropic shorthand ids to supported native API ids."""
+    return _ANTHROPIC_SHORTHAND_ALIASES.get(model_name, model_name)
+
+
 def _normalize_provider_alias(provider_name: str) -> str:
     """Resolve provider aliases to Hermes' canonical ids."""
     raw = (provider_name or "").strip().lower()
@@ -367,11 +381,13 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
             return _dots_to_hyphens(bare)
         return bare
 
-    # --- Anthropic: strip matching provider prefix, dots -> hyphens ---
+    # --- Anthropic: strip matching provider prefix, repair common Claude
+    #     shorthands, then dots -> hyphens ---
     if provider in _DOT_TO_HYPHEN_PROVIDERS:
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:
             return bare
+        bare = _repair_anthropic_shorthand(bare)
         return _dots_to_hyphens(bare)
 
     # --- Copilot / Copilot ACP: delegate to the Copilot-specific

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -260,7 +260,7 @@ class TestTryCodex:
             client, model = _try_codex()
 
         assert client is not None
-        assert model == "gpt-5.2-codex"
+        assert model == "gpt-5.3-codex"
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
 
@@ -474,7 +474,7 @@ class TestGetTextAuxiliaryClient:
         from agent.auxiliary_client import CodexAuxiliaryClient
 
         assert isinstance(client, CodexAuxiliaryClient)
-        assert model == "gpt-5.2-codex"
+        assert model == "gpt-5.3-codex"
 
 # ── Payment / credit exhaustion fallback ─────────────────────────────────
 
@@ -573,11 +573,11 @@ class TestTryPaymentFallback:
         with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_nous", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_codex", return_value=(mock_codex, "gpt-5.2-codex")), \
+             patch("agent.auxiliary_client._try_codex", return_value=(mock_codex, "gpt-5.3-codex")), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
             client, model, label = _try_payment_fallback("openrouter")
         assert client is mock_codex
-        assert model == "gpt-5.2-codex"
+        assert model == "gpt-5.3-codex"
         assert label == "openai-codex"
 
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -51,6 +51,14 @@ class TestAnthropicDotToHyphen:
         result = normalize_model_for_provider("anthropic/claude-sonnet-4.6", "anthropic")
         assert result == "claude-sonnet-4-6"
 
+    @pytest.mark.parametrize("model", [
+        "claude-sonnet-4",
+        "anthropic/claude-sonnet-4",
+    ])
+    def test_anthropic_repairs_common_shorthand_alias(self, model):
+        """Common shorthand should resolve to Anthropic's currently supported Sonnet 4 id."""
+        assert normalize_model_for_provider(model, "anthropic") == "claude-sonnet-4-6"
+
 
 # ── OpenCode Zen regression ────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,7 +17,7 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """When cache is fresh and refs match, check_for_updates should return cached value without calling git."""
     from hermes_cli.banner import check_for_updates
 
     # Create a fake git repo and fresh cache
@@ -26,10 +26,18 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "head": "abc12345",
+        "upstream": "def67890",
+    }))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    with (
+        patch("hermes_cli.banner._git_short_hash", side_effect=["abc12345", "def67890"]),
+        patch("hermes_cli.banner.subprocess.run") as mock_run,
+    ):
         result = check_for_updates()
 
     assert result == 3
@@ -51,10 +59,41 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     mock_result = MagicMock(returncode=0, stdout="5\n")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+    with (
+        patch("hermes_cli.banner._git_short_hash", side_effect=["head1234", "upstream9"]),
+        patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run,
+    ):
         result = check_for_updates()
 
     assert result == 5
+    assert mock_run.call_count == 2  # git fetch + git rev-list
+
+
+def test_check_for_updates_ignores_fresh_cache_when_git_state_changes(tmp_path, monkeypatch):
+    """Fresh cache must be invalidated when HEAD/upstream refs changed since it was written."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 13,
+        "head": "oldhead12",
+        "upstream": "oldup123",
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    with (
+        patch("hermes_cli.banner._git_short_hash", side_effect=["newhead34", "newup567", "newhead34", "newup567"]),
+        patch("hermes_cli.banner.subprocess.run", return_value=MagicMock(returncode=0, stdout="0\n")) as mock_run,
+    ):
+        result = check_for_updates()
+
+    assert result == 0
     assert mock_run.call_count == 2  # git fetch + git rev-list
 
 


### PR DESCRIPTION
## Summary
- preserve Codex auxiliary auth/header fixes on top of latest upstream
- switch Codex auxiliary fallback to gpt-5.3-codex and update regression tests
- invalidate stale cached update-check behind counts when refs change
- repair Anthropic Claude shorthand ids like claude-sonnet-4 for direct Anthropic usage

## Validation
- python -m pytest tests/agent/test_auxiliary_client.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_model_normalize.py -q
- python -m hermes_cli.main chat -Q --provider anthropic -m claude-sonnet-4 -q 'Reply with exactly: ANTHROPIC_OK'
- python -m hermes_cli.main chat -Q -q 'Reply with exactly: SMOKE_OK'