### PR TITLE
fix(models): Copilot /model validation when /models is unreachable

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2111,6 +2111,37 @@ def validate_requested_model(
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)
 
+    # GitHub Copilot: /models may return HTTP 403 for tokens that can still use chat
+    # completions. Fall back to the built-in Copilot catalog when live listing fails.
+    if normalized in {"copilot", "copilot-acp"} and api_models is None:
+        static_models = _PROVIDER_MODELS.get(normalized, [])
+        static_set = set(static_models)
+        if requested_for_lookup in static_set:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        auto = get_close_matches(requested_for_lookup, static_models, n=1, cutoff=0.9)
+        if auto:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "corrected_model": auto[0],
+                "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+            }
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                "Note: GitHub Copilot `/models` could not be fetched (often HTTP 403 on "
+                "listing despite working chat). Hermes saved this model ID; retry if inference fails."
+            ),
+        }
+
     if api_models is not None:
         if requested_for_lookup in set(api_models):
             # API confirmed the model exists

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -481,6 +481,23 @@ class TestValidateApiFallback:
         assert result["accepted"] is False
         assert result["persist"] is False
 
+    def test_copilot_accepts_builtin_catalog_when_models_unreachable(self):
+        """Copilot /models can 403 while chat works; fall back to static list (#12086)."""
+        with patch("hermes_cli.models.fetch_api_models", return_value=None):
+            result = validate_requested_model("gpt-5.4", "copilot", api_key="token")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result.get("message") is None
+
+    def test_copilot_unknown_model_persists_when_models_unreachable(self):
+        with patch("hermes_cli.models.fetch_api_models", return_value=None):
+            result = validate_requested_model("future-unknown-model", "copilot", api_key="token")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "could not be fetched" in result["message"]
+
     def test_custom_endpoint_warns_with_probed_url_and_v1_hint(self):
         with patch(
             "hermes_cli.models.probe_api_models",


### PR DESCRIPTION
﻿## Summary
- When GitHub Copilot live `/models` cannot be fetched (common HTTP 403 while chat still works), `validate_requested_model` now falls back to the built-in Copilot catalog instead of hard-failing Discord `/model`.
- Unknown model IDs still save with a warning so users are not blocked when listing is down.

## Test plan
- Ran tests/hermes_cli/test_model_validation.py::TestValidateApiFallback new cases

Closes #12086.
