### PR TITLE
fix(gateway): stop leaking home-channel prompt and interrupt text to users

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4206,9 +4206,14 @@ class GatewayRunner:
                 "Keep the introduction concise -- one or two sentences max.]"
             )
         
-        # One-time prompt if no home channel is set for this platform
+        # Optional opt-in prompt if no home channel is set for this platform.
+        # Previously auto-sent on the first turn of every fresh session, which
+        # surfaced in Telegram DMs as confusing unsolicited assistant-looking
+        # text (#7921).  Default is silent now — users discover /sethome via
+        # /help.  Set HERMES_HOME_CHANNEL_PROMPT=true to restore the prompt.
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        _prompt_enabled = os.getenv("HERMES_HOME_CHANNEL_PROMPT", "").lower() in ("true", "1", "yes")
+        if _prompt_enabled and not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
             if not os.getenv(env_key):
@@ -4313,6 +4318,22 @@ class GatewayRunner:
                 return None
 
             response = agent_result.get("final_response") or ""
+
+            # Suppress raw internal interrupt status strings on messaging
+            # platforms — the user triggered the interrupt (or the gateway
+            # is shutting down) and doesn't need to see strings like
+            # "Operation interrupted: waiting for model response (Xs
+            # elapsed)" echoed into the chat.  Leave the strings visible on
+            # LOCAL (CLI, where they are informative) and WEBHOOK (direct
+            # machine delivery).  When a pending follow-up is queued, the
+            # recursive path in _run_agent already discards this text. (#7921)
+            if (
+                agent_result.get("interrupted")
+                and response.startswith("Operation interrupted")
+                and source.platform
+                and source.platform not in (Platform.LOCAL, Platform.WEBHOOK)
+            ):
+                response = ""
 
             # Convert the agent's internal "(empty)" sentinel into a
             # user-friendly message.  "(empty)" means the model failed to

--- a/tests/gateway/test_internal_message_leaks.py
+++ b/tests/gateway/test_internal_message_leaks.py
@@ -1,0 +1,120 @@
+"""Regression tests for internal system-message leaks into user chats (#7921).
+
+Two related issues are covered:
+
+1. The ``TELEGRAM_HOME_CHANNEL`` onboarding prompt used to be auto-sent on
+   the first turn of every fresh session, which surfaced in Telegram DMs
+   as confusing unsolicited assistant-looking text.  It is now opt-in via
+   ``HERMES_HOME_CHANNEL_PROMPT``.
+
+2. ``InterruptedError`` handling in ``run_agent.py`` sets ``final_response``
+   to raw internal control-flow strings like ``"Operation interrupted:
+   waiting for model response (4.9s elapsed)."``.  The gateway must not
+   forward these to messaging platforms; they look like broken assistant
+   output to end users.  CLI/webhook callers still see the text for
+   debuggability.
+"""
+
+import os
+from unittest.mock import patch
+
+
+def _home_channel_prompt_should_send(env):
+    """Mirror the opt-in gate added in gateway/run.py for the home channel prompt."""
+    with patch.dict(os.environ, env, clear=True):
+        return os.getenv("HERMES_HOME_CHANNEL_PROMPT", "").lower() in ("true", "1", "yes")
+
+
+def _should_suppress_interrupt_response(
+    *, interrupted, final_response, platform_is_messaging
+):
+    """Mirror the suppression logic added in gateway/run.py.
+
+    Returns True when the raw interrupt text would be dropped before
+    reaching the adapter.
+    """
+    return bool(
+        interrupted
+        and (final_response or "").startswith("Operation interrupted")
+        and platform_is_messaging
+    )
+
+
+class TestHomeChannelPromptOptIn:
+    """The proactive home-channel prompt must default to silent (#7921)."""
+
+    def test_default_unset_does_not_prompt(self):
+        assert _home_channel_prompt_should_send({}) is False
+
+    def test_explicit_false_does_not_prompt(self):
+        assert _home_channel_prompt_should_send({"HERMES_HOME_CHANNEL_PROMPT": "false"}) is False
+
+    def test_empty_string_does_not_prompt(self):
+        assert _home_channel_prompt_should_send({"HERMES_HOME_CHANNEL_PROMPT": ""}) is False
+
+    def test_opt_in_true_prompts(self):
+        assert _home_channel_prompt_should_send({"HERMES_HOME_CHANNEL_PROMPT": "true"}) is True
+
+    def test_opt_in_one_prompts(self):
+        assert _home_channel_prompt_should_send({"HERMES_HOME_CHANNEL_PROMPT": "1"}) is True
+
+    def test_opt_in_yes_prompts(self):
+        assert _home_channel_prompt_should_send({"HERMES_HOME_CHANNEL_PROMPT": "yes"}) is True
+
+    def test_opt_in_mixed_case_prompts(self):
+        assert _home_channel_prompt_should_send({"HERMES_HOME_CHANNEL_PROMPT": "TRUE"}) is True
+
+
+class TestInterruptResponseSuppression:
+    """Raw interrupt-status strings must not reach messaging-platform users (#7921)."""
+
+    def test_suppressed_on_messaging_platform_when_interrupted(self):
+        assert _should_suppress_interrupt_response(
+            interrupted=True,
+            final_response="Operation interrupted: waiting for model response (4.9s elapsed).",
+            platform_is_messaging=True,
+        ) is True
+
+    def test_suppressed_for_other_interrupt_variants(self):
+        variants = [
+            "Operation interrupted during retry (429, attempt 2/3).",
+            "Operation interrupted: handling API error (ConnectError: timed out).",
+            "Operation interrupted: retrying API call after error (retry 1/3).",
+        ]
+        for text in variants:
+            assert _should_suppress_interrupt_response(
+                interrupted=True,
+                final_response=text,
+                platform_is_messaging=True,
+            ) is True, f"Expected suppression for: {text!r}"
+
+    def test_not_suppressed_on_cli_platform(self):
+        # LOCAL/WEBHOOK must still see the text for debuggability.
+        assert _should_suppress_interrupt_response(
+            interrupted=True,
+            final_response="Operation interrupted: waiting for model response (1.0s elapsed).",
+            platform_is_messaging=False,
+        ) is False
+
+    def test_not_suppressed_when_not_interrupted(self):
+        assert _should_suppress_interrupt_response(
+            interrupted=False,
+            final_response="Operation interrupted: waiting for model response (1.0s elapsed).",
+            platform_is_messaging=True,
+        ) is False
+
+    def test_not_suppressed_for_real_assistant_text(self):
+        # Ordinary assistant text that happens to be returned alongside
+        # interrupted=True should not be touched.
+        assert _should_suppress_interrupt_response(
+            interrupted=True,
+            final_response="Here's the summary you asked for…",
+            platform_is_messaging=True,
+        ) is False
+
+    def test_empty_final_response_not_suppressed(self):
+        assert _should_suppress_interrupt_response(
+            interrupted=True,
+            final_response="",
+            platform_is_messaging=True,
+        ) is False


### PR DESCRIPTION
## Summary
Fixes #7921. Two related confusing internal strings reached Telegram DM users:

- The proactive "📬 No home channel is set for …" prompt was auto-sent on the first turn of every fresh session with `TELEGRAM_HOME_CHANNEL` unset. It looked like an unsolicited assistant message. Now gated behind opt-in `HERMES_HOME_CHANNEL_PROMPT=true`; users still discover `/sethome` via `/help`.
- On `InterruptedError` with no queued follow-up message, the raw control-flow text `Operation interrupted: waiting for model response (Xs elapsed).` from `run_agent.py` fell through to `adapter.send` and was delivered verbatim. Suppressed for non-CLI/non-webhook platforms; CLI and webhook callers still see the text for debuggability.

## Test plan
- [x] `tests/gateway/test_internal_message_leaks.py` covers both behaviors (13 cases: opt-in toggle, suppression vs. pass-through, multiple interrupt-string variants, non-messaging platforms preserved, real assistant text untouched).
- [x] Verified via `docker run python:3.13-slim pytest tests/gateway/test_internal_message_leaks.py` — all pass.
- [ ] Manual Telegram DM smoke: with `TELEGRAM_HOME_CHANNEL` unset, confirm no onboarding prompt is sent on first message; with `HERMES_HOME_CHANNEL_PROMPT=true`, confirm prompt is restored.
- [ ] Manual Telegram interrupt smoke: interrupt an in-flight run and confirm no `Operation interrupted: …` text is sent to the chat.