### PR TITLE
fix: point optional-dep install hints at the venv's python

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7017,8 +7017,7 @@ class HermesCLI:
                 )
             raise RuntimeError(
                 "Voice mode requires sounddevice and numpy.\n"
-                "Install with: pip install sounddevice numpy\n"
-                "Or: pip install hermes-agent[voice]"
+                f"Install with: {sys.executable} -m pip install sounddevice numpy"
             )
         if not reqs.get("stt_available", reqs.get("stt_key_set")):
             raise RuntimeError(
@@ -7294,8 +7293,7 @@ class HermesCLI:
                     _cprint(f"  {_DIM}Then install/update the Termux:API Android app for microphone capture{_RST}")
                     _cprint(f"  {_BOLD}Option 2: pkg install python-numpy portaudio && python -m pip install sounddevice{_RST}")
                 else:
-                    _cprint(f"\n  {_BOLD}Install: pip install {' '.join(reqs['missing_packages'])}{_RST}")
-                    _cprint(f"  {_DIM}Or: pip install hermes-agent[voice]{_RST}")
+                    _cprint(f"\n  {_BOLD}Install: {sys.executable} -m pip install {' '.join(reqs['missing_packages'])}{_RST}")
             return
 
         with self._voice_lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5520,8 +5520,7 @@ class GatewayRunner:
             if "pynacl" in err_lower or "nacl" in err_lower or "davey" in err_lower:
                 return (
                     "Voice dependencies are missing (PyNaCl / davey). "
-                    "Install or reinstall Hermes with the messaging extra, e.g. "
-                    "`pip install hermes-agent[messaging]`."
+                    f"Install with: `{sys.executable} -m pip install PyNaCl`"
                 )
             return f"Failed to join voice channel: {e}"
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -895,8 +895,8 @@ def run_doctor(args):
                 _model_count = len(_br_resp.get("modelSummaries", []))
                 print(f"\r  {color('✓', Colors.GREEN)} {_label} {color(f'({_auth_var}, {_region}, {_model_count} models)', Colors.DIM)}           ")
             except ImportError:
-                print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color('(boto3 not installed — pip install hermes-agent[bedrock])', Colors.DIM)}           ")
-                issues.append("Install boto3 for Bedrock: pip install hermes-agent[bedrock]")
+                print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'(boto3 not installed — {sys.executable} -m pip install boto3)', Colors.DIM)}           ")
+                issues.append(f"Install boto3 for Bedrock: {sys.executable} -m pip install boto3")
             except Exception as _e:
                 _err_name = type(_e).__name__
                 print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'({_err_name}: {_e})', Colors.DIM)}           ")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6029,7 +6029,7 @@ def cmd_dashboard(args):
         import uvicorn  # noqa: F401
     except ImportError:
         print("Web UI dependencies not installed.")
-        print("Install them with:  pip install hermes-agent[web]")
+        print(f"Install them with:  {sys.executable} -m pip install 'fastapi' 'uvicorn[standard]'")
         sys.exit(1)
 
     if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -56,7 +56,7 @@ try:
 except ImportError:
     raise SystemExit(
         "Web UI requires fastapi and uvicorn.\n"
-        "Run 'hermes web' to auto-install, or: pip install hermes-agent[web]"
+        f"Install with: {sys.executable} -m pip install 'fastapi' 'uvicorn[standard]'"
     )
 
 WEB_DIST = Path(__file__).parent / "web_dist"

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -433,7 +433,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     if not _MCP_SERVER_AVAILABLE:
         raise ImportError(
             "MCP server requires the 'mcp' package. "
-            "Install with: pip install 'hermes-agent[mcp]'"
+            f"Install with: {sys.executable} -m pip install 'mcp'"
         )
 
     mcp = FastMCP(
@@ -838,7 +838,7 @@ def run_mcp_server(verbose: bool = False) -> None:
     if not _MCP_SERVER_AVAILABLE:
         print(
             "Error: MCP server requires the 'mcp' package.\n"
-            "Install with: pip install 'hermes-agent[mcp]'",
+            f"Install with: {sys.executable} -m pip install 'mcp'",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -15,6 +15,7 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -582,8 +583,7 @@ class AudioRecorder:
         except (ImportError, OSError) as e:
             raise RuntimeError(
                 "Voice mode requires sounddevice and numpy.\n"
-                "Install with: pip install sounddevice numpy\n"
-                "Or: pip install hermes-agent[voice]"
+                f"Install with: {sys.executable} -m pip install sounddevice numpy"
             ) from e
 
         with self._lock:


### PR DESCRIPTION
## Summary
Error messages that tell users to install optional extras (`fastapi`, `uvicorn`, `mcp`, `sounddevice`, `PyNaCl`, `boto3`) now point at the venv's Python instead of a bare `pip install hermes-agent[extra]`, so the copy-pasted command targets the right environment.

Root cause: the curl installer creates a venv at `~/.hermes/hermes-agent/venv/`, but the error hints said `pip install hermes-agent[web]`. A bare `pip` resolves to the user's system pip, which either hits PEP 668 externally-managed-environment (Ubuntu 24.04+, Debian 12+) or installs into the wrong Python. Reported on Discord — user ran `hermes dashboard`, followed the hint literally, got errors.

Also drops a stale `hermes web` reference in `web_server.py` (that command does not exist; only `hermes dashboard` does).

## Changes
All user-facing `pip install hermes-agent[extra]` hints now expand to `{sys.executable} -m pip install <concrete packages>`:

| File | Site |
|---|---|
| `hermes_cli/main.py` | `cmd_dashboard` fastapi/uvicorn |
| `hermes_cli/web_server.py` | module-level ImportError (also drops stale `hermes web` suggestion) |
| `mcp_serve.py` | `create_mcp_server` + `run_mcp_server` mcp |
| `hermes_cli/doctor.py` | Bedrock `boto3` check |
| `cli.py` | `/voice on` RuntimeError + `/voice` check output |
| `tools/voice_mode.py` | `_import_audio` RuntimeError (plus `import sys` since it was missing) |
| `gateway/run.py` | Discord voice-channel join failure |

## Validation

| | Before | After |
|---|---|---|
| `hermes dashboard` hint | `pip install hermes-agent[web]` | `/home/.../venv/bin/python3 -m pip install 'fastapi' 'uvicorn[standard]'` |
| py_compile | — | 7/7 files pass |
| E2E (import-blocked `cmd_dashboard`) | — | Prints venv-path hint; exits 1 |
