### PR TITLE
fix(approval): preserve tracebacks in config/allowlist load warnings

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -388,7 +388,7 @@ def load_permanent_allowlist() -> set:
             load_permanent(patterns)
         return patterns
     except Exception as e:
-        logger.warning("Failed to load permanent allowlist: %s", e)
+        logger.warning("Failed to load permanent allowlist: %s", e, exc_info=True)
         return set()
 
 
@@ -400,7 +400,7 @@ def save_permanent_allowlist(patterns: set):
         config["command_allowlist"] = list(patterns)
         save_config(config)
     except Exception as e:
-        logger.warning("Could not save allowlist: %s", e)
+        logger.warning("Could not save allowlist: %s", e, exc_info=True)
 
 
 # =========================================================================
@@ -514,7 +514,7 @@ def _get_approval_config() -> dict:
         config = load_config()
         return config.get("approvals", {}) or {}
     except Exception as e:
-        logger.warning("Failed to load approval config: %s", e)
+        logger.warning("Failed to load approval config: %s", e, exc_info=True)
         return {}
 
 
@@ -816,7 +816,7 @@ def check_all_command_guards(command: str, env_type: str,
             try:
                 notify_cb(approval_data)
             except Exception as exc:
-                logger.warning("Gateway approval notify failed: %s", exc)
+                logger.warning("Gateway approval notify failed: %s", exc, exc_info=True)
                 with _lock:
                     queue = _gateway_queues.get(session_key, [])
                     if entry in queue:


### PR DESCRIPTION
## What

Four `except ... as e/exc:` warnings in `tools/approval.py` log only the exception string. Adds `exc_info=True` to each:

- \`tools/approval.py:391\` — permanent-allowlist load failure
- \`tools/approval.py:403\` — allowlist save failure
- \`tools/approval.py:517\` — approval config load failure
- \`tools/approval.py:819\` — gateway approval notify-callback failure

## Why

Same bug class as the surrounding exc_info audit (#12004..#12044). The allowlist / config load paths read JSON files and hit disk — failures usually mean a corrupt file, a permission issue, or a write-during-read race. The gateway notify callback is user-supplied and can raise anything. Stacks in all four cases immediately narrow the diagnosis.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/tools/ -k approval -q

## Platforms tested

Code review; error paths are rare.

## Closes

Proactive audit follow-up — no dedicated issue.