### PR TITLE
fix(webhook): preserve exception tracebacks in error/warning logs

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -273,7 +273,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 ", ".join(self._dynamic_routes.keys()) or "(none)",
             )
         except Exception as e:
-            logger.error("[webhook] Failed to reload dynamic routes: %s", e)
+            logger.error("[webhook] Failed to reload dynamic routes: %s", e, exc_info=True)
 
     async def _handle_webhook(self, request: "web.Request") -> "web.Response":
         """POST /webhooks/{route_name} — receive and process a webhook event."""
@@ -310,7 +310,7 @@ class WebhookAdapter(BasePlatformAdapter):
         try:
             raw_body = await request.read()
         except Exception as e:
-            logger.error("[webhook] Failed to read body: %s", e)
+            logger.error("[webhook] Failed to read body: %s", e, exc_info=True)
             return web.json_response({"error": "Bad request"}, status=400)
 
         # Validate HMAC signature (skip for INSECURE_NO_AUTH testing mode)
@@ -392,7 +392,7 @@ class WebhookAdapter(BasePlatformAdapter):
                             "[webhook] Skill '%s' not found", skill_name
                         )
             except Exception as e:
-                logger.warning("[webhook] Skill loading failed: %s", e)
+                logger.warning("[webhook] Skill loading failed: %s", e, exc_info=True)
 
         # Build a unique delivery ID
         delivery_id = request.headers.get(
@@ -623,7 +623,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 success=False, error="gh CLI not installed"
             )
         except Exception as e:
-            logger.error("[webhook] github_comment delivery error: %s", e)
+            logger.error("[webhook] github_comment delivery error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
     async def _deliver_cross_platform(


### PR DESCRIPTION
## What

Four `except Exception as e:` blocks in `gateway/platforms/webhook.py` log only `%s` of the exception, discarding the traceback.

Sites:
- L276 dynamic-route reload failure
- L313 request-body read failure
- L395 per-route skill-loading warning
- L626 \`github_comment\` gh-CLI delivery error

## Why

Same bug class as #12004/#12005/#12007/#12018/#12021/#12024/#12033/#12034/#12035/#12036/#12037. Webhook failures — especially route reload and skill load — need the stack frame to narrow down which config or skill entry raised.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/gateway/ -k webhook -q

## Platforms tested

Webhook adapter. Error paths are rare so not re-produced live.

## Closes

Proactive audit follow-up — no dedicated issue.