### PR TITLE
fix(tools): preserve tracebacks in MCP, sandbox, and credential warnings

### DIFF
--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -166,7 +166,7 @@ def _load_config_files() -> List[Dict[str, str]]:
                             "container_path": container_path,
                         })
     except Exception as e:
-        logger.warning("Could not read terminal.credential_files from config: %s", e)
+        logger.warning("Could not read terminal.credential_files from config: %s", e, exc_info=True)
 
     _config_files = result
     return _config_files

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1009,7 +1009,7 @@ class MCPServerTask:
                     self.name, url, config.get("oauth"),
                 )
             except Exception as exc:
-                logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
+                logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc, exc_info=True)
                 raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -159,7 +159,7 @@ def maybe_persist_tool_result(
                 )
                 return _build_persisted_message(preview, has_more, len(content), remote_path)
         except Exception as exc:
-            logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
+            logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc, exc_info=True)
 
     logger.info(
         "Inline-truncating large tool result: %s (%d chars, no sandbox write)",


### PR DESCRIPTION
## What

Three \`except ... as exc/e:\` warnings across tool-side infrastructure drop the traceback:

- \`tools/mcp_tool.py:1012\` — MCP OAuth setup failure (logs then re-raises)
- \`tools/tool_result_storage.py:162\` — sandbox write-through failure
- \`tools/credential_files.py:169\` — credential_files config read failure

Adds \`exc_info=True\` to all three.

## Why

Same bug class as the surrounding exc_info audit (#12004..#12049). OAuth-setup failures are the most high-leverage because the warning is accompanied by a \`raise\` — the log line is the *only* chance to see the underlying cause before the exception is swallowed further up. The sandbox and credential-files warnings are rare diagnostic-only paths that still benefit from stacks when they fire.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/ -q

## Platforms tested

Code review; all three error paths are rare.

## Closes

Proactive audit follow-up — no dedicated issue.