### PR TITLE
fix(agent): preserve tracebacks in prompt_builder and trajectory warnings

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -545,7 +545,7 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
 
         return True, frontmatter, extract_skill_description(frontmatter)
     except Exception as e:
-        logger.warning("Failed to parse skill file %s: %s", skill_file, e)
+        logger.warning("Failed to parse skill file %s: %s", skill_file, e, exc_info=True)
         return True, {}, ""
 
 

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -53,4 +53,4 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
-        logger.warning("Failed to save trajectory: %s", e)
+        logger.warning("Failed to save trajectory: %s", e, exc_info=True)


### PR DESCRIPTION
## What

Two `except Exception as e:` warnings log only `%s` of the exception:

- \`agent/prompt_builder.py:548\` — skill-file frontmatter parse failure
- \`agent/trajectory.py:56\`     — trajectory-log write failure

Adds \`exc_info=True\` to both.

## Why

Same bug class as the surrounding exc_info audit (#12004..#12042). A malformed skill manifest often fails with cryptic YAML errors; the stack tells us *which* parser raised. Trajectory writes fail rarely — disk-full, fs-readonly, permission drift — and those all have distinctive tracebacks that shorten the diagnostic loop.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -q

## Platforms tested

Code review; both error paths are rare.

## Closes

Proactive audit follow-up — no dedicated issue.