### PR TITLE
fix(mattermost): honor metadata.thread_id in send() so delivery-path replies land in-thread (#12063)

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -263,15 +263,31 @@ class MattermostAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
 
+        # Resolve the Mattermost root post id for thread routing from either
+        # the explicit ``reply_to`` argument or ``metadata["thread_id"]``.
+        # ``gateway/delivery.py`` injects the delivery target's thread via
+        # ``metadata`` rather than ``reply_to`` — without the metadata
+        # fallback, delivery-side replies silently land at the channel root
+        # instead of inside the intended thread.  ``reply_to`` still wins
+        # when both are present, preserving the explicit-argument contract.
+        # See issue #12063.
+        root_post_id: Optional[str] = None
+        if self._reply_mode == "thread":
+            if reply_to:
+                root_post_id = reply_to
+            elif metadata and isinstance(metadata, dict):
+                md_thread = metadata.get("thread_id")
+                if isinstance(md_thread, str) and md_thread:
+                    root_post_id = md_thread
+
         last_id = None
         for chunk in chunks:
             payload: Dict[str, Any] = {
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            if root_post_id:
+                payload["root_id"] = root_post_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -241,6 +241,129 @@ class TestMattermostSend:
 
         assert result.success is False
 
+    # ------------------------------------------------------------------
+    # Regression for #12063 — thread routing via metadata["thread_id"]
+    # ------------------------------------------------------------------
+    # ``gateway/delivery.py`` injects thread context into ``metadata``,
+    # not into the ``reply_to`` argument.  Before the fix,
+    # ``MattermostAdapter.send()`` only honored ``reply_to``, so delivery-
+    # path replies silently landed at the channel root even when
+    # ``reply_mode == 'thread'`` and a valid thread_id was present.
+
+    def _stub_ok_post(self, post_id: str = "post_x") -> AsyncMock:
+        """Install a 200-OK stub on ``self.adapter._session.post`` and
+        return the mocked response for inspection."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": post_id})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        return mock_resp
+
+    @pytest.mark.asyncio
+    async def test_send_metadata_thread_id_sets_root_id(self):
+        """metadata['thread_id'] must route to root_id under thread mode."""
+        self.adapter._reply_mode = "thread"
+        self._stub_ok_post("post_a")
+
+        result = await self.adapter.send(
+            "channel_1", "reply via delivery path",
+            metadata={"thread_id": "root_abc"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_abc"
+
+    @pytest.mark.asyncio
+    async def test_send_reply_to_takes_precedence_over_metadata_thread_id(self):
+        """Explicit ``reply_to`` wins when both are supplied — preserves
+        the pre-fix contract for callers who already use reply_to."""
+        self.adapter._reply_mode = "thread"
+        self._stub_ok_post("post_b")
+
+        result = await self.adapter.send(
+            "channel_1", "mixed",
+            reply_to="explicit_root",
+            metadata={"thread_id": "metadata_root"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "explicit_root"
+
+    @pytest.mark.asyncio
+    async def test_send_metadata_thread_id_ignored_when_reply_mode_off(self):
+        """When threading is disabled, metadata.thread_id must NOT route.
+        Matches the existing ``reply_to`` semantics under ``reply_mode='off'``."""
+        self.adapter._reply_mode = "off"
+        self._stub_ok_post("post_c")
+
+        result = await self.adapter.send(
+            "channel_1", "root post",
+            metadata={"thread_id": "root_xyz"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_without_thread_metadata_no_root_id(self):
+        """When neither reply_to nor metadata.thread_id is set, root_id
+        must not appear.  Canary for the post-fix default path."""
+        self.adapter._reply_mode = "thread"
+        self._stub_ok_post("post_d")
+
+        result = await self.adapter.send("channel_1", "plain top-level post")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_metadata_thread_id_non_string_is_ignored(self):
+        """A malformed ``metadata.thread_id`` (non-string / empty) must
+        not be forwarded as ``root_id``.  Mattermost's posts API rejects
+        non-string ``root_id`` with 400; we fail closed locally instead."""
+        self.adapter._reply_mode = "thread"
+        self._stub_ok_post("post_e")
+
+        for bad in (None, "", 12345, ["root_list"], {"inner": "root"}):
+            self.adapter._session.post.reset_mock()
+            result = await self.adapter.send(
+                "channel_1", "guard",
+                metadata={"thread_id": bad},
+            )
+            assert result.success is True
+            payload = self.adapter._session.post.call_args[1]["json"]
+            assert "root_id" not in payload, (
+                f"thread_id={bad!r} was forwarded unexpectedly"
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_all_chunks_carry_root_id_from_metadata(self):
+        """Multi-chunk replies must keep the metadata-resolved root_id on
+        every chunk (not just the first)."""
+        self.adapter._reply_mode = "thread"
+        self._stub_ok_post("post_f")
+
+        # Force chunking by exceeding MAX_POST_LENGTH.
+        from gateway.platforms.mattermost import MAX_POST_LENGTH
+        long_content = "x" * (MAX_POST_LENGTH * 2 + 7)
+
+        await self.adapter.send(
+            "channel_1", long_content,
+            metadata={"thread_id": "root_multi"},
+        )
+
+        calls = self.adapter._session.post.call_args_list
+        assert len(calls) >= 2, f"expected multi-chunk, got {len(calls)} call(s)"
+        for call in calls:
+            assert call[1]["json"]["root_id"] == "root_multi"
+
 
 # ---------------------------------------------------------------------------
 # WebSocket event parsing


### PR DESCRIPTION
## What does this PR do?

Fixes #12063.

`MattermostAdapter.send()` accepted a `metadata` parameter but never read it — `root_id` was only set when callers passed the explicit `reply_to` argument. The gateway delivery path at [`gateway/delivery.py:249-252`](https://github.com/NousResearch/hermes-agent/blob/main/gateway/delivery.py#L249) injects thread context via `metadata["thread_id"]` instead:

```python
send_metadata = dict(metadata or {})
if target.thread_id and "thread_id" not in send_metadata:
    send_metadata["thread_id"] = target.thread_id
return await adapter.send(target.chat_id, content, metadata=send_metadata or None)
```

So with `reply_mode='thread'` and a valid `target.thread_id`, Mattermost silently posted top-level to the channel root. The reporter's minimal repro:

```python
await adapter.send('chan', 'hello', metadata={'thread_id': 'root123'})
# Observed payload on main:
# {'channel_id': 'chan', 'message': 'hello'}    ← root_id missing
```

## Fix

Resolve the Mattermost `root_id` once per call from both sources:

```python
if self._reply_mode == "thread":
    if reply_to:
        root_post_id = reply_to
    elif metadata and isinstance(metadata, dict):
        md_thread = metadata.get("thread_id")
        if isinstance(md_thread, str) and md_thread:
            root_post_id = md_thread
```

- **Precedence**: explicit `reply_to` wins when both are present — preserves the pre-fix contract for any caller that already uses `reply_to`.
- **Type safety**: non-string / empty `metadata["thread_id"]` is rejected defensively (Mattermost's `POST /posts` would otherwise 400 on a non-string `root_id`).
- **Multi-chunk**: the resolver is hoisted out of the chunk loop so long messages carry the same `root_id` on every chunk.

## Precedence / compat truth table

| `reply_to` | `metadata["thread_id"]` | `_reply_mode` | Before | After |
|---|---|---|---|---|
| set | any | `"thread"` | `root_id=reply_to` | **unchanged** |
| set | any | `"off"` | no `root_id` | **unchanged** |
| `None` | valid string | `"thread"` | **no `root_id`** (bug) | `root_id=metadata.thread_id` ✓ |
| `None` | valid string | `"off"` | no `root_id` | **unchanged** |
| `None` | `None` / `""` / non-str | `"thread"` | no `root_id` | **unchanged** |
| `None` | `None` | `"thread"` | no `root_id` | **unchanged** |

## Narrow scope — explicitly not changed

`send_image`, `send_image_file`, and `send_document` all accept `metadata` but route thread context through `_send_remote_file` (`mattermost.py:471`) / `_send_local_file` (`:509`) using the same `reply_to`-only pattern. Those helpers have the analogous gap, but the reporter specifically scoped #12063 to `send()` and text-message replies are the dominant gateway delivery path. **I deliberately did not sweep** — extending to the file-upload path is a clean follow-up if reviewers want it bundled here. Happy to do it in this PR if that's preferred, or to open a tracking issue.

## Pre-empt reviewer Q&A

**Q: Why not normalize at the delivery layer so Mattermost always gets `reply_to`?**
That would push Mattermost-specific routing knowledge into `gateway/delivery.py`, which is intentionally platform-agnostic. The platform adapter is the right place to reconcile its own threading semantics. Other adapters (Slack, Matrix, etc.) may handle this differently and shouldn't be forced through a shared normalizer.

**Q: Is `metadata["thread_id"]` a stable key?**
Yes — it's pinned by `gateway/delivery.py:251` (`send_metadata["thread_id"] = target.thread_id`) and by `SessionSource.thread_id` across the delivery-target abstraction. Grep-verified: no other writer in the codebase.

**Q: Could a malformed `metadata` dict crash `send()`?**
No — `metadata and isinstance(metadata, dict)` guards against `None` and non-dict values, and `isinstance(md_thread, str) and md_thread` rejects `None`, empty strings, ints, lists, and nested dicts. Covered by `test_send_metadata_thread_id_non_string_is_ignored`.

**Q: Multi-chunk handling?**
Resolved once before the chunk loop, applied to every chunk. Covered by `test_send_all_chunks_carry_root_id_from_metadata`.

## Regression coverage

`tests/gateway/test_mattermost.py::TestMattermostSend` gains 6 new tests covering the full precedence table:

- `test_send_metadata_thread_id_sets_root_id` — the core regression; **fails on `origin/main`** with `KeyError: 'root_id'`.
- `test_send_reply_to_takes_precedence_over_metadata_thread_id` — pins the explicit-argument-wins rule.
- `test_send_metadata_thread_id_ignored_when_reply_mode_off` — off-mode canary.
- `test_send_without_thread_metadata_no_root_id` — no-override default canary.
- `test_send_metadata_thread_id_non_string_is_ignored` — type safety against `None` / `""` / int / list / dict.
- `test_send_all_chunks_carry_root_id_from_metadata` — multi-chunk fidelity; **also fails on `origin/main`**.

## How to test

1. Focused suite:
   ```
   source venv/bin/activate
   python -m pytest tests/gateway/test_mattermost.py -q
   ```
   → **49 passed** (43 existing + 6 new).

2. Verify tests catch the bug on origin/main:
   ```
   git stash push gateway/platforms/mattermost.py
   python -m pytest tests/gateway/test_mattermost.py::TestMattermostSend -v
   ```
   → 2 fail with `KeyError: 'root_id'`. Restore with `git stash pop`.

3. CI-aligned broad suite — baseline failure set intact, none in `gateway/platforms/mattermost.py` or `tests/gateway/test_mattermost.py`.

Tested on: macOS 15 (Darwin 25.5.0), Python 3.11.15.

## Related Issue

Fixes #12063

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/mattermost.py`: `send()` now resolves `root_id` from both `reply_to` (existing) and `metadata["thread_id"]` (new), with explicit-argument precedence, defensive type checking, and multi-chunk fidelity.
- `tests/gateway/test_mattermost.py`: 6 new regression tests covering the precedence truth table.

## Adjacent surfaces checked

- `gateway/delivery.py:249-252` — confirmed `send_metadata["thread_id"]` injection contract. Unchanged.
- `_send_remote_file` / `_send_local_file` — noted in "Narrow scope" above.
- Other adapters (Slack, Matrix, Telegram, Discord) — out of scope; each has its own threading semantics.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs — none on #12063
- [x] Only changes related to this fix
- [x] Ran the CI-aligned test command and classified failures baseline-vs-change
- [x] Added tests (6 new; 2 fail on `origin/main` without the fix)
- [x] Tested on macOS 15 (Darwin 25.5.0), Python 3.11.15

### Documentation & Housekeeping

- [x] No docs changes needed — internal adapter behavior, no config-key or public API changes
- [x] No cross-platform impact — Mattermost adapter only
- [x] No tool descriptions/schemas touched

## Notes for reviewers

- No standalone lint command is defined; CI runs `python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`.
- No `hermes_cli/**` changes — the Nix workflow should not trigger.