### PR TITLE
fix(cli): coerce max_turns config to int

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1702,9 +1702,9 @@ class HermesCLI:
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns
         elif CLI_CONFIG["agent"].get("max_turns"):
-            self.max_turns = CLI_CONFIG["agent"]["max_turns"]
+            self.max_turns = int(CLI_CONFIG["agent"]["max_turns"])
         elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
-            self.max_turns = CLI_CONFIG["max_turns"]
+            self.max_turns = int(CLI_CONFIG["max_turns"])
         elif os.getenv("HERMES_MAX_ITERATIONS"):
             self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
         else:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -180,6 +180,7 @@ AUTHOR_MAP = {
     "sjtuwbh@gmail.com": "Cygra",
     "srhtsrht17@gmail.com": "Sertug17",
     "stephenschoettler@gmail.com": "stephenschoettler",
+    "binhnt.ht.92@gmail.com": "binhnt92",
     "tanishq231003@gmail.com": "yyovil",
     "tesseracttars@gmail.com": "tesseracttars-creator",
     "tianliangjay@gmail.com": "xingkongliang",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -75,6 +75,11 @@ class TestMaxTurnsResolution:
         cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "42"})
         assert cli_obj.max_turns == 42
 
+    def test_agent_config_string_max_turns_is_coerced_to_int(self):
+        cli_obj = _make_cli(config_overrides={"agent": {"max_turns": "12"}})
+        assert isinstance(cli_obj.max_turns, int)
+        assert cli_obj.max_turns == 12
+
     def test_legacy_root_max_turns_is_used_when_agent_key_exists_without_value(self):
         cli_obj = _make_cli(config_overrides={"agent": {}, "max_turns": 77})
         assert cli_obj.max_turns == 77


### PR DESCRIPTION
When `agent.max_turns` is read from config, quoted YAML values are preserved as strings. That lets values like `"12"` reach the agent loop as `str`, where they later fail at runtime during numeric comparisons.

The env-var path already does `int(os.getenv("HERMES_MAX_ITERATIONS"))`; this makes the config path behave the same way.

## Changes Made

- `cli.py`: coerce nested `agent.max_turns` and legacy root-level `max_turns` to `int` during CLI initialization
- `tests/cli/test_cli_init.py`: add a regression test covering quoted YAML values like `"12"`

## How to Test

```bash
python3 -m pytest tests/cli/test_cli_init.py -q
```

Validated locally before and after the fix:
- before: `str 12` followed by `TypeError: '<' not supported between instances of 'int' and 'str'`
- after: `int 12` and the comparison succeeds

## Checklist

- [x] I've added a regression test for my changes
- [x] I've run `python3 -m pytest tests/cli/test_cli_init.py -q`
- [x] I've verified the original repro before and after the fix on Linux