### PR TITLE
feat(agent): make primary-provider API retry count configurable

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9038,7 +9038,14 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 3
+            # Number of API retries before giving up on the primary provider.
+            # Overridable via HERMES_API_MAX_RETRIES for users who want to
+            # failover to a configured fallback provider sooner instead of
+            # burning minutes on a flapping upstream (see issue #11616).
+            try:
+                max_retries = max(0, int(os.getenv("HERMES_API_MAX_RETRIES", "3")))
+            except (TypeError, ValueError):
+                max_retries = 3
             primary_recovery_attempted = False
             max_compression_attempts = 3
             codex_auth_retry_attempted=False

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -346,6 +346,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `HERMES_HUMAN_DELAY_MAX_MS` | Custom delay range maximum (ms) |
 | `HERMES_QUIET` | Suppress non-essential output (`true`/`false`) |
 | `HERMES_API_TIMEOUT` | LLM API call timeout in seconds (default: `1800`) |
+| `HERMES_API_MAX_RETRIES` | API retry attempts before giving up on the primary provider (default: `3`). Lower values failover to configured fallback providers sooner; `0` disables retries entirely. |
 | `HERMES_STREAM_READ_TIMEOUT` | Streaming socket read timeout in seconds (default: `120`). Auto-increased to `HERMES_API_TIMEOUT` for local providers. Increase if local LLMs time out during long code generation. |
 | `HERMES_STREAM_STALE_TIMEOUT` | Stale stream detection timeout in seconds (default: `180`). Auto-disabled for local providers. Triggers connection kill if no chunks arrive within this window. |
 | `HERMES_EXEC_ASK` | Enable execution approval prompts in gateway mode (`true`/`false`) |


### PR DESCRIPTION
## What & why

The per-call API retry loop in \`run_agent.py\` uses a hardcoded \`max_retries = 3\`. Users with a configured \`fallback_model\` who would rather fail over sooner after an unresponsive primary had no way to shorten the wait — three attempts with exponential backoff stretch to 15+ minutes on a flapping upstream before the fallback kicks in.

Issue [#11616](https://github.com/NousResearch/hermes-agent/issues/11616) logs exactly this scenario on Qwen via OpenRouter:

\`\`\`
[20:12] ⚠️ No response from provider for 180s (model: qwen/qwen3-coder-480b-…). Reconnecting…
[20:13] ⏳ Retrying in 2.0s (attempt 1/3)…
[20:17] ⏳ Retrying in 4.5s (attempt 2/3)…
[20:20] ⚠️ No response from provider for 180s. Reconnecting…   ← full retry budget burned
\`\`\`

## Change

Read the retry budget from \`HERMES_API_MAX_RETRIES\` (default \`3\`, clamped to non-negative, falls back to \`3\` on malformed values). \`0\` disables retries entirely, so one failed call routes directly to the fallback provider.

\`\`\`python
# before
max_retries = 3
# after
try:
    max_retries = max(0, int(os.getenv(\"HERMES_API_MAX_RETRIES\", \"3\")))
except (TypeError, ValueError):
    max_retries = 3
\`\`\`

The env-var-based knob matches the existing \`HERMES_API_TIMEOUT\` / \`HERMES_API_CALL_STALE_TIMEOUT\` pattern in the same file and avoids opening a \`config.yaml\` schema discussion for a single integer. A nested \`agent.max_api_retries\` config knob (as the issue reporter proposed in ex-1) is a reasonable follow-up if self-hosters ask for it.

Also document the new variable alongside \`HERMES_API_TIMEOUT\` in \`website/docs/reference/environment-variables.md\`.

## How to test

\`\`\`bash
# Default behaviour unchanged
unset HERMES_API_MAX_RETRIES
python -c \"import os; print(int(os.getenv('HERMES_API_MAX_RETRIES', '3')))\"  # 3

# Lower for fast failover
export HERMES_API_MAX_RETRIES=1
python -c \"import os; print(int(os.getenv('HERMES_API_MAX_RETRIES', '3')))\"  # 1

# Zero disables retries entirely
export HERMES_API_MAX_RETRIES=0
python -c \"import os; print(int(os.getenv('HERMES_API_MAX_RETRIES', '3')))\"  # 0

# Malformed values fall back to 3
export HERMES_API_MAX_RETRIES=not-a-number
\`\`\`

No existing tests pin the \`max_retries = 3\` literal; the default preserves today's behaviour byte-for-byte.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Closes #11616.