### PR TITLE
fix(gateway): persist memory/skill nudge counters across turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8601,6 +8601,18 @@ class GatewayRunner:
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
 
+            _persisted_memory_turns = 0
+            _persisted_skill_iters = 0
+            if session_key and getattr(self, "session_store", None):
+                try:
+                    _persisted_memory_turns = self.session_store.get_memory_nudge_turns(session_key)
+                except Exception:
+                    _persisted_memory_turns = 0
+                try:
+                    _persisted_skill_iters = self.session_store.get_skill_nudge_iters(session_key)
+                except Exception:
+                    _persisted_skill_iters = 0
+
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
             # schemas for prompt cache hits.
@@ -8653,6 +8665,14 @@ class GatewayRunner:
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
+                try:
+                    agent._turns_since_memory = _persisted_memory_turns
+                except Exception:
+                    pass
+                try:
+                    agent._iters_since_skill = _persisted_skill_iters
+                except Exception:
+                    pass
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
                         _cache[session_key] = (agent, _sig)
@@ -8894,6 +8914,16 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+
+            if session_key and getattr(self, "session_store", None):
+                try:
+                    self.session_store.update_session(
+                        session_key,
+                        memory_turns_since_review=getattr(agent, "_turns_since_memory", 0),
+                        skill_iters_since_review=getattr(agent, "_iters_since_skill", 0),
+                    )
+                except Exception:
+                    pass
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -376,6 +376,15 @@ class SessionEntry:
     # this session (create a new session_id) so the user starts fresh.
     # Set by /stop to break stuck-resume loops (#7536).
     suspended: bool = False
+
+    # Turn-based memory review cadence for gateway-created agents. Persisted so
+    # fresh AIAgent instances (cache miss, restart, config change) don't lose
+    # the counter between user messages.
+    memory_turns_since_review: int = 0
+
+    # Tool-iteration-based skill review cadence for gateway-created agents.
+    # Persisted for the same reason as memory_turns_since_review.
+    skill_iters_since_review: int = 0
     
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -396,6 +405,8 @@ class SessionEntry:
             "cost_status": self.cost_status,
             "memory_flushed": self.memory_flushed,
             "suspended": self.suspended,
+            "memory_turns_since_review": self.memory_turns_since_review,
+            "skill_iters_since_review": self.skill_iters_since_review,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -433,6 +444,8 @@ class SessionEntry:
             cost_status=data.get("cost_status", "unknown"),
             memory_flushed=data.get("memory_flushed", False),
             suspended=data.get("suspended", False),
+            memory_turns_since_review=data.get("memory_turns_since_review", 0),
+            skill_iters_since_review=data.get("skill_iters_since_review", 0),
         )
 
 
@@ -774,6 +787,8 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        memory_turns_since_review: int = None,
+        skill_iters_since_review: int = None,
     ) -> None:
         """Update lightweight session metadata after an interaction."""
         with self._lock:
@@ -784,7 +799,41 @@ class SessionStore:
                 entry.updated_at = _now()
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
+                if memory_turns_since_review is not None:
+                    try:
+                        entry.memory_turns_since_review = max(0, int(memory_turns_since_review))
+                    except (TypeError, ValueError):
+                        entry.memory_turns_since_review = 0
+                if skill_iters_since_review is not None:
+                    try:
+                        entry.skill_iters_since_review = max(0, int(skill_iters_since_review))
+                    except (TypeError, ValueError):
+                        entry.skill_iters_since_review = 0
                 self._save()
+
+    def get_memory_nudge_turns(self, session_key: str) -> int:
+        """Return persisted memory-review turns for the active session key."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry:
+                return 0
+            try:
+                return max(0, int(getattr(entry, "memory_turns_since_review", 0) or 0))
+            except (TypeError, ValueError):
+                return 0
+
+    def get_skill_nudge_iters(self, session_key: str) -> int:
+        """Return persisted skill-review iterations for the active session key."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if not entry:
+                return 0
+            try:
+                return max(0, int(getattr(entry, "skill_iters_since_review", 0) or 0))
+            except (TypeError, ValueError):
+                return 0
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/tests/gateway/test_memory_nudge_persistence.py
+++ b/tests/gateway/test_memory_nudge_persistence.py
@@ -1,0 +1,280 @@
+"""Tests for gateway memory/skill nudge counter persistence across fresh agent instances."""
+
+import importlib
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class SilentAdapter(BasePlatformAdapter):
+    def __init__(self, platform=Platform.FEISHU):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"msg-{len(self.sent)}")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class CounterStore:
+    def __init__(self):
+        self.memory_turns = 0
+        self.skill_iters = 0
+        self.updated = []
+
+    def get_memory_nudge_turns(self, session_key: str) -> int:
+        return self.memory_turns
+
+    def get_skill_nudge_iters(self, session_key: str) -> int:
+        return self.skill_iters
+
+    def update_session(
+        self,
+        session_key: str,
+        last_prompt_tokens=None,
+        memory_turns_since_review=None,
+        skill_iters_since_review=None,
+    ):
+        if memory_turns_since_review is not None:
+            self.memory_turns = memory_turns_since_review
+        if skill_iters_since_review is not None:
+            self.skill_iters = skill_iters_since_review
+        self.updated.append(
+            {
+                "session_key": session_key,
+                "last_prompt_tokens": last_prompt_tokens,
+                "memory_turns_since_review": memory_turns_since_review,
+                "skill_iters_since_review": skill_iters_since_review,
+            }
+        )
+
+
+class FakeAgent:
+    starts = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.model = kwargs.get("model", "fake-model")
+        self._turns_since_memory = 0
+        self._iters_since_skill = 0
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).starts.append(
+            {
+                "memory": self._turns_since_memory,
+                "skill": self._iters_since_skill,
+            }
+        )
+        self._turns_since_memory += 4
+        self._iters_since_skill += 3
+        return {
+            "final_response": f"ok:{message}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ThresholdReviewAgent(FakeAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).starts.append(
+            {
+                "memory": self._turns_since_memory,
+                "skill": self._iters_since_skill,
+            }
+        )
+        if self._turns_since_memory >= 9:
+            self._turns_since_memory = 0
+            cb = getattr(self, "background_review_callback", None)
+            if cb:
+                cb("💾 Memory updated.")
+        else:
+            self._turns_since_memory += 1
+
+        if self._iters_since_skill >= 14:
+            self._iters_since_skill = 0
+            cb = getattr(self, "background_review_callback", None)
+            if cb:
+                cb("🛠️ Skill reviewed.")
+        else:
+            self._iters_since_skill += 1
+
+        return {
+            "final_response": f"ok:{message}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter, session_store):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner.session_store = session_store
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None  # force fresh agent each turn
+    runner._running_agents_ts = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+        streaming=None,
+    )
+    runner._resolve_session_agent_runtime = lambda **kwargs: (
+        "fake-model",
+        {"api_key": "***", "provider": "custom", "base_url": "http://127.0.0.1:8080/v1"},
+    )
+    runner._resolve_turn_agent_config = lambda message, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+        "request_overrides": None,
+    }
+    runner._load_reasoning_config = lambda: None
+    runner._load_service_tier = lambda: None
+    runner._agent_config_signature = lambda *args, **kwargs: "sig"
+    runner._cleanup_agent_resources = lambda agent: None
+    runner._evict_cached_agent = lambda session_key: None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_persists_memory_and_skill_nudge_counters_across_fresh_agents(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    session_store = CounterStore()
+    adapter = SilentAdapter()
+    runner = _make_runner(adapter, session_store)
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_test_chat",
+        chat_type="dm",
+        user_id="ou_test_user",
+    )
+
+    FakeAgent.starts = []
+
+    first = await runner._run_agent(
+        message="first",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:feishu:dm:oc_test_chat",
+    )
+    second = await runner._run_agent(
+        message="second",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:feishu:dm:oc_test_chat",
+    )
+
+    assert first["final_response"] == "ok:first"
+    assert second["final_response"] == "ok:second"
+    assert FakeAgent.starts == [
+        {"memory": 0, "skill": 0},
+        {"memory": 4, "skill": 3},
+    ]
+    assert session_store.memory_turns == 8
+    assert session_store.skill_iters == 6
+    assert [u["memory_turns_since_review"] for u in session_store.updated] == [4, 8]
+    assert [u["skill_iters_since_review"] for u in session_store.updated] == [3, 6]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_releases_background_review_when_persisted_counters_hit_threshold(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ThresholdReviewAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    session_store = CounterStore()
+    session_store.memory_turns = 9
+    session_store.skill_iters = 14
+    adapter = SilentAdapter()
+    runner = _make_runner(adapter, session_store)
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_test_chat",
+        chat_type="dm",
+        user_id="ou_test_user",
+    )
+    session_key = "agent:main:feishu:dm:oc_test_chat"
+
+    ThresholdReviewAgent.starts = []
+
+    result = await runner._run_agent(
+        message="threshold",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "ok:threshold"
+    assert ThresholdReviewAgent.starts == [{"memory": 9, "skill": 14}]
+    assert adapter.sent == []
+
+    release_cb = adapter._post_delivery_callbacks[session_key]
+    await __import__("asyncio").to_thread(release_cb)
+    await __import__("asyncio").sleep(0)
+
+    assert [msg["content"] for msg in adapter.sent] == [
+        "💾 Memory updated.",
+        "🛠️ Skill reviewed.",
+    ]
+    assert session_store.memory_turns == 0
+    assert session_store.skill_iters == 0

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -84,6 +84,27 @@ def agent_with_memory_tool():
         return a
 
 
+@pytest.fixture()
+def agent_with_memory_and_skill_tools():
+    """Agent whose valid_tool_names includes memory + skill_manage."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs("web_search", "memory", "skill_manage"),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-k...7890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()
@@ -4134,6 +4155,28 @@ class TestMemoryNudgeCounterPersistence:
         preamble = src[:preamble_end]
         assert "self._turns_since_memory = 0" not in preamble
         assert "self._iters_since_skill = 0" not in preamble
+
+    def test_real_agent_triggers_background_review_when_thresholds_hit(self, agent_with_memory_and_skill_tools):
+        """Real AIAgent should call background review once persisted counters hit thresholds."""
+        agent = agent_with_memory_and_skill_tools
+        agent.client.chat.completions.create.return_value = _mock_response(content="done")
+        agent._memory_store = object()
+        agent._memory_nudge_interval = 10
+        agent._skill_nudge_interval = 15
+        agent._turns_since_memory = 9
+        agent._iters_since_skill = 14
+        agent._spawn_background_review = MagicMock()
+
+        result = agent.run_conversation("trigger review")
+
+        assert result["final_response"] == "done"
+        agent._spawn_background_review.assert_called_once()
+        kwargs = agent._spawn_background_review.call_args.kwargs
+        assert kwargs["review_memory"] is True
+        assert kwargs["review_skills"] is True
+        assert isinstance(kwargs["messages_snapshot"], list)
+        assert agent._turns_since_memory == 0
+        assert agent._iters_since_skill == 0
 
 
 class TestDeadRetryCode:


### PR DESCRIPTION
## Summary

This PR fixes gateway-side nudge cadence resets by persisting memory and skill review counters across turns.

Previously, gateway conversations could create a fresh `AIAgent` between messages. Because `_turns_since_memory` and `_iters_since_skill` lived only in agent memory, the review cadence could reset unexpectedly and fail to trigger at the configured interval.

## Changes

### Persistence
- Added persisted session fields for:
  - `memory_turns_since_review`
  - `skill_iters_since_review`
- Serialized/deserialized both values in `SessionEntry`

### SessionStore
- Extended `update_session()` to write both counters
- Added helpers to read persisted counters:
  - `get_memory_nudge_turns(session_key)`
  - `get_skill_nudge_iters(session_key)`

### Gateway runtime
- Restored persisted counters into fresh gateway-created `AIAgent` instances
- Saved updated counter values back to the session store after each turn

## Tests

Added regression coverage for:

- persistence of memory/skill counters across fresh gateway agents
- threshold-triggered deferred background review notifications in the gateway path
- real `AIAgent` threshold-triggered background review behavior

## Why this matters

This makes review cadence behave consistently in gateway sessions even when:
- the agent cache misses
- the agent is rebuilt due to config changes
- the gateway creates a fresh `AIAgent` for a later turn
- session state is reloaded from persisted session metadata

## Result

After this change:

- memory nudge cadence persists across gateway turns
- skill nudge cadence persists across gateway turns
- threshold-triggered background review behavior is covered by regression tests

## Validation

Targeted test coverage passed, including:

- `tests/gateway/test_memory_nudge_persistence.py`
- `tests/gateway/test_run_progress_topics.py`
- `tests/gateway/test_session_*.py`
- `tests/gateway/test_agent_cache.py`
- `tests/run_agent/test_run_agent.py::TestMemoryNudgeCounterPersistence`
