### PR TITLE
fix(whatsapp): keep essential history sync

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -27,6 +27,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { shouldSyncHistoryMessage } from './history_sync.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -131,6 +132,7 @@ async function startSocket() {
     printQRInTerminal: false,
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
+    shouldSyncHistoryMessage,
     markOnlineOnConnect: false,
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)

--- a/scripts/whatsapp-bridge/history_sync.js
+++ b/scripts/whatsapp-bridge/history_sync.js
@@ -1,0 +1,7 @@
+// Baileys 7.x overrides the default history-sync callback to
+// `() => !!syncFullHistory` when the caller does not provide one.
+// Hermes wants to skip the full history download, but it still needs
+// bootstrap / recent syncs for LID mappings and group participation.
+export function shouldSyncHistoryMessage(sync) {
+  return sync?.syncType !== 2;
+}

--- a/scripts/whatsapp-bridge/history_sync.test.mjs
+++ b/scripts/whatsapp-bridge/history_sync.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldSyncHistoryMessage } from './history_sync.js';
+
+test('keeps essential history sync types when full history download is disabled', () => {
+  assert.equal(shouldSyncHistoryMessage({ syncType: 0 }), true);
+  assert.equal(shouldSyncHistoryMessage({ syncType: 1 }), true);
+  assert.equal(shouldSyncHistoryMessage({ syncType: 2 }), false);
+  assert.equal(shouldSyncHistoryMessage({ syncType: 3 }), true);
+});


### PR DESCRIPTION
## Summary
- add an explicit Baileys 7.x history-sync callback for the WhatsApp bridge
- keep essential bootstrap/recent sync types while still declining the full history download
- add a small Node regression test for the sync decision helper

## Problem
Fixes #11951.

The WhatsApp bridge set `syncFullHistory: false` without providing `shouldSyncHistoryMessage`. In Baileys 7.x that causes the library to replace its normal default with `() => !!syncFullHistory`, which disables all history sync when Hermes says `false`.

## Solution
Provide an explicit callback that rejects only `FULL` history sync (`syncType === 2`) while allowing the other sync types Hermes still needs for LID mappings and group participation.

## Verification
- `/opt/homebrew/opt/node/bin/node --test scripts/whatsapp-bridge/history_sync.test.mjs scripts/whatsapp-bridge/allowlist.test.mjs`
- code-path verification: `scripts/whatsapp-bridge/bridge.js` now passes `shouldSyncHistoryMessage` alongside `syncFullHistory: false`
