### PR TITLE
fix(discord): support html attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -562,6 +562,7 @@ DOCUMENT_CACHE_DIR = get_hermes_dir("cache/documents", "document_cache")
 
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
+    ".html": "text/html",
     ".md": "text/markdown",
     ".txt": "text/plain",
     ".log": "text/plain",

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3112,7 +3112,7 @@ class DiscordAdapter(BasePlatformAdapter):
                             logger.info("[Discord] Cached user document: %s", cached_path)
                             # Inject text content for plain-text documents (capped at 100 KB)
                             MAX_TEXT_INJECT_BYTES = 100 * 1024
-                            if ext in (".md", ".txt", ".log") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                            if ext in (".html", ".md", ".txt", ".log") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                                 try:
                                     text_content = raw_bytes.decode("utf-8")
                                     display_name = att.filename or f"document{ext}"

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -210,6 +210,26 @@ class TestIncomingDocumentHandling:
         assert "# Title" in event.text
 
     @pytest.mark.asyncio
+    async def test_html_document_cached_and_injected(self, adapter):
+        """HTML files should be passed through as readable documents."""
+        file_content = b"<html><body><h1>Status</h1><p>All good</p></body></html>"
+
+        with _mock_aiohttp_download(file_content):
+            msg = make_message(
+                attachments=[make_attachment(filename="report.html", content_type="text/html")],
+                content="inspect this page",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["text/html"]
+        assert "[Content of report.html]:" in event.text
+        assert "<h1>Status</h1>" in event.text
+        assert "inspect this page" in event.text
+
+    @pytest.mark.asyncio
     async def test_log_content_injected(self, adapter):
         """.log file under 100KB should be treated as text/plain and injected."""
         file_content = b"BLE trace line 1\nBLE trace line 2"


### PR DESCRIPTION
## Summary
- add `.html` to the shared gateway document type allowlist
- cache Discord HTML attachments as documents instead of skipping them
- inject small HTML file contents into the event text for direct agent inspection

## Problem
Fixes #11860.

Discord attachment handling skipped `.html` files entirely because the shared document allowlist did not include HTML. In practice that meant messages with attached HTML artifacts never put an accessible file path or inline content into agent context.

## Solution
Treat `.html` as a supported document type and include it in Discord's small text-document injection path. That makes attached HTML files show up like other readable artifacts instead of being dropped as unsupported.

## Verification
- `python3 -m pytest -o addopts='' tests/gateway/test_discord_document_handling.py`
- repo-local repro previously logged `Unsupported document type '.html' (text/html), skipping`; after the fix the HTML attachment is cached and injected into the event text
