### PR TITLE
fix(gateway): make PID and runtime status writes atomic

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -17,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -185,7 +186,24 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload))
+    serialized = json.dumps(payload)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        suffix=".tmp",
+        prefix=f".{path.name}.",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(serialized)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -81,6 +81,30 @@ class TestGatewayPidState:
         assert status.get_running_pid(pid_path, cleanup_stale=False) == os.getpid()
         assert pid_path.exists()
 
+    def test_write_pid_file_preserves_existing_record_when_replace_fails(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        original = {
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 123,
+        }
+        pid_path.write_text(json.dumps(original))
+
+        def fail_replace(src, dst):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(status.os, "replace", fail_replace)
+
+        try:
+            status.write_pid_file()
+        except OSError:
+            pass
+
+        assert json.loads(pid_path.read_text()) == original
+        assert not list(tmp_path.glob("*.tmp"))
+
 
 class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):
@@ -149,6 +173,32 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["state"] == "connected"
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
+
+    def test_write_runtime_status_preserves_existing_file_on_replace_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        original = {
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+            "platforms": {},
+            "updated_at": "2025-01-01T00:00:00Z",
+        }
+        state_path.write_text(json.dumps(original))
+
+        def fail_replace(src, dst):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(status.os, "replace", fail_replace)
+
+        try:
+            status.write_runtime_status(gateway_state="startup_failed")
+        except OSError:
+            pass
+
+        assert json.loads(state_path.read_text()) == original
+        assert not list(tmp_path.glob("*.tmp"))
 
 
 class TestTerminatePid:


### PR DESCRIPTION
## Summary

Make gateway PID and runtime status file writes atomic so interrupted writes do not corrupt the last known good state.

## Problem

`gateway/status.py` was writing JSON state files in place with `Path.write_text()`. If the process crashed or I/O failed during a write, the existing file could be truncated or left partially written.

That can make a still-running or recently-started gateway appear missing because later reads treat the PID/status file as empty or invalid JSON.

## Fix

- write JSON payloads to a temporary file in the same directory
- flush and `fsync()` the temp file before replacement
- replace the target with `os.replace()` for atomic swap semantics
- clean up the temp file on failure

This preserves the previous valid state file if the replacement step fails.

## Tests

Added regression coverage for both state file paths:

- preserve existing `gateway.pid` contents when `os.replace()` fails
- preserve existing `gateway_state.json` contents when `os.replace()` fails
- ensure no temporary files are left behind after failure

## Validation

```bash
uv run python -m pytest tests/gateway/test_status.py -q -n 4

28 passed, 4 warnings in 0.79s