### PR TITLE
fix(tools): preserve tracebacks in terminal_tool and debug_helpers error logs

### DIFF
--- a/tools/debug_helpers.py
+++ b/tools/debug_helpers.py
@@ -86,7 +86,7 @@ class DebugSession:
                 json.dump(payload, f, indent=2, ensure_ascii=False)
             logger.debug("%s debug log saved: %s", self.tool_name, filepath)
         except Exception as e:
-            logger.error("Error saving %s debug log: %s", self.tool_name, e)
+            logger.error("Error saving %s debug log: %s", self.tool_name, e, exc_info=True)
 
     def get_session_info(self) -> Dict[str, Any]:
         """Return a summary dict suitable for returning from get_debug_session_info()."""

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -871,7 +871,7 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
             if "404" in error_str or "not found" in error_str.lower():
                 logger.info("Environment for task %s already cleaned up", task_id)
             else:
-                logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", task_id, e, exc_info=True)
 
 
 def _cleanup_thread_worker():
@@ -1002,7 +1002,7 @@ def cleanup_vm(task_id: str):
         if "404" in error_str or "not found" in error_str.lower():
             logger.info("Environment for task %s already cleaned up", task_id)
         else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+            logger.warning("Error cleaning up environment for task %s: %s", task_id, e, exc_info=True)
 
 
 def _atexit_cleanup():


### PR DESCRIPTION
## What

Three \`except Exception as e:\` warnings/errors in tool-side infrastructure log only the exception string:

- \`tools/terminal_tool.py:874\` — environment-cleanup failure in task cleanup
- \`tools/terminal_tool.py:1005\` — environment-cleanup failure in a sibling cleanup path
- \`tools/debug_helpers.py:89\` — failure to save per-tool debug log JSON

Adds \`exc_info=True\` to all three.

## Why

Same bug class as the surrounding exc_info audit (#12004..#12047). The terminal-tool cleanup sites already branch on \"404/not found\" and explicitly fall through here when *something else* raised — so the error path is where we most want the stack. \`debug_helpers\` failures are a meta-signal (we can't even log properly), and the stack tells us why.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/tools/ -q

## Platforms tested

Code review; both cleanup and debug-log paths are rare error branches.

## Closes

Proactive audit follow-up — no dedicated issue.