### PR TITLE
fix(feishu): use time.monotonic() for QR-poll deadline

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3924,12 +3924,12 @@ def _poll_registration(
     Returns dict with app_id, app_secret, domain, open_id on success.
     Returns None on failure.
     """
-    deadline = time.time() + expire_in
+    deadline = time.monotonic() + expire_in
     current_domain = domain
     domain_switched = False
     poll_count = 0
 
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         base_url = _accounts_base_url(current_domain)
         try:
             res = _post_registration(base_url, {


### PR DESCRIPTION
## What

In `gateway/platforms/feishu.py::poll_until_authorized`, the deadline loop uses `time.time()` both to compute the deadline and to check elapsed time in the loop condition.

## Why

`time.time()` returns the system wall-clock, which is **not monotonic** — it can jump backward (NTP step, DST, manual adjustment, VM suspend/resume) or forward by large amounts. When this happens mid-poll:

- A backward jump extends the effective poll window unboundedly.
- A forward jump causes the loop to exit early, aborting authorization before the user has had time to scan the QR code.

`time.monotonic()` is the documented Python API for interval / deadline timing and is immune to wall-clock adjustments.

This is the same bug class as PR #12002 (copilot_acp_client + feishu matrix), now applied to the QR-polling path.

## How to test

This is a mechanical `time.time()` → `time.monotonic()` substitution on a pair that was clearly computing a relative deadline (deadline = now + expire_in, then loop while now < deadline). No new tests needed — the behavior change is only observable under wall-clock jumps.

Local run of existing feishu gateway tests:

```
uv pip install -e ".[dev]" --quiet
python -m pytest tests/gateway/ -k feishu -q
```

## Platforms tested

Manual code review + existing tests. The QR flow itself requires a live Feishu OAuth endpoint so I did not reproduce the clock-jump scenario end-to-end.

## Closes

Related to #12002's audit — proactive follow-up, no dedicated issue.