### PR TITLE
fix(environments): replace deprecated asyncio.get_event_loop() calls

### DIFF
--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -403,7 +403,7 @@ class HermesAgentLoop:
                                     # Run tool calls in a thread pool so backends that
                                     # use asyncio.run() internally (modal, docker, daytona) get
                                     # a clean event loop instead of deadlocking.
-                                    loop = asyncio.get_event_loop()
+                                    loop = asyncio.get_running_loop()
                                     # Capture current tool_name/args for the lambda
                                     _tn, _ta, _tid = tool_name, args, self.task_id
                                     tool_result = await loop.run_in_executor(

--- a/environments/benchmarks/terminalbench_2/terminalbench2_env.py
+++ b/environments/benchmarks/terminalbench_2/terminalbench2_env.py
@@ -575,7 +575,7 @@ class TerminalBench2EvalEnv(HermesAgentBaseEnv):
                 # other tasks, tqdm updates, and timeout timers).
                 ctx = ToolContext(task_id)
                 try:
-                    loop = asyncio.get_event_loop()
+                    loop = asyncio.get_running_loop()
                     reward = await loop.run_in_executor(
                         None,  # default thread pool
                         self._run_tests, eval_item, ctx, task_name,


### PR DESCRIPTION
## What & why

Two more production call sites use \`asyncio.get_event_loop()\` from inside \`async def\` functions:

| Location | Context |
| --- | --- |
| \`environments/agent_loop.py:406\` | HermesAgentLoop tool dispatch when the backend (modal / docker / daytona) internally calls \`asyncio.run()\` |
| \`environments/benchmarks/terminalbench_2/terminalbench2_env.py:578\` | terminal-bench eval reward calculation |

As with the \`web_server\` companion fix (PR #12014), these are always invoked with a running loop, so \`asyncio.get_running_loop()\` is the non-deprecated equivalent. No behaviour change.

\`tests/gateway/test_voice_command.py:1668\` already asserts against the deprecated call for a different code path, so this continues the maintainer-led migration.

## Change

\`\`\`diff
-                                    loop = asyncio.get_event_loop()
+                                    loop = asyncio.get_running_loop()
\`\`\`

(× 2, one site per file.)

## How to test

\`\`\`bash
python -c \"from environments.agent_loop import HermesAgentLoop; print('ok')\"
python -c \"from environments.benchmarks.terminalbench_2 import terminalbench2_env; print('ok')\"
\`\`\`

Both import cleanly.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Follow-up to PR #12014 — same fix pattern across \`environments/\`. No further non-test occurrences remain after this PR lands.