### PR TITLE
fix(email): preserve exception tracebacks in error logs

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -286,7 +286,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap.logout()
             logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
         except Exception as e:
-            logger.error("[Email] IMAP connection failed: %s", e)
+            logger.error("[Email] IMAP connection failed: %s", e, exc_info=True)
             return False
 
         try:
@@ -297,7 +297,7 @@ class EmailAdapter(BasePlatformAdapter):
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
-            logger.error("[Email] SMTP connection failed: %s", e)
+            logger.error("[Email] SMTP connection failed: %s", e, exc_info=True)
             return False
 
         self._running = True
@@ -325,7 +325,7 @@ class EmailAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.error("[Email] Poll error: %s", e)
+                logger.error("[Email] Poll error: %s", e, exc_info=True)
             await asyncio.sleep(self._poll_interval)
 
     async def _check_inbox(self) -> None:
@@ -399,7 +399,7 @@ class EmailAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
         except Exception as e:
-            logger.error("[Email] IMAP fetch error: %s", e)
+            logger.error("[Email] IMAP fetch error: %s", e, exc_info=True)
         return results
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
@@ -477,7 +477,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send failed to %s: %s", chat_id, e)
+            logger.error("[Email] Send failed to %s: %s", chat_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     def _send_email(
@@ -559,7 +559,7 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
-            logger.error("[Email] Send document failed: %s", e)
+            logger.error("[Email] Send document failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     def _send_email_with_attachment(


### PR DESCRIPTION
## What

Six `logger.error` calls in `gateway/platforms/email.py` live inside `except Exception as e:` blocks but log only the exception string. This PR adds `exc_info=True` to all six.

Sites:
- L289 IMAP connection failed
- L300 SMTP connection failed
- L328 Poll error
- L402 IMAP fetch error
- L480 Send failed
- L562 Send document failed

## Why

When these fire in production (network flakiness, IMAP server quirks, auth changes), the current log line is:

    [Email] Send failed to user@example.com: timeout

With no stack. `exc_info=True` preserves the full traceback — same observability improvement as #12004, #12005, #12007, #12018, #12021, #12024, and the companion telegram PR.

## How to test

Additive logging change only — no behavior difference.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/gateway/ -k email -q

## Platforms tested

Code review; each error path is a rare failure mode so not re-produced in a live session.

## Closes

Proactive audit follow-up — no dedicated issue.