### PR TITLE
fix(web_server): replace deprecated asyncio.get_event_loop() calls

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -383,7 +383,7 @@ async def get_status():
     remote_health_body: dict | None = None
 
     if not gateway_running and _GATEWAY_HEALTH_URL:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         alive, remote_health_body = await loop.run_in_executor(
             None, _probe_gateway_health
         )
@@ -1341,7 +1341,7 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
                     client_id=client_id,
                     scope=scope,
                 )
-        device_data = await asyncio.get_event_loop().run_in_executor(None, _do_nous_device_request)
+        device_data = await asyncio.get_running_loop().run_in_executor(None, _do_nous_device_request)
         sid, sess = _new_oauth_session("nous", "device_code")
         sess["device_code"] = str(device_data["device_code"])
         sess["interval"] = int(device_data["interval"])
@@ -1630,7 +1630,7 @@ async def submit_oauth_code(provider_id: str, body: OAuthSubmitBody, request: Re
     """Submit the auth code for PKCE flows. Token-protected."""
     _require_token(request)
     if provider_id == "anthropic":
-        return await asyncio.get_event_loop().run_in_executor(
+        return await asyncio.get_running_loop().run_in_executor(
             None, _submit_anthropic_pkce, body.session_id, body.code,
         )
     raise HTTPException(status_code=400, detail=f"submit not supported for {provider_id}")


### PR DESCRIPTION
## What & why

Three call sites in the dashboard \`web_server\` used \`asyncio.get_event_loop()\` to obtain the running loop so they could schedule blocking operations via \`loop.run_in_executor\`.

\`asyncio.get_event_loop()\` is [deprecated as of Python 3.10](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) when called from code that is actually inside a running loop — in that context \`asyncio.get_running_loop()\` is the correct API and is what the deprecation pathway points callers at. All three sites are \`async def\` functions executed by the uvicorn event loop, so they are always called with a loop already running.

Notably, \`tests/gateway/test_voice_command.py:1668\` already asserts against the same pattern (\`\"play_in_voice_channel should NOT use deprecated asyncio.get_event_loop()\"\`), so this fix aligns \`web_server\` with the direction the maintainers are already moving.

## Change

Swap \`asyncio.get_event_loop()\` → \`asyncio.get_running_loop()\` at three sites in \`hermes_cli/web_server.py\`:

| Line | Context |
| --- | --- |
| 386 | \`/api/health\` gateway probe (dashboard) |
| 1344 | Nous device-code OAuth init |
| 1633 | Anthropic PKCE submit endpoint |

Pure API migration — behaviour is unchanged when a loop is running, which is always the case here.

## How to test

\`\`\`bash
python -c \"from hermes_cli.web_server import app; print('ok')\"
\`\`\`

Imports cleanly. No existing tests pin the deprecated call name.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

The same deprecated call exists in a couple of other non-test files (\`environments/agent_loop.py\`, \`environments/benchmarks/terminalbench_2/terminalbench2_env.py\`); keeping this PR scoped to the dashboard web server for a clean review. Follow-ups are straightforward.