### PR TITLE
fix(weixin): replace assert with explicit raise after retry loop

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1552,7 +1552,15 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
-        assert last_error is not None
+        # Retry loop exited without success; last_error must be set because
+        # the loop only exits through the except branch. Use an explicit
+        # raise rather than ``assert`` so Python's -O/-OO optimization flags
+        # cannot strip the invariant check.
+        if last_error is None:
+            raise RuntimeError(
+                "weixin retry loop exited without success or error — "
+                "this should be impossible"
+            )
         raise last_error
 
     async def send(


### PR DESCRIPTION
`assert last_error is not None` inside `_send_chunk`'s post-retry fallthrough guard is stripped by `python -O` / `-OO`, reducing the invariant to a no-op and silently letting `None` reach `raise last_error` which then raises `TypeError: exceptions must derive from BaseException`.

Replace with an explicit `if last_error is None: raise RuntimeError(...)` so the guard holds regardless of the interpreter's optimization level.

Companion to PR #12019 (mcp_oauth). Completes the `assert`-in-production sweep for the repo — no other non-test sites remain.