### PR TITLE
fix(cli): fall back to PollSelector when kqueue can't register stdin (macOS 26+)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -146,6 +146,25 @@ def _apply_profile_override() -> None:
 
 _apply_profile_override()
 
+# macOS 26+ regression: kqueue cannot register stdin (fd 0) for async
+# reading, causing OSError [Errno 22] Invalid argument.  prompt_toolkit
+# triggers this via loop.add_reader(0, ...) in Vt100Input._attached_input().
+# Fall back to PollSelector which works correctly.  Must run BEFORE any
+# prompt_toolkit import (cli.py imports it at module level).
+# See: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1943
+if sys.platform == "darwin":
+    try:
+        import selectors as _selectors
+
+        _sel = _selectors.DefaultSelector()
+        _sel.register(0, _selectors.EVENT_READ)
+        _sel.unregister(0)
+        del _sel
+    except OSError:
+        _selectors.DefaultSelector = _selectors.PollSelector
+    except Exception:
+        pass  # non-interactive (fd 0 unavailable) — safe to skip
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.config import get_hermes_home


### PR DESCRIPTION
## What does this PR do?

Fixes a crash on macOS 26+ where `hermes` (interactive chat mode) fails immediately with:

```
OSError: [Errno 22] Invalid argument
  ...
  selectors.py, line 523, in register
    self._selector.control([kev], 0, 0)
```

macOS 26 introduced a kqueue regression where registering stdin (fd 0) for `EVENT_READ` raises `OSError [Errno 22] Invalid argument`. `prompt_toolkit` triggers this via `loop.add_reader(0, ...)` in `Vt100Input._attached_input()`.

## Root Cause

Python's `selectors.KqueueSelector` (default on macOS) can no longer register fd 0 on macOS 26+. The existing workaround from #8560 (fstat guard + exception handler) doesn't prevent this crash because the `OSError` fires inside `prompt_toolkit`'s context manager `__enter__`, before our exception handler is reached.

## Fix

Probe kqueue early in startup (after `_apply_profile_override()`, before any `prompt_toolkit` import). If `KqueueSelector` can't register stdin, replace `selectors.DefaultSelector` with `PollSelector`, which works correctly.

Only activates on `sys.platform == "darwin"` when kqueue is actually broken — zero impact on other platforms or older macOS versions.

## Related Issue

- Upstream: [prompt-toolkit#1943](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1943)
- Upstream PR (unmerged): [prompt-toolkit#2065](https://github.com/prompt-toolkit/python-prompt-toolkit/pull/2065)
- Related prior fix: #8560 (handles broken stdin from uv-managed Python, but not this kqueue regression)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Add kqueue probe + PollSelector fallback after `_apply_profile_override()`, before any `prompt_toolkit` import

## How to Test

1. On macOS 26+: Run `hermes` — previously crashed with `OSError [Errno 22]`, now starts normally
2. On older macOS / Linux: No behavior change — kqueue probe passes, no fallback triggered
3. Verify the probe: `python -c "import selectors; s=selectors.DefaultSelector(); s.register(0, selectors.EVENT_READ); s.unregister(0)"` — fails on macOS 26+ with `KqueueSelector`, passes with `PollSelector`

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventional-commits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: macOS 26.4.1 (Tahoe, Apple Silicon M4 Pro)

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture changes, or tool behavior changes