### PR TITLE
fix: render /profile output through CLI console

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4030,10 +4030,13 @@ class HermesCLI:
         display = display_hermes_home()
         profile_name = get_active_profile_name()
 
-        print()
-        print(f"  Profile: {profile_name}")
-        print(f"  Home:    {display}")
-        print()
+        lines = [
+            "",
+            f"  Profile: {profile_name}",
+            f"  Home:    {display}",
+            "",
+        ]
+        self.console.print("\n".join(lines), highlight=False, markup=False)
 
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -86,7 +86,7 @@ def test_show_session_status_prints_gateway_style_summary():
     assert kwargs.get("markup") is False
 
 
-def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path, capsys):
+def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path):
     """Profile detection works for custom-root deployments (not under ~/.hermes)."""
     cli_obj = _make_cli()
     profile_home = tmp_path / "profiles" / "coder"
@@ -96,6 +96,9 @@ def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path, caps
 
     cli_obj._handle_profile_command()
 
-    out = capsys.readouterr().out
-    assert "Profile: coder" in out
-    assert f"Home:    {profile_home}" in out
+    printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
+    assert "Profile: coder" in printed
+    assert f"Home:    {profile_home}" in printed
+    _, kwargs = cli_obj.console.print.call_args
+    assert kwargs.get("highlight") is False
+    assert kwargs.get("markup") is False


### PR DESCRIPTION
## Summary
- route `/profile` output through `self.console.print(...)` instead of raw `print(...)`
- keep profile output plain-text by disabling Rich markup/highlighting
- update the CLI test to assert the command uses the interactive console path

## Testing
- `source venv/bin/activate && python -m pytest tests/cli/test_cli_status_command.py tests/gateway/test_status_command.py -q`

## Problem
`/profile` was registered and dispatched, but in the interactive CLI its output was written with raw `print(...)`, which could disappear under the prompt_toolkit renderer. `/status` already used `self.console.print(...)`, so this aligns `/profile` with the working path.