### PR TITLE
fix(update): handle EOF in stash-restore prompt

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4511,7 +4511,12 @@ def _restore_stashed_changes(
         if input_fn is not None:
             response = input_fn("Restore local changes now? [Y/n]", "y")
         else:
-            response = input().strip().lower()
+            try:
+                response = input().strip().lower()
+            except (KeyboardInterrupt, EOFError):
+                print()
+                print("No interactive input available — skipping automatic restore.")
+                response = "n"
         if response not in ("", "y", "yes"):
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -116,6 +116,30 @@ def test_restore_stashed_changes_can_skip_restore_and_keep_stash(monkeypatch, tm
     assert "git stash apply abc123" in out
 
 
+def test_restore_stashed_changes_handles_eof_and_keeps_stash(monkeypatch, tmp_path, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    def _raise_eof():
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", _raise_eof)
+
+    restored = hermes_main._restore_stashed_changes(["git"], tmp_path, "abc123", prompt_user=True)
+
+    assert restored is False
+    assert calls == []
+    out = capsys.readouterr().out
+    assert "No interactive input available — skipping automatic restore." in out
+    assert "Your changes are still preserved in git stash." in out
+    assert "git stash apply abc123" in out
+
+
 def test_restore_stashed_changes_applies_without_prompt_when_disabled(monkeypatch, tmp_path, capsys):
     calls = []
 


### PR DESCRIPTION
## Summary
- handle EOFError/KeyboardInterrupt in update stash-restore prompt path
- when interactive input is unavailable, skip auto-restore safely instead of crashing
- keep stash intact and print manual restore guidance

## Root cause
- `_restore_stashed_changes()` called `input()` directly in prompt mode
- in non-interactive/closed-stdin contexts, `input()` raised EOFError and aborted `hermes update`

## Test plan
- added `test_restore_stashed_changes_handles_eof_and_keeps_stash`
- ran: `scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py -k "restore_stashed_changes"`
- result: 8 passed
