### PR TITLE
fix(gateway): respect platform reasoning display state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6314,10 +6314,21 @@ class GatewayRunner:
         """
         import yaml
 
+        from gateway.display_config import resolve_display_setting
+
         args = event.get_command_args().strip().lower()
         config_path = _hermes_home / "config.yaml"
         self._reasoning_config = self._load_reasoning_config()
-        self._show_reasoning = self._load_show_reasoning()
+        platform_key = _platform_config_key(event.source.platform)
+        user_config = _load_gateway_config()
+        self._show_reasoning = bool(
+            resolve_display_setting(
+                user_config,
+                platform_key,
+                "show_reasoning",
+                getattr(self, "_show_reasoning", False),
+            )
+        )
 
         def _save_config_key(key_path: str, value):
             """Save a dot-separated key to config.yaml."""

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -100,6 +100,33 @@ class TestReasoningCommand:
         assert runner._show_reasoning is True
 
     @pytest.mark.asyncio
+    async def test_reasoning_command_status_uses_platform_show_reasoning_override(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "agent:\n"
+            "  reasoning_effort: medium\n"
+            "display:\n"
+            "  show_reasoning: false\n"
+            "  platforms:\n"
+            "    telegram:\n"
+            "      show_reasoning: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+        runner._show_reasoning = False
+
+        result = await runner._handle_reasoning_command(_make_event("/reasoning", platform=Platform.TELEGRAM))
+
+        assert "**Display:** on ✓" in result
+        assert runner._show_reasoning is True
+
+    @pytest.mark.asyncio
     async def test_handle_reasoning_command_updates_config_and_cache(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- make `/reasoning` status resolve `show_reasoning` with the same per-platform override logic used by normal response rendering
- keep the command output aligned with the effective runtime display state for the current platform
- add regression coverage for a Telegram-specific `display.platforms.telegram.show_reasoning` override

## Verification
- `source venv/bin/activate && pytest -q tests/gateway/test_reasoning_command.py::TestReasoningCommand::test_reasoning_command_status_uses_platform_show_reasoning_override tests/gateway/test_reasoning_command.py`

Closes #11903
