### PR TITLE
fix(install): show npm progress so browser-deps install does not look hung

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1129,8 +1129,9 @@ install_node_deps() {
 
     if [ -f "$INSTALL_DIR/package.json" ]; then
         log_info "Installing Node.js dependencies (browser tools)..."
+        log_info "This may take several minutes — browser packages download ~80MB of binaries."
         cd "$INSTALL_DIR"
-        npm install --silent 2>/dev/null || {
+        npm install --no-fund --no-audit || {
             log_warn "npm install failed (browser tools may not work)"
         }
         log_success "Node.js dependencies installed"


### PR DESCRIPTION
## Summary

Closes #8145.

`install.sh` was running `npm install --silent 2>/dev/null` for the top-level `package.json`, which hides both npm's output **and** the postinstall output from the two browser dependencies:

- `@askjo/camofox-browser` — downloads a ~80MB custom Firefox binary on install
- `agent-browser` — has its own bundled setup step

On slower networks this step can take several minutes with zero visible progress, so users reasonably conclude the installer is hung and kill it at the `Installing Node.js dependencies (browser tools)...` line (the exact symptom in #8145).

Fix:

- Drop `--silent 2>/dev/null` so postinstall download progress is visible.
- Replace with `--no-fund --no-audit` to keep output focused (no funding banners / audit advisories) while still surfacing errors and download progress.
- Add a one-line `log_info` above the call explicitly telling users the step can take several minutes and why.

Narrow scope: only the first `npm install` (the browser-tools one called out in the bug) is touched. TUI and WhatsApp-bridge installs are left alone — no reports of those hanging, and keeping the diff small avoids widening scope.

## Test plan

- [x] `bash -n scripts/install.sh` passes (validated in `bash:5.2` Docker image).
- [ ] Manual: fresh Ubuntu 22.04 install — confirm progress lines appear during browser-deps install and the step completes without looking hung.