### PR TITLE
fix(codex): preserve proxy env when creating OpenAI client

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4568,7 +4568,12 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        proxy_env_keys = (
+            "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY",
+            "http_proxy", "https_proxy", "all_proxy",
+        )
+        has_proxy_env = any(os.getenv(key) for key in proxy_env_keys)
+        if "http_client" not in client_kwargs and not has_proxy_env:
             try:
                 import httpx as _httpx
                 import socket as _socket

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -35,3 +35,27 @@ def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
     assert kwargs == snapshot, (
         f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
     )
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_preserves_proxy_env_transport(mock_openai, monkeypatch):
+    mock_openai.return_value = MagicMock()
+    monkeypatch.setenv("https_proxy", "http://127.0.0.1:7897")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        model="gpt-5.4",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = {
+        "api_key": "test-key",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+    }
+
+    agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    assert "http_client" not in mock_openai.call_args.kwargs


### PR DESCRIPTION
## Summary

Fixes a regression where Codex requests can time out for users who rely on `http_proxy` / `https_proxy`.

`_create_openai_client()` injects a custom `httpx.Client` with `HTTPTransport(socket_options=...)` for TCP keepalives. When proxy environment variables are configured, passing a custom transport
bypasses httpx's default environment proxy handling. This causes Codex requests to `https://chatgpt.com/backend-api/codex` to attempt direct connection instead of using the configured proxy.

## Root Cause

With proxy env vars configured, the default httpx client can reach the Codex endpoint through the proxy, but the custom transport path times out:

```text
default_httpx status=401 elapsed=1.07s
custom_transport_keepalive ERROR ConnectTimeout elapsed=20.03s

## Fix

Skip the keepalive http_client injection when any proxy environment variable is present:

- HTTP_PROXY
- HTTPS_PROXY
- ALL_PROXY
- http_proxy
- https_proxy
- all_proxy

This preserves default OpenAI SDK / httpx proxy behavior for proxied environments, while keeping the keepalive transport for non-proxy environments.

## Tests

Added a regression test to ensure _create_openai_client() does not inject a custom http_client when proxy env vars are set.

Tested locally:

HERMES_HOME=/tmp/hermes-test-home python -m pytest \
  tests/run_agent/test_create_openai_client_kwargs_isolation.py \
  tests/run_agent/test_create_openai_client_reuse.py -q

4 passed

Note: scripts/run_tests.sh could not run in my local venv because pip is missing:

/venv/bin/python: No module named pip