### PR TITLE
Fix custom provider support for base_url and list-format models

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1855,7 +1855,7 @@ def _normalize_custom_provider_entry(
         normalized["model"] = model_name.strip()
 
     models = entry.get("models")
-    if isinstance(models, dict) and models:
+    if isinstance(models, (dict, list)) and models:
         normalized["models"] = models
 
     context_length = entry.get("context_length")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6272,6 +6272,26 @@ def cmd_logs(args):
     )
 
 
+def _get_provider_choices():
+    """Get all available provider choices including custom ones from config."""
+    # Builtin providers
+    builtin = ["auto", "openrouter", "nous", "openai-codex", "copilot-acp", 
+               "copilot", "anthropic", "gemini", "xai", "ollama-cloud", 
+               "huggingface", "zai", "kimi-coding", "kimi-coding-cn", 
+               "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee", "nvidia"]
+    
+    # Try to load custom providers from config
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        custom_providers = config.get("providers", {})
+        if custom_providers:
+            builtin.extend(custom_providers.keys())
+    except Exception:
+        pass  # If config loading fails, just use builtin providers
+    
+    return builtin
+
 def main():
     """Main entry point for hermes CLI."""
     parser = argparse.ArgumentParser(
@@ -6405,28 +6425,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=[
-            "auto",
-            "openrouter",
-            "nous",
-            "openai-codex",
-            "copilot-acp",
-            "copilot",
-            "anthropic",
-            "gemini",
-            "xai",
-            "ollama-cloud",
-            "huggingface",
-            "zai",
-            "kimi-coding",
-            "kimi-coding-cn",
-            "minimax",
-            "minimax-cn",
-            "kilocode",
-            "xiaomi",
-            "arcee",
-            "nvidia",
-        ],
+        choices=_get_provider_choices(),
         default=None,
         help="Inference provider (default: auto)",
     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1040,7 +1040,7 @@ def list_authenticated_providers(
             if not isinstance(ep_cfg, dict):
                 continue
             display_name = ep_cfg.get("name", "") or ep_name
-            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
+            api_url = ep_cfg.get("base_url", "") or ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
 
             # Build models list from both default_model and full models array


### PR DESCRIPTION
## Summary
This PR fixes three bugs that prevent custom providers from working correctly when using the v12+ `providers:` configuration format with `base_url` field and list-format `models`.

## Problem
Users configuring custom providers like this:
```yaml
providers:
  alibaba-coding:
    base_url: https://coding.dashscope.aliyuncs.com/v1
    api_key: sk-xxx
    models:
      - qwen3.5-plus
      - qwen3-max-2026-01-23
      - qwen3-coder-next
```

Experience three issues:
1. **CLI rejects the provider** - `hermes chat --provider alibaba-coding` fails with "invalid choice"
2. **Model picker shows duplicate entries** - Provider appears twice, one with "0 models"
3. **Models not loaded** - Custom provider shows "(0 models)" in picker UI

## Root Causes

### Bug 1: Hardcoded provider choices in CLI (main.py:6427)
The `--provider` argument used a hardcoded list of builtin providers, rejecting any custom providers defined in config.

### Bug 2: Missing base_url field check (model_switch.py:1043)
The user_providers section only checked `api` and `url` fields, but the newer config format uses `base_url` (matching OpenAI-compatible API conventions).

### Bug 3: Models field type mismatch (config.py:1831)
The normalization function only accepted dict-format models:
```python
if isinstance(models, dict) and models:
```

But list-format (which is more intuitive for simple provider configs) was rejected, causing models to be dropped during normalization.

## Changes

### 1. Dynamic provider loading (main.py)
- Added `_get_provider_choices()` function that loads config at argparse setup time
- Merges builtin + custom providers from `config.yaml`
- Falls back gracefully if config loading fails

### 2. Support base_url field (model_switch.py)
- Updated API URL lookup to check `base_url` first, then `api`, then `url`
- Maintains backward compatibility with legacy formats

### 3. Accept list-format models (config.py)
- Changed type check from `dict` to `(dict, list)`
- Both formats now work correctly

## Testing

Before fix:
```
$ hermes chat --provider alibaba-coding
error: argument --provider: invalid choice: 'alibaba-coding'

# Model picker shows:
# - alibaba-coding (8 models)
# - alibaba-coding (0 models)  ← duplicate with no models
```

After fix:
```
$ hermes chat --provider alibaba-coding
# Works correctly

# Model picker shows:
# - alibaba-coding (8 models)  ← single entry, all models loaded
```

## Impact
- ✅ Zero breaking changes - all existing configs continue to work
- ✅ Enables proper support for v12+ provider configuration format
- ✅ Consistent field priority across codebase (base_url → api → url)
- ✅ Supports both dict and list formats for models field

## Checklist
- [x] Fixes affect only custom provider loading logic
- [x] Backward compatible with legacy config formats
- [x] Tested with real custom provider configuration
- [x] No new dependencies added