### PR TITLE
fix(whatsapp): add exc_info=True to session-lock acquire warning

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -293,7 +293,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if not self._acquire_platform_lock('whatsapp-session', str(self._session_path), 'WhatsApp session'):
                 return False
         except Exception as e:
-            logger.warning("[%s] Could not acquire session lock (non-fatal): %s", self.name, e)
+            logger.warning("[%s] Could not acquire session lock (non-fatal): %s", self.name, e, exc_info=True)
 
         # Auto-install npm dependencies if node_modules doesn't exist
         bridge_dir = bridge_path.parent


### PR DESCRIPTION
## What

One-site follow-up to the exc_info audit: `_acquire_session_lock` in `gateway/platforms/whatsapp.py` emits a non-fatal warning on `except Exception as e:` without the traceback.

## Why

The warning is explicitly labelled \"non-fatal\" and the adapter continues. That makes the log line the *only* way we'll learn a lock-acquire problem happened in production — so dropping the traceback is the worst place to do it. Adding \`exc_info=True\` preserves the stack.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/gateway/ -k whatsapp -q

## Platforms tested

WhatsApp adapter. Error branch is rare so not re-produced live.

## Closes

Proactive audit follow-up — no dedicated issue.