### PR TITLE
fix(file_tools): allowlist macOS user-writable temp subtrees under /private/var/

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -118,21 +118,31 @@ class TestCheckSensitivePathMacOSTempAllowlist:
     ``/private/var/folders/…``) and ``/tmp`` (symlink to ``/private/tmp/``).
     Blocking those broke ``test_file_staleness.py`` on macOS and, more
     importantly, real user workflows where the agent writes to a temp dir.
+
+    The allowlist is macOS-only (``_ALLOWLIST_ACTIVE = sys.platform ==
+    'darwin'``).  Tests that exercise the allowlist force the flag on via
+    monkeypatch so they run identically on Linux CI and macOS.
     """
 
-    def test_private_var_folders_allowed(self):
+    @pytest.fixture
+    def force_allowlist_active(self, monkeypatch):
+        """Force the macOS allowlist on so allowlist-path tests exercise
+        the logic on Linux CI too.  No-op if already darwin."""
+        monkeypatch.setattr("tools.file_tools._ALLOWLIST_ACTIVE", True)
+
+    def test_private_var_folders_allowed(self, force_allowlist_active):
         """macOS ``tempfile.gettempdir()`` resolves under this prefix."""
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path(
             "/private/var/folders/fx/abc/T/my_temp_file.txt"
         ) is None
 
-    def test_private_tmp_allowed(self):
+    def test_private_tmp_allowed(self, force_allowlist_active):
         """``/tmp`` on macOS is a symlink into ``/private/tmp/``."""
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/tmp/scratch.txt") is None
 
-    def test_actual_tempfile_path_allowed(self):
+    def test_actual_tempfile_path_allowed(self, force_allowlist_active):
         """The exact path shape produced by ``tempfile.TemporaryDirectory()``
         on macOS must not trip the sensitive-path check (this was the
         ``test_file_staleness.py`` failure mode)."""
@@ -146,57 +156,149 @@ class TestCheckSensitivePathMacOSTempAllowlist:
 
     # --- Sensitive subtrees still blocked ---------------------------------
 
-    def test_private_var_db_still_blocked(self):
+    def test_private_var_db_still_blocked(self, force_allowlist_active):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/db/something") is not None
 
-    def test_private_var_log_still_blocked(self):
+    def test_private_var_log_still_blocked(self, force_allowlist_active):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/log/system.log") is not None
 
-    def test_private_var_root_still_blocked(self):
+    def test_private_var_root_still_blocked(self, force_allowlist_active):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/root/.ssh/id_rsa") is not None
 
-    def test_private_var_mail_still_blocked(self):
+    def test_private_var_mail_still_blocked(self, force_allowlist_active):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/mail/alice") is not None
 
-    def test_private_var_spool_still_blocked(self):
+    def test_private_var_spool_still_blocked(self, force_allowlist_active):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/spool/cron/root") is not None
 
     # --- Canary: /etc/, /boot/, /private/etc/ stay blocked ----------------
 
-    def test_private_etc_still_blocked_after_allowlist(self):
+    def test_private_etc_still_blocked_after_allowlist(self, force_allowlist_active):
         """The allowlist must not weaken the /private/etc/ symlink-bypass
         guard that #8734 / 311dac19 established."""
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/etc/hosts") is not None
         assert _check_sensitive_path("/private/etc/ssh/sshd_config") is not None
 
-    def test_non_macos_paths_still_blocked(self):
+    def test_non_macos_paths_still_blocked(self, force_allowlist_active):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/etc/passwd") is not None
         assert _check_sensitive_path("/boot/grub/grub.cfg") is not None
         assert _check_sensitive_path("/usr/lib/systemd/system/sshd.service") is not None
 
-    def test_allowlist_helper_is_path_prefix_scoped(self):
+    def test_allowlist_helper_is_path_prefix_scoped(self, force_allowlist_active):
         """``_is_allowlisted_sensitive_path`` must not match paths that
         merely *contain* an allowlisted substring — only prefix matches
         count.  Prevents trivial bypass via e.g. a sensitive file whose
-        name happens to contain ``/private/var/folders/``."""
+        name happens to contain ``/private/var/folders/``.
+
+        The allowlist contains both the symlink-resolved
+        (``/private/var/folders/...``) and the un-resolved
+        (``/var/folders/...``) forms so the AND guard validates each
+        independently-sanitised path form against the same allowlist
+        set.  Supplying the resolved form for both arguments is a valid
+        allowlisted path (e.g. a caller-provided realpath-already-
+        resolved path)."""
         from tools.file_tools import _is_allowlisted_sensitive_path
-        # Literal allowlist prefix → True
+        # Both forms under the resolved prefix → allowlisted.
         assert _is_allowlisted_sensitive_path(
             "/private/var/folders/fx/foo.txt",
             "/private/var/folders/fx/foo.txt",
         ) is True
-        # Path that contains the substring but doesn't start with it → False
+        # Path that contains the substring but doesn't start with it → blocked.
         assert _is_allowlisted_sensitive_path(
             "/private/var/db/fake/private/var/folders/x",
             "/private/var/db/fake/private/var/folders/x",
         ) is False
+
+    def test_allowlist_accepts_different_prefix_forms_for_resolved_and_normalized(
+        self, force_allowlist_active,
+    ):
+        """The real-world macOS tempfile case: ``os.path.normpath`` does
+        not follow symlinks, so the un-resolved ``/var/folders/...`` and
+        the realpath-resolved ``/private/var/folders/...`` forms of the
+        same file differ.  Each form must be separately checked against
+        the full allowlist so both check out."""
+        from tools.file_tools import _is_allowlisted_sensitive_path
+        assert _is_allowlisted_sensitive_path(
+            "/private/var/folders/fx/abc/T/file.txt",  # realpath form
+            "/var/folders/fx/abc/T/file.txt",           # normpath form
+        ) is True
+
+    def test_allowlist_requires_both_resolved_and_normalized(self, force_allowlist_active):
+        """AND-guard: an allowlisted ``resolved`` without an allowlisted
+        ``normalized`` (or vice versa) must not exempt the path.  Defeats
+        a symlink-substitution attack where an attacker plants
+        ``/private/var/folders/evil -> /etc/sudoers`` — ``resolved``
+        becomes ``/etc/sudoers`` (not allowlisted) and the AND guard
+        blocks the write even though ``normalized`` is allowlisted."""
+        from tools.file_tools import _is_allowlisted_sensitive_path
+        assert _is_allowlisted_sensitive_path(
+            "/etc/sudoers",                  # resolved: not allowlisted (attack)
+            "/private/var/folders/fx/evil",  # normalized: allowlisted
+        ) is False
+        assert _is_allowlisted_sensitive_path(
+            "/private/var/folders/fx/evil",  # resolved: allowlisted
+            "/etc/sudoers",                  # normalized: not allowlisted
+        ) is False
+
+    def test_realpath_exception_cannot_bypass_guard(self, force_allowlist_active, monkeypatch):
+        """Regression for the second Copilot concern: if ``os.path.realpath``
+        raises, the resolver must fall back to the *normalised* path, not
+        to the raw caller-supplied string.  A crafted path that is raw-
+        allowlisted but normalises to ``/etc/sudoers`` must be blocked."""
+        from tools.file_tools import _check_sensitive_path
+
+        def _raising_realpath(p):
+            raise OSError("simulated realpath failure")
+
+        monkeypatch.setattr("tools.file_tools.os.path.realpath", _raising_realpath)
+
+        # Path looks allowlisted in raw form but normalises to /etc/sudoers.
+        crafted = "/private/var/folders/../../etc/sudoers"
+        result = _check_sensitive_path(crafted)
+        assert result is not None, (
+            "realpath-exception fallback must not allow a crafted path "
+            "whose normalised form is /etc/sudoers"
+        )
+        assert "sensitive system path" in result
+
+
+class TestAllowlistPlatformGate:
+    """Verify the macOS allowlist is inactive on non-darwin platforms so
+    the fix cannot accidentally broaden Linux / Windows semantics."""
+
+    def test_allowlist_inactive_on_linux(self, monkeypatch):
+        """On Linux (``sys.platform != 'darwin'``), an exotic user-created
+        ``/private/var/folders/…`` tree must still be blocked — Linux has
+        no OS-level convention that these paths are user-writable, so
+        preserve the pre-fix behaviour byte-for-byte for the path that
+        actually hits a sensitive prefix.
+
+        Note: ``/private/tmp/`` does not match any sensitive prefix on
+        origin/main either (``/private/var/`` is the prefix, not
+        ``/private/``), so its behaviour on Linux is unchanged and
+        irrelevant to the platform gate.  The gate matters for
+        ``/private/var/folders/…`` specifically, which *does* match
+        ``/private/var/``."""
+        monkeypatch.setattr("tools.file_tools._ALLOWLIST_ACTIVE", False)
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(
+            "/private/var/folders/fx/abc/T/foo.txt"
+        ) is not None
+
+    def test_allowlist_default_is_darwin_only(self):
+        """Sanity check: the platform gate is derived from
+        ``sys.platform``.  On this test host the module-level constant
+        matches ``sys.platform == 'darwin'``."""
+        import sys
+        import tools.file_tools as ft
+        assert ft._ALLOWLIST_ACTIVE is (sys.platform == "darwin")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -107,5 +107,97 @@ class TestCheckSensitivePathMacOSBypass:
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
 
+class TestCheckSensitivePathMacOSTempAllowlist:
+    """Verify ``_check_sensitive_path`` permits macOS user-writable temp
+    trees that sit *syntactically* under ``/private/var/`` but are, by OS
+    design, per-user writable locations.
+
+    Regression for the bycatch introduced in 311dac19: the ``/private/var/``
+    prefix added for the ``/private/etc`` symlink bypass also blocked
+    ``tempfile.gettempdir()`` output on macOS (which resolves to
+    ``/private/var/folders/…``) and ``/tmp`` (symlink to ``/private/tmp/``).
+    Blocking those broke ``test_file_staleness.py`` on macOS and, more
+    importantly, real user workflows where the agent writes to a temp dir.
+    """
+
+    def test_private_var_folders_allowed(self):
+        """macOS ``tempfile.gettempdir()`` resolves under this prefix."""
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(
+            "/private/var/folders/fx/abc/T/my_temp_file.txt"
+        ) is None
+
+    def test_private_tmp_allowed(self):
+        """``/tmp`` on macOS is a symlink into ``/private/tmp/``."""
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/tmp/scratch.txt") is None
+
+    def test_actual_tempfile_path_allowed(self):
+        """The exact path shape produced by ``tempfile.TemporaryDirectory()``
+        on macOS must not trip the sensitive-path check (this was the
+        ``test_file_staleness.py`` failure mode)."""
+        import tempfile
+        from tools.file_tools import _check_sensitive_path
+        with tempfile.TemporaryDirectory() as tmp:
+            candidate = os.path.join(tmp, "write_target.txt")
+            assert _check_sensitive_path(candidate) is None, (
+                f"Sensitive-path check rejected a plain tempfile path: {candidate!r}"
+            )
+
+    # --- Sensitive subtrees still blocked ---------------------------------
+
+    def test_private_var_db_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/db/something") is not None
+
+    def test_private_var_log_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/log/system.log") is not None
+
+    def test_private_var_root_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/root/.ssh/id_rsa") is not None
+
+    def test_private_var_mail_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/mail/alice") is not None
+
+    def test_private_var_spool_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/spool/cron/root") is not None
+
+    # --- Canary: /etc/, /boot/, /private/etc/ stay blocked ----------------
+
+    def test_private_etc_still_blocked_after_allowlist(self):
+        """The allowlist must not weaken the /private/etc/ symlink-bypass
+        guard that #8734 / 311dac19 established."""
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/etc/hosts") is not None
+        assert _check_sensitive_path("/private/etc/ssh/sshd_config") is not None
+
+    def test_non_macos_paths_still_blocked(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/etc/passwd") is not None
+        assert _check_sensitive_path("/boot/grub/grub.cfg") is not None
+        assert _check_sensitive_path("/usr/lib/systemd/system/sshd.service") is not None
+
+    def test_allowlist_helper_is_path_prefix_scoped(self):
+        """``_is_allowlisted_sensitive_path`` must not match paths that
+        merely *contain* an allowlisted substring — only prefix matches
+        count.  Prevents trivial bypass via e.g. a sensitive file whose
+        name happens to contain ``/private/var/folders/``."""
+        from tools.file_tools import _is_allowlisted_sensitive_path
+        # Literal allowlist prefix → True
+        assert _is_allowlisted_sensitive_path(
+            "/private/var/folders/fx/foo.txt",
+            "/private/var/folders/fx/foo.txt",
+        ) is True
+        # Path that contains the substring but doesn't start with it → False
+        assert _is_allowlisted_sensitive_path(
+            "/private/var/db/fake/private/var/folders/x",
+            "/private/var/db/fake/private/var/folders/x",
+        ) is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import sys
 import threading
 from pathlib import Path
 from typing import Optional
@@ -155,6 +156,34 @@ _SENSITIVE_PATH_PREFIXES = (
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
+# On macOS ``/private/var/`` is in the sensitive prefix list to catch the
+# ``/etc`` → ``/private/etc`` and ``/var`` → ``/private/var`` symlink bypass
+# that was fixed in commit 311dac19.  However ``/private/var/folders/`` is the
+# macOS per-user temporary directory (``tempfile.mkdtemp()`` / ``/tmp`` both
+# resolve there), so the blanket prefix is too broad.  The allowlist below
+# carves out exactly those user-writable subtrees; everything else under
+# ``/private/var/`` (``/private/var/db/``, ``/private/var/log/``, etc.)
+# remains blocked.  We require BOTH the ``resolved`` (realpath) form AND the
+# ``normalized`` (normpath) form to fall under an allowlisted prefix — the AND
+# guard defeats a symlink-substitution bypass where an attacker creates a
+# symlink from an allowlisted path into a blocked system directory.
+_MACOS_TEMP_PREFIXES = (
+    "/private/var/folders/",  # realpath form of macOS per-user temp
+    "/var/folders/",           # un-resolved symlink form
+    "/private/tmp/",           # realpath form of /tmp on macOS
+    "/tmp/",                   # un-resolved symlink form
+)
+
+
+def _is_macos_user_temp(resolved: str, normalized: str) -> bool:
+    """Return True when both resolved and normalized are in macOS user-writable temp."""
+    if sys.platform != "darwin":
+        return False
+    return (
+        any(resolved.startswith(p) for p in _MACOS_TEMP_PREFIXES)
+        and any(normalized.startswith(p) for p in _MACOS_TEMP_PREFIXES)
+    )
+
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
@@ -169,6 +198,8 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
+            if _is_macos_user_temp(resolved, normalized):
+                return None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -92,11 +92,40 @@ def _is_blocked_device(filepath: str) -> bool:
 
 # Paths that file tools should refuse to write to without going through the
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
+#
+# ``/private/etc/`` and ``/private/var/`` exist to catch the macOS case where
+# ``/etc`` and ``/var`` are symlinks into ``/private`` — they were added in
+# 311dac19 to close a ``/private/etc`` symlink bypass of ``/etc``.  The broad
+# ``/private/var/`` prefix has a false-positive hazard, though: on macOS the
+# per-user temporary directory (``tempfile.gettempdir()``) resolves under
+# ``/private/var/folders/...``, and so does ``/tmp`` (symlink to
+# ``/private/tmp/``).  Blocking those blocks legitimate, documented,
+# user-writable spaces and breaks both tests and real workflows.  The
+# allowlist below carves out exactly those macOS-temp subtrees — nothing
+# else under ``/private/var/`` (notably ``/private/var/db/``,
+# ``/private/var/log/``, ``/private/var/root/``, ``/private/var/mail/``,
+# ``/private/var/spool/``) is exempted.
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
     "/private/etc/", "/private/var/",
 )
+_SENSITIVE_PATH_ALLOWLIST = (
+    # macOS per-user temp directory (what ``tempfile.gettempdir()`` returns
+    # after symlink resolution).  User-writable by design.
+    "/private/var/folders/",
+    # ``/tmp`` on macOS is a symlink into ``/private/tmp/``.
+    "/private/tmp/",
+)
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
+
+
+def _is_allowlisted_sensitive_path(resolved: str, normalized: str) -> bool:
+    """Return True for paths that look sensitive by prefix but are actually
+    user-writable (macOS temp directories, primarily)."""
+    for allowed in _SENSITIVE_PATH_ALLOWLIST:
+        if resolved.startswith(allowed) or normalized.startswith(allowed):
+            return True
+    return False
 
 
 def _check_sensitive_path(filepath: str) -> str | None:
@@ -112,6 +141,10 @@ def _check_sensitive_path(filepath: str) -> str | None:
     )
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
+            if _is_allowlisted_sensitive_path(resolved, normalized):
+                # Looks sensitive by prefix, but it's a documented
+                # user-writable location (e.g. macOS temp) — permit.
+                return None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import sys
 import threading
 from pathlib import Path
 from tools.binary_extensions import has_binary_extension
@@ -110,31 +111,62 @@ _SENSITIVE_PATH_PREFIXES = (
     "/private/etc/", "/private/var/",
 )
 _SENSITIVE_PATH_ALLOWLIST = (
-    # macOS per-user temp directory (what ``tempfile.gettempdir()`` returns
-    # after symlink resolution).  User-writable by design.
-    "/private/var/folders/",
-    # ``/tmp`` on macOS is a symlink into ``/private/tmp/``.
-    "/private/tmp/",
+    # macOS per-user temp directory.  ``tempfile.gettempdir()`` returns
+    # the un-resolved ``/var/folders/...`` form; ``os.path.realpath``
+    # expands it to ``/private/var/folders/...``.  Both forms must be in
+    # the allowlist so the AND guard in
+    # ``_is_allowlisted_sensitive_path`` can confirm each independently-
+    # sanitised path form lives under a user-writable prefix.
+    "/private/var/folders/",  # realpath-resolved form
+    "/var/folders/",           # normpath-unresolved form
+    # ``/tmp`` on macOS is a symlink into ``/private/tmp/``.  Same
+    # dual-form rationale.
+    "/private/tmp/",           # realpath-resolved form
+    "/tmp/",                   # normpath-unresolved form
 )
+# The allowlist is macOS-specific: on Linux / Windows these literal
+# ``/private/...`` paths are not an OS convention, so the previous
+# behaviour (block if it matches the sensitive prefix) is preserved.
+_ALLOWLIST_ACTIVE = sys.platform == "darwin"
+
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
 def _is_allowlisted_sensitive_path(resolved: str, normalized: str) -> bool:
     """Return True for paths that look sensitive by prefix but are actually
-    user-writable (macOS temp directories, primarily)."""
-    for allowed in _SENSITIVE_PATH_ALLOWLIST:
-        if resolved.startswith(allowed) or normalized.startswith(allowed):
-            return True
-    return False
+    user-writable (macOS temp directories, primarily).
+
+    Requires *both* ``resolved`` and ``normalized`` to start with a
+    (potentially different) allowlisted prefix — the AND guard defeats
+    a symlink-substitution bypass where an attacker creates
+    ``/private/var/folders/evil -> /etc/sudoers`` and writes to the
+    symlinked name: ``resolved`` points at ``/etc/sudoers`` and fails
+    its allowlist check, so the path is blocked despite the allowlisted
+    ``normalized``.  Both forms are sanitised (``normalized`` via
+    ``normpath`` / ``expanduser``, ``resolved`` via ``realpath`` or,
+    on exception, a fall-back to ``normalized``), so no raw attacker-
+    controlled string reaches this check.
+    """
+    if not _ALLOWLIST_ACTIVE:
+        return False
+    resolved_ok = any(resolved.startswith(a) for a in _SENSITIVE_PATH_ALLOWLIST)
+    if not resolved_ok:
+        return False
+    normalized_ok = any(normalized.startswith(a) for a in _SENSITIVE_PATH_ALLOWLIST)
+    return normalized_ok
 
 
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
+    normalized = os.path.normpath(os.path.expanduser(filepath))
     try:
         resolved = os.path.realpath(os.path.expanduser(filepath))
     except (OSError, ValueError):
-        resolved = filepath
-    normalized = os.path.normpath(os.path.expanduser(filepath))
+        # Fail closed: never fall back to the raw, un-normalised
+        # ``filepath``.  The raw form can carry ``..`` segments that slip
+        # through prefix matching — use the normalised form, which has
+        # already been sanitised via ``normpath``/``expanduser``.
+        resolved = normalized
     _err = (
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."


### PR DESCRIPTION
## What does this PR do?

Fixes the file-tool sensitive-path guard so it permits writes to macOS per-user temp directories (\`/private/var/folders/…\`, \`/private/tmp/…\`) while continuing to block every genuinely sensitive subtree.

## Root cause

Commit 311dac19 added \`/private/var/\` to \`_SENSITIVE_PATH_PREFIXES\` to close the \`/etc\` → \`/private/etc\` symlink bypass on macOS.  The prefix is correct for blocking system-owned paths, but \`/private/var/folders/\` is the macOS per-user temporary directory (\`tempfile.mkdtemp()\` returns paths there, and \`/tmp\` is a symlink into \`/private/tmp/\`).

## Fix

Adds \`_is_macos_user_temp(resolved, normalized)\` with a **dual-form AND guard**: both the \`realpath\`-resolved form and the \`normpath\`-normalized form of the path must fall under an allowlisted prefix.  The AND requirement defeats a symlink-substitution bypass: if an attacker creates a symlink from an allowlisted path into a blocked system path, \`realpath\` resolves through the symlink to the blocked target and fails the check.

Allowlisted prefixes (macOS only, gated on \`sys.platform == "darwin"\`):
- \`/private/var/folders/\` and \`/var/folders/\` (per-user temp, both symlink forms)
- \`/private/tmp/\` and \`/tmp/\` (system temp, both symlink forms)

## Tests

- All 6 \`TestWriteInvalidatesDedup\` tests now pass (they use \`tempfile.mkdtemp()\` which resolves to \`/private/var/folders/…\` on macOS and were being blocked as sensitive paths).
- All 28 tests in \`tests/tools/test_file_read_guards.py\` pass.
- No change to Linux/Windows behavior (guard is \`sys.platform == "darwin"\` only).