### PR TITLE
fix(model_switch): add built-in direct aliases for kimi-for-coding

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -170,7 +170,10 @@ class DirectAlias(NamedTuple):
 
 
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
-_BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
+_BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {
+    "kimi": DirectAlias("kimi-for-coding", "kimi-coding", "https://api.kimi.com/coding"),
+    "kimi-for-coding": DirectAlias("kimi-for-coding", "kimi-coding", "https://api.kimi.com/coding"),
+}
 
 # Merged dict (builtins + user config); populated by _load_direct_aliases()
 DIRECT_ALIASES: dict[str, DirectAlias] = {}


### PR DESCRIPTION
## Problem

The models.dev catalog for the `kimi-coding` provider currently lists `k2p5` and `kimi-k2-thinking`, but the live Kimi For Coding API only exposes `kimi-for-coding`.

This causes `/model kimi` to resolve to the non-existent `kimi-k2-thinking` via alias resolution, because `kimi-k2-thinking` is the only model in the cached catalog that starts with the `kimi` family prefix.

## Solution

Add built-in direct aliases so that both `kimi` and `kimi-for-coding` resolve directly to the correct model, bypassing the stale models.dev catalog lookup.

## Changes

- Updated `_BUILTIN_DIRECT_ALIASES` in `hermes_cli/model_switch.py`