### PR TITLE
fix(client): inject explicit httpx client for custom endpoints to prevent stale connection errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4366,7 +4366,42 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
-        client = OpenAI(**client_kwargs)
+
+        # For custom/direct endpoints, inject an explicit httpx client with
+        # conservative connection pool limits and keepalive settings.
+        # Without this, the shared OpenAI client reuses stale pooled connections
+        # that the server has already closed, causing ~80% APIConnectionError
+        # failures even when the endpoint is healthy (issue #11969).
+        # Direct Python SDK calls always succeed because they create a fresh
+        # client (and thus a fresh pool) on every invocation.
+        kwargs = dict(client_kwargs)
+        if "http_client" not in kwargs:
+            _base = str(kwargs.get("base_url", "")).lower()
+            _is_aggregator = any(x in _base for x in ("openrouter.ai", "openai.com", "anthropic.com"))
+            if not _is_aggregator:
+                try:
+                    import httpx as _httpx
+                    kwargs["http_client"] = _httpx.Client(
+                        timeout=_httpx.Timeout(
+                            connect=10.0,
+                            read=300.0,
+                            write=30.0,
+                            pool=10.0,
+                        ),
+                        limits=_httpx.Limits(
+                            max_connections=10,
+                            max_keepalive_connections=2,
+                            keepalive_expiry=30.0,
+                        ),
+                    )
+                    logger.debug(
+                        "OpenAI client: injected explicit httpx client for custom endpoint (%s)",
+                        reason,
+                    )
+                except ImportError:
+                    pass  # httpx not available — fall through to default
+
+        client = OpenAI(**kwargs)
         logger.info(
             "OpenAI client created (%s, shared=%s) %s",
             reason,


### PR DESCRIPTION
## Problem

When using a custom/direct endpoint, the shared `OpenAI` client reuses pooled TCP connections that the server has already closed, causing ~80% `APIConnectionError` failures. Direct Python SDK calls always succeed because they create a fresh client (and connection pool) on every invocation.

From the reporter:
> When executing `hermes chat -q "hello"` repeatedly, success rate is extremely low (~20%). When calling the same endpoint directly via Python SDK, success rate is 100%.

**Root cause:** The OpenAI SDK defaults to keeping connections alive indefinitely. For custom endpoints (especially corporate/on-prem gateways), the server closes idle connections after a short timeout. The next request reuses the stale socket → `APIConnectionError`.

## Fix

In `_create_openai_client()`, inject an explicit `httpx.Client` for non-aggregator endpoints with:
- `keepalive_expiry=30s` — discard connections idle >30s
- `max_keepalive_connections=2` — small pool, fewer stale sockets
- Conservative timeouts: `connect=10s`, `read=300s`, `write=30s`

Only applied when:
- Endpoint is not an aggregator (openrouter/openai/anthropic manage their own retry infra)
- Caller has not already provided `http_client` in kwargs

Fixes #11969