### PR TITLE
fix: exclude completion_tokens from compression trigger for reasoning models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11049,9 +11049,14 @@ class AIAgent:
                         self.iteration_budget.refund()
                     
                     # Use real token counts from the API response to decide
-                    # compression.  prompt_tokens + completion_tokens is the
-                    # actual context size the provider reported plus the
-                    # assistant turn — a tight lower bound for the next prompt.
+                    # compression.  Use only prompt_tokens — completion_tokens
+                    # (including reasoning tokens for thinking models) are
+                    # ephemeral output that don't consume context window space
+                    # for the next API call.  This prevents premature
+                    # compression for reasoning models like GLM-5.1, QwQ, etc.
+                    # where reasoning tokens inflate the apparent usage.
+                    # (Fixes #12026)
+                    #
                     # Tool results appended above aren't counted yet, but the
                     # threshold (default 50%) leaves ample headroom; if tool
                     # results push past it, the next API call will report the
@@ -11064,10 +11069,7 @@ class AIAgent:
                     # should_compress(0) never fires.  (#2153)
                     _compressor = self.context_compressor
                     if _compressor.last_prompt_tokens > 0:
-                        _real_tokens = (
-                            _compressor.last_prompt_tokens
-                            + _compressor.last_completion_tokens
-                        )
+                        _real_tokens = _compressor.last_prompt_tokens
                     else:
                         _real_tokens = estimate_messages_tokens_rough(messages)
 


### PR DESCRIPTION
## Summary

Fixes premature context compression for reasoning models (GLM-5.1, QwQ, etc.) by excluding completion_tokens from the compression trigger calculation.

## Root Cause

The compression trigger was summing  to determine when to compress context. For reasoning models,  includes internal thinking/reasoning tokens that are ephemeral output and don't consume context window space for the next API call.

This caused compression to fire when the model had only used ~42% of its actual context window, because reasoning tokens inflated the calculated token count past the 50% threshold.

**Example:**
- Actual prompt: 85,000 tokens (42% of 202K context)
- Completion: 20,000 tokens (15K reasoning + 5K visible)
- Old calculation: 85K + 20K = 105K → exceeds 101K threshold → **premature compression!**

## Fix

Use only  for the compression trigger. The prompt already represents actual context window consumption — it's what the provider charges for and what determines whether the next request will fit.

## Impact

- Prevents cascading premature session splits for reasoning models
- Preserves conversation continuity
- Reduces wasted tokens from unnecessary compression/replay cycles

## Test Plan
- [x] Relevant unit tests pass (, )
- [x] Verified compression still triggers correctly based on prompt size

Closes NousResearch/hermes-agent#12026