### PR TITLE
fix(run_agent): sync primary runtime state with resolved runtime

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1057,12 +1057,35 @@ class AIAgent:
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
-                _routed_client, _ = resolve_provider_client(
+                _routed_client, _resolved_model = resolve_provider_client(
                     self.provider or "auto", model=self.model, raw_codex=True)
                 if _routed_client is not None:
+                    _resolved_base_url = str(_routed_client.base_url)
+                    # router が確定した runtime 情報を primary state に戻す。
+                    # 未確定初期化では base_url だけが埋まり、model/provider が
+                    # 空のまま残ると _primary_runtime も不整合になる。
+                    if _resolved_model and not self.model:
+                        self.model = _resolved_model
+                    if not self.provider:
+                        _resolved_base_lower = _resolved_base_url.lower()
+                        if "openrouter" in _resolved_base_lower:
+                            self.provider = "openrouter"
+                        elif "chatgpt.com/backend-api/codex" in _resolved_base_lower:
+                            self.provider = "openai-codex"
+                        elif "api.x.ai" in _resolved_base_lower:
+                            self.provider = "xai"
+                        elif (
+                            "api.anthropic.com" in _resolved_base_lower
+                            or _resolved_base_lower.rstrip("/").endswith("/anthropic")
+                        ):
+                            self.provider = "anthropic"
+                        elif "bedrock-runtime" in _resolved_base_lower:
+                            self.provider = "bedrock"
+                        elif _resolved_base_url:
+                            self.provider = "custom"
                     client_kwargs = {
                         "api_key": _routed_client.api_key,
-                        "base_url": str(_routed_client.base_url),
+                        "base_url": _resolved_base_url,
                     }
                     # Preserve any default_headers the router set
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -112,6 +112,71 @@ class TestPrimaryRuntimeSnapshot:
         rt = agent._primary_runtime
         assert "anthropic_api_key" not in rt
 
+    @pytest.mark.parametrize(
+        ("provider", "resolved_model", "resolved_base_url", "expected_provider"),
+        [
+            (
+                None,
+                "minimax/minimax-m2.5",
+                "https://openrouter.ai/api/v1",
+                "openrouter",
+            ),
+            (
+                None,
+                "qwen2.5-coder:14b",
+                "http://localhost:11434/v1",
+                "custom",
+            ),
+            (
+                "openrouter",
+                "google/gemini-2.5-flash",
+                "https://openrouter.ai/api/v1",
+                "openrouter",
+            ),
+        ],
+    )
+    def test_snapshot_reflects_routed_runtime_state(
+        self,
+        provider,
+        resolved_model,
+        resolved_base_url,
+        expected_provider,
+    ):
+        """Router の解決結果が primary state に反映されることを確認する。"""
+        mock_client = _mock_resolve(
+            base_url=resolved_base_url,
+            api_key="resolved-key-1234",
+        )
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("run_agent.fetch_model_metadata", return_value={}),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_client, resolved_model),
+            ),
+        ):
+            agent = AIAgent(
+                model="",
+                provider=provider,
+                base_url=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.model == resolved_model
+        assert agent.provider == expected_provider
+        assert agent.base_url == resolved_base_url
+        assert agent._fallback_chain == []
+
+        rt = agent._primary_runtime
+        assert rt["model"] == resolved_model
+        assert rt["provider"] == expected_provider
+        assert rt["base_url"] == resolved_base_url
+
 
 # =============================================================================
 # _restore_primary_runtime()


### PR DESCRIPTION
## What does this PR do?

Fixes an inconsistency in `AIAgent` initialization when the initial primary runtime inputs are unresolved and the actual runtime is later resolved by `resolve_provider_client()`.

This keeps the primary runtime state internally consistent before `_primary_runtime` is snapshotted.

Fixes #12078

## Changes made

- update `run_agent.py`
  - receive the resolved model from `resolve_provider_client()`
  - if `self.model` is empty, sync it from the resolved runtime
  - if `self.provider` is empty, derive/fill it from the resolved base URL
  - keep the resolved `base_url` in sync with the routed runtime

- add regression tests in `tests/run_agent/test_primary_runtime_restore.py`
  - auto -> openrouter
  - auto -> custom/direct
  - same-provider resolution

## Why

Previously, `base_url` could be updated from the routed runtime while `model` and/or `provider` remained empty or stale.

That allowed `_primary_runtime` to snapshot inconsistent values, which could affect later restore / fallback behavior.

## Scope

This PR is intentionally minimal.

It only addresses synchronization of the primary runtime state during initialization.

It does **not** include unrelated local RTK built-in terminal changes or `.bak` cleanup.

## Validation

- added regression coverage for the unresolved -> resolved runtime cases above
- local targeted tests passed
- local compile check passed

