### PR TITLE
fix(mcp-oauth): proxy asend responses through HermesMCPOAuthProvider wrapper

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -139,3 +139,66 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert isinstance(provider, _HERMES_PROVIDER_CLS)
     assert provider._hermes_server_name == "srv"
 
+
+@pytest.mark.asyncio
+async def test_async_auth_flow_proxies_asend_responses(tmp_path, monkeypatch):
+    """Wrapper preserves bidirectional generator semantics.
+
+    httpx drives auth flows by sending Responses back into the generator
+    via ``gen.asend(response)``. The wrapper MUST forward those values
+    into the inner SDK generator's ``response = yield request`` slot. A
+    naive ``async for item in inner: yield item`` only iterates and
+    silently drops every sent value, causing the SDK to see ``None``
+    where it expects an ``httpx.Response`` and crash on
+    ``response.status_code`` (mcp/client/auth/oauth2.py:514).
+
+    Regression test: drives the wrapper through a two-roundtrip cycle and
+    asserts the inner generator received the exact response objects sent
+    via ``asend``.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools.mcp_oauth_manager import (
+        _HERMES_PROVIDER_CLS, reset_manager_for_tests,
+    )
+    reset_manager_for_tests()
+    assert _HERMES_PROVIDER_CLS is not None
+
+    received_by_inner: list = []
+
+    async def fake_inner_flow(self, request):
+        received_by_inner.append(("first_request", request))
+        response_a = yield "request_A"
+        received_by_inner.append(("after_first_yield", response_a))
+        response_b = yield "request_B"
+        received_by_inner.append(("after_second_yield", response_b))
+
+    monkeypatch.setattr(
+        _HERMES_PROVIDER_CLS.__bases__[0],
+        "async_auth_flow",
+        fake_inner_flow,
+    )
+
+    # Build a provider without invoking the SDK's real init by calling
+    # __new__ + minimal attribute setup; the wrapper only touches
+    # _hermes_server_name and the manager's disk-watch hook.
+    provider = _HERMES_PROVIDER_CLS.__new__(_HERMES_PROVIDER_CLS)
+    provider._hermes_server_name = "srv"
+
+    flow = provider.async_auth_flow(object())  # request value is opaque to wrapper
+
+    item1 = await flow.__anext__()
+    assert item1 == "request_A"
+    item2 = await flow.asend("RESPONSE_1")
+    assert item2 == "request_B"
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend("RESPONSE_2")
+
+    # The critical assertion: the inner generator must have observed the
+    # responses we sent through the wrapper, not None.
+    assert ("after_first_yield", "RESPONSE_1") in received_by_inner, (
+        f"inner generator did not receive sent response; got {received_by_inner!r}"
+    )
+    assert ("after_second_yield", "RESPONSE_2") in received_by_inner, (
+        f"inner generator did not receive sent response; got {received_by_inner!r}"
+    )
+

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -125,9 +125,27 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
-            # Delegate to the SDK's auth flow
-            async for item in super().async_auth_flow(request):
-                yield item
+            # Delegate to the SDK's auth flow with bidirectional send/yield
+            # semantics. The httpx auth-flow protocol is a bidirectional
+            # generator: the SDK yields a request, the consumer sends back
+            # the response via ``gen.asend(response)``, and the SDK reads
+            # it as the value of ``response = yield request``. The naive
+            # ``async for item in inner: yield item`` pattern only iterates
+            # via ``__anext__()`` (equivalent to ``asend(None)``), so every
+            # response sent into the wrapper is silently dropped. The inner
+            # SDK generator then sees ``None`` where it expects an
+            # ``httpx.Response`` and crashes on
+            # ``response.status_code`` (mcp/client/auth/oauth2.py:514),
+            # surfacing as ``'NoneType' object has no attribute
+            # 'status_code'`` for every OAuth-protected MCP server.
+            inner = super().async_auth_flow(request)
+            sent = None
+            try:
+                while True:
+                    item = await inner.asend(sent)
+                    sent = yield item
+            except StopAsyncIteration:
+                return
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
Every connection attempt to an OAuth-protected MCP server crashes with `'NoneType' object has no attribute 'status_code'` before the authorization URL is even generated, breaking all such servers (fresh auth and cached-token fast path alike).

Root cause: the `HermesMCPOAuthProvider.async_auth_flow` wrapper uses `async for item in super().async_auth_flow(request): yield item` to delegate to the SDK's bidirectional generator. That pattern only iterates (effectively `asend(None)` each step), so every value httpx sends back via `gen.asend(response)` is silently dropped. The inner SDK generator's `response = yield request` therefore reads `None`, and the very next line `if response.status_code == 401:` ([`mcp/client/auth/oauth2.py:514`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/client/auth/oauth2.py)) crashes.

Fix: explicit bidirectional proxying via `await inner.asend(sent)` in a `while True` loop, with `StopAsyncIteration` terminating cleanly. The pre-flow disk-watch hook is preserved.

## Standalone reproducer

The bug is a generic Python async-generator delegation issue, independent of MCP / httpx:

```python
import asyncio

async def inner():
    sent = yield "first"
    print(f"inner got: {sent!r}")
    sent = yield "second"
    print(f"inner got: {sent!r}")

async def buggy_wrapper():
    async for item in inner():
        yield item

async def drive(gen):
    g = gen
    await g.asend(None)
    await g.asend("RESPONSE_1")
    try:
        await g.asend("RESPONSE_2")
    except StopAsyncIteration:
        pass

asyncio.run(drive(buggy_wrapper()))
# Output:
#   inner got: None     <- "RESPONSE_1" was lost
#   inner got: None     <- "RESPONSE_2" was lost
```

## Real-world repro

Configure any HTTP MCP server with `auth: oauth` in `~/.hermes/config.yaml`:

```yaml
mcp_servers:
  example:
    url: https://example.com/mcp
    auth: oauth
```

Then `hermes mcp test example` (or any tool invocation that triggers MCP discovery) produces:

```
x Connection failed: 'NoneType' object has no attribute 'status_code'
```

Stack:
```
File "tools/mcp_oauth_manager.py", line 129, in async_auth_flow
    async for item in super().async_auth_flow(request):
File "mcp/client/auth/oauth2.py", line 514, in async_auth_flow
    if response.status_code == 401:
AttributeError: 'NoneType' object has no attribute 'status_code'
```

## Why existing tests miss this

`tests/tools/test_mcp_oauth_manager.py` and `tests/tools/test_mcp_oauth_integration.py` exercise the manager's side effects (mtime invalidation, 401 dedup) by calling `provider._initialize()` directly. Neither ever drives `provider.async_auth_flow(request)` through a real `.asend(response)` cycle, so the broken delegation in the wrapper is never exercised.

## Test plan

- [x] New regression test `test_async_auth_flow_proxies_asend_responses` drives the wrapper through a two-roundtrip asend cycle and asserts the inner generator received the exact response objects sent in.
- [x] Test fails on the previous implementation: `inner generator did not receive sent response; got [..., (..., None), (..., None)]` (surfaces the root cause directly).
- [x] Test passes on the fix.
- [x] Existing OAuth test suites still pass (50/50: `test_mcp_oauth_manager.py`, `test_mcp_oauth_integration.py`, `test_mcp_oauth.py`).
- [x] End-to-end verified against a live OAuth-protected MCP server (CalDAV via OAuth 2.1 PKCE): prior to the fix, every connection failed with the NoneType error; after the fix, the authorization URL is generated, browser auth completes, and the server reports its full tool list.

## Notes

- The fix is the minimum possible, only the delegation pattern changes; the pre-flow disk-watch hook is untouched.
- Affects every OAuth-protected MCP server, including the cached-token fast path (every request still goes through `async_auth_flow`).