### PR TITLE
fix(browser_providers): add exc_info=True to session-close error logs

### DIFF
--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -196,7 +196,7 @@ class BrowserUseProvider(CloudBrowserProvider):
                 )
                 return False
         except Exception as e:
-            logger.error("Exception closing Browser Use session %s: %s", session_id, e)
+            logger.error("Exception closing Browser Use session %s: %s", session_id, e, exc_info=True)
             return False
 
     def emergency_cleanup(self, session_id: str) -> None:

--- a/tools/browser_providers/browserbase.py
+++ b/tools/browser_providers/browserbase.py
@@ -192,7 +192,7 @@ class BrowserbaseProvider(CloudBrowserProvider):
                 )
                 return False
         except Exception as e:
-            logger.error("Exception closing Browserbase session %s: %s", session_id, e)
+            logger.error("Exception closing Browserbase session %s: %s", session_id, e, exc_info=True)
             return False
 
     def emergency_cleanup(self, session_id: str) -> None:

--- a/tools/browser_providers/firecrawl.py
+++ b/tools/browser_providers/firecrawl.py
@@ -91,7 +91,7 @@ class FirecrawlProvider(CloudBrowserProvider):
                 )
                 return False
         except Exception as e:
-            logger.error("Exception closing Firecrawl session %s: %s", session_id, e)
+            logger.error("Exception closing Firecrawl session %s: %s", session_id, e, exc_info=True)
             return False
 
     def emergency_cleanup(self, session_id: str) -> None:


### PR DESCRIPTION
## What

Three `except Exception as e:` fallback branches in the managed browser providers log only the exception string and lose the traceback:

- tools/browser_providers/browser_use.py:199
- tools/browser_providers/firecrawl.py:94
- tools/browser_providers/browserbase.py:195

Each fires when \`close_session\` receives an unexpected exception from the provider HTTP layer or SDK. Adds \`exc_info=True\` to all three.

## Why

Same bug class as #12004/#12005/#12007/#12018/#12021/#12024/#12033/#12034/#12035/#12036/#12037/#12038/#12039. Session-close failures are the rare path where we actually want the stack: they hint at credential rotation, network partitions, or upstream API changes — all of which are easier to diagnose with the traceback.

## How to test

Additive logging change only — no behavior difference.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -q

## Platforms tested

tools/browser_providers/* — error branch is rare so not reproduced live.

## Closes

Proactive audit follow-up — no dedicated issue.