### PR TITLE
Respect proxy env when constructing injected OpenAI clients

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4512,7 +4512,14 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        _proxy_env_present = any(
+            os.getenv(name)
+            for name in (
+                "http_proxy", "https_proxy", "all_proxy",
+                "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
+            )
+        )
+        if "http_client" not in client_kwargs and not _proxy_env_present:
             try:
                 import httpx as _httpx
                 import socket as _socket

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -35,3 +35,31 @@ def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
     assert kwargs == snapshot, (
         f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
     )
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_respects_proxy_env(mock_openai, monkeypatch):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.4",
+        provider="openai-codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+    agent._create_openai_client(
+        {"api_key": "test-key", "base_url": "https://chatgpt.com/backend-api/codex"},
+        reason="test",
+        shared=False,
+    )
+
+    assert "http_client" not in mock_openai.call_args.kwargs, (
+        "_create_openai_client injected a custom http_client even though proxy "
+        "environment variables were present; that bypasses env proxy handling "
+        "and breaks providers that require a local proxy path."
+    )


### PR DESCRIPTION
## Summary
- skip injected custom `httpx.Client` creation when standard proxy env vars are present
- preserve the existing keepalive transport path when no proxy env is configured
- add a regression test to lock the proxy-aware behavior

## Problem
`_create_openai_client()` injects a custom `httpx.Client(transport=HTTPTransport(...))` to set TCP keepalive socket options. That transport path does not inherit environment proxy settings, so providers that rely on `HTTP(S)_PROXY` or `ALL_PROXY` silently bypass the user's proxy path.

In practice this broke `openai-codex` for local proxy setups: Codex CLI requests succeeded, but Hermes requests to `chatgpt.com/backend-api/codex` timed out because Hermes was effectively direct-connecting.

## Validation
- `python -m pytest -q tests/run_agent/test_create_openai_client_kwargs_isolation.py tests/run_agent/test_create_openai_client_reuse.py`
- live repro with proxy env configured: `hermes -p memecoinscout chat -q "只回复 ok" -Q --provider openai-codex -m gpt-5.4` now returns `ok`