### PR TITLE
feat(agent): make smart_model_routing complex keywords configurable

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -59,11 +59,55 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
+def _normalize_keyword_list(value: Any) -> set[str]:
+    """Coerce a config value into a lowercase-stripped set of keywords.
+
+    Accepts a list/tuple of strings; ignores other types and non-string
+    entries so malformed config degrades to the built-in behavior rather
+    than crashing the router.
+    """
+    if not isinstance(value, (list, tuple)):
+        return set()
+    out: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        word = item.strip().lower()
+        if word:
+            out.add(word)
+    return out
+
+
+def _resolve_complex_keywords(cfg: Dict[str, Any]) -> set[str]:
+    """Return the effective complex-keyword set for this routing config.
+
+    - ``complex_keywords`` (list[str]) fully replaces the built-in list.
+    - ``complex_keywords_extra`` (list[str]) extends the built-in list.
+    - When both are set, ``complex_keywords`` wins (full override) and
+      ``complex_keywords_extra`` is ignored — preserving the predictable
+      behavior a self-hoster who sets an explicit list would expect.
+    - Malformed values (non-list, non-string entries) are silently
+      ignored so a broken config falls back to the built-in list.
+    """
+    override = _normalize_keyword_list(cfg.get("complex_keywords"))
+    if override:
+        return override
+    extra = _normalize_keyword_list(cfg.get("complex_keywords_extra"))
+    return _COMPLEX_KEYWORDS | extra
+
+
 def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Return the configured cheap-model route when a message looks simple.
 
     Conservative by design: if the message has signs of code/tool/debugging/
     long-form work, keep the primary model.
+
+    Routing skips the cheap model when the message contains any keyword in
+    the effective complex-keyword set. The set defaults to a built-in
+    English list and can be extended or fully overridden via
+    ``complex_keywords_extra`` / ``complex_keywords`` in ``routing_config``
+    — useful for non-English workflows where the built-in list misses
+    domain-specific triggers.
     """
     cfg = routing_config or {}
     if not _coerce_bool(cfg.get("enabled"), False):
@@ -97,7 +141,7 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
 
     lowered = text.lower()
     words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
-    if words & _COMPLEX_KEYWORDS:
+    if words & _resolve_complex_keywords(cfg):
         return None
 
     route = dict(cheap_model)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2860,6 +2860,19 @@ _FALLBACK_COMMENT = """
 #   cheap_model:
 #     provider: openrouter
 #     model: google/gemini-2.5-flash
+#   # Optional: extend the built-in complex-keyword list (e.g. for
+#   # non-English workflows — messages containing any of these words
+#   # stay on the primary model).
+#   # complex_keywords_extra:
+#   #   - błąd
+#   #   - analiza
+#   #   - napraw
+#   # Optional: fully override the built-in list (takes precedence
+#   # over complex_keywords_extra).
+#   # complex_keywords:
+#   #   - debug
+#   #   - error
+#   #   - implement
 """
 
 
@@ -2904,6 +2917,19 @@ _COMMENTED_SECTIONS = """
 #   cheap_model:
 #     provider: openrouter
 #     model: google/gemini-2.5-flash
+#   # Optional: extend the built-in complex-keyword list (e.g. for
+#   # non-English workflows — messages containing any of these words
+#   # stay on the primary model).
+#   # complex_keywords_extra:
+#   #   - błąd
+#   #   - analiza
+#   #   - napraw
+#   # Optional: fully override the built-in list (takes precedence
+#   # over complex_keywords_extra).
+#   # complex_keywords:
+#   #   - debug
+#   #   - error
+#   #   - implement
 """
 
 

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -38,6 +38,63 @@ def test_skips_tool_heavy_prompt_keywords():
     assert choose_cheap_model_route(prompt, _BASE_CONFIG) is None
 
 
+def test_complex_keywords_extra_extends_builtin():
+    """Additional keywords in config should trigger routing skip while
+    built-in keywords keep working — useful for non-English workflows."""
+    cfg = {**_BASE_CONFIG, "complex_keywords_extra": ["błąd", "napraw"]}
+    # Polish trigger word is caught only when extended.
+    assert choose_cheap_model_route("co to za błąd w systemie?", cfg) is None
+    # Built-in keyword still triggers.
+    assert choose_cheap_model_route("debug this for me", cfg) is None
+    # Harmless short prompt still routes to cheap model.
+    assert choose_cheap_model_route("what time is it?", cfg) is not None
+
+
+def test_complex_keywords_full_override_replaces_builtin():
+    """Setting ``complex_keywords`` replaces the built-in list entirely."""
+    cfg = {**_BASE_CONFIG, "complex_keywords": ["zzzonly"]}
+    # Built-in 'debug' no longer triggers since the list was overridden.
+    assert choose_cheap_model_route("debug this for me", cfg) is not None
+    # Only the overridden keyword triggers.
+    assert choose_cheap_model_route("what is zzzonly", cfg) is None
+
+
+def test_complex_keywords_override_beats_extra():
+    """When both config keys are present, full override wins for predictability."""
+    cfg = {
+        **_BASE_CONFIG,
+        "complex_keywords": ["solo"],
+        "complex_keywords_extra": ["będzie"],
+    }
+    # 'debug' no longer triggers — overridden list is authoritative.
+    assert choose_cheap_model_route("debug this for me", cfg) is not None
+    # The extra list is ignored when full override is set.
+    assert choose_cheap_model_route("coś będzie tutaj", cfg) is not None
+    # Only the override entry triggers.
+    assert choose_cheap_model_route("solo trip", cfg) is None
+
+
+def test_complex_keywords_normalize_case_and_whitespace():
+    """Entries are normalized to lowercase and stripped."""
+    cfg = {**_BASE_CONFIG, "complex_keywords_extra": ["  BŁĄD  ", "Napraw"]}
+    assert choose_cheap_model_route("co to za błąd?", cfg) is None
+    assert choose_cheap_model_route("prosze napraw", cfg) is None
+
+
+def test_complex_keywords_ignore_invalid_types():
+    """Malformed values fall back to built-in behavior instead of crashing."""
+    # Non-list types are ignored.
+    for bad in [{"not": "a list"}, "string", 42, None]:
+        cfg = {**_BASE_CONFIG, "complex_keywords_extra": bad}
+        # Built-in keyword still works.
+        assert choose_cheap_model_route("debug this", cfg) is None
+        # Short simple prompt still routes.
+        assert choose_cheap_model_route("hi there", cfg) is not None
+    # Non-string entries inside a list are skipped silently.
+    cfg = {**_BASE_CONFIG, "complex_keywords_extra": ["ok", 1, None, "fine"]}
+    assert choose_cheap_model_route("ok fine", cfg) is None
+
+
 def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_resolved(monkeypatch):
     from agent.smart_model_routing import resolve_turn_route
 


### PR DESCRIPTION
## What & why

`smart_model_routing` routes short/simple turns to a cheap model, but skips that route when the message contains any word from a hardcoded English set (`debug`, `error`, `refactor`, `docker`, …). The English-only list fails open for non-English users: e.g. a Polish request saying \"napraw ten błąd\" (fix this error) never trips the guard, so complex debugging work silently routes to the cheap model even when the user expects primary-model quality.

Per [#11814](https://github.com/NousResearch/hermes-agent/issues/11814), let self-hosters tune the list via `config.yaml` without patching source.

## Change

Two optional keys under `smart_model_routing`:

```yaml
smart_model_routing:
  enabled: true
  cheap_model: {provider: openrouter, model: google/gemini-2.5-flash}
  # Extend the built-in list (keeps English defaults + adds entries):
  complex_keywords_extra:
    - błąd
    - napraw
  # OR replace the built-in list entirely:
  # complex_keywords:
  #   - debug
  #   - error
```

Semantics (matches issue author's recommended Option 3):

- `complex_keywords` → **full override** — replaces the built-in set.
- `complex_keywords_extra` → **extend** — union with the built-in set.
- When both are set, full override wins (predictability for self-hosters who write an explicit list).
- Malformed values (non-list, non-string entries) degrade silently to built-ins.
- Entries are lowercased + stripped.
- **Default behavior unchanged** — both keys absent means the built-in list is used as before.

## How to test

```bash
pytest tests/agent/test_smart_model_routing.py -v
```

→ **11 passed**. 5 new test cases cover:

- `test_complex_keywords_extra_extends_builtin` — Polish trigger word routes correctly once added.
- `test_complex_keywords_full_override_replaces_builtin` — built-in `debug` stops triggering when overridden.
- `test_complex_keywords_override_beats_extra` — precedence rule when both keys are set.
- `test_complex_keywords_normalize_case_and_whitespace` — \`\"  BŁĄD  \"\` normalizes to `błąd`.
- `test_complex_keywords_ignore_invalid_types` — malformed values fall back to built-ins rather than crashing.

Commented example in `hermes_cli/config.py` updated to document both keys (two sections kept in sync).

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Closes #11814