### PR TITLE
fix(gateway): honor queue mode for busy telegram follow-ups

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -522,6 +522,32 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(streaming_cfg, dict):
                 gw_data["streaming"] = streaming_cfg
 
+            display_cfg = yaml_cfg.get("display")
+            if isinstance(display_cfg, dict) and "busy_input_mode" in display_cfg:
+                busy_mode = str(display_cfg.get("busy_input_mode", "")).strip().lower()
+                if busy_mode in {"interrupt", "queue"}:
+                    platforms_data = gw_data.setdefault("platforms", {})
+                    if not isinstance(platforms_data, dict):
+                        platforms_data = {}
+                        gw_data["platforms"] = platforms_data
+                    for plat in Platform:
+                        if plat == Platform.LOCAL:
+                            continue
+                        plat_data = platforms_data.setdefault(plat.value, {})
+                        if not isinstance(plat_data, dict):
+                            plat_data = {}
+                            platforms_data[plat.value] = plat_data
+                        extra = plat_data.setdefault("extra", {})
+                        if not isinstance(extra, dict):
+                            extra = {}
+                            plat_data["extra"] = extra
+                        extra.setdefault("busy_input_mode", busy_mode)
+                else:
+                    logger.warning(
+                        "Ignoring invalid display.busy_input_mode in config.yaml (expected 'interrupt' or 'queue', got %r)",
+                        display_cfg.get("busy_input_mode"),
+                    )
+
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]
 
@@ -570,6 +596,16 @@ def load_gateway_config() -> GatewayConfig:
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
+                if "busy_input_mode" in platform_cfg:
+                    busy_mode = str(platform_cfg["busy_input_mode"]).strip().lower()
+                    if busy_mode in {"interrupt", "queue"}:
+                        bridged["busy_input_mode"] = busy_mode
+                    else:
+                        logger.warning(
+                            "Ignoring invalid %s.busy_input_mode in config.yaml (expected 'interrupt' or 'queue', got %r)",
+                            plat.value,
+                            platform_cfg.get("busy_input_mode"),
+                        )
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -891,6 +891,8 @@ class BasePlatformAdapter(ABC):
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
+        _busy_mode = str(self.config.extra.get("busy_input_mode", "interrupt")).strip().lower()
+        self._busy_input_mode = "queue" if _busy_mode == "queue" else "interrupt"
 
     @property
     def has_fatal_error(self) -> bool:
@@ -1645,6 +1647,11 @@ class BasePlatformAdapter(ABC):
             # then process them immediately after the current task finishes.
             if event.message_type == MessageType.PHOTO:
                 logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
+                merge_pending_message_event(self._pending_messages, session_key, event)
+                return  # Don't interrupt now - will run after current task completes
+
+            if self._busy_input_mode == "queue":
+                logger.debug("[%s] New message while session %s is active — queueing without interrupt", self.name, session_key)
                 merge_pending_message_event(self._pending_messages, session_key, event)
                 return  # Don't interrupt now - will run after current task completes
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1423,18 +1423,19 @@ class GatewayRunner:
             return False  # let default path handle it
 
         # Store the message so it's processed as the next turn after the
-        # interrupt causes the current run to exit.
+        # current run exits.
         from gateway.platforms.base import merge_pending_message_event
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
-        # Interrupt the running agent — this aborts in-flight tool calls and
-        # causes the agent loop to exit at the next check point.
         running_agent = self._running_agents.get(session_key)
-        if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
-            try:
-                running_agent.interrupt(event.text)
-            except Exception:
-                pass  # don't let interrupt failure block the ack
+        if self._busy_input_mode != "queue":
+            # Interrupt the running agent — this aborts in-flight tool calls and
+            # causes the agent loop to exit at the next check point.
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                try:
+                    running_agent.interrupt(event.text)
+                except Exception:
+                    pass  # don't let interrupt failure block the ack
 
         # Debounce: only send an acknowledgment once every 30 seconds per session
         # to avoid spamming the user when they send multiple messages quickly
@@ -1467,10 +1468,16 @@ class GatewayRunner:
                 pass
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
-        message = (
-            f"⚡ Interrupting current task{status_detail}. "
-            f"I'll respond to your message shortly."
-        )
+        if self._busy_input_mode == "queue":
+            message = (
+                f"⏳ Current task still running{status_detail}. "
+                f"Your message is queued for the next turn."
+            )
+        else:
+            message = (
+                f"⚡ Interrupting current task{status_detail}. "
+                f"I'll respond to your message shortly."
+            )
 
         thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
         try:
@@ -3115,6 +3122,10 @@ class GatewayRunner:
                     if self._queue_during_drain_enabled()
                     else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
                 )
+            if self._busy_input_mode == "queue":
+                logger.debug("PRIORITY queue follow-up for session %s", _quick_key[:20])
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
             running_agent.interrupt(event.text)
             if _quick_key in self._pending_messages:

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -70,6 +70,9 @@ def _make_runner():
     runner.session_store = None
     runner.hooks = MagicMock()
     runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
     return runner, _AGENT_PENDING_SENTINEL
 
 
@@ -90,6 +93,30 @@ def _make_adapter(platform_val="telegram"):
 
 class TestBusySessionAck:
     """User sends a message while agent is running — should get acknowledgment."""
+
+    @pytest.mark.asyncio
+    async def test_handle_message_queue_mode_queues_without_interrupt(self):
+        """Runner queue mode must not interrupt an active agent for follow-up text."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="follow up in queue mode")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._busy_input_mode = "queue"
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert sk in adapter._pending_messages
+        assert adapter._pending_messages[sk] is event
+        assert sk not in runner._pending_messages
+        running_agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):


### PR DESCRIPTION
## Summary
- honor `display.busy_input_mode: queue` when a follow-up arrives during an active gateway run
- propagate busy input mode from `config.yaml` into platform extra config
- send queue-specific busy acknowledgements instead of interrupting the running agent
- add regression coverage for queue-mode follow-up handling

## Test Plan
- [x] `python3 -m pytest -q tests/gateway/test_busy_session_ack.py tests/gateway/test_restart_drain.py tests/gateway/test_duplicate_reply_suppression.py`

## Context
This fixes a real user-facing bug where Telegram follow-up messages were still interrupting long-running work even with queue mode enabled.