### PR TITLE
docs: fix dashboard docker compose example

### DIFF
--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -135,6 +135,7 @@ services:
     #   - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     #   - OPENAI_API_KEY=${OPENAI_API_KEY}
     #   - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+    #   - TELEGRAM_ALLOWED_USERS=${TELEGRAM_ALLOWED_USERS}
     deploy:
       resources:
         limits:
@@ -145,7 +146,7 @@ services:
     image: nousresearch/hermes-agent:latest
     container_name: hermes-dashboard
     restart: unless-stopped
-    command: dashboard --host 0.0.0.0
+    command: dashboard --host 0.0.0.0 --insecure
     ports:
       - "9119:9119"
     volumes:
@@ -168,6 +169,14 @@ networks:
 ```
 
 Start with `docker compose up -d` and view logs with `docker compose logs -f`.
+
+`--insecure` is required here because the dashboard intentionally refuses
+non-localhost binds unless you opt in. Without it, the container starts,
+prints a refusal message, and exits before serving port `9119`.
+
+Platform allowlists such as `TELEGRAM_ALLOWED_USERS` can be kept in the
+mounted `~/.hermes/.env` file or forwarded explicitly through the Compose
+`environment:` section.
 
 ## Resource limits
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -23,13 +23,14 @@ This starts a local web server and opens `http://127.0.0.1:9119` in your browser
 | `--port` | `9119` | Port to run the web server on |
 | `--host` | `127.0.0.1` | Bind address |
 | `--no-open` | — | Don't auto-open the browser |
+| `--insecure` | — | Allow non-localhost binds (dangerous: exposes secrets on the network) |
 
 ```bash
 # Custom port
 hermes dashboard --port 8080
 
-# Bind to all interfaces (use with caution on shared networks)
-hermes dashboard --host 0.0.0.0
+# Bind to all interfaces (requires explicit insecure opt-in)
+hermes dashboard --host 0.0.0.0 --insecure
 
 # Start without opening browser
 hermes dashboard --no-open


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker dashboard documentation so the documented Compose setup actually works.

The current docs show the dashboard service as:

`command: dashboard --host 0.0.0.0`

but Hermes intentionally refuses non-localhost binds unless `--insecure` is also passed. With the documented Compose example, `docker compose up -d` starts the container and then the dashboard exits before serving port `9119`.

This PR updates the docs to:
- use `dashboard --host 0.0.0.0 --insecure` in the Compose example
- clarify that `--insecure` is required for the containerized dashboard case
- update the dashboard CLI docs so the non-localhost example matches the real behavior
- document that allowlist settings such as `TELEGRAM_ALLOWED_USERS` can be kept in the mounted `~/.hermes/.env` file or forwarded explicitly through Compose environment variables

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/user-guide/docker.md`
- Updated `website/docs/user-guide/features/web-dashboard.md`
- Fixed the Docker Compose dashboard command to use `--insecure`
- Added a note explaining why the current documented Compose example fails without `--insecure`
- Added `TELEGRAM_ALLOWED_USERS` to the optional forwarded environment variable examples
- Clarified that platform allowlists can come from `~/.hermes/.env` or the Compose `environment:` section

## How to Test

1. Follow the current Docker Compose dashboard example from the docs using:
   `command: dashboard --host 0.0.0.0`
2. Run:
   `docker compose up -d`
3. Check the dashboard logs:
   `docker compose logs dashboard`

Expected current failure:
- port `9119` does not serve the dashboard
- the logs show:

```text
Refusing to bind to 0.0.0.0 — the dashboard exposes API keys and config without robust authentication.
Use --insecure to override (NOT recommended on untrusted networks).
