### PR TITLE
fix(codex): avoid ChatGPT Codex stream timeouts

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4568,7 +4568,12 @@ class AIAgent:
         # constructs a fresh one — no stale closed transport can be reused.
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
-        if "http_client" not in client_kwargs:
+        _base_url_lower = str(client_kwargs.get("base_url", "")).lower()
+        _is_codex_backend = (
+            self.provider == "openai-codex"
+            or "chatgpt.com/backend-api/codex" in _base_url_lower
+        )
+        if "http_client" not in client_kwargs and not _is_codex_backend:
             try:
                 import httpx as _httpx
                 import socket as _socket
@@ -4799,6 +4804,14 @@ class AIAgent:
         import httpx as _httpx
 
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
+        # ChatGPT Codex's backend-api endpoint has proven flaky with the
+        # SDK's high-level responses.stream() wrapper in this environment:
+        # the same payload succeeds via responses.create(stream=True) but
+        # repeatedly raises APITimeoutError through responses.stream().
+        # Bypass the wrapper for this backend and use the lower-level
+        # streaming create path directly.
+        if "chatgpt.com/backend-api/codex" in (self.base_url or "").lower():
+            return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
         max_stream_retries = 1
         has_tool_calls = False
         first_delta_fired = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -4569,10 +4569,7 @@ class AIAgent:
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
         _base_url_lower = str(client_kwargs.get("base_url", "")).lower()
-        _is_codex_backend = (
-            self.provider == "openai-codex"
-            or "chatgpt.com/backend-api/codex" in _base_url_lower
-        )
+        _is_codex_backend = "chatgpt.com/backend-api/codex" in _base_url_lower
         if "http_client" not in client_kwargs and not _is_codex_backend:
             try:
                 import httpx as _httpx

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -35,3 +35,24 @@ def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
     assert kwargs == snapshot, (
         f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
     )
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_skips_custom_http_client_for_codex_backend(mock_openai):
+    client = MagicMock()
+    mock_openai.return_value = client
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        model="gpt-5.4",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = {"api_key": "test-key", "base_url": "https://chatgpt.com/backend-api/codex"}
+    result = agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    assert result is client
+    assert "http_client" not in mock_openai.call_args.kwargs

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -56,3 +56,24 @@ def test_create_openai_client_skips_custom_http_client_for_codex_backend(mock_op
 
     assert result is client
     assert "http_client" not in mock_openai.call_args.kwargs
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_keeps_custom_http_client_for_non_chatgpt_codex_urls(mock_openai):
+    client = MagicMock()
+    mock_openai.return_value = client
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://proxy.example.com/v1",
+        provider="openai-codex",
+        model="gpt-5.4",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = {"api_key": "test-key", "base_url": "https://proxy.example.com/v1"}
+    result = agent._create_openai_client(kwargs, reason="test", shared=False)
+
+    assert result is client
+    assert "http_client" in mock_openai.call_args.kwargs

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -400,6 +400,7 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
 
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
     agent = _build_agent(monkeypatch)
+    agent.base_url = "https://api.githubcopilot.com"
     calls = {"stream": 0}
 
     def _fake_stream(**kwargs):
@@ -424,6 +425,7 @@ def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
 
 def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(monkeypatch):
     agent = _build_agent(monkeypatch)
+    agent.base_url = "https://api.githubcopilot.com"
     calls = {"stream": 0, "create": 0}
 
     def _fake_stream(**kwargs):
@@ -451,6 +453,7 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
 
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     agent = _build_agent(monkeypatch)
+    agent.base_url = "https://api.githubcopilot.com"
     calls = {"stream": 0, "create": 0}
     create_stream = _FakeCreateStream(
         [
@@ -483,6 +486,28 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_uses_create_stream_path_for_chatgpt_codex_backend(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    stream_client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: (_ for _ in ()).throw(AssertionError("responses.stream should be bypassed")),
+            create=lambda **kwargs: _codex_message_response("unused"),
+        )
+    )
+
+    fallback_response = _codex_message_response("create stream shortcut ok")
+    monkeypatch.setattr(agent, "_ensure_primary_openai_client", lambda reason=None: stream_client)
+    monkeypatch.setattr(
+        agent,
+        "_run_codex_create_stream_fallback",
+        lambda api_kwargs, client=None: fallback_response,
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output[0].content[0].text == "create stream shortcut ok"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a timeout issue when Hermes talks to the ChatGPT Codex backend through the Responses API.

For that backend, the SDK's `responses.stream()` path has been flaky in practice, while `responses.create(stream=True)` succeeds reliably. This PR narrows the workaround to the ChatGPT Codex path by:

- bypassing the custom injected `httpx` transport for the affected Codex backend
- routing that backend through the existing `create(stream=True)` fallback path
- preserving the existing `responses.stream()` behavior for other Codex-style backends covered by the current tests

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- update `_create_openai_client()` to avoid injecting the custom `httpx` transport for the affected Codex backend
- update `_run_codex_stream()` to short-circuit directly to `_run_codex_create_stream_fallback()` for the ChatGPT Codex backend
- add a regression test covering the skipped transport injection
- add a regression test covering the direct create-stream fallback path
- adjust existing Codex stream tests so they continue to exercise the non-ChatGPT backend behavior

## How to Test

1. Run `uv run --with pytest --with pytest-xdist pytest tests/run_agent/test_create_openai_client_kwargs_isolation.py tests/run_agent/test_run_agent_codex_responses.py`
2. Authenticate Hermes with the ChatGPT Codex backend
3. Run `hermes chat -q "hi" --provider openai-codex -Q --yolo --max-turns 1` and confirm the request completes instead of timing out

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
