### PR TITLE
fix(hooks): reject scalar manifest events

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -102,6 +102,12 @@ class HookRegistry:
                 if not events:
                     print(f"[hooks] Skipping {hook_name}: no events declared", flush=True)
                     continue
+                if not isinstance(events, list) or not all(isinstance(event, str) and event for event in events):
+                    print(
+                        f"[hooks] Skipping {hook_name}: invalid events declaration (expected list of strings)",
+                        flush=True,
+                    )
+                    continue
 
                 # Dynamically load the handler module
                 spec = importlib.util.spec_from_file_location(

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -81,6 +81,22 @@ class TestDiscoverAndLoad:
 
         assert len(reg.loaded_hooks) == 0
 
+    def test_skips_scalar_events_manifest(self, tmp_path, capsys):
+        hook_dir = tmp_path / "scalar-events"
+        hook_dir.mkdir()
+        (hook_dir / "HOOK.yaml").write_text("name: scalar-events\nevents: agent:start\n")
+        (hook_dir / "handler.py").write_text("def handle(e, c): pass\n")
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        captured = capsys.readouterr()
+        assert len(reg.loaded_hooks) == 0
+        assert "invalid events" in captured.out.lower()
+        assert "agent:start" not in reg._handlers
+        assert "a" not in reg._handlers
+
     def test_skips_no_handle_function(self, tmp_path):
         hook_dir = tmp_path / "no-handle"
         hook_dir.mkdir()


### PR DESCRIPTION
## Summary
- reject invalid scalar `events:` declarations in `HOOK.yaml`
- require `events` to be a list of non-empty strings before registering handlers
- add regression coverage so malformed manifests no longer register character-by-character event keys

## Verification
- `source venv/bin/activate && pytest -q tests/gateway/test_hooks.py::TestDiscoverAndLoad::test_skips_scalar_events_manifest tests/gateway/test_hooks.py`

Closes #11902
