### PR TITLE
fix(wecom): preserve exception tracebacks on outbound failures

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1247,7 +1247,7 @@ class WeComAdapter(BasePlatformAdapter):
         except FileNotFoundError as exc:
             return SendResult(success=False, error=str(exc))
         except Exception as exc:
-            logger.error("[%s] Failed to prepare outbound media %s: %s", self.name, media_source, exc)
+            logger.error("[%s] Failed to prepare outbound media %s: %s", self.name, media_source, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
         if prepared["rejected"]:
@@ -1283,7 +1283,7 @@ class WeComAdapter(BasePlatformAdapter):
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending media to WeCom")
         except Exception as exc:
-            logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc)
+            logger.error("[%s] Failed to send media %s: %s", self.name, media_source, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
         caption_result = None
@@ -1347,7 +1347,7 @@ class WeComAdapter(BasePlatformAdapter):
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
-            logger.error("[%s] Send failed: %s", self.name, exc)
+            logger.error("[%s] Send failed: %s", self.name, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
         error = self._response_error(response)


### PR DESCRIPTION
## What & why

Three \`except Exception as exc:\` blocks in the WeCom adapter log only \`str(exc)\` without \`exc_info=True\`:

| Location | Method | Failure mode |
| --- | --- | --- |
| \`wecom.py:1250\` | \`_send_media\` → \`_prepare_outbound_media\` | Media preparation failure |
| \`wecom.py:1286\` | \`_send_media\` → upload/assemble | Upload or assemble failure |
| \`wecom.py:1350\` | \`send()\` | Catch-all after the \`asyncio.TimeoutError\` guard |

The [contributing guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing#coding-standards) calls for \`exc_info=True\` on error logs. Without it, operators lose the traceback, exception type, and any chained cause — exactly the information needed to triage an outbound delivery failure without attaching a debugger.

Companion to PR #12004 (same fix in \`gateway/stream_consumer.py\`).

## Change

Append \`exc_info=True\` to each of the three \`logger.error(...)\` calls. Pure logging enrichment; no control-flow change. The \`%s\` arguments already receive \`exc\` for the message body, so the change is purely additive.

\`\`\`diff
-            logger.error(\"[%s] Failed to prepare outbound media %s: %s\", self.name, media_source, exc)
+            logger.error(\"[%s] Failed to prepare outbound media %s: %s\", self.name, media_source, exc, exc_info=True)
\`\`\`

(× 3.)

## How to test

Pure logging enrichment; import sanity:

\`\`\`bash
python -c \"from gateway.platforms.wecom import WeComAdapter; print('ok')\"
\`\`\`

Existing WeCom tests continue to pass.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Follow-up to PR #12004 — same \`logger.error(..., %s, e)\` pattern. Other call sites (slack, feishu) still have the issue and can be tackled in follow-up PRs.