### PR TITLE
fix(mattermost): avoid mention prefix collisions

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -50,6 +50,12 @@ _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
 
 
+def _mention_token_regex(pattern: str) -> re.Pattern[str]:
+    """Match a Mattermost mention token without swallowing prefix collisions."""
+    escaped = re.escape(pattern)
+    return re.compile(rf"(?<![A-Za-z0-9_.-]){escaped}(?![A-Za-z0-9_.-])", re.IGNORECASE)
+
+
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter can be used."""
     token = os.getenv("MATTERMOST_TOKEN", "")
@@ -630,10 +636,8 @@ class MattermostAdapter(BasePlatformAdapter):
                 f"@{self._bot_username}",
                 f"@{self._bot_user_id}",
             ]
-            has_mention = any(
-                pattern.lower() in message_text.lower()
-                for pattern in mention_patterns
-            )
+            mention_regexes = [_mention_token_regex(pattern) for pattern in mention_patterns]
+            has_mention = any(regex.search(message_text) for regex in mention_regexes)
 
             if require_mention and not is_free_channel and not has_mention:
                 logger.debug(
@@ -644,10 +648,8 @@ class MattermostAdapter(BasePlatformAdapter):
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
-                for pattern in mention_patterns:
-                    message_text = re.sub(
-                        re.escape(pattern), "", message_text, flags=re.IGNORECASE
-                    ).strip()
+                for regex in mention_regexes:
+                    message_text = regex.sub("", message_text).strip()
 
         # Resolve sender info.
         sender_id = post.get("user_id", "")
@@ -736,5 +738,4 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(msg_event)
-
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -473,6 +473,16 @@ class TestMattermostMentionBehavior:
             assert "@hermes-bot" not in msg.text
             assert "2+2" in msg.text
 
+    @pytest.mark.asyncio
+    async def test_prefix_collision_does_not_count_as_mention(self):
+        """@hermes-bot2 must not trigger mention-gating for @hermes-bot."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_REQUIRE_MENTION", None)
+            await self.adapter._handle_ws_event(
+                self._make_event("@hermes-bot2 hello")
+            )
+            assert not self.adapter.handle_message.called
+
 
 # ---------------------------------------------------------------------------
 # File upload (send_image)


### PR DESCRIPTION
## Summary
- fix Mattermost mention gating so `@hermes-bot2` does not match `@hermes-bot`
- strip only whole mention tokens instead of raw substrings
- add a regression test covering prefix-collision channel messages

## Problem
Fixes #11901.

Mattermost channel mention gating previously used case-insensitive substring matching. That caused prefix collisions like `@hermes-bot2 hello` to be treated as a real mention of `@hermes-bot`, and the forwarded text was corrupted to `2 hello`.

## Solution
Use token-boundary-aware regex matching for mention detection and stripping. This keeps normal `@hermes-bot` mentions working while rejecting longer usernames that merely share the same prefix.

## Verification
- `python3 -m pytest -o addopts= tests/gateway/test_mattermost.py`
- repo-local repro for `@hermes-bot2 hello` now leaves `handle_message` uncalled
