### PR TITLE
fix(telegram): ignore bot-authored messages to prevent self-ingestion

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2285,7 +2285,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _should_process_message(self, message: Message, *, is_command: bool = False) -> bool:
         """Apply Telegram group trigger rules.
 
-        DMs remain unrestricted. Group/supergroup messages are accepted when:
+        DMs remain unrestricted (except bot-authored messages). Group/supergroup messages are accepted when:
         - the chat is explicitly allowlisted in ``free_response_chats``
         - ``require_mention`` is disabled
         - the message is a command
@@ -2293,6 +2293,11 @@ class TelegramAdapter(BasePlatformAdapter):
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
         """
+        # Ignore messages authored by the bot itself (prevents self-ingestion)
+        from_user = getattr(message, "from_user", None)
+        if from_user and getattr(from_user, "is_bot", False):
+            return False
+
         if not self._is_group_chat(message):
             return True
         thread_id = getattr(message, "message_thread_id", None)

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -104,6 +104,50 @@ def test_invalid_regex_patterns_are_ignored():
     assert adapter._should_process_message(_group_message("hello everyone")) is False
 
 
+def test_bot_authored_messages_are_ignored():
+    """Bot-authored messages should not be processed as user input (issue #11905)."""
+    adapter = _make_adapter(require_mention=False)
+
+    # Regular user message should be processed
+    user_message = SimpleNamespace(
+        text="hello",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=123, type="private"),
+        reply_to_message=None,
+        from_user=SimpleNamespace(id=456, is_bot=False),
+    )
+    assert adapter._should_process_message(user_message) is True
+
+    # Bot-authored message should be ignored
+    bot_message = SimpleNamespace(
+        text="[SYSTEM: Background process ...]",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=123, type="private"),
+        reply_to_message=None,
+        from_user=SimpleNamespace(id=999, is_bot=True),
+    )
+    assert adapter._should_process_message(bot_message) is False
+
+    # Group chat bot message should also be ignored
+    bot_group_message = SimpleNamespace(
+        text="status update",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=-100, type="group"),
+        reply_to_message=None,
+        from_user=SimpleNamespace(id=999, is_bot=True),
+    )
+    assert adapter._should_process_message(bot_group_message) is False
+
+
 def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()


### PR DESCRIPTION
## Summary
Fixes #11905 - Telegram gateway was processing its own bot-authored messages as inbound user turns, causing unintended behavior including system notifications re-entering the conversation.

## Root Cause
The  method in the Telegram adapter did not check if messages were authored by the bot itself. For DMs, it returned  unconditionally without filtering bot messages.

## Fix
Added a check at the start of  to detect and ignore messages where  is . This prevents:
- System/status messages (e.g., "[SYSTEM: Background process ...]") from being processed as user input
- Bot's own responses from being re-ingested
- Cross-topic noise from synthetic messages

## Test Plan
- [x] Added  test case covering:
  - Regular user messages (should be processed)
  - Bot-authored DM messages (should be ignored)
  - Bot-authored group messages (should be ignored)
- [x] All existing tests pass

## Changes
- : Added bot check in 
- : Added regression test

Closes #11905