### PR TITLE
fix(feishu): support formal release clarify actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,13 @@ COPY . /opt/hermes
 WORKDIR /opt/hermes
 
 # Install Node dependencies and Playwright as root (--with-deps needs apt)
-RUN npm install --prefer-offline --no-audit && \
-    npx playwright install --with-deps chromium --only-shell && \
+RUN npm config set fetch-retries 5 && \
+    npm config set fetch-retry-mintimeout 20000 && \
+    npm config set fetch-retry-maxtimeout 120000 && \
+    for i in 1 2 3; do rm -rf /opt/hermes/node_modules && npm install --prefer-offline --no-audit && break || { if [ "$i" -eq 3 ]; then exit 1; fi; echo "retry npm install $i"; rm -rf /opt/hermes/node_modules; sleep 15; }; done && \
+    for i in 1 2 3; do npx playwright install --with-deps chromium --only-shell && break || { if [ "$i" -eq 3 ]; then exit 1; fi; echo "retry playwright install $i"; sleep 15; }; done && \
     cd /opt/hermes/scripts/whatsapp-bridge && \
-    npm install --prefer-offline --no-audit && \
+    for i in 1 2 3; do rm -rf /opt/hermes/scripts/whatsapp-bridge/node_modules && npm install --prefer-offline --no-audit && break || { if [ "$i" -eq 3 ]; then exit 1; fi; echo "retry whatsapp-bridge npm install $i"; rm -rf /opt/hermes/scripts/whatsapp-bridge/node_modules; sleep 15; }; done && \
     npm cache clean --force
 
 # Hand ownership to hermes user, then install Python deps in a virtualenv
@@ -39,7 +42,7 @@ RUN uv venv && \
     uv pip install --no-cache-dir -e ".[all]"
 
 USER root
-RUN chmod +x /opt/hermes/docker/entrypoint.sh
+RUN sed -i 's/\r$//' /opt/hermes/docker/entrypoint.sh && chmod +x /opt/hermes/docker/entrypoint.sh
 
 ENV HERMES_HOME=/opt/data
 VOLUME [ "/opt/data" ]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1082,6 +1082,21 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: list[str],
+        clarify_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a multiple-choice clarify prompt when the platform supports it.
+
+        Platforms without rich interaction can keep the default text fallback by
+        returning ``success=False``.
+        """
+        return SendResult(success=False, error="Not supported")
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
         Send a typing indicator.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1095,6 +1095,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
+        # Clarify button state (clarify_id → {session_key, message_id, chat_id})
+        self._clarify_state: Dict[str, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         self._load_seen_message_ids()
 
@@ -1520,6 +1522,79 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: List[str],
+        clarify_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify multiple-choice prompt as a Feishu interactive card."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        clarify_choices = [str(choice).strip() for choice in choices if str(choice).strip()][:4]
+        if not clarify_choices:
+            return SendResult(success=False, error="Clarify prompt requires at least one choice")
+
+        try:
+            session_key = ""
+            if isinstance(metadata, dict):
+                session_key = str(metadata.get("session_key") or "").strip()
+
+            def _btn(label: str, choice_value: str, btn_type: str = "default") -> dict:
+                return {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": btn_type,
+                    "value": {
+                        "clarify_id": clarify_id,
+                        "clarify_choice": choice_value,
+                    },
+                }
+
+            actions = [
+                _btn(
+                    f"{idx}. {choice}" if len(choice) <= 40 else f"{idx}. {choice[:37]}...",
+                    choice,
+                    "primary" if idx == 1 else "default",
+                )
+                for idx, choice in enumerate(clarify_choices, 1)
+            ]
+
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "❓ Decision Required", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": question.strip() or "Please choose an option."},
+                    {"tag": "action", "actions": actions},
+                ],
+            }
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send_clarify_prompt failed")
+            if result.success and session_key:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify_prompt failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
@@ -1535,6 +1610,23 @@ class FeishuAdapter(BasePlatformAdapter):
                 {
                     "tag": "markdown",
                     "content": f"{icon} **{label}** by {user_name}",
+                },
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ Decision Recorded", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": f"✅ **Selected:** {choice}\n**By:** {user_name}",
                 },
             ],
         }
@@ -2042,6 +2134,29 @@ class FeishuAdapter(BasePlatformAdapter):
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
 
+        clarify_id = action_value.get("clarify_id") if isinstance(action_value, dict) else None
+        clarify_choice = action_value.get("clarify_choice") if isinstance(action_value, dict) else None
+        if clarify_id and clarify_choice:
+            operator = getattr(event, "operator", None)
+            open_id = str(getattr(operator, "open_id", "") or "")
+            user_name = self._get_cached_sender_name(open_id) or open_id
+            self._submit_on_loop(
+                loop,
+                self._resolve_clarify(str(clarify_id), str(clarify_choice), user_name),
+            )
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_resolved_clarify_card(
+                    choice=str(clarify_choice),
+                    user_name=user_name,
+                )
+                response.card = card
+            return response
+
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
             return None
@@ -2063,7 +2178,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if approval_id is None:
             logger.debug("[Feishu] Card action missing approval_id, ignoring")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
-        choice = _APPROVAL_CHOICE_MAP.get(action_value.get("hermes_action"), "deny")
+        hermes_action = str(action_value.get("hermes_action") or "")
+        choice = _APPROVAL_CHOICE_MAP.get(hermes_action, "deny")
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
@@ -2096,6 +2212,29 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)
+
+    async def _resolve_clarify(self, clarify_id: str, choice: str, user_name: str) -> None:
+        """Pop clarify state and resolve the waiting gateway clarify prompt."""
+        state = self._clarify_state.pop(clarify_id, None)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return
+        try:
+            gateway_runner = getattr(self, "gateway_runner", None)
+            if gateway_runner is None:
+                logger.warning("[Feishu] Missing gateway runner while resolving clarify %s", clarify_id)
+                return
+            resolved = gateway_runner._resolve_pending_clarify(state["session_key"], choice)
+            logger.info(
+                "Feishu button resolved clarify=%s for session %s (choice=%s, user=%s, resolved=%s)",
+                clarify_id,
+                state["session_key"],
+                choice,
+                user_name,
+                resolved,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Feishu button: %s", exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -2187,7 +2326,6 @@ class FeishuAdapter(BasePlatformAdapter):
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
-
         synthetic_text = f"/card {action_tag}"
         if action_value:
             try:
@@ -2198,10 +2336,14 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
         sender_profile = await self._resolve_sender_profile(sender_id)
         chat_info = await self.get_chat_info(chat_id)
+        chat_type = self._resolve_source_chat_type(
+            chat_info=chat_info,
+            event_chat_type=str(chat_info.get("raw_type") or chat_info.get("type") or "p2p"),
+        )
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
+            chat_type=chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=None,
@@ -2212,7 +2354,7 @@ class FeishuAdapter(BasePlatformAdapter):
             message_type=MessageType.COMMAND,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=None,
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import queue
 import re
 import shlex
 import sys
@@ -25,7 +26,8 @@ import tempfile
 import threading
 import time
 from collections import OrderedDict
-from contextvars import copy_context
+import uuid
+from contextvars import ContextVar, Token, copy_context
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
@@ -340,6 +342,186 @@ logger = logging.getLogger(__name__)
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
 
+_FORMAL_RELEASE_BINDING_KEYS = (
+    "tenant_id",
+    "task_id",
+    "session_id",
+    "correlation_id",
+    "version",
+)
+_clarify_binding_metadata: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "gateway_clarify_binding_metadata",
+    default=None,
+)
+_WEEK9_RELEASE_FREEZE_RECORD_RELATIVE_PATH = (
+    Path("reports") / "week9" / "release-freeze-record.json"
+)
+
+
+def _resolve_week9_release_freeze_record_path() -> Path:
+    """Resolve the Week 9 freeze record across local and container layouts."""
+    candidates = [
+        Path(__file__).resolve().parents[3] / _WEEK9_RELEASE_FREEZE_RECORD_RELATIVE_PATH,
+        Path(__file__).resolve().parents[2] / _WEEK9_RELEASE_FREEZE_RECORD_RELATIVE_PATH,
+        _hermes_home / "workspace" / _WEEK9_RELEASE_FREEZE_RECORD_RELATIVE_PATH,
+        _hermes_home / _WEEK9_RELEASE_FREEZE_RECORD_RELATIVE_PATH,
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    raise FileNotFoundError(
+        f"Week 9 release freeze record not found in any known location: "
+        + ", ".join(str(path) for path in candidates)
+    )
+
+
+def _normalize_clarify_binding_metadata(binding: Any) -> Optional[Dict[str, Any]]:
+    """Normalize internal clarify binding metadata for gateway-side state."""
+    if not isinstance(binding, dict):
+        return None
+
+    normalized: Dict[str, Any] = {}
+    for key, value in binding.items():
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            normalized[str(key)] = value
+
+    release_scope = str(normalized.get("release_scope") or "").strip().lower()
+    formal_release = bool(normalized.get("formal_release")) or release_scope in {
+        "formal_release",
+        "week9_formal_release",
+    }
+    if formal_release:
+        normalized["formal_release"] = True
+        normalized["release_scope"] = release_scope or "formal_release"
+        normalized["missing_fields"] = [
+            field
+            for field in _FORMAL_RELEASE_BINDING_KEYS
+            if not str(normalized.get(field) or "").strip()
+        ]
+
+    return normalized or None
+
+
+def set_current_clarify_binding_metadata(
+    binding: Optional[Dict[str, Any]],
+) -> Token[Optional[Dict[str, Any]]]:
+    """Bind internal clarify metadata to the current gateway/agent context."""
+    return _clarify_binding_metadata.set(_normalize_clarify_binding_metadata(binding))
+
+
+def reset_current_clarify_binding_metadata(
+    token: Token[Optional[Dict[str, Any]]],
+) -> None:
+    """Restore the prior clarify binding metadata context."""
+    _clarify_binding_metadata.reset(token)
+
+
+def get_current_clarify_binding_metadata() -> Optional[Dict[str, Any]]:
+    """Return the current gateway-side clarify binding metadata, if any."""
+    binding = _clarify_binding_metadata.get()
+    return dict(binding) if isinstance(binding, dict) else None
+
+
+def _load_week9_formal_release_binding_metadata() -> Dict[str, Any]:
+    """Load frozen Week 9 formal-release coordinates for gateway clarify binding."""
+    freeze_record_path = _resolve_week9_release_freeze_record_path()
+    with open(freeze_record_path, encoding="utf-8-sig") as _freeze_file:
+        freeze_record = json.load(_freeze_file) or {}
+
+    evidence_coordinates = freeze_record.get("week9_evidence_coordinates")
+    if not isinstance(evidence_coordinates, dict):
+        evidence_coordinates = freeze_record.get("evidence") or {}
+    if not isinstance(evidence_coordinates, dict):
+        evidence_coordinates = {}
+
+    binding = _normalize_clarify_binding_metadata(
+        {
+            "formal_release": True,
+            "release_scope": "week9_formal_release",
+            "authorization_channel": freeze_record.get("authorization_channel"),
+            "decision_stage": freeze_record.get("decision_stage"),
+            **evidence_coordinates,
+        }
+    )
+    if not isinstance(binding, dict):
+        raise RuntimeError("Week 9 release freeze metadata is unavailable.")
+
+    missing_fields = [str(field) for field in (binding.get("missing_fields") or []) if str(field).strip()]
+    if missing_fields:
+        raise RuntimeError(
+            "Week 9 release freeze metadata is incomplete: "
+            + ", ".join(missing_fields)
+            + "."
+        )
+    return binding
+
+
+def _build_week9_formal_release_initiator_message() -> str:
+    """Build the internal gateway-only initiator prompt for Week 9 release approval."""
+    return (
+        "[System note: This gateway-only turn initiates the Week 9 formal release approval flow. "
+        "The release subject is the Hermes Week 9 formal release governance flow for the Hermes acceptance runtime on Win11 + Docker; this is not a production release. "
+        "The authorization channel is Feishu. The frozen ownership boundary includes rollback_authority=noah and oncall_owner=noah. "
+        "The approval record must stay bound to tenant_id=tenant-demo-acme, task_id=task-week2-demo-001, session_id=session-week2-demo-001, correlation_id=corr-week2-demo-001, version=0.2.0. "
+        "The required output namespace is artifacts/week9/hermes-runtime/, artifacts/week9/release-approval/<tenant_id>/<correlation_id>/<version>/..., and reports/week9/*.json. "
+        "Do not ask the user what Week 9 refers to. "
+        "Use the normal clarify mechanism immediately to request an explicit approve-or-deny decision for this Week 9 formal release flow. "
+        "Keep user-facing wording concise and truthful. "
+        "Do not claim release approval, production readiness, or deployment completion unless the user explicitly confirms it.]\n\n"
+        "Initiate the Week 9 formal release approval flow and collect an explicit approve-or-deny decision."
+    )
+
+
+def _build_week9_formal_release_question() -> tuple[str, List[str]]:
+    """Return the forced clarify prompt for Week 9 formal release approval."""
+    return (
+        "**Week 9 Formal Release Approval — Hermes Runtime (Win11 + Docker)**\n\n"
+        "This is a **non-production acceptance release** only.\n\n"
+        "**Release metadata:**\n"
+        "- **Tenant:** tenant-demo-acme\n"
+        "- **Task:** task-week2-demo-001\n"
+        "- **Session:** session-week2-demo-001\n"
+        "- **Correlation ID:** corr-week2-demo-001\n"
+        "- **Version:** 0.2.0\n"
+        "- **Ownership boundary:** rollback_authority=noah, oncall_owner=noah\n\n"
+        "**Proposed artifact paths:**\n"
+        "- `artifacts/week9/hermes-runtime/`\n"
+        "- `artifacts/week9/release-approval/tenant-demo-acme/corr-week2-demo-001/0.2.0/`\n"
+        "- `reports/week9/*.json`\n\n"
+        "**Do you approve or deny this Week 9 formal release?**",
+        [
+            "✅ Approve — proceed with Week 9 release",
+            "❌ Deny — reject Week 9 release",
+            "⏸️ Hold — defer to a later decision",
+        ],
+    )
+
+
+def _extract_slash_command_word(text: Optional[str]) -> Optional[str]:
+    """Extract a normalized slash-command word from raw message text."""
+    stripped = str(text or "").strip()
+    if not stripped.startswith("/"):
+        return None
+    command_word = stripped[1:].split(None, 1)[0].strip().lower()
+    if not command_word:
+        return None
+    return command_word.replace("_", "-")
+
+
+def _resolve_gateway_only_command(
+    command: Optional[str],
+) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Resolve gateway-only hidden commands into message overrides + binding."""
+    normalized = str(command or "").strip().lower().replace("_", "-")
+    if normalized != "formal-release":
+        return None, None
+    return (
+        _build_week9_formal_release_initiator_message(),
+        _load_week9_formal_release_binding_metadata(),
+    )
+
 
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances."""
@@ -646,6 +828,10 @@ class GatewayRunner:
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+        # Track pending clarify prompts per session so gateway platforms can
+        # answer agent-issued business questions while the agent thread blocks.
+        self._pending_clarify: Dict[str, Dict[str, Any]] = {}
+        self._clarify_resolution_state: Dict[str, Dict[str, Any]] = {}
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
@@ -1388,6 +1574,201 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+    @staticmethod
+    def _clarify_timeout_response() -> str:
+        return (
+            "The user did not provide a response within the time limit. "
+            "Use your best judgement to make the choice and proceed."
+        )
+
+    @staticmethod
+    def _clarify_cancel_response(reason: str) -> str:
+        return (
+            "The pending clarify prompt was cancelled because "
+            f"{reason}. Stop and wait for a fresh user instruction before proceeding."
+        )
+
+    @staticmethod
+    def _is_fail_closed_clarify_binding(binding_metadata: Any) -> bool:
+        return isinstance(binding_metadata, dict) and bool(binding_metadata.get("formal_release"))
+
+    def _build_pending_clarify_state(
+        self,
+        *,
+        clarify_id: str,
+        question: str,
+        choices: List[str],
+        response_queue: queue.Queue[str],
+        created_at: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        binding_metadata = get_current_clarify_binding_metadata()
+        return {
+            "clarify_id": clarify_id,
+            "question": question,
+            "choices": list(choices),
+            "response_queue": response_queue,
+            "created_at": time.time() if created_at is None else float(created_at),
+            "binding_metadata": binding_metadata,
+            "fail_closed_ready": self._is_fail_closed_clarify_binding(binding_metadata),
+            "last_invalid_attempt": None,
+        }
+
+    def _get_clarify_resolution_store(self) -> Dict[str, Dict[str, Any]]:
+        store = getattr(self, "_clarify_resolution_state", None)
+        if isinstance(store, dict):
+            return store
+        store = {}
+        self._clarify_resolution_state = store
+        return store
+
+    def _record_clarify_resolution(
+        self,
+        session_key: str,
+        pending: Dict[str, Any],
+        *,
+        response: str,
+        outcome: str,
+    ) -> None:
+        binding_metadata = pending.get("binding_metadata")
+        fail_closed_ready = bool(
+            pending.get("fail_closed_ready")
+            or self._is_fail_closed_clarify_binding(binding_metadata)
+        )
+        fail_closed_reason = outcome if fail_closed_ready and outcome != "answered" else None
+        self._get_clarify_resolution_store()[session_key] = {
+            "clarify_id": str(pending.get("clarify_id") or ""),
+            "question": str(pending.get("question") or ""),
+            "response": response,
+            "outcome": outcome,
+            "resolved_at": time.time(),
+            "binding_metadata": dict(binding_metadata) if isinstance(binding_metadata, dict) else None,
+            "fail_closed_ready": fail_closed_ready,
+            "fail_closed_reason": fail_closed_reason,
+            "last_invalid_attempt": pending.get("last_invalid_attempt"),
+        }
+
+    def _mark_pending_clarify_invalid(
+        self,
+        pending: Dict[str, Any],
+        *,
+        reason: str,
+    ) -> None:
+        pending["last_invalid_attempt"] = {
+            "reason": reason,
+            "at": time.time(),
+            "fail_closed_ready": bool(
+                pending.get("fail_closed_ready")
+                or self._is_fail_closed_clarify_binding(pending.get("binding_metadata"))
+            ),
+        }
+
+    def _extract_pending_clarify_response(
+        self,
+        pending: Dict[str, Any],
+        event: MessageEvent,
+    ) -> Optional[str]:
+        """Parse a user response for a pending clarify prompt."""
+        choices = [str(c) for c in (pending.get("choices") or []) if str(c).strip()]
+        command = event.get_command()
+
+        if command == "card":
+            raw_args = (event.get_command_args() or "").strip()
+            action_tag, _, payload_text = raw_args.partition(" ")
+            if action_tag != "button" or not payload_text:
+                return None
+            try:
+                payload = json.loads(payload_text)
+            except Exception:
+                return None
+            if not isinstance(payload, dict):
+                return None
+            clarify_id = str(payload.get("clarify_id") or "").strip()
+            if clarify_id != str(pending.get("clarify_id") or "").strip():
+                self._mark_pending_clarify_invalid(pending, reason="clarify_id_mismatch")
+                return None
+            choice = str(payload.get("clarify_choice") or "").strip()
+            if choices and not any(choice.casefold() == existing.casefold() for existing in choices):
+                self._mark_pending_clarify_invalid(pending, reason="invalid_choice")
+                return None
+            return choice or None
+
+        text = (event.text or "").strip()
+        if not text or event.is_command():
+            return None
+
+        if not choices:
+            return text
+
+        if text.isdigit():
+            idx = int(text) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx]
+
+        lowered = text.casefold()
+        for choice in choices:
+            if lowered == choice.casefold():
+                return choice
+
+        return text
+
+    def _resolve_pending_clarify(
+        self,
+        session_key: str,
+        response: str,
+        outcome: str = "answered",
+    ) -> bool:
+        """Deliver a response to the waiting clarify callback for *session_key*."""
+        pending = self._pending_clarify.pop(session_key, None)
+        if not pending:
+            return False
+        self._record_clarify_resolution(
+            session_key,
+            pending,
+            response=response,
+            outcome=outcome,
+        )
+        response_queue = pending.get("response_queue")
+        if response_queue is not None:
+            try:
+                response_queue.put_nowait(response)
+            except Exception:
+                logger.debug(
+                    "Failed to deliver clarify response for %s",
+                    session_key[:30],
+                    exc_info=True,
+                )
+        logger.info(
+            "Resolved clarify prompt for session %s with outcome=%s response=%r",
+            session_key[:30],
+            outcome,
+            response[:120],
+        )
+        return True
+
+    def _cancel_pending_clarify(self, session_key: str, reason: str) -> bool:
+        """Cancel a pending clarify prompt for *session_key* if one exists."""
+        return self._resolve_pending_clarify(
+            session_key,
+            self._clarify_cancel_response(reason),
+            outcome="cancelled",
+        )
+
+    def _consume_pending_clarify(self, event: MessageEvent, session_key: str) -> bool:
+        pending_session_key = session_key
+        event_metadata = getattr(event, "metadata", None)
+        if isinstance(event_metadata, dict):
+            explicit_session_key = str(event_metadata.get("session_key") or "").strip()
+            if explicit_session_key:
+                pending_session_key = explicit_session_key
+
+        pending = self._pending_clarify.get(pending_session_key)
+        if not pending:
+            return False
+        response = self._extract_pending_clarify_response(pending, event)
+        if response is None:
+            return False
+        return self._resolve_pending_clarify(pending_session_key, response)
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
@@ -1517,6 +1898,7 @@ class GatewayRunner:
 
     def _interrupt_running_agents(self, reason: str) -> None:
         for session_key, agent in list(self._running_agents.items()):
+            self._cancel_pending_clarify(session_key, reason)
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -2409,6 +2791,8 @@ class GatewayRunner:
             self.adapters.clear()
             self._running_agents.clear()
             self._running_agents_ts.clear()
+            self._pending_clarify.clear()
+            self._get_clarify_resolution_store().clear()
             self._pending_messages.clear()
             self._pending_approvals.clear()
             if hasattr(self, '_busy_ack_ts'):
@@ -2577,7 +2961,9 @@ class GatewayRunner:
             if not check_feishu_requirements():
                 logger.warning("Feishu: lark-oapi not installed or FEISHU_APP_ID/SECRET not set")
                 return None
-            return FeishuAdapter(config)
+            adapter = FeishuAdapter(config)
+            adapter.gateway_runner = self
+            return adapter
 
         elif platform == Platform.WECOM_CALLBACK:
             from gateway.platforms.wecom_callback import (
@@ -2971,6 +3357,10 @@ class GatewayRunner:
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Stop requested")
+                self._cancel_pending_clarify(
+                    _quick_key,
+                    "the user stopped the current session",
+                )
                 # Force-clean: remove the session lock regardless of agent state
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -2991,6 +3381,10 @@ class GatewayRunner:
                 running_agent = self._running_agents.get(_quick_key)
                 if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
                     running_agent.interrupt("Session reset requested")
+                self._cancel_pending_clarify(
+                    _quick_key,
+                    "the user reset the session",
+                )
                 # Clear any pending messages so the old text doesn't replay
                 adapter = self.adapters.get(source.platform)
                 if adapter and hasattr(adapter, 'get_pending_message'):
@@ -3054,6 +3448,15 @@ class GatewayRunner:
                     return await self._handle_profile_command(event)
                 if _cmd_def_inner.name == "update":
                     return await self._handle_update_command(event)
+
+            if self._consume_pending_clarify(event, _quick_key):
+                return None
+
+            if self._pending_clarify.get(_quick_key):
+                return (
+                    "A decision is waiting for your reply. Tap one of the card buttons, "
+                    "or reply with the option number/text to continue."
+                )
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
@@ -3125,6 +3528,17 @@ class GatewayRunner:
 
         # Check for commands
         command = event.get_command()
+        _clarify_binding_metadata: Optional[Dict[str, Any]] = None
+
+        if command:
+            try:
+                _message_override, _clarify_binding_metadata = _resolve_gateway_only_command(command)
+                if _message_override is not None:
+                    event.text = _message_override
+                    command = None
+            except Exception as e:
+                logger.warning("Failed to prepare Week 9 formal release initiator: %s", e)
+                return str(e)
         
         # Emit command:* hook for any recognized slash command.
         # GATEWAY_KNOWN_COMMANDS is derived from the central COMMAND_REGISTRY
@@ -3405,7 +3819,12 @@ class GatewayRunner:
         self._running_agents_ts[_quick_key] = time.time()
 
         try:
-            return await self._handle_message_with_agent(event, source, _quick_key)
+            return await self._handle_message_with_agent(
+                event,
+                source,
+                _quick_key,
+                clarify_binding_metadata=_clarify_binding_metadata,
+            )
         finally:
             # If _run_agent replaced the sentinel with a real agent and
             # then cleaned it up, this is a no-op.  If we exited early
@@ -3576,7 +3995,14 @@ class GatewayRunner:
 
         return message_text
 
-    async def _handle_message_with_agent(self, event, source, _quick_key: str):
+    async def _handle_message_with_agent(
+        self,
+        event,
+        source,
+        _quick_key: str,
+        *,
+        clarify_binding_metadata: Optional[Dict[str, Any]] = None,
+    ):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
@@ -4053,6 +4479,7 @@ class GatewayRunner:
                 session_key=session_key,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                clarify_binding_metadata=clarify_binding_metadata,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -8512,6 +8939,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        clarify_binding_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -8829,7 +9257,9 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_thread_metadata = {"session_key": session_key or ""}
+        if _progress_thread_id:
+            _status_thread_metadata["thread_id"] = _progress_thread_id
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter:
@@ -9063,6 +9493,7 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            agent.clarify_callback = None
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")
@@ -9262,6 +9693,107 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
 
+            def _clarify_callback_sync(question: str, choices: Optional[List[str]]) -> str:
+                timeout_cfg = user_config.get("clarify", {}) if isinstance(user_config, dict) else {}
+                try:
+                    timeout = int(timeout_cfg.get("timeout", 120))
+                except Exception:
+                    timeout = 120
+                timeout = max(1, timeout)
+
+                response_queue: queue.Queue[str] = queue.Queue()
+                clarify_id = uuid.uuid4().hex[:12]
+                clarify_choices = [str(c).strip() for c in (choices or []) if str(c).strip()][:4]
+                self._pending_clarify[_approval_session_key] = self._build_pending_clarify_state(
+                    clarify_id=clarify_id,
+                    question=question,
+                    choices=clarify_choices,
+                    response_queue=response_queue,
+                )
+
+                if _status_adapter:
+                    _status_adapter.pause_typing_for_chat(_status_chat_id)
+
+                def _send_plain_text_prompt() -> None:
+                    if not _status_adapter:
+                        return
+                    lines = [f"❓ {question.strip()}"]
+                    if clarify_choices:
+                        lines.append("")
+                        for idx, choice in enumerate(clarify_choices, 1):
+                            lines.append(f"{idx}. {choice}")
+                        lines.append("")
+                        lines.append("Reply with the option number, the option text, or your own answer.")
+                    else:
+                        lines.append("")
+                        lines.append("Reply with your answer in chat.")
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.send(
+                            _status_chat_id,
+                            "\n".join(lines),
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=15)
+
+                try:
+                    if (
+                        _status_adapter
+                        and clarify_choices
+                        and getattr(type(_status_adapter), "send_clarify_prompt", None) is not None
+                    ):
+                        clarify_result = asyncio.run_coroutine_threadsafe(
+                            _status_adapter.send_clarify_prompt(
+                                chat_id=_status_chat_id,
+                                question=question,
+                                choices=clarify_choices,
+                                clarify_id=clarify_id,
+                                metadata=_status_thread_metadata,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=15)
+                        if not getattr(clarify_result, "success", False):
+                            logger.warning(
+                                "Interactive clarify send failed, falling back to text: %s",
+                                getattr(clarify_result, "error", None),
+                            )
+                            _send_plain_text_prompt()
+                    else:
+                        _send_plain_text_prompt()
+                except Exception as _clarify_send_error:
+                    logger.warning(
+                        "Clarify prompt send failed, falling back to plain text: %s",
+                        _clarify_send_error,
+                    )
+                    try:
+                        _send_plain_text_prompt()
+                    except Exception as _clarify_plain_error:
+                        logger.error("Failed to send clarify prompt: %s", _clarify_plain_error)
+
+                try:
+                    while True:
+                        try:
+                            return response_queue.get(timeout=1)
+                        except queue.Empty:
+                            pending = self._pending_clarify.get(_approval_session_key)
+                            if not pending or pending.get("clarify_id") != clarify_id:
+                                return self._clarify_cancel_response("the pending question was replaced")
+                            if (time.time() - float(pending.get("created_at", time.time()))) >= timeout:
+                                break
+                    timeout_response = self._clarify_timeout_response()
+                    self._resolve_pending_clarify(
+                        _approval_session_key,
+                        timeout_response,
+                        outcome="timeout",
+                    )
+                    return timeout_response
+                finally:
+                    pending = self._pending_clarify.get(_approval_session_key)
+                    if pending and pending.get("clarify_id") == clarify_id:
+                        self._pending_clarify.pop(_approval_session_key, None)
+                    if _status_adapter:
+                        _status_adapter.resume_typing_for_chat(_status_chat_id)
+
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
@@ -9285,10 +9817,28 @@ class GatewayRunner:
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
+            _clarify_binding_token = set_current_clarify_binding_metadata(
+                clarify_binding_metadata
+            )
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
+                agent.clarify_callback = _clarify_callback_sync
+                if (
+                    isinstance(clarify_binding_metadata, dict)
+                    and str(clarify_binding_metadata.get("release_scope") or "").strip().lower()
+                    == "week9_formal_release"
+                ):
+                    forced_question, forced_choices = _build_week9_formal_release_question()
+                    forced_decision = _clarify_callback_sync(forced_question, forced_choices)
+                    message = (
+                        "[System note: The required Week 9 formal release decision has already been collected via the gateway clarify flow. "
+                        f"Recorded decision: {forced_decision}]\n\n"
+                        + message
+                    )
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
+                self._pending_clarify.pop(_approval_session_key, None)
+                reset_current_clarify_binding_metadata(_clarify_binding_token)
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
@@ -9866,6 +10416,7 @@ class GatewayRunner:
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_clarify_binding_metadata: Optional[Dict[str, Any]] = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     next_message = await self._prepare_inbound_message_text(
@@ -9877,6 +10428,32 @@ class GatewayRunner:
                         return result
                     next_message_id = getattr(pending_event, "message_id", None)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+
+                _pending_gateway_command = _extract_slash_command_word(
+                    getattr(pending_event, "text", None) if pending_event is not None else next_message
+                )
+                if _pending_gateway_command:
+                    try:
+                        _message_override, next_clarify_binding_metadata = _resolve_gateway_only_command(
+                            _pending_gateway_command
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to prepare pending gateway-only command /%s: %s",
+                            _pending_gateway_command,
+                            e,
+                        )
+                        return {
+                            "final_response": str(e),
+                            "messages": updated_history,
+                            "api_calls": result.get("api_calls", 0),
+                            "tools": result.get("tools", []),
+                            "history_offset": len(updated_history),
+                            "failed": True,
+                            "error": str(e),
+                        }
+                    if _message_override is not None:
+                        next_message = _message_override
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -9901,6 +10478,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    clarify_binding_metadata=next_clarify_binding_metadata,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -4,7 +4,10 @@ Verifies that users get an immediate status response instead of total silence
 when the agent is working on a task. See PR fix for the @Lonely__MH report.
 """
 import asyncio
+import threading
 import time
+from types import SimpleNamespace
+from typing import Any, Optional, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,14 +18,15 @@ import pytest
 import sys, types
 
 _tg = types.ModuleType("telegram")
-_tg.constants = types.ModuleType("telegram.constants")
+_tg_constants = types.ModuleType("telegram.constants")
 _ct = MagicMock()
 _ct.SUPERGROUP = "supergroup"
 _ct.GROUP = "group"
 _ct.PRIVATE = "private"
-_tg.constants.ChatType = _ct
+setattr(_tg, "constants", _tg_constants)
+setattr(_tg_constants, "ChatType", _ct)
 sys.modules.setdefault("telegram", _tg)
-sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.constants", _tg_constants)
 sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
 
 from gateway.platforms.base import (
@@ -31,6 +35,14 @@ from gateway.platforms.base import (
     MessageType,
     SessionSource,
     build_session_key,
+)
+from gateway.config import Platform
+from gateway.run import (
+    _load_week9_formal_release_binding_metadata,
+    _resolve_week9_release_freeze_record_path,
+    get_current_clarify_binding_metadata,
+    reset_current_clarify_binding_metadata,
+    set_current_clarify_binding_metadata,
 )
 
 
@@ -63,11 +75,13 @@ def _make_runner():
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._pending_messages = {}
+    runner._pending_clarify = {}
+    runner._clarify_resolution_state = {}
     runner._busy_ack_ts = {}
     runner._draining = False
     runner.adapters = {}
     runner.config = MagicMock()
-    runner.session_store = None
+    runner.session_store = MagicMock()
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()
     return runner, _AGENT_PENDING_SENTINEL
@@ -75,12 +89,30 @@ def _make_runner():
 
 def _make_adapter(platform_val="telegram"):
     """Build a minimal adapter mock."""
-    adapter = MagicMock()
+    class _AdapterMock(MagicMock):
+        async def edit_message(self, *args, **kwargs):
+            return None
+
+    adapter = _AdapterMock()
     adapter._pending_messages = {}
     adapter._send_with_retry = AsyncMock()
+    adapter.MAX_MESSAGE_LENGTH = 4096
     adapter.config = MagicMock()
     adapter.config.extra = {}
     adapter.platform = MagicMock(value=platform_val)
+    return adapter
+
+
+def _attach_immediate_formal_release_clarify(adapter, runner, session_key, decision="✅ Approve — proceed with Week 9 release"):
+    async def _send_clarify_prompt(*args, **kwargs):
+        runner._resolve_pending_clarify(
+            session_key,
+            decision,
+            outcome="answered",
+        )
+        return SimpleNamespace(success=True, message_id=f"clarify-{kwargs['clarify_id']}")
+
+    setattr(type(adapter), "send_clarify_prompt", _send_clarify_prompt)
     return adapter
 
 
@@ -291,3 +323,695 @@ class TestBusySessionAck:
 
         result = await runner._handle_active_session_busy_message(event, sk)
         assert result is False  # not handled, let default path try
+
+
+class TestPendingClarify:
+    """Pending clarify prompts should consume replies and cancel cleanly."""
+
+    def test_consumes_card_button_reply(self):
+        runner, _sentinel = _make_runner()
+        event = _make_event(text='/card button {"clarify_id":"clarify_1","clarify_choice":"同意执行"}')
+        sk = build_session_key(event.source)
+
+        response_queue = MagicMock()
+        runner._pending_clarify[sk] = {
+            "clarify_id": "clarify_1",
+            "choices": ["同意执行", "需要修改"],
+            "response_queue": response_queue,
+        }
+
+        resolved = runner._consume_pending_clarify(event, sk)
+
+        assert resolved is True
+        response_queue.put_nowait.assert_called_once_with("同意执行")
+        assert sk not in runner._pending_clarify
+
+    def test_rejects_card_choice_not_in_pending_options(self):
+        runner, _sentinel = _make_runner()
+        event = _make_event(text='/card button {"clarify_id":"clarify_1","clarify_choice":"伪造选项"}')
+        sk = build_session_key(event.source)
+
+        response_queue = MagicMock()
+        runner._pending_clarify[sk] = {
+            "clarify_id": "clarify_1",
+            "choices": ["同意执行", "需要修改"],
+            "response_queue": response_queue,
+        }
+
+        resolved = runner._consume_pending_clarify(event, sk)
+
+        assert resolved is False
+        response_queue.put_nowait.assert_not_called()
+        assert sk in runner._pending_clarify
+
+    def test_cancel_pending_clarify_pushes_cancel_response(self):
+        runner, _sentinel = _make_runner()
+        event = _make_event(text="hello")
+        sk = build_session_key(event.source)
+
+        response_queue = MagicMock()
+        runner._pending_clarify[sk] = {
+            "clarify_id": "clarify_2",
+            "choices": ["A", "B"],
+            "response_queue": response_queue,
+        }
+
+        cancelled = runner._cancel_pending_clarify(sk, "the user reset the session")
+
+        assert cancelled is True
+        response_queue.put_nowait.assert_called_once()
+        delivered = response_queue.put_nowait.call_args[0][0]
+        assert "the user reset the session" in delivered
+        assert sk not in runner._pending_clarify
+
+    def test_formal_release_binding_marks_fail_closed_cancel(self):
+        runner, _sentinel = _make_runner()
+        event = _make_event(text="hello")
+        sk = build_session_key(event.source)
+
+        response_queue = MagicMock()
+        token = set_current_clarify_binding_metadata({
+            "formal_release": True,
+            "tenant_id": "tenant-demo-acme",
+            "task_id": "task-week2-demo-001",
+            "session_id": "session-week2-demo-001",
+            "correlation_id": "corr-week2-demo-001",
+            "version": "0.2.0",
+        })
+        try:
+            runner._pending_clarify[sk] = runner._build_pending_clarify_state(
+                clarify_id="clarify_release_1",
+                question="是否正式放行？",
+                choices=["同意放行", "拒绝放行"],
+                response_queue=response_queue,
+            )
+        finally:
+            reset_current_clarify_binding_metadata(token)
+
+        cancelled = runner._cancel_pending_clarify(sk, "the user reset the session")
+
+        assert cancelled is True
+        state = runner._clarify_resolution_state[sk]
+        assert state["outcome"] == "cancelled"
+        assert state["fail_closed_ready"] is True
+        assert state["fail_closed_reason"] == "cancelled"
+        assert state["binding_metadata"]["correlation_id"] == "corr-week2-demo-001"
+
+    def test_invalid_choice_is_retained_until_timeout_for_formal_release(self):
+        runner, _sentinel = _make_runner()
+        event = _make_event(text='/card button {"clarify_id":"clarify_release_2","clarify_choice":"伪造放行"}')
+        sk = build_session_key(event.source)
+
+        response_queue = MagicMock()
+        token = set_current_clarify_binding_metadata({
+            "release_scope": "formal_release",
+            "tenant_id": "tenant-demo-acme",
+            "task_id": "task-week2-demo-001",
+            "session_id": "session-week2-demo-001",
+            "correlation_id": "corr-week2-demo-001",
+            "version": "0.2.0",
+        })
+        try:
+            runner._pending_clarify[sk] = runner._build_pending_clarify_state(
+                clarify_id="clarify_release_2",
+                question="是否正式放行？",
+                choices=["同意放行", "拒绝放行"],
+                response_queue=response_queue,
+            )
+        finally:
+            reset_current_clarify_binding_metadata(token)
+
+        resolved = runner._consume_pending_clarify(event, sk)
+
+        assert resolved is False
+        pending = runner._pending_clarify[sk]
+        assert pending["last_invalid_attempt"]["reason"] == "invalid_choice"
+        assert pending["last_invalid_attempt"]["fail_closed_ready"] is True
+
+        timeout_response = runner._clarify_timeout_response()
+        assert runner._resolve_pending_clarify(sk, timeout_response, outcome="timeout") is True
+        state = runner._clarify_resolution_state[sk]
+        assert state["outcome"] == "timeout"
+        assert state["fail_closed_ready"] is True
+        assert state["fail_closed_reason"] == "timeout"
+        assert state["last_invalid_attempt"]["reason"] == "invalid_choice"
+
+    def test_generic_clarify_resolution_remains_non_fail_closed(self):
+        runner, _sentinel = _make_runner()
+        event = _make_event(text="2")
+        sk = build_session_key(event.source)
+
+        response_queue = MagicMock()
+        runner._pending_clarify[sk] = runner._build_pending_clarify_state(
+            clarify_id="clarify_generic_1",
+            question="选哪个？",
+            choices=["A", "B"],
+            response_queue=response_queue,
+        )
+
+        resolved = runner._consume_pending_clarify(event, sk)
+
+        assert resolved is True
+        state = runner._clarify_resolution_state[sk]
+        assert state["outcome"] == "answered"
+        assert state["response"] == "B"
+        assert state["fail_closed_ready"] is False
+        assert state["fail_closed_reason"] is None
+
+
+class TestClarifyBindingContext:
+    def test_non_dict_binding_metadata_is_ignored(self):
+        token = set_current_clarify_binding_metadata(None)
+        try:
+            assert get_current_clarify_binding_metadata() is None
+        finally:
+            reset_current_clarify_binding_metadata(token)
+
+    def test_formal_release_binding_tracks_missing_fields(self):
+        token = set_current_clarify_binding_metadata({
+            "release_scope": "formal_release",
+            "correlation_id": "corr-week2-demo-001",
+        })
+        try:
+            binding = get_current_clarify_binding_metadata()
+        finally:
+            reset_current_clarify_binding_metadata(token)
+
+        assert binding is not None
+        assert binding["formal_release"] is True
+        assert binding["release_scope"] == "formal_release"
+        assert "tenant_id" in binding["missing_fields"]
+        assert "task_id" in binding["missing_fields"]
+        assert "session_id" in binding["missing_fields"]
+        assert "version" in binding["missing_fields"]
+        assert "correlation_id" not in binding["missing_fields"]
+
+
+class _ClarifyBindingAgent:
+    runner: Any = None
+    session_key: Optional[str] = None
+    last_turn_binding: Optional[dict[str, Any]] = None
+    last_user_message: Optional[str] = None
+    last_pending_snapshot: Optional[dict[str, Any]] = None
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+
+    def interrupt(self, *_args, **_kwargs):
+        return None
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+        type(self).last_turn_binding = get_current_clarify_binding_metadata()
+        type(self).last_user_message = user_message
+        if type(self).runner is not None and type(self).session_key:
+            pending_state = type(self).runner._build_pending_clarify_state(
+                clarify_id="clarify_release_turn",
+                question="是否正式放行？",
+                choices=["同意放行", "拒绝放行"],
+                response_queue=MagicMock(),
+            )
+            type(self).last_pending_snapshot = dict(pending_state)
+            type(self).runner._pending_clarify[type(self).session_key] = pending_state
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+            "tools": [],
+        }
+
+
+def _install_fake_clarify_agent(monkeypatch):
+    fake_run_agent = cast(Any, types.ModuleType("run_agent"))
+    fake_run_agent.AIAgent = _ClarifyBindingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_turn_runner(tmp_path, session_key="agent:main:telegram:dm:12345"):
+    from gateway.run import GatewayRunner
+
+    session_entry = SimpleNamespace(
+        session_id="session-1",
+        session_key=session_key,
+        created_at=1.0,
+        updated_at=1.0,
+        was_auto_reset=False,
+        last_prompt_tokens=0,
+    )
+
+    runner = cast(Any, object.__new__(GatewayRunner))
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._smart_model_routing = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_clarify = {}
+    runner._clarify_resolution_state = {}
+    runner._busy_ack_ts = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner._update_prompt_pending = {}
+    runner._background_tasks = set()
+    runner._draining = False
+    runner.hooks = SimpleNamespace(loaded_hooks=False, emit=AsyncMock())
+    runner.config = SimpleNamespace(
+        streaming=None,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    runner.session_store = SimpleNamespace(
+        _generate_session_key=lambda source: session_key,
+        get_or_create_session=lambda source: session_entry,
+        load_transcript=lambda session_id: [],
+        rewrite_transcript=MagicMock(),
+        append_to_transcript=MagicMock(),
+        update_session=MagicMock(),
+        has_any_sessions=lambda: True,
+        config=SimpleNamespace(
+            get_reset_policy=lambda **kwargs: SimpleNamespace(
+                notify=False,
+                notify_exclude_platforms=(),
+                idle_minutes=60,
+                at_hour=0,
+            )
+        ),
+    )
+    runner._get_proxy_url = lambda: None
+    runner._get_or_create_gateway_honcho = lambda key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    runner._enrich_message_with_transcription = AsyncMock(return_value="ENRICHED")
+    runner._set_session_env = lambda context: []
+    runner._clear_session_env = lambda tokens: None
+    runner._clear_restart_failure_count = lambda session_key: None
+    runner._should_send_voice_reply = lambda *args, **kwargs: False
+    runner._deliver_media_from_response = AsyncMock()
+    runner._evict_cached_agent = lambda session_key: None
+    runner._cleanup_agent_resources = lambda agent: None
+
+    return runner, session_entry
+
+
+def _make_turn_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="user-1",
+        user_name="tester",
+    )
+
+
+class TestWeek9FormalReleaseInitiator:
+    def test_resolve_week9_freeze_record_from_hermes_workspace(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+
+        freeze_path = (
+            tmp_path
+            / "workspace"
+            / "reports"
+            / "week9"
+            / "release-freeze-record.json"
+        )
+        freeze_path.parent.mkdir(parents=True, exist_ok=True)
+        freeze_path.write_text(
+            '{"authorization_channel":"feishu","decision_stage":"week9-release-freeze-record","week9_evidence_coordinates":{"tenant_id":"tenant-demo-acme","task_id":"task-week2-demo-001","session_id":"session-week2-demo-001","correlation_id":"corr-week2-demo-001","version":"0.2.0"}}',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(
+            gateway_run.Path,
+            "resolve",
+            lambda self: freeze_path.parents[3] / "gateway" / "run.py",
+            raising=False,
+        )
+
+        resolved = _resolve_week9_release_freeze_record_path()
+        binding = _load_week9_formal_release_binding_metadata()
+
+        assert resolved == freeze_path
+        assert binding["release_scope"] == "week9_formal_release"
+        assert binding["correlation_id"] == "corr-week2-demo-001"
+
+    def test_gateway_only_command_helper_recognizes_formal_release(self):
+        import gateway.run as gateway_run
+
+        resolve_gateway_only_command = getattr(gateway_run, "_resolve_gateway_only_command")
+        message, binding = resolve_gateway_only_command("formal-release")
+
+        assert message is not None
+        assert "Week 9 formal release approval flow" in message
+        assert "Hermes acceptance runtime on Win11 + Docker" in message
+        assert "Do not ask the user what Week 9 refers to" in message
+        assert "collect an explicit approve-or-deny decision" in message
+        assert binding is not None
+        assert binding["formal_release"] is True
+        assert binding["release_scope"] == "week9_formal_release"
+
+    def test_gateway_only_command_helper_ignores_normal_commands(self):
+        import gateway.run as gateway_run
+
+        extract_slash_command_word = getattr(gateway_run, "_extract_slash_command_word")
+        resolve_gateway_only_command = getattr(gateway_run, "_resolve_gateway_only_command")
+
+        assert extract_slash_command_word("/formal-release") == "formal-release"
+        assert extract_slash_command_word("/formal_release now") == "formal-release"
+        assert extract_slash_command_word("hello") is None
+        assert resolve_gateway_only_command("help") == (None, None)
+
+    @pytest.mark.asyncio
+    async def test_initiator_turn_snapshots_formal_release_binding(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+        import hermes_cli.tools_config as tools_config
+
+        _install_fake_clarify_agent(monkeypatch)
+        runner, session_entry = _make_turn_runner(tmp_path)
+        _ClarifyBindingAgent.runner = runner
+        _ClarifyBindingAgent.session_key = session_entry.session_key
+        _ClarifyBindingAgent.last_turn_binding = None
+        _ClarifyBindingAgent.last_user_message = None
+        _ClarifyBindingAgent.last_pending_snapshot = None
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(gateway_run, "_config_path", tmp_path / "config.yaml")
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        monkeypatch.setattr(gateway_run, "build_session_context", lambda source, config, session_entry: {})
+        monkeypatch.setattr(gateway_run, "build_session_context_prompt", lambda context, redact_pii=False: "")
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+        (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        adapter = _attach_immediate_formal_release_clarify(
+            _make_adapter(platform_val="telegram"),
+            runner,
+            session_entry.session_key,
+        )
+        adapter.get_pending_message = MagicMock(return_value=None)
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg-onboarding"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        runner._is_user_authorized = lambda source: True
+        event = MessageEvent(
+            text="/formal-release",
+            message_type=MessageType.COMMAND,
+            source=_make_turn_source(),
+            message_id="msg-formal-release",
+        )
+
+        response = await runner._handle_message(event)
+
+        resolution = runner._clarify_resolution_state.get(session_entry.session_key)
+        assert response == "ok"
+        assert resolution is not None
+        binding = resolution["binding_metadata"]
+        assert binding is not None
+        assert binding["formal_release"] is True
+        assert binding["release_scope"] == "week9_formal_release"
+        assert binding["tenant_id"] == "tenant-demo-acme"
+        assert binding["task_id"] == "task-week2-demo-001"
+        assert binding["session_id"] == "session-week2-demo-001"
+        assert binding["correlation_id"] == "corr-week2-demo-001"
+        assert binding["version"] == "0.2.0"
+        assert resolution["outcome"] == "answered"
+        assert resolution["response"] == "✅ Approve — proceed with Week 9 release"
+        assert _ClarifyBindingAgent.last_turn_binding is not None
+        assert _ClarifyBindingAgent.last_turn_binding["correlation_id"] == "corr-week2-demo-001"
+        assert "Week 9 formal release approval flow" in (_ClarifyBindingAgent.last_user_message or "")
+        assert "Recorded decision: ✅ Approve — proceed with Week 9 release" in (_ClarifyBindingAgent.last_user_message or "")
+
+    @pytest.mark.asyncio
+    async def test_formal_release_forces_gateway_clarify_before_agent_turn(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+        import hermes_cli.tools_config as tools_config
+
+        _install_fake_clarify_agent(monkeypatch)
+        runner, session_entry = _make_turn_runner(tmp_path)
+        _ClarifyBindingAgent.runner = runner
+        _ClarifyBindingAgent.session_key = session_entry.session_key
+        _ClarifyBindingAgent.last_turn_binding = None
+        _ClarifyBindingAgent.last_user_message = None
+        _ClarifyBindingAgent.last_pending_snapshot = None
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(gateway_run, "_config_path", tmp_path / "config.yaml")
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {"clarify": {"timeout": 120}})
+        monkeypatch.setattr(gateway_run, "build_session_context", lambda source, config, session_entry: {})
+        monkeypatch.setattr(gateway_run, "build_session_context_prompt", lambda context, redact_pii=False: "")
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+        (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        response_iter = iter(["✅ Approve — proceed with Week 9 release"])
+
+        class _StatusAdapter(_make_adapter().__class__):
+            async def send_clarify_prompt(self, *args, **kwargs):
+                clarify_id = kwargs["clarify_id"]
+                pending = runner._pending_clarify[session_entry.session_key]
+                runner._resolve_pending_clarify(
+                    session_entry.session_key,
+                    next(response_iter),
+                    outcome="answered",
+                )
+                return SimpleNamespace(success=True, message_id=f"clarify-{clarify_id}")
+
+        adapter = _StatusAdapter()
+        adapter._pending_messages = {}
+        adapter.get_pending_message = MagicMock(return_value=None)
+        adapter._send_with_retry = AsyncMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg-onboarding"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.config = MagicMock()
+        adapter.config.extra = {}
+        adapter.platform = MagicMock(value="telegram")
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        runner._is_user_authorized = lambda source: True
+        event = MessageEvent(
+            text="/formal-release",
+            message_type=MessageType.COMMAND,
+            source=_make_turn_source(),
+            message_id="msg-formal-release-force",
+        )
+
+        response = await runner._handle_message(event)
+
+        assert response == "ok"
+        assert _ClarifyBindingAgent.last_user_message is not None
+        assert "Recorded decision: ✅ Approve — proceed with Week 9 release" in _ClarifyBindingAgent.last_user_message
+        assert "Week 9 formal release approval flow" in _ClarifyBindingAgent.last_user_message
+        assert "Hermes acceptance runtime on Win11 + Docker" in _ClarifyBindingAgent.last_user_message
+
+    @pytest.mark.asyncio
+    async def test_ambient_binding_resets_after_turn(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+        import hermes_cli.tools_config as tools_config
+
+        _install_fake_clarify_agent(monkeypatch)
+        runner, session_entry = _make_turn_runner(tmp_path)
+        _ClarifyBindingAgent.runner = runner
+        _ClarifyBindingAgent.session_key = session_entry.session_key
+        _ClarifyBindingAgent.last_turn_binding = None
+        _ClarifyBindingAgent.last_pending_snapshot = None
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+        adapter = _attach_immediate_formal_release_clarify(
+            _make_adapter(platform_val="telegram"),
+            runner,
+            session_entry.session_key,
+        )
+        adapter.get_pending_message = MagicMock(return_value=None)
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg-ambient"))
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        result = await runner._run_agent(
+            message="Initiate the Week 9 formal release approval flow.",
+            context_prompt="",
+            history=[],
+            source=_make_turn_source(),
+            session_id=session_entry.session_id,
+            session_key=session_entry.session_key,
+            clarify_binding_metadata=_load_week9_formal_release_binding_metadata(),
+        )
+
+        assert result["final_response"] == "ok"
+        assert _ClarifyBindingAgent.last_turn_binding is not None
+        assert _ClarifyBindingAgent.last_turn_binding["release_scope"] == "week9_formal_release"
+        assert get_current_clarify_binding_metadata() is None
+
+    @pytest.mark.asyncio
+    async def test_normal_turn_does_not_inherit_release_binding(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+        import hermes_cli.tools_config as tools_config
+
+        _install_fake_clarify_agent(monkeypatch)
+        runner, session_entry = _make_turn_runner(tmp_path)
+        _ClarifyBindingAgent.runner = runner
+        _ClarifyBindingAgent.session_key = session_entry.session_key
+        _ClarifyBindingAgent.last_turn_binding = None
+        _ClarifyBindingAgent.last_pending_snapshot = None
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+        outer_token = set_current_clarify_binding_metadata(
+            _load_week9_formal_release_binding_metadata()
+        )
+        try:
+            result = await runner._run_agent(
+                message="普通澄清轮次",
+                context_prompt="",
+                history=[],
+                source=_make_turn_source(),
+                session_id=session_entry.session_id,
+                session_key=session_entry.session_key,
+                clarify_binding_metadata=None,
+            )
+
+            pending = _ClarifyBindingAgent.last_pending_snapshot
+            assert pending is not None
+            assert result["final_response"] == "ok"
+            assert _ClarifyBindingAgent.last_turn_binding is None
+            assert pending["binding_metadata"] is None
+            current_binding = get_current_clarify_binding_metadata()
+            assert current_binding is not None
+            assert current_binding["release_scope"] == "week9_formal_release"
+        finally:
+            reset_current_clarify_binding_metadata(outer_token)
+
+    @pytest.mark.asyncio
+    async def test_pending_formal_release_followup_keeps_binding(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+        import hermes_cli.tools_config as tools_config
+
+        _install_fake_clarify_agent(monkeypatch)
+        runner, session_entry = _make_turn_runner(tmp_path)
+        _ClarifyBindingAgent.runner = runner
+        _ClarifyBindingAgent.session_key = session_entry.session_key
+        _ClarifyBindingAgent.last_turn_binding = None
+        _ClarifyBindingAgent.last_user_message = None
+        _ClarifyBindingAgent.last_pending_snapshot = None
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        monkeypatch.setattr(gateway_run, "_config_path", tmp_path / "config.yaml")
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+        monkeypatch.setattr(gateway_run, "build_session_context", lambda source, config, session_entry: {})
+        monkeypatch.setattr(gateway_run, "build_session_context_prompt", lambda context, redact_pii=False: "")
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "***",
+                "command": None,
+                "args": [],
+                "credential_pool": None,
+            },
+        )
+        monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+        (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        adapter = _make_adapter(platform_val="telegram")
+        adapter._active_sessions = {session_entry.session_key: asyncio.Event()}
+        adapter._post_delivery_callbacks = {}
+        adapter.send = AsyncMock()
+        adapter.send_typing = AsyncMock()
+        _attach_immediate_formal_release_clarify(adapter, runner, session_entry.session_key)
+        runner.adapters[Platform.TELEGRAM] = adapter
+
+        source = _make_turn_source()
+        pending_event = MessageEvent(
+            text="/formal-release",
+            message_type=MessageType.COMMAND,
+            source=source,
+            message_id="msg-followup-formal-release",
+        )
+        adapter.get_pending_message = MagicMock(side_effect=[pending_event, None])
+
+        result = await runner._run_agent(
+            message="上一轮普通回复",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=session_entry.session_id,
+            session_key=session_entry.session_key,
+        )
+
+        pending = _ClarifyBindingAgent.last_pending_snapshot
+        assert result["final_response"] == "ok"
+        assert pending is not None
+        assert pending["binding_metadata"] is not None
+        assert pending["binding_metadata"]["release_scope"] == "week9_formal_release"
+        assert _ClarifyBindingAgent.last_turn_binding is not None
+        assert _ClarifyBindingAgent.last_turn_binding["correlation_id"] == "corr-week2-demo-001"
+        assert "Week 9 formal release approval flow" in (_ClarifyBindingAgent.last_user_message or "")

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -38,6 +38,7 @@ def _ensure_feishu_mocks():
 _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
 import gateway.platforms.feishu as feishu_module
 from gateway.platforms.feishu import FeishuAdapter
 
@@ -208,6 +209,89 @@ class TestFeishuExecApproval:
         assert ids[0] != ids[1]
 
 
+class TestFeishuClarifyPrompt:
+    """Test send_clarify_prompt sends an interactive decision card."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_clarify_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_clarify_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify_prompt(
+                chat_id="oc_12345",
+                question="架构方案设计好了，是否继续执行？",
+                choices=["同意执行", "需要修改", "废弃当前方案"],
+                clarify_id="clarify_001",
+                metadata={"session_key": "sess-clarify-001"},
+            )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "blue"
+        assert "继续执行" in card["elements"][0]["content"]
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 3
+        assert actions[0]["value"]["clarify_id"] == "clarify_001"
+        assert actions[0]["value"]["clarify_choice"] == "同意执行"
+        assert adapter._clarify_state["clarify_001"]["session_key"] == "sess-clarify-001"
+        for action in actions:
+            assert set(action["value"].keys()) == {"clarify_id", "clarify_choice"}
+            assert "binding_metadata" not in action["value"]
+            assert "formal_release" not in action["value"]
+            assert "tenant_id" not in action["value"]
+
+    @pytest.mark.asyncio
+    async def test_requires_at_least_one_choice(self):
+        adapter = _make_adapter()
+        result = await adapter.send_clarify_prompt(
+            chat_id="oc_12345",
+            question="继续吗？",
+            choices=[],
+            clarify_id="clarify_002",
+        )
+        assert result.success is False
+        assert "at least one choice" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_clarify_falls_back_when_interactive_send_fails(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._pending_clarify = {}
+        response_queue = MagicMock()
+        runner._pending_clarify["sess-1"] = {
+            "clarify_id": "clarify_003",
+            "choices": ["同意执行", "需要修改"],
+            "response_queue": response_queue,
+        }
+
+        source = SessionSource(
+            platform=MagicMock(value="feishu"),
+            chat_id="oc_12345",
+            chat_type="private",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text='/card button {"clarify_id":"clarify_003","clarify_choice":"需要修改"}',
+            message_type=MessageType.COMMAND,
+            source=source,
+            message_id="msg_card_clarify",
+        )
+
+        assert runner._consume_pending_clarify(event, "sess-1") is True
+        response_queue.put_nowait.assert_called_once_with("需要修改")
+
+
 # ===========================================================================
 # _resolve_approval — approval state pop + gateway resolution
 # ===========================================================================
@@ -311,6 +395,39 @@ class TestNonApprovalCardAction:
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
 
+    @pytest.mark.asyncio
+    async def test_clarify_card_action_preserves_private_chat_type_and_skips_ack_id(self):
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"clarify_id": "clarify_123", "clarify_choice": "approve"},
+            chat_id="oc_private_dm",
+            open_id="ou_u1",
+            token="c-card-token-123",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u1", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(
+                adapter,
+                "get_chat_info",
+                new_callable=AsyncMock,
+                return_value={"name": "Private Chat", "type": "dm", "raw_type": "p2p"},
+            ),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_called_once()
+        event = mock_handle.call_args[0][0]
+        assert event.source.chat_type in {"private", "dm"}
+        assert event.message_id is None
+        assert '"clarify_id": "clarify_123"' in event.text
+        assert '"clarify_choice": "approve"' in event.text
+
 
 # ===========================================================================
 # _on_card_action_trigger — inline card response for approval actions
@@ -410,6 +527,35 @@ class TestCardActionCallbackResponse:
 
         assert response is not None
         assert response.card is None
+
+    def test_returns_card_for_clarify_action(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._clarify_state["clarify_123"] = {
+            "session_key": "sess-clarify-123",
+            "message_id": "msg_clarify_123",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"clarify_id": "clarify_123", "clarify_choice": "同意执行"},
+            open_id="ou_alice",
+        )
+        adapter._sender_name_cache["ou_alice"] = ("Alice", 9999999999)
+
+        with patch.object(adapter, "_resolve_clarify", new_callable=AsyncMock) as mock_resolve, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro) as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        mock_submit.assert_called_once()
+        mock_resolve.assert_called_once_with("clarify_123", "同意执行", "Alice")
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Decision Recorded" in card["header"]["title"]["content"]
+        assert "同意执行" in card["elements"][0]["content"]
+        assert "Alice" in card["elements"][0]["content"]
 
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- wire the gateway clarify flow so Week 9 formal release decisions can resolve through the existing Feishu card action path
- route Feishu interactive card clicks directly into clarify resolution while preserving the existing approval-card behavior
- add gateway tests covering formal release clarify handling and Feishu button resolution

## Why
This reuses Hermes' existing interactive-card approval pattern for formal release clarify prompts instead of introducing a separate platform-specific flow. It improves Feishu parity for real release decision handling while keeping the gateway fail-closed and test-covered.