### PR TITLE
fix(telegram): preserve exception tracebacks in error/warning logs

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -388,7 +388,7 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             self._polling_network_error_count = 0
         except Exception as retry_err:
-            logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err)
+            logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err, exc_info=True)
             # start_polling failed — polling is dead and no further error
             # callbacks will fire, so schedule the next retry ourselves.
             if not self.has_fatal_error:
@@ -1190,7 +1190,7 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
+            logger.warning("[%s] send_update_prompt failed: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def send_exec_approval(
@@ -1254,7 +1254,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
+            logger.warning("[%s] send_exec_approval failed: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def send_model_picker(
@@ -1328,7 +1328,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            logger.warning("[%s] send_model_picker failed: %s", self.name, e)
+            logger.warning("[%s] send_model_picker failed: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     _MODEL_PAGE_SIZE = 8
@@ -1482,7 +1482,7 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 result_text = await callback(chat_id, model_id, provider_slug)
             except Exception as exc:
-                logger.error("Model picker switch failed: %s", exc)
+                logger.error("Model picker switch failed: %s", exc, exc_info=True)
                 result_text = f"Error switching model: {exc}"
 
             # Edit message to show confirmation, remove buttons
@@ -1622,7 +1622,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         count, session_key, choice, user_display,
                     )
                 except Exception as exc:
-                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+                    logger.error("Failed to resolve gateway approval from Telegram button: %s", exc, exc_info=True)
             return
 
         # --- Update prompt callbacks ---
@@ -1655,7 +1655,7 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.info("Telegram update prompt answered '%s' by user %s",
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
-            logger.error("Failed to write update response from callback: %s", exc)
+            logger.error("Failed to write update response from callback: %s", exc, exc_info=True)
 
     async def send_voice(
         self,


### PR DESCRIPTION
## What

Seven `logger.error` / `logger.warning` calls in `gateway/platforms/telegram.py` live inside `except ... as <var>:` blocks but log only the exception string (`%s`), dropping the traceback. This PR adds `exc_info=True` to all seven.

Sites:
- `_handle_polling_network_error` reconnect-failed warning (line ~391)
- `send_update_prompt` failure warning (~1193)
- `send_exec_approval` failure warning (~1257)
- `send_model_picker` failure warning (~1331)
- Model-picker callback switch error (~1485)
- Telegram approval-button gateway-resolution error (~1625)
- Update-response callback write error (~1658)

## Why

When any of these fire in production (network flakiness, Telegram API changes, library regressions, unexpected payload shapes), the current log line is:

    [tg] send_exec_approval failed: BadRequest

With no traceback, debugging requires guessing the call site or re-running the scenario with a debugger attached. `exc_info=True` preserves the full stack — identical observability improvement as #12004, #12005, #12007, #12018, #12021, #12024 applied to the same class of bug in telegram.

## How to test

Mechanical + additive change; no behavior difference except richer logs. Existing tests continue to pass:

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/gateway/ -k telegram -q

## Platforms tested

Telegram (code paths only — each except branch is a rare failure mode; not reproduced in a live session).

## Closes

Proactive audit follow-up — no dedicated issue.