### PR TITLE
fix: back-fill model/provider after resolve_provider_client (#12078)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1057,8 +1057,9 @@ class AIAgent:
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
-                _routed_client, _ = resolve_provider_client(
-                    self.provider or "auto", model=self.model, raw_codex=True)
+                _resolved_provider = self.provider or "auto"
+                _routed_client, _resolved_model = resolve_provider_client(
+                    _resolved_provider, model=self.model, raw_codex=True)
                 if _routed_client is not None:
                     client_kwargs = {
                         "api_key": _routed_client.api_key,
@@ -1067,6 +1068,12 @@ class AIAgent:
                     # Preserve any default_headers the router set
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
                         client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    # Back-fill model/provider so _primary_runtime captures
+                    # the fully-resolved state (fixes #12078).
+                    if not self.model and _resolved_model:
+                        self.model = _resolved_model
+                    if not self.provider and _resolved_provider != "auto":
+                        self.provider = _resolved_provider
                 else:
                     # When the user explicitly chose a non-OpenRouter provider
                     # but no credentials were found, fail fast with a clear

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -112,6 +112,58 @@ class TestPrimaryRuntimeSnapshot:
         rt = agent._primary_runtime
         assert "anthropic_api_key" not in rt
 
+    def test_snapshot_consistent_after_resolve_provider_client_backfills_model(self):
+        """When model is initially empty and resolve_provider_client resolves it,
+        _primary_runtime must capture the resolved model (fixes #12078)."""
+        mock_client = _mock_resolve(base_url="https://openrouter.ai/api/v1", api_key="rtr-key")
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(mock_client, "google/gemini-2.5-flash")),
+        ):
+            agent = AIAgent(
+                api_key="",       # empty — triggers resolve path
+                base_url="",      # empty — triggers resolve path
+                model="",         # empty — should be back-filled
+                provider="",      # empty — "auto" used, stays empty
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        rt = agent._primary_runtime
+        # Model must be the resolved value, not empty
+        assert rt["model"] == "google/gemini-2.5-flash"
+        assert agent.model == "google/gemini-2.5-flash"
+        # base_url must match what the router returned
+        assert rt["base_url"] == "https://openrouter.ai/api/v1"
+
+    def test_snapshot_consistent_after_resolve_provider_client_backfills_provider(self):
+        """When provider is initially empty but resolve_provider_client is called
+        with a concrete provider, _primary_runtime must capture it (#12078)."""
+        mock_client = _mock_resolve(base_url="https://api.nous.ai/v1", api_key="nous-key")
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(mock_client, "hermes-3-405b")),
+        ):
+            agent = AIAgent(
+                api_key="",
+                base_url="",
+                model="",
+                provider="nous",  # explicit provider — should be preserved
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        rt = agent._primary_runtime
+        assert rt["provider"] == "nous"
+        assert rt["model"] == "hermes-3-405b"
+        assert rt["base_url"] == "https://api.nous.ai/v1"
+
 
 # =============================================================================
 # _restore_primary_runtime()


### PR DESCRIPTION
## Problem
`AIAgent.__init__` captures `_primary_runtime` before `resolve_provider_client()` fully resolves `model` and `provider`, leading to an inconsistent snapshot where `base_url` is set but `model`/`provider` may still be empty.

## Fix
Back-fill `self.model` and `self.provider` from `resolve_provider_client()`'s return values before the `_primary_runtime` snapshot is captured, ensuring it always reflects the fully resolved state.

## Tests
Added two tests verifying model and provider back-fill paths produce consistent `_primary_runtime` snapshots.

Fixes #12078