### PR TITLE
fix(session): derive profile from HERMES_HOME instead of hardcoding 'main'

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -446,6 +446,12 @@ def build_session_key(
 
     This is the single source of truth for session key construction.
 
+    The ``agent:<profile>`` prefix is derived from ``HERMES_HOME`` via
+    :func:`hermes_constants.get_profile_name`.  Named profiles
+    (``~/.hermes/profiles/<name>``) produce ``agent:<name>:…``; the
+    default profile produces ``agent:main:…``, preserving backward
+    compatibility.
+
     DM rules:
       - DMs include chat_id when present, so each private conversation is isolated.
       - thread_id further differentiates threaded DMs within the same DM chat.
@@ -465,18 +471,22 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
+    from hermes_constants import get_profile_name
+
+    profile = get_profile_name()
+    prefix = f"agent:{profile}"
     platform = source.platform.value
     if source.chat_type == "dm":
         if source.chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{source.chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{source.chat_id}"
+                return f"{prefix}:{platform}:dm:{source.chat_id}:{source.thread_id}"
+            return f"{prefix}:{platform}:dm:{source.chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{prefix}:{platform}:dm:{source.thread_id}"
+        return f"{prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -18,6 +18,22 @@ def get_hermes_home() -> Path:
     return Path(val) if val else Path.home() / ".hermes"
 
 
+def get_profile_name() -> str:
+    """Return the current profile name derived from HERMES_HOME.
+
+    Profile detection logic:
+      - If HERMES_HOME is ``<root>/profiles/<name>``, returns ``<name>``.
+      - Otherwise returns ``"main"`` (the default profile).
+
+    This is used wherever the profile identity matters at runtime,
+    e.g. session key construction for multi-profile isolation.
+    """
+    home = get_hermes_home()
+    if home.parent.name == "profiles":
+        return home.name
+    return "main"
+
+
 def get_default_hermes_root() -> Path:
     """Return the root Hermes directory for profile-level operations.
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1062,3 +1062,102 @@ class TestRewriteTranscriptPreservesReasoning:
         assert after[0].get("reasoning") == "I need to think step by step."
         assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
         assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
+
+
+class TestBuildSessionKeyProfileIsolation:
+    """Session keys must include the active profile name, not hardcode 'main'.
+
+    Fixes #12099: build_session_key() hardcodes 'agent:main', breaking
+    multi-profile session isolation.
+    """
+
+    def test_default_profile_uses_main(self):
+        """Default profile (no HERMES_HOME or standard ~/.hermes) → 'agent:main'."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        # Default env (no HERMES_HOME set to a profiles/ path) → "main"
+        with patch("hermes_constants.get_hermes_home", return_value=Path.home() / ".hermes"):
+            key = build_session_key(source)
+        assert key == "agent:main:telegram:dm:12345"
+
+    def test_named_profile_uses_profile_name_dm(self):
+        """Named profile 'coder' → 'agent:coder' in DM session keys."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        with patch(
+            "hermes_constants.get_hermes_home",
+            return_value=Path.home() / ".hermes" / "profiles" / "coder",
+        ):
+            key = build_session_key(source)
+        assert key == "agent:coder:telegram:dm:12345"
+
+    def test_named_profile_uses_profile_name_group(self):
+        """Named profile 'wechat-bot' → 'agent:wechat-bot' in group keys."""
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="guild-456",
+            chat_type="group",
+            user_id="alice",
+        )
+        with patch(
+            "hermes_constants.get_hermes_home",
+            return_value=Path.home() / ".hermes" / "profiles" / "wechat-bot",
+        ):
+            key = build_session_key(source)
+        assert key == "agent:wechat-bot:discord:group:guild-456:alice"
+
+    def test_named_profile_dm_with_thread(self):
+        """Named profile with threaded DM → profile prefix preserved."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="99",
+            chat_type="dm",
+            thread_id="t42",
+        )
+        with patch(
+            "hermes_constants.get_hermes_home",
+            return_value=Path.home() / ".hermes" / "profiles" / "feishu",
+        ):
+            key = build_session_key(source)
+        assert key == "agent:feishu:telegram:dm:99:t42"
+
+    def test_different_profiles_produce_different_keys(self):
+        """Same source, different profiles → different session keys (no collision)."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+        )
+        with patch(
+            "hermes_constants.get_hermes_home",
+            return_value=Path.home() / ".hermes" / "profiles" / "alpha",
+        ):
+            key_alpha = build_session_key(source)
+        with patch(
+            "hermes_constants.get_hermes_home",
+            return_value=Path.home() / ".hermes" / "profiles" / "beta",
+        ):
+            key_beta = build_session_key(source)
+        assert key_alpha != key_beta
+        assert "agent:alpha:" in key_alpha
+        assert "agent:beta:" in key_beta
+
+    def test_docker_profile_path(self):
+        """Docker layout /opt/data/profiles/worker → 'agent:worker'."""
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="55",
+            chat_type="dm",
+        )
+        with patch(
+            "hermes_constants.get_hermes_home",
+            return_value=Path("/opt/data/profiles/worker"),
+        ):
+            key = build_session_key(source)
+        assert key == "agent:worker:telegram:dm:55"

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -111,3 +111,41 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestGetProfileName:
+    """Tests for get_profile_name() — profile identity from HERMES_HOME."""
+
+    def test_default_returns_main(self, tmp_path, monkeypatch):
+        """When HERMES_HOME is ~/.hermes (default), returns 'main'."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        from hermes_constants import get_profile_name
+        assert get_profile_name() == "main"
+
+    def test_no_env_returns_main(self, monkeypatch):
+        """When HERMES_HOME is unset, falls back to ~/.hermes → 'main'."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        from hermes_constants import get_profile_name
+        assert get_profile_name() == "main"
+
+    def test_named_profile(self, tmp_path, monkeypatch):
+        """HERMES_HOME=<root>/profiles/coder → 'coder'."""
+        monkeypatch.setenv(
+            "HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "coder")
+        )
+        from hermes_constants import get_profile_name
+        assert get_profile_name() == "coder"
+
+    def test_docker_profile(self, tmp_path, monkeypatch):
+        """Docker layout: /opt/data/profiles/worker → 'worker'."""
+        monkeypatch.setenv(
+            "HERMES_HOME", str(Path("/opt/data/profiles/worker"))
+        )
+        from hermes_constants import get_profile_name
+        assert get_profile_name() == "worker"
+
+    def test_custom_non_profile_path(self, tmp_path, monkeypatch):
+        """Arbitrary HERMES_HOME that is not under profiles/ → 'main'."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "my-custom-hermes"))
+        from hermes_constants import get_profile_name
+        assert get_profile_name() == "main"


### PR DESCRIPTION
## Summary

`build_session_key()` hardcodes `agent:main` as the session key prefix, ignoring the current profile configuration. When multiple profiles are used (WeChat, Feishu, etc.), sessions from different profiles collide under the same `agent:main` namespace.

## Problem

Reported in #12099:

1. **Session key collision** — the same user's conversations across different profiles generate identical session keys
2. **Cross-profile memory confusion** — WeChat messages may read/write to another profile's memory
3. **Broken multi-profile isolation** — the core session isolation promise of the profile system is violated

## Root Cause

All six `agent:main` references in `build_session_key()` are hardcoded string literals:

```python
return f"agent:main:{platform}:dm:{source.chat_id}"
...
key_parts = ["agent:main", platform, source.chat_type]
```

## Fix

**1. `hermes_constants.py` — add `get_profile_name()`**

Derives the active profile name from `HERMES_HOME`:
- `~/.hermes/profiles/coder` → `"coder"`
- `~/.hermes` (default) → `"main"`
- `/opt/data/profiles/worker` (Docker) → `"worker"`

Uses the same `parent.name == "profiles"` detection already used in `get_default_hermes_root()`. Import-safe, no new dependencies.

**2. `gateway/session.py` — use profile-aware prefix**

Replaces all hardcoded `"agent:main"` with `f"agent:{profile}"` where `profile = get_profile_name()`.

## Backward Compatibility

- Default profile (no `HERMES_HOME` or `~/.hermes`) still produces `agent:main:...` keys — **no migration needed**.
- Named profiles get proper isolation with `agent:<name>:...` keys.
- Existing sessions on the default profile continue to work unchanged.

## Tests

- `TestGetProfileName`: 5 test cases for profile name derivation (default, unset, named, Docker, custom path)
- `TestBuildSessionKeyProfileIsolation`: 6 test cases for session key profile isolation (default, named DM, named group, threaded DM, cross-profile collision, Docker layout)

Fixes #12099