### PR TITLE
fix(models): accept known DashScope models offline

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2190,6 +2190,21 @@ def validate_requested_model(
         except Exception:
             pass  # Fall through to generic warning
 
+    # DashScope's coding endpoint can reject or omit `/models` even when
+    # provider-catalog models remain valid for real requests.
+    if normalized == "alibaba":
+        catalog_models = provider_model_ids(normalized)
+        if requested_for_lookup in set(catalog_models):
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": (
+                    f"Note: could not reach the Alibaba Cloud (DashScope) API to validate `{requested}`, "
+                    "but this model exists in Hermes' DashScope catalog."
+                ),
+            }
+
     provider_label = _PROVIDER_LABELS.get(normalized, normalized)
     return {
         "accepted": False,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -476,6 +476,15 @@ class TestValidateApiFallback:
         assert result["accepted"] is False
         assert result["persist"] is False
 
+    def test_dashscope_catalog_model_accepted_when_api_down(self):
+        with patch("hermes_cli.models.provider_model_ids", return_value=["kimi-k2.5", "glm-5"]):
+            result = _validate("kimi-k2.5", provider="dashscope", api_models=None)
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert "DashScope catalog" in result["message"]
+
     def test_unknown_provider_rejected_when_api_down(self):
         result = _validate("some-model", provider="totally-unknown", api_models=None)
         assert result["accepted"] is False


### PR DESCRIPTION
## Summary
- accept DashScope catalog models when live /models probing is unavailable
- keep provider-backed validation for exact known model IDs instead of rejecting them outright
- add a regression test for the DashScope API-unreachable path

## Problem
Fixes #11954.

`hermes model` currently rejects DashScope models like `kimi-k2.5` even when they are valid and usable, because validation falls through to a hard failure whenever the endpoint cannot serve `/models`.

## Solution
When the provider is DashScope and live API probing is unavailable, fall back to Hermes' built-in DashScope catalog before rejecting the model. This keeps known-good model IDs selectable while still preserving the existing hard failure for unknown providers and unknown model names.

## Verification
- `python3 -m pytest -o addopts='' tests/hermes_cli/test_model_validation.py -k "dashscope_catalog_model_accepted_when_api_down or TestValidateApiFallback"`
- repo-local repro: `validate_requested_model("kimi-k2.5", "dashscope", ...)` now accepts the model when `/models` probing returns unavailable
