### PR TITLE
fix(mcp_oauth): add exc_info=True to _read_json warning

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -150,7 +150,7 @@ def _read_json(path: Path) -> dict | None:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Failed to read %s: %s", path, exc)
+        logger.warning("Failed to read %s: %s", path, exc, exc_info=True)
         return None
 
 


### PR DESCRIPTION
`_read_json` catches `json.JSONDecodeError` and `OSError` but logs only `str(exc)` without `exc_info=True`. Since this helper reads OAuth token and client-info files, a decoder traceback is exactly what operators need to distinguish a truncated token file from a permission denial from a malformed-JSON restore path.

Companion to PR #12019 (same file, `assert` → `raise` fix), and to the exc_info sweep in #12004 / #12005 / #12007 / #12018 / #12021. +1/-1.