### PR TITLE
fix(feishu): render markdown tables via card v2 `table` component

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -128,6 +128,14 @@ _TABLE_SEPARATOR_RE = re.compile(r"^\s*\|[:\-| ]+\|\s*$")
 _TABLE_HINT_RE = re.compile(r"^\s*\|[:\- ]+\|", re.MULTILINE)
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$", re.MULTILINE)
 _HTML_BR_RE = re.compile(r"<br\s*/?\s*>", re.IGNORECASE)
+# Detects inline markdown (bold/italic/code/link) in a table cell so the
+# column can be promoted from plain ``text`` to ``lark_md`` for rendering.
+_INLINE_MD_IN_CELL_RE = re.compile(
+    r"\*\*[^*\n]+\*\*"
+    r"|__[^_\n]+__"
+    r"|`[^`\n]+`"
+    r"|\[[^\]]+\]\([^)]+\)"
+)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -501,17 +509,29 @@ def _split_markdown_for_feishu(content: str) -> list[dict]:
 
 
 def _build_feishu_table_element(headers: list[str], rows: list[list[str]]) -> dict:
-    """Build a Feishu card v2 ``table`` component from parsed GFM table data."""
-    columns = [
-        {
+    """Build a Feishu card v2 ``table`` component from parsed GFM table data.
+
+    A column is emitted with ``data_type: "lark_md"`` when any cell in that
+    column contains inline markdown (``**bold**``, ``*italic*``, ``` `code` ```,
+    ``[text](url)``) so Feishu renders the formatting instead of showing
+    literal ``**`` / backticks. Columns of pure plain text stay on the
+    safer ``text`` type.
+    """
+    columns: list[dict] = []
+    for idx, header in enumerate(headers):
+        column_cells = [row[idx] if idx < len(row) else "" for row in rows]
+        data_type = (
+            "lark_md"
+            if any(_INLINE_MD_IN_CELL_RE.search(cell) for cell in column_cells)
+            else "text"
+        )
+        columns.append({
             "name": f"col_{idx}",
             "display_name": header,
-            "data_type": "text",
+            "data_type": data_type,
             "width": "auto",
             "horizontal_align": "left",
-        }
-        for idx, header in enumerate(headers)
-    ]
+        })
     row_data = [
         {f"col_{idx}": cell for idx, cell in enumerate(row)}
         for row in rows

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -122,6 +122,12 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+# Detects a GFM table separator row such as ``|---|---|`` or ``|:---:|---:|``.
+_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|[:\-| ]+\|\s*$")
+# Detects presence of a GFM table anywhere in a block of content.
+_TABLE_HINT_RE = re.compile(r"^\s*\|[:\- ]+\|", re.MULTILINE)
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$", re.MULTILINE)
+_HTML_BR_RE = re.compile(r"<br\s*/?\s*>", re.IGNORECASE)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -429,6 +435,129 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _transform_text_for_feishu(text: str) -> str:
+    """Adjust inline markdown so it renders acceptably in Feishu.
+
+    Feishu's post ``md`` and card ``markdown`` grammars do not support ATX
+    headings or raw ``<br>`` tags — without this transform, ``# foo`` shows
+    as literal text and ``<br>`` shows as ``<br>`` in the rendered message.
+    Headings are rewritten as bold lines and ``<br>`` tags are replaced with
+    real newlines so emphasis and line breaks display as intended.
+    """
+    text = _HEADING_RE.sub(lambda m: f"**{m.group(2)}**", text)
+    text = _HTML_BR_RE.sub("\n", text)
+    return text
+
+
+def _is_table_row(s: str) -> bool:
+    stripped = s.strip()
+    return stripped.startswith("|") and stripped.endswith("|") and len(stripped) >= 2
+
+
+def _split_markdown_for_feishu(content: str) -> list[dict]:
+    """Split markdown content into ordered text/table segments.
+
+    Each segment is either ``{"type": "text", "content": str}`` for regular
+    markdown, or ``{"type": "table", "headers": list[str], "rows": list[list[str]]}``
+    for a GFM table (header row followed by a ``| --- |`` separator row).
+    """
+    lines = content.split("\n")
+    segments: list[dict] = []
+    text_buffer: list[str] = []
+    i = 0
+    n = len(lines)
+
+    def flush_text() -> None:
+        if not text_buffer:
+            return
+        joined = "\n".join(text_buffer).strip("\n")
+        if joined.strip():
+            segments.append({"type": "text", "content": joined})
+        text_buffer.clear()
+
+    while i < n:
+        line = lines[i]
+        if (
+            _is_table_row(line)
+            and i + 1 < n
+            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            flush_text()
+            headers = [c.strip() for c in line.strip().strip("|").split("|")]
+            i += 2
+            rows: list[list[str]] = []
+            while i < n and _is_table_row(lines[i]):
+                cells = [c.strip() for c in lines[i].strip().strip("|").split("|")]
+                cells = (cells + [""] * len(headers))[: len(headers)]
+                rows.append(cells)
+                i += 1
+            segments.append({"type": "table", "headers": headers, "rows": rows})
+            continue
+        text_buffer.append(line)
+        i += 1
+
+    flush_text()
+    return segments
+
+
+def _build_feishu_table_element(headers: list[str], rows: list[list[str]]) -> dict:
+    """Build a Feishu card v2 ``table`` component from parsed GFM table data."""
+    columns = [
+        {
+            "name": f"col_{idx}",
+            "display_name": header,
+            "data_type": "text",
+            "width": "auto",
+            "horizontal_align": "left",
+        }
+        for idx, header in enumerate(headers)
+    ]
+    row_data = [
+        {f"col_{idx}": cell for idx, cell in enumerate(row)}
+        for row in rows
+    ]
+    return {
+        "tag": "table",
+        "page_size": 10,
+        "row_height": "low",
+        "header_style": {
+            "text_align": "left",
+            "text_size": "normal",
+            "background_style": "grey",
+            "text_color": "default",
+            "bold": True,
+            "lines": 1,
+        },
+        "columns": columns,
+        "rows": row_data,
+    }
+
+
+def _build_markdown_card_payload(content: str) -> str:
+    """Build a Feishu card JSON v2 payload that renders tables natively.
+
+    Feishu's post ``md`` and card ``markdown`` elements both silently drop
+    GFM pipe tables. The only Feishu surface that renders tabular data is
+    the card v2 ``table`` component, so content containing a markdown table
+    is emitted as an interactive card where each GFM table becomes a native
+    table element and surrounding markdown stays in ``markdown`` elements.
+    """
+    segments = _split_markdown_for_feishu(content)
+    elements: list[dict] = []
+    for seg in segments:
+        if seg["type"] == "text":
+            md = _transform_text_for_feishu(seg["content"]).strip()
+            if md:
+                elements.append({"tag": "markdown", "content": md})
+        else:
+            elements.append(_build_feishu_table_element(seg["headers"], seg["rows"]))
+    card = {
+        "schema": "2.0",
+        "body": {"elements": elements},
+    }
+    return json.dumps(card, ensure_ascii=False)
+
+
 def _build_markdown_post_payload(content: str) -> str:
     return json.dumps(
         {
@@ -437,7 +566,7 @@ def _build_markdown_post_payload(content: str) -> str:
                     [
                         {
                             "tag": "md",
-                            "text": content,
+                            "text": _transform_text_for_feishu(content),
                         }
                     ]
                 ],
@@ -3364,6 +3493,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        # Feishu's post ``md`` and card ``markdown`` elements silently drop
+        # GFM tables, so any content containing a markdown table is routed to
+        # a card v2 payload whose native ``table`` component renders rows.
+        if _TABLE_HINT_RE.search(content):
+            return "interactive", _build_markdown_card_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2581,9 +2581,37 @@ class TestAdapterBehavior(unittest.TestCase):
         card = json.loads(_build_markdown_card_payload(content))
         table_elem = next(e for e in card["body"]["elements"] if e["tag"] == "table")
         row = table_elem["rows"][0]
-        # Cell text is stored verbatim; Feishu's text cell renders **bold**/`code`.
+        # Cell text is stored verbatim so Feishu can render the inline markdown.
         self.assertEqual(row["col_0"], "**粗体**")
         self.assertEqual(row["col_1"], "`code`")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_table_promotes_columns_with_markdown_to_lark_md(self):
+        from gateway.platforms.feishu import _build_markdown_card_payload
+
+        # col_0 has plain text, col_1 mixes plain and **bold** cells — col_1
+        # must become lark_md so Feishu renders the bold instead of showing
+        # literal `**` characters.
+        content = (
+            "| 区服 | DAU |\n"
+            "| --- | --- |\n"
+            "| 国际服 | **13,316** |\n"
+            "| null | 1,047 |\n"
+        )
+        card = json.loads(_build_markdown_card_payload(content))
+        table_elem = next(e for e in card["body"]["elements"] if e["tag"] == "table")
+        self.assertEqual(table_elem["columns"][0]["data_type"], "text")
+        self.assertEqual(table_elem["columns"][1]["data_type"], "lark_md")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_table_stays_text_when_no_markdown(self):
+        from gateway.platforms.feishu import _build_markdown_card_payload
+
+        content = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |"
+        card = json.loads(_build_markdown_card_payload(content))
+        table_elem = next(e for e in card["body"]["elements"] if e["tag"] == "table")
+        for col in table_elem["columns"]:
+            self.assertEqual(col["data_type"], "text")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_interactive_card_for_table_markdown(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2291,7 +2291,12 @@ class TestAdapterBehavior(unittest.TestCase):
         payload = json.loads(adapter._build_post_payload("# 标题\n访问 [文档](https://example.com)"))
 
         elements = payload["zh_cn"]["content"][0]
-        self.assertEqual(elements, [{"tag": "md", "text": "# 标题\n访问 [文档](https://example.com)"}])
+        # Feishu's ``md`` grammar does not render ATX headings, so ``# 标题``
+        # is rewritten as a bold line so the emphasis survives rendering.
+        self.assertEqual(
+            elements,
+            [{"tag": "md", "text": "**标题**\n访问 [文档](https://example.com)"}],
+        )
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_wraps_markdown_in_md_tag(self):
@@ -2503,6 +2508,117 @@ class TestAdapterBehavior(unittest.TestCase):
             rows,
             [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_transform_text_for_feishu_rewrites_headings_and_br(self):
+        from gateway.platforms.feishu import _transform_text_for_feishu
+
+        # Feishu renders neither ATX headings nor ``<br>`` tags, so both are
+        # rewritten (``#`` to bold, ``<br>`` to newline) before sending.
+        out = _transform_text_for_feishu("# H1\n## H2\nline a<br>line b<br/>line c")
+        self.assertIn("**H1**", out)
+        self.assertIn("**H2**", out)
+        self.assertNotIn("#", out)
+        self.assertNotIn("<br", out.lower())
+        self.assertIn("line a\nline b\nline c", out)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_routes_tables_to_interactive_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "| col1 | col2 |\n| --- | --- |\n| a | b |\n| c | d |"
+        msg_type, payload = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "interactive")
+        card = json.loads(payload)
+        self.assertEqual(card["schema"], "2.0")
+        table_elem = next(e for e in card["body"]["elements"] if e["tag"] == "table")
+        self.assertEqual(
+            [c["display_name"] for c in table_elem["columns"]],
+            ["col1", "col2"],
+        )
+        self.assertEqual(
+            [[row["col_0"], row["col_1"]] for row in table_elem["rows"]],
+            [["a", "b"], ["c", "d"]],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_keeps_non_table_markdown_on_post(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, payload = adapter._build_outbound_payload(
+            "可以用 **粗体** 和 *斜体*。"
+        )
+        self.assertEqual(msg_type, "post")
+        element = json.loads(payload)["zh_cn"]["content"][0][0]
+        # Inline-only markdown passes through unchanged — no headings/<br> to rewrite.
+        self.assertEqual(element["text"], "可以用 **粗体** 和 *斜体*。")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_splits_text_and_tables_in_order(self):
+        from gateway.platforms.feishu import _build_markdown_card_payload
+
+        content = (
+            "# 标题\n"
+            "正文段落\n\n"
+            "| a | b |\n| --- | --- |\n| 1 | 2 |\n\n"
+            "结尾。"
+        )
+        card = json.loads(_build_markdown_card_payload(content))
+        tags = [e["tag"] for e in card["body"]["elements"]]
+        self.assertEqual(tags, ["markdown", "table", "markdown"])
+        self.assertIn("**标题**", card["body"]["elements"][0]["content"])
+        self.assertEqual(card["body"]["elements"][2]["content"], "结尾。")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_table_preserves_inline_markdown_in_cells(self):
+        from gateway.platforms.feishu import _build_markdown_card_payload
+
+        content = "| 功能 | 描述 |\n| --- | --- |\n| **粗体** | `code` |"
+        card = json.loads(_build_markdown_card_payload(content))
+        table_elem = next(e for e in card["body"]["elements"] if e["tag"] == "table")
+        row = table_elem["rows"][0]
+        # Cell text is stored verbatim; Feishu's text cell renders **bold**/`code`.
+        self.assertEqual(row["col_0"], "**粗体**")
+        self.assertEqual(row["col_1"], "`code`")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_card_for_table_markdown(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        table_content = "| col1 | col2 |\n| --- | --- |\n| a | b |"
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=table_content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        card = json.loads(captured["request"].request_body.content)
+        self.assertEqual(card["schema"], "2.0")
+        table_elem = next(e for e in card["body"]["elements"] if e["tag"] == "table")
+        self.assertEqual(len(table_elem["columns"]), 2)
+        self.assertEqual(len(table_elem["rows"]), 1)
 
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")


### PR DESCRIPTION
## Summary

When Hermes sends a response containing a markdown table to Feishu/Lark, the table rows arrive missing — Feishu's post `md` and card `markdown` grammars both silently drop GFM pipe-table syntax, and the same grammars also render `<br>` tags and ATX headings as literal text. The result is a message where the data the user asked for simply isn't there.

This PR routes any content that contains a GFM table to a **card JSON v2** payload whose native [`table` component](https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-json-v2-components/content-components/table) renders tabular data properly. Each GFM table is parsed and converted to a typed `table` element (text columns + per-row cells); the surrounding markdown is emitted as `markdown` elements in the same card.

For non-table markdown, the existing post `md` path is kept, but with two small fix-ups so the content no longer shows literal junk:

- ATX headings (`# foo`, `## foo`, …) are rewritten as `**foo**` bold lines (Feishu `md` does not render any heading levels).
- `<br>` / `<br/>` HTML tags are replaced with real newlines (Feishu `md` does not render HTML line-break tags).

See [`create_json`](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/create_json) for the supported post-md grammar.

### Before

```
### Income in the last 7 days
| Date       | Week | Income   |
| ---------- | ---- | ----------: |
| 2026-04-11 | Saturday | $10  |
| 2026-04-12 | Sunday | $11  |
```

Arrives in Feishu as `### Income in the last 7 days` (literal `###`, no heading), with the table rows stripped entirely.

### After

The same input arrives as a card with:
- a `markdown` element containing `**Income in the last 7 days**`
- a native Feishu `table` (sortable, paginated) with the 3 columns and 2 rows

## What's covered

- `_split_markdown_for_feishu(content)` – parses content into ordered text / table segments.
- `_build_feishu_table_element(headers, rows)` – emits a card v2 `table` component (`data_type: "text"` cells; inline `**bold**` / `` `code` `` / links survive verbatim).
- `_build_markdown_card_payload(content)` – builds the full card (`schema: "2.0"`, `body.elements`).
- `_transform_text_for_feishu(text)` – rewrites headings → bold, `<br>` → `\n`.
- `_build_outbound_payload` – routes to `interactive` when tables are present, otherwise the existing post / text paths.

## Test plan

- [x] `pytest tests/gateway/test_feishu.py` — 109 passed (no regressions). New cases:
  - `test_transform_text_for_feishu_rewrites_headings_and_br`
  - `test_build_outbound_payload_routes_tables_to_interactive_card`
  - `test_build_outbound_payload_keeps_non_table_markdown_on_post`
  - `test_card_splits_text_and_tables_in_order`
  - `test_card_table_preserves_inline_markdown_in_cells`
  - `test_send_uses_interactive_card_for_table_markdown`
- [x] `test_build_post_payload_extracts_title_and_links` updated to expect `**Title**` instead of `# Title` (the new heading transform).
- [x] Manual verification in a Feishu chat: heading + table + bullets renders as a card with a real table and bold heading (no literal `#`, no literal `<br>`, no rows dropped).