### PR TITLE
Fix leaked session rows and stale long-running delegate status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1614,6 +1614,21 @@ class GatewayRunner:
         except Exception:
             pass
 
+    def _should_emit_long_running_notification(
+        self,
+        session_key: Optional[str],
+        agent: Any,
+        executor_task: Optional[asyncio.Future],
+    ) -> bool:
+        """Only notify while this task still owns the live run for the session."""
+        if agent is None:
+            return False
+        if executor_task is not None and executor_task.done():
+            return False
+        if session_key and self._running_agents.get(session_key) is not agent:
+            return False
+        return True
+
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
 
@@ -3923,6 +3938,7 @@ class GatewayRunner:
                                     session_id=session_entry.session_id,
                                 )
                                 try:
+                                    _hyg_agent._end_session_on_close = False
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
                                     loop = asyncio.get_running_loop()
@@ -6582,6 +6598,7 @@ class GatewayRunner:
                 session_id=session_entry.session_id,
             )
             try:
+                tmp_agent._end_session_on_close = False
                 tmp_agent._print_fn = lambda *a, **kw: None
 
                 compressor = tmp_agent.context_compressor
@@ -9597,6 +9614,7 @@ class GatewayRunner:
         _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 600))
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
+        _executor_task = None
 
         async def _notify_long_running():
             if _NOTIFY_INTERVAL is None:
@@ -9606,17 +9624,22 @@ class GatewayRunner:
                 return
             while True:
                 await asyncio.sleep(_NOTIFY_INTERVAL)
+                if _executor_task is not None and _executor_task.done():
+                    break
                 _elapsed_mins = int((time.time() - _notify_start) // 60)
-                # Include agent activity context if available.
                 _agent_ref = agent_holder[0]
+                if not self._should_emit_long_running_notification(
+                    session_key, _agent_ref, _executor_task
+                ):
+                    break
                 _status_detail = ""
-                if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
+                if hasattr(_agent_ref, "get_activity_summary"):
                     try:
                         _a = _agent_ref.get_activity_summary()
                         _parts = [f"iteration {_a['api_call_count']}/{_a['max_iterations']}"]
                         if _a.get("current_tool"):
                             _parts.append(f"running: {_a['current_tool']}")
-                        else:
+                        elif _a.get("last_activity_desc"):
                             _parts.append(_a.get("last_activity_desc", ""))
                         _status_detail = " — " + ", ".join(_parts)
                     except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1235,6 +1235,11 @@ class AIAgent:
         # SQLite session store (optional -- provided by CLI or gateway)
         self._session_db = session_db
         self._parent_session_id = parent_session_id
+        # Most agents own their session row and should finalize it on close().
+        # Some temporary helper agents (manual compression/session-hygiene) rotate
+        # the session forward to a continuation row that must remain open after the
+        # helper is torn down; those callers explicitly override this flag.
+        self._end_session_on_close = True
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
         if self._session_db:
             try:
@@ -3407,6 +3412,7 @@ class AIAgent:
         - Browser daemon sessions
         - Active child agents (subagent delegation)
         - OpenAI/httpx client connections
+        - Owned SQLite session rows for fully-finished agent lifecycles
 
         Safe to call multiple times (idempotent).  Each cleanup step is
         independently guarded so a failure in one does not prevent the rest.
@@ -3453,6 +3459,19 @@ class AIAgent:
             if client is not None:
                 self._close_openai_client(client, reason="agent_close", shared=True)
                 self.client = None
+        except Exception:
+            pass
+
+        # 6. Finalize the owned SQLite session row unless this agent is only a
+        # temporary helper that deliberately handed session ownership forward
+        # (for example manual compression helpers that rotate to a continuation
+        # session_id and must leave that new row open for the caller).
+        try:
+            if getattr(self, "_end_session_on_close", True):
+                session_db = getattr(self, "_session_db", None)
+                session_id = getattr(self, "session_id", None)
+                if session_db and session_id:
+                    session_db.end_session(session_id, "agent_close")
         except Exception:
             pass
 

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -291,3 +291,47 @@ class TestBusySessionAck:
 
         result = await runner._handle_active_session_busy_message(event, sk)
         assert result is False  # not handled, let default path try
+
+
+class TestLongRunningNotificationOwnership:
+    def test_notification_stops_after_session_ownership_moves(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._running_agents = {}
+
+        original_agent = MagicMock()
+        replacement_agent = MagicMock()
+        runner._running_agents["sess"] = replacement_agent
+
+        assert runner._should_emit_long_running_notification(
+            "sess", original_agent, executor_task=None
+        ) is False
+
+    def test_notification_stops_after_executor_finishes(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        agent = MagicMock()
+        runner._running_agents = {"sess": agent}
+
+        done_task = MagicMock()
+        done_task.done.return_value = True
+
+        assert runner._should_emit_long_running_notification(
+            "sess", agent, executor_task=done_task
+        ) is False
+
+    def test_notification_continues_for_live_active_run(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        agent = MagicMock()
+        runner._running_agents = {"sess": agent}
+
+        live_task = MagicMock()
+        live_task.done.return_value = False
+
+        assert runner._should_emit_long_running_notification(
+            "sess", agent, executor_task=live_task
+        ) is True

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -157,6 +157,44 @@ class TestAgentCloseMethod:
             child_2.close.assert_called_once()
             assert agent._active_children == []
 
+    def test_close_ends_owned_session_row(self):
+        """close() should finalize the agent's owned SQLite session row."""
+        from unittest.mock import MagicMock, patch
+
+        with patch("run_agent.AIAgent.__init__", return_value=None):
+            from run_agent import AIAgent
+            agent = AIAgent.__new__(AIAgent)
+            agent.session_id = "test-close-session-row"
+            agent._active_children = []
+            agent._active_children_lock = threading.Lock()
+            agent.client = None
+            agent._end_session_on_close = True
+            agent._session_db = MagicMock()
+
+            agent.close()
+
+            agent._session_db.end_session.assert_called_once_with(
+                "test-close-session-row", "agent_close"
+            )
+
+    def test_close_skips_session_end_for_forwarded_continuation_agents(self):
+        """Temporary helper agents can opt out when they handed session ownership forward."""
+        from unittest.mock import MagicMock, patch
+
+        with patch("run_agent.AIAgent.__init__", return_value=None):
+            from run_agent import AIAgent
+            agent = AIAgent.__new__(AIAgent)
+            agent.session_id = "test-close-forwarded-session"
+            agent._active_children = []
+            agent._active_children_lock = threading.Lock()
+            agent.client = None
+            agent._end_session_on_close = False
+            agent._session_db = MagicMock()
+
+            agent.close()
+
+            agent._session_db.end_session.assert_not_called()
+
     def test_close_survives_partial_failures(self):
         """close() continues cleanup even if one step fails."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
- finalize owned SQLite session rows from `AIAgent.close()` so finished agents do not leave `ended_at IS NULL`
- preserve continuation sessions created by manual compression/session-hygiene helper agents by opting those temporary agents out of close-time finalization
- stop long-running gateway notifications once the executor is done or the session key now points at a different live agent, preventing stale `running: delegate_task` updates from an old run
- add regression tests for both session finalization ownership and long-running notification ownership

## Testing
- `pytest -q tests/tools/test_zombie_process_cleanup.py tests/gateway/test_busy_session_ack.py`
- `pytest -q tests/run_agent/test_exit_cleanup_interrupt.py tests/gateway/test_gateway_inactivity_timeout.py tests/cron/test_cron_inactivity_timeout.py`

Closes #12029.
