### PR TITLE
fix: preserve None content for assistant messages to avoid Anthropic HTTP 400

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6464,7 +6464,7 @@ class AIAgent:
 
         msg = {
             "role": "assistant",
-            "content": assistant_message.content or "",
+            "content": assistant_message.content,
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }
@@ -6540,6 +6540,9 @@ class AIAgent:
                     tc_dict["extra_content"] = extra
                 tool_calls.append(tc_dict)
             msg["tool_calls"] = tool_calls
+            # Some providers require non-None content when tool_calls are present.
+            if msg["content"] is None:
+                msg["content"] = ""
 
         return msg
 


### PR DESCRIPTION
Fixes #11906

When assistant_message.content is None (tool-call-only response), the previous code converted it to an empty string. Anthropic-compatible proxies reject empty text content blocks with HTTP 400: `"messages: text content blocks must be non-empty"`.

**Fix:** Preserve `None` as `None` when no tool calls are present. Only coalesce to empty string when `tool_calls` exist (some APIs require non-None content alongside tool_calls).

Changes:
- `run_agent.py`: Change `assistant_message.content or ""` to `assistant_message.content` in the message builder
- Add safety check: when tool_calls are present but content is None, set to empty string