### PR TITLE
fix(bedrock_adapter): add exc_info=True to model-discovery warnings

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -865,7 +865,7 @@ def discover_bedrock_models(
     try:
         client = _get_bedrock_control_client(region)
     except Exception as e:
-        logger.warning("Failed to create Bedrock client for model discovery: %s", e)
+        logger.warning("Failed to create Bedrock client for model discovery: %s", e, exc_info=True)
         return []
 
     models = []
@@ -907,7 +907,7 @@ def discover_bedrock_models(
             })
             seen_ids.add(model_id.lower())
     except Exception as e:
-        logger.warning("Failed to list Bedrock foundation models: %s", e)
+        logger.warning("Failed to list Bedrock foundation models: %s", e, exc_info=True)
 
     # 2. Discover inference profiles (cross-region, better capacity)
     try:


### PR DESCRIPTION
## What

Two `except Exception as e:` warnings in the AWS Bedrock model-discovery path log only `%s` of the exception:

- `agent/bedrock_adapter.py:868` — \`_get_bedrock_control_client\` failure
- `agent/bedrock_adapter.py:910` — \`list_foundation_models\` failure

Add \`exc_info=True\` to both.

## Why

Same bug class as #12004..#12040. Bedrock's client-create and list calls commonly fail for subtle AWS reasons — IAM role mismatch, region without service availability, expired STS session, proxy 502. Without the traceback we lose the call-site that would tell us which layer failed.

## How to test

Additive logging change only — no behavior difference.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -k bedrock -q

## Platforms tested

Code review; error paths are rare so not reproduced against live AWS.

## Closes

Proactive audit follow-up — no dedicated issue.