### PR TITLE
feat(gateway): add `/cc` command to route messages to Claude Code CLI

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3406,9 +3406,9 @@ class GatewayRunner:
         if _cc_session_key in self._cc_mode and not command:
             msg_text = (event.text or "").strip()
             if msg_text:
-                if msg_text.lower() in ("退出", "quit", "exit", "stop"):
+                if msg_text.lower() in ("quit", "exit", "stop"):
                     self._cc_mode.discard(_cc_session_key)
-                    return "📤 已退出 Claude Code 模式，回到 Hermes。"
+                    return "📤 Left Claude Code mode — back to Hermes."
                 return await self._run_cc_task(_cc_session_key, msg_text, event)
 
         # ── Claim this session before any await ───────────────────────
@@ -6486,9 +6486,12 @@ class GatewayRunner:
         if not task:
             if session_key in self._cc_mode:
                 self._cc_mode.discard(session_key)
-                return "📤 已退出 Claude Code 模式，回到 Hermes。"
+                return "📤 Left Claude Code mode — back to Hermes."
             self._cc_mode.add(session_key)
-            return "🤖 已进入 Claude Code 模式（Max 订阅）。直接发消息即可，输入 /cc 退出。"
+            return (
+                "🤖 Claude Code mode ON (Max subscription). "
+                "Send messages directly; type /cc (or quit/exit/stop) to leave."
+            )
 
         return await self._run_cc_task(session_key, task, event)
 
@@ -6525,18 +6528,18 @@ class GatewayRunner:
                 env={**os.environ},
             )
         except subprocess.TimeoutExpired:
-            return "❌ Claude Code 执行超时（300秒）"
+            return "❌ Claude Code timed out (300 s)."
         except FileNotFoundError:
-            return "❌ claude CLI 未安装。运行: npm i -g @anthropic-ai/claude-code"
+            return "❌ claude CLI not installed. Run: npm i -g @anthropic-ai/claude-code"
 
         if result.returncode != 0:
-            error = result.stderr.strip()[:500] or "未知错误"
+            error = result.stderr.strip()[:500] or "unknown error"
             logger.error("/cc error (exit %d): %s", result.returncode, error)
-            return f"❌ Claude Code 错误:\n{error}"
+            return f"❌ Claude Code error:\n{error}"
 
         try:
             data = json.loads(result.stdout.strip())
-            response = data.get("result", "（无输出）")
+            response = data.get("result", "(no output)")
             new_session_id = data.get("session_id", "")
             turns = data.get("num_turns", 0)
             cost = data.get("total_cost_usd", 0)
@@ -6547,7 +6550,7 @@ class GatewayRunner:
             footer = f"\n\n---\n⏱ {turns} turns | 💰 ${cost:.4f}"
             return response + footer
         except (json.JSONDecodeError, KeyError):
-            return result.stdout.strip() or "（无输出）"
+            return result.stdout.strip() or "(no output)"
 
     async def _handle_yolo_command(self, event: MessageEvent) -> str:
         """Handle /yolo — toggle dangerous command approval bypass for this session only."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3190,6 +3190,13 @@ class GatewayRunner:
         if canonical == "cc":
             return await self._handle_cc_command(event)
 
+        # While a session is in CC mode, ``/clear`` is redirected to the
+        # Claude Code session reset. Outside CC mode this command stays
+        # ``cli_only`` and falls through to the unknown-command notice as
+        # before, so non-CC users are unaffected.
+        if canonical == "clear" and self._session_key_for_source(event.source) in self._cc_mode:
+            return self._handle_cc_clear(event)
+
         if canonical == "plan":
             try:
                 from agent.skill_commands import build_plan_path, build_skill_invocation_message
@@ -6494,6 +6501,21 @@ class GatewayRunner:
             )
 
         return await self._run_cc_task(session_key, task, event)
+
+    def _handle_cc_clear(self, event: MessageEvent) -> str:
+        """Handle ``/clear`` while in CC mode.
+
+        Drops the cached Claude Code ``session_id`` for this gateway session
+        so the next ``/cc`` invocation starts a fresh Claude Code conversation
+        (no ``--resume``). ``claude -p`` is a one-shot print mode and has no
+        interactive ``/clear`` of its own, so we implement the equivalent by
+        clearing the bridge's own session cache.
+        """
+        session_key = self._session_key_for_source(event.source)
+        had_session = self._cc_sessions.pop(session_key, None) is not None
+        if had_session:
+            return "🧹 Claude Code session cleared — next message starts fresh."
+        return "🧹 No active Claude Code session to clear."
 
     async def _run_cc_task(self, session_key: str, task: str, event: MessageEvent) -> str:
         """Invoke ``claude -p`` as a subprocess and format the JSON response.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3187,6 +3187,9 @@ class GatewayRunner:
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
+        if canonical == "cc":
+            return await self._handle_cc_command(event)
+
         if canonical == "plan":
             try:
                 from agent.skill_commands import build_plan_path, build_skill_invocation_message
@@ -3393,6 +3396,20 @@ class GatewayRunner:
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
+
+        # ── CC mode: route all non-command messages to Claude Code ──
+        # When a session has toggled into CC mode via bare /cc, bare text
+        # messages are forwarded to the local `claude` CLI instead of the
+        # Hermes agent. Slash commands still dispatch normally so the user
+        # can leave the mode.
+        _cc_session_key = self._session_key_for_source(event.source)
+        if _cc_session_key in self._cc_mode and not command:
+            msg_text = (event.text or "").strip()
+            if msg_text:
+                if msg_text.lower() in ("退出", "quit", "exit", "stop"):
+                    self._cc_mode.discard(_cc_session_key)
+                    return "📤 已退出 Claude Code 模式，回到 Hermes。"
+                return await self._run_cc_task(_cc_session_key, msg_text, event)
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there
@@ -6449,6 +6466,88 @@ class GatewayRunner:
         if _save_config_key("agent.service_tier", saved_value):
             return f"⚡ ✓ Priority Processing: **{label}** (saved to config)\n_(takes effect on next message)_"
         return f"⚡ ✓ Priority Processing: **{label}** (this session only)"
+
+    # Per-session Claude Code session IDs, used for multi-turn continuity.
+    _cc_sessions: Dict[str, str] = {}
+    # Per-session CC-mode toggle. Non-command messages from sessions in this
+    # set are forwarded to `claude -p` instead of the Hermes agent.
+    _cc_mode: set = set()
+
+    async def _handle_cc_command(self, event: MessageEvent) -> str:
+        """Handle /cc — toggle sticky CC mode or execute a one-off task.
+
+        ``/cc`` with no args toggles the sticky mode for this session: while
+        enabled, all non-command messages are routed to Claude Code. ``/cc
+        <task>`` runs a single ``claude -p`` invocation without touching mode.
+        """
+        session_key = self._session_key_for_source(event.source)
+        task = event.get_command_args().strip()
+
+        if not task:
+            if session_key in self._cc_mode:
+                self._cc_mode.discard(session_key)
+                return "📤 已退出 Claude Code 模式，回到 Hermes。"
+            self._cc_mode.add(session_key)
+            return "🤖 已进入 Claude Code 模式（Max 订阅）。直接发消息即可，输入 /cc 退出。"
+
+        return await self._run_cc_task(session_key, task, event)
+
+    async def _run_cc_task(self, session_key: str, task: str, event: MessageEvent) -> str:
+        """Invoke ``claude -p`` as a subprocess and format the JSON response.
+
+        Remembers the returned ``session_id`` per gateway session so the next
+        invocation can resume the Claude Code conversation with ``--resume``.
+        """
+        import subprocess
+
+        cmd = [
+            "claude", "-p", task,
+            "--output-format", "json",
+            "--max-turns", "20",
+        ]
+
+        prev_session = self._cc_sessions.get(session_key)
+        if prev_session:
+            cmd.extend(["--resume", prev_session])
+
+        logger.info(
+            "/cc: session=%s resume=%s task=%r",
+            session_key[:20], bool(prev_session), task[:80],
+        )
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                cwd=os.path.expanduser("~"),
+                env={**os.environ},
+            )
+        except subprocess.TimeoutExpired:
+            return "❌ Claude Code 执行超时（300秒）"
+        except FileNotFoundError:
+            return "❌ claude CLI 未安装。运行: npm i -g @anthropic-ai/claude-code"
+
+        if result.returncode != 0:
+            error = result.stderr.strip()[:500] or "未知错误"
+            logger.error("/cc error (exit %d): %s", result.returncode, error)
+            return f"❌ Claude Code 错误:\n{error}"
+
+        try:
+            data = json.loads(result.stdout.strip())
+            response = data.get("result", "（无输出）")
+            new_session_id = data.get("session_id", "")
+            turns = data.get("num_turns", 0)
+            cost = data.get("total_cost_usd", 0)
+
+            if new_session_id:
+                self._cc_sessions[session_key] = new_session_id
+
+            footer = f"\n\n---\n⏱ {turns} turns | 💰 ${cost:.4f}"
+            return response + footer
+        except (json.JSONDecodeError, KeyError):
+            return result.stdout.strip() or "（无输出）"
 
     async def _handle_yolo_command(self, event: MessageEvent) -> str:
         """Handle /yolo — toggle dangerous command approval bypass for this session only."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -166,6 +166,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
     CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
+    CommandDef("cc", "Execute task via Claude Code CLI (Max subscription)", "Tools & Skills",
+               args_hint="<task>", gateway_only=True),
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",


### PR DESCRIPTION
Closes #12122.

## Summary

Adds a `/cc` gateway command that lets any connected chat channel (Feishu, Slack, Discord, Telegram, …) forward messages to the local `claude` CLI instead of running the Hermes agent. Useful for users on a Claude Max subscription who want access to Claude Code's full tool / skill ecosystem from a chat client.

Two modes:

- **One-shot** — `/cc summarize the last 50 lines of ~/logs/app.log` runs a single `claude -p` invocation and returns the result.
- **Sticky CC mode** — bare `/cc` toggles a per-session mode; while enabled, every non-command message is forwarded to `claude -p`. Slash commands still dispatch normally. Users leave with `/cc`, `quit`, `exit`, or `stop`.

Multi-turn continuity is preserved: the `session_id` returned by Claude Code is cached per gateway session and passed back via `--resume <id>` on the next invocation, so context carries across turns in the same chat.

## Behavior details

Subprocess invocation:
```
claude -p <task> --output-format json --max-turns 20 [--resume <prev_session_id>]
```
- `cwd=os.path.expanduser("~")` — matches what the user sees when they run `claude` in a fresh terminal.
- `timeout=300`.
- JSON output parsed; reply = `<result>\n\n---\n⏱ <num_turns> turns | 💰 $<total_cost_usd>`.
- `FileNotFoundError` → `❌ claude CLI not installed. Run: npm i -g @anthropic-ai/claude-code`.
- Non-zero exit → `❌ Claude Code error: <stderr first 500 chars>`.

## Scope

| File | Change |
|---|---|
| `hermes_cli/commands.py` | +2 lines: one `CommandDef("cc", …, gateway_only=True)` entry so the command appears in `/help` and routes to the handler. |
| `gateway/run.py` | +99 lines: dispatch `/cc` in the command router; CC-mode hijack in the message handler; `_cc_sessions` / `_cc_mode` class state; `_handle_cc_command` + `_run_cc_task` methods. |

No changes to platform adapters.

## Test plan

- [x] `pytest tests/hermes_cli/ tests/gateway/` — 2301 passed, 3 pre-existing unrelated failures on `origin/main` (WSL systemd-detection tests and one web-server schema test), none introduced by this change.
- [x] Module imports cleanly (`import gateway.run; import hermes_cli.commands`).
- [x] Manual: invoke `/cc` in a gateway-connected chat; verify toggle mode, one-off execution, and multi-turn `--resume` continuity.

## Design questions worth discussing (see #12122)

1. `_cc_sessions` / `_cc_mode` are in-memory class state — single gateway process only. Should they persist to the state DB?
2. Per-user authorization within a channel — should `/cc` gate on operator identity, or is that the host's responsibility?
3. Configurable `max-turns` / `timeout` / `cwd` — env vars or `config.yaml` section?
4. Streaming vs single-reply for long runs.