### PR TITLE
fix(dingtalk): track incoming-message task to prevent GC mid-flight

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -1340,10 +1340,14 @@ class _IncomingHandler(
 
             # Fire-and-forget: return ACK immediately, process in background.
             # Blocking here would prevent the SDK from sending heartbeats,
-            # eventually causing a disconnect.  _on_message is wrapped so
-            # exceptions inside the task surface in logs instead of
-            # disappearing into the event loop.
-            asyncio.create_task(self._safe_on_message(chatbot_msg))
+            # eventually causing a disconnect.  ``_spawn_bg`` adds the task
+            # to ``self._bg_tasks`` — without that, the event loop only
+            # holds a weak reference and the message-processing task can
+            # be garbage-collected mid-flight (Python docs:
+            # https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task).
+            # ``_safe_on_message`` wraps _on_message so exceptions inside
+            # the task surface in logs instead of disappearing silently.
+            self._adapter._spawn_bg(self._safe_on_message(chatbot_msg))
         except Exception:
             logger.exception(
                 "[%s] Error preparing incoming message", self._adapter.name

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -681,6 +681,58 @@ class TestIncomingHandlerProcess:
         processing_gate.set()
         await asyncio.sleep(0.05)
 
+    @pytest.mark.asyncio
+    async def test_process_tracks_message_task_to_prevent_gc(self):
+        """The background message-processing task must be registered with
+        the adapter's ``_bg_tasks`` set so the event loop keeps a strong
+        reference to it. Without tracking, ``asyncio.create_task`` only
+        receives a weak reference from the loop and Python can
+        garbage-collect the task mid-flight (see Python docs for
+        ``asyncio.create_task``). That would ACK the DingTalk message at
+        the SDK level while silently dropping the agent turn.
+        """
+        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+
+        processing_started = asyncio.Event()
+        processing_gate = asyncio.Event()
+
+        async def slow_on_message(msg):
+            processing_started.set()
+            await processing_gate.wait()
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._on_message = slow_on_message
+        handler = _IncomingHandler(adapter, asyncio.get_running_loop())
+
+        callback = MagicMock()
+        callback.data = {
+            "msgtype": "text",
+            "text": {"content": "test"},
+            "senderId": "u",
+            "conversationId": "c",
+            "sessionWebhook": "https://oapi.dingtalk.com/x",
+            "msgId": "m",
+        }
+
+        assert len(adapter._bg_tasks) == 0
+        await handler.process(callback)
+        # Wait until _on_message actually starts so we know the task
+        # is in-flight, not just scheduled but immediately discarded.
+        await asyncio.wait_for(processing_started.wait(), timeout=1.0)
+
+        # While the task is awaiting the gate, it must be tracked.
+        assert len(adapter._bg_tasks) >= 1, (
+            "message-processing task was not registered with _bg_tasks — "
+            "it may be garbage-collected before completing"
+        )
+
+        # Release the gate and let _bg_tasks' done-callback discard the task.
+        processing_gate.set()
+        await asyncio.sleep(0.05)
+        assert len(adapter._bg_tasks) == 0, (
+            "done-callback should have removed the completed task"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Text extraction — mention preservation + platform sanity


### PR DESCRIPTION
## What & why

\`_IncomingHandler.process\` spawned \`_safe_on_message\` with a bare \`asyncio.create_task(...)\` while the surrounding handler already had a tracking helper — \`_spawn_bg\` — that adds tasks to \`self._bg_tasks\`. Python's event loop only keeps a **weak** reference to tasks returned by \`create_task\`; the [Python docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) explicitly warn that an untracked task can be garbage-collected before it completes.

The same class uses \`_spawn_bg\` for the \"🤔Thinking\" emotion reaction five lines earlier — the main message-processing task was the only fire-and-forget path that slipped the net.

In practice the leak rarely materialises because the outbound HTTP call inside \`_on_message\` keeps the task anchored to its transport. But the race window is real: the DingTalk SDK ACK is returned **before** the processing task gets far enough to start any I/O, so a GC pass in that window silently drops the user's message with no error surfaced (the SDK already got its STATUS_OK).

## Change

\`gateway/platforms/dingtalk.py\`:

\`\`\`python
# before
asyncio.create_task(self._safe_on_message(chatbot_msg))
# after
self._adapter._spawn_bg(self._safe_on_message(chatbot_msg))
\`\`\`

\`_spawn_bg\` adds the task to \`self._bg_tasks\` (strong ref) and installs a done-callback that discards it on completion. The same set is cancelled + awaited on \`disconnect()\`, so teardown stays clean.

## How to test

\`\`\`bash
pytest tests/gateway/test_dingtalk.py::TestIncomingHandlerProcess -v
\`\`\`

→ **4 passed** (3 pre-existing + 1 new). New test \`test_process_tracks_message_task_to_prevent_gc\` builds an adapter + handler, starts \`process()\` with a gated \`_on_message\`, and asserts:

1. \`_bg_tasks\` is empty before dispatch.
2. Once processing has begun (gated via an \`asyncio.Event\`), \`_bg_tasks\` has ≥1 entry — proving the task is strongly referenced mid-flight.
3. After the gate is released, \`_bg_tasks\` drains to 0 — proving the done-callback discards completed tasks.

Tests require \`dingtalk-stream\` installed (part of \`[all]\`, as with the rest of \`TestIncomingHandlerProcess\`).

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13, dingtalk-stream 0.24.3.

## Related

No open issue explicitly targets this — found during a proactive audit of \`asyncio.create_task\` sites. Diff is small enough to stand on its own.