### PR TITLE
feat(mcp): make max_reconnect_retries configurable per server

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -736,3 +736,190 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Configurable per-server reconnect retry limit
+#
+# Salvage of PR #12128 against current main's park-and-self-probe design.
+# `max_reconnect_retries` is read from per-server config; the default still
+# falls back to the `_MAX_RECONNECT_RETRIES` module constant. `0` is a
+# sentinel meaning "retry forever" — the server never parks.
+# ---------------------------------------------------------------------------
+
+class TestMCPReconnectRetryConfig:
+    """Per-server `max_reconnect_retries` is configurable; `0` means retry forever.
+
+    Behavior contract:
+      - No config                    → falls back to `_MAX_RECONNECT_RETRIES`.
+      - `max_reconnect_retries = N`  → park after N reconnect failures.
+      - `max_reconnect_retries = 0`  → never park (retry indefinitely).
+    """
+
+    def test_init_default_matches_module_constant(self):
+        """__init__ seeds `max_reconnect_retries` from the module constant so
+        the slot is populated (and the attribute is usable) before `run()`
+        applies any per-server config."""
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        server = MCPServerTask("test-init-default")
+        assert server.max_reconnect_retries == _MAX_RECONNECT_RETRIES
+
+    def test_run_reads_max_reconnect_retries_from_config(self):
+        """`run()` reads `max_reconnect_retries` from per-server config and
+        overrides the `__init__` default before the first transport attempt."""
+        from tools.mcp_tool import MCPServerTask
+
+        captured: dict = {}
+
+        async def fake_run_stdio(self_inner, config):
+            captured["value"] = self_inner.max_reconnect_retries
+            self_inner._ready.set()
+            raise ConnectionError("bail out of run loop")
+
+        async def _run():
+            server = MCPServerTask("test-config-read")
+            with patch.object(MCPServerTask, "_run_stdio", fake_run_stdio):
+                task = asyncio.ensure_future(
+                    server.run({"command": "x", "max_reconnect_retries": 11})
+                )
+                await server._ready.wait()
+                server._shutdown_event.set()
+                server._reconnect_event.set()
+                await asyncio.wait_for(task, timeout=5)
+            assert captured.get("value") == 11
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_parks_after_configured_limit(self):
+        """`max_reconnect_retries=N` parks the server once `_reconnect_retries`
+        exceeds N. The parking log message records the configured limit,
+        distinguishing it from the default constant."""
+        import logging
+        import re
+
+        from tools.mcp_tool import MCPServerTask
+
+        CONFIGURED = 2
+
+        async def fake_run_stdio(self_inner, config):
+            if not self_inner._ready.is_set():
+                self_inner._ready.set()
+            raise ConnectionError("post-ready drop")
+
+        # Capture the real asyncio.sleep before patching so fast_sleep can
+        # yield without recursing into itself.
+        real_asyncio_sleep = asyncio.sleep
+
+        async def fast_sleep(_d):
+            await real_asyncio_sleep(0)
+
+        captured_logs: list = []
+
+        class _Sink(logging.Handler):
+            def emit(self, record):
+                captured_logs.append(record.getMessage())
+
+        sink = _Sink()
+        mcp_logger = logging.getLogger("tools.mcp_tool")
+        mcp_logger.addHandler(sink)
+        try:
+            async def _run():
+                server = MCPServerTask("test-park-limit")
+                with patch.object(MCPServerTask, "_run_stdio", fake_run_stdio), \
+                     patch("tools.mcp_tool.asyncio.sleep", fast_sleep), \
+                     patch("tools.mcp_tool._PARKED_RETRY_INTERVAL", 0.01), \
+                     patch("tools.mcp_tool._MAX_BACKOFF_SECONDS", 0.0):
+                    task = asyncio.ensure_future(
+                        server.run({
+                            "command": "x",
+                            "max_reconnect_retries": CONFIGURED,
+                        })
+                    )
+                    # Let at least one park-revive cycle complete.
+                    await real_asyncio_sleep(0.2)
+                    server._shutdown_event.set()
+                    server._reconnect_event.set()
+                    await asyncio.wait_for(task, timeout=5)
+
+            asyncio.get_event_loop().run_until_complete(_run())
+        finally:
+            mcp_logger.removeHandler(sink)
+
+        park_msgs = [
+            m for m in captured_logs
+            if "parking" in m and "failed after" in m
+        ]
+        assert park_msgs, "expected at least one parking log message"
+        # Format: "MCP server 'X' failed after N reconnection attempts, parking; ..."
+        match = re.search(r"failed after (\d+) reconnection", park_msgs[0])
+        assert match is not None, f"unexpected log format: {park_msgs[0]!r}"
+        assert int(match.group(1)) == CONFIGURED, (
+            f"parking limit should honor config ({CONFIGURED}), "
+            f"got {match.group(1)}"
+        )
+
+    def test_zero_disables_parking(self):
+        """`max_reconnect_retries=0` disables parking: the server reconnects
+        indefinitely even after the default cap would have parked it."""
+        import logging
+
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        call_count = 0
+
+        async def fake_run_stdio(self_inner, config):
+            nonlocal call_count
+            call_count += 1
+            if not self_inner._ready.is_set():
+                self_inner._ready.set()
+            raise ConnectionError("post-ready drop")
+
+        real_asyncio_sleep = asyncio.sleep
+
+        async def fast_sleep(_d):
+            await real_asyncio_sleep(0)
+
+        captured_logs: list = []
+
+        class _Sink(logging.Handler):
+            def emit(self, record):
+                captured_logs.append(record.getMessage())
+
+        sink = _Sink()
+        mcp_logger = logging.getLogger("tools.mcp_tool")
+        mcp_logger.addHandler(sink)
+        try:
+            async def _run():
+                server = MCPServerTask("test-zero-forever")
+                with patch.object(MCPServerTask, "_run_stdio", fake_run_stdio), \
+                     patch("tools.mcp_tool.asyncio.sleep", fast_sleep), \
+                     patch("tools.mcp_tool._PARKED_RETRY_INTERVAL", 0.01), \
+                     patch("tools.mcp_tool._MAX_BACKOFF_SECONDS", 0.0):
+                    task = asyncio.ensure_future(
+                        server.run({
+                            "command": "x",
+                            "max_reconnect_retries": 0,
+                        })
+                    )
+                    # Run long enough that the default cap (5) would have
+                    # parked the server many times over.
+                    await real_asyncio_sleep(0.3)
+                    server._shutdown_event.set()
+                    server._reconnect_event.set()
+                    await asyncio.wait_for(task, timeout=5)
+
+            asyncio.get_event_loop().run_until_complete(_run())
+        finally:
+            mcp_logger.removeHandler(sink)
+
+        # Must have attempted far more reconnects than the default cap allows
+        # without parking.
+        assert call_count > _MAX_RECONNECT_RETRIES + 5, (
+            f"only {call_count} calls — 0=forever not honored"
+        )
+        # No parking log should have fired.
+        assert not any("parking" in m for m in captured_logs), (
+            f"max_reconnect_retries=0 should never park, but got: "
+            f"{[m for m in captured_logs if 'parking' in m]}"
+        )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1527,12 +1527,14 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries",
+        "max_reconnect_retries",
     )
 
     def __init__(self, name: str):
         self.name = name
         self.session: Optional[Any] = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
+        self.max_reconnect_retries: int = _MAX_RECONNECT_RETRIES
         self._task: Optional[asyncio.Task] = None
         self._ready = asyncio.Event()
         self._shutdown_event = asyncio.Event()
@@ -2611,6 +2613,7 @@ class MCPServerTask:
         """
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+        self.max_reconnect_retries = config.get("max_reconnect_retries", _MAX_RECONNECT_RETRIES)
         self._auth_type = (config.get("auth") or "").lower().strip()
         self._idle_timeout_seconds = _get_lifecycle_seconds(config, "idle_timeout_seconds")
         self._max_lifetime_seconds = _get_lifecycle_seconds(config, "max_lifetime_seconds")
@@ -2823,11 +2826,11 @@ class MCPServerTask:
                     return
 
                 self._reconnect_retries += 1
-                if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
+                if self.max_reconnect_retries > 0 and self._reconnect_retries > self.max_reconnect_retries:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
                         "parking; will self-probe every %ds until it recovers: %s",
-                        self.name, _MAX_RECONNECT_RETRIES,
+                        self.name, self.max_reconnect_retries,
                         _PARKED_RETRY_INTERVAL, exc,
                     )
                     # Do NOT return — exiting the task orphans the server:
@@ -2856,15 +2859,15 @@ class MCPServerTask:
                     )
                     # One probe attempt per wake: budget of 1 so a still-dead
                     # server parks again for another interval instead of
-                    # burning 5 rapid retries each cycle.
-                    self._reconnect_retries = _MAX_RECONNECT_RETRIES
+                    # burning the full retry budget each cycle.
+                    self._reconnect_retries = self.max_reconnect_retries
                     backoff = 1.0
                     continue
 
                 logger.warning(
                     "MCP server '%s' connection lost (attempt %d/%d), "
                     "reconnecting in %.0fs: %s",
-                    self.name, self._reconnect_retries, _MAX_RECONNECT_RETRIES,
+                    self.name, self._reconnect_retries, self.max_reconnect_retries,
                     backoff, exc,
                 )
                 await asyncio.sleep(backoff)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1033,6 +1033,7 @@ class MCPServerTask:
         """
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+        self.max_reconnect_retries = config.get("max_reconnect_retries", _MAX_RECONNECT_RETRIES)
         self._auth_type = (config.get("auth") or "").lower().strip()
 
         # Set up sampling handler if enabled and SDK types are available
@@ -1106,18 +1107,18 @@ class MCPServerTask:
                     return
 
                 retries += 1
-                if retries > _MAX_RECONNECT_RETRIES:
+                if retries > self.max_reconnect_retries:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "
                         "giving up: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
+                        self.name, self.max_reconnect_retries, exc,
                     )
                     return
 
                 logger.warning(
                     "MCP server '%s' connection lost (attempt %d/%d), "
                     "reconnecting in %.0fs: %s",
-                    self.name, retries, _MAX_RECONNECT_RETRIES,
+                    self.name, retries, self.max_reconnect_retries,
                     backoff, exc,
                 )
                 await asyncio.sleep(backoff)

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -297,6 +297,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `client_key` | string | Client private-key PEM path (when separate from `client_cert`) |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout (also bounds the MCP `initialize` handshake) |
+| `max_reconnect_retries` | int | Reconnect attempts before a dropped server is parked and self-probed periodically. `0` = retry forever (never park). Default: `5`. |
 | `idle_timeout_seconds` | number | Recycle a stdio server after this many seconds without a tool call (`0` = never, default). The server restarts transparently on the next tool call. |
 | `max_lifetime_seconds` | number | Recycle a stdio server after this total age (`0` = never, default). Restarts transparently on next use. |
 | `enabled` | bool | If `false`, Hermes skips the server entirely |


### PR DESCRIPTION
## Problem

`_MAX_RECONNECT_RETRIES` is a module-level constant (`5`) in `tools/mcp_tool.py`. For MCP servers behind reverse proxies with session expiry (e.g., wiki-brain, custom knowledge bases), the default limit is too aggressive — Hermes parks the server after 5 reconnect failures even when a longer budget would let it recover on its own.

There is no way to tune this without patching source.

## Solution

Read `max_reconnect_retries` from per-server config, falling back to the existing default (`5`):

```yaml
mcp_servers:
  wiki-brain:
    url: http://localhost:8764
    max_reconnect_retries: 50   # park after 50 reconnect failures instead of 5
```

`0` is a sentinel meaning **retry forever** — the server never parks and reconnects indefinitely. Useful for servers with known long recovery windows where parking-induced tool deregistration is undesirable.

```yaml
mcp_servers:
  flaky-server:
    url: http://localhost:8764
    max_reconnect_retries: 0    # never park
```

## Changes

Salvage of the original 4-line submission against current `main`'s park-and-self-probe reconnect design (#16788, #57129). The original branch predated main's `_reconnect_retries` instance-variable refactor and the parking redesign; this updates the same config knob to land on top.

Per @teknium1's review on the original PR:

- **`__slots__`** — Add `max_reconnect_retries` to `MCPServerTask.__slots__`. The class is slot-backed; without this the assignment raises `AttributeError`.
- **`__init__` default** — Seed `self.max_reconnect_retries: int = _MAX_RECONNECT_RETRIES` in `__init__`, mirroring the existing `tool_timeout` pattern, so the attribute exists before `run()` applies per-server config.
- **`run()` config read** — `self.max_reconnect_retries = config.get("max_reconnect_retries", _MAX_RECONNECT_RETRIES)`.
- **Reconnect loop** — Replace all four `_MAX_RECONNECT_RETRIES` references in the loop body with `self.max_reconnect_retries`, including the parked-state probe-budget reset. Without that consistency, a non-default cap would burn `N` retries per park-revive cycle instead of one.
- **`0 = retry forever`** — Parking condition becomes `if self.max_reconnect_retries > 0 and self._reconnect_retries > self.max_reconnect_retries:` — short-circuited when the configured value is `0`. Suggested by @teknium1 on #37533.
- **Tests** — New `TestMCPReconnectRetryConfig` in `tests/tools/test_mcp_stability.py`: default fallback, config override, configurable park threshold (asserts the parking log reports the configured limit, not the constant), and the `0 = forever` case (asserts no parking log fires after the default cap would have parked many times over).
- **Docs** — Row in the Common keys table of `website/docs/user-guide/features/mcp.md`, including the `0 = retry forever` semantic.

## Backward Compatibility

✅ **Fully backward compatible.** Default remains `5` when no config is specified. Existing configs behave identically.

## Related

- #37533 — closed with credit; the budget-reset-after-healthy portion landed via #59222. This PR rebases only the config-knob portion, as @teknium1 suggested in the close comment.
