### PR TITLE
fix(rl_training): anchor async supervisor tasks to RunState

### DIFF
--- a/tests/tools/test_rl_training_tool.py
+++ b/tests/tools/test_rl_training_tool.py
@@ -140,3 +140,32 @@ class TestStopTrainingRunStatus:
         state = _make_run_state()
         _stop_training_run(state)  # should not raise
         assert state.status == "pending"
+
+
+class TestRunStateAsyncTaskFields:
+    """Regression: RunState must carry strong references to its async
+    supervisor tasks so Python's weak-reference tracking cannot GC them
+    mid-run (Python docs warn about this for ``asyncio.create_task``).
+    """
+
+    def test_spawn_task_and_monitor_task_default_none(self):
+        state = _make_run_state()
+        assert state.spawn_task is None
+        assert state.monitor_task is None
+
+    def test_task_fields_accept_asyncio_task_instances(self):
+        import asyncio
+
+        async def _run():
+            async def _noop():
+                return None
+
+            spawn = asyncio.create_task(_noop())
+            monitor = asyncio.create_task(_noop())
+            state = _make_run_state(spawn_task=spawn, monitor_task=monitor)
+            assert state.spawn_task is spawn
+            assert state.monitor_task is monitor
+            await spawn
+            await monitor
+
+        asyncio.run(_run())

--- a/tools/rl_training_tool.py
+++ b/tools/rl_training_tool.py
@@ -137,6 +137,12 @@ class RunState:
     api_process: Optional[subprocess.Popen] = None
     trainer_process: Optional[subprocess.Popen] = None
     env_process: Optional[subprocess.Popen] = None
+    # Strong references to async workers. asyncio.create_task() only
+    # gives the event loop a weak reference — Python can GC the task
+    # mid-run and silently drop training-process supervision. Storing
+    # them on RunState anchors the lifetime to _active_runs.
+    spawn_task: Optional[asyncio.Task] = None
+    monitor_task: Optional[asyncio.Task] = None
 
 
 # Global state
@@ -419,8 +425,10 @@ async def _spawn_training_run(run_state: RunState, config_path: Path):
         run_state.start_time = time.time()
         logger.info("[%s] Training run started successfully!", run_id)
         
-        # Start background monitoring
-        asyncio.create_task(_monitor_training_run(run_state))
+        # Start background monitoring. Storing the task on RunState keeps
+        # a strong reference (RunState lives in _active_runs) so the
+        # supervisor is not garbage-collected mid-run.
+        run_state.monitor_task = asyncio.create_task(_monitor_training_run(run_state))
         
     except Exception as e:
         run_state.status = "failed"
@@ -792,8 +800,10 @@ async def rl_start_training() -> str:
     
     _active_runs[run_id] = run_state
     
-    # Start training in background
-    asyncio.create_task(_spawn_training_run(run_state, config_path))
+    # Start training in background. Keep a strong reference via
+    # RunState so the spawn coroutine is not garbage-collected before
+    # it finishes launching the three training processes.
+    run_state.spawn_task = asyncio.create_task(_spawn_training_run(run_state, config_path))
     
     return json.dumps({
         "run_id": run_id,


### PR DESCRIPTION
## What & why

\`_spawn_training_run\` and \`_monitor_training_run\` were scheduled with bare \`asyncio.create_task(...)\` calls and the return values thrown away. Python's event loop only holds a **weak** reference to tasks returned by \`create_task\` — the [docs explicitly warn](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) that untracked tasks can be garbage-collected before completing.

For \`rl_training_tool\` this matters concretely:

- \`_spawn_training_run\` launches the three training subprocesses (API, trainer, environment). If the task is GC'd between its \`await\` points, a partially-started run is left orphaned and \`rl_check_status\` never shows progress.
- \`_monitor_training_run\` runs for the lifetime of a job, sleeping 30s between polls. Each \`await asyncio.sleep(30)\` is a valid GC point for an untracked task.

Fourth PR in the proactive \`asyncio.create_task\` audit — see #11997 (dingtalk), #11998 (weixin), #12000 (qqbot). This one is different because \`rl_training_tool\` is module-level, not an adapter with a class/bg_tasks set.

## Change

Store both tasks on \`RunState\` (which is itself held strongly by the module-level \`_active_runs\` dict). The reference chain becomes:

\`\`\`
_active_runs (module-level) → RunState → Task
\`\`\`

so tasks stay reachable as long as the run does — and they become eligible for GC naturally after \`_active_runs[run_id]\` is removed.

\`\`\`python
@dataclass
class RunState:
    ...
    # Strong references to async workers.
    spawn_task: Optional[asyncio.Task] = None
    monitor_task: Optional[asyncio.Task] = None

# Site 1 — line 423
run_state.monitor_task = asyncio.create_task(_monitor_training_run(run_state))

# Site 2 — line 796
run_state.spawn_task = asyncio.create_task(_spawn_training_run(run_state, config_path))
\`\`\`

## How to test

\`\`\`bash
pytest tests/tools/test_rl_training_tool.py -q
\`\`\`

→ **14 passed** (12 pre-existing + 2 new). New tests in \`TestRunStateAsyncTaskFields\`:

- \`test_spawn_task_and_monitor_task_default_none\` — defaults preserve backwards-compat with callers that construct \`RunState\` directly.
- \`test_task_fields_accept_asyncio_task_instances\` — the fields round-trip a real \`asyncio.Task\`.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Companion to #11997, #11998, #12000 — same underlying bug pattern across the codebase, caught via a proactive audit of \`grep -rn 'asyncio\\.create_task('\`.