### PR TITLE
fix: align gateway scope truth and detached system actions

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,10 +6,12 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import shlex
 import shutil
 import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
@@ -106,6 +108,16 @@ def find_gateway_pids(exclude_pids: set | None = None) -> list:
         "hermes gateway",
         "gateway/run.py",
     ]
+    management_markers = [
+        " gateway status",
+        " gateway install",
+        " gateway uninstall",
+        " gateway start",
+        " gateway stop",
+        " gateway restart",
+        " gateway setup",
+        " gateway --help",
+    ]
 
     try:
         if is_windows():
@@ -122,7 +134,8 @@ def find_gateway_pids(exclude_pids: set | None = None) -> list:
                     current_cmd = line[len("CommandLine="):]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId="):]
-                    if any(p in current_cmd for p in patterns):
+                    lowered = current_cmd.lower()
+                    if any(p in current_cmd for p in patterns) and not any(marker in lowered for marker in management_markers):
                         try:
                             pid = int(pid_str)
                             if pid != os.getpid() and pid not in pids and pid not in _exclude:
@@ -140,6 +153,9 @@ def find_gateway_pids(exclude_pids: set | None = None) -> list:
             for line in result.stdout.split('\n'):
                 # Skip grep and current process
                 if 'grep' in line or str(os.getpid()) in line:
+                    continue
+                lowered = line.lower()
+                if any(marker in lowered for marker in management_markers):
                     continue
                 for pattern in patterns:
                     if pattern in line:
@@ -354,16 +370,167 @@ def _service_scope_label(system: bool = False) -> str:
     return "system" if system else "user"
 
 
+def _read_systemd_env_from_unit(unit_path: Path, key: str) -> str | None:
+    if not unit_path.exists():
+        return None
+
+    quoted_prefix = f'Environment="{key}='
+    plain_prefix = f"Environment={key}="
+    for line in unit_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith(quoted_prefix):
+            value = stripped[len(quoted_prefix):]
+            return value[:-1] if value.endswith('"') else value
+        if stripped.startswith(plain_prefix):
+            return stripped[len(plain_prefix):]
+    return None
+
+
+def _matching_systemd_units(hermes_home: Path | None = None) -> list[dict]:
+    current_home = (hermes_home or get_hermes_home()).resolve()
+    current_home_text = str(current_home)
+    requested_name = get_service_name()
+    rows = []
+
+    for system, scope, root in (
+        (False, "user", Path.home() / ".config" / "systemd" / "user"),
+        (True, "system", Path("/etc/systemd/system")),
+    ):
+        if not root.exists():
+            continue
+        canonical_path = get_systemd_unit_path(system=system)
+        for unit_path in sorted(root.glob("hermes-gateway*.service")):
+            configured_home = _read_systemd_env_from_unit(unit_path, "HERMES_HOME")
+            matches_current_home = unit_path == canonical_path
+            if configured_home:
+                try:
+                    matches_current_home = str(Path(configured_home).resolve()) == current_home_text
+                except Exception:
+                    matches_current_home = configured_home == current_home_text
+            if not matches_current_home:
+                continue
+            rows.append({
+                "name": unit_path.stem,
+                "path": unit_path,
+                "system": system,
+                "scope": scope,
+                "canonical": unit_path.stem == requested_name,
+                "configured_home": configured_home,
+            })
+    return rows
+
+
+def _systemd_unit_runtime(unit_name: str, system: bool = False) -> dict:
+    command = _systemctl_cmd(system) + ["is-active", unit_name]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "active": None,
+            "reachable": False,
+            "state": "timeout",
+            "error": str(exc),
+            "command": " ".join(command),
+        }
+    except FileNotFoundError as exc:
+        return {
+            "active": None,
+            "reachable": False,
+            "state": "systemctl-missing",
+            "error": str(exc),
+            "command": " ".join(command),
+        }
+
+    stdout = (result.stdout or "").strip()
+    stderr = (result.stderr or "").strip()
+    state = stdout or ("unreachable" if "Failed to connect to bus" in stderr else "unknown")
+    reachable = "Failed to connect to bus" not in stderr
+    active = stdout == "active" if reachable else None
+    if reachable and active is False and not state:
+        state = "inactive"
+
+    return {
+        "active": active,
+        "reachable": reachable,
+        "state": state,
+        "stdout": stdout,
+        "stderr": stderr,
+        "exit_code": result.returncode,
+        "command": " ".join(command),
+    }
+
+
+def get_gateway_systemd_report(requested_scope: str | None = None) -> dict:
+    requested_name = get_service_name()
+    units = []
+    for row in _matching_systemd_units():
+        if requested_scope in {"user", "system"} and row["scope"] != requested_scope:
+            continue
+        runtime = _systemd_unit_runtime(row["name"], system=bool(row["system"]))
+        units.append({**row, "runtime": runtime})
+
+    if not units:
+        return {
+            "installed": False,
+            "requested_name": requested_name,
+            "requested_scope": requested_scope,
+            "units": [],
+        }
+
+    def _sort_key(item: dict) -> tuple:
+        runtime = item.get("runtime", {})
+        scope_match = requested_scope is not None and item.get("scope") == requested_scope
+        return (
+            runtime.get("active") is True,
+            scope_match,
+            item.get("canonical") is True,
+            runtime.get("reachable") is True,
+            item.get("scope") == "system",
+        )
+
+    chosen = max(units, key=_sort_key)
+    return {
+        "installed": True,
+        "requested_name": requested_name,
+        "requested_scope": requested_scope,
+        "unit_name": chosen["name"],
+        "unit_path": str(chosen["path"]),
+        "scope": chosen["scope"],
+        "system": bool(chosen["system"]),
+        "canonical": bool(chosen["canonical"]),
+        "configured_home": chosen.get("configured_home"),
+        "active": chosen["runtime"].get("active"),
+        "reachable": chosen["runtime"].get("reachable"),
+        "state": chosen["runtime"].get("state"),
+        "runtime": chosen["runtime"],
+        "units": [
+            {
+                "name": item["name"],
+                "path": str(item["path"]),
+                "scope": item["scope"],
+                "canonical": bool(item["canonical"]),
+                "configured_home": item.get("configured_home"),
+                "active": item["runtime"].get("active"),
+                "reachable": item["runtime"].get("reachable"),
+                "state": item["runtime"].get("state"),
+            }
+            for item in units
+        ],
+        "drifted": chosen["name"] != requested_name,
+    }
+
+
 def get_installed_systemd_scopes() -> list[str]:
     scopes = []
-    seen_paths: set[Path] = set()
-    for system, label in ((False, "user"), (True, "system")):
-        unit_path = get_systemd_unit_path(system=system)
-        if unit_path in seen_paths:
-            continue
-        if unit_path.exists():
-            scopes.append(label)
-            seen_paths.add(unit_path)
+    for row in _matching_systemd_units():
+        scope = row.get("scope")
+        if scope and scope not in scopes:
+            scopes.append(scope)
     return scopes
 
 
@@ -379,10 +546,45 @@ def print_systemd_scope_conflict_warning() -> None:
     rendered_scopes = " + ".join(scopes)
     print_warning(f"Both user and system gateway services are installed ({rendered_scopes}).")
     print_info("  This is confusing and can make start/stop/status behavior ambiguous.")
-    print_info("  Default gateway commands target the user service unless you pass --system.")
-    print_info("  Keep one of these:")
-    print_info("    hermes gateway uninstall")
+    print_info("  Default gateway commands auto-target the best matching service for this HERMES_HOME.")
+    print_info("  Pass --user or --system to force the scope explicitly.")
+    print_info("  Inspect explicitly:")
+    print_info("    hermes gateway status --user")
+    print_info("    hermes gateway status --system")
+    print_info("  Clean up explicitly:")
+    print_info("    hermes gateway uninstall --user")
     print_info("    sudo hermes gateway uninstall --system")
+
+
+def _requested_systemd_scope(system: bool = False, user: bool = False) -> str | None:
+    if system and user:
+        raise ValueError("Choose only one of --system or --user.")
+    if system:
+        return "system"
+    if user:
+        return "user"
+    return None
+
+
+
+def _resolve_systemd_service_target(system: bool = False, user: bool = False) -> dict:
+    requested_scope = _requested_systemd_scope(system=system, user=user)
+    report = get_gateway_systemd_report(requested_scope=requested_scope)
+    if report.get("installed"):
+        return report
+
+    selected_system = _select_systemd_scope(system=system, user=user)
+    return {
+        "installed": False,
+        "requested_name": get_service_name(),
+        "requested_scope": requested_scope,
+        "unit_name": get_service_name(),
+        "unit_path": str(get_systemd_unit_path(system=selected_system)),
+        "scope": _service_scope_label(selected_system),
+        "system": selected_system,
+        "canonical": True,
+        "drifted": False,
+    }
 
 
 def _require_root_for_system_service(action: str) -> None:
@@ -425,11 +627,141 @@ def _read_systemd_user_from_unit(unit_path: Path) -> str | None:
     return None
 
 
+_wsl_detected: bool | None = None
+
+
 def _default_system_service_user() -> str | None:
     for candidate in (os.getenv("SUDO_USER"), os.getenv("USER"), os.getenv("LOGNAME")):
         if candidate and candidate.strip() and candidate.strip() != "root":
             return candidate.strip()
     return None
+
+
+def _is_wsl() -> bool:
+    global _wsl_detected
+    if _wsl_detected is not None:
+        return _wsl_detected
+    try:
+        _wsl_detected = "microsoft" in Path("/proc/version").read_text(encoding="utf-8").lower()
+    except Exception:
+        _wsl_detected = False
+    return _wsl_detected
+
+
+def _find_wsl_executable() -> str | None:
+    candidates = [
+        "/mnt/c/Windows/System32/wsl.exe",
+        shutil.which("wsl.exe"),
+        shutil.which("wsl"),
+    ]
+    for candidate in candidates:
+        if candidate and (not os.path.isabs(candidate) or Path(candidate).exists()):
+            return candidate
+    return None
+
+
+def _running_from_gateway_surface() -> bool:
+    return bool(os.getenv("HERMES_GATEWAY_SESSION") or os.getenv("HERMES_SESSION_PLATFORM"))
+
+
+def _should_detach_system_service_action(report: dict | None = None) -> bool:
+    report = report or {}
+    return (
+        is_linux()
+        and bool(report.get("installed"))
+        and bool(report.get("system"))
+        and _running_from_gateway_surface()
+    )
+
+
+def _detached_gateway_log_path(action_name: str, hermes_home: str) -> Path:
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    log_dir = Path(hermes_home) / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    return log_dir / f"gateway-{action_name}-{timestamp}.log"
+
+
+def _schedule_detached_system_gateway_cli(action_name: str, hermes_args: list[str]) -> tuple[str, Path]:
+    target = _resolve_systemd_service_target(system=True, user=False)
+    if not bool(target.get("system")):
+        raise ValueError("Detached gateway control only supports system-scope services")
+
+    unit_name = target.get("unit_name") or get_service_name()
+    unit_path_text = target.get("unit_path")
+    unit_path = Path(unit_path_text) if unit_path_text else get_systemd_unit_path(system=True)
+    configured_user = _read_systemd_user_from_unit(unit_path) or _default_system_service_user()
+    username, _, home_dir = _system_service_identity(run_as_user=configured_user)
+    hermes_home = _read_systemd_env_from_unit(unit_path, "HERMES_HOME") or _hermes_home_for_target_user(home_dir)
+    log_path = _detached_gateway_log_path(action_name, hermes_home)
+    transient_unit = f"{unit_name}-{action_name}-{int(time.time())}"
+
+    hermes_cmd = shlex.join(shlex.split(get_hermes_cli_path()) + hermes_args)
+    env_assignments = " ".join(
+        [
+            f"HOME={shlex.quote(home_dir)}",
+            f"USER={shlex.quote(username)}",
+            f"LOGNAME={shlex.quote(username)}",
+            f"HERMES_HOME={shlex.quote(hermes_home)}",
+        ]
+    )
+    log_path_quoted = shlex.quote(str(log_path))
+    log_dir_quoted = shlex.quote(str(log_path.parent))
+    shell_script = (
+        "set -euo pipefail; "
+        f"mkdir -p {log_dir_quoted}; "
+        f"printf '%s\\n' \"=== $(date '+%Y-%m-%d %H:%M:%S %Z') detached gateway {action_name} start ===\" >> {log_path_quoted}; "
+        "sleep 2; "
+        f"env {env_assignments} {hermes_cmd} >> {log_path_quoted} 2>&1; "
+        "status=$?; "
+        f"printf '%s\\n' \"=== detached gateway {action_name} exit ${'{'}status{'}'} ===\" >> {log_path_quoted}; "
+        "exit \"$status\""
+    )
+    systemd_run_cmd = [
+        "systemd-run",
+        "--unit",
+        transient_unit,
+        "--collect",
+        "--service-type=oneshot",
+        "--no-block",
+        "/bin/bash",
+        "-lc",
+        shell_script,
+    ]
+
+    launch_cmd = systemd_run_cmd
+    if os.geteuid() != 0:
+        if not _is_wsl():
+            raise PermissionError(
+                f"System gateway {action_name} requires root. Re-run with sudo."
+            )
+        wsl_exe = _find_wsl_executable()
+        distro = os.getenv("WSL_DISTRO_NAME")
+        if not wsl_exe or not distro:
+            raise PermissionError(
+                f"System gateway {action_name} requires root, and no WSL root bridge is available. Re-run with sudo."
+            )
+        launch_cmd = [wsl_exe, "-d", distro, "-u", "root", "--", *systemd_run_cmd]
+
+    subprocess.run(launch_cmd, check=True, timeout=30)
+    return transient_unit, log_path
+
+
+def _print_detached_system_gateway_notice(action_name: str, transient_unit: str, log_path: Path) -> None:
+    print(f"✓ Scheduled detached system gateway {action_name}")
+    print(f"  Unit: {transient_unit}")
+    print(f"  Log:  {log_path}")
+
+
+def _exit_missing_systemd_scope(action_name: str, requested_scope: str, *, suggest_install: bool = True) -> None:
+    scope_flag = " --system" if requested_scope == "system" else " --user"
+    prefix = "sudo " if requested_scope == "system" else ""
+    print(f"✗ Gateway {requested_scope} service is not installed")
+    print(f"  {action_name.capitalize()} only targets the requested {requested_scope} scope.")
+    if suggest_install:
+        print(f"  Run: {prefix}hermes gateway install{scope_flag}")
+    else:
+        print(f"  Check: hermes gateway status{scope_flag}")
+    sys.exit(1)
 
 
 def prompt_linux_gateway_install_scope() -> str | None:
@@ -723,29 +1055,40 @@ def _normalize_service_definition(text: str) -> str:
     return "\n".join(line.rstrip() for line in text.strip().splitlines())
 
 
-def systemd_unit_is_current(system: bool = False) -> bool:
-    unit_path = get_systemd_unit_path(system=system)
+def _expected_systemd_unit_text(unit_path: Path, system: bool = False) -> str:
+    expected_user = _read_systemd_user_from_unit(unit_path) if system else None
+    return generate_systemd_unit(system=system, run_as_user=expected_user)
+
+
+def systemd_unit_path_is_current(unit_path: Path, system: bool = False) -> bool:
     if not unit_path.exists():
         return False
 
     installed = unit_path.read_text(encoding="utf-8")
-    expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    expected = generate_systemd_unit(system=system, run_as_user=expected_user)
+    expected = _expected_systemd_unit_text(unit_path, system=system)
     return _normalize_service_definition(installed) == _normalize_service_definition(expected)
+
+
+def systemd_unit_is_current(system: bool = False) -> bool:
+    return systemd_unit_path_is_current(get_systemd_unit_path(system=system), system=system)
+
+
+
+def refresh_systemd_unit_path_if_needed(unit_path: Path, system: bool = False) -> bool:
+    """Rewrite an installed systemd unit when the generated definition has changed."""
+    if not unit_path.exists() or systemd_unit_path_is_current(unit_path, system=system):
+        return False
+
+    unit_path.write_text(_expected_systemd_unit_text(unit_path, system=system), encoding="utf-8")
+    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True, timeout=30)
+    print(f"↻ Updated gateway {_service_scope_label(system)} service definition at: {unit_path}")
+    return True
 
 
 
 def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
     """Rewrite the installed systemd unit when the generated definition has changed."""
-    unit_path = get_systemd_unit_path(system=system)
-    if not unit_path.exists() or systemd_unit_is_current(system=system):
-        return False
-
-    expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    unit_path.write_text(generate_systemd_unit(system=system, run_as_user=expected_user), encoding="utf-8")
-    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True, timeout=30)
-    print(f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install")
-    return True
+    return refresh_systemd_unit_path_if_needed(get_systemd_unit_path(system=system), system=system)
 
 
 
@@ -808,13 +1151,20 @@ def _ensure_linger_enabled() -> None:
     _print_linger_enable_warning(username, detail or linger_detail)
 
 
-def _select_systemd_scope(system: bool = False) -> bool:
-    if system:
+def _select_systemd_scope(system: bool = False, user: bool = False) -> bool:
+    requested_scope = _requested_systemd_scope(system=system, user=user)
+    if requested_scope == "system":
         return True
+    if requested_scope == "user":
+        return False
+    report = get_gateway_systemd_report()
+    if report.get("installed"):
+        return bool(report.get("system"))
     return get_systemd_unit_path(system=True).exists() and not get_systemd_unit_path(system=False).exists()
 
 
-def systemd_install(force: bool = False, system: bool = False, run_as_user: str | None = None):
+def systemd_install(force: bool = False, system: bool = False, user: bool = False, run_as_user: str | None = None):
+    system = _requested_systemd_scope(system=system, user=user) == "system"
     if system:
         _require_root_for_system_service("install")
 
@@ -822,9 +1172,9 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
     scope_flag = " --system" if system else ""
 
     if unit_path.exists() and not force:
-        if not systemd_unit_is_current(system=system):
+        if not systemd_unit_path_is_current(unit_path, system=system):
             print(f"↻ Repairing outdated {_service_scope_label(system)} systemd service at: {unit_path}")
-            refresh_systemd_unit_if_needed(system=system)
+            refresh_systemd_unit_path_if_needed(unit_path, system=system)
             subprocess.run(_systemctl_cmd(system) + ["enable", get_service_name()], check=True, timeout=30)
             print(f"✓ {_service_scope_label(system).capitalize()} service definition updated")
             return
@@ -858,15 +1208,19 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
     print_systemd_scope_conflict_warning()
 
 
-def systemd_uninstall(system: bool = False):
-    system = _select_systemd_scope(system)
+def systemd_uninstall(system: bool = False, user: bool = False):
+    target = _resolve_systemd_service_target(system=system, user=user)
+    system = bool(target.get("system"))
+    unit_name = target.get("unit_name") or get_service_name()
+    unit_path_text = target.get("unit_path")
+    unit_path = Path(unit_path_text) if unit_path_text else get_systemd_unit_path(system=system)
+
     if system:
         _require_root_for_system_service("uninstall")
 
-    subprocess.run(_systemctl_cmd(system) + ["stop", get_service_name()], check=False, timeout=90)
-    subprocess.run(_systemctl_cmd(system) + ["disable", get_service_name()], check=False, timeout=30)
+    subprocess.run(_systemctl_cmd(system) + ["stop", unit_name], check=False, timeout=90)
+    subprocess.run(_systemctl_cmd(system) + ["disable", unit_name], check=False, timeout=30)
 
-    unit_path = get_systemd_unit_path(system=system)
     if unit_path.exists():
         unit_path.unlink()
         print(f"✓ Removed {unit_path}")
@@ -875,87 +1229,132 @@ def systemd_uninstall(system: bool = False):
     print(f"✓ {_service_scope_label(system).capitalize()} service uninstalled")
 
 
-def systemd_start(system: bool = False):
-    system = _select_systemd_scope(system)
+def systemd_start(system: bool = False, user: bool = False):
+    target = _resolve_systemd_service_target(system=system, user=user)
+    system = bool(target.get("system"))
+    unit_name = target.get("unit_name") or get_service_name()
+    unit_path_text = target.get("unit_path")
+    unit_path = Path(unit_path_text) if unit_path_text else get_systemd_unit_path(system=system)
+
     if system:
         _require_root_for_system_service("start")
-    refresh_systemd_unit_if_needed(system=system)
-    subprocess.run(_systemctl_cmd(system) + ["start", get_service_name()], check=True, timeout=30)
+    refresh_systemd_unit_path_if_needed(unit_path, system=system)
+    subprocess.run(_systemctl_cmd(system) + ["start", unit_name], check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service started")
 
 
 
-def systemd_stop(system: bool = False):
-    system = _select_systemd_scope(system)
+def systemd_stop(system: bool = False, user: bool = False):
+    target = _resolve_systemd_service_target(system=system, user=user)
+    system = bool(target.get("system"))
+    unit_name = target.get("unit_name") or get_service_name()
+
     if system:
         _require_root_for_system_service("stop")
-    subprocess.run(_systemctl_cmd(system) + ["stop", get_service_name()], check=True, timeout=90)
+    subprocess.run(_systemctl_cmd(system) + ["stop", unit_name], check=True, timeout=90)
     print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
 
 
 
-def systemd_restart(system: bool = False):
-    system = _select_systemd_scope(system)
+def systemd_restart(system: bool = False, user: bool = False):
+    target = _resolve_systemd_service_target(system=system, user=user)
+    system = bool(target.get("system"))
+    unit_name = target.get("unit_name") or get_service_name()
+    unit_path_text = target.get("unit_path")
+    unit_path = Path(unit_path_text) if unit_path_text else get_systemd_unit_path(system=system)
+
     if system:
         _require_root_for_system_service("restart")
-    refresh_systemd_unit_if_needed(system=system)
-    subprocess.run(_systemctl_cmd(system) + ["restart", get_service_name()], check=True, timeout=90)
+    refresh_systemd_unit_path_if_needed(unit_path, system=system)
+    subprocess.run(_systemctl_cmd(system) + ["restart", unit_name], check=True, timeout=90)
     print(f"✓ {_service_scope_label(system).capitalize()} service restarted")
 
 
 
-def systemd_status(deep: bool = False, system: bool = False):
-    system = _select_systemd_scope(system)
-    unit_path = get_systemd_unit_path(system=system)
-    scope_flag = " --system" if system else ""
+def _gateway_restart_command(system: bool = False, user: bool = False) -> str:
+    return f"{'sudo ' if system else ''}hermes gateway restart{' --system' if system else ' --user' if user else ''}"
 
-    if not unit_path.exists():
+
+
+def _gateway_repair_preview_command(system: bool = False, user: bool = False, cleanup_legacy: bool = False) -> str:
+    scope_flag = ' --system' if system else ' --user' if user else ''
+    command = f"hermes gateway repair{scope_flag}"
+    if cleanup_legacy:
+        command += " --cleanup-legacy"
+    return command
+
+
+
+def _gateway_repair_apply_command(system: bool = False, user: bool = False, cleanup_legacy: bool = False) -> str:
+    scope_flag = ' --system' if system else ' --user' if user else ''
+    command = f"{'sudo ' if system else ''}hermes gateway repair{scope_flag} --apply"
+    if cleanup_legacy:
+        command += " --cleanup-legacy"
+    return command
+
+
+
+def systemd_status(deep: bool = False, system: bool = False, user: bool = False, auto_select: bool = False):
+    requested_scope = None if auto_select else _requested_systemd_scope(system=system, user=user)
+    if requested_scope is None and not auto_select:
+        requested_scope = _service_scope_label(_select_systemd_scope())
+    report = get_gateway_systemd_report(requested_scope=requested_scope)
+    scope_flag = " --system" if requested_scope == "system" else " --user" if requested_scope == "user" else ""
+
+    if not report.get("installed"):
+        install_system = requested_scope == "system"
         print("✗ Gateway service is not installed")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print(f"  Run: {'sudo ' if install_system else ''}hermes gateway install{scope_flag}")
         return
+
+    active_scope = report.get("scope")
+    active_system = bool(report.get("system"))
+    unit_name = report.get("unit_name") or get_service_name()
+    unit_path = Path(report.get("unit_path")) if report.get("unit_path") else get_systemd_unit_path(system=active_system)
 
     if has_conflicting_systemd_units():
         print_systemd_scope_conflict_warning()
         print()
 
-    if not systemd_unit_is_current(system=system):
+    if report.get("drifted"):
+        print_warning(f"Gateway service identity drift detected: using {unit_name} instead of canonical {get_service_name()}.")
+        print_info("  The current HERMES_HOME is still service-managed, but under a legacy/non-canonical unit name.")
+        print_info(f"  Preview cutover: {_gateway_repair_preview_command(system=active_system, user=requested_scope == 'user')}")
+        print_info(f"  Apply when ready: {_gateway_repair_apply_command(system=active_system, user=requested_scope == 'user', cleanup_legacy=True)}")
+        print()
+
+    if unit_path.exists() and not systemd_unit_path_is_current(unit_path, system=active_system):
         print("⚠ Installed gateway service definition is outdated")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway restart{scope_flag}  # auto-refreshes the unit")
+        print(f"  Run: {_gateway_restart_command(system=active_system, user=requested_scope == 'user')}  # auto-refreshes the unit")
+        if report.get("drifted"):
+            print(f"  Or preview full cutover: {_gateway_repair_preview_command(system=active_system, user=requested_scope == 'user')}" )
         print()
 
     subprocess.run(
-        _systemctl_cmd(system) + ["status", get_service_name(), "--no-pager"],
+        _systemctl_cmd(active_system) + ["status", unit_name, "--no-pager"],
         capture_output=False,
         timeout=10,
     )
 
-    result = subprocess.run(
-        _systemctl_cmd(system) + ["is-active", get_service_name()],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-
-    status = result.stdout.strip()
-
-    if status == "active":
-        print(f"✓ {_service_scope_label(system).capitalize()} gateway service is running")
+    if report.get("active") is True:
+        print(f"✓ {active_scope.capitalize()} gateway service is running")
+    elif report.get("reachable") is False:
+        print(f"⚠ {active_scope.capitalize()} gateway service status is unreachable from this shell")
     else:
-        print(f"✗ {_service_scope_label(system).capitalize()} gateway service is stopped")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway start{scope_flag}")
+        print(f"✗ {active_scope.capitalize()} gateway service is stopped")
+        start_command = f"{'sudo ' if active_system else ''}hermes gateway start{' --system' if active_system else ' --user' if requested_scope == 'user' else ''}"
+        print(f"  Run: {start_command}")
 
-    configured_user = _read_systemd_user_from_unit(unit_path) if system else None
+    configured_user = _read_systemd_user_from_unit(unit_path) if active_system else None
     if configured_user:
         print(f"Configured to run as: {configured_user}")
 
-    runtime_lines = _runtime_health_lines()
-    if runtime_lines:
+    if deep:
         print()
-        print("Recent gateway health:")
-        for line in runtime_lines:
-            print(f"  {line}")
+        print("Recent journal:")
+        subprocess.run(_journalctl_cmd(active_system) + ["-u", unit_name, "-n", "20", "--no-pager"], timeout=10)
 
-    if system:
+    if active_system:
         print("✓ System service starts at boot without requiring systemd linger")
     elif deep:
         print_systemd_linger_guidance()
@@ -966,11 +1365,6 @@ def systemd_status(deep: bool = False, system: bool = False):
         elif linger_enabled is False:
             print("⚠ Systemd linger is disabled (gateway may stop when you log out)")
             print("  Run: sudo loginctl enable-linger $USER")
-
-    if deep:
-        print()
-        print("Recent logs:")
-        subprocess.run(_journalctl_cmd(system) + ["-u", get_service_name(), "-n", "20", "--no-pager"], timeout=10)
 
 
 # =============================================================================
@@ -1774,7 +2168,7 @@ def _setup_whatsapp():
 def _is_service_installed() -> bool:
     """Check if the gateway is installed as a system service."""
     if is_linux():
-        return get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()
+        return bool(get_gateway_systemd_report().get("installed"))
     elif is_macos():
         return get_launchd_plist_path().exists()
     return False
@@ -1783,31 +2177,9 @@ def _is_service_installed() -> bool:
 def _is_service_running() -> bool:
     """Check if the gateway service is currently running."""
     if is_linux():
-        user_unit_exists = get_systemd_unit_path(system=False).exists()
-        system_unit_exists = get_systemd_unit_path(system=True).exists()
-
-        if user_unit_exists:
-            try:
-                result = subprocess.run(
-                    _systemctl_cmd(False) + ["is-active", get_service_name()],
-                    capture_output=True, text=True, timeout=10,
-                )
-                if result.stdout.strip() == "active":
-                    return True
-            except subprocess.TimeoutExpired:
-                pass
-
-        if system_unit_exists:
-            try:
-                result = subprocess.run(
-                    _systemctl_cmd(True) + ["is-active", get_service_name()],
-                    capture_output=True, text=True, timeout=10,
-                )
-                if result.stdout.strip() == "active":
-                    return True
-            except subprocess.TimeoutExpired:
-                pass
-
+        report = get_gateway_systemd_report()
+        if report.get("installed"):
+            return report.get("active") is True
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         try:
@@ -2078,6 +2450,14 @@ def gateway_setup():
 # Main Command Handler
 # =============================================================================
 
+def _requested_systemd_scope_from_args(args) -> str | None:
+    return _requested_systemd_scope(
+        system=getattr(args, 'system', False),
+        user=getattr(args, 'user', False),
+    )
+
+
+
 def gateway_command(args):
     """Handle gateway subcommands."""
     subcmd = getattr(args, 'gateway_command', None)
@@ -2100,10 +2480,12 @@ def gateway_command(args):
             managed_error("install gateway service (managed by NixOS)")
             return
         force = getattr(args, 'force', False)
-        system = getattr(args, 'system', False)
+        requested_scope = _requested_systemd_scope_from_args(args)
+        system = requested_scope == "system"
+        user = requested_scope == "user"
         run_as_user = getattr(args, 'run_as_user', None)
         if is_linux():
-            systemd_install(force=force, system=system, run_as_user=run_as_user)
+            systemd_install(force=force, system=system, user=user, run_as_user=run_as_user)
         elif is_macos():
             launchd_install(force)
         else:
@@ -2115,19 +2497,102 @@ def gateway_command(args):
         if is_managed():
             managed_error("uninstall gateway service (managed by NixOS)")
             return
-        system = getattr(args, 'system', False)
+        requested_scope = _requested_systemd_scope_from_args(args)
+        system = requested_scope == "system"
+        user = requested_scope == "user"
+        linux_service_report = (
+            get_gateway_systemd_report(requested_scope=requested_scope)
+            if is_linux() else {}
+        )
+        if is_linux() and not linux_service_report.get("installed"):
+            if requested_scope is not None:
+                _exit_missing_systemd_scope("uninstall", requested_scope, suggest_install=False)
+            print("✗ Gateway service is not installed")
+            print("  Uninstall only removes an installed service definition.")
+            print("  Check: hermes gateway status --user")
+            print("  Check: hermes gateway status --system")
+            sys.exit(1)
+        if is_linux() and _should_detach_system_service_action(linux_service_report):
+            try:
+                transient_unit, log_path = _schedule_detached_system_gateway_cli(
+                    "uninstall",
+                    ["gateway", "uninstall", "--system"],
+                )
+            except (PermissionError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+                print(str(exc))
+                sys.exit(1)
+            _print_detached_system_gateway_notice("uninstall", transient_unit, log_path)
+            return
         if is_linux():
-            systemd_uninstall(system=system)
+            systemd_uninstall(system=system, user=user)
         elif is_macos():
             launchd_uninstall()
         else:
             print("Not supported on this platform.")
             sys.exit(1)
-    
+
+    elif subcmd == "repair":
+        if not is_linux():
+            print("Gateway canonical repair is only supported for Linux systemd services.")
+            sys.exit(1)
+
+        requested_scope = _requested_systemd_scope_from_args(args)
+        repair_report = get_gateway_systemd_report(requested_scope=requested_scope)
+        detached_repair_args = ["gateway", "repair", "--system", "--apply"]
+        if getattr(args, 'cleanup_legacy', False):
+            detached_repair_args.append("--cleanup-legacy")
+        if getattr(args, 'dry_run', False):
+            detached_repair_args.append("--dry-run")
+
+        if getattr(args, 'apply', False) and _should_detach_system_service_action(repair_report):
+            try:
+                transient_unit, log_path = _schedule_detached_system_gateway_cli("repair", detached_repair_args)
+            except (PermissionError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+                print(str(exc))
+                sys.exit(1)
+            _print_detached_system_gateway_notice("repair", transient_unit, log_path)
+            return
+
+        try:
+            import scripts.gateway_canonical_repair as repair_script
+
+            repair_args = []
+            if getattr(args, 'system', False):
+                repair_args.append("--system")
+            if getattr(args, 'user', False):
+                repair_args.append("--user")
+            if getattr(args, 'apply', False):
+                repair_args.append("--apply")
+            if getattr(args, 'dry_run', False):
+                repair_args.append("--dry-run")
+            if getattr(args, 'cleanup_legacy', False):
+                repair_args.append("--cleanup-legacy")
+
+            exit_code = repair_script.main(repair_args)
+        except (PermissionError, RuntimeError, ValueError) as exc:
+            print(str(exc))
+            sys.exit(1)
+        if exit_code:
+            sys.exit(exit_code)
+
     elif subcmd == "start":
-        system = getattr(args, 'system', False)
+        requested_scope = _requested_systemd_scope_from_args(args)
+        system = requested_scope == "system"
+        user = requested_scope == "user"
+        linux_service_report = (
+            get_gateway_systemd_report(requested_scope=requested_scope)
+            if is_linux() else {}
+        )
+        if is_linux() and not linux_service_report.get("installed"):
+            if requested_scope is not None:
+                _exit_missing_systemd_scope("start", requested_scope)
+            print("✗ Gateway service is not installed")
+            print("  Start only targets an installed service definition.")
+            print("  Run: hermes gateway install --user")
+            print("  Run: sudo hermes gateway install --system")
+            sys.exit(1)
         if is_linux():
-            systemd_start(system=system)
+            systemd_start(system=system, user=user)
         elif is_macos():
             launchd_start()
         else:
@@ -2136,14 +2601,35 @@ def gateway_command(args):
     
     elif subcmd == "stop":
         stop_all = getattr(args, 'all', False)
-        system = getattr(args, 'system', False)
+        requested_scope = _requested_systemd_scope_from_args(args)
+        system = requested_scope == "system"
+        user = requested_scope == "user"
+        linux_service_report = (
+            get_gateway_systemd_report(requested_scope=requested_scope)
+            if is_linux() else {}
+        )
+
+        if not stop_all and is_linux() and requested_scope is not None and not linux_service_report.get("installed"):
+            _exit_missing_systemd_scope("stop", requested_scope)
+
+        if not stop_all and is_linux() and _should_detach_system_service_action(linux_service_report):
+            try:
+                transient_unit, log_path = _schedule_detached_system_gateway_cli(
+                    "stop",
+                    ["gateway", "stop", "--system"],
+                )
+            except (PermissionError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+                print(str(exc))
+                sys.exit(1)
+            _print_detached_system_gateway_notice("stop", transient_unit, log_path)
+            return
 
         if stop_all:
             # --all: kill every gateway process on the machine
             service_available = False
-            if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if is_linux() and linux_service_report.get("installed"):
                 try:
-                    systemd_stop(system=system)
+                    systemd_stop(system=system, user=user)
                     service_available = True
                 except subprocess.CalledProcessError:
                     pass
@@ -2162,9 +2648,9 @@ def gateway_command(args):
         else:
             # Default: stop only the current profile's gateway
             service_available = False
-            if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if is_linux() and linux_service_report.get("installed"):
                 try:
-                    systemd_stop(system=system)
+                    systemd_stop(system=system, user=user)
                     service_available = True
                 except subprocess.CalledProcessError:
                     pass
@@ -2187,13 +2673,34 @@ def gateway_command(args):
     elif subcmd == "restart":
         # Try service first, fall back to killing and restarting
         service_available = False
-        system = getattr(args, 'system', False)
+        requested_scope = _requested_systemd_scope_from_args(args)
+        system = requested_scope == "system"
+        user = requested_scope == "user"
         service_configured = False
+        linux_service_report = (
+            get_gateway_systemd_report(requested_scope=requested_scope)
+            if is_linux() else {}
+        )
+
+        if is_linux() and requested_scope is not None and not linux_service_report.get("installed"):
+            _exit_missing_systemd_scope("restart", requested_scope)
+
+        if is_linux() and _should_detach_system_service_action(linux_service_report):
+            try:
+                transient_unit, log_path = _schedule_detached_system_gateway_cli(
+                    "restart",
+                    ["gateway", "restart", "--system"],
+                )
+            except (PermissionError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+                print(str(exc))
+                sys.exit(1)
+            _print_detached_system_gateway_notice("restart", transient_unit, log_path)
+            return
         
-        if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+        if is_linux() and linux_service_report.get("installed"):
             service_configured = True
             try:
-                systemd_restart(system=system)
+                systemd_restart(system=system, user=user)
                 service_available = True
             except subprocess.CalledProcessError:
                 pass
@@ -2241,11 +2748,17 @@ def gateway_command(args):
     
     elif subcmd == "status":
         deep = getattr(args, 'deep', False)
-        system = getattr(args, 'system', False)
-        
-        # Check for service first
-        if is_linux() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
-            systemd_status(deep, system=system)
+        requested_scope = _requested_systemd_scope_from_args(args)
+        system = requested_scope == "system"
+        user = requested_scope == "user"
+        systemd_report = get_gateway_systemd_report(requested_scope=requested_scope) if is_linux() else None
+
+        # On Linux, explicit --user/--system status must stay on the requested
+        # systemd lane even when that lane is currently uninstalled. Otherwise a
+        # running process owned by another scope can be misreported as a manual
+        # foreground gateway.
+        if is_linux() and (requested_scope is not None or systemd_report.get("installed")):
+            systemd_status(deep, system=system, user=user, auto_select=requested_scope is None)
         elif is_macos() and get_launchd_plist_path().exists():
             launchd_status(deep)
         else:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4376,31 +4376,55 @@ For more help on a command:
     
     # gateway start
     gateway_start = gateway_subparsers.add_parser("start", help="Start gateway service")
-    gateway_start.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_start_scope = gateway_start.add_mutually_exclusive_group()
+    gateway_start_scope.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_start_scope.add_argument("--user", action="store_true", help="Target the Linux user-level gateway service")
     
     # gateway stop
     gateway_stop = gateway_subparsers.add_parser("stop", help="Stop gateway service")
-    gateway_stop.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_stop_scope = gateway_stop.add_mutually_exclusive_group()
+    gateway_stop_scope.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_stop_scope.add_argument("--user", action="store_true", help="Target the Linux user-level gateway service")
     gateway_stop.add_argument("--all", action="store_true", help="Stop ALL gateway processes across all profiles")
     
     # gateway restart
     gateway_restart = gateway_subparsers.add_parser("restart", help="Restart gateway service")
-    gateway_restart.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_restart_scope = gateway_restart.add_mutually_exclusive_group()
+    gateway_restart_scope.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_restart_scope.add_argument("--user", action="store_true", help="Target the Linux user-level gateway service")
     
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")
     gateway_status.add_argument("--deep", action="store_true", help="Deep status check")
-    gateway_status.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_status_scope = gateway_status.add_mutually_exclusive_group()
+    gateway_status_scope.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_status_scope.add_argument("--user", action="store_true", help="Target the Linux user-level gateway service")
     
     # gateway install
     gateway_install = gateway_subparsers.add_parser("install", help="Install gateway as service")
     gateway_install.add_argument("--force", action="store_true", help="Force reinstall")
-    gateway_install.add_argument("--system", action="store_true", help="Install as a Linux system-level service (starts at boot)")
+    gateway_install_scope = gateway_install.add_mutually_exclusive_group()
+    gateway_install_scope.add_argument("--system", action="store_true", help="Install as a Linux system-level service (starts at boot)")
+    gateway_install_scope.add_argument("--user", action="store_true", help="Install as a Linux user-level service")
     gateway_install.add_argument("--run-as-user", dest="run_as_user", help="User account the Linux system service should run as")
     
     # gateway uninstall
     gateway_uninstall = gateway_subparsers.add_parser("uninstall", help="Uninstall gateway service")
-    gateway_uninstall.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_uninstall_scope = gateway_uninstall.add_mutually_exclusive_group()
+    gateway_uninstall_scope.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_uninstall_scope.add_argument("--user", action="store_true", help="Target the Linux user-level gateway service")
+
+    # gateway repair
+    gateway_repair = gateway_subparsers.add_parser(
+        "repair",
+        help="Plan or execute canonical gateway service repair",
+    )
+    gateway_repair_scope = gateway_repair.add_mutually_exclusive_group()
+    gateway_repair_scope.add_argument("--system", action="store_true", help="Target the Linux system-level gateway service")
+    gateway_repair_scope.add_argument("--user", action="store_true", help="Target the Linux user-level gateway service")
+    gateway_repair.add_argument("--apply", action="store_true", help="Execute the repair instead of printing the dry-run plan")
+    gateway_repair.add_argument("--dry-run", action="store_true", help="Print the repair plan explicitly (this is the default mode)")
+    gateway_repair.add_argument("--cleanup-legacy", action="store_true", help="Delete the legacy unit file after canonical ownership is verified")
 
     # gateway setup
     gateway_subparsers.add_parser("setup", help="Configure messaging platforms")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -79,6 +79,21 @@ def _effective_provider_label() -> str:
     return provider_label(effective)
 
 
+def _gateway_restart_command(system: bool = False, user: bool = False) -> str:
+    return f"{'sudo ' if system else ''}hermes gateway restart{' --system' if system else ' --user' if user else ''}"
+
+
+def _gateway_repair_preview_command(system: bool = False) -> str:
+    return f"hermes gateway repair{' --system' if system else ''}"
+
+
+def _gateway_repair_apply_command(system: bool = False, cleanup_legacy: bool = False) -> str:
+    command = f"{'sudo ' if system else ''}hermes gateway repair{' --system' if system else ''} --apply"
+    if cleanup_legacy:
+        command += " --cleanup-legacy"
+    return command
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
     show_all = getattr(args, 'all', False)
@@ -309,22 +324,37 @@ def show_status(args):
     
     if sys.platform.startswith('linux'):
         try:
-            from hermes_cli.gateway import get_service_name
-            _gw_svc = get_service_name()
+            from hermes_cli.gateway import get_gateway_systemd_report, systemd_unit_path_is_current
+            gateway_report = get_gateway_systemd_report()
         except Exception:
-            _gw_svc = "hermes-gateway"
-        try:
-            result = subprocess.run(
-                ["systemctl", "--user", "is-active", _gw_svc],
-                capture_output=True,
-                text=True,
-                timeout=5
+            gateway_report = {"installed": False}
+            systemd_unit_path_is_current = None
+
+        is_active = gateway_report.get("active") is True
+        state_label = "running" if is_active else (gateway_report.get("state") or "stopped")
+        manager_label = f"systemd ({gateway_report.get('scope')})" if gateway_report.get("installed") else "systemd (user)"
+        print(f"  Status:       {check_mark(is_active)} {state_label}")
+        print(f"  Manager:      {manager_label}")
+        if gateway_report.get("installed"):
+            unit_name = gateway_report.get("unit_name")
+            active_system = bool(gateway_report.get("system"))
+            unit_path = Path(gateway_report.get("unit_path")) if gateway_report.get("unit_path") else None
+            outdated = bool(
+                unit_path
+                and unit_path.exists()
+                and systemd_unit_path_is_current is not None
+                and not systemd_unit_path_is_current(unit_path, system=active_system)
             )
-            is_active = result.stdout.strip() == "active"
-        except subprocess.TimeoutExpired:
-            is_active = False
-        print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-        print("  Manager:      systemd (user)")
+            if gateway_report.get("drifted"):
+                print(f"  Unit:         {unit_name} (legacy/non-canonical)")
+                print("  Drift:        yes")
+                print(f"  Preview:      {_gateway_repair_preview_command(system=active_system)}")
+                print(f"  Apply:        {_gateway_repair_apply_command(system=active_system, cleanup_legacy=True)}")
+            else:
+                print(f"  Unit:         {unit_name}")
+            if outdated:
+                print("  Definition:   outdated")
+                print(f"  Refresh:      {_gateway_restart_command(system=active_system)}")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label

--- a/scripts/gateway_canonical_repair.py
+++ b/scripts/gateway_canonical_repair.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Plan or execute canonical gateway repair for the current HERMES_HOME.
+
+This script is intentionally conservative:
+- default mode is dry-run
+- --apply is required for side effects
+- system-scope repair requires root
+
+The main use case is a default ~/.hermes gateway that is still owned by a
+legacy/non-canonical systemd unit such as `hermes-gateway-17b8e69b` while the
+canonical unit should be `hermes-gateway`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import hermes_cli.gateway as gateway_cli
+
+
+def _current_target(requested_scope: str | None = None) -> dict:
+    report = gateway_cli.get_gateway_systemd_report(requested_scope=requested_scope)
+    if not report.get("installed"):
+        raise ValueError("No matching gateway systemd unit found for the current HERMES_HOME")
+
+    system = bool(report.get("system"))
+    unit_name = report.get("unit_name") or gateway_cli.get_service_name()
+    unit_path = Path(report.get("unit_path")) if report.get("unit_path") else gateway_cli.get_systemd_unit_path(system=system)
+    canonical_name = gateway_cli.get_service_name()
+    scope = report.get("scope") or ("system" if system else "user")
+    configured_user = gateway_cli._read_systemd_user_from_unit(unit_path) if system else None
+    outdated = unit_path.exists() and not gateway_cli.systemd_unit_path_is_current(unit_path, system=system)
+
+    return {
+        "installed": True,
+        "scope": scope,
+        "system": system,
+        "current_unit": unit_name,
+        "current_unit_path": str(unit_path),
+        "canonical_unit": canonical_name,
+        "drifted": bool(report.get("drifted")),
+        "outdated": outdated,
+        "active": report.get("active"),
+        "configured_user": configured_user,
+        "report": report,
+    }
+
+
+def _script_apply_command(requested_scope: str | None = None, cleanup_legacy: bool = False) -> str:
+    script_path = Path(__file__).resolve()
+    python_path = Path(sys.executable).resolve()
+    scope_flag = " --system" if requested_scope == "system" else " --user" if requested_scope == "user" else ""
+    suffix = " --cleanup-legacy" if cleanup_legacy else ""
+    prefix = "sudo " if requested_scope == "system" else ""
+    return f"{prefix}{python_path} {script_path}{scope_flag} --apply{suffix}"
+
+
+def build_repair_plan(requested_scope: str | None = None, cleanup_legacy: bool = False) -> dict:
+    target = _current_target(requested_scope=requested_scope)
+    ctl = "sudo systemctl" if target["system"] else "systemctl --user"
+    run_as_user = target.get("configured_user") or os.getenv("SUDO_USER") or os.getenv("USER") or "<user>"
+    steps: list[dict] = []
+
+    if not target["drifted"] and not target["outdated"]:
+        steps.append(
+            {
+                "id": "noop",
+                "summary": "No canonical repair is needed; the current unit already matches the expected service identity and definition.",
+                "command": None,
+            }
+        )
+    else:
+        if target["outdated"]:
+            command = "sudo hermes gateway restart --system" if target["system"] else f"hermes gateway restart{' --user' if target['scope'] == 'user' else ''}"
+            steps.append(
+                {
+                    "id": "refresh-live-unit",
+                    "summary": f"Refresh the live unit definition for {target['current_unit']} before or during cutover.",
+                    "command": command,
+                }
+            )
+
+        if target["drifted"]:
+            install_cmd = (
+                f"sudo hermes gateway install --system --run-as-user {run_as_user}"
+                if target["system"]
+                else "hermes gateway install --user"
+            )
+            steps.extend(
+                [
+                    {
+                        "id": "stage-canonical",
+                        "summary": f"Stage the canonical unit {target['canonical_unit']} without assuming it owns the live process yet.",
+                        "command": install_cmd,
+                    },
+                    {
+                        "id": "disable-legacy",
+                        "summary": f"Disable legacy unit {target['current_unit']} so it does not restart during cutover.",
+                        "command": f"{ctl} disable {target['current_unit']}",
+                    },
+                    {
+                        "id": "stop-legacy",
+                        "summary": f"Stop legacy unit {target['current_unit']}.",
+                        "command": f"{ctl} stop {target['current_unit']}",
+                    },
+                    {
+                        "id": "start-canonical",
+                        "summary": f"Start canonical unit {target['canonical_unit']}.",
+                        "command": f"{ctl} start {target['canonical_unit']}",
+                    },
+                    {
+                        "id": "verify-canonical",
+                        "summary": f"Verify that {target['canonical_unit']} is now the active owner.",
+                        "command": f"{ctl} status {target['canonical_unit']} --no-pager",
+                    },
+                    {
+                        "id": "rollback-legacy",
+                        "summary": f"If canonical start fails, bring legacy unit {target['current_unit']} back immediately.",
+                        "command": f"{ctl} start {target['current_unit']}",
+                    },
+                ]
+            )
+            if cleanup_legacy:
+                steps.append(
+                    {
+                        "id": "cleanup-legacy-file",
+                        "summary": f"Remove the legacy unit file {target['current_unit_path']} after canonical ownership is verified.",
+                        "command": f"sudo rm -f {target['current_unit_path']} && {ctl} daemon-reload",
+                    }
+                )
+
+    return {
+        "repair_needed": not (len(steps) == 1 and steps[0]["id"] == "noop"),
+        "required_root": bool(target["system"]),
+        "current_scope": target["scope"],
+        "current_unit": target["current_unit"],
+        "current_unit_path": target["current_unit_path"],
+        "canonical_unit": target["canonical_unit"],
+        "drifted": target["drifted"],
+        "outdated": target["outdated"],
+        "active": target["active"],
+        "configured_user": target.get("configured_user"),
+        "cleanup_legacy": cleanup_legacy,
+        "steps": steps,
+        "apply_command": _script_apply_command(requested_scope=target['scope'], cleanup_legacy=cleanup_legacy),
+    }
+
+
+def _print_plan(plan: dict) -> None:
+    print()
+    print("Gateway canonical repair plan")
+    print("=" * 30)
+    print(f"Current unit:   {plan['current_unit']}")
+    print(f"Current scope:  {plan['current_scope']}")
+    print(f"Canonical unit: {plan['canonical_unit']}")
+    print(f"Drifted:        {plan['drifted']}")
+    print(f"Outdated:       {plan['outdated']}")
+    print(f"Root needed:    {plan['required_root']}")
+    if plan.get("configured_user"):
+        print(f"Run-as user:    {plan['configured_user']}")
+    print()
+
+    for idx, step in enumerate(plan["steps"], start=1):
+        print(f"{idx}. {step['summary']}")
+        if step.get("command"):
+            print(f"   {step['command']}")
+
+    print()
+    print("Scripted apply:")
+    print(f"  {plan['apply_command']}")
+    print()
+
+
+def apply_repair_plan(requested_scope: str | None = None, cleanup_legacy: bool = False) -> int:
+    target = _current_target(requested_scope=requested_scope)
+    system = bool(target["system"])
+    current_unit = target["current_unit"]
+    canonical_unit = target["canonical_unit"]
+    unit_path = Path(target["current_unit_path"])
+    scope_label = target["scope"]
+    run_as_user = target.get("configured_user")
+    ctl = gateway_cli._systemctl_cmd(system)
+
+    if system and os.geteuid() != 0:
+        raise PermissionError("System-scope canonical repair requires root. Re-run with sudo and --apply.")
+
+    if target["outdated"]:
+        changed = gateway_cli.refresh_systemd_unit_path_if_needed(unit_path, system=system)
+        if changed:
+            print(f"Refreshed unit definition at {unit_path}")
+
+    if target["drifted"]:
+        gateway_cli.systemd_install(force=False, system=system, user=not system, run_as_user=run_as_user)
+        subprocess.run(ctl + ["disable", current_unit], check=False, timeout=30)
+        subprocess.run(ctl + ["stop", current_unit], check=True, timeout=90)
+        subprocess.run(ctl + ["start", canonical_unit], check=True, timeout=90)
+
+        verify = gateway_cli.get_gateway_systemd_report(requested_scope=scope_label)
+        if verify.get("unit_name") != canonical_unit or verify.get("active") is not True:
+            raise RuntimeError(
+                f"Canonical unit did not become active (got unit={verify.get('unit_name')} active={verify.get('active')})"
+            )
+        print(f"Canonical unit {canonical_unit} is now active")
+
+        if cleanup_legacy and unit_path.exists():
+            unit_path.unlink()
+            subprocess.run(ctl + ["daemon-reload"], check=True, timeout=30)
+            print(f"Removed legacy unit file {unit_path}")
+    else:
+        print("No canonical identity drift detected; nothing to cut over.")
+
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Plan or execute canonical gateway repair for the current HERMES_HOME")
+    parser.add_argument("--apply", action="store_true", help="Execute the repair instead of printing a dry-run plan")
+    parser.add_argument("--dry-run", action="store_true", help="Print the repair plan explicitly (this is the default mode)")
+    parser.add_argument("--cleanup-legacy", action="store_true", help="Delete the legacy unit file after canonical ownership is verified")
+    scope_group = parser.add_mutually_exclusive_group()
+    scope_group.add_argument("--system", action="store_true", help="Force system-scope planning/execution")
+    scope_group.add_argument("--user", action="store_true", help="Force user-scope planning/execution")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    requested_scope = "system" if args.system else "user" if args.user else None
+
+    if args.apply:
+        return apply_repair_plan(requested_scope=requested_scope, cleanup_legacy=args.cleanup_legacy)
+
+    plan = build_repair_plan(requested_scope=requested_scope, cleanup_legacy=args.cleanup_legacy)
+    _print_plan(plan)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -35,16 +35,26 @@ class TestSystemdLingerStatus:
 
 def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys):
     unit_path = tmp_path / "hermes-gateway.service"
-    unit_path.write_text("[Unit]\n")
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
 
-    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
     monkeypatch.setattr(gateway, "get_systemd_linger_status", lambda: (False, ""))
+    monkeypatch.setattr(
+        gateway,
+        "get_gateway_systemd_report",
+        lambda requested_scope=None: {
+            "installed": True,
+            "scope": "user",
+            "system": False,
+            "unit_name": gateway.get_service_name(),
+            "unit_path": str(unit_path),
+            "active": True,
+            "reachable": True,
+        },
+    )
 
     def fake_run(cmd, capture_output=False, text=False, check=False, **kwargs):
-        if cmd[:4] == ["systemctl", "--user", "status", gateway.get_service_name()]:
+        if cmd == ["systemctl", "--user", "status", gateway.get_service_name(), "--no-pager"]:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
-        if cmd[:3] == ["systemctl", "--user", "is-active"]:
-            return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
         raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)
@@ -119,19 +129,8 @@ def test_systemd_install_system_scope_skips_linger_and_uses_systemctl(monkeypatc
     assert "System service installed and enabled" in out
 
 
-def test_conflicting_systemd_units_warning(monkeypatch, tmp_path, capsys):
-    user_unit = tmp_path / "user" / "hermes-gateway.service"
-    system_unit = tmp_path / "system" / "hermes-gateway.service"
-    user_unit.parent.mkdir(parents=True)
-    system_unit.parent.mkdir(parents=True)
-    user_unit.write_text("[Unit]\n", encoding="utf-8")
-    system_unit.write_text("[Unit]\n", encoding="utf-8")
-
-    monkeypatch.setattr(
-        gateway,
-        "get_systemd_unit_path",
-        lambda system=False: system_unit if system else user_unit,
-    )
+def test_conflicting_systemd_units_warning(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "get_installed_systemd_scopes", lambda: ["user", "system"])
 
     gateway.print_systemd_scope_conflict_warning()
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -4,7 +4,10 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import hermes_cli.gateway as gateway_cli
+import scripts.gateway_canonical_repair as repair_script
 
 
 class TestSystemdServiceRefresh:
@@ -77,6 +80,41 @@ class TestSystemdServiceRefresh:
             ["systemctl", "--user", "restart", gateway_cli.get_service_name()],
         ]
 
+    def test_systemd_restart_targets_active_legacy_system_unit(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway-17b8e69b.service"
+        unit_path.write_text("old unit\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": True,
+                "scope": "system",
+                "unit_name": "hermes-gateway-17b8e69b",
+                "unit_path": str(unit_path),
+                "drifted": True,
+            },
+        )
+        monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_require_root_for_system_service", lambda action: None)
+
+        calls = []
+
+        def fake_run(cmd, check=True, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.systemd_restart()
+
+        assert unit_path.read_text(encoding="utf-8") == "new unit\n"
+        assert calls[:2] == [
+            ["systemctl", "daemon-reload"],
+            ["systemctl", "restart", "hermes-gateway-17b8e69b"],
+        ]
+
 
 class TestGeneratedSystemdUnits:
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
@@ -106,17 +144,18 @@ class TestGatewayStopCleanup:
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):
         """Without --all, stop uses systemd (if available) and does NOT call
         the global kill_gateway_processes()."""
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("unit\n", encoding="utf-8")
-
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {"installed": True, "system": False, "unit_name": "hermes-gateway"},
+        )
 
         service_calls = []
         kill_calls = []
 
-        monkeypatch.setattr(gateway_cli, "systemd_stop", lambda system=False: service_calls.append("stop"))
+        monkeypatch.setattr(gateway_cli, "systemd_stop", lambda system=False, user=False: service_calls.append("stop"))
         monkeypatch.setattr(
             gateway_cli,
             "kill_gateway_processes",
@@ -131,17 +170,18 @@ class TestGatewayStopCleanup:
 
     def test_stop_all_sweeps_all_gateway_processes(self, tmp_path, monkeypatch):
         """With --all, stop uses systemd AND calls the global kill_gateway_processes()."""
-        unit_path = tmp_path / "hermes-gateway.service"
-        unit_path.write_text("unit\n", encoding="utf-8")
-
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
-        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {"installed": True, "system": False, "unit_name": "hermes-gateway"},
+        )
 
         service_calls = []
         kill_calls = []
 
-        monkeypatch.setattr(gateway_cli, "systemd_stop", lambda system=False: service_calls.append("stop"))
+        monkeypatch.setattr(gateway_cli, "systemd_stop", lambda system=False, user=False: service_calls.append("stop"))
         monkeypatch.setattr(
             gateway_cli,
             "kill_gateway_processes",
@@ -252,26 +292,14 @@ class TestLaunchdServiceRecovery:
 
 
 class TestGatewayServiceDetection:
-    def test_is_service_running_checks_system_scope_when_user_scope_is_inactive(self, monkeypatch):
-        user_unit = SimpleNamespace(exists=lambda: True)
-        system_unit = SimpleNamespace(exists=lambda: True)
-
+    def test_is_service_running_uses_matching_systemd_report(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(
             gateway_cli,
-            "get_systemd_unit_path",
-            lambda system=False: system_unit if system else user_unit,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {"installed": True, "active": True, "system": True},
         )
-
-        def fake_run(cmd, capture_output=True, text=True, **kwargs):
-            if cmd == ["systemctl", "--user", "is-active", gateway_cli.get_service_name()]:
-                return SimpleNamespace(returncode=0, stdout="inactive\n", stderr="")
-            if cmd == ["systemctl", "is-active", gateway_cli.get_service_name()]:
-                return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
-            raise AssertionError(f"Unexpected command: {cmd}")
-
-        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         assert gateway_cli._is_service_running() is True
 
@@ -285,33 +313,557 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(
             gateway_cli,
             "systemd_install",
-            lambda force=False, system=False, run_as_user=None: calls.append((force, system, run_as_user)),
+            lambda force=False, system=False, user=False, run_as_user=None: calls.append((force, system, user, run_as_user)),
         )
 
         gateway_cli.gateway_command(
-            SimpleNamespace(gateway_command="install", force=True, system=True, run_as_user="alice")
+            SimpleNamespace(gateway_command="install", force=True, system=True, user=False, run_as_user="alice")
         )
 
-        assert calls == [(True, True, "alice")]
+        assert calls == [(True, True, False, "alice")]
 
     def test_gateway_status_prefers_system_service_when_only_system_unit_exists(self, monkeypatch):
-        user_unit = SimpleNamespace(exists=lambda: False)
-        system_unit = SimpleNamespace(exists=lambda: True)
-
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
         monkeypatch.setattr(
             gateway_cli,
-            "get_systemd_unit_path",
-            lambda system=False: system_unit if system else user_unit,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {"installed": True, "system": True, "unit_name": "hermes-gateway-legacy"},
         )
 
         calls = []
-        monkeypatch.setattr(gateway_cli, "systemd_status", lambda deep=False, system=False: calls.append((deep, system)))
+        monkeypatch.setattr(
+            gateway_cli,
+            "systemd_status",
+            lambda deep=False, system=False, user=False, auto_select=False: calls.append((deep, system, user, auto_select)),
+        )
 
-        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False, user=False))
 
-        assert calls == [(False, False)]
+        assert calls == [(False, False, False, True)]
+
+    def test_gateway_status_can_target_user_scope_explicitly(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {"installed": requested_scope == "user", "system": False, "unit_name": "hermes-gateway"},
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "systemd_status",
+            lambda deep=False, system=False, user=False, auto_select=False: calls.append((deep, system, user, auto_select)),
+        )
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False, user=True))
+
+        assert calls == [(False, False, True, False)]
+
+    def test_gateway_status_user_scope_does_not_fall_back_to_manual_process_view_when_user_service_missing(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {"installed": False, "system": False, "scope": requested_scope or "user"},
+        )
+
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "systemd_status",
+            lambda deep=False, system=False, user=False, auto_select=False: calls.append((deep, system, user, auto_select)),
+        )
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [691964])
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False, user=True))
+
+        assert calls == [(False, False, True, False)]
+
+    def test_gateway_repair_passes_flags_to_repair_script(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        calls = []
+        monkeypatch.setattr(repair_script, "main", lambda argv=None: calls.append(list(argv or [])) or 0)
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="repair",
+                system=True,
+                user=False,
+                apply=True,
+                dry_run=False,
+                cleanup_legacy=True,
+            )
+        )
+
+        assert calls == [["--system", "--apply", "--cleanup-legacy"]]
+
+    def test_gateway_repair_can_target_user_scope(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        calls = []
+        monkeypatch.setattr(repair_script, "main", lambda argv=None: calls.append(list(argv or [])) or 0)
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="repair",
+                system=False,
+                user=True,
+                apply=False,
+                dry_run=False,
+                cleanup_legacy=True,
+            )
+        )
+
+        assert calls == [["--user", "--cleanup-legacy"]]
+
+    def test_gateway_restart_explicit_system_scope_missing_service_does_not_restart_manual_gateway(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": False,
+                "system": requested_scope == "system",
+                "scope": requested_scope or "system",
+            },
+        )
+        monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
+
+        manual_calls = []
+        monkeypatch.setattr(gateway_cli, "stop_profile_gateway", lambda: manual_calls.append("stop") or False)
+        monkeypatch.setattr(gateway_cli, "run_gateway", lambda *args, **kwargs: manual_calls.append("run"))
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="restart", system=True, user=False))
+
+        assert exc.value.code == 1
+        assert manual_calls == []
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
+
+    def test_gateway_stop_explicit_system_scope_missing_service_does_not_stop_manual_gateway(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": False,
+                "system": requested_scope == "system",
+                "scope": requested_scope or "system",
+            },
+        )
+
+        manual_calls = []
+        monkeypatch.setattr(gateway_cli, "stop_profile_gateway", lambda: manual_calls.append("stop") or False)
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="stop", system=True, user=False, all=False))
+
+        assert exc.value.code == 1
+        assert manual_calls == []
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
+
+    def test_gateway_start_explicit_system_scope_missing_service_exits_cleanly(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": False,
+                "system": requested_scope == "system",
+                "scope": requested_scope or "system",
+            },
+        )
+
+        start_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_start", lambda system=False, user=False: start_calls.append((system, user)))
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="start", system=True, user=False))
+
+        assert exc.value.code == 1
+        assert start_calls == []
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
+
+    def test_gateway_start_without_installed_service_exits_cleanly(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": False,
+                "system": False,
+                "scope": requested_scope or "user",
+            },
+        )
+
+        start_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_start", lambda system=False, user=False: start_calls.append((system, user)))
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="start", system=False, user=False))
+
+        assert exc.value.code == 1
+        assert start_calls == []
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
+
+    def test_gateway_uninstall_explicit_system_scope_missing_service_exits_cleanly(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": False,
+                "system": requested_scope == "system",
+                "scope": requested_scope or "system",
+            },
+        )
+
+        uninstall_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_uninstall", lambda system=False, user=False: uninstall_calls.append((system, user)))
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="uninstall", system=True, user=False))
+
+        assert exc.value.code == 1
+        assert uninstall_calls == []
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
+
+    def test_gateway_uninstall_without_installed_service_exits_cleanly(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": False,
+                "system": False,
+                "scope": requested_scope or "user",
+            },
+        )
+
+        uninstall_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_uninstall", lambda system=False, user=False: uninstall_calls.append((system, user)))
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.gateway_command(SimpleNamespace(gateway_command="uninstall", system=False, user=False))
+
+        assert exc.value.code == 1
+        assert uninstall_calls == []
+        output = capsys.readouterr().out
+        assert "not installed" in output.lower()
+
+    def test_gateway_restart_from_gateway_surface_schedules_detached_system_lane(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": True,
+                "scope": "system",
+                "unit_name": "hermes-gateway",
+            },
+        )
+
+        scheduled = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_schedule_detached_system_gateway_cli",
+            lambda action_name, hermes_args: scheduled.append((action_name, hermes_args)) or ("hermes-gateway-restart-123", Path("/tmp/restart.log")),
+        )
+
+        direct_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_restart", lambda system=False, user=False: direct_calls.append((system, user)))
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="restart", system=True, user=False))
+
+        assert direct_calls == []
+        assert scheduled == [(
+            "restart",
+            ["gateway", "restart", "--system"],
+        )]
+        output = capsys.readouterr().out
+        assert "detached" in output.lower()
+
+    def test_gateway_uninstall_from_gateway_surface_schedules_detached_system_lane(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": True,
+                "scope": "system",
+                "unit_name": "hermes-gateway",
+            },
+        )
+
+        scheduled = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_schedule_detached_system_gateway_cli",
+            lambda action_name, hermes_args: scheduled.append((action_name, hermes_args)) or ("hermes-gateway-uninstall-123", Path("/tmp/uninstall.log")),
+        )
+
+        uninstall_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_uninstall", lambda system=False, user=False: uninstall_calls.append((system, user)))
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="uninstall", system=True, user=False))
+
+        assert uninstall_calls == []
+        assert scheduled == [(
+            "uninstall",
+            ["gateway", "uninstall", "--system"],
+        )]
+        output = capsys.readouterr().out
+        assert "detached" in output.lower()
+
+    def test_gateway_stop_from_gateway_surface_schedules_detached_system_lane(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": True,
+                "scope": "system",
+                "unit_name": "hermes-gateway",
+            },
+        )
+
+        scheduled = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_schedule_detached_system_gateway_cli",
+            lambda action_name, hermes_args: scheduled.append((action_name, hermes_args)) or ("hermes-gateway-stop-123", Path("/tmp/stop.log")),
+        )
+
+        direct_calls = []
+        monkeypatch.setattr(gateway_cli, "systemd_stop", lambda system=False, user=False: direct_calls.append((system, user)))
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="stop", system=True, user=False, all=False))
+
+        assert direct_calls == []
+        assert scheduled == [(
+            "stop",
+            ["gateway", "stop", "--system"],
+        )]
+        output = capsys.readouterr().out
+        assert "detached" in output.lower()
+
+    def test_gateway_repair_apply_from_gateway_surface_schedules_detached_system_lane(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": True,
+                "scope": "system",
+                "unit_name": "hermes-gateway",
+            },
+        )
+
+        scheduled = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_schedule_detached_system_gateway_cli",
+            lambda action_name, hermes_args: scheduled.append((action_name, hermes_args)) or ("hermes-gateway-repair-123", Path("/tmp/repair.log")),
+        )
+
+        repair_calls = []
+        monkeypatch.setattr(repair_script, "main", lambda argv=None: repair_calls.append(list(argv or [])) or 0)
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(
+                gateway_command="repair",
+                system=True,
+                user=False,
+                apply=True,
+                dry_run=False,
+                cleanup_legacy=True,
+            )
+        )
+
+        assert repair_calls == []
+        assert scheduled == [(
+            "repair",
+            ["gateway", "repair", "--system", "--apply", "--cleanup-legacy"],
+        )]
+        output = capsys.readouterr().out
+        assert "detached" in output.lower()
+
+    def test_schedule_detached_system_gateway_cli_uses_wsl_root_bridge(self, monkeypatch, tmp_path):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text("[Service]\nUser=wutj\nEnvironment=HERMES_HOME=/home/wutj/.hermes\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "_resolve_systemd_service_target",
+            lambda system=False, user=False: {
+                "scope": "system",
+                "system": True,
+                "unit_name": "hermes-gateway",
+                "unit_path": str(unit_path),
+            },
+        )
+        monkeypatch.setattr(gateway_cli, "_system_service_identity", lambda run_as_user=None: ("wutj", "wutj", "/home/wutj"))
+        monkeypatch.setattr(gateway_cli, "get_hermes_cli_path", lambda: "/home/wutj/.local/bin/hermes")
+        monkeypatch.setattr(gateway_cli, "_is_wsl", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_find_wsl_executable", lambda: "/mnt/c/Windows/System32/wsl.exe")
+        monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 1000)
+        monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+
+        calls = []
+
+        def fake_run(cmd, check=True, timeout=None, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        unit_name, log_path = gateway_cli._schedule_detached_system_gateway_cli(
+            "restart",
+            ["gateway", "restart", "--system"],
+        )
+
+        assert unit_name.startswith("hermes-gateway-restart-")
+        assert log_path.name.startswith("gateway-restart-")
+        assert calls and calls[0][:6] == [
+            "/mnt/c/Windows/System32/wsl.exe",
+            "-d",
+            "Ubuntu",
+            "-u",
+            "root",
+            "--",
+        ]
+        assert "systemd-run" in calls[0]
+        assert "gateway restart --system" in calls[0][-1]
+
+    def test_systemd_status_surfaces_repair_commands_for_drifted_system_unit(self, tmp_path, monkeypatch, capsys):
+        unit_path = tmp_path / "hermes-gateway-17b8e69b.service"
+        unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": True,
+                "scope": "system",
+                "unit_name": "hermes-gateway-17b8e69b",
+                "unit_path": str(unit_path),
+                "drifted": True,
+                "active": True,
+                "reachable": True,
+            },
+        )
+        monkeypatch.setattr(gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: True)
+        monkeypatch.setattr(gateway_cli, "_read_systemd_user_from_unit", lambda path: "wutj")
+        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.systemd_status(system=True)
+
+        output = capsys.readouterr().out
+        assert "Preview cutover: hermes gateway repair --system" in output
+        assert "Apply when ready: sudo hermes gateway repair --system --apply --cleanup-legacy" in output
+
+    def test_systemd_status_user_scope_surfaces_user_repair_commands(self, tmp_path, monkeypatch, capsys):
+        unit_path = tmp_path / "hermes-gateway-17b8e69b.service"
+        unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": False,
+                "scope": "user",
+                "unit_name": "hermes-gateway-17b8e69b",
+                "unit_path": str(unit_path),
+                "drifted": True,
+                "active": False,
+                "reachable": True,
+            },
+        )
+        monkeypatch.setattr(gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: False)
+        monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway")
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, "enabled"))
+
+        gateway_cli.systemd_status(user=True)
+
+        output = capsys.readouterr().out
+        assert "Preview cutover: hermes gateway repair --user" in output
+        assert "Apply when ready: hermes gateway repair --user --apply --cleanup-legacy" in output
+        assert "Run: hermes gateway restart --user  # auto-refreshes the unit" in output
+
+    def test_resolve_systemd_service_target_can_force_user_scope(self, tmp_path, monkeypatch):
+        user_unit_path = tmp_path / "hermes-gateway.service"
+        user_unit_path.write_text("[Unit]\n", encoding="utf-8")
+        system_unit_path = tmp_path / "hermes-gateway-legacy.service"
+        system_unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_systemd_report",
+            lambda requested_scope=None: {
+                "installed": True,
+                "system": requested_scope == "system",
+                "scope": requested_scope or "system",
+                "unit_name": "hermes-gateway-legacy" if requested_scope != "user" else "hermes-gateway",
+                "unit_path": str(system_unit_path if requested_scope != "user" else user_unit_path),
+            },
+        )
+
+        target = gateway_cli._resolve_systemd_service_target(user=True)
+
+        assert target["scope"] == "user"
+        assert target["system"] is False
+        assert target["unit_name"] == "hermes-gateway"
+        assert target["unit_path"] == str(user_unit_path)
+
+    def test_scope_conflict_warning_mentions_explicit_user_cleanup(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "get_installed_systemd_scopes", lambda: ["user", "system"])
+
+        gateway_cli.print_systemd_scope_conflict_warning()
+
+        output = capsys.readouterr().out
+        assert "Pass --user or --system to force the scope explicitly." in output
+        assert "hermes gateway status --user" in output
+        assert "hermes gateway uninstall --user" in output
+        assert "sudo hermes gateway uninstall --system" in output
 
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,14 +1,78 @@
 from types import SimpleNamespace
 
+import hermes_cli.gateway as gateway_cli
 from hermes_cli.status import show_status
 
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_surfaces_gateway_repair_hints_for_drifted_outdated_unit(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    unit_path = tmp_path / "hermes-gateway-17b8e69b.service"
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_gateway_systemd_report",
+        lambda: {
+            "installed": True,
+            "active": True,
+            "state": "running",
+            "scope": "system",
+            "system": True,
+            "unit_name": "hermes-gateway-17b8e69b",
+            "unit_path": str(unit_path),
+            "drifted": True,
+        },
+    )
+    monkeypatch.setattr(gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Unit:         hermes-gateway-17b8e69b (legacy/non-canonical)" in output
+    assert "Drift:        yes" in output
+    assert "Preview:      hermes gateway repair --system" in output
+    assert "Apply:        sudo hermes gateway repair --system --apply --cleanup-legacy" in output
+    assert "Definition:   outdated" in output
+    assert "Refresh:      sudo hermes gateway restart --system" in output
+
+
+def test_show_status_skips_gateway_repair_hints_when_unit_is_canonical_and_current(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_gateway_systemd_report",
+        lambda: {
+            "installed": True,
+            "active": True,
+            "state": "running",
+            "scope": "system",
+            "system": True,
+            "unit_name": "hermes-gateway",
+            "unit_path": str(unit_path),
+            "drifted": False,
+        },
+    )
+    monkeypatch.setattr(gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: True)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Unit:         hermes-gateway" in output
+    assert "Preview:" not in output
+    assert "Apply:" not in output
+    assert "Definition:" not in output
+    assert "Refresh:" not in output

--- a/tests/test_gateway_canonical_repair.py
+++ b/tests/test_gateway_canonical_repair.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from scripts.gateway_canonical_repair import build_repair_plan
+import scripts.gateway_canonical_repair as repair_script
+
+
+def test_build_repair_plan_for_legacy_system_unit(tmp_path, monkeypatch):
+    unit_path = tmp_path / "hermes-gateway-17b8e69b.service"
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        repair_script.gateway_cli,
+        "get_gateway_systemd_report",
+        lambda requested_scope=None: {
+            "installed": True,
+            "system": True,
+            "scope": "system",
+            "unit_name": "hermes-gateway-17b8e69b",
+            "unit_path": str(unit_path),
+            "drifted": True,
+            "active": True,
+        },
+    )
+    monkeypatch.setattr(repair_script.gateway_cli, "get_service_name", lambda: "hermes-gateway")
+    monkeypatch.setattr(repair_script.gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: False)
+    monkeypatch.setattr(repair_script.gateway_cli, "_read_systemd_user_from_unit", lambda path: "wutj")
+
+    plan = build_repair_plan(cleanup_legacy=True)
+
+    commands = [step["command"] for step in plan["steps"] if step.get("command")]
+    assert plan["repair_needed"] is True
+    assert plan["required_root"] is True
+    assert plan["current_unit"] == "hermes-gateway-17b8e69b"
+    assert plan["canonical_unit"] == "hermes-gateway"
+    assert "sudo hermes gateway restart --system" in commands
+    assert "sudo hermes gateway install --system --run-as-user wutj" in commands
+    assert "sudo systemctl disable hermes-gateway-17b8e69b" in commands
+    assert "sudo systemctl stop hermes-gateway-17b8e69b" in commands
+    assert "sudo systemctl start hermes-gateway" in commands
+    assert any("rm -f" in command for command in commands)
+    assert plan["apply_command"].endswith("--apply --cleanup-legacy")
+
+
+def test_build_repair_plan_is_noop_when_canonical_unit_is_current(tmp_path, monkeypatch):
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        repair_script.gateway_cli,
+        "get_gateway_systemd_report",
+        lambda requested_scope=None: {
+            "installed": True,
+            "system": True,
+            "scope": "system",
+            "unit_name": "hermes-gateway",
+            "unit_path": str(unit_path),
+            "drifted": False,
+            "active": True,
+        },
+    )
+    monkeypatch.setattr(repair_script.gateway_cli, "get_service_name", lambda: "hermes-gateway")
+    monkeypatch.setattr(repair_script.gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: True)
+    monkeypatch.setattr(repair_script.gateway_cli, "_read_systemd_user_from_unit", lambda path: "wutj")
+
+    plan = build_repair_plan()
+
+    assert plan["repair_needed"] is False
+    assert plan["steps"] == [
+        {
+            "id": "noop",
+            "summary": "No canonical repair is needed; the current unit already matches the expected service identity and definition.",
+            "command": None,
+        }
+    ]
+
+
+def test_build_repair_plan_for_user_scope_avoids_sudo(tmp_path, monkeypatch):
+    unit_path = tmp_path / "hermes-gateway-coder.service"
+    unit_path.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        repair_script.gateway_cli,
+        "get_gateway_systemd_report",
+        lambda requested_scope=None: {
+            "installed": True,
+            "system": False,
+            "scope": "user",
+            "unit_name": "hermes-gateway-deadbeef",
+            "unit_path": str(unit_path),
+            "drifted": True,
+            "active": True,
+        },
+    )
+    monkeypatch.setattr(repair_script.gateway_cli, "get_service_name", lambda: "hermes-gateway")
+    monkeypatch.setattr(repair_script.gateway_cli, "systemd_unit_path_is_current", lambda path, system=False: True)
+    monkeypatch.setattr(repair_script.gateway_cli, "_read_systemd_user_from_unit", lambda path: None)
+
+    plan = build_repair_plan()
+
+    commands = [step["command"] for step in plan["steps"] if step.get("command")]
+    assert plan["required_root"] is False
+    assert "hermes gateway install --user" in commands
+    assert "systemctl --user disable hermes-gateway-deadbeef" in commands
+    assert "systemctl --user start hermes-gateway" in commands
+    assert " --user --apply" in plan["apply_command"]
+    assert all(not command.startswith("sudo ") for command in commands)


### PR DESCRIPTION
## Summary
- align gateway truth and action surfaces around explicit `--system` / `--user`
- route gateway-surface system `stop` / `restart` / `uninstall` / `repair --apply` through the detached control lane
- add canonical repair entrypoint plus focused regression coverage
- keep status hints aligned with the real gateway service owner

## Test Plan
- source venv/bin/activate && pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_status.py tests/test_gateway_canonical_repair.py -q
- source venv/bin/activate && python -m py_compile hermes_cli/gateway.py hermes_cli/main.py hermes_cli/status.py scripts/gateway_canonical_repair.py
