### PR TITLE
fix(url_safety): add exc_info=True to fail-closed safety warning

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -114,5 +114,5 @@ def is_safe_url(url: str) -> bool:
     except Exception as exc:
         # Fail closed on unexpected errors — don't let parsing edge cases
         # become SSRF bypass vectors
-        logger.warning("Blocked request — URL safety check error for %s: %s", url, exc)
+        logger.warning("Blocked request — URL safety check error for %s: %s", url, exc, exc_info=True)
         return False


### PR DESCRIPTION
## What

One-site follow-up to the exc_info audit: the outer \`except Exception as exc:\` in \`tools/url_safety.py\` \`is_safe_url\` fails closed and emits a \"Blocked request — URL safety check error\" warning without the traceback.

## Why

This branch is the SSRF-protection fail-closed path. When it fires, we've learned that either a URL shape or our parsing logic surprised us — exactly the case where knowing the exception origin (urllib vs socket vs ipaddress vs our own validator) helps us strengthen the safety check. Losing the traceback means we only know *that* we blocked, not *why*.

Same bug class as #12004..#12050.

## How to test

Additive logging change only.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/tools/ -k url_safety -q

## Platforms tested

Code review; fail-closed branch is rare but high-value.

## Closes

Proactive audit follow-up — no dedicated issue.