### PR TITLE
[codex] fix gateway session key isolation for named profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -568,7 +568,9 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    ``agent:{profile}:{platform}:{chat_type}:{chat_id}[:{extra}...]``,
+    where ``{profile}`` is ``main`` for the default profile or a named
+    Hermes profile (see :func:`hermes_constants.get_profile_name`).
     Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
@@ -578,7 +580,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
         result = {
             "platform": parts[2],
             "chat_type": parts[3],

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -587,7 +587,17 @@ def build_session_key(
       - Without participant identifiers, or when isolation is disabled, messages fall back to one
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
+
+    The ``agent:<profile>`` prefix is derived from ``HERMES_HOME`` via
+    :func:`hermes_constants.get_profile_name`.  Named profiles
+    (``<root>/profiles/<name>``) emit ``agent:<name>:…``; the default
+    profile continues to emit ``agent:main:…`` so existing session keys
+    remain stable.  Without this scoping, concurrent profiles sharing the
+    same gateway would collide in the session namespace.
     """
+    from hermes_constants import get_profile_name
+
+    prefix = f"agent:{get_profile_name()}"
     platform = source.platform.value
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
@@ -596,11 +606,11 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_chat_id}"
+                return f"{prefix}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+            return f"{prefix}:{platform}:dm:{dm_chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{prefix}:{platform}:dm:{source.thread_id}"
+        return f"{prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -608,7 +618,7 @@ def build_session_key(
         # single group member gets two isolated per-user sessions when the
         # bridge reshuffles alias forms.
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -18,6 +18,22 @@ def get_hermes_home() -> Path:
     return Path(val) if val else Path.home() / ".hermes"
 
 
+def get_profile_name() -> str:
+    """Return the active Hermes profile name.
+
+    When ``HERMES_HOME`` is ``<root>/profiles/<name>`` (standard or Docker
+    layout), returns ``<name>``.  Otherwise returns ``"main"``.
+
+    Used by consumers that need per-profile isolation at runtime — notably
+    gateway session keys, which must not collide across profiles for the
+    same platform/chat identifiers.
+    """
+    home = get_hermes_home()
+    if home.parent.name == "profiles":
+        return home.name
+    return "main"
+
+
 def get_default_hermes_root() -> Path:
     """Return the root Hermes directory for profile-level operations.
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -496,6 +496,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -413,4 +413,16 @@ def test_parse_session_key_too_short():
 
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
-    assert _parse_session_key("agent:cron:telegram:dm:123") is None
+    # Empty profile segment (``agent::…``) is not a real session key.
+    assert _parse_session_key("agent::telegram:dm:123") is None
+
+
+def test_parse_session_key_named_profile():
+    """Named-profile keys (``agent:<profile>:…``) must parse like default keys."""
+    result = _parse_session_key("agent:coder:telegram:dm:chat1:topic42")
+    assert result == {
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "chat1",
+        "thread_id": "topic42",
+    }

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1232,3 +1232,112 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("reasoning_content") == "provider scratchpad"
         assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
+
+
+class TestBuildSessionKeyProfileScoping:
+    """Session keys must be scoped by the active Hermes profile.
+
+    Regression coverage for #12099: ``build_session_key()`` used to hardcode
+    ``agent:main`` as the prefix, so concurrent Hermes profiles (e.g.
+    ``<root>/profiles/wechat`` + ``<root>/profiles/feishu``) produced
+    colliding session keys for the same platform/chat identifiers.
+    """
+
+    def test_default_profile_is_backward_compatible(self, monkeypatch):
+        """Default profile (no HERMES_HOME under ``profiles/``) → ``agent:main:``."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        assert build_session_key(source) == "agent:main:telegram:dm:12345"
+
+    def test_named_profile_uses_profile_in_prefix(self, tmp_path, monkeypatch):
+        """Named profile → ``agent:<name>:…`` (both DM and group shapes)."""
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "coder")
+        )
+        dm = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        group = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-456",
+            chat_type="group",
+            user_id="alice",
+        )
+        assert build_session_key(dm) == "agent:coder:telegram:dm:12345"
+        assert build_session_key(group) == "agent:coder:discord:group:guild-456:alice"
+
+    def test_named_profile_dm_with_thread(self, tmp_path, monkeypatch):
+        """Threaded DM under a named profile preserves both thread_id and profile."""
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "feishu")
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="99",
+            chat_type="dm",
+            thread_id="t42",
+        )
+        assert build_session_key(source) == "agent:feishu:telegram:dm:99:t42"
+
+    def test_different_profiles_do_not_collide(self, tmp_path, monkeypatch):
+        """Same source under two named profiles yields distinct session keys."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "alpha")
+        )
+        key_alpha = build_session_key(source)
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "beta")
+        )
+        key_beta = build_session_key(source)
+        assert key_alpha == "agent:alpha:telegram:dm:12345"
+        assert key_beta == "agent:beta:telegram:dm:12345"
+        assert key_alpha != key_beta
+
+    def test_docker_profile_path(self, monkeypatch):
+        """Docker layout ``/opt/data/profiles/worker`` → ``agent:worker:…``."""
+        monkeypatch.setenv("HERMES_HOME", "/opt/data/profiles/worker")
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="55",
+            chat_type="dm",
+        )
+        assert build_session_key(source) == "agent:worker:telegram:dm:55"
+
+    def test_build_and_parse_roundtrip_named_profile(self, tmp_path, monkeypatch):
+        """``_parse_session_key()`` must accept keys produced for named profiles.
+
+        #12103 only fixed the construction side; without this round-trip the
+        gateway parses named-profile keys to ``None`` and loses routing.
+        """
+        from gateway.run import _parse_session_key
+
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "coder")
+        )
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chan1",
+            chat_type="thread",
+            thread_id="thread99",
+        )
+        key = build_session_key(source)
+        assert key == "agent:coder:discord:thread:chan1:thread99"
+
+        parsed = _parse_session_key(key)
+        assert parsed == {
+            "platform": "discord",
+            "chat_type": "thread",
+            "chat_id": "chan1",
+            "thread_id": "thread99",
+        }

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 import hermes_constants
-from hermes_constants import get_default_hermes_root, is_container
+from hermes_constants import get_default_hermes_root, get_profile_name, is_container
 
 
 class TestGetDefaultHermesRoot:
@@ -111,3 +111,34 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestGetProfileName:
+    """Tests for get_profile_name() — the runtime profile identity."""
+
+    def test_no_hermes_home_returns_main(self, monkeypatch):
+        """HERMES_HOME unset → default profile ``main``."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert get_profile_name() == "main"
+
+    def test_default_hermes_home_returns_main(self, tmp_path, monkeypatch):
+        """HERMES_HOME = ``<something>/.hermes`` (no profile) → ``main``."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        assert get_profile_name() == "main"
+
+    def test_named_profile_standard_layout(self, tmp_path, monkeypatch):
+        """HERMES_HOME = ``<root>/profiles/<name>`` → ``<name>``."""
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "coder")
+        )
+        assert get_profile_name() == "coder"
+
+    def test_named_profile_docker_layout(self, monkeypatch):
+        """Docker layout ``/opt/data/profiles/worker`` → ``worker``."""
+        monkeypatch.setenv("HERMES_HOME", "/opt/data/profiles/worker")
+        assert get_profile_name() == "worker"
+
+    def test_custom_non_profile_path_returns_main(self, tmp_path, monkeypatch):
+        """HERMES_HOME outside any ``profiles/`` parent → ``main``."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom-hermes"))
+        assert get_profile_name() == "main"


### PR DESCRIPTION
## Summary
- scope gateway session keys by the active Hermes profile instead of hardcoding `agent:main`
- preserve `agent:main` for the default/custom-root deployment so existing session keys remain stable
- teach `_parse_session_key()` to understand named-profile session keys and add regression coverage

## Root Cause
`build_session_key()` always emitted the `agent:main` prefix, so named profiles shared the same gateway session namespace. That let different profiles generate colliding session keys for the same platform/chat identifiers.

## Testing
- `python -m pytest tests/gateway/test_session.py -q`
- `python -m pytest tests/gateway/test_background_process_notifications.py -q`
- `python -m pytest tests/gateway/test_interrupt_key_match.py -q tests/gateway/test_resume_command.py -q tests/gateway/test_session_model_reset.py -q tests/gateway/test_session_race_guard.py -q`

Fixes #12099
