### PR TITLE
fix(feishu): add exc_info=True to send_exec_approval warning

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1517,7 +1517,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 }
             return result
         except Exception as exc:
-            logger.warning("[Feishu] send_exec_approval failed: %s", exc)
+            logger.warning("[Feishu] send_exec_approval failed: %s", exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
     @staticmethod


### PR DESCRIPTION
Last remaining feishu call site missing `exc_info=True` on a `logger.warning` inside an `except Exception` block. The rest of the adapter already uses `exc_info=True` on all similar error paths.

Completes the exc_info sweep for the feishu adapter. Companion to #12004 (stream_consumer), #12005 (wecom), #12007 (slack), #12018 (matrix). +1/-1.