### PR TITLE
fix: /reasoning status should respect per-platform show_reasoning override

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5656,7 +5656,19 @@ class GatewayRunner:
                 level = "none (disabled)"
             else:
                 level = rc.get("effort", "medium")
-            display_state = "on ✓" if self._show_reasoning else "off"
+            # Use per-platform resolution so /reasoning shows the effective state
+            # for the current platform, not just the global fallback.
+            try:
+                from gateway.display_config import resolve_display_setting as _rds
+                platform_key = _platform_config_key(event.source.platform)
+                user_config = {}
+                if config_path.exists():
+                    with open(config_path, encoding="utf-8") as f:
+                        user_config = yaml.safe_load(f) or {}
+                show_effective = _rds(user_config, platform_key, "show_reasoning", self._show_reasoning)
+            except Exception:
+                show_effective = self._show_reasoning
+            display_state = "on ✓" if show_effective else "off"
             return (
                 "🧠 **Reasoning Settings**\n\n"
                 f"**Effort:** `{level}`\n"


### PR DESCRIPTION
Fixes #11903

The `_handle_reasoning_command` method only reads the global `display.show_reasoning` key via `_load_show_reasoning()`, ignoring per-platform overrides in `display.platforms.<platform>.show_reasoning`. Response rendering already uses `resolve_display_setting()` for per-platform resolution (line 3621).

**Fix:** In the status display path (`/reasoning` without args), use `resolve_display_setting()` to get the effective per-platform value so the command reports the correct state for the current platform.

With config like:
```yaml
display:
  show_reasoning: false
  platforms:
    telegram:
      show_reasoning: true
```

Running `/reasoning` from Telegram now correctly shows `**Display:** on ✓` instead of `**Display:** off`.