### PR TITLE
fix(delegate): read fresh config.yaml so delegation.model edits take effect (#11999)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1462,7 +1462,13 @@ class TestLoadConfigFreshReads(unittest.TestCase):
         ``_resolve_delegation_credentials(_load_config(), parent)`` picks
         up the post-startup override and produces non-None model/provider
         in the credential bundle, so ``_build_child_agent`` subsequently
-        overrides the parent model."""
+        overrides the parent model.
+
+        Patches ``hermes_cli.runtime_provider.resolve_runtime_provider``
+        with a fixed credential bundle so the test is hermetic — does
+        not depend on a real ``ANTHROPIC_API_KEY`` / OAuth token or any
+        network-side behaviour of the runtime provider pipeline.
+        """
         import tempfile, os
         from tools.delegate_tool import _load_config, _resolve_delegation_credentials
 
@@ -1478,11 +1484,19 @@ class TestLoadConfigFreshReads(unittest.TestCase):
             with open(os.path.join(hhome, "config.yaml"), "w") as fh:
                 import yaml as _yaml
                 _yaml.safe_dump({"model": "claude-opus-4-6"}, fh)
-            prev_home = os.environ.get("HERMES_HOME")
-            prev_key = os.environ.get("ANTHROPIC_API_KEY")
-            os.environ["HERMES_HOME"] = hhome
-            os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
-            try:
+            with patch.dict(
+                os.environ,
+                {"HERMES_HOME": hhome, "ANTHROPIC_API_KEY": "sk-test"},
+                clear=False,
+            ), patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "provider": "anthropic",
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "sk-test",
+                    "api_mode": "anthropic_messages",
+                },
+            ):
                 # User adds override
                 with open(os.path.join(hhome, "config.yaml"), "w") as fh:
                     import yaml as _yaml
@@ -1501,15 +1515,6 @@ class TestLoadConfigFreshReads(unittest.TestCase):
                 # which must now land on the delegation model, not parent's.
                 effective = creds["model"] or parent.model
                 self.assertEqual(effective, "claude-sonnet-4-20250514")
-            finally:
-                if prev_home is None:
-                    os.environ.pop("HERMES_HOME", None)
-                else:
-                    os.environ["HERMES_HOME"] = prev_home
-                if prev_key is None:
-                    os.environ.pop("ANTHROPIC_API_KEY", None)
-                else:
-                    os.environ["ANTHROPIC_API_KEY"] = prev_key
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -14,6 +14,7 @@ import os
 import sys
 import threading
 import time
+import types
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -1284,6 +1285,231 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
+
+
+# =========================================================================
+# _load_config — regression for #11999
+# =========================================================================
+# ``delegate_task`` used to short-circuit through ``cli.CLI_CONFIG``, a dict
+# populated **once** at module-import time.  In long-lived CLI sessions this
+# meant ``delegation.model`` / ``delegation.provider`` edits to ``config.yaml``
+# after startup were silently ignored — subagents kept running on the parent's
+# model regardless of the user's override.  The check
+# (``if cfg: return cfg``) also misfired at startup when CLI_CONFIG contained
+# only built-in defaults — that's still a truthy dict, so the persistent
+# ``hermes_cli.config.load_config()`` path was never reached.
+#
+# The fix makes ``_load_config`` always read fresh from
+# ``hermes_cli.config.load_config()`` so config.yaml is the single source of
+# truth for every delegate_task call.
+
+
+class TestLoadConfigFreshReads(unittest.TestCase):
+    """Regression tests for #11999: ``_load_config`` must pick up
+    ``config.yaml`` edits made after CLI startup."""
+
+    def _write_config(self, path, content):
+        import yaml
+        with open(path, "w") as fh:
+            yaml.safe_dump(content, fh)
+
+    def test_picks_up_delegation_override_written_after_startup(self):
+        """Simulate the reporter's scenario: CLI started with no delegation
+        override, then user edits config.yaml.  ``_load_config`` must
+        return the new values."""
+        import tempfile, os
+        from tools.delegate_tool import _load_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            hhome = os.path.join(tmp, ".hermes")
+            os.makedirs(hhome)
+            cfg_path = os.path.join(hhome, "config.yaml")
+
+            # Startup state: no delegation section
+            self._write_config(cfg_path, {"model": "claude-opus-4-6"})
+            prev_home = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = hhome
+            try:
+                # User edits config.yaml AFTER startup
+                self._write_config(cfg_path, {
+                    "model": "claude-opus-4-6",
+                    "delegation": {
+                        "model": "claude-sonnet-4-20250514",
+                        "provider": "anthropic",
+                    },
+                })
+                cfg = _load_config()
+                self.assertEqual(cfg.get("model"), "claude-sonnet-4-20250514")
+                self.assertEqual(cfg.get("provider"), "anthropic")
+            finally:
+                if prev_home is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = prev_home
+
+    def test_ignores_stale_cli_config_cache(self):
+        """Even when ``cli.CLI_CONFIG`` contains stale default values,
+        ``_load_config`` must consult the persistent config, not the
+        import-time cache.
+
+        Before the fix, a truthy-but-all-defaults CLI_CONFIG
+        (``{"model": "", "provider": "", ...}``) would short-circuit
+        the fresh read and return empty overrides — which the
+        downstream resolver interpreted as "no override, inherit from
+        parent"."""
+        import tempfile, os, sys
+        from tools.delegate_tool import _load_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            hhome = os.path.join(tmp, ".hermes")
+            os.makedirs(hhome)
+            cfg_path = os.path.join(hhome, "config.yaml")
+            self._write_config(cfg_path, {
+                "delegation": {
+                    "model": "claude-sonnet-4-20250514",
+                    "provider": "anthropic",
+                },
+            })
+
+            prev_home = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = hhome
+
+            # Plant a stale CLI_CONFIG in sys.modules to simulate the
+            # import-time cache having empty-default delegation.
+            fake_cli = types.ModuleType("cli")
+            fake_cli.CLI_CONFIG = {
+                "delegation": {
+                    "max_iterations": 45,
+                    "default_toolsets": ["terminal", "file", "web"],
+                    "model": "",      # stale default
+                    "provider": "",   # stale default
+                    "base_url": "",
+                    "api_key": "",
+                },
+            }
+            prev_cli = sys.modules.get("cli")
+            sys.modules["cli"] = fake_cli
+            try:
+                cfg = _load_config()
+                self.assertEqual(cfg.get("model"), "claude-sonnet-4-20250514",
+                    f"stale CLI_CONFIG leaked into _load_config: {cfg}")
+                self.assertEqual(cfg.get("provider"), "anthropic")
+            finally:
+                if prev_cli is None:
+                    sys.modules.pop("cli", None)
+                else:
+                    sys.modules["cli"] = prev_cli
+                if prev_home is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = prev_home
+
+    def test_returns_dict_when_config_missing_delegation_section(self):
+        """With no delegation section at all in config.yaml, the
+        returned dict must be a proper dict (the defaults from
+        ``DEFAULT_CONFIG['delegation']``) so callers can safely
+        ``.get("model")`` without type errors."""
+        import tempfile, os
+        from tools.delegate_tool import _load_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            hhome = os.path.join(tmp, ".hermes")
+            os.makedirs(hhome)
+            self._write_config(os.path.join(hhome, "config.yaml"),
+                               {"model": "claude-opus-4-6"})
+
+            prev_home = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = hhome
+            try:
+                cfg = _load_config()
+                self.assertIsInstance(cfg, dict)
+                # defaults-only → empty-string overrides, no crash on .get()
+                self.assertEqual(cfg.get("model", ""), "")
+                self.assertEqual(cfg.get("provider", ""), "")
+            finally:
+                if prev_home is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = prev_home
+
+    def test_non_dict_delegation_section_is_coerced_to_empty(self):
+        """A malformed ``delegation: something_not_a_dict`` entry must
+        yield an empty dict, not a list/string that would crash
+        ``.get()`` calls downstream in ``_resolve_delegation_credentials``."""
+        import tempfile, os
+        from tools.delegate_tool import _load_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            hhome = os.path.join(tmp, ".hermes")
+            os.makedirs(hhome)
+            # Write raw YAML to bypass safe_dump's dict coercion.
+            with open(os.path.join(hhome, "config.yaml"), "w") as fh:
+                fh.write("model: claude-opus-4-6\ndelegation: not-a-dict\n")
+
+            prev_home = os.environ.get("HERMES_HOME")
+            os.environ["HERMES_HOME"] = hhome
+            try:
+                cfg = _load_config()
+                self.assertEqual(cfg, {})
+            finally:
+                if prev_home is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = prev_home
+
+    def test_end_to_end_resolve_uses_fresh_config(self):
+        """Integration: the fix means
+        ``_resolve_delegation_credentials(_load_config(), parent)`` picks
+        up the post-startup override and produces non-None model/provider
+        in the credential bundle, so ``_build_child_agent`` subsequently
+        overrides the parent model."""
+        import tempfile, os
+        from tools.delegate_tool import _load_config, _resolve_delegation_credentials
+
+        parent = _make_mock_parent()
+        parent.model = "claude-opus-4-6"
+        parent.provider = "anthropic"
+        parent.base_url = "https://api.anthropic.com"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            hhome = os.path.join(tmp, ".hermes")
+            os.makedirs(hhome)
+            # Start with no override
+            with open(os.path.join(hhome, "config.yaml"), "w") as fh:
+                import yaml as _yaml
+                _yaml.safe_dump({"model": "claude-opus-4-6"}, fh)
+            prev_home = os.environ.get("HERMES_HOME")
+            prev_key = os.environ.get("ANTHROPIC_API_KEY")
+            os.environ["HERMES_HOME"] = hhome
+            os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
+            try:
+                # User adds override
+                with open(os.path.join(hhome, "config.yaml"), "w") as fh:
+                    import yaml as _yaml
+                    _yaml.safe_dump({
+                        "model": "claude-opus-4-6",
+                        "delegation": {
+                            "model": "claude-sonnet-4-20250514",
+                            "provider": "anthropic",
+                        },
+                    }, fh)
+                cfg = _load_config()
+                creds = _resolve_delegation_credentials(cfg, parent)
+                self.assertEqual(creds["model"], "claude-sonnet-4-20250514")
+                # and ``_build_child_agent`` will later do:
+                #    effective_model = creds["model"] or parent.model
+                # which must now land on the delegation model, not parent's.
+                effective = creds["model"] or parent.model
+                self.assertEqual(effective, "claude-sonnet-4-20250514")
+            finally:
+                if prev_home is None:
+                    os.environ.pop("HERMES_HOME", None)
+                else:
+                    os.environ["HERMES_HOME"] = prev_home
+                if prev_key is None:
+                    os.environ.pop("ANTHROPIC_API_KEY", None)
+                else:
+                    os.environ["ANTHROPIC_API_KEY"] = prev_key
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1044,9 +1044,9 @@ def _load_config() -> dict:
     that caused ``delegation.model`` / ``delegation.provider`` changes
     made after startup to be silently ignored — see issue #11999.  The
     short-circuit also misfired on startup configs that only contained
-    the built-in defaults (empty-string ``model``/``provider`` and a
-    ``max_iterations`` float): those produced a truthy-but-empty dict
-    that bypassed the persistent read entirely.
+    the built-in defaults (empty-string ``model``/``provider`` alongside
+    an integer ``max_iterations``): those produced a truthy-but-empty
+    dict that bypassed the persistent read entirely.
 
     The persistent ``load_config()`` pipeline is cheap (single YAML
     parse over a deep-merged deepcopy of ``DEFAULT_CONFIG``) and is the

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1032,24 +1032,35 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load the delegation section from ``~/.hermes/config.yaml``.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Always reads fresh via ``hermes_cli.config.load_config()`` so that an
+    edit to ``config.yaml`` is picked up on the next ``delegate_task``
+    call without needing a CLI restart.
+
+    Earlier versions short-circuited through ``cli.CLI_CONFIG`` when it
+    was available, but that dict is populated **once** at
+    module-import time and is never re-read.  In long-lived CLI sessions,
+    that caused ``delegation.model`` / ``delegation.provider`` changes
+    made after startup to be silently ignored — see issue #11999.  The
+    short-circuit also misfired on startup configs that only contained
+    the built-in defaults (empty-string ``model``/``provider`` and a
+    ``max_iterations`` float): those produced a truthy-but-empty dict
+    that bypassed the persistent read entirely.
+
+    The persistent ``load_config()`` pipeline is cheap (single YAML
+    parse over a deep-merged deepcopy of ``DEFAULT_CONFIG``) and is the
+    same path the gateway and cron use, so unifying everyone on that
+    source of truth also removes a subtle CLI-only divergence.  In the
+    rare case ``hermes_cli.config`` can't be imported (heavily cut-down
+    installs), returns an empty dict so callers fall back to their
+    inherit-from-parent defaults.
     """
-    try:
-        from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
-            return cfg
-    except Exception:
-        pass
     try:
         from hermes_cli.config import load_config
         full = load_config()
-        return full.get("delegation", {})
+        delegation = full.get("delegation", {})
+        return delegation if isinstance(delegation, dict) else {}
     except Exception:
         return {}
 


### PR DESCRIPTION
## What does this PR do?

Fixes #11999.

`delegate_task` silently ignored `delegation.model` / `delegation.provider` overrides in `~/.hermes/config.yaml` — subagents kept running on the parent's model regardless of what the user configured, defeating the whole point of cost-tiered delegation (Sonnet subagents under an Opus parent, say). The reporter's exact scenario:

```yaml
delegation:
  model: claude-sonnet-4-20250514
  provider: anthropic
```

Parent on `claude-opus-4-6`. Expected: child runs on Sonnet. Actual: child runs on Opus; result metadata confirms `"model": "claude-opus-4-6"`. Reporter also observed "persists across /reset commands and config reloads" — an important symptom that points at the actual root cause.

## Root cause

`tools/delegate_tool.py::_load_config()` short-circuited through `cli.CLI_CONFIG`, a dict populated **once** at module-import time:

```python
def _load_config() -> dict:
    try:
        from cli import CLI_CONFIG
        cfg = CLI_CONFIG.get("delegation", {})
        if cfg:
            return cfg       # <-- returns stale CACHED value
    except Exception:
        pass
    try:
        from hermes_cli.config import load_config
        full = load_config()
        return full.get("delegation", {})    # <-- fresh read (never reached on CLI)
    except Exception:
        return {}
```

Two independent bugs in this short-circuit:

1. **Cache staleness.** `CLI_CONFIG` is built by `cli.load_cli_config()` at module import and is never re-read. An edit to `~/.hermes/config.yaml` after the CLI starts — including adding a new `delegation:` section — is invisible to `delegate_task`. `/reset` and config-reload commands don't re-run `load_cli_config`, which is exactly the reporter's "persists across /reset" symptom.

2. **Truthy-but-empty defaults always win.** cli.py populates `CLI_CONFIG["delegation"]` with built-in defaults (`{"max_iterations": 45, "default_toolsets": [...], "model": "", "provider": "", "base_url": "", "api_key": ""}`) even when the user's config.yaml has no delegation section at all. That's a truthy dict (non-empty), so `if cfg: return cfg` fires and the persistent `hermes_cli.config.load_config()` path is never reached. Downstream, `configured_model = str(cfg.get("model") or "").strip() or None` resolves to `None`, `_resolve_delegation_credentials` sets `provider: None` (inherit-from-parent), and `_build_child_agent` does `effective_model = model or parent_agent.model` → the parent model wins.

Reproduced in a minimal sandbox:

```
At CLI startup, CLI_CONFIG['delegation'] = {'model': '', 'provider': '', ...}
After user edits config.yaml, delegation.model is claude-sonnet-4-20250514
_load_config() returned: {'model': '', 'provider': '', ...}
BUG REPRODUCED: _load_config returned stale model=''
```

## Fix

Drop the stale `CLI_CONFIG` short-circuit. Always read fresh via `hermes_cli.config.load_config()`:

```python
def _load_config() -> dict:
    try:
        from hermes_cli.config import load_config
        full = load_config()
        delegation = full.get("delegation", {})
        return delegation if isinstance(delegation, dict) else {}
    except Exception:
        return {}
```

Also hardens against a malformed `delegation: not-a-dict` value — the old code returned the non-dict verbatim, which then crashed `_resolve_delegation_credentials` on `.get("model")`. Coerce to `{}` so callers safely fall back to inherit-from-parent defaults.

## Precedence / compat table

| Scenario | Before | After |
| --- | --- | --- |
| Edit `delegation.model` after CLI startup | **silently ignored** (stale CLI_CONFIG) | picked up on next `delegate_task` |
| Gateway / cron (cli.py not imported) | already read fresh (fallback path) | read fresh (**unchanged**) |
| Startup with no `delegation:` section | stale CLI_CONFIG defaults returned → inherit-from-parent | fresh `load_config()` returns DEFAULT_CONFIG delegation → inherit-from-parent (**same result**) |
| `delegation.model: ""` explicitly | inherit-from-parent | inherit-from-parent (**unchanged**) |
| `delegation: not-a-dict` (malformed) | non-dict leaks to `.get()` → AttributeError | coerced to `{}` → inherit-from-parent |
| Runtime mutation of `CLI_CONFIG["delegation"]` | picked up | n/a (grep-verified: nothing in the codebase mutates this at runtime) |

## Narrow scope — explicitly not changed

- **`_resolve_delegation_credentials`** — downstream of `_load_config`, already correct given a fresh config dict. No change needed.
- **`_build_child_agent` / `AIAgent.__init__`** — same; the bug is purely at the config-read layer.
- **`cli.CLI_CONFIG`** — left as-is. Grep confirms no runtime writer to `CLI_CONFIG["delegation"]` anywhere, so dropping its use in `_load_config` loses no runtime-only data.
- **Performance** — `load_config()` is a single YAML parse plus `copy.deepcopy(DEFAULT_CONFIG)`, measured <1 ms. `delegate_task` is called at most once per user turn; the cost is negligible.

## Pre-empt reviewer Q&A

**Q: Why not just re-populate `CLI_CONFIG` on file-change or /reset?**
That would solve this bug but introduces a much larger invariant to maintain (every mutation point of every config section would have to either poll or be hooked). Reading fresh per-call is simpler, has a localized fix, and matches how gateway/cron already operate — so we're unifying instead of diverging further.

**Q: Could this regress any path that relied on `CLI_CONFIG`'s import-time snapshot?**
Grepped every reader of `CLI_CONFIG["delegation"]` — only `tools/delegate_tool.py::_load_config()`. Nothing else reads this section, nothing writes to it at runtime.

**Q: `load_config()` calls `ensure_hermes_home()`. Side-effect concerns like #11983?**
For delegate_task specifically: `ensure_hermes_home()` creates `~/.hermes` subdirs and seeds `SOUL.md` if they don't exist. This is idempotent after first call. `delegate_task` is only invoked from an AIAgent tool-dispatch loop where the parent agent has already initialized `~/.hermes` (it couldn't have gotten to tool-dispatch otherwise). So the side-effect is a confirmed no-op in this call context. Additionally, the pre-fix fallback path (which fires in gateway/cron) **already** used `load_config()`, so this side effect was already part of the function's behaviour on the only paths that mattered.

**Q: Why coerce non-dict delegation to `{}` instead of raising?**
`_load_config` is best-effort at all other exit points (catches any exception → `{}`). Keeping that contract means callers don't have to learn a new failure mode — they still fall through to inherit-from-parent. A warning-log could be nice follow-up but the behavioural contract is maintained.

## Regression coverage

`tests/tools/test_delegate.py` gets `TestLoadConfigFreshReads` (5 tests):

1. `test_ignores_stale_cli_config_cache` — plants a stale `cli` module with empty-default `CLI_CONFIG` in `sys.modules`, writes an override to `config.yaml`, asserts `_load_config()` returns the override. **Fails on `origin/main`** with the exact reporter symptom: `AssertionError: '' != 'claude-sonnet-4-20250514'`.
2. `test_picks_up_delegation_override_written_after_startup` — end-user scenario: edit `config.yaml`, call `_load_config`, get the edit.
3. `test_non_dict_delegation_section_is_coerced_to_empty` — hardens `.get()` callers downstream; also **fails on `origin/main`** (old code returned the non-dict string verbatim).
4. `test_returns_dict_when_config_missing_delegation_section` — pins graceful handling when `delegation:` isn't configured at all.
5. `test_end_to_end_resolve_uses_fresh_config` — integration through `_resolve_delegation_credentials` all the way to `effective_model = creds["model"] or parent.model`.

## How to test

1. Focused suite:
   ```
   source venv/bin/activate
   python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py -q
   ```
   → **77 passed** (72 pre-existing + 5 new).

2. Verify the regression is caught on origin/main:
   ```
   git stash push tools/delegate_tool.py
   python -m pytest tests/tools/test_delegate.py::TestLoadConfigFreshReads -v
   ```
   → 2 fail (`test_ignores_stale_cli_config_cache`, `test_non_dict_delegation_section_is_coerced_to_empty`). Restore with `git stash pop`.

3. Manual repro (the sandbox script above), before & after.

4. CI-aligned broad suite:
   ```
   python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=line -n auto
   ```
   → 12824 passed, 39 skipped, 15 pre-existing baseline failures (dingtalk ×N, matrix, wsl ×2, approve_deny ×2, file_staleness ×2, local_interrupt_cleanup, plus a couple of known flakes in tools/). All reproduce on clean `origin/main`; none in `tools/delegate_tool.py` or `tests/tools/test_delegate.py`.

Tested on: macOS 15 (Darwin 25.5.0), Python 3.11.15.

## Related Issue

Fixes #11999

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: rewrite `_load_config` to always read fresh from `hermes_cli.config.load_config()`; add defensive dict-coercion against malformed config values.
- `tests/tools/test_delegate.py`: add `TestLoadConfigFreshReads` — 5 regression tests (2 fail cleanly on `origin/main`).

## Adjacent surfaces checked

- `_resolve_delegation_credentials` — downstream; verified correct given fresh config. Unchanged.
- `_build_child_agent` — receives `creds["model"]`; verified it correctly wins over `parent_agent.model` when present. Unchanged.
- `AIAgent.__init__` model resolution (`run_agent.py:708`, `:772`) — preserves user-supplied model. Unchanged.
- All four `preserve_dots=self._anthropic_preserve_dots()` call sites — unrelated. Unchanged.
- `cli.CLI_CONFIG` writers — grep-confirmed none for `delegation`. No data loss from dropping the short-circuit.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] Searched for existing PRs — none on #11999
- [x] Only changes related to this fix
- [x] Ran the CI-aligned test command and classified failures baseline-vs-change
- [x] Added tests for my changes (5 new; 2 fail on `origin/main` without the fix)
- [x] Tested on macOS 15 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] No docs changes needed — config-read internals, no public API surface
- [x] No config-key changes — existing `delegation.model` / `delegation.provider` keys behave as their docstrings already promised
- [x] No architecture/workflow changes
- [x] Cross-platform impact: none — pure Python, no OS-specific paths
- [x] No tool descriptions/schemas touched

## Notes for reviewers

- No standalone lint command is defined; CI runs `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` (matches `.github/workflows/tests.yml`).
- No `hermes_cli/**` changes — the Nix workflow should not trigger.