### PR TITLE
fix(gateway): preserve explicit delivery target ids

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -53,9 +53,10 @@ class DeliveryTarget:
         - "telegram" → Telegram home channel
         - "telegram:123456" → specific Telegram chat
         """
-        target = target.strip().lower()
+        raw_target = target.strip()
+        normalized_target = raw_target.lower()
         
-        if target == "origin":
+        if normalized_target == "origin":
             if origin:
                 return cls(
                     platform=origin.platform,
@@ -67,25 +68,28 @@ class DeliveryTarget:
                 # Fallback to local if no origin
                 return cls(platform=Platform.LOCAL, is_origin=True)
         
-        if target == "local":
+        if normalized_target == "local":
             return cls(platform=Platform.LOCAL)
         
         # Check for platform:chat_id or platform:chat_id:thread_id format
-        if ":" in target:
-            parts = target.split(":", 2)
-            platform_str = parts[0]
-            chat_id = parts[1] if len(parts) > 1 else None
-            thread_id = parts[2] if len(parts) > 2 else None
+        if ":" in raw_target:
+            platform_str, remainder = raw_target.split(":", 1)
             try:
-                platform = Platform(platform_str)
-                return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
+                platform = Platform(platform_str.lower())
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)
+
+            chat_id = remainder
+            thread_id = None
+            if platform != Platform.MATRIX and ":" in remainder:
+                chat_id, thread_id = remainder.split(":", 1)
+
+            return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
         
         # Just a platform name (use home channel)
         try:
-            platform = Platform(target)
+            platform = Platform(normalized_target)
             return cls(platform=platform)
         except ValueError:
             # Unknown platform, treat as local

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -40,6 +40,18 @@ class TestParseTargetPlatformChat:
         target = DeliveryTarget.parse("unknown_platform")
         assert target.platform == Platform.LOCAL
 
+    def test_explicit_chat_id_preserves_case(self):
+        target = DeliveryTarget.parse("slack:C123ABC")
+        assert target.platform == Platform.SLACK
+        assert target.chat_id == "C123ABC"
+        assert target.thread_id is None
+
+    def test_matrix_room_id_with_colon_is_not_split_into_thread(self):
+        target = DeliveryTarget.parse("matrix:!RoomABC:example.org")
+        assert target.platform == Platform.MATRIX
+        assert target.chat_id == "!RoomABC:example.org"
+        assert target.thread_id is None
+
 
 class TestTargetToStringRoundtrip:
     def test_origin_roundtrip(self):


### PR DESCRIPTION
## Summary
- preserve explicit delivery target chat IDs verbatim instead of lowercasing the whole target string
- avoid splitting Matrix room IDs into `chat_id` + `thread_id` just because the room ID contains `:`
- add regression coverage for Slack case-sensitive IDs and Matrix room IDs

## Verification
- `source venv/bin/activate && pytest -q tests/gateway/test_delivery.py`

Closes #11768
