### PR TITLE
feat: make smart_model_routing complex keywords configurable via config

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 from utils import is_truthy_value
 
-_COMPLEX_KEYWORDS = {
+_DEFAULT_COMPLEX_KEYWORDS = {
     "debug",
     "debugging",
     "implement",
@@ -44,6 +44,25 @@ _COMPLEX_KEYWORDS = {
     "docker",
     "kubernetes",
 }
+
+
+def _resolve_complex_keywords(cfg: Dict[str, Any]) -> set:
+    """Build the effective complex-keywords set from config.
+
+    - complex_keywords_override: if set, replaces the defaults entirely.
+    - complex_keywords_extra: merged with the base set (defaults or override).
+    """
+    override = cfg.get("complex_keywords_override")
+    if isinstance(override, list):
+        base = {str(k).lower() for k in override}
+    else:
+        base = set(_DEFAULT_COMPLEX_KEYWORDS)
+
+    extra = cfg.get("complex_keywords_extra")
+    if isinstance(extra, list):
+        base |= {str(k).lower() for k in extra}
+
+    return base
 
 _URL_RE = re.compile(r"https?://|www\.", re.IGNORECASE)
 
@@ -97,7 +116,8 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
 
     lowered = text.lower()
     words = {token.strip(".,:;!?()[]{}\"'`") for token in lowered.split()}
-    if words & _COMPLEX_KEYWORDS:
+    complex_keywords = _resolve_complex_keywords(cfg)
+    if words & complex_keywords:
         return None
 
     route = dict(cheap_model)

--- a/cli.py
+++ b/cli.py
@@ -281,6 +281,8 @@ def load_cli_config() -> Dict[str, Any]:
             "max_simple_chars": 160,
             "max_simple_words": 28,
             "cheap_model": {},
+            "complex_keywords_extra": [],
+            "complex_keywords_override": None,
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,4 +1,4 @@
-from agent.smart_model_routing import choose_cheap_model_route
+from agent.smart_model_routing import choose_cheap_model_route, _DEFAULT_COMPLEX_KEYWORDS
 
 
 _BASE_CONFIG = {
@@ -59,3 +59,39 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+# --- complex_keywords_extra / complex_keywords_override tests ---
+
+
+def test_extra_keywords_block_routing():
+    """complex_keywords_extra adds new keywords that block cheap routing."""
+    cfg = {**_BASE_CONFIG, "complex_keywords_extra": ["banana"]}
+    # "banana" is not a default keyword, so without extra it routes cheap
+    assert choose_cheap_model_route("banana", {**_BASE_CONFIG}) is not None
+    # With extra it should be blocked
+    assert choose_cheap_model_route("banana", cfg) is None
+
+
+def test_override_replaces_defaults():
+    """complex_keywords_override fully replaces the default keyword set."""
+    cfg = {**_BASE_CONFIG, "complex_keywords_override": ["banana"]}
+    # "debug" is a default keyword but not in the override list
+    assert choose_cheap_model_route("debug", cfg) is not None
+    # "banana" is in the override list
+    assert choose_cheap_model_route("banana", cfg) is None
+
+
+def test_override_plus_extra():
+    """extra merges on top of override when both are set."""
+    cfg = {**_BASE_CONFIG, "complex_keywords_override": ["banana"], "complex_keywords_extra": ["mango"]}
+    assert choose_cheap_model_route("banana", cfg) is None
+    assert choose_cheap_model_route("mango", cfg) is None
+    # default keyword not in either list
+    assert choose_cheap_model_route("debug", cfg) is not None
+
+
+def test_defaults_unchanged_without_config():
+    """Without override/extra, the default keyword set is used."""
+    assert choose_cheap_model_route("debug", _BASE_CONFIG) is None
+    assert choose_cheap_model_route("kubernetes", _BASE_CONFIG) is None


### PR DESCRIPTION
Closes #11814

## Summary
Makes the hardcoded `_COMPLEX_KEYWORDS` list in `smart_model_routing.py` configurable through `config.yaml`.

## Changes
- **`agent/smart_model_routing.py`**: Renamed `_COMPLEX_KEYWORDS` → `_DEFAULT_COMPLEX_KEYWORDS`, added `_resolve_complex_keywords(cfg)` that reads config
- **`cli.py`**: Added `complex_keywords_extra` and `complex_keywords_override` to config schema
- **`tests/agent/test_smart_model_routing.py`**: 4 new tests covering extra, override, combined, and default behavior

## Config keys (under `smart_model_routing`)
- `complex_keywords_extra`: list of additional keywords merged with defaults
- `complex_keywords_override`: optional full replacement list (replaces defaults entirely)

All 10 routing tests pass.