### PR TITLE
fix: Windows UTF-8 encoding for file operations

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -582,7 +582,7 @@ def _load_context_cache() -> Dict[str, int]:
     if not path.exists():
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         return data.get("context_lengths", {})
     except Exception as e:
@@ -604,7 +604,7 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     path = _get_context_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -143,7 +143,7 @@ def nous_rate_limit_remaining() -> Optional[float]:
     """
     path = _state_path()
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             state = json.load(f)
         reset_at = state.get("reset_at", 0)
         remaining = reset_at - time.time()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -712,7 +712,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
-                with open(_cfg_path) as _f:
+                with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):
@@ -1003,7 +1003,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
     lock_fd = None
     try:
-        lock_fd = open(_LOCK_FILE, "w")
+        lock_fd = open(_LOCK_FILE, "w", encoding="utf-8")
         if fcntl:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -510,7 +510,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             import yaml as _yaml
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
             # Navigate to platforms.telegram.extra.dm_topics
@@ -534,7 +534,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         break
 
             if changed:
-                with open(config_path, "w") as f:
+                with open(config_path, "w", encoding="utf-8") as f:
                     _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
                 logger.info(
                     "[%s] Persisted thread_id=%s for topic '%s' in config.yaml",
@@ -2782,7 +2782,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             import yaml as _yaml
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
             dm_topics = (


### PR DESCRIPTION
## Summary
Add encoding='utf-8' to file operations across key modules to fix Windows compatibility issues.

## Impact
This fixes encoding issues on Windows where the default encoding is cp1252, which can cause failures when processing Chinese characters or other non-ASCII content.

## Changes
- **agent/model_metadata.py** - Add encoding='utf-8' to context cache read/write operations
- **agent/nous_rate_guard.py** - Add encoding='utf-8' to rate limit state file read
- **cron/scheduler.py** - Add encoding='utf-8' to config.yaml and lock file operations
- **gateway/platforms/telegram.py** - Add encoding='utf-8' to config.yaml read/write operations

## Why
Windows default encoding is cp1252, which fails when processing Chinese characters or other non-ASCII content in config files, cache files, and state files. This PR ensures consistent UTF-8 encoding across all text file operations.

Fixes Windows support for Chinese users.