### PR TITLE
fix(homeassistant_tool): preserve tracebacks in tool-error logs

### DIFF
--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -229,7 +229,7 @@ def _handle_list_entities(args: dict, **kw) -> str:
         result = _run_async(_async_list_entities(domain=domain, area=area))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_list_entities error: %s", e)
+        logger.error("ha_list_entities error: %s", e, exc_info=True)
         return tool_error(f"Failed to list entities: {e}")
 
 
@@ -244,7 +244,7 @@ def _handle_get_state(args: dict, **kw) -> str:
         result = _run_async(_async_get_state(entity_id))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_get_state error: %s", e)
+        logger.error("ha_get_state error: %s", e, exc_info=True)
         return tool_error(f"Failed to get state for {entity_id}: {e}")
 
 
@@ -284,7 +284,7 @@ def _handle_call_service(args: dict, **kw) -> str:
         result = _run_async(_async_call_service(domain, service, entity_id, data))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_call_service error: %s", e)
+        logger.error("ha_call_service error: %s", e, exc_info=True)
         return tool_error(f"Failed to call {domain}.{service}: {e}")
 
 
@@ -333,7 +333,7 @@ def _handle_list_services(args: dict, **kw) -> str:
         result = _run_async(_async_list_services(domain=domain))
         return json.dumps({"result": result})
     except Exception as e:
-        logger.error("ha_list_services error: %s", e)
+        logger.error("ha_list_services error: %s", e, exc_info=True)
         return tool_error(f"Failed to list services: {e}")
 
 


### PR DESCRIPTION
## What

Four top-level homeassistant_tool entrypoints (\`ha_list_entities\`, \`ha_get_state\`, \`ha_call_service\`, \`ha_list_services\`) log only the exception string in their outer \`except Exception as e:\` handlers and lose the traceback. Adds \`exc_info=True\` to each.

## Why

Same bug class as the surrounding exc_info audit (#12004..#12043). These tool wrappers surface the error string to the agent as a \`tool_error\` and log separately — so the log line is the only diagnostic surface for the HA operator. The stack points at whether the REST call, the websocket client, or the inline JSON handling raised.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -k homeassistant -q

## Platforms tested

Code review; error paths are rare.

## Closes

Proactive audit follow-up — no dedicated issue.