### PR TITLE
fix(tests): merge code_execution category and sync hardcoded config version

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -233,6 +233,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "approvals": "security",
     "human_delay": "display",
     "smart_model_routing": "agent",
+    "code_execution": "terminal",
     "dashboard": "display",
 }
 

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 18
+        assert DEFAULT_CONFIG["_config_version"] == 19


### PR DESCRIPTION
## Summary

Two CI regressions are currently breaking every open PR against `main`:

### 1. `test_no_single_field_categories` — `code_execution` single-field

`hermes_cli/config.py:775` introduces a `code_execution` category with a single field (`mode`), violating `count >= 2` in `tests/hermes_cli/test_web_server.py:369`.

**Fix**: route `code_execution` through the existing `_CATEGORY_MERGE` map into `terminal` (semantic fit: both deal with shell/exec surface).

### 2. `test_config_version_matches_current_schema` — stale assertion

`_config_version` was bumped to `19` in `hermes_cli/config.py:805` but `tests/tools/test_browser_camofox_state.py:67` still asserts `== 18`.

**Fix**: sync the expectation to `19`.

## Scope

Intentionally minimal — two assertions, no behavior change, no refactor. Unblocks every PR currently failing CI with these two specific errors (including #12120 where this was spotted).

## Test plan

- [ ] CI green on this PR
- [ ] Re-run CI on PRs that were stuck on these two tests