### PR TITLE
fix(bluebubbles): add exc_info=True to webhook parse error log

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -775,7 +775,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )[0]
                 payload = json.loads(payload_str) if payload_str else {}
         except Exception as exc:
-            logger.error("[bluebubbles] webhook parse error: %s", exc)
+            logger.error("[bluebubbles] webhook parse error: %s", exc, exc_info=True)
             return web.json_response({"error": "invalid payload"}, status=400)
 
         event_type = self._value(payload.get("type"), payload.get("event")) or ""


### PR DESCRIPTION
## What

One-site follow-up to the ongoing exc_info audit (#12004/#12005/#12007/#12018/#12021/#12024/#12033/#12034/#12035/#12036): `_handle_webhook` in `gateway/platforms/bluebubbles.py` logs only `%s` of the parse exception.

## Why

Without the traceback, a malformed BlueBubbles payload produces only:

    [bluebubbles] webhook parse error: Expecting value: line 1 column 1 (char 0)

with no indication of which branch (form-decode, JSON-decode, or field-extract) failed. `exc_info=True` restores the stack.

## How to test

Additive logging change only — no behavior difference.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/gateway/ -k bluebubbles -q

## Platforms tested

BlueBubbles webhook path; error branch is rare so not re-produced live.

## Closes

Proactive audit follow-up — no dedicated issue.