### PR TITLE
fix(gateway): soften stale delegate_task status updates

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5271,6 +5271,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._enqueue_fifo(session_key, event, adapter)
 
+    def _format_agent_status_parts(
+        self,
+        summary: dict[str, Any],
+        *,
+        started_at: float = 0,
+        now_ts: Optional[float] = None,
+        include_iteration: bool = True,
+        tool_label_prefix: str = "running: ",
+    ) -> list[str]:
+        """Format activity details shared by busy acks and heartbeats.
+
+        ``delegate_task`` is different from an ordinary tool call: the parent
+        can remain inside it while a child agent performs the real work. Once
+        the parent has been idle briefly, describe that state as a delegated
+        wait instead of repeatedly presenting the parent's tool and iteration
+        as if they were still advancing.
+        """
+        now_ts = time.time() if now_ts is None else now_ts
+        parts: list[str] = []
+
+        if started_at:
+            elapsed_min = int((now_ts - started_at) / 60)
+            if elapsed_min > 0:
+                parts.append(f"{elapsed_min} min elapsed")
+
+        current_tool = summary.get("current_tool")
+        idle_secs = float(summary.get("seconds_since_activity") or 0.0)
+        is_stale_delegate = current_tool == "delegate_task" and idle_secs >= 15
+
+        iteration = summary.get("api_call_count", 0)
+        max_iter = summary.get("max_iterations", 0)
+        if include_iteration and max_iter and not is_stale_delegate:
+            parts.append(f"iteration {iteration}/{max_iter}")
+
+        if current_tool:
+            if is_stale_delegate:
+                parts.append("waiting on delegated task")
+                if idle_secs >= 60:
+                    parts.append(f"parent idle {int(idle_secs // 60)} min")
+            else:
+                parts.append(f"{tool_label_prefix}{current_tool}")
+        elif summary.get("last_activity_desc"):
+            parts.append(str(summary["last_activity_desc"]))
+
+        return parts
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
@@ -5563,18 +5609,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if busy_ack_detail_enabled and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 summary = running_agent.get_activity_summary()
-                iteration = summary.get("api_call_count", 0)
-                max_iter = summary.get("max_iterations", 0)
-                current_tool = summary.get("current_tool")
-                start_ts = self._running_agents_ts.get(session_key, 0)
-                if start_ts:
-                    elapsed_min = int((now - start_ts) / 60)
-                    if elapsed_min > 0:
-                        status_parts.append(f"{elapsed_min} min elapsed")
-                if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
-                if current_tool:
-                    status_parts.append(f"running: {current_tool}")
+                status_parts = self._format_agent_status_parts(
+                    summary,
+                    started_at=self._running_agents_ts.get(session_key, 0),
+                    now_ts=now,
+                )
             except Exception:
                 pass
 
@@ -19377,7 +19416,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key, agent_holder[0], _exec_ref
                 ):
                     break
-                _elapsed_mins = int((time.time() - _notify_start) // 60)
+                _now = time.time()
+                _elapsed_mins = int((_now - _notify_start) // 60)
                 # Include agent activity context if available. Default
                 # heartbeat is terse: elapsed + current tool. Verbose
                 # iteration counter is gated on busy_ack_detail so users
@@ -19395,14 +19435,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
-                        _parts = []
-                        if _want_iteration_detail:
-                            _parts.append(
-                                f"iteration {_a['api_call_count']}/{_a['max_iterations']}"
-                            )
-                        _action = _a.get("current_tool") or _a.get("last_activity_desc")
-                        if _action:
-                            _parts.append(str(_action))
+                        _parts = self._format_agent_status_parts(
+                            _a,
+                            now_ts=_now,
+                            include_iteration=_want_iteration_detail,
+                            tool_label_prefix="",
+                        )
                         if _parts:
                             _status_detail = " — " + ", ".join(_parts)
                     except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1374,6 +1374,49 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+    def _format_agent_status_parts(
+        self,
+        summary: dict[str, Any],
+        *,
+        started_at: float = 0,
+        now_ts: float | None = None,
+    ) -> list[str]:
+        """Format user-facing activity details for busy and heartbeat messages.
+
+        Delegate tasks are special: the parent agent can sit inside
+        ``delegate_task`` for a long time while a child/subagent does the real
+        work. Repeating ``running: delegate_task`` makes the parent look frozen,
+        so stale delegate waits get a softer label instead.
+        """
+        now_ts = now_ts or time.time()
+        parts: list[str] = []
+
+        if started_at:
+            elapsed_min = int((now_ts - started_at) / 60)
+            if elapsed_min > 0:
+                parts.append(f"{elapsed_min} min elapsed")
+
+        current_tool = summary.get("current_tool")
+        idle_secs = float(summary.get("seconds_since_activity") or 0.0)
+        is_stale_delegate = current_tool == "delegate_task" and idle_secs >= 15
+
+        iteration = summary.get("api_call_count", 0)
+        max_iter = summary.get("max_iterations", 0)
+        if max_iter and not is_stale_delegate:
+            parts.append(f"iteration {iteration}/{max_iter}")
+
+        if current_tool:
+            if is_stale_delegate:
+                parts.append("waiting on delegated task")
+                if idle_secs >= 60:
+                    parts.append(f"parent idle {int(idle_secs // 60)} min")
+            else:
+                parts.append(f"running: {current_tool}")
+        elif summary.get("last_activity_desc"):
+            parts.append(summary["last_activity_desc"])
+
+        return parts
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
@@ -1432,23 +1475,20 @@ class GatewayRunner:
 
         self._busy_ack_ts[session_key] = now
 
-        # Build a status-rich acknowledgment
+        # Build a status-rich acknowledgment.
+        # Delegate tasks are special: the parent agent can sit on current_tool=
+        # delegate_task for a long time while a child/subagent does the real work.
+        # Repeating "running: delegate_task" makes the parent look frozen even
+        # though it's just waiting on delegated work. Avoid that stale wording.
         status_parts = []
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 summary = running_agent.get_activity_summary()
-                iteration = summary.get("api_call_count", 0)
-                max_iter = summary.get("max_iterations", 0)
-                current_tool = summary.get("current_tool")
-                start_ts = self._running_agents_ts.get(session_key, 0)
-                if start_ts:
-                    elapsed_min = int((now - start_ts) / 60)
-                    if elapsed_min > 0:
-                        status_parts.append(f"{elapsed_min} min elapsed")
-                if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
-                if current_tool:
-                    status_parts.append(f"running: {current_tool}")
+                status_parts = self._format_agent_status_parts(
+                    summary,
+                    started_at=self._running_agents_ts.get(session_key, 0),
+                    now_ts=now,
+                )
             except Exception:
                 pass
 
@@ -9117,19 +9157,21 @@ class GatewayRunner:
                 return
             while True:
                 await asyncio.sleep(_NOTIFY_INTERVAL)
-                _elapsed_mins = int((time.time() - _notify_start) // 60)
+                _now = time.time()
+                _elapsed_mins = int((_now - _notify_start) // 60)
                 # Include agent activity context if available.
                 _agent_ref = agent_holder[0]
                 _status_detail = ""
                 if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
-                        _parts = [f"iteration {_a['api_call_count']}/{_a['max_iterations']}"]
-                        if _a.get("current_tool"):
-                            _parts.append(f"running: {_a['current_tool']}")
-                        else:
-                            _parts.append(_a.get("last_activity_desc", ""))
-                        _status_detail = " — " + ", ".join(_parts)
+                        _parts = self._format_agent_status_parts(
+                            _a,
+                            started_at=self._running_agents_ts.get(session_key, 0),
+                            now_ts=_now,
+                        )
+                        if _parts:
+                            _status_detail = " — " + ", ".join(_parts)
                     except Exception:
                         pass
                 try:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -98,6 +98,27 @@ def _make_adapter(platform_val="telegram"):
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
 
+    def test_format_agent_status_parts_softens_stale_delegate_task(self):
+        runner, _ = _make_runner()
+
+        parts = runner._format_agent_status_parts(
+            {
+                "api_call_count": 4,
+                "max_iterations": 200,
+                "current_tool": "delegate_task",
+                "last_activity_desc": "delegate_task",
+                "seconds_since_activity": 4200,
+            },
+            started_at=800,
+            now_ts=5000,
+        )
+
+        assert parts == [
+            "70 min elapsed",
+            "waiting on delegated task",
+            "parent idle 70 min",
+        ]
+
     @pytest.mark.asyncio
     async def test_handle_message_queue_mode_queues_without_interrupt(self):
         """Runner queue mode must not interrupt an active agent for text follow-ups."""
@@ -605,6 +626,44 @@ class TestBusySessionAck:
         assert "21/60" in content  # iteration
         assert "terminal" in content  # current tool
         assert "10 min" in content  # elapsed
+
+    @pytest.mark.asyncio
+    async def test_busy_ack_softens_stale_delegate_when_detail_is_enabled(
+        self, monkeypatch
+    ):
+        """Verbose busy acks describe an idle parent as waiting on its child."""
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"busy_ack_detail": True}}}},
+        )
+        runner, _ = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="status?")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 4,
+            "max_iterations": 200,
+            "current_tool": "delegate_task",
+            "last_activity_desc": "delegate_task",
+            "seconds_since_activity": 4200,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 4200
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "waiting on delegated task" in content
+        assert "parent idle 70 min" in content
+        assert "delegate_task" not in content
+        assert "iteration 4/200" not in content
 
     @pytest.mark.asyncio
     async def test_telegram_omits_status_detail_by_default(self):

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -91,6 +91,27 @@ def _make_adapter(platform_val="telegram"):
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
 
+    def test_format_agent_status_parts_softens_stale_delegate_task(self):
+        runner, _ = _make_runner()
+        parts = runner._format_agent_status_parts(
+            {
+                "api_call_count": 4,
+                "max_iterations": 200,
+                "current_tool": "delegate_task",
+                "last_activity_ts": time.time() - 4200,
+                "last_activity_desc": "delegate_task",
+                "seconds_since_activity": 4200,
+            },
+            started_at=time.time() - 4200,
+            now_ts=time.time(),
+        )
+
+        assert "70 min elapsed" in parts
+        assert "waiting on delegated task" in parts
+        assert "parent idle 70 min" in parts
+        assert all("delegate_task" not in part for part in parts)
+        assert all("iteration 4/200" not in part for part in parts)
+
     @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):
         """First message during busy session should get a status ack."""
@@ -237,6 +258,35 @@ class TestBusySessionAck:
         assert "21/60" in content  # iteration
         assert "terminal" in content  # current tool
         assert "10 min" in content  # elapsed
+
+    @pytest.mark.asyncio
+    async def test_busy_ack_softens_stale_delegate_task_status(self):
+        runner, sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="yo")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 4,
+            "max_iterations": 200,
+            "current_tool": "delegate_task",
+            "last_activity_ts": time.time() - 4200,
+            "last_activity_desc": "delegate_task",
+            "seconds_since_activity": 4200,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 4200
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "waiting on delegated task" in content
+        assert "parent idle 70 min" in content
+        assert "delegate_task" not in content
+        assert "iteration 4/200" not in content
 
     @pytest.mark.asyncio
     async def test_draining_still_works(self):

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -121,6 +121,26 @@ class ProgressAgent:
         return {"final_response": "done", "messages": [], "api_calls": 1}
 
 
+class DelegateWaitingAgent:
+    """Stays alive long enough for the heartbeat loop to inspect it."""
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def get_activity_summary(self):
+        return {
+            "api_call_count": 4,
+            "max_iterations": 200,
+            "current_tool": "delegate_task",
+            "last_activity_desc": "delegate_task",
+            "seconds_since_activity": 4200,
+        }
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        time.sleep(0.5)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
 class FailingAgent:
     def __init__(self, **kwargs):
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
@@ -198,6 +218,54 @@ def _install_fakes(monkeypatch, agent_cls, *, cleanup_on: bool):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_softens_stale_delegate_status(monkeypatch, tmp_path):
+    """The live heartbeat uses the shared delegate-wait wording."""
+    # Leave enough time for the separately scheduled ownership tracker to
+    # replace the pending sentinel with the live agent before the first tick.
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.15")
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, DelegateWaitingAgent, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "busy_ack_detail": True,
+                        "long_running_notifications": True,
+                    }
+                }
+            }
+        },
+    )
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    heartbeat_texts = [entry["content"] for entry in adapter.sent]
+    heartbeat_texts.extend(entry["content"] for entry in adapter.edits)
+
+    assert result["final_response"] == "done"
+    assert heartbeat_texts
+    assert any("waiting on delegated task" in text for text in heartbeat_texts)
+    assert any("parent idle 70 min" in text for text in heartbeat_texts)
+    assert all("delegate_task" not in text for text in heartbeat_texts)
+    assert all("iteration 4/200" not in text for text in heartbeat_texts)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared formatter for gateway busy/heartbeat status details
- stop advertising stale `running: delegate_task` when the parent agent has been idle and is just waiting on delegated work
- cover the new wording with busy-session regression tests

## Why
The gateway was repeatedly surfacing messages like `iteration 4/200, running: delegate_task` long after the parent agent had gone idle. That makes the parent look frozen even when it is merely waiting on delegated work.

This patch softens that stale state to `waiting on delegated task` and, once the parent has been idle for at least a minute, also shows `parent idle Xm`. For these stale delegate waits we intentionally drop the iteration counter, because repeating the same `4/200` number is more misleading than helpful.

## Testing
- `pytest -q tests/gateway/test_busy_session_ack.py`
- `pytest -q tests/gateway/test_status_command.py tests/gateway/test_gateway_inactivity_timeout.py`
- `python -m compileall gateway/run.py tests/gateway/test_busy_session_ack.py`

## Notes
This fixes the gateway status-reporting side of the bug cluster. It does **not** attempt to solve the separate session-finalization / ghost-open-session issue tracked in #12029.