### PR TITLE
feat: /notify HTTP endpoint for external push notifications

### DIFF
--- a/gateway/notify.py
+++ b/gateway/notify.py
@@ -13,17 +13,21 @@ no way to reach the user without consuming LLM tokens or waiting for a cron tick
 The endpoint accepts a simple POST:
 
     POST /notify
+    Authorization: Bearer <secret>
     {
         "platform": "telegram",
         "chat_id": "123456789",
-        "message": "🎉 You have a new match!"
+        "message": "🎉 You have a new match!",
+        "thread_id": "optional_thread_id"
     }
 
 The gateway routes the message through the existing platform adapters — same
 delivery infrastructure used by cron jobs, but triggered externally.
 
-Security: Protected by a configurable bearer token (HERMES_NOTIFY_SECRET).
-If not set, the endpoint is disabled by default.
+Security:
+  - Protected by a required bearer token (HERMES_NOTIFY_SECRET).
+  - If no secret is configured, the server does NOT start.
+  - Rate limited: 1 message per chat_id per 30 seconds.
 
 Configuration in config.yaml:
 
@@ -36,9 +40,11 @@ Configuration in config.yaml:
 Or via environment variable: HERMES_NOTIFY_SECRET=your-secret-token
 """
 
-import json
 import logging
-from typing import Optional
+import time
+from typing import Dict, Optional
+
+from .config import Platform
 
 logger = logging.getLogger(__name__)
 
@@ -49,16 +55,32 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None
 
+# Rate limit: 1 message per chat per 30 seconds
+_RATE_LIMIT_SECONDS = 30
+_rate_limit_cache: Dict[str, float] = {}
 
-def check_notify_requirements() -> bool:
-    """Check if aiohttp is available."""
-    return AIOHTTP_AVAILABLE
+
+def _platform_from_string(name: str) -> Optional[Platform]:
+    """Convert a platform string to a Platform enum, or None if invalid."""
+    try:
+        return Platform(name.lower())
+    except ValueError:
+        return None
 
 
 class NotifyServer:
     """Lightweight HTTP server for external push notifications."""
 
-    def __init__(self, gateway, secret: Optional[str] = None, host: str = "127.0.0.1", port: int = 8643):
+    def __init__(self, gateway, secret: str, host: str = "127.0.0.1", port: int = 8643):
+        """
+        Args:
+            gateway: The running Gateway instance (has .adapters dict).
+            secret: Required bearer token. Cannot be empty.
+            host: Bind address (default loopback only).
+            port: Bind port.
+        """
+        if not secret:
+            raise ValueError("NotifyServer requires a non-empty secret")
         self.gateway = gateway
         self.secret = secret
         self.host = host
@@ -68,44 +90,77 @@ class NotifyServer:
 
     async def handle_notify(self, request: web.Request) -> web.Response:
         """Handle POST /notify — deliver a message to a user."""
-        # Auth check
-        if self.secret:
-            auth = request.headers.get("Authorization", "")
-            if auth != f"Bearer {self.secret}":
-                return web.json_response({"error": "Unauthorized"}, status=401)
+        # Auth check (always required — secret is guaranteed non-empty)
+        auth = request.headers.get("Authorization", "")
+        if auth != f"Bearer {self.secret}":
+            return web.json_response({"error": "Unauthorized"}, status=401)
 
+        # Parse body
         try:
             body = await request.json()
         except Exception:
             return web.json_response({"error": "Invalid JSON"}, status=400)
 
-        platform = body.get("platform")
-        chat_id = body.get("chat_id")
-        message = body.get("message")
+        platform_str = body.get("platform", "")
+        chat_id = body.get("chat_id", "")
+        message = body.get("message", "")
+        thread_id = body.get("thread_id")  # optional
 
-        if not platform or not chat_id or not message:
+        if not platform_str or not chat_id or not message:
             return web.json_response(
                 {"error": "Missing required fields: platform, chat_id, message"},
                 status=400,
             )
 
-        # Find the platform adapter and send directly
+        # Validate platform
+        platform = _platform_from_string(platform_str)
+        if platform is None:
+            return web.json_response(
+                {"error": "Unknown platform", "valid": [p.value for p in Platform]},
+                status=400,
+            )
+
+        # Rate limit per chat
+        rate_key = f"{platform.value}:{chat_id}"
+        now = time.monotonic()
+        last_sent = _rate_limit_cache.get(rate_key, 0)
+        if now - last_sent < _RATE_LIMIT_SECONDS:
+            retry_after = int(_RATE_LIMIT_SECONDS - (now - last_sent)) + 1
+            return web.json_response(
+                {"error": "Rate limited", "retry_after": retry_after},
+                status=429,
+            )
+
+        # Look up adapter
+        adapter = self.gateway.adapters.get(platform)
+        if adapter is None:
+            return web.json_response(
+                {"error": f"Platform '{platform.value}' not configured or not running"},
+                status=404,
+            )
+
+        # Send via adapter.send() — the standard BasePlatformAdapter interface
         try:
-            adapter = self.gateway.get_platform_adapter(platform)
-            if adapter is None:
-                return web.json_response(
-                    {"error": f"Platform '{platform}' not configured or not running"},
-                    status=404,
-                )
+            metadata = {}
+            if thread_id:
+                metadata["thread_id"] = thread_id
 
-            # Use the adapter's send method directly
-            result = await adapter.send_message(chat_id, message)
-            logger.info(f"notify: delivered to {platform}:{chat_id}")
-            return web.json_response({"ok": True, "platform": platform, "chat_id": chat_id})
+            await adapter.send(
+                chat_id,
+                message,
+                metadata=metadata or None,
+            )
+            _rate_limit_cache[rate_key] = now
+            logger.info("notify: delivered to %s:%s", platform.value, chat_id)
+            return web.json_response({
+                "ok": True,
+                "platform": platform.value,
+                "chat_id": chat_id,
+            })
 
-        except Exception as e:
-            logger.error(f"notify: delivery failed to {platform}:{chat_id}: {e}")
-            return web.json_response({"error": str(e)}, status=500)
+        except Exception:
+            logger.exception("notify: delivery failed to %s:%s", platform.value, chat_id)
+            return web.json_response({"error": "Delivery failed"}, status=500)
 
     async def handle_health(self, request: web.Request) -> web.Response:
         """GET /notify/health — simple health check."""
@@ -127,9 +182,9 @@ class NotifyServer:
         site = web.TCPSite(self._runner, self.host, self.port)
         try:
             await site.start()
-            logger.info(f"Notify endpoint: http://{self.host}:{self.port}/notify")
+            logger.info("Notify endpoint: http://%s:%d/notify", self.host, self.port)
         except OSError as e:
-            logger.warning(f"Notify: failed to bind {self.host}:{self.port}: {e}")
+            logger.warning("Notify: failed to bind %s:%d: %s", self.host, self.port, e)
 
     async def stop(self):
         """Stop the notify server."""

--- a/gateway/notify.py
+++ b/gateway/notify.py
@@ -1,0 +1,137 @@
+"""
+Notify endpoint — lightweight HTTP endpoint for external push notifications.
+
+Enables external services (webhooks, background jobs, other agents) to push
+messages directly to a user's chat without going through the LLM. Zero token
+cost, sub-second delivery.
+
+This solves a fundamental gap: Hermes currently only sends messages in response
+to user input or scheduled cron jobs. External services that need to notify a
+user in real-time (match notifications, approval status changes, alerts) have
+no way to reach the user without consuming LLM tokens or waiting for a cron tick.
+
+The endpoint accepts a simple POST:
+
+    POST /notify
+    {
+        "platform": "telegram",
+        "chat_id": "123456789",
+        "message": "🎉 You have a new match!"
+    }
+
+The gateway routes the message through the existing platform adapters — same
+delivery infrastructure used by cron jobs, but triggered externally.
+
+Security: Protected by a configurable bearer token (HERMES_NOTIFY_SECRET).
+If not set, the endpoint is disabled by default.
+
+Configuration in config.yaml:
+
+    notify:
+      enabled: true
+      secret: "your-secret-token"
+      # host: "127.0.0.1"   # default: loopback only
+      # port: 8643           # default: gateway port + 1
+
+Or via environment variable: HERMES_NOTIFY_SECRET=your-secret-token
+"""
+
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from aiohttp import web
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    web = None
+
+
+def check_notify_requirements() -> bool:
+    """Check if aiohttp is available."""
+    return AIOHTTP_AVAILABLE
+
+
+class NotifyServer:
+    """Lightweight HTTP server for external push notifications."""
+
+    def __init__(self, gateway, secret: Optional[str] = None, host: str = "127.0.0.1", port: int = 8643):
+        self.gateway = gateway
+        self.secret = secret
+        self.host = host
+        self.port = port
+        self._app = None
+        self._runner = None
+
+    async def handle_notify(self, request: web.Request) -> web.Response:
+        """Handle POST /notify — deliver a message to a user."""
+        # Auth check
+        if self.secret:
+            auth = request.headers.get("Authorization", "")
+            if auth != f"Bearer {self.secret}":
+                return web.json_response({"error": "Unauthorized"}, status=401)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON"}, status=400)
+
+        platform = body.get("platform")
+        chat_id = body.get("chat_id")
+        message = body.get("message")
+
+        if not platform or not chat_id or not message:
+            return web.json_response(
+                {"error": "Missing required fields: platform, chat_id, message"},
+                status=400,
+            )
+
+        # Find the platform adapter and send directly
+        try:
+            adapter = self.gateway.get_platform_adapter(platform)
+            if adapter is None:
+                return web.json_response(
+                    {"error": f"Platform '{platform}' not configured or not running"},
+                    status=404,
+                )
+
+            # Use the adapter's send method directly
+            result = await adapter.send_message(chat_id, message)
+            logger.info(f"notify: delivered to {platform}:{chat_id}")
+            return web.json_response({"ok": True, "platform": platform, "chat_id": chat_id})
+
+        except Exception as e:
+            logger.error(f"notify: delivery failed to {platform}:{chat_id}: {e}")
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def handle_health(self, request: web.Request) -> web.Response:
+        """GET /notify/health — simple health check."""
+        return web.json_response({"status": "ok"})
+
+    async def start(self):
+        """Start the notify HTTP server."""
+        if not AIOHTTP_AVAILABLE:
+            logger.warning("Notify: aiohttp not installed, skipping")
+            return
+
+        self._app = web.Application()
+        self._app.router.add_post("/notify", self.handle_notify)
+        self._app.router.add_get("/notify/health", self.handle_health)
+
+        self._runner = web.AppRunner(self._app)
+        await self._runner.setup()
+
+        site = web.TCPSite(self._runner, self.host, self.port)
+        try:
+            await site.start()
+            logger.info(f"Notify endpoint: http://{self.host}:{self.port}/notify")
+        except OSError as e:
+            logger.warning(f"Notify: failed to bind {self.host}:{self.port}: {e}")
+
+    async def stop(self):
+        """Stop the notify server."""
+        if self._runner:
+            await self._runner.cleanup()

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,234 @@
+"""Tests for gateway/notify.py"""
+
+import asyncio
+import time
+import pytest
+
+# ---- Minimal stubs so we can test without the full gateway ----
+
+class FakeSendResult:
+    def __init__(self):
+        self.success = True
+        self.message_id = "msg_1"
+
+class FakeAdapter:
+    """Mimics BasePlatformAdapter.send()"""
+    def __init__(self, platform_value="telegram"):
+        self.sent = []
+        self.platform_value = platform_value
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return FakeSendResult()
+
+class FailAdapter:
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        raise RuntimeError("adapter exploded")
+
+
+# We need to build Platform enum stub or import the real one
+# For isolated testing, use a stub:
+from enum import Enum
+class Platform(Enum):
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+
+class FakeGateway:
+    def __init__(self, adapters=None):
+        self.adapters = adapters or {}
+
+
+# Patch the Platform import in notify module
+import importlib
+import gateway.config
+gateway.config.Platform = Platform
+import gateway.notify as notify_mod
+notify_mod.Platform = Platform
+
+# ---- Fixtures ----
+
+@pytest.fixture
+def secret():
+    return "test-secret-12345"
+
+@pytest.fixture
+def gateway_with_telegram():
+    adapter = FakeAdapter()
+    gw = FakeGateway({Platform.TELEGRAM: adapter})
+    return gw, adapter
+
+@pytest.fixture
+def gateway_with_discord():
+    adapter = FakeAdapter("discord")
+    gw = FakeGateway({Platform.DISCORD: adapter})
+    return gw, adapter
+
+
+# ---- Tests ----
+
+class TestNotifyServerInit:
+    def test_requires_secret(self):
+        """#1: Empty secret must raise, not silently allow all."""
+        with pytest.raises(ValueError, match="non-empty secret"):
+            notify_mod.NotifyServer(FakeGateway(), secret="")
+
+    def test_none_secret(self):
+        with pytest.raises(ValueError, match="non-empty secret"):
+            notify_mod.NotifyServer(FakeGateway(), secret=None)
+
+    def test_valid_secret(self, secret):
+        server = notify_mod.NotifyServer(FakeGateway(), secret=secret)
+        assert server.secret == secret
+
+
+class TestHandleNotify:
+    """Integration tests using aiohttp test client."""
+
+    @pytest.fixture
+    async def client(self, gateway_with_telegram, secret, aiohttp_client):
+        gw, _ = gateway_with_telegram
+        server = notify_mod.NotifyServer(gw, secret=secret)
+        # Build app manually
+        from aiohttp import web
+        app = web.Application()
+        app.router.add_post("/notify", server.handle_notify)
+        app.router.add_get("/notify/health", server.handle_health)
+        # Clear rate limit cache between tests
+        notify_mod._rate_limit_cache.clear()
+        return await aiohttp_client(app)
+
+    @pytest.mark.asyncio
+    async def test_no_auth(self, client):
+        resp = await client.post("/notify", json={
+            "platform": "telegram", "chat_id": "123", "message": "hi"
+        })
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_wrong_auth(self, client, secret):
+        resp = await client.post("/notify", json={
+            "platform": "telegram", "chat_id": "123", "message": "hi"
+        }, headers={"Authorization": "Bearer wrong"})
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_valid_send(self, client, secret, gateway_with_telegram):
+        _, adapter = gateway_with_telegram
+        resp = await client.post("/notify", json={
+            "platform": "telegram", "chat_id": "123", "message": "hello"
+        }, headers={"Authorization": f"Bearer {secret}"})
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["ok"] is True
+        assert len(adapter.sent) == 1
+        assert adapter.sent[0]["chat_id"] == "123"
+        assert adapter.sent[0]["content"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_thread_id(self, client, secret, gateway_with_telegram):
+        """#5: thread_id support."""
+        _, adapter = gateway_with_telegram
+        resp = await client.post("/notify", json={
+            "platform": "telegram", "chat_id": "123", "message": "hi",
+            "thread_id": "thread_456"
+        }, headers={"Authorization": f"Bearer {secret}"})
+        assert resp.status == 200
+        assert adapter.sent[0]["metadata"] == {"thread_id": "thread_456"}
+
+    @pytest.mark.asyncio
+    async def test_missing_fields(self, client, secret):
+        resp = await client.post("/notify", json={
+            "platform": "telegram"
+        }, headers={"Authorization": f"Bearer {secret}"})
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_invalid_platform(self, client, secret):
+        resp = await client.post("/notify", json={
+            "platform": "nonexistent", "chat_id": "123", "message": "hi"
+        }, headers={"Authorization": f"Bearer {secret}"})
+        assert resp.status == 400
+        data = await resp.json()
+        assert "Unknown platform" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_platform_not_configured(self, client, secret):
+        """Discord not in gateway_with_telegram fixture."""
+        resp = await client.post("/notify", json={
+            "platform": "discord", "chat_id": "123", "message": "hi"
+        }, headers={"Authorization": f"Bearer {secret}"})
+        assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_json(self, client, secret):
+        resp = await client.post("/notify",
+            data=b"not json",
+            headers={"Authorization": f"Bearer {secret}", "Content-Type": "application/json"}
+        )
+        assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rate_limit(self, client, secret):
+        """#3: Rate limiting per chat."""
+        headers = {"Authorization": f"Bearer {secret}"}
+        body = {"platform": "telegram", "chat_id": "rate_test", "message": "1"}
+        resp1 = await client.post("/notify", json=body, headers=headers)
+        assert resp1.status == 200
+        resp2 = await client.post("/notify", json=body, headers=headers)
+        assert resp2.status == 429
+        data = await resp2.json()
+        assert "retry_after" in data
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_different_chats(self, client, secret):
+        """Different chat_ids are rate-limited independently."""
+        headers = {"Authorization": f"Bearer {secret}"}
+        resp1 = await client.post("/notify", json={
+            "platform": "telegram", "chat_id": "chat_a", "message": "1"
+        }, headers=headers)
+        assert resp1.status == 200
+        resp2 = await client.post("/notify", json={
+            "platform": "telegram", "chat_id": "chat_b", "message": "1"
+        }, headers=headers)
+        assert resp2.status == 200
+
+    @pytest.mark.asyncio
+    async def test_error_no_leak(self, client, secret):
+        """#2: Error responses must not leak internal details."""
+        # Replace adapter with one that raises
+        # We need a fresh client for this
+        gw = FakeGateway({Platform.TELEGRAM: FailAdapter()})
+        server = notify_mod.NotifyServer(gw, secret=secret)
+        from aiohttp import web
+        from aiohttp.test_utils import TestClient, TestServer
+        app = web.Application()
+        app.router.add_post("/notify", server.handle_notify)
+        notify_mod._rate_limit_cache.clear()
+        async with TestClient(TestServer(app)) as cl:
+            resp = await cl.post("/notify", json={
+                "platform": "telegram", "chat_id": "123", "message": "hi"
+            }, headers={"Authorization": f"Bearer {secret}"})
+            assert resp.status == 500
+            data = await resp.json()
+            # Must NOT contain "adapter exploded"
+            assert "exploded" not in data.get("error", "")
+            assert data["error"] == "Delivery failed"
+
+    @pytest.mark.asyncio
+    async def test_health(self, client):
+        resp = await client.get("/notify/health")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_log_format(self, client, secret, caplog):
+        """#8: Logging uses %-style, not f-string."""
+        import logging
+        with caplog.at_level(logging.INFO, logger="gateway.notify"):
+            resp = await client.post("/notify", json={
+                "platform": "telegram", "chat_id": "log_test", "message": "hi"
+            }, headers={"Authorization": f"Bearer {secret}"})
+            assert resp.status == 200
+        # Verify log message exists (format is tested by the fact we use %s in code)
+        assert any("delivered" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

Hermes is currently one-directional for messaging: it responds to user input or runs scheduled cron jobs. External services that need to push real-time notifications to users — match alerts, approval status changes, webhook events — have no lightweight path. The only options are:

1. **Cron polling** — up to 60s delay, not real-time
2. **Webhook platform** — routes through the LLM, consumes tokens for every notification
3. **inject_message** — CLI-only, not available in gateway mode

## Solution

Add a `/notify` HTTP endpoint to the gateway that delivers messages directly to users through existing platform adapters. Zero LLM tokens, sub-second delivery.

```
POST /notify
{
  "platform": "telegram",
  "chat_id": "123456789",
  "message": "🎉 You have a new match!"
}
```

This makes Hermes bidirectional — any external service with the notify secret can push a message to any connected platform.

## Use Cases

- **Database webhooks**: Supabase/Firebase change → notify user instantly
- **Inter-agent communication**: Agent A notifies Agent B's user without LLM cost
- **Background job alerts**: Long-running task completes → push result
- **Plugin notifications**: Plugins can notify users from background threads

## Security

- Bearer token auth (`HERMES_NOTIFY_SECRET` env var)
- Disabled by default if no secret is set
- Loopback-only by default (`127.0.0.1`)

## Files Changed

- `gateway/notify.py` — New file: NotifyServer class with `/notify` POST + `/notify/health` GET

## Integration

The gateway would start the NotifyServer alongside other platform adapters. The notify server uses the same `send_message` interface that cron delivery uses — no new platform-specific code needed.

---

*Submitted by the [Antenna](https://antenna.fyi) team. We built an agent-mediated social discovery tool and hit this exact gap: our Supabase backend detects new matches/event approvals but has no way to push notifications to Hermes users without burning LLM tokens.*