### PR TITLE
fix(dingtalk): accept credentials from platforms.dingtalk.extra in startup check

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -110,11 +110,19 @@ DINGTALK_TYPE_MAPPING = {
 }
 
 
-def check_dingtalk_requirements() -> bool:
-    """Check if DingTalk dependencies are available and configured."""
+def check_dingtalk_requirements(config: Optional[PlatformConfig] = None) -> bool:
+    """Check if DingTalk dependencies are available and configured.
+
+    Credentials are accepted from ``config.extra`` (preferred — matches
+    ``DingTalkAdapter.__init__``) or the ``DINGTALK_CLIENT_ID`` /
+    ``DINGTALK_CLIENT_SECRET`` environment variables as a fallback.
+    """
     if not DINGTALK_STREAM_AVAILABLE or not HTTPX_AVAILABLE:
         return False
-    if not os.getenv("DINGTALK_CLIENT_ID") or not os.getenv("DINGTALK_CLIENT_SECRET"):
+    extra = (config.extra if config else None) or {}
+    client_id = extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID")
+    client_secret = extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
+    if not client_id or not client_secret:
         return False
     return True
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2567,8 +2567,8 @@ class GatewayRunner:
 
         elif platform == Platform.DINGTALK:
             from gateway.platforms.dingtalk import DingTalkAdapter, check_dingtalk_requirements
-            if not check_dingtalk_requirements():
-                logger.warning("DingTalk: dingtalk-stream not installed or DINGTALK_CLIENT_ID/SECRET not set")
+            if not check_dingtalk_requirements(config):
+                logger.warning("DingTalk: dingtalk-stream not installed or client_id/client_secret not set (checked platforms.dingtalk.extra and DINGTALK_CLIENT_ID/SECRET env vars)")
                 return None
             return DingTalkAdapter(config)
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -45,6 +45,36 @@ class TestDingTalkRequirements:
         from gateway.platforms.dingtalk import check_dingtalk_requirements
         assert check_dingtalk_requirements() is True
 
+    def test_returns_true_when_credentials_in_config_extra(self, monkeypatch):
+        """Credentials supplied via ``platforms.dingtalk.extra`` should satisfy
+        the check even when env vars are absent — mirrors
+        ``DingTalkAdapter.__init__`` precedence.
+        """
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        from gateway.platforms.dingtalk import check_dingtalk_requirements
+        config = PlatformConfig(
+            enabled=True,
+            extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
+        )
+        assert check_dingtalk_requirements(config) is True
+
+    def test_returns_false_when_config_extra_partial(self, monkeypatch):
+        """Partial credentials in config.extra (e.g. missing secret) are rejected."""
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        from gateway.platforms.dingtalk import check_dingtalk_requirements
+        config = PlatformConfig(enabled=True, extra={"client_id": "cfg-id"})
+        assert check_dingtalk_requirements(config) is False
+
 
 # ---------------------------------------------------------------------------
 # Adapter construction


### PR DESCRIPTION
## What & why

`check_dingtalk_requirements()` only read `DINGTALK_CLIENT_ID` / `DINGTALK_CLIENT_SECRET` from env, but `DingTalkAdapter.__init__` already reads credentials from `PlatformConfig.extra`. Result: a valid config-driven setup — exactly the pattern the module docstring documents —

```yaml
platforms:
  dingtalk:
    enabled: true
    extra:
      client_id: "..."
      client_secret: "..."
```

— was rejected at gateway startup before the adapter could connect.

## Change

- `gateway/platforms/dingtalk.py`: `check_dingtalk_requirements()` now accepts an optional `config: PlatformConfig | None` and reads `config.extra` first, falling back to env vars — matching `DingTalkAdapter.__init__` precedence.
- `gateway/run.py`: pass `config` through at the call site. Warning message updated to reflect both credential sources.
- The parameter is optional for backward compatibility — existing env-only callers keep working unchanged.

## How to test

The reproduction from the issue now succeeds:

```python
from gateway.config import PlatformConfig
from gateway.platforms.dingtalk import DingTalkAdapter, check_dingtalk_requirements

cfg = PlatformConfig(enabled=True, token='x', extra={
    'client_id': 'cfg-id',
    'client_secret': 'cfg-secret',
})
adapter = DingTalkAdapter(cfg)
assert adapter._client_id and adapter._client_secret
assert check_dingtalk_requirements(cfg) is True  # previously False
```

Two regression tests added to `tests/gateway/test_dingtalk.py::TestDingTalkRequirements`:

- `test_returns_true_when_credentials_in_config_extra` — the issue's scenario
- `test_returns_false_when_config_extra_partial` — partial creds still rejected

Ran `pytest tests/gateway/test_dingtalk.py::TestDingTalkRequirements` → 5 passed. Full file: same pre-existing failures in `TestCardLifecycle` / `TestIncomingHandlerProcess` that require the optional DingTalk SDK (unaffected by this change — confirmed by running the same suite against `upstream/main` before the patch).

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13

## Related

Closes #11769