### PR TITLE
fix: do not let no-op Home Assistant events consume cooldown

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -288,7 +288,6 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         last = self._last_event_time.get(entity_id, 0)
         if (now - last) < self._cooldown_seconds:
             return
-        self._last_event_time[entity_id] = now
 
         # Build human-readable message
         old_state = event_data.get("old_state", {})
@@ -297,6 +296,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
         if not message:
             return
+
+        self._last_event_time[entity_id] = now
 
         # Build MessageEvent and forward to handler
         source = self.build_source(

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -385,6 +385,21 @@ class TestCooldown:
         assert adapter.handle_message.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_noop_state_change_does_not_consume_cooldown(self):
+        adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
+
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "20", "20", new_attrs={"friendly_name": "Temp"})
+        )
+        assert adapter.handle_message.call_count == 0
+        assert "sensor.temp" not in adapter._last_event_time
+
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "20", "21", new_attrs={"friendly_name": "Temp"})
+        )
+        assert adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_different_entities_independent_cooldowns(self):
         adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
 


### PR DESCRIPTION
## Summary
- fix the Home Assistant adapter so no-op state_changed events do not consume the per-entity cooldown
- update the cooldown timestamp only after _format_state_change(...) produces a real message
- add a regression test that proves a 20 -> 20 event no longer suppresses the following 20 -> 21 change

Closes #12062.

## Testing
- python3 -m pytest -o addopts= tests/gateway/test_homeassistant.py
