### PR TITLE
fix(weixin): use time.monotonic() for QR-poll deadline

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1024,11 +1024,11 @@ async def qr_login(
         except Exception as _qr_exc:
             print(f"（终端二维码渲染失败: {_qr_exc}，请直接打开上面的二维码链接）")
 
-        deadline = time.time() + timeout_seconds
+        deadline = time.monotonic() + timeout_seconds
         current_base_url = ILINK_BASE_URL
         refresh_count = 0
 
-        while time.time() < deadline:
+        while time.monotonic() < deadline:
             try:
                 status_resp = await _api_get(
                     session,


### PR DESCRIPTION
## What

In `gateway/platforms/weixin.py::_run_qr_flow`, the QR-login deadline uses `time.time()`. Switched to `time.monotonic()`.

## Why

`time.time()` is the system wall-clock — not monotonic. NTP step, VM suspend/resume, DST, or manual adjustment can jump it backward or forward mid-poll:

- Forward jump → loop exits before the user has had time to scan/confirm → silent auth failure.
- Backward jump → loop runs well past the intended `timeout_seconds`, tying up the event loop.

`time.monotonic()` is the documented Python API for interval timing (PEP 418) and is immune to these jumps.

Same bug class as #12002 (copilot_acp + feishu matrix) and the companion feishu QR-poll fix.

## How to test

Mechanical substitution on a classic deadline pattern (`deadline = now + timeout; while now < deadline`). No behavior change unless wall-clock jumps; no new tests required. Ran existing weixin gateway tests locally.

## Platforms tested

Code review + existing `tests/gateway/` weixin tests. End-to-end QR flow requires live iLink infrastructure, not reproduced here.

## Closes

Proactive audit follow-up — no dedicated issue.