### PR TITLE
fix(matrix): preserve exception tracebacks on E2EE and auth failures

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -326,7 +326,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     )
                     return False
         except Exception as exc:
-            logger.error("Matrix: post-upload key verification failed: %s", exc)
+            logger.error("Matrix: post-upload key verification failed: %s", exc, exc_info=True)
             return False
         return True
 
@@ -342,6 +342,7 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.error(
                 "Matrix: cannot verify device keys on server: %s — refusing E2EE",
                 exc,
+                exc_info=True,
             )
             return False
 
@@ -356,7 +357,7 @@ class MatrixAdapter(BasePlatformAdapter):
             try:
                 await olm.share_keys()
             except Exception as exc:
-                logger.error("Matrix: failed to re-upload device keys: %s", exc)
+                logger.error("Matrix: failed to re-upload device keys: %s", exc, exc_info=True)
                 return False
             return await self._reverify_keys_after_upload(client, local_ed25519)
 
@@ -396,6 +397,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     "Try generating a new access token to get a fresh device.",
                     client.device_id,
                     exc,
+                    exc_info=True,
                 )
                 return False
             return await self._reverify_keys_after_upload(client, local_ed25519)
@@ -465,6 +467,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.error(
                     "Matrix: whoami failed — check MATRIX_ACCESS_TOKEN and MATRIX_HOMESERVER: %s",
                     exc,
+                    exc_info=True,
                 )
                 await api.session.close()
                 return False


### PR DESCRIPTION
## What & why

Five \`except Exception as exc:\` blocks in the Matrix adapter log only \`str(exc)\` without \`exc_info=True\`:

| Method | Failure mode |
| --- | --- |
| \`_reverify_keys_after_upload\` (line 329) | Post-upload key verification failure |
| \`_upload_keys_if_needed\` (line 342) | Initial device-key query failure |
| \`_upload_keys_if_needed\` (line 359) | Re-upload device keys failure |
| \`_upload_keys_if_needed\` (line 394) | Initial device key upload failure |
| \`connect\` (line 465) | Whoami / access-token validation failure |

These are E2EE- and auth-critical paths. A silent traceback-less failure during device-key verification or upload makes it hard for operators to tell whether their Matrix bot is failing because of a stale token, a federation timeout, or an olm state mismatch — all three fail with different tracebacks, which \`str(exc)\` alone flattens.

The [contributing guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing#coding-standards) asks for \`exc_info=True\` on error logs.

Fourth PR in the \`exc_info=True\` audit — see #12004 (stream_consumer), #12005 (wecom), #12007 (slack).

## Change

Append \`exc_info=True\` to each of the five call sites. Pure logging enrichment; no control-flow change.

## How to test

\`\`\`bash
python -c \"from gateway.platforms.matrix import MatrixAdapter; print('ok')\"
\`\`\`

Imports cleanly.

## Platforms tested

- macOS (Darwin 25.3.0), Python 3.11.13. Change is platform-agnostic.

## Related

Companion to PR #12004, #12005, #12007. Feishu still has one outstanding site in \`send_exec_approval\` — can be a follow-up if desired.