### PR TITLE
fix(homeassistant): preserve exception tracebacks in error/warning logs

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -134,7 +134,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             return True
 
         except Exception as e:
-            logger.error("[%s] Failed to connect: %s", self.name, e)
+            logger.error("[%s] Failed to connect: %s", self.name, e, exc_info=True)
             return False
 
     async def _ws_connect(self) -> bool:
@@ -224,7 +224,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 return
             except Exception as e:
-                logger.warning("[%s] WebSocket error: %s", self.name, e)
+                logger.warning("[%s] WebSocket error: %s", self.name, e, exc_info=True)
 
             if not self._running:
                 return
@@ -242,7 +242,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
                     backoff_idx = 0  # Reset on successful reconnect
                     logger.info("[%s] Reconnected", self.name)
             except Exception as e:
-                logger.warning("[%s] Reconnection failed: %s", self.name, e)
+                logger.warning("[%s] Reconnection failed: %s", self.name, e, exc_info=True)
 
     async def _read_events(self) -> None:
         """Read events from WebSocket until disconnected."""


### PR DESCRIPTION
## What

Three `except Exception as e:` blocks in `gateway/platforms/homeassistant.py` log only `%s` of the exception and drop the traceback.

Sites:
- L137 `connect` failure (startup error, returns False)
- L227 WebSocket read-loop error (triggers reconnect)
- L245 Reconnect failure (backoff retry)

Adds `exc_info=True` to each.

## Why

Same bug class as #12004, #12005, #12007, #12018, #12021, #12024, and the telegram/email/mattermost companions. Home Assistant's WS transport can fail for dozens of reasons (auth, token rotation, server restart, proxy 502); without the traceback we lose the call-site and can only guess.

## How to test

Additive logging change only — no behavior difference.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/gateway/ -q

## Platforms tested

Home Assistant WS adapter. Each error path is rare so not reproduced in a live session.

## Closes

Proactive audit follow-up — no dedicated issue.