### PR TITLE
fix(tirith_security): preserve tracebacks in cosign and tirith spawn warnings

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -249,7 +249,7 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
                           result.returncode, result.stderr.strip())
             return False
     except (OSError, subprocess.TimeoutExpired) as exc:
-        logger.warning("cosign execution failed: %s", exc)
+        logger.warning("cosign execution failed: %s", exc, exc_info=True)
         return None
 
 
@@ -640,7 +640,7 @@ def check_command_security(command: str) -> dict:
         )
     except OSError as exc:
         # Covers FileNotFoundError, PermissionError, exec format error
-        logger.warning("tirith spawn failed: %s", exc)
+        logger.warning("tirith spawn failed: %s", exc, exc_info=True)
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith unavailable: {exc}"}
         return {"action": "block", "findings": [], "summary": f"tirith spawn failed (fail-closed): {exc}"}


### PR DESCRIPTION
## What

Two \`except ... as exc:\` warnings in \`tools/tirith_security.py\` log only the exception string:

- L252 — \`cosign\` subprocess exec failure (OSError / TimeoutExpired)
- L643 — \`tirith\` binary spawn failure (OSError)

Adds \`exc_info=True\` to both.

## Why

Same bug class as the surrounding exc_info audit (#12004..#12048). Security-tool spawn failures are especially valuable to see with full stack because the failure mode — missing binary, PATH misconfig, exec-format error on a new platform — is usually specific to a single hop in the resolve/spawn chain.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -k tirith -q

## Platforms tested

Code review; both sites are rare failure paths.

## Closes

Proactive audit follow-up — no dedicated issue.