### PR TITLE
fix(qqbot): track fire-and-forget dispatch tasks to prevent GC mid-flight

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -41,7 +41,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 try:
@@ -186,6 +186,11 @@ class QQAdapter(BasePlatformAdapter):
         self._http_client: Optional[httpx.AsyncClient] = None
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
+        # Strong references to fire-and-forget dispatch tasks (resume /
+        # identify / inbound message handlers) so the event loop's
+        # weak-ref-only tracking of ``create_task`` does not garbage-
+        # collect them mid-flight.
+        self._bg_tasks: Set[asyncio.Task] = set()
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
@@ -293,6 +298,15 @@ class QQAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             self._heartbeat_task = None
+
+        # Cancel any in-flight fire-and-forget tasks (resume / identify
+        # / inbound message handlers) so they don't keep running after
+        # the WebSocket is torn down.
+        if self._bg_tasks:
+            for task in list(self._bg_tasks):
+                task.cancel()
+            await asyncio.gather(*self._bg_tasks, return_exceptions=True)
+            self._bg_tasks.clear()
 
         await self._cleanup()
         self._release_platform_lock()
@@ -685,18 +699,24 @@ class QQAdapter(BasePlatformAdapter):
             self._session_id = None
             self._last_seq = None
 
-    @staticmethod
-    def _create_task(coro):
+    def _create_task(self, coro):
         """Schedule a coroutine, silently skipping if no event loop is running.
 
-        This avoids ``RuntimeError: no running event loop`` when tests call
-        ``_dispatch_payload`` synchronously outside of ``asyncio.run()``.
+        Tracks the task in ``self._bg_tasks`` so the event loop's
+        weak-reference tracking of ``create_task`` does not
+        garbage-collect it mid-flight (see Python docs for
+        ``asyncio.create_task``). Returns ``None`` when called from a
+        synchronous test context where no loop is running, so callers
+        that chose to ignore the return value continue to work.
         """
         try:
             loop = asyncio.get_running_loop()
-            return loop.create_task(coro)
         except RuntimeError:
             return None
+        task = loop.create_task(coro)
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)
+        return task
 
     def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
         """Route inbound WebSocket payloads (dispatch synchronously, spawn async handlers)."""
@@ -740,7 +760,7 @@ class QQAdapter(BasePlatformAdapter):
                     "GUILD_MESSAGE_CREATE",
                     "GUILD_AT_MESSAGE_CREATE",
             ):
-                asyncio.create_task(self._on_message(t, d))
+                self._create_task(self._on_message(t, d))
             else:
                 logger.debug("[%s] Unhandled dispatch: %s", self._log_tag, t)
             return

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -582,3 +582,92 @@ class TestWaitForReconnection:
         assert not result.success
         assert result.retryable is True
         assert "Not connected" in result.error
+
+
+class TestQQBackgroundTaskTracking:
+    """Regression: fire-and-forget dispatch tasks (resume / identify /
+    inbound message handlers) must be tracked in ``_bg_tasks`` so
+    Python's weak-reference tracking of ``create_task`` does not
+    garbage-collect them mid-flight.
+    """
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    def test_create_task_tracks_and_discards(self):
+        async def _run():
+            adapter = self._make_adapter()
+            assert len(adapter._bg_tasks) == 0
+
+            gate = asyncio.Event()
+
+            async def work():
+                await gate.wait()
+
+            task = adapter._create_task(work())
+            assert task is not None
+            assert len(adapter._bg_tasks) == 1
+
+            gate.set()
+            for _ in range(5):
+                await asyncio.sleep(0)
+                if len(adapter._bg_tasks) == 0:
+                    break
+            assert len(adapter._bg_tasks) == 0
+
+        asyncio.run(_run())
+
+    def test_create_task_returns_none_without_running_loop(self):
+        """Preserves backwards-compat for tests that invoke
+        ``_dispatch_payload`` synchronously."""
+        adapter = self._make_adapter()
+
+        async def never_runs():
+            pass
+
+        coro = never_runs()
+        try:
+            result = adapter._create_task(coro)
+            assert result is None
+            assert len(adapter._bg_tasks) == 0
+        finally:
+            coro.close()
+
+    def test_dispatch_inbound_uses_tracked_task(self):
+        """The dispatch path for inbound message types must now route
+        through ``_create_task`` — the bare ``asyncio.create_task`` at
+        the dispatch site would have left the message-handling task
+        subject to GC mid-flight.
+        """
+        async def _run():
+            adapter = self._make_adapter()
+            started = asyncio.Event()
+            gate = asyncio.Event()
+
+            async def fake_on_message(t, d):
+                started.set()
+                await gate.wait()
+
+            adapter._on_message = fake_on_message
+            adapter._dispatch_payload({
+                "op": 0,
+                "t": "C2C_MESSAGE_CREATE",
+                "s": 1,
+                "d": {"id": "m1"},
+            })
+
+            await asyncio.wait_for(started.wait(), timeout=1.0)
+            assert len(adapter._bg_tasks) == 1, (
+                "inbound dispatch task is not tracked — it could be "
+                "garbage-collected before the user's message is processed"
+            )
+
+            gate.set()
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if len(adapter._bg_tasks) == 0:
+                    break
+            assert len(adapter._bg_tasks) == 0
+
+        asyncio.run(_run())


### PR DESCRIPTION
## What & why

Three fire-and-forget paths in the QQ adapter held tasks only via Python's weak reference tracking:

1. \`_dispatch_payload(Hello)\` scheduled \`_send_resume\` / \`_send_identify\` via \`_create_task\` — a \`@staticmethod\` that called \`loop.create_task()\` and threw the return value away.
2. \`_dispatch_payload(op=0, t=C2C_MESSAGE_CREATE / GROUP_AT_MESSAGE_CREATE / DIRECT_MESSAGE_CREATE / GUILD_MESSAGE_CREATE / GUILD_AT_MESSAGE_CREATE)\` scheduled \`_on_message(t, d)\` via a bare \`asyncio.create_task()\`.

Python's event loop keeps only a **weak** reference to tasks returned by \`create_task\` — the [docs explicitly warn](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) that untracked tasks can be garbage-collected before completing. The inbound-message path is the concerning one: a GC pass in the narrow window between dispatch and the first \`await\` inside \`_on_message\` silently drops the user's message before any I/O anchors the task.

Companion to #11997 (dingtalk) and #11998 (weixin) from the same proactive audit.

## Change

- Convert \`_create_task\` from \`@staticmethod\` to an instance method that registers the new task in \`self._bg_tasks\` and installs a done-callback to discard it on completion.
- Preserve the existing \"return \`None\` when no running loop\" behaviour so synchronous test fixtures that drive \`_dispatch_payload\` continue to work.
- Route the inbound dispatch call through \`_create_task\` as well, so all fire-and-forget paths share the same tracking infrastructure (previously line 743 used bare \`asyncio.create_task\`).
- \`disconnect()\` now cancels + awaits \`_bg_tasks\` before tearing down the WebSocket, so no orphaned tasks keep running after shutdown.

## How to test

\`\`\`bash
pytest tests/gateway/test_qqbot.py -q
\`\`\`

→ **74 passed** (71 pre-existing + 3 new) — the pre-existing \`RuntimeWarning: coroutine '_send_identify' was never awaited\` is the same warning upstream/main emits; my change preserved the existing \`return None when no running loop\` semantics and doesn't introduce new warnings.

New \`TestQQBackgroundTaskTracking\` covers:

- \`test_create_task_tracks_and_discards\` — single task is registered in \`_bg_tasks\` while running, removed by the done-callback after completion.
- \`test_create_task_returns_none_without_running_loop\` — backwards-compat with the synchronous test fixtures that drive \`_dispatch_payload\` outside an event loop.
- \`test_dispatch_inbound_uses_tracked_task\` — the 5 inbound message types now dispatch through \`_create_task\` so their handlers are strongly referenced.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Third PR in the \`asyncio.create_task\` audit — see #11997 (dingtalk) and #11998 (weixin). Bluebubbles and \`tools/rl_training_tool\` still have untracked sites; keeping each adapter a separate PR for clean review.