### PR TITLE
fix(weixin): track fire-and-forget tasks to prevent GC mid-flight

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -27,7 +27,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import quote, urlparse
 
 logger = logging.getLogger(__name__)
@@ -1129,6 +1129,10 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_session: Optional[aiohttp.ClientSession] = None
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
+        # Strong references to fire-and-forget background tasks so the
+        # event loop's weak-ref-only tracking of asyncio.create_task()
+        # does not garbage-collect them mid-flight.
+        self._bg_tasks: Set[asyncio.Task] = set()
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
         self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
@@ -1221,6 +1225,14 @@ class WeixinAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
+        # Cancel any in-flight fire-and-forget tasks (inbound processing,
+        # typing-ticket fetches) so they don't keep writing after the
+        # HTTP sessions close.
+        if self._bg_tasks:
+            for task in list(self._bg_tasks):
+                task.cancel()
+            await asyncio.gather(*self._bg_tasks, return_exceptions=True)
+            self._bg_tasks.clear()
         if self._poll_session and not self._poll_session.closed:
             await self._poll_session.close()
         self._poll_session = None
@@ -1230,6 +1242,19 @@ class WeixinAdapter(BasePlatformAdapter):
         self._release_platform_lock()
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
+
+    def _spawn_bg(self, coro) -> None:
+        """Start a fire-and-forget coroutine and track it for cleanup.
+
+        Python's event loop keeps only a weak reference to tasks
+        returned by ``asyncio.create_task``; without a strong reference
+        in ``self._bg_tasks``, an untracked task can be
+        garbage-collected before completing. See:
+        https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+        """
+        task = asyncio.create_task(coro)
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
 
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None
@@ -1280,7 +1305,7 @@ class WeixinAdapter(BasePlatformAdapter):
                     _save_sync_buf(self._hermes_home, self._account_id, sync_buf)
 
                 for message in response.get("msgs") or []:
-                    asyncio.create_task(self._process_message_safe(message))
+                    self._spawn_bg(self._process_message_safe(message))
             except asyncio.CancelledError:
                 break
             except Exception as exc:
@@ -1320,7 +1345,7 @@ class WeixinAdapter(BasePlatformAdapter):
         context_token = str(message.get("context_token") or "").strip()
         if context_token:
             self._token_store.set(self._account_id, sender_id, context_token)
-        asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
+        self._spawn_bg(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
 
         item_list = message.get("item_list") or []
         text = _extract_text(item_list)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -758,3 +758,59 @@ class TestWeixinVoiceSending:
         assert voice_item["encode_type"] == 6
         assert voice_item["sample_rate"] == 24000
         assert voice_item["bits_per_sample"] == 16
+
+
+class TestWeixinBackgroundTaskTracking:
+    """Regression: fire-and-forget tasks spawned during poll_loop /
+    message processing must be tracked in ``_bg_tasks`` so Python's weak
+    reference tracking cannot garbage-collect them mid-flight.
+    """
+
+    def test_spawn_bg_tracks_task_and_discards_on_completion(self):
+        async def _run():
+            adapter = _make_adapter()
+            assert len(adapter._bg_tasks) == 0
+
+            gate = asyncio.Event()
+
+            async def work():
+                await gate.wait()
+
+            adapter._spawn_bg(work())
+            # While the coroutine is awaiting the gate, the task must be
+            # strongly referenced by _bg_tasks — without this, the event
+            # loop only holds a weak ref and the task can be GC'd.
+            assert len(adapter._bg_tasks) == 1
+
+            gate.set()
+            # Let the done-callback run (it discards the task from the set).
+            for _ in range(5):
+                await asyncio.sleep(0)
+                if len(adapter._bg_tasks) == 0:
+                    break
+            assert len(adapter._bg_tasks) == 0
+
+        asyncio.run(_run())
+
+    def test_spawn_bg_captures_multiple_concurrent_tasks(self):
+        async def _run():
+            adapter = _make_adapter()
+            gates = [asyncio.Event() for _ in range(5)]
+
+            async def work(g):
+                await g.wait()
+
+            for g in gates:
+                adapter._spawn_bg(work(g))
+
+            assert len(adapter._bg_tasks) == 5
+
+            for g in gates:
+                g.set()
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if len(adapter._bg_tasks) == 0:
+                    break
+            assert len(adapter._bg_tasks) == 0
+
+        asyncio.run(_run())


### PR DESCRIPTION
## What & why

\`_poll_loop\` spawned \`_process_message_safe\` with a bare \`asyncio.create_task(...)\` for every inbound message, and \`_process_message\` did the same for \`_maybe_fetch_typing_ticket\`. Python's event loop only keeps a **weak** reference to tasks returned by \`create_task\`; the [Python docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) explicitly warn that untracked tasks can be garbage-collected mid-flight.

The weixin long-poll drains buffered messages in tight bursts, so a GC pass at the wrong moment silently drops the user's message **after** the sync buffer has already been advanced — the lost message cannot be re-polled.

Same root cause as the DingTalk fix in PR #11997 (separate PR because the adapters don't share infrastructure for this).

## Change

Mirror the tracking pattern the DingTalk adapter uses:

- \`self._bg_tasks: Set[asyncio.Task] = set()\` in \`__init__\`
- \`_spawn_bg(coro)\` helper — \`create_task\` + add to set + \`add_done_callback(discard)\`
- Route both fire-and-forget sites through \`_spawn_bg\`:
  - \`_poll_loop\` → \`_process_message_safe\` (inbound dispatch)
  - \`_process_message\` → \`_maybe_fetch_typing_ticket\`
- \`disconnect()\` cancels + awaits \`_bg_tasks\` before closing HTTP sessions, so no orphaned tasks keep writing after teardown

## How to test

\`\`\`bash
pytest tests/gateway/test_weixin.py -q
\`\`\`

→ **44 passed** (2 new). Regression tests in \`TestWeixinBackgroundTaskTracking\`:

- \`test_spawn_bg_tracks_task_and_discards_on_completion\` — single task is added to \`_bg_tasks\` while awaiting, removed by the done-callback after completion.
- \`test_spawn_bg_captures_multiple_concurrent_tasks\` — 5 concurrent tasks all tracked simultaneously, all drained after completion.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Found during a proactive audit of untracked \`asyncio.create_task\` sites across platform adapters. Companion to PR #11997 (dingtalk). Further untracked sites exist in \`qqbot\`, \`bluebubbles\`, \`rl_training_tool\` — keeping each adapter its own PR to keep reviews scoped.