### PR TITLE
fix(model_metadata): fall through to defaults when endpoint has model but no context_length

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -996,20 +996,19 @@ def get_model_context_length(
             context_length = matched.get("context_length")
             if isinstance(context_length, int):
                 return context_length
-        if not _is_known_provider_base_url(base_url):
-            # 3. Try querying local server directly
-            if is_local_endpoint(base_url):
-                local_ctx = _query_local_context_length(model, base_url)
-                if local_ctx and local_ctx > 0:
-                    save_context_length(model, base_url, local_ctx)
-                    return local_ctx
-            logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
+            # Matched but no context_length — fall through to models.dev
+            # and hardcoded defaults rather than immediately defaulting to 128K.
+            logger.debug(
+                "Endpoint %s has model %r but no context_length metadata — "
+                "falling through to models.dev and hardcoded defaults.",
+                base_url, model,
             )
-            return DEFAULT_FALLBACK_CONTEXT
+        # 3. Try querying local server directly (custom endpoints only)
+        if is_local_endpoint(base_url):
+            local_ctx = _query_local_context_length(model, base_url)
+            if local_ctx and local_ctx > 0:
+                save_context_length(model, base_url, local_ctx)
+                return local_ctx
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -170,6 +170,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "perplexity": "perplexity",
     "cohere": "cohere",
     "ollama-cloud": "ollama-cloud",
+    "ollama": "ollama-cloud",
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -22,6 +22,7 @@ from unittest.mock import patch, MagicMock
 from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
+    DEFAULT_FALLBACK_CONTEXT,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -290,7 +291,10 @@ class TestGetModelContextLength:
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
-    def test_custom_endpoint_without_metadata_skips_name_based_default(self, mock_endpoint_fetch, mock_fetch):
+    def test_custom_endpoint_empty_metadata_falls_through_to_defaults(self, mock_endpoint_fetch, mock_fetch):
+        """When a custom endpoint returns no model metadata at all,
+        resolution should fall through to models.dev and hardcoded defaults
+        rather than immediately defaulting to 128K (probe tier 0)."""
         mock_fetch.return_value = {}
         mock_endpoint_fetch.return_value = {}
 
@@ -300,7 +304,39 @@ class TestGetModelContextLength:
             api_key="test-key",
         )
 
-        assert result == CONTEXT_PROBE_TIERS[0]
+        # "glm" substring matches the hardcoded DEFAULT_CONTEXT_LENGTHS entry
+        # which returns 202752, rather than the probe-tier fallback of 128K
+        assert result == 202752
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_custom_endpoint_match_no_context_length_falls_through(self, mock_endpoint_fetch, mock_fetch):
+        """Regression: when a custom endpoint lists a model but its metadata
+        has no context_length field, the resolver must fall through to models.dev
+        and hardcoded defaults instead of returning the 128K fallback.
+
+        Any OpenAI-compatible server (Ollama, Chutes, LM Studio, etc.) may
+        return {name: "model-name"} without context_length — the resolution
+        chain should keep trying rather than giving up at step 2.
+        """
+        mock_fetch.return_value = {}
+        # Endpoint returns the model but with no context_length
+        mock_endpoint_fetch.return_value = {
+            "glm-5.1": {"name": "glm-5.1"}
+        }
+
+        result = get_model_context_length(
+            "glm-5.1",
+            # Use an unknown custom endpoint — known provider URLs skip
+            # the endpoint metadata block entirely, so the regression path
+            # wouldn't be exercised with e.g. ollama.com.
+            base_url="https://llm.chutes.ai/v1",
+            provider="custom",
+        )
+
+        # Should fall through to the hardcoded "glm": 202752 default,
+        # NOT return 128000 (DEFAULT_FALLBACK_CONTEXT)
+        assert result == 202752
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")


### PR DESCRIPTION
## Problem

When any OpenAI-compatible custom endpoint (Ollama Cloud, Chutes, LM Studio, local vLLM, etc.) returns a model in its `/v1/models` response but without a `context_length` field, the context resolution chain in `get_model_context_length()` immediately returned `DEFAULT_FALLBACK_CONTEXT` (128K) at step 2, bypassing models.dev, OpenRouter, and hardcoded defaults entirely.

This is a provider-agnostic bug — any server that lists models without complete metadata hits this wall. The specific trigger was GLM-5.1 on Ollama Cloud resolving to 128K instead of the correct 202,752 window, but the same issue affects any model on any custom endpoint with incomplete `/v1/models` responses.

## Root Cause

In `agent/model_metadata.py`, when step 2 matched a model at a custom endpoint but found no `context_length` in the response, two things happened before the early return:

1. If `_is_known_provider_base_url()` returned `True`, the code skipped the endpoint query entirely (correct — Copilot/OpenAI report provider-limited context, not model context).
2. If `_is_known_provider_base_url()` returned `False` and `is_local_endpoint()` returned `False`, the code immediately returned `DEFAULT_FALLBACK_CONTEXT` (128K) — **incorrect**. It should have continued to steps 3-8 which check models.dev and hardcoded defaults.

## Changes

### `agent/model_metadata.py`
- **Remove early `return DEFAULT_FALLBACK_CONTEXT`** when an endpoint matches a model but `context_length` is missing. Instead, log a `debug` message and fall through to steps 3-8 (local probe, Anthropic API, models.dev, hardcoded defaults).
- **Move local server query out of the `_is_known_provider_base_url` guard** so it still fires for known-provider local endpoints. No behavioral change with current `_URL_TO_PROVIDER` entries (all remote), but eliminates an incorrect nesting dependency.

### `agent/models_dev.py`
- **Add `"ollama" → "ollama-cloud"` mapping** in `PROVIDER_TO_MODELS_DEV`. When a user configures `provider: ollama` (the natural name for Ollama Cloud), step 5's `lookup_models_dev_context("ollama-cloud", model)` can now resolve context windows via models.dev.

### `tests/agent/test_model_metadata.py`
- **Fix regression test** to use `https://llm.chutes.ai/v1` (unknown custom endpoint) instead of `https://ollama.com/v1` (known provider). The old URL skipped the patched code path entirely — `ollama.com` is in `_URL_TO_PROVIDER`, so `_is_known_provider_base_url()` returned `True`, and the endpoint metadata block was never entered.
- **Remove misleading `assert result == DEFAULT_FALLBACK_CONTEXT or result == 202752`** — this would accept the old buggy 128K value.
- **Rename test** from `test_custom_endpoint_without_metadata_skips_name_based_default` → `test_custom_endpoint_empty_metadata_falls_through_to_defaults` (empty endpoint response) and add `test_custom_endpoint_match_no_context_length_falls_through` (endpoint returns model without context_length).
- **Add explicit `mock_endpoint_fetch.return_value = {}`** to the empty-metadata test instead of relying on MagicMock default behavior.

## Testing

```
$ python -m pytest tests/agent/test_model_metadata.py -v
81 passed in 1.48s
```

Both new tests specifically exercise the patched code path:
- `test_custom_endpoint_empty_metadata_falls_through_to_defaults` — empty endpoint response, model resolves via hardcoded defaults
- `test_custom_endpoint_match_no_context_length_falls_through` — endpoint returns model name but no context_length, resolves via hardcoded defaults instead of 128K

## Architecture Context

`get_model_context_length()` has a 10-step resolution chain. Steps 1-2 are fast local lookups (cache, endpoint metadata). Steps 3-8 are progressively more expensive (local probe, Anthropic API, OpenRouter, models.dev, hardcoded defaults). Step 9 is a final local probe. Step 10 is the 128K fallback.

The fix ensures that failing at step 2 doesn't short-circuit the entire chain. This aligns with the documented resolution order and the design intent of having multiple fallback layers.