### PR TITLE
fix(cli): harden update check and non-interactive approvals

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -131,12 +131,14 @@ def check_for_updates() -> Optional[int]:
     or ``None`` if the check fails or isn't applicable.
     """
     hermes_home = get_hermes_home()
-    repo_dir = hermes_home / "hermes-agent"
+    project_root = Path(__file__).parent.parent.resolve()
+    repo_dir = project_root
     cache_file = hermes_home / ".update_check"
 
-    # Must be a git repo — fall back to project root for dev installs
+    # Prefer the active project root when Hermes is running from a git checkout.
+    # Only fall back to ~/.hermes/hermes-agent for older install layouts.
     if not (repo_dir / ".git").exists():
-        repo_dir = Path(__file__).parent.parent.resolve()
+        repo_dir = hermes_home / "hermes-agent"
     if not (repo_dir / ".git").exists():
         return None
 

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -192,7 +192,20 @@ def approval_callback(cli, command: str, description: str) -> str:
 
     Uses cli._approval_lock to serialize concurrent requests (e.g. from
     parallel delegation subtasks) so each prompt gets its own turn.
+
+    If no interactive TUI/app is attached, deny immediately with explicit
+    guidance instead of idling until the approval timeout expires.
     """
+    if not getattr(cli, "_app", None):
+        cprint(
+            "\n"
+            f"{_DIM}  Approval required but no interactive approval client is active. "
+            "Denying command immediately. Re-run from an interactive Hermes CLI/session "
+            "or use a safer non-destructive command path if possible." \
+            f"{_RST}"
+        )
+        return "deny"
+
     lock = getattr(cli, "_approval_lock", None)
     if lock is None:
         import threading

--- a/tests/hermes_cli/test_callbacks.py
+++ b/tests/hermes_cli/test_callbacks.py
@@ -1,0 +1,24 @@
+import types
+
+from hermes_cli import callbacks
+
+
+class DummyCLI:
+    _app = None
+
+
+def test_approval_callback_denies_immediately_without_interactive_client(monkeypatch):
+    messages = []
+    monkeypatch.setattr(callbacks, "cprint", messages.append)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "cli",
+        types.SimpleNamespace(CLI_CONFIG={"approvals": {"timeout": 60}}),
+    )
+
+    result = callbacks.approval_callback(DummyCLI(), "rm -rf /tmp/demo", "dangerous")
+
+    assert result == "deny"
+    assert messages
+    assert "no interactive approval client is active" in messages[0]
+    assert "Denying command immediately" in messages[0]


### PR DESCRIPTION
## Summary
- prefer the active git checkout root for CLI update checks and only fall back to `~/.hermes/hermes-agent` for legacy layouts
- deny dangerous approval prompts immediately when no interactive approval client is attached instead of idling until timeout
- add regression coverage for the non-interactive approval path

## Test Plan
- [x] `source .venv/bin/activate && python -m pytest tests/hermes_cli/test_callbacks.py -q`

