### PR TITLE
Added `ENV PATH="/opt/hermes/.venv/bin:$PATH"` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN uv venv && \
 USER root
 RUN chmod +x /opt/hermes/docker/entrypoint.sh
 
+# Add virtualenv bin to PATH so hermes command is available when entering container
+ENV PATH="/opt/hermes/.venv/bin:$PATH"
 ENV HERMES_HOME=/opt/data
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue where users couldn't run the `hermes` command directly after entering the Docker container. The problem was that the virtualenv bin directory wasn't included in the container's PATH, causing "bash: hermes: command not found" errors when trying to use the hermes command interactively.

The solution adds the virtualenv bin directory to the container's PATH via an ENV instruction in the Dockerfile. This ensures the hermes command is available both when the container starts via entrypoint and when users enter the container interactively.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change 

<!-- Check the one that applies. --> 

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) 
- [ ] ✨ New feature (non-breaking change that adds functionality) 
- [ ] 🔒 Security fix 
- [ ] 📝 Documentation update 
- [ ] ✅ Tests (adding or improving test coverage) 
- [ ] ♻️ Refactor (no behavior change) 
- [ ] 🎯 New skill (bundled or hub) 

## Changes Made 

<!-- List the specific changes. Include file paths for code changes. --> 

- Modified `/Users/xiangyong/dev/hermes-agent/Dockerfile` to add `ENV PATH="/opt/hermes/.venv/bin:$PATH"` instruction

## How to Test 

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. --> 

1. Build the Docker image with the updated Dockerfile
2. Run the container in interactive mode: `docker run -it --rm hermes-agent bash`
3. Inside the container, run `hermes --version` - it should now work without "command not found" error
4. Verify the entrypoint still works: `docker run --rm hermes-agent hermes --version`

## Checklist 

<!-- Complete these before requesting review. --> 

### Code 

- [x] I've read the `https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md` 
- [x] My commit messages follow `https://www.conventionalcommits.org/`  (`fix(scope):`, `feat(scope):`, etc.) 
- [x] I searched for `https://github.com/NousResearch/hermes-agent/pulls`  to make sure this isn't a duplicate 
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) 
- [x] I've run `pytest tests/ -q` and all tests pass 
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) 
- [x] I've tested on my platform: macOS 15.2 

### Documentation & Housekeeping 

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. --> 

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A 
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A 
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A 
- [x] I've considered cross-platform impact (Windows, macOS) per the `https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility`  — or N/A 
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A 

## Screenshots / Logs

Before the fix:

```
hermes@c29ea15bf6f7:/opt/hermes$ hermes
bash: hermes: command not found
```

After the fix:

```
hermes@c29ea15bf6f7:/opt/hermes/.venv/bin$ hermes --version
Hermes Agent v0.10.0 (2026.4.16)
Project: /opt/hermes
Python: 3.13.5
OpenAI SDK: 2.32.0
```