### PR TITLE
fix(slack): preserve exception tracebacks in error/warning logs

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -148,7 +148,7 @@ class SlackAdapter(BasePlatformAdapter):
                         team_label = entry.get("team_name", team_id) if isinstance(entry, dict) else team_id
                         logger.info("[Slack] Loaded saved token for workspace %s", team_label)
             except Exception as e:
-                logger.warning("[Slack] Failed to read %s: %s", tokens_file, e)
+                logger.warning("[Slack] Failed to read %s: %s", tokens_file, e, exc_info=True)
 
         try:
             if not self._acquire_platform_lock('slack-app-token', app_token, 'Slack app token'):
@@ -1377,7 +1377,7 @@ class SlackAdapter(BasePlatformAdapter):
                 blocks=updated_blocks,
             )
         except Exception as e:
-            logger.warning("[Slack] Failed to update approval message: %s", e)
+            logger.warning("[Slack] Failed to update approval message: %s", e, exc_info=True)
 
         # Resolve the approval — this unblocks the agent thread
         try:
@@ -1388,7 +1388,7 @@ class SlackAdapter(BasePlatformAdapter):
                 count, session_key, choice, user_name,
             )
         except Exception as exc:
-            logger.error("Failed to resolve gateway approval from Slack button: %s", exc)
+            logger.error("Failed to resolve gateway approval from Slack button: %s", exc, exc_info=True)
 
         # (approval state already consumed by atomic pop above)
 
@@ -1500,7 +1500,7 @@ class SlackAdapter(BasePlatformAdapter):
             return content
 
         except Exception as e:
-            logger.warning("[Slack] Failed to fetch thread context: %s", e)
+            logger.warning("[Slack] Failed to fetch thread context: %s", e, exc_info=True)
             return ""
 
     async def _handle_slash_command(self, command: dict) -> None:


### PR DESCRIPTION
## What & why

Four \`except Exception as …:\` blocks in \`gateway/platforms/slack.py\` log only \`str(exc)\` without \`exc_info=True\`:

| Location | Method | Failure mode |
| --- | --- | --- |
| \`slack.py:151\` | \`_load_saved_tokens\` | Token file read failure |
| \`slack.py:1380\` | \`_handle_approval_button\` | Failure updating the approval-message block in Slack |
| \`slack.py:1391\` | \`_handle_approval_button\` | Failure propagating the resolved approval back to the agent thread |
| \`slack.py:1503\` | \`_fetch_thread_context\` | Failure pulling thread history from Slack |

The [contributing guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing#coding-standards) calls for \`exc_info=True\` on these paths so operators see the traceback and exception type, not just the \`str(exc)\` summary.

The second block (\`Failed to resolve gateway approval\`) is the most consequential: an un-tracebacked failure there silently drops the approval signal while the agent sits blocked on \`Event.wait()\` inside \`tools/approval.py\`.

Third PR in the \`exc_info=True\` audit — see #12004 (stream_consumer), #12005 (wecom).

## Change

Append \`exc_info=True\` to each of the four \`logger.{error,warning}(...)\` calls. Pure logging enrichment; no control-flow change.

## How to test

Import sanity:

\`\`\`bash
python -c \"from gateway.platforms.slack import SlackAdapter; print('ok')\"
\`\`\`

Existing slack tests continue to pass.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Companion to PR #12004 (stream_consumer) and PR #12005 (wecom). Feishu and matrix still have the same issue in a few call sites and can be tackled in follow-ups.