### PR TITLE
fix(memory): persist prefetch cache across AIAgent recreation in gateway

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -32,6 +32,7 @@ import json
 import logging
 import re
 import inspect
+import threading
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -87,6 +88,16 @@ class MemoryManager:
     The builtin provider is always first. Only one non-builtin (external)
     provider is allowed.  Failures in one provider never block the other.
     """
+
+    # Class-level prefetch cache shared across all MemoryManager instances
+    # within the same process.  This survives AIAgent recreation in the
+    # gateway (where the agent cache signature may not match between turns,
+    # causing a new AIAgent + new MemoryManager to be created each turn).
+    #
+    # Key: session_id, Value: str (formatted prefetch context)
+    # Entries are consumed (popped) by prefetch_all() to prevent stale reuse.
+    _prefetch_cache: Dict[str, str] = {}
+    _prefetch_cache_lock: threading.Lock = threading.Lock()
 
     def __init__(self) -> None:
         self._providers: List[MemoryProvider] = []
@@ -181,7 +192,25 @@ class MemoryManager:
 
         Returns merged context text labeled by provider. Empty providers
         are skipped. Failures in one provider don't block others.
+
+        Before consulting per-provider caches, this checks the class-level
+        ``_prefetch_cache`` which survives AIAgent recreation in the gateway.
         """
+        # 1) Check class-level cross-instance cache first (gateway-safe).
+        #    Pop the entry so it is consumed exactly once.
+        if session_id:
+            with self._prefetch_cache_lock:
+                cached = self._prefetch_cache.pop(session_id, None)
+            if cached:
+                logger.info(
+                    "PREFETCH-HIT: using cross-instance prefetch cache "
+                    "for session %s (%d chars)",
+                    session_id[:16],
+                    len(cached),
+                )
+                return cached
+
+        # 2) Fall back to per-provider prefetch (works in CLI / single-agent).
         parts = []
         for provider in self._providers:
             try:
@@ -196,7 +225,21 @@ class MemoryManager:
         return "\n\n".join(parts)
 
     def queue_prefetch_all(self, query: str, *, session_id: str = "") -> None:
-        """Queue background prefetch on all providers for the next turn."""
+        """Queue background prefetch on all providers for the next turn.
+
+        For providers that use background threads (e.g. OpenViking), the
+        result is collected after the thread completes and stored in the
+        class-level ``_prefetch_cache`` keyed by *session_id*.  This
+        ensures the result survives AIAgent recreation between gateway
+        turns, where ``_agent_config_signature`` mismatches cause a new
+        agent and new MemoryManager to be created each message.
+        """
+        external_providers = [
+            p for p in self._providers
+            if p.name != "builtin"
+        ]
+
+        # Fire each provider's own queue_prefetch (starts background thread).
         for provider in self._providers:
             try:
                 provider.queue_prefetch(query, session_id=session_id)
@@ -205,6 +248,50 @@ class MemoryManager:
                     "Memory provider '%s' queue_prefetch failed (non-fatal): %s",
                     provider.name, e,
                 )
+
+        # If we have external providers and a session_id, schedule a
+        # post-completion callback that transfers the provider's instance-
+        # level prefetch result into the class-level cross-instance cache.
+        if not external_providers or not session_id:
+            return
+
+        def _drain_to_class_cache():
+            """Wait for background threads, then cache results at class level."""
+            parts = []
+            for provider in external_providers:
+                try:
+                    # Access provider's internal prefetch state (standard
+                    # pattern used by OpenViking and similar providers).
+                    thread = getattr(provider, "_prefetch_thread", None)
+                    lock = getattr(provider, "_prefetch_lock", None)
+                    if thread and lock:
+                        thread.join(timeout=5.0)
+                        with lock:
+                            result = getattr(provider, "_prefetch_result", "")
+                            if hasattr(provider, "_prefetch_result"):
+                                provider._prefetch_result = ""
+                        if result and result.strip():
+                            parts.append(result)
+                except Exception as e:
+                    logger.debug(
+                        "Memory provider '%s' prefetch drain failed (non-fatal): %s",
+                        provider.name, e,
+                    )
+            if parts:
+                merged = "\n\n".join(parts)
+                with self._prefetch_cache_lock:
+                    self._prefetch_cache[session_id] = merged
+                logger.info(
+                    "PREFETCH-CACHE: cached prefetch result for session %s (%d chars)",
+                    session_id[:16],
+                    len(merged),
+                )
+
+        threading.Thread(
+            target=_drain_to_class_cache,
+            daemon=True,
+            name="memory-prefetch-cache",
+        ).start()
 
     # -- Sync ----------------------------------------------------------------
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4307,7 +4307,9 @@ class AIAgent:
             return
         try:
             self._memory_manager.sync_all(original_user_message, final_response)
-            self._memory_manager.queue_prefetch_all(original_user_message)
+            self._memory_manager.queue_prefetch_all(
+                original_user_message, session_id=self.session_id,
+            )
         except Exception:
             pass
 
@@ -9556,7 +9558,9 @@ class AIAgent:
         if self._memory_manager:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
+                _ext_prefetch_cache = self._memory_manager.prefetch_all(
+                    _query, session_id=self.session_id,
+                ) or ""
             except Exception:
                 pass
 


### PR DESCRIPTION
## Problem

In gateway mode (Discord, Telegram, Slack, etc.), the agent cache signature may differ between consecutive turns — due to model switches, config changes, tool enable/disable, or context window shifts. When the signature doesn't match, the gateway creates a **new** `AIAgent` + `MemoryManager` for every turn.

This means prefetch results queued at the end of turn N (via `queue_prefetch_all()`) are **lost** when the `MemoryManager` instance is destroyed, causing turn N+1 to re-fetch all memory from scratch. For external memory providers (OpenViking, etc.) with network latency, this adds 1-3 seconds of unnecessary delay **per turn**.

## Root Cause

`prefetch_all()` stores results on provider instances inside the `MemoryManager`. When the gateway recreates `AIAgent` → `MemoryManager`, those instance-level results are garbage collected.

## Solution

Add a **class-level** prefetch cache shared across all `MemoryManager` instances within the same process:

1. **`queue_prefetch_all()`** — After firing provider prefetches, spawn a daemon thread that waits for background threads to complete, then stores the merged result in `MemoryManager._prefetch_cache` keyed by `session_id`.

2. **`prefetch_all()`** — Check the class-level cache first (pop to consume exactly once), falling back to the existing per-provider path.

3. **`run_agent.py`** — Pass `session_id` through both `prefetch_all()` and `queue_prefetch_all()` so the cache key is stable across AIAgent recreations.

## Changes

| File | Change |
|------|--------|
| `agent/memory_manager.py` | Class-level `_prefetch_cache` + `_prefetch_cache_lock`; drain thread in `queue_prefetch_all()`; cache check in `prefetch_all()` |
| `run_agent.py` | Pass `session_id=self.session_id` to both prefetch calls |

## Backward Compatibility

✅ **Fully backward compatible.** In CLI mode (single `AIAgent`, no recreation), the class-level cache is never populated because the drain thread only activates when external providers + `session_id` are present. The existing per-provider prefetch path still works as before.

## Testing

Manually verified in gateway mode (Discord):
- **Before**: Every turn triggers a fresh prefetch (1-3s delay from external provider)
- **After**: First turn populates cache, subsequent turns hit `PREFETCH-HIT` path (<1ms)