### PR TITLE
fix(terminal): reap backgrounded children in LocalEnvironment

### DIFF
--- a/tests/tools/test_local_backgrounded_reap.py
+++ b/tests/tools/test_local_backgrounded_reap.py
@@ -1,0 +1,118 @@
+"""Regression tests for reaping backgrounded children in LocalEnvironment.
+
+When a command backgrounds a long-lived process (``python3 -m http.server &``,
+``node server.js &``, etc.), the child inherits the shell's stdout pipe.
+After the shell itself exits, the drain thread in ``_wait_for_process``
+stays blocked reading the pipe because the child still holds the write end.
+Before the fix this manifested as:
+
+* ``execute()`` returned promptly, but the child survived indefinitely,
+  holding ports/fds and leaking across successive gateway iterations.
+* ``LocalEnvironment._kill_process`` fallback (``proc.kill()``) was a
+  no-op on the already-reaped shell leader, so nothing reached the
+  backgrounded child.
+
+The fix is twofold:
+
+1. ``base.py`` — if the drain thread is still alive after the join grace
+   period, call ``_kill_process(proc)`` to tear down the whole group.
+2. ``local.py`` — signal the group via ``proc.pid`` directly (it was the
+   setsid leader at spawn) instead of ``os.getpgid(proc.pid)``, which
+   raises ``ProcessLookupError`` once the leader has been reaped.
+"""
+import os
+import socket
+import time
+
+import pytest
+
+from tools.environments.local import LocalEnvironment
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "logs").mkdir(exist_ok=True)
+
+
+def _pgid_still_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("::", port))
+        except OSError:
+            return True
+    return False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_execute_reaps_backgrounded_child_holding_stdout():
+    """A command that backgrounds a long-lived process must not leave it
+    running after execute() returns. The http.server child inherits the
+    shell's stdout; without the fix it survives and keeps the port bound."""
+    env = LocalEnvironment(cwd="/tmp")
+    port = _free_port()
+    try:
+        t0 = time.monotonic()
+        result = env.execute(f"python3 -m http.server {port} &", timeout=30)
+        elapsed = time.monotonic() - t0
+
+        # Shell itself exited normally; the reap happens in post-exit cleanup.
+        assert result["returncode"] == 0, result
+        # Drain-join grace is 5 s; reap adds another 2 s at most.
+        assert elapsed < 15, (
+            f"execute() took {elapsed:.1f}s — reap path likely didn't engage; "
+            f"before the fix this would hang until the caller's timeout."
+        )
+
+        # Give SIGTERM a moment to be delivered and the socket torn down.
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            if not _port_in_use(port):
+                break
+            time.sleep(0.1)
+
+        assert not _port_in_use(port), (
+            f"port {port} is still bound after execute() returned — the "
+            f"backgrounded http.server child was not reaped."
+        )
+    finally:
+        try:
+            env.cleanup()
+        except Exception:
+            pass
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group semantics only")
+def test_execute_does_not_regress_plain_commands():
+    """Fast commands that don't background anything must still return
+    quickly (well under the 5 s drain-join grace) and succeed."""
+    env = LocalEnvironment(cwd="/tmp")
+    try:
+        for cmd in ("echo hermes", "pwd", "ls /tmp | head -1"):
+            t0 = time.monotonic()
+            result = env.execute(cmd, timeout=10)
+            elapsed = time.monotonic() - t0
+            assert result["returncode"] == 0, (cmd, result)
+            assert elapsed < 3, (
+                f"{cmd!r} took {elapsed:.2f}s — plain commands should not "
+                f"hit the drain-join grace path."
+            )
+    finally:
+        try:
+            env.cleanup()
+        except Exception:
+            pass

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -555,6 +555,16 @@ class BaseEnvironment(ABC):
 
         drain_thread.join(timeout=5)
 
+        # If the drain thread is still running after the shell exited, a
+        # backgrounded child (e.g. `python3 -m http.server 8080 &`) inherited
+        # the stdout pipe and is keeping it open. Without cleanup the child
+        # stays alive holding ports/fds, and the next terminal call's drain
+        # can block on the same pipe. Reap the whole process group so the
+        # command returns cleanly and leaves no orphans.
+        if drain_thread.is_alive():
+            self._kill_process(proc)
+            drain_thread.join(timeout=2)
+
         try:
             proc.stdout.close()
         except Exception:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -276,22 +276,38 @@ class LocalEnvironment(BaseEnvironment):
         return proc
 
     def _kill_process(self, proc):
-        """Kill the entire process group (all children)."""
-        try:
-            if _IS_WINDOWS:
-                proc.terminate()
-            else:
-                pgid = os.getpgid(proc.pid)
-                os.killpg(pgid, signal.SIGTERM)
-                try:
-                    proc.wait(timeout=1.0)
-                except subprocess.TimeoutExpired:
-                    os.killpg(pgid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
+        """Kill the entire process group (all children).
+
+        ``_run_bash`` spawns the shell with ``preexec_fn=os.setsid``, making
+        it the leader of a new session/process group with ``pgid == pid``.
+        Signal the group via ``proc.pid`` directly rather than calling
+        ``os.getpgid(proc.pid)``: when this runs in the post-poll cleanup
+        path the leader is already reaped, and ``getpgid`` then raises
+        ``ProcessLookupError`` — the previous code fell back to
+        ``proc.kill()``, which is a no-op on a dead leader and leaves the
+        group's other members (e.g. a backgrounded ``http.server``) alive.
+        """
+        if _IS_WINDOWS:
             try:
-                proc.kill()
+                proc.terminate()
             except Exception:
                 pass
+            return
+
+        pgid = proc.pid
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            proc.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(pgid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+        except Exception:
+            pass
 
     def _update_cwd(self, result: dict):
         """Read CWD from temp file (local-only, no round-trip needed)."""


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where any terminal command that backgrounds a long-lived process (e.g. `python3 -m http.server 8080 &`, `vite &`, `npm run dev &`) leaves the child process running after `execute()` returns. The child inherits the shell's stdout pipe, so even after the shell itself exits normally the drain thread in `_wait_for_process` stays blocked reading the pipe — and the `LocalEnvironment._kill_process` fallback silently fails to signal it because the shell (the pgroup leader) has already been reaped.

Under the CLI this presents as orphaned ports/fds. Under the gateway it's worse: the tool call never completes, and the entire agent iteration stalls until `agent.gateway_timeout` (default 30 min) fires.

## Related Issue

No existing issue — reproducible live in `hermes chat -q "…"` by asking the agent to "serve a site on port 8080". Happy to file one if preferred; assumed the fix-with-repro-test is sufficient.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`tools/environments/base.py`** (`_wait_for_process`): if the drain thread is still alive after the 5 s join grace, call `_kill_process(proc)` to tear down the whole group, then briefly re-join to collect any final output.
- **`tools/environments/local.py`** (`_kill_process`): signal the group via `proc.pid` directly (it was the `setsid` leader at spawn) instead of `os.getpgid(proc.pid)`. When invoked from the post-poll cleanup path the leader has already been reaped, so `getpgid` raises `ProcessLookupError` — the previous fallback called `proc.kill()` on the dead leader, a no-op. Windows branch unchanged in behaviour.
- **`tests/tools/test_local_backgrounded_reap.py`** (new): regression coverage.

## How to Test

Minimal repro without the patch:

```python
from tools.environments.local import LocalEnvironment
env = LocalEnvironment(cwd="/tmp")
env.execute("python3 -m http.server 8099 &", timeout=30)
# Before fix: call returns but port 8099 stays bound indefinitely.
# After fix:  port 8099 is free by the time execute() returns.
```

Or via the full tests:

```bash
pytest tests/tools/test_local_backgrounded_reap.py -v
pytest tests/tools/test_local_env_blocklist.py \
       tests/tools/test_local_tempdir.py \
       tests/tools/test_base_environment.py \
       tests/tools/test_env_passthrough.py \
       tests/tools/test_local_backgrounded_reap.py -q
# 54 passed (on macOS 15.3 / arm64, Python 3.11)
```

The new test covers both the reap path and a regression check that plain commands still return in <3 s (i.e. don't hit the new branch).

Note: `tests/tools/test_local_interrupt_cleanup.py::test_wait_for_process_kills_subprocess_on_keyboardinterrupt` is flaky on `upstream/main` independently of this PR (test-setup issue finding the subprocess via psutil). It fails the same way before and after these changes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(terminal):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/tools/ ... -q` — 54 passed (pre-existing interrupt-cleanup flake noted above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.3 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal cleanup path, no user-facing API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — Windows branch in `_kill_process` preserves the original `proc.terminate()` behaviour; the new test is `skipif(os.name == "nt")`; only POSIX process-group semantics were refactored.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (tool contract unchanged; this only affects internal cleanup timing, not outputs)

## Screenshots / Logs

Before (live repro from the gateway log that motivated this):

```
07:20:31  inbound: "can you design and build a landing page for a diamond jewellery retailer…"
[agent runs: cd …/diamond-retailer && python3 -m http.server 8080 &]
07:57:12  ERROR gateway.run: Agent idle for 1801s (timeout 1800s) in session …
                last_activity=executing tool: terminal | iteration=13/250 | tool=terminal
```

`ps` afterwards showed the shell reparented to init (PPID=1) and the backgrounded `http.server` child still holding port 8080 — the pattern this PR fixes.