### PR TITLE
fix(agent): honor proxy-aware OpenAI client routing (#5454)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4559,10 +4559,12 @@ class AIAgent:
         # every 10s, give up after 3 → dead peer detected within ~60s.
         #
         # Proxy interaction (#11609): handing httpx an explicit ``transport=``
-        # makes it skip env-proxy mount construction, so HTTPS_PROXY / system
-        # proxy users silently direct-connect. Rather than reimplement httpx's
-        # trust_env proxy resolution, skip keepalive injection whenever a proxy
-        # is configured and let the SDK build its default proxy-aware client.
+        # makes it skip env-proxy mount construction, so proxied users can
+        # silently direct-connect. Delegate to the SDK/httpx default client
+        # only when the current target host would actually route through the
+        # configured proxy. Hosts bypassed by NO_PROXY should keep the direct
+        # path keepalive transport, or we regress the local-provider hang fix
+        # from #10324.
         #
         # Safety against #10933: the ``client_kwargs = dict(client_kwargs)``
         # above means this injection only lands in the local per-call copy,
@@ -4574,7 +4576,7 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs and not self._has_proxy_configured():
+        if "http_client" not in client_kwargs and not self._should_delegate_proxy_routing(client_kwargs.get("base_url")):
             try:
                 import httpx as _httpx
                 import socket as _socket
@@ -4602,18 +4604,37 @@ class AIAgent:
         return client
 
     @staticmethod
-    def _has_proxy_configured() -> bool:
-        """Return True when any outbound HTTP proxy is configured."""
+    def _should_delegate_proxy_routing(base_url: Any) -> bool:
+        """Return True when httpx should own proxy routing for this target."""
         try:
             import urllib.request as _urlreq
+            from urllib.parse import urlparse
 
             proxies = _urlreq.getproxies()
         except Exception:
             return False
-        return any(
+        has_proxy = any(
             str(proxies.get(key) or "").strip()
             for key in ("http", "https", "all")
         )
+        if not has_proxy:
+            return False
+
+        candidate = str(base_url or "").strip()
+        if not candidate:
+            return True
+
+        try:
+            hostname = urlparse(candidate).hostname
+        except Exception:
+            return True
+        if not hostname:
+            return True
+
+        try:
+            return not _urlreq.proxy_bypass(hostname)
+        except Exception:
+            return True
 
     @staticmethod
     def _iter_client_sockets(http_client: Any):

--- a/run_agent.py
+++ b/run_agent.py
@@ -4558,6 +4558,12 @@ class AIAgent:
         # the agent hangs until manually killed.  Probes after 30s idle, retry
         # every 10s, give up after 3 → dead peer detected within ~60s.
         #
+        # Proxy interaction (#11609): handing httpx an explicit ``transport=``
+        # makes it skip env-proxy mount construction, so HTTPS_PROXY / system
+        # proxy users silently direct-connect. Rather than reimplement httpx's
+        # trust_env proxy resolution, skip keepalive injection whenever a proxy
+        # is configured and let the SDK build its default proxy-aware client.
+        #
         # Safety against #10933: the ``client_kwargs = dict(client_kwargs)``
         # above means this injection only lands in the local per-call copy,
         # never back into ``self._client_kwargs``.  Each ``_create_openai_client``
@@ -4568,7 +4574,7 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        if "http_client" not in client_kwargs and not self._has_proxy_configured():
             try:
                 import httpx as _httpx
                 import socket as _socket
@@ -4596,6 +4602,58 @@ class AIAgent:
         return client
 
     @staticmethod
+    def _has_proxy_configured() -> bool:
+        """Return True when any outbound HTTP proxy is configured."""
+        try:
+            import urllib.request as _urlreq
+
+            proxies = _urlreq.getproxies()
+        except Exception:
+            return False
+        return any(
+            str(proxies.get(key) or "").strip()
+            for key in ("http", "https", "all")
+        )
+
+    @staticmethod
+    def _iter_client_sockets(http_client: Any):
+        """Yield every live TCP socket owned by an httpx client."""
+        if http_client is None:
+            return
+        transports = []
+        default_transport = getattr(http_client, "_transport", None)
+        if default_transport is not None:
+            transports.append(default_transport)
+        mounts = getattr(http_client, "_mounts", None) or {}
+        for mount_transport in mounts.values():
+            if mount_transport is not None:
+                transports.append(mount_transport)
+        for transport in transports:
+            pool = getattr(transport, "_pool", None)
+            if pool is None:
+                continue
+            connections = (
+                getattr(pool, "_connections", None)
+                or getattr(pool, "_pool", None)
+                or []
+            )
+            for conn in list(connections):
+                stream = (
+                    getattr(conn, "_network_stream", None)
+                    or getattr(conn, "_stream", None)
+                )
+                if stream is None:
+                    continue
+                sock = getattr(stream, "_sock", None)
+                if sock is None:
+                    nested = getattr(stream, "stream", None)
+                    if nested is not None:
+                        sock = getattr(nested, "_sock", None)
+                if sock is None:
+                    continue
+                yield sock
+
+    @staticmethod
     def _force_close_tcp_sockets(client: Any) -> int:
         """Force-close underlying TCP sockets to prevent CLOSE-WAIT accumulation.
 
@@ -4612,35 +4670,7 @@ class AIAgent:
         closed = 0
         try:
             http_client = getattr(client, "_client", None)
-            if http_client is None:
-                return 0
-            transport = getattr(http_client, "_transport", None)
-            if transport is None:
-                return 0
-            pool = getattr(transport, "_pool", None)
-            if pool is None:
-                return 0
-            # httpx uses httpcore connection pools; connections live in
-            # _connections (list) or _pool (list) depending on version.
-            connections = (
-                getattr(pool, "_connections", None)
-                or getattr(pool, "_pool", None)
-                or []
-            )
-            for conn in list(connections):
-                stream = (
-                    getattr(conn, "_network_stream", None)
-                    or getattr(conn, "_stream", None)
-                )
-                if stream is None:
-                    continue
-                sock = getattr(stream, "_sock", None)
-                if sock is None:
-                    sock = getattr(stream, "stream", None)
-                    if sock is not None:
-                        sock = getattr(sock, "_sock", None)
-                if sock is None:
-                    continue
+            for sock in AIAgent._iter_client_sockets(http_client):
                 try:
                     sock.shutdown(_socket.SHUT_RDWR)
                 except OSError:
@@ -4723,39 +4753,15 @@ class AIAgent:
         client = getattr(self, "client", None)
         if client is None:
             return False
+        import socket as _socket
+
         try:
             http_client = getattr(client, "_client", None)
             if http_client is None:
                 return False
-            transport = getattr(http_client, "_transport", None)
-            if transport is None:
-                return False
-            pool = getattr(transport, "_pool", None)
-            if pool is None:
-                return False
-            connections = (
-                getattr(pool, "_connections", None)
-                or getattr(pool, "_pool", None)
-                or []
-            )
             dead_count = 0
-            for conn in list(connections):
-                # Check for connections that are idle but have closed sockets
-                stream = (
-                    getattr(conn, "_network_stream", None)
-                    or getattr(conn, "_stream", None)
-                )
-                if stream is None:
-                    continue
-                sock = getattr(stream, "_sock", None)
-                if sock is None:
-                    sock = getattr(stream, "stream", None)
-                    if sock is not None:
-                        sock = getattr(sock, "_sock", None)
-                if sock is None:
-                    continue
+            for sock in AIAgent._iter_client_sockets(http_client):
                 # Probe socket health with a non-blocking recv peek
-                import socket as _socket
                 try:
                     sock.setblocking(False)
                     data = sock.recv(1, _socket.MSG_PEEK | _socket.MSG_DONTWAIT)

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -188,11 +188,16 @@ def test_replace_primary_openai_client_survives_repeated_rebuilds():
     )
 
 
-def _stub_proxies(monkeypatch, proxies):
+def _stub_proxies(monkeypatch, proxies, *, bypass_hosts=()):
     """Stub urllib's proxy discovery so tests stay hermetic."""
     import urllib.request
 
     monkeypatch.setattr(urllib.request, "getproxies", lambda: dict(proxies))
+    monkeypatch.setattr(
+        urllib.request,
+        "proxy_bypass",
+        lambda host: host in set(bypass_hosts),
+    )
     for name in (
         "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
         "http_proxy", "https_proxy", "all_proxy", "no_proxy",
@@ -275,18 +280,18 @@ def test_create_openai_client_keepalive_direct_path_when_no_proxy(monkeypatch):
     )
 
 
-def test_has_proxy_configured_matches_urllib_getproxies(monkeypatch):
+def test_should_delegate_proxy_routing_matches_proxy_resolution(monkeypatch):
     _stub_proxies(monkeypatch, {})
-    assert AIAgent._has_proxy_configured() is False
+    assert AIAgent._should_delegate_proxy_routing("https://api.example.com/v1") is False
 
     _stub_proxies(monkeypatch, {"https": "http://10.0.0.1:8080"})
-    assert AIAgent._has_proxy_configured() is True
+    assert AIAgent._should_delegate_proxy_routing("https://api.example.com/v1") is True
 
     _stub_proxies(monkeypatch, {})
-    assert AIAgent._has_proxy_configured() is False
+    assert AIAgent._should_delegate_proxy_routing("https://api.example.com/v1") is False
 
     _stub_proxies(monkeypatch, {"no": "localhost"})
-    assert AIAgent._has_proxy_configured() is False
+    assert AIAgent._should_delegate_proxy_routing("https://api.example.com/v1") is False
 
 
 def test_create_openai_client_skips_injection_for_system_proxy(monkeypatch):
@@ -309,6 +314,34 @@ def test_create_openai_client_skips_injection_for_system_proxy(monkeypatch):
         "System-level proxy config should also suppress keepalive transport "
         "injection."
     )
+
+
+def test_create_openai_client_keeps_keepalive_when_no_proxy_bypasses_localhost(monkeypatch):
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    _stub_proxies(
+        monkeypatch,
+        {"http": "http://10.0.0.1:8080", "no": "localhost,127.0.0.1"},
+        bypass_hosts={"localhost", "127.0.0.1"},
+    )
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "http://localhost:1234/v1",
+            },
+            reason="no_proxy_localhost",
+            shared=False,
+        )
+
+    http_client = constructed[0]._http_client
+    assert http_client is not None, (
+        "NO_PROXY-bypassed localhost targets should keep the direct-path "
+        "keepalive transport."
+    )
+    assert _has_keepalive(http_client._transport)
 
 
 def _fake_httpx_client_with_mock_sockets(default_sock, mount_sock):

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -186,3 +186,175 @@ def test_replace_primary_openai_client_survives_repeated_rebuilds():
         "Some _create_openai_client calls returned the same object across "
         "a teardown — rebuild is not producing fresh clients"
     )
+
+
+def _stub_proxies(monkeypatch, proxies):
+    """Stub urllib's proxy discovery so tests stay hermetic."""
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "getproxies", lambda: dict(proxies))
+    for name in (
+        "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+        "http_proxy", "https_proxy", "all_proxy", "no_proxy",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _has_keepalive(transport):
+    if transport is None:
+        return False
+    pool = getattr(transport, "_pool", None)
+    return bool(getattr(pool, "_socket_options", None))
+
+
+def test_create_openai_client_skips_injection_when_https_proxy_set(monkeypatch):
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    _stub_proxies(monkeypatch, {"https": "http://127.0.0.1:7897"})
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="proxy_env_https",
+            shared=False,
+        )
+
+    assert len(constructed) == 1
+    assert "http_client" not in constructed[0]._kwargs
+    assert constructed[0]._http_client is None, (
+        "Proxy-configured clients must delegate to the SDK default transport "
+        "so httpx can apply trust_env proxy mounts."
+    )
+
+
+def test_create_openai_client_skips_injection_for_each_proxy_key(monkeypatch):
+    agent = _make_agent()
+
+    for key in ("http", "https", "all"):
+        constructed: list = []
+        fake_openai = _make_fake_openai_factory(constructed)
+        _stub_proxies(monkeypatch, {key: "http://127.0.0.1:7897"})
+
+        with patch("run_agent.OpenAI", fake_openai):
+            agent._create_openai_client(
+                {
+                    "api_key": "test-key-value",
+                    "base_url": "https://api.example.com/v1",
+                },
+                reason=f"proxy_{key}",
+                shared=False,
+            )
+
+        assert constructed[0]._http_client is None
+
+
+def test_create_openai_client_keepalive_direct_path_when_no_proxy(monkeypatch):
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    _stub_proxies(monkeypatch, {})
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="no_proxy_keepalive",
+            shared=False,
+        )
+
+    http_client = constructed[0]._http_client
+    assert http_client is not None
+    assert _has_keepalive(http_client._transport), (
+        "Direct-connect path lost keepalive socket options."
+    )
+
+
+def test_has_proxy_configured_matches_urllib_getproxies(monkeypatch):
+    _stub_proxies(monkeypatch, {})
+    assert AIAgent._has_proxy_configured() is False
+
+    _stub_proxies(monkeypatch, {"https": "http://10.0.0.1:8080"})
+    assert AIAgent._has_proxy_configured() is True
+
+    _stub_proxies(monkeypatch, {})
+    assert AIAgent._has_proxy_configured() is False
+
+    _stub_proxies(monkeypatch, {"no": "localhost"})
+    assert AIAgent._has_proxy_configured() is False
+
+
+def test_create_openai_client_skips_injection_for_system_proxy(monkeypatch):
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+    _stub_proxies(monkeypatch, {"https": "http://10.0.0.1:8080"})
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://api.example.com/v1",
+            },
+            reason="system_proxy",
+            shared=False,
+        )
+
+    assert constructed[0]._http_client is None, (
+        "System-level proxy config should also suppress keepalive transport "
+        "injection."
+    )
+
+
+def _fake_httpx_client_with_mock_sockets(default_sock, mount_sock):
+    from types import SimpleNamespace
+
+    def _conn(sock):
+        stream = SimpleNamespace(_sock=sock)
+        return SimpleNamespace(_network_stream=stream)
+
+    def _transport(sock):
+        pool = SimpleNamespace(_connections=[_conn(sock)])
+        return SimpleNamespace(_pool=pool)
+
+    class _URLPattern:
+        def __init__(self, pattern):
+            self._pattern = pattern
+
+    mounts = {_URLPattern("https://"): _transport(mount_sock)}
+    return SimpleNamespace(
+        _transport=_transport(default_sock),
+        _mounts=mounts,
+    )
+
+
+def test_iter_client_sockets_covers_mounts():
+    default_sock = MagicMock(name="default_sock")
+    mount_sock = MagicMock(name="mount_sock")
+    http_client = _fake_httpx_client_with_mock_sockets(default_sock, mount_sock)
+
+    seen = list(AIAgent._iter_client_sockets(http_client))
+    assert default_sock in seen
+    assert mount_sock in seen, (
+        "Proxy-mount sockets must be included in client socket iteration."
+    )
+
+
+def test_force_close_tcp_sockets_closes_mount_sockets():
+    default_sock = MagicMock(name="default_sock")
+    mount_sock = MagicMock(name="mount_sock")
+    http_client = _fake_httpx_client_with_mock_sockets(default_sock, mount_sock)
+    fake_openai = MagicMock(_client=http_client)
+
+    closed = AIAgent._force_close_tcp_sockets(fake_openai)
+
+    assert closed == 2
+    default_sock.shutdown.assert_called_once()
+    default_sock.close.assert_called_once()
+    mount_sock.shutdown.assert_called_once()
+    mount_sock.close.assert_called_once()


### PR DESCRIPTION
## Summary
- skip injected keepalive `httpx.Client` creation when a proxy is configured so the OpenAI SDK/httpx default `trust_env` path owns routing
- preserve the existing TCP keepalive transport on the direct-connect path
- extend socket cleanup/dead-connection probing to walk proxy mount transports as well as the default transport
- add regression coverage for proxy detection, direct-path keepalive, and mount-based socket cleanup

## Problem
`run_agent.py::_create_openai_client()` currently injects `httpx.HTTPTransport(socket_options=...)` to mitigate the CLOSE-WAIT hang from #10324.

That transport path has an important side effect: once Hermes hands httpx an explicit transport, httpx no longer constructs its normal proxy mounts from `trust_env=True`. In practice this means LLM traffic can silently bypass `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` or system proxy settings and direct-connect instead.

That matches the behavior reported in #5454 and the later generalized report in #11609.

## Why this fix
There were a few prior approaches in related PRs:
- `#11414`, `#11664`, `#11943`: skip injection when proxy env vars are present
- `#11702`: explicitly wire `proxy=` onto the custom `HTTPTransport`
- `#11733`: detect proxies the same way httpx does and let the SDK/httpx default client own proxy routing, while broadening cleanup for mount-based transports

This PR follows the `#11733` direction because it is the most correct salvage:
- it uses `urllib.request.getproxies()` so detection matches httpx `trust_env` behavior more closely than env-only checks
- it avoids partially reimplementing httpx proxy semantics around `NO_PROXY` and system proxy sources
- it fixes the adjacent cleanup gap where proxied clients place live sockets under `_mounts`, which the old `_force_close_tcp_sockets()` / `_cleanup_dead_connections()` logic would miss

## Changes
- `run_agent.py`
  - add `AIAgent._has_proxy_configured()` using `urllib.request.getproxies()`
  - gate keepalive transport injection on `not self._has_proxy_configured()`
  - add `AIAgent._iter_client_sockets()` covering both `_transport` and `_mounts`
  - refactor `_force_close_tcp_sockets()` and `_cleanup_dead_connections()` to reuse that iterator
- `tests/run_agent/test_create_openai_client_reuse.py`
  - add proxy/detection regression tests
  - lock the direct-path keepalive invariant
  - add coverage that mount-based sockets are included in cleanup

## Verification
- `uv run --extra dev pytest tests/run_agent/test_create_openai_client_reuse.py tests/run_agent/test_create_openai_client_kwargs_isolation.py -q`
- `uv run --extra dev pytest tests/agent/test_proxy_and_url_validation.py -q`
- `python3 -m py_compile run_agent.py tests/run_agent/test_create_openai_client_reuse.py`

## Notes
- This intentionally keeps the proxy path on the SDK/httpx default client rather than preserving the custom keepalive transport there.
- Direct-connect users still retain the #10324 mitigation.
- Proxied users regain httpx-native proxy resolution instead of Hermes trying to reproduce it incompletely.

Closes #5454
Related to #10324
Related to #11609
