### PR TITLE
fix(mattermost): honor metadata.thread_id for thread replies

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -264,14 +264,21 @@ class MattermostAdapter(BasePlatformAdapter):
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
 
         last_id = None
+        # Thread support: explicit reply_to wins; gateway delivery also passes
+        # thread context via metadata["thread_id"] (see gateway/delivery.py).
+        root_post_id = reply_to
+        if not root_post_id and metadata:
+            tid = metadata.get("thread_id")
+            if tid:
+                root_post_id = str(tid)
+
         for chunk in chunks:
             payload: Dict[str, Any] = {
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            if root_post_id and self._reply_mode == "thread":
+                payload["root_id"] = root_post_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -206,6 +206,55 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_with_thread_from_metadata(self):
+        """Gateway delivery passes thread_id in metadata; it should become root_id."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post789"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply in thread!",
+            metadata={"thread_id": "root_from_meta"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_from_meta"
+
+    @pytest.mark.asyncio
+    async def test_send_reply_to_overrides_metadata_thread_id(self):
+        """Explicit reply_to should win over metadata.thread_id."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post999"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Reply!",
+            reply_to="explicit_root",
+            metadata={"thread_id": "ignored_root"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "explicit_root"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"


### PR DESCRIPTION
﻿## Summary
- MattermostAdapter.send now maps gateway metadata.thread_id to API root_id when reply_mode is thread, matching gateway/delivery.py behavior
- Explicit reply_to still takes precedence over metadata.thread_id

## Test plan
- Ran tests/gateway/test_mattermost.py::TestMattermostSend (new tests for metadata thread and reply_to precedence)

Closes #12063.
