### PR TITLE
fix(hermes_cli/backup): preserve tracebacks across snapshot/restore errors

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -89,12 +89,12 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
         conn.close()
         return True
     except Exception as exc:
-        logger.warning("SQLite safe copy failed for %s: %s", src, exc)
+        logger.warning("SQLite safe copy failed for %s: %s", src, exc, exc_info=True)
         try:
             shutil.copy2(src, dst)
             return True
         except Exception as exc2:
-            logger.error("Raw copy also failed for %s: %s", src, exc2)
+            logger.error("Raw copy also failed for %s: %s", src, exc2, exc_info=True)
             return False
 
 
@@ -512,7 +512,7 @@ def create_quick_snapshot(
                 shutil.copy2(src, dst)
             manifest[rel] = dst.stat().st_size
         except (OSError, PermissionError) as exc:
-            logger.warning("Could not snapshot %s: %s", rel, exc)
+            logger.warning("Could not snapshot %s: %s", rel, exc, exc_info=True)
 
     if not manifest:
         shutil.rmtree(snap_dir, ignore_errors=True)
@@ -606,7 +606,7 @@ def restore_quick_snapshot(
                 shutil.copy2(src, dst)
             restored += 1
         except (OSError, PermissionError) as exc:
-            logger.error("Failed to restore %s: %s", rel, exc)
+            logger.error("Failed to restore %s: %s", rel, exc, exc_info=True)
 
     logger.info("Restored %d files from snapshot %s", restored, snapshot_id)
     return restored > 0
@@ -629,7 +629,7 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
             shutil.rmtree(d)
             deleted += 1
         except OSError as exc:
-            logger.warning("Failed to prune snapshot %s: %s", d.name, exc)
+            logger.warning("Failed to prune snapshot %s: %s", d.name, exc, exc_info=True)
 
     return deleted
 


### PR DESCRIPTION
## What

Five `except ... as exc/exc2:` warnings and errors in `hermes_cli/backup.py` log only the exception string. This PR adds `exc_info=True` to all five:

- L92  — SQLite safe-copy failure (falls through to raw copy)
- L97  — raw copy fallback failure (both paths exhausted)
- L515 — per-file snapshot failure
- L609 — per-file restore failure
- L632 — snapshot-prune failure

## Why

Same bug class as the surrounding exc_info audit (#12004..#12051). Backup/restore is a user-data path — when it fails silently the user loses the one signal that would let them tell whether the error was recoverable (permission, disk-full, SQLite lock) or a genuine bug. `exc_info=True` restores the diagnostic surface.

## How to test

Additive logging change only — no behavior difference.

    uv pip install -e \".[dev]\" --quiet
    python -m pytest tests/hermes_cli/test_backup.py -q

## Platforms tested

Code review; all five error paths are rare failure modes.

## Closes

Proactive audit follow-up — no dedicated issue.