### PR TITLE
fix(google): preserve tracebacks in OAuth and Code Assist warnings

### DIFF
--- a/agent/google_code_assist.py
+++ b/agent/google_code_assist.py
@@ -252,7 +252,7 @@ def load_code_assist(
                     cloudaicompanion_project=project_id,
                 )
             last_err = exc
-            logger.warning("loadCodeAssist failed on %s: %s", endpoint, exc)
+            logger.warning("loadCodeAssist failed on %s: %s", endpoint, exc, exc_info=True)
             continue
     if last_err:
         raise last_err
@@ -327,7 +327,7 @@ def onboard_user(
             try:
                 poll_resp = _post_json(poll_url, {}, access_token, user_agent_model=user_agent_model)
             except CodeAssistError as exc:
-                logger.warning("Onboarding poll attempt %d failed: %s", attempt + 1, exc)
+                logger.warning("Onboarding poll attempt %d failed: %s", attempt + 1, exc, exc_info=True)
                 continue
             if poll_resp.get("done"):
                 return poll_resp

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -475,7 +475,7 @@ def load_credentials() -> Optional[GoogleCredentials]:
             raw = path.read_text(encoding="utf-8")
         data = json.loads(raw)
     except (json.JSONDecodeError, OSError, IOError) as exc:
-        logger.warning("Failed to read Google OAuth credentials at %s: %s", path, exc)
+        logger.warning("Failed to read Google OAuth credentials at %s: %s", path, exc, exc_info=True)
         return None
     if not isinstance(data, dict):
         return None
@@ -518,7 +518,7 @@ def clear_credentials() -> None:
         except FileNotFoundError:
             pass
         except OSError as exc:
-            logger.warning("Failed to remove Google OAuth credentials at %s: %s", path, exc)
+            logger.warning("Failed to remove Google OAuth credentials at %s: %s", path, exc, exc_info=True)
 
 
 # =============================================================================


### PR DESCRIPTION
## What

Four `except ... as exc:` branches in the Google integration log only the exception string:

- \`agent/google_oauth.py:478\` — credential-file read failure
- \`agent/google_oauth.py:521\` — credential-file remove failure
- \`agent/google_code_assist.py:255\` — \`loadCodeAssist\` endpoint retry
- \`agent/google_code_assist.py:330\` — onboarding-poll retry

Adds \`exc_info=True\` to all four.

## Why

Same bug class as the surrounding exc_info audit (#12004..#12041). Google's OAuth / Code Assist paths fail for reasons that are hard to identify without the stack — file-lock contention, token-format regressions, 401 rotation mid-flight.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -k google -q

## Platforms tested

Code review; each error path is rare so not reproduced live.

## Closes

Proactive audit follow-up — no dedicated issue.