### PR TITLE
feat(feishu): support interactive clarify card resolution

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1095,6 +1095,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
+        # Clarify button state (clarify_id → {session_key, message_id, chat_id})
+        self._clarify_state: Dict[str, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         self._load_seen_message_ids()
 
@@ -1520,6 +1522,79 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: List[str],
+        clarify_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify multiple-choice prompt as a Feishu interactive card."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        clarify_choices = [str(choice).strip() for choice in choices if str(choice).strip()][:4]
+        if not clarify_choices:
+            return SendResult(success=False, error="Clarify prompt requires at least one choice")
+
+        try:
+            session_key = ""
+            if isinstance(metadata, dict):
+                session_key = str(metadata.get("session_key") or "").strip()
+
+            def _btn(label: str, choice_value: str, btn_type: str = "default") -> dict:
+                return {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "type": btn_type,
+                    "value": {
+                        "clarify_id": clarify_id,
+                        "clarify_choice": choice_value,
+                    },
+                }
+
+            actions = [
+                _btn(
+                    f"{idx}. {choice}" if len(choice) <= 40 else f"{idx}. {choice[:37]}...",
+                    choice,
+                    "primary" if idx == 1 else "default",
+                )
+                for idx, choice in enumerate(clarify_choices, 1)
+            ]
+
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "❓ Decision Required", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": question.strip() or "Please choose an option."},
+                    {"tag": "action", "actions": actions},
+                ],
+            }
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+            result = self._finalize_send_result(response, "send_clarify_prompt failed")
+            if result.success and session_key:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify_prompt failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
@@ -1535,6 +1610,23 @@ class FeishuAdapter(BasePlatformAdapter):
                 {
                     "tag": "markdown",
                     "content": f"{icon} **{label}** by {user_name}",
+                },
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ Decision Recorded", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": f"✅ **Selected:** {choice}\n**By:** {user_name}",
                 },
             ],
         }
@@ -2042,6 +2134,29 @@ class FeishuAdapter(BasePlatformAdapter):
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
 
+        clarify_id = action_value.get("clarify_id") if isinstance(action_value, dict) else None
+        clarify_choice = action_value.get("clarify_choice") if isinstance(action_value, dict) else None
+        if clarify_id and clarify_choice:
+            operator = getattr(event, "operator", None)
+            open_id = str(getattr(operator, "open_id", "") or "")
+            user_name = self._get_cached_sender_name(open_id) or open_id
+            self._submit_on_loop(
+                loop,
+                self._resolve_clarify(str(clarify_id), str(clarify_choice), user_name),
+            )
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_resolved_clarify_card(
+                    choice=str(clarify_choice),
+                    user_name=user_name,
+                )
+                response.card = card
+            return response
+
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
             return None
@@ -2063,7 +2178,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if approval_id is None:
             logger.debug("[Feishu] Card action missing approval_id, ignoring")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
-        choice = _APPROVAL_CHOICE_MAP.get(action_value.get("hermes_action"), "deny")
+        hermes_action = str(action_value.get("hermes_action") or "")
+        choice = _APPROVAL_CHOICE_MAP.get(hermes_action, "deny")
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
@@ -2096,6 +2212,29 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)
+
+    async def _resolve_clarify(self, clarify_id: str, choice: str, user_name: str) -> None:
+        """Pop clarify state and resolve the waiting gateway clarify prompt."""
+        state = self._clarify_state.pop(clarify_id, None)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return
+        try:
+            gateway_runner = getattr(self, "gateway_runner", None)
+            if gateway_runner is None:
+                logger.warning("[Feishu] Missing gateway runner while resolving clarify %s", clarify_id)
+                return
+            resolved = gateway_runner._resolve_pending_clarify(state["session_key"], choice)
+            logger.info(
+                "Feishu button resolved clarify=%s for session %s (choice=%s, user=%s, resolved=%s)",
+                clarify_id,
+                state["session_key"],
+                choice,
+                user_name,
+                resolved,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Feishu button: %s", exc)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -2187,7 +2326,6 @@ class FeishuAdapter(BasePlatformAdapter):
         action = getattr(event, "action", None)
         action_tag = str(getattr(action, "tag", "") or "button")
         action_value = getattr(action, "value", {}) or {}
-
         synthetic_text = f"/card {action_tag}"
         if action_value:
             try:
@@ -2198,10 +2336,14 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id = SimpleNamespace(open_id=open_id, user_id=None, union_id=None)
         sender_profile = await self._resolve_sender_profile(sender_id)
         chat_info = await self.get_chat_info(chat_id)
+        chat_type = self._resolve_source_chat_type(
+            chat_info=chat_info,
+            event_chat_type=str(chat_info.get("raw_type") or chat_info.get("type") or "p2p"),
+        )
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
-            chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type="group"),
+            chat_type=chat_type,
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
             thread_id=None,
@@ -2212,7 +2354,7 @@ class FeishuAdapter(BasePlatformAdapter):
             message_type=MessageType.COMMAND,
             source=source,
             raw_message=data,
-            message_id=token or str(uuid.uuid4()),
+            message_id=None,
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -38,6 +38,7 @@ def _ensure_feishu_mocks():
 _ensure_feishu_mocks()
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
 import gateway.platforms.feishu as feishu_module
 from gateway.platforms.feishu import FeishuAdapter
 
@@ -208,6 +209,89 @@ class TestFeishuExecApproval:
         assert ids[0] != ids[1]
 
 
+class TestFeishuClarifyPrompt:
+    """Test send_clarify_prompt sends an interactive decision card."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_clarify_card(self):
+        adapter = _make_adapter()
+
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_clarify_001"),
+        )
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify_prompt(
+                chat_id="oc_12345",
+                question="架构方案设计好了，是否继续执行？",
+                choices=["同意执行", "需要修改", "废弃当前方案"],
+                clarify_id="clarify_001",
+                metadata={"session_key": "sess-clarify-001"},
+            )
+
+        assert result.success is True
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["template"] == "blue"
+        assert "继续执行" in card["elements"][0]["content"]
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 3
+        assert actions[0]["value"]["clarify_id"] == "clarify_001"
+        assert actions[0]["value"]["clarify_choice"] == "同意执行"
+        assert adapter._clarify_state["clarify_001"]["session_key"] == "sess-clarify-001"
+        for action in actions:
+            assert set(action["value"].keys()) == {"clarify_id", "clarify_choice"}
+            assert "binding_metadata" not in action["value"]
+            assert "formal_release" not in action["value"]
+            assert "tenant_id" not in action["value"]
+
+    @pytest.mark.asyncio
+    async def test_requires_at_least_one_choice(self):
+        adapter = _make_adapter()
+        result = await adapter.send_clarify_prompt(
+            chat_id="oc_12345",
+            question="继续吗？",
+            choices=[],
+            clarify_id="clarify_002",
+        )
+        assert result.success is False
+        assert "at least one choice" in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_clarify_falls_back_when_interactive_send_fails(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._pending_clarify = {}
+        response_queue = MagicMock()
+        runner._pending_clarify["sess-1"] = {
+            "clarify_id": "clarify_003",
+            "choices": ["同意执行", "需要修改"],
+            "response_queue": response_queue,
+        }
+
+        source = SessionSource(
+            platform=MagicMock(value="feishu"),
+            chat_id="oc_12345",
+            chat_type="private",
+            user_id="user1",
+        )
+        event = MessageEvent(
+            text='/card button {"clarify_id":"clarify_003","clarify_choice":"需要修改"}',
+            message_type=MessageType.COMMAND,
+            source=source,
+            message_id="msg_card_clarify",
+        )
+
+        assert runner._consume_pending_clarify(event, "sess-1") is True
+        response_queue.put_nowait.assert_called_once_with("需要修改")
+
+
 # ===========================================================================
 # _resolve_approval — approval state pop + gateway resolution
 # ===========================================================================
@@ -311,6 +395,39 @@ class TestNonApprovalCardAction:
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
 
+    @pytest.mark.asyncio
+    async def test_clarify_card_action_preserves_private_chat_type_and_skips_ack_id(self):
+        adapter = _make_adapter()
+
+        data = _make_card_action_data(
+            action_value={"clarify_id": "clarify_123", "clarify_choice": "approve"},
+            chat_id="oc_private_dm",
+            open_id="ou_u1",
+            token="c-card-token-123",
+        )
+
+        with (
+            patch.object(
+                adapter, "_resolve_sender_profile", new_callable=AsyncMock,
+                return_value={"user_id": "ou_u1", "user_name": "Dave", "user_id_alt": None},
+            ),
+            patch.object(
+                adapter,
+                "get_chat_info",
+                new_callable=AsyncMock,
+                return_value={"name": "Private Chat", "type": "dm", "raw_type": "p2p"},
+            ),
+            patch.object(adapter, "_handle_message_with_guards", new_callable=AsyncMock) as mock_handle,
+        ):
+            await adapter._handle_card_action_event(data)
+
+        mock_handle.assert_called_once()
+        event = mock_handle.call_args[0][0]
+        assert event.source.chat_type in {"private", "dm"}
+        assert event.message_id is None
+        assert '"clarify_id": "clarify_123"' in event.text
+        assert '"clarify_choice": "approve"' in event.text
+
 
 # ===========================================================================
 # _on_card_action_trigger — inline card response for approval actions
@@ -410,6 +527,35 @@ class TestCardActionCallbackResponse:
 
         assert response is not None
         assert response.card is None
+
+    def test_returns_card_for_clarify_action(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._clarify_state["clarify_123"] = {
+            "session_key": "sess-clarify-123",
+            "message_id": "msg_clarify_123",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"clarify_id": "clarify_123", "clarify_choice": "同意执行"},
+            open_id="ou_alice",
+        )
+        adapter._sender_name_cache["ou_alice"] = ("Alice", 9999999999)
+
+        with patch.object(adapter, "_resolve_clarify", new_callable=AsyncMock) as mock_resolve, \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro) as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        mock_submit.assert_called_once()
+        mock_resolve.assert_called_once_with("clarify_123", "同意执行", "Alice")
+        assert response is not None
+        assert response.card is not None
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Decision Recorded" in card["header"]["title"]["content"]
+        assert "同意执行" in card["elements"][0]["content"]
+        assert "Alice" in card["elements"][0]["content"]
 
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
## What changed
- add send_clarify_prompt() support in the Feishu adapter to render gateway clarify choices as interactive cards
- route Feishu clarify button actions directly into gateway pending clarify resolution
- add Feishu-focused tests for clarify card rendering and clarify callback/card-action behavior

## Why
This adds platform-native Feishu UX on top of the gateway clarify core flow, while preserving graceful fallback when interactive send fails.

## How to test
- pytest tests/gateway/test_feishu_approval_buttons.py -v

## Platforms tested
- Windows (local development environment)

## Related
- Depends on gateway clarify core flow: #11977