### PR TITLE
fix: include all models from custom_providers[].models in model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1103,6 +1103,13 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            # Also include models listed under the 'models' dict key
+            entry_models = entry.get("models")
+            if isinstance(entry_models, dict):
+                for m in entry_models:
+                    m_stripped = m.strip()
+                    if m_stripped and m_stripped not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_stripped)
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:


### PR DESCRIPTION
## Summary

The `/model` picker only shows the single default model from each `custom_providers` entry, ignoring the `models` dict that can list multiple models with per-model config (e.g. `context_length`).

Fixes #11677

## Problem

In `model_switch.py:1103`, the picker reads only `entry.get("model")`:

```python
default_model = (entry.get("model") or "").strip()
if default_model and default_model not in groups[slug]["models"]:
    groups[slug]["models"].append(default_model)
```

But a custom provider config can list multiple models:

```yaml
custom_providers:
  - name: "Thor"
    base_url: "https://thor.example.com/v1"
    model: "gemma-4-26B-A4B-it-MXFP4_MOE"
    models:
      Qwen3.6-35B-A3B-MXFP4_MOE:
        context_length: 32768
      Qwen3.5-122B-A10B-MXFP4_MOE:
        context_length: 65536
      gemma-4-31B-it-Q4_K_M:
```

The picker only shows `gemma-4-26B-A4B-it-MXFP4_MOE` (from `model`), not the four models from `models`.

## Fix

After adding the default `model`, also iterate the `models` dict keys and append them to the picker row. This matches the existing `isinstance(models, dict)` check in `config.py:1858`.

## Files changed

- `hermes_cli/model_switch.py` — iterate `models` dict keys in custom provider grouping (+7 lines)