### PR TITLE
fix: use time.monotonic() for timeout deadlines, not time.time()

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -418,8 +418,8 @@ class CopilotACPClient:
             proc.stdin.write(json.dumps(payload) + "\n")
             proc.stdin.flush()
 
-            deadline = time.time() + timeout_seconds
-            while time.time() < deadline:
+            deadline = time.monotonic() + timeout_seconds
+            while time.monotonic() < deadline:
                 if proc.poll() is not None:
                     break
                 try:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3924,12 +3924,12 @@ def _poll_registration(
     Returns dict with app_id, app_secret, domain, open_id on success.
     Returns None on failure.
     """
-    deadline = time.time() + expire_in
+    deadline = time.monotonic() + expire_in
     current_domain = domain
     domain_switched = False
     poll_count = 0
 
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         base_url = _accounts_base_url(current_domain)
         try:
             res = _post_registration(base_url, {


### PR DESCRIPTION
## What & why

Two deadline-based polling loops computed their timeout with \`time.time()\`, which reflects the **system wall clock**. That clock can jump:

- **Backward** on NTP resync, VM pause/resume, or when a user manually sets the clock — the loop keeps polling past the intended duration.
- **Forward** on some DST transitions or NTP step corrections — the loop exits early.

\`time.monotonic()\` only moves forward, so the loop always exits when the intended duration has actually elapsed. This is the textbook Python idiom for timeouts ([\`time\` docs](https://docs.python.org/3/library/time.html#time.monotonic)).

## Change

- \`agent/copilot_acp_client.py:421\` — JSON-RPC request/response wait inside \`_run_prompt\`. A backward clock jump during a Copilot ACP round-trip kept the loop polling past \`timeout_seconds\`.
- \`gateway/platforms/feishu.py:3927\` — Feishu QR login polling inside \`_poll_registration\`. A clock jump during the 60+-second device-code window could drop the registration early or spin past the intended expiry.

Both deadlines are only compared against \`time.*()\` (never logged, persisted, or compared against an absolute wall-clock value), so swapping to \`time.monotonic()\` is a drop-in replacement with no behavioural change under a stable clock.

Left unchanged: the third occurrence in \`gateway/platforms/weixin.py:1027\` — also a deadline loop but it overlaps with the file I'm editing in PR #11998, kept separate to avoid a merge conflict.

## How to test

The fix is a 4-line mechanical swap of \`time.time()\` → \`time.monotonic()\` on matched \`deadline = …\` / \`while … < deadline\` pairs. No existing tests exercise the affected code paths with a clock jump, and adding a test that mocks the system clock for two unrelated files would be disproportionate to the change. Manual verification:

\`\`\`bash
# Linter/import sanity
python -c \"import agent.copilot_acp_client as m; assert m.time; print('ok')\"
python -c \"import gateway.platforms.feishu as m; print('ok')\"
\`\`\`

Both import cleanly on my machine.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic; \`time.monotonic()\` is in stdlib since Python 3.3.

## Related

Found during a proactive audit for \`deadline = time.time()\` / \`while time.time() < deadline\` idioms. Companion to the async-task tracking audit in #11997, #11998, #12000, #12001 — same spirit (proactive correctness fixes).