### PR TITLE
fix(gateway): session key profile isolation + cron ticker cleanup + /new None guard

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -901,10 +901,13 @@ class GatewayRunner:
             except Exception:
                 pass
         config = getattr(self, "config", None)
+        from .session import get_active_profile
+        profile = get_active_profile()
         return build_session_key(
             source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            profile=profile,
         )
 
     def _resolve_session_agent_runtime(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4516,8 +4516,9 @@ class GatewayRunner:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _old_sid = old_entry.session_id if old_entry else None
-            _invoke_hook("on_session_finalize", session_id=_old_sid,
-                         platform=source.platform.value if source.platform else "")
+            if _old_sid is not None:
+                _invoke_hook("on_session_finalize", session_id=_old_sid,
+                             platform=source.platform.value if source.platform else "")
         except Exception:
             pass
 
@@ -10360,21 +10361,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
-    if runner.should_exit_with_failure:
-        if runner.exit_reason:
-            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
-        return False
-    
-    # Stop cron ticker cleanly
-    cron_stop.set()
-    cron_thread.join(timeout=5)
-
-    # Close MCP server connections
     try:
-        from tools.mcp_tool import shutdown_mcp_servers
-        shutdown_mcp_servers()
-    except Exception:
-        pass
+        if runner.should_exit_with_failure:
+            if runner.exit_reason:
+                logger.error("Gateway exiting with failure: %s", runner.exit_reason)
+            return False
+    finally:
+        # Stop cron ticker cleanly (must run even on failure path)
+        cron_stop.set()
+        cron_thread.join(timeout=5)
+
+        # Close MCP server connections
+        try:
+            from tools.mcp_tool import shutdown_mcp_servers
+            shutdown_mcp_servers()
+        except Exception:
+            pass
 
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -441,6 +441,7 @@ def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
     thread_sessions_per_user: bool = False,
+    profile: str = "main",
 ) -> str:
     """Build a deterministic session key from a message source.
 
@@ -465,18 +466,19 @@ def build_session_key(
         shared session per chat.
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
+    agent_prefix = f"agent:{profile}"
     platform = source.platform.value
     if source.chat_type == "dm":
         if source.chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{source.chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{source.chat_id}"
+                return f"{agent_prefix}:{platform}:dm:{source.chat_id}:{source.thread_id}"
+            return f"{agent_prefix}:{platform}:dm:{source.chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{agent_prefix}:{platform}:dm:{source.thread_id}"
+        return f"{agent_prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [agent_prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)
@@ -494,6 +496,25 @@ def build_session_key(
         key_parts.append(str(participant_id))
 
     return ":".join(key_parts)
+
+
+def get_active_profile() -> str:
+    """Get the active profile name for session key isolation.
+
+    Returns the profile name when using a non-default profile
+    (i.e. HERMES_HOME points to ~/.hermes/profiles/<name>).
+    Returns "main" for the default profile to preserve backward-compatible
+    session keys (agent:main:*).
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        name = get_active_profile_name()
+        # "default" means standard ~/.hermes — keep "main" for backward compat
+        if name and name != "default":
+            return name
+    except Exception:
+        pass
+    return "main"
 
 
 class SessionStore:
@@ -578,6 +599,7 @@ class SessionStore:
             source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            profile=get_active_profile(),
         )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:


### PR DESCRIPTION
Three small gateway bugfixes:

1. Session key profile isolation (#12099)

build_session_key() hardcodes 'agent:main' in all session keys. When running
multiple Hermes profiles (HERMES_HOME=~/.hermes/profiles/<name>), different
profiles share the same session keys, causing conversation leakage.

Fix: add profile parameter to build_session_key(). get_active_profile() returns
the active profile name for non-default profiles, or main for backward compat.

2. Cron ticker and MCP cleanup on failure path (#12175)

When should_exit_with_failure is True, return False skipped both
cron_stop.set() and shutdown_mcp_servers(), leaking the cron ticker
thread and MCP connections. Wrapped in try/finally so cleanup always runs.

3. Guard /new against None session in finalize hook (#12176)

_handle_reset_command() called on_session_finalize(session_id=None)
when no prior session existed. Skip hook invocation when _old_sid is None.

Testing: 3233 passed, 0 new failures (13 pre-existing).