### PR TITLE
fix(streaming): surface dropped tool-call on mid-stream stall

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5579,7 +5579,7 @@ class AIAgent:
                 raise result["error"]
             return result["response"]
 
-        result = {"response": None, "error": None}
+        result = {"response": None, "error": None, "partial_tool_names": []}
         request_client_holder = {"client": None}
         first_delta_fired = {"done": False}
         deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
@@ -5751,6 +5751,14 @@ class AIAgent:
                             tool_gen_notified.add(idx)
                             _fire_first_delta()
                             self._fire_tool_gen_started(name)
+                            # Record the partial tool-call name so the outer
+                            # stub-builder can surface a user-visible warning
+                            # if streaming dies before this tool's arguments
+                            # are fully delivered.  Without this, a stall
+                            # during tool-call JSON generation lets the stub
+                            # at line ~6107 return `tool_calls=None`, silently
+                            # discarding the attempted action.
+                            result["partial_tool_names"].append(name)
 
                 if chunk.choices[0].finish_reason:
                     finish_reason = chunk.choices[0].finish_reason
@@ -6117,13 +6125,44 @@ class AIAgent:
                 _partial_text = (
                     getattr(self, "_current_streamed_assistant_text", "") or ""
                 ).strip() or None
-                logger.warning(
-                    "Partial stream delivered before error; returning stub "
-                    "response with %s chars of recovered content to prevent "
-                    "duplicate messages: %s",
-                    len(_partial_text or ""),
-                    result["error"],
-                )
+
+                # If the stream died while the model was emitting a tool call,
+                # the stub below will silently set `tool_calls=None` and the
+                # agent loop will treat the turn as complete — the attempted
+                # action is lost with no user-facing signal.  Append a
+                # human-visible warning to the stub content so (a) the user
+                # knows something failed, and (b) the next turn's model sees
+                # in conversation history what was attempted and can retry.
+                _partial_names = list(result.get("partial_tool_names") or [])
+                if _partial_names:
+                    _name_str = ", ".join(_partial_names[:3])
+                    if len(_partial_names) > 3:
+                        _name_str += f", +{len(_partial_names) - 3} more"
+                    _warn = (
+                        f"\n\n⚠ Stream stalled mid tool-call "
+                        f"({_name_str}); the action was not executed. "
+                        f"Ask me to retry if you want to continue."
+                    )
+                    _partial_text = (_partial_text or "") + _warn
+                    # Also fire as a streaming delta so the user sees it now
+                    # instead of only in the persisted transcript.
+                    try:
+                        self._fire_stream_delta(_warn)
+                    except Exception:
+                        pass
+                    logger.warning(
+                        "Partial stream dropped tool call(s) %s after %s chars "
+                        "of text; surfaced warning to user: %s",
+                        _partial_names, len(_partial_text or ""), result["error"],
+                    )
+                else:
+                    logger.warning(
+                        "Partial stream delivered before error; returning stub "
+                        "response with %s chars of recovered content to prevent "
+                        "duplicate messages: %s",
+                        len(_partial_text or ""),
+                        result["error"],
+                    )
                 _stub_msg = SimpleNamespace(
                     role="assistant", content=_partial_text, tool_calls=None,
                     reasoning_content=None,

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -952,3 +952,138 @@ class TestAnthropicStreamCallbacks:
         agent._interruptible_streaming_api_call({})
 
         assert touch_calls.count("receiving stream response") == len(events)
+
+
+class TestPartialToolCallWarning:
+    """Regression: when a stream dies mid tool-call argument generation after
+    text was already delivered, the partial-stream stub at run_agent.py
+    line ~6107 used to silently set ``tool_calls=None`` and return
+    ``finish_reason=stop``, losing the attempted action with zero user-facing
+    signal.  Live-observed Apr 2026 with MiniMax M2.7 on a 6-minute audit
+    task — agent streamed commentary, emitted a write_file tool call,
+    MiniMax stalled for 240 s mid-arguments, stale-stream detector killed
+    the connection, the stub returned, session ended with no file written
+    and no error shown.
+
+    Fix: when the stream accumulator captured any tool-call names before the
+    error, the stub now appends a user-visible warning to content AND fires
+    it as a stream delta so the user sees it immediately.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_partial_tool_call_surfaces_warning(self, mock_close, mock_create):
+        """Stream with text + partial tool-call name + mid-stream error
+        produces a stub whose content contains the user-visible warning
+        and whose tool_calls is None."""
+        from run_agent import AIAgent
+
+        class _StallError(RuntimeError):
+            pass
+
+        def _stalling_stream():
+            yield _make_stream_chunk(content="Let me write the audit: ")
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="write_file"),
+            ])
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "/tmp/x", '),
+            ])
+            raise _StallError("simulated upstream stall")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stalling_stream()
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        fired_deltas: list = []
+        agent._fire_stream_delta = lambda text: fired_deltas.append(text)
+        agent._current_streamed_assistant_text = "Let me write the audit: "
+
+        import os as _os
+        _prev = _os.environ.get("HERMES_STREAM_RETRIES")
+        _os.environ["HERMES_STREAM_RETRIES"] = "0"
+        try:
+            response = agent._interruptible_streaming_api_call({})
+        finally:
+            if _prev is None:
+                _os.environ.pop("HERMES_STREAM_RETRIES", None)
+            else:
+                _os.environ["HERMES_STREAM_RETRIES"] = _prev
+
+        content = response.choices[0].message.content or ""
+        assert "Let me write the audit:" in content, (
+            f"Partial text not preserved in stub: {content!r}"
+        )
+        assert "Stream stalled mid tool-call" in content, (
+            f"Stub content is missing the dropped-tool-call warning; users "
+            f"get silent failure.  Got content={content!r}"
+        )
+        assert "write_file" in content, (
+            f"Warning should name the dropped tool. Got: {content!r}"
+        )
+        assert response.choices[0].message.tool_calls is None
+        assert any("Stream stalled mid tool-call" in d for d in fired_deltas), (
+            f"Warning was not surfaced as a live stream delta. "
+            f"fired_deltas={fired_deltas}"
+        )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_partial_text_only_no_warning(self, mock_close, mock_create):
+        """Text-only partial stream (no tool call mid-flight) keeps the
+        pre-fix behaviour: bare recovered text, no warning noise."""
+        from run_agent import AIAgent
+
+        class _StallError(RuntimeError):
+            pass
+
+        def _stalling_stream():
+            yield _make_stream_chunk(content="Here's my answer so far")
+            raise _StallError("simulated upstream stall")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _stalling_stream()
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+        agent._current_streamed_assistant_text = "Here's my answer so far"
+
+        import os as _os
+        _prev = _os.environ.get("HERMES_STREAM_RETRIES")
+        _os.environ["HERMES_STREAM_RETRIES"] = "0"
+        try:
+            response = agent._interruptible_streaming_api_call({})
+        finally:
+            if _prev is None:
+                _os.environ.pop("HERMES_STREAM_RETRIES", None)
+            else:
+                _os.environ["HERMES_STREAM_RETRIES"] = _prev
+
+        content = response.choices[0].message.content or ""
+        assert content == "Here's my answer so far", (
+            f"Pre-fix behaviour regressed for text-only partial streams: {content!r}"
+        )
+        assert "Stream stalled" not in content, (
+            f"Unexpected warning on text-only partial stream: {content!r}"
+        )
+


### PR DESCRIPTION
## Summary
Users no longer get a silent failure when a streaming model stalls mid tool-call — the dropped tool is now named in a user-visible warning appended to the assistant message.

## Root cause
When a stream dies after text was already delivered, the partial-stream recovery path at the end of `_interruptible_streaming_api_call` returns a stub with the recovered text and `tool_calls=None`, `finish_reason=stop`. That's correct for text-only stalls (retrying would duplicate the text), but when a tool call was in flight, the attempted action is lost with no indication — agent treats the turn as complete, session exits cleanly, nothing happened.

## Changes
- `run_agent.py`: streaming accumulator records each tool-call name into `result['partial_tool_names']` as soon as the name is known.
- `run_agent.py`: stub builder checks that list and, when non-empty, appends `⚠ Stream stalled mid tool-call (<names>); the action was not executed. Ask me to retry if you want to continue.` to `content`, and also fires it as a live stream delta so the user sees it *before* the turn closes, not just in the persisted transcript.
- `run_agent.py`: text-only partial streams keep the original bare-recovery behaviour (no warning noise for a scenario the previous design already handled correctly).
- `tests/run_agent/test_streaming.py`: two new regression tests — one asserts the warning fires + names the dropped tool + reaches the live delta callback, one asserts text-only partial streams are unchanged.

## Validation
| Scenario | Before | After |
|---|---|---|
| Stream dies mid tool-call, text already delivered | Silent exit code 0, no indication | Warning in content + live delta, user sees which tool was dropped |
| Text-only partial stream | Bare recovered text | Unchanged |
| `tests/run_agent/test_streaming.py` | 24 passed | 26 passed (2 new) |

---

## Reproduction methodology (for future re-verification)

### 1. Environment setup
```bash
# Isolated HERMES_HOME so prior state doesn't leak in
mkdir -p /tmp/hermes-minimax-eval && cp ~/.hermes/.env /tmp/hermes-minimax-eval/.env
cat > /tmp/hermes-minimax-eval/config.yaml <<'EOF'
_config_version: 5
display:
  streaming: true
agent:
  max_turns: 50
EOF
```

### 2. The trigger prompt
Substantive enough that MiniMax M2.7 emits leading commentary, starts a `write_file` tool call, and needs to generate a large JSON arguments blob — that's when the stall hits the 240 s stale-stream detector:
```bash
cat > /tmp/hermes-prompt.txt <<'EOF'
You have access to the hermes-agent repo at /home/teknium/.hermes/hermes-agent.
Audit how interrupts and subprocess cleanup work across ALL execution backends:

1. Read tools/environments/base.py, local.py, docker.py, ssh_env.py (if exists,
   else list what's there), modal_utils.py, and any daytona/singularity files.
2. For each backend identify: how _wait_for_process polls, how _kill_process
   works, what happens if the agent is interrupted mid-execution, what happens
   if the agent process crashes.
3. Check interrupt propagation to in-flight commands per backend.
4. Write a thorough markdown audit to /tmp/minimax-audit.md with one section
   per backend, including line-number references and concrete code excerpts.
5. At the end, list inconsistencies or potential bugs across backends.

Take your time, read actual code, don't speculate. I want real evidence.
EOF
```

### 3. Run the session (non-interactive, so `-q` captures the full lifecycle cleanly)
```bash
HERMES_HOME=/tmp/hermes-minimax-eval \
HERMES_DEBUG_INTERRUPT=1 \
PYTHONPATH=/home/teknium/.hermes/hermes-agent \
/home/teknium/.hermes/hermes-agent/venv/bin/python3 -m hermes_cli.main chat \
    --provider openrouter \
    --model minimax/minimax-m2.7 \
    --yolo \
    -q "$(cat /tmp/hermes-prompt.txt)" \
    2>&1 | tee /tmp/hermes-minimax-repro/session.log
```
(Note the slug form — `--provider openrouter --model minimax/minimax-m2.7`. Using `--model openrouter/minimax/minimax-m2.7` fails HTTP 400 "not a valid model ID".)

### 4. The observed failure (on `main` before this PR)
- Agent streams reasoning + commentary for ~4-6 minutes
- Eventually emits tool calls: `search_files`, `read_file` on each backend module — visible as `🔎 grep`, `📖 read` lines
- Reaches the summary step: streams `"Now I have all the information needed. Let me write the comprehensive audit:"` as text content, then starts emitting a `write_file` tool call
- MiniMax goes silent mid-JSON-arguments
- After 240 s (scaled stale-stream threshold at this context size, `_stream_stale_timeout` in `run_agent.py`), hermes emits `⚠️ No response from provider for 240s ... Reconnecting...`
- Connection is closed, retry runs, also fails the same way
- Final: `deltas_were_sent["yes"] = True` path at line ~6085 takes over → returns a stub with `tool_calls=None`, `finish_reason="stop"`
- Agent treats the turn as complete, writes session footer (`Duration: Xm Ys`, `Messages: N (M user, K tool calls)`)
- **No `/tmp/minimax-audit.md` is written. No error is surfaced to the user. Exit code is 0.**

### 5. Root cause confirmation
Read `run_agent.py` lines 6039-6072 (the `if result["error"] is not None` branch after the streaming while loop):
```python
if deltas_were_sent["yes"]:
    _partial_text = (getattr(self, "_current_streamed_assistant_text", "") or "").strip() or None
    logger.warning("Partial stream delivered before error; returning stub ...")
    _stub_msg = SimpleNamespace(
        role="assistant", content=_partial_text, tool_calls=None,  # ← !!!
        reasoning_content=None,
    )
    return SimpleNamespace(
        id="partial-stream-stub",
        choices=[SimpleNamespace(index=0, message=_stub_msg, finish_reason="stop")],
        ...
    )
```
`tool_calls=None` hard-codes the loss of any in-progress tool call. `tool_calls_acc` (the dict accumulating partial tool-call deltas) is in scope inside `_call_chat_completions` only, so the stub builder can't see it. The fix threads the partial tool names through the shared `result` dict.

### 6. Deterministic repro without a live model (what the new unit test does)
`tests/run_agent/test_streaming.py::TestPartialToolCallWarning::test_partial_tool_call_surfaces_warning` constructs a fake stream as a generator that yields:
1. A text chunk (`content="Let me write the audit: "`) — flips `deltas_were_sent["yes"]`
2. A tool_call delta with `name="write_file"` — populates `tool_calls_acc` + `result["partial_tool_names"]`
3. A tool_call delta with partial args — extends `tool_calls_acc`
4. Then `raise _StallError(...)` — simulates the mid-stream connection death

It patches `_create_request_openai_client` so that the mock's `chat.completions.create` returns this generator, constructs an `AIAgent` with `api_mode="chat_completions"`, and calls `_interruptible_streaming_api_call({})` directly. Runs in ~1 second with no network, no real model. Asserts the stub content contains both the recovered text AND `"Stream stalled mid tool-call"` AND the tool name `"write_file"` AND that the warning was also fired as a live delta.

The paired test `test_partial_text_only_no_warning` uses the same pattern minus the tool-call deltas and asserts the pre-fix bare-recovery behaviour is unchanged for text-only partial streams.

### 7. Re-running just this PR's tests
```bash
cd /home/teknium/.hermes/hermes-agent
scripts/run_tests.sh tests/run_agent/test_streaming.py::TestPartialToolCallWarning -v
```
Expected: 2 passed in <2 s.

### 8. Related environmental gotchas encountered during the hunt
- `tools.*` INFO logging is suppressed under `quiet_mode` via `run_agent.py:923`. Set `HERMES_DEBUG_INTERRUPT=1` to see trace from `tools/environments/base.py` + `tools/interrupt.py`.
- Post-session cleanup (memory flush, title gen, any aux tasks) runs synchronously in-process after the `Duration:` footer. On MiniMax M2.7 that extends wall-clock uptime by minutes. Not a hang.
- `~/.hermes/hermes-agent/` standalone clone lags behind `origin/main` — set `PYTHONPATH` to a worktree for live-test of just-merged fixes.
