### PR TITLE
docs(terminal): warn against stacking watch_patterns + notify_on_complete

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1126,7 +1126,7 @@ def terminal_tool(
         workdir: Working directory for this command (optional, uses session cwd if not set)
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, auto-notify the agent when the process exits
-        watch_patterns: List of strings to watch for in background output; triggers notification on match
+        watch_patterns: List of strings to watch for in background output; fires a notification on first match per pattern. Use ONLY for mid-process signals (errors, readiness markers) that appear before exit. For end-of-run markers use notify_on_complete instead — stacking both produces duplicate, delayed notifications.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -1724,7 +1724,7 @@ TERMINAL_SCHEMA = {
             "watch_patterns": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "List of strings to watch for in background process output. When any pattern matches a line of output, you'll be notified with the matching text — like notify_on_complete but triggers mid-process on specific output. Use for monitoring logs, watching for errors, or waiting for specific events (e.g. [\"ERROR\", \"FAIL\", \"listening on port\"])."
+                "description": "Strings to watch for in background process output. Fires a notification the first time each pattern matches a line of output. **Use ONLY for mid-process signals** you want to react to before the process exits — errors, readiness markers, intermediate step markers (e.g. [\"ERROR\", \"Traceback\", \"listening on port\"]). Do NOT use for end-of-run markers (summary headers, 'DONE', 'PASS' printed right before exit) — use `notify_on_complete` for that instead. Stacking end-of-run patterns on top of `notify_on_complete` produces duplicate, delayed notifications that arrive after you've already moved on, since delivery is asynchronous and continues after the process exits."
             }
         },
         "required": ["command"]


### PR DESCRIPTION
## Summary

Reshape the `watch_patterns` schema description so agents stop pairing it with `notify_on_complete` on end-of-run markers.

## Why

Stacking both features on the same event produces duplicate, delayed notifications: delivery is async and fires after the process has already exited, so matches on end-of-run markers (`"SUMMARY"`, `"DONE"`, `"PASS"` printed right before exit) arrive after the agent has already polled/waited and moved on. Caught live today — a three-probe session fired three stale popups each arriving long after its probe had completed and been consumed.

The previous description framed `watch_patterns` as *"like notify_on_complete but triggers mid-process on specific output,"* which reads as "same thing, just earlier" and invites stacking.

## Changes

- **`tools/terminal_tool.py` JSON schema**: `watch_patterns.description` now says explicitly: mid-process signals only (errors, readiness markers, intermediate steps), don't use for end-of-run markers, use `notify_on_complete` for that, stacking produces duplicate stale notifications.
- **`terminal_tool()` function docstring** updated to match.

No behavioural change.

## Validation

| | Before | After |
|---|---|---|
| `tests/tools/test_watch_patterns.py` + `test_notify_on_complete.py` + `test_terminal_foreground_timeout_cap.py` | 50 passed | 50 passed |
| `py_compile tools/terminal_tool.py` | ok | ok |
| Schema description contains "mid-process", "notify_on_complete", "duplicate" | no | yes |