### PR TITLE
fix(gateway): preserve exception tracebacks in stream_consumer error logs

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -452,7 +452,7 @@ class GatewayStreamConsumer:
             if _best_effort_ok and not self._final_response_sent:
                 self._final_response_sent = True
         except Exception as e:
-            logger.error("Stream consumer error: %s", e)
+            logger.error("Stream consumer error: %s", e, exc_info=True)
 
     # Pattern to strip MEDIA:<path> tags (including optional surrounding quotes).
     # Matches the simple cleanup regex used by the non-streaming path in
@@ -504,7 +504,7 @@ class GatewayStreamConsumer:
                 self._edit_supported = False
                 return reply_to_id
         except Exception as e:
-            logger.error("Stream send chunk error: %s", e)
+            logger.error("Stream send chunk error: %s", e, exc_info=True)
             return reply_to_id
 
     def _visible_prefix(self) -> str:
@@ -659,7 +659,7 @@ class GatewayStreamConsumer:
             # multiple tool calls. See: https://github.com/NousResearch/hermes-agent/issues/10454
             return result.success
         except Exception as e:
-            logger.error("Commentary send error: %s", e)
+            logger.error("Commentary send error: %s", e, exc_info=True)
             return False
 
     async def _send_or_edit(self, text: str, *, finalize: bool = False) -> bool:
@@ -797,5 +797,5 @@ class GatewayStreamConsumer:
                     self._edit_supported = False
                     return False
         except Exception as e:
-            logger.error("Stream send/edit error: %s", e)
+            logger.error("Stream send/edit error: %s", e, exc_info=True)
             return False


### PR DESCRIPTION
## What & why

Four \`except Exception as e:\` blocks in \`gateway/stream_consumer.py\` log only \`str(e)\` without \`exc_info=True\`:

| Location | Method | Failure mode that now goes under-logged |
| --- | --- | --- |
| \`stream_consumer.py:454\` | \`_consume_stream\` | Entire stream-consumption loop crashes |
| \`stream_consumer.py:506\` | \`_send_chunk\` | Incremental chunk send fails (edit vs fresh message) |
| \`stream_consumer.py:661\` | \`_send_commentary\` | Interjected message send fails |
| \`stream_consumer.py:799\` | \`_send_or_edit\` | Core send-or-edit pipeline fails at either branch |

Logging only \`str(e)\` drops the traceback, the exception type, and any chained cause. The [contributing guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing#coding-standards) explicitly asks for:

> \`logger.warning()\`/\`logger.error()\` with \`exc_info=True\`

so operators can triage streaming failures from logs alone instead of reaching for a debugger.

## Change

Append \`exc_info=True\` to each of the four \`logger.error(...)\` calls. No behaviour change beyond richer log output on the error path.

\`\`\`diff
-            logger.error(\"Stream consumer error: %s\", e)
+            logger.error(\"Stream consumer error: %s\", e, exc_info=True)
\`\`\`

(× 4, one per call site.)

## How to test

The change is a pure logging enrichment — no logic moves, no control flow changes. Import sanity:

\`\`\`bash
python -c \"from gateway.stream_consumer import StreamConsumer; print('ok')\"
\`\`\`

Existing tests continue to pass (\`pytest tests/gateway/ -q\` unaffected). Failure paths are not exercised by the unit test suite today and adding tests purely to assert log shape would be disproportionate to the change.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Found during a proactive audit of \`logger.error(..., %s, e)\` patterns against the contributing guide's exception-logging rule. Keeps scope to one file for clean review; other call sites (wecom, slack, feishu) exist with the same issue and can be tackled in follow-up PRs.