### PR TITLE
fix(tui): clickable hyperlinks and skill slash command dispatch

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -258,6 +258,72 @@ def test_slash_exec_rejects_skill_commands(server):
     assert "skill command" in resp["error"]["message"]
 
 
+@pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan"])
+def test_slash_exec_rejects_pending_input_commands(server, cmd):
+    """slash.exec must reject commands that use _pending_input in the CLI."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+
+    resp = server.handle_request({
+        "id": "r1",
+        "method": "slash.exec",
+        "params": {"command": cmd, "session_id": sid},
+    })
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4018
+    assert "pending-input command" in resp["error"]["message"]
+
+
+def test_command_dispatch_queue_sends_message(server):
+    """command.dispatch /queue returns {type: 'send', message: ...} for the TUI."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+
+    resp = server.handle_request({
+        "id": "r1",
+        "method": "command.dispatch",
+        "params": {"name": "queue", "arg": "tell me about quantum computing", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "tell me about quantum computing"
+
+
+def test_command_dispatch_queue_requires_arg(server):
+    """command.dispatch /queue without an argument returns an error."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+
+    resp = server.handle_request({
+        "id": "r2",
+        "method": "command.dispatch",
+        "params": {"name": "queue", "arg": "", "session_id": sid},
+    })
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4004
+
+
+def test_command_dispatch_steer_fallback_sends_message(server):
+    """command.dispatch /steer with no active agent falls back to send."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+
+    resp = server.handle_request({
+        "id": "r3",
+        "method": "command.dispatch",
+        "params": {"name": "steer", "arg": "focus on testing", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "focus on testing"
+
+
 def test_command_dispatch_returns_skill_payload(server):
     """command.dispatch returns structured skill payload for the TUI to send()."""
     sid = "test-session"

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -245,7 +245,7 @@ def test_slash_exec_rejects_skill_commands(server):
     # Mock scan_skill_commands to return a known skill
     fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
 
-    with patch("agent.skill_commands.scan_skill_commands", return_value=fake_skills):
+    with patch("agent.skill_commands.get_skill_commands", return_value=fake_skills):
         resp = server.handle_request({
             "id": "r1",
             "method": "slash.exec",
@@ -322,6 +322,90 @@ def test_command_dispatch_steer_fallback_sends_message(server):
     result = resp["result"]
     assert result["type"] == "send"
     assert result["message"] == "focus on testing"
+
+
+def test_command_dispatch_retry_finds_last_user_message(server):
+    """command.dispatch /retry walks session['history'] to find the last user message."""
+    sid = "test-session"
+    history = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+        {"role": "user", "content": "second question"},
+        {"role": "assistant", "content": "second answer"},
+    ]
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r4",
+        "method": "command.dispatch",
+        "params": {"name": "retry", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "second question"
+    # Verify history was truncated: everything from last user message onward removed
+    assert len(server._sessions[sid]["history"]) == 2
+    assert server._sessions[sid]["history"][-1]["role"] == "assistant"
+    assert server._sessions[sid]["history_version"] == 1
+
+
+def test_command_dispatch_retry_empty_history(server):
+    """command.dispatch /retry with empty history returns error."""
+    sid = "test-session"
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r5",
+        "method": "command.dispatch",
+        "params": {"name": "retry", "session_id": sid},
+    })
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4018
+
+
+def test_command_dispatch_retry_handles_multipart_content(server):
+    """command.dispatch /retry extracts text from multipart content lists."""
+    sid = "test-session"
+    history = [
+        {"role": "user", "content": [
+            {"type": "text", "text": "analyze this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+        ]},
+        {"role": "assistant", "content": "I see the image."},
+    ]
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r6",
+        "method": "command.dispatch",
+        "params": {"name": "retry", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "analyze this"
 
 
 def test_command_dispatch_returns_skill_payload(server):

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -231,3 +231,51 @@ def test_cli_exec_blocked(server, argv):
 ])
 def test_cli_exec_allowed(server, argv):
     assert server._cli_exec_blocked(argv) is None
+
+
+# ── slash.exec skill command interception ────────────────────────────
+
+
+def test_slash_exec_rejects_skill_commands(server):
+    """slash.exec must reject skill commands so the TUI falls through to command.dispatch."""
+    # Register a mock session
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid, "agent": None}
+
+    # Mock scan_skill_commands to return a known skill
+    fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
+
+    with patch("agent.skill_commands.scan_skill_commands", return_value=fake_skills):
+        resp = server.handle_request({
+            "id": "r1",
+            "method": "slash.exec",
+            "params": {"command": "hermes-agent-dev", "session_id": sid},
+        })
+
+    # Should return an error so the TUI's .catch() fires command.dispatch
+    assert "error" in resp
+    assert resp["error"]["code"] == 4018
+    assert "skill command" in resp["error"]["message"]
+
+
+def test_command_dispatch_returns_skill_payload(server):
+    """command.dispatch returns structured skill payload for the TUI to send()."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+
+    fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
+    fake_msg = "Loaded skill content here"
+
+    with patch("agent.skill_commands.scan_skill_commands", return_value=fake_skills), \
+         patch("agent.skill_commands.build_skill_invocation_message", return_value=fake_msg):
+        resp = server.handle_request({
+            "id": "r2",
+            "method": "command.dispatch",
+            "params": {"name": "hermes-agent-dev", "session_id": sid},
+        })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "skill"
+    assert result["message"] == fake_msg
+    assert result["name"] == "hermes-agent-dev"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1949,6 +1949,13 @@ _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/logs", "Show recent gateway log lines", "TUI"),
 ]
 
+# Commands that queue messages onto _pending_input in the CLI.
+# In the TUI the slash worker subprocess has no reader for that queue,
+# so slash.exec rejects them → TUI falls through to command.dispatch.
+_PENDING_INPUT_COMMANDS: frozenset[str] = frozenset({
+    "retry", "queue", "q", "steer", "plan",
+})
+
 
 @method("commands.catalog")
 def _(rid, params: dict) -> dict:
@@ -2127,20 +2134,32 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"type": "send", "message": arg})
 
     if name == "retry":
-        agent = session.get("agent") if session else None
-        if agent and hasattr(agent, "conversation_history"):
-            hist = agent.conversation_history or []
-            for m in reversed(hist):
-                if m.get("role") == "user":
-                    content = m.get("content", "")
-                    if isinstance(content, list):
-                        content = " ".join(
-                            p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"
-                        )
-                    if content:
-                        return _ok(rid, {"type": "send", "message": content})
+        if not session:
+            return _err(rid, 4001, "no active session to retry")
+        history = session.get("history", [])
+        if not history:
             return _err(rid, 4018, "no previous user message to retry")
-        return _err(rid, 4018, "no active session to retry")
+        # Walk backwards to find the last user message
+        last_user_idx = None
+        for i in range(len(history) - 1, -1, -1):
+            if history[i].get("role") == "user":
+                last_user_idx = i
+                break
+        if last_user_idx is None:
+            return _err(rid, 4018, "no previous user message to retry")
+        content = history[last_user_idx].get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"
+            )
+        if not content:
+            return _err(rid, 4018, "last user message is empty")
+        # Truncate history: remove everything from the last user message onward
+        # (mirrors CLI retry_last() which strips the failed exchange)
+        with session["history_lock"]:
+            session["history"] = history[:last_user_idx]
+            session["history_version"] = int(session.get("history_version", 0)) + 1
+        return _ok(rid, {"type": "send", "message": content})
 
     if name == "steer":
         if not arg:
@@ -2159,9 +2178,16 @@ def _(rid, params: dict) -> dict:
     if name == "plan":
         try:
             from agent.skill_commands import build_skill_invocation_message as _bsim, build_plan_path
-            plan_path = build_plan_path(session.get("session_key", "") if session else "")
-            msg = _bsim("/plan", f"{arg} {plan_path}".strip() if arg else plan_path,
-                        task_id=session.get("session_key", "") if session else "")
+            user_instruction = arg or ""
+            plan_path = build_plan_path(user_instruction)
+            msg = _bsim(
+                "/plan", user_instruction,
+                task_id=session.get("session_key", "") if session else "",
+                runtime_note=(
+                    "Save the markdown plan with write_file to this exact relative path "
+                    f"inside the active workspace/backend cwd: {plan_path}"
+                ),
+            )
             if msg:
                 return _ok(rid, {"type": "send", "message": msg})
         except Exception as e:
@@ -2383,19 +2409,12 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
 
-    # Skill slash commands (e.g. /hermes-agent-dev) must NOT go through the
-    # slash worker — process_command() queues the skill payload onto
-    # _pending_input which nobody reads in the worker subprocess.  Reject
-    # here so the TUI falls through to command.dispatch which handles skills
-    # correctly (builds the invocation message and returns it to the client).
-    #
-    # The same applies to /retry, /queue, /steer, and /plan — they all
-    # put messages on _pending_input that the slash worker never reads.
+    # Skill slash commands and _pending_input commands must NOT go through the
+    # slash worker — see _PENDING_INPUT_COMMANDS definition above.
     # (/browser connect/disconnect also uses _pending_input for context
     # notes, but the actual browser operations need the slash worker's
     # env-var side effects, so they stay in slash.exec — only the context
     # note to the model is lost, which is low-severity.)
-    _PENDING_INPUT_COMMANDS = frozenset({"retry", "queue", "q", "steer", "plan"})
     _cmd_parts = cmd.split() if not cmd.startswith("/") else cmd.lstrip("/").split()
     _cmd_base = _cmd_parts[0] if _cmd_parts else ""
 
@@ -2403,9 +2422,9 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4018, f"pending-input command: use command.dispatch for /{_cmd_base}")
 
     try:
-        from agent.skill_commands import scan_skill_commands
+        from agent.skill_commands import get_skill_commands
         _cmd_key = f"/{_cmd_base}"
-        if _cmd_key in scan_skill_commands():
+        if _cmd_key in get_skill_commands():
             return _err(rid, 4018, f"skill command: use command.dispatch for {_cmd_key}")
     except Exception:
         pass

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2117,6 +2117,56 @@ def _(rid, params: dict) -> dict:
     except Exception:
         pass
 
+    # ── Commands that queue messages onto _pending_input in the CLI ───
+    # In the TUI the slash worker subprocess has no reader for that queue,
+    # so we handle them here and return a structured payload.
+
+    if name in ("queue", "q"):
+        if not arg:
+            return _err(rid, 4004, "usage: /queue <prompt>")
+        return _ok(rid, {"type": "send", "message": arg})
+
+    if name == "retry":
+        agent = session.get("agent") if session else None
+        if agent and hasattr(agent, "conversation_history"):
+            hist = agent.conversation_history or []
+            for m in reversed(hist):
+                if m.get("role") == "user":
+                    content = m.get("content", "")
+                    if isinstance(content, list):
+                        content = " ".join(
+                            p.get("text", "") for p in content if isinstance(p, dict) and p.get("type") == "text"
+                        )
+                    if content:
+                        return _ok(rid, {"type": "send", "message": content})
+            return _err(rid, 4018, "no previous user message to retry")
+        return _err(rid, 4018, "no active session to retry")
+
+    if name == "steer":
+        if not arg:
+            return _err(rid, 4004, "usage: /steer <prompt>")
+        agent = session.get("agent") if session else None
+        if agent and hasattr(agent, "steer"):
+            try:
+                accepted = agent.steer(arg)
+                if accepted:
+                    return _ok(rid, {"type": "exec", "output": f"⏩ Steer queued — arrives after the next tool call: {arg[:80]}{'...' if len(arg) > 80 else ''}"})
+            except Exception:
+                pass
+        # Fallback: no active run, treat as next-turn message
+        return _ok(rid, {"type": "send", "message": arg})
+
+    if name == "plan":
+        try:
+            from agent.skill_commands import build_skill_invocation_message as _bsim, build_plan_path
+            plan_path = build_plan_path(session.get("session_key", "") if session else "")
+            msg = _bsim("/plan", f"{arg} {plan_path}".strip() if arg else plan_path,
+                        task_id=session.get("session_key", "") if session else "")
+            if msg:
+                return _ok(rid, {"type": "send", "message": msg})
+        except Exception as e:
+            return _err(rid, 5030, f"plan skill failed: {e}")
+
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
 
 
@@ -2338,9 +2388,23 @@ def _(rid, params: dict) -> dict:
     # _pending_input which nobody reads in the worker subprocess.  Reject
     # here so the TUI falls through to command.dispatch which handles skills
     # correctly (builds the invocation message and returns it to the client).
+    #
+    # The same applies to /retry, /queue, /steer, and /plan — they all
+    # put messages on _pending_input that the slash worker never reads.
+    # (/browser connect/disconnect also uses _pending_input for context
+    # notes, but the actual browser operations need the slash worker's
+    # env-var side effects, so they stay in slash.exec — only the context
+    # note to the model is lost, which is low-severity.)
+    _PENDING_INPUT_COMMANDS = frozenset({"retry", "queue", "q", "steer", "plan"})
+    _cmd_parts = cmd.split() if not cmd.startswith("/") else cmd.lstrip("/").split()
+    _cmd_base = _cmd_parts[0] if _cmd_parts else ""
+
+    if _cmd_base in _PENDING_INPUT_COMMANDS:
+        return _err(rid, 4018, f"pending-input command: use command.dispatch for /{_cmd_base}")
+
     try:
         from agent.skill_commands import scan_skill_commands
-        _cmd_key = f"/{cmd.split()[0]}" if not cmd.startswith("/") else f"/{cmd.lstrip('/').split()[0]}"
+        _cmd_key = f"/{_cmd_base}"
         if _cmd_key in scan_skill_commands():
             return _err(rid, 4018, f"skill command: use command.dispatch for {_cmd_key}")
     except Exception:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2333,6 +2333,19 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
 
+    # Skill slash commands (e.g. /hermes-agent-dev) must NOT go through the
+    # slash worker — process_command() queues the skill payload onto
+    # _pending_input which nobody reads in the worker subprocess.  Reject
+    # here so the TUI falls through to command.dispatch which handles skills
+    # correctly (builds the invocation message and returns it to the client).
+    try:
+        from agent.skill_commands import scan_skill_commands
+        _cmd_key = f"/{cmd.split()[0]}" if not cmd.startswith("/") else f"/{cmd.lstrip('/').split()[0]}"
+        if _cmd_key in scan_skill_commands():
+            return _err(rid, 4018, f"skill command: use command.dispatch for {_cmd_key}")
+    except Exception:
+        pass
+
     worker = session.get("slash_worker")
     if not worker:
         try:

--- a/ui-tui/src/__tests__/asCommandDispatch.test.ts
+++ b/ui-tui/src/__tests__/asCommandDispatch.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { asCommandDispatch } from '../lib/rpc.js'
 
 describe('asCommandDispatch', () => {
-  it('parses exec, alias, and skill', () => {
+  it('parses exec, alias, skill, and send', () => {
     expect(asCommandDispatch({ type: 'exec', output: 'hi' })).toEqual({ type: 'exec', output: 'hi' })
     expect(asCommandDispatch({ type: 'alias', target: 'help' })).toEqual({ type: 'alias', target: 'help' })
     expect(asCommandDispatch({ type: 'skill', name: 'x', message: 'do' })).toEqual({
@@ -11,11 +11,17 @@ describe('asCommandDispatch', () => {
       name: 'x',
       message: 'do'
     })
+    expect(asCommandDispatch({ type: 'send', message: 'hello world' })).toEqual({
+      type: 'send',
+      message: 'hello world'
+    })
   })
 
   it('rejects malformed payloads', () => {
     expect(asCommandDispatch(null)).toBeNull()
     expect(asCommandDispatch({ type: 'alias' })).toBeNull()
     expect(asCommandDispatch({ type: 'skill', name: 1 })).toBeNull()
+    expect(asCommandDispatch({ type: 'send' })).toBeNull()
+    expect(asCommandDispatch({ type: 'send', message: 42 })).toBeNull()
   })
 })

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -152,6 +152,36 @@ describe('createSlashHandler', () => {
     })
     expect(ctx.transcript.send).toHaveBeenCalledWith(skillMessage)
   })
+
+  it('handles send-type dispatch for /plan command', async () => {
+    const planMessage = 'Plan skill content loaded'
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.reject(new Error('pending-input command'))
+            }
+
+            if (method === 'command.dispatch') {
+              return Promise.resolve({ type: 'send', message: planMessage })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/plan create a REST API')).toBe(true)
+    await vi.waitFor(() => {
+      expect(ctx.transcript.send).toHaveBeenCalledWith(planMessage)
+    })
+  })
 })
 
 const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -121,6 +121,37 @@ describe('createSlashHandler', () => {
     expect(createSlashHandler(ctx)('/h')).toBe(true)
     expect(ctx.transcript.panel).toHaveBeenCalledWith(expect.any(String), expect.any(Array))
   })
+
+  it('falls through to command.dispatch for skill commands and sends the message', async () => {
+    const skillMessage = 'Use this skill to do X.\n\n## Steps\n1. First step'
+
+    const ctx = buildCtx({
+      gateway: {
+        gw: {
+          getLogTail: vi.fn(() => ''),
+          request: vi.fn((method: string) => {
+            if (method === 'slash.exec') {
+              return Promise.reject(new Error('skill command: use command.dispatch'))
+            }
+
+            if (method === 'command.dispatch') {
+              return Promise.resolve({ type: 'skill', message: skillMessage, name: 'hermes-agent-dev' })
+            }
+
+            return Promise.resolve({})
+          })
+        },
+        rpc: vi.fn(() => Promise.resolve({}))
+      }
+    })
+
+    const h = createSlashHandler(ctx)
+    expect(h('/hermes-agent-dev')).toBe(true)
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith('⚡ loading skill: hermes-agent-dev')
+    })
+    expect(ctx.transcript.send).toHaveBeenCalledWith(skillMessage)
+  })
 })
 
 const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({

--- a/ui-tui/src/app/createSlashHandler.ts
+++ b/ui-tui/src/app/createSlashHandler.ts
@@ -105,6 +105,10 @@ export function createSlashHandler(ctx: SlashHandlerContext): (cmd: string) => b
 
               return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: skill payload missing message`)
             }
+
+            if (d.type === 'send') {
+              return d.message?.trim() ? send(d.message) : sys(`/${parsed.name}: empty message`)
+            }
           })
           .catch(guardedErr)
       })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1,4 +1,4 @@
-import { type ScrollBoxHandle, useApp, useHasSelection, useSelection, useStdout } from '@hermes/ink'
+import { type ScrollBoxHandle, useApp, useHasSelection, useSelection, useStdout, useTerminalTitle } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
@@ -283,6 +283,13 @@ export function useMainApp(gw: GatewayClient) {
   })
 
   useConfigSync({ gw, setBellOnComplete, setVoiceEnabled, sid: ui.sid })
+
+  // ── Terminal tab title ─────────────────────────────────────────────
+  // Show model name + status so users can identify the Hermes tab.
+  const shortModel = ui.info?.model?.replace(/^.*\//, '') ?? ''
+  const titleStatus = ui.busy ? '⏳' : '✓'
+  const terminalTitle = shortModel ? `${titleStatus} ${shortModel} — Hermes` : 'Hermes'
+  useTerminalTitle(terminalTitle)
 
   useEffect(() => {
     if (!ui.sid || !stdout) {

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@hermes/ink'
+import { Box, Link, Text } from '@hermes/ink'
 import { memo, type ReactNode, useMemo } from 'react'
 
 import type { Theme } from '../theme.js'
@@ -22,10 +22,12 @@ type Fence = {
   len: number
 }
 
-const renderLink = (key: number, t: Theme, label: string) => (
-  <Text color={t.color.amber} key={key} underline>
-    {label}
-  </Text>
+const renderLink = (key: number, t: Theme, label: string, url: string) => (
+  <Link key={key} url={url}>
+    <Text color={t.color.amber} underline>
+      {label}
+    </Text>
+  </Link>
 )
 
 const trimBareUrl = (value: string) => {
@@ -38,9 +40,11 @@ const trimBareUrl = (value: string) => {
 }
 
 const renderAutolink = (key: number, t: Theme, raw: string) => (
-  <Text color={t.color.amber} key={key} underline>
-    {raw.replace(/^mailto:/, '')}
-  </Text>
+  <Link key={key} url={raw}>
+    <Text color={t.color.amber} underline>
+      {raw.replace(/^mailto:/, '')}
+    </Text>
+  </Link>
 )
 
 const indentDepth = (indent: string) => Math.floor(indent.replace(/\t/g, '  ').length / 2)
@@ -141,7 +145,7 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
         </Text>
       )
     } else if (m[4] && m[5]) {
-      parts.push(renderLink(parts.length, t, m[4]))
+      parts.push(renderLink(parts.length, t, m[4], m[5]))
     } else if (m[6]) {
       parts.push(renderAutolink(parts.length, t, m[6]))
     } else if (m[7]) {

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -28,12 +28,18 @@ export const MessageLine = memo(function MessageLine({
   }
 
   if (msg.role === 'tool') {
+    const preview = compactPreview(hasAnsi(msg.text) ? stripAnsi(msg.text) : msg.text, Math.max(24, cols - 14)) ||
+      '(empty tool result)'
+
     return (
       <Box alignSelf="flex-start" borderColor={t.color.dim} borderStyle="round" marginLeft={3} paddingX={1}>
-        <Text color={t.color.dim} wrap="truncate-end">
-          {compactPreview(hasAnsi(msg.text) ? stripAnsi(msg.text) : msg.text, Math.max(24, cols - 14)) ||
-            '(empty tool result)'}
-        </Text>
+        {hasAnsi(msg.text) ? (
+          <Ansi>{compactPreview(msg.text, Math.max(24, cols - 14)) || '(empty tool result)'}</Ansi>
+        ) : (
+          <Text color={t.color.dim} wrap="truncate-end">
+            {preview}
+          </Text>
+        )}
       </Box>
     )
   }

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -28,13 +28,14 @@ export const MessageLine = memo(function MessageLine({
   }
 
   if (msg.role === 'tool') {
-    const preview = compactPreview(hasAnsi(msg.text) ? stripAnsi(msg.text) : msg.text, Math.max(24, cols - 14)) ||
-      '(empty tool result)'
+    const maxChars = Math.max(24, cols - 14)
+    const stripped = hasAnsi(msg.text) ? stripAnsi(msg.text) : msg.text
+    const preview = compactPreview(stripped, maxChars) || '(empty tool result)'
 
     return (
       <Box alignSelf="flex-start" borderColor={t.color.dim} borderStyle="round" marginLeft={3} paddingX={1}>
         {hasAnsi(msg.text) ? (
-          <Ansi>{compactPreview(msg.text, Math.max(24, cols - 14)) || '(empty tool result)'}</Ansi>
+          <Text wrap="truncate-end"><Ansi>{msg.text}</Ansi></Text>
         ) : (
           <Text color={t.color.dim} wrap="truncate-end">
             {preview}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -47,6 +47,7 @@ export type CommandDispatchResponse =
   | { output?: string; type: 'exec' | 'plugin' }
   | { target: string; type: 'alias' }
   | { message?: string; name: string; type: 'skill' }
+  | { message: string; type: 'send' }
 
 // ── Config ───────────────────────────────────────────────────────────
 

--- a/ui-tui/src/lib/rpc.ts
+++ b/ui-tui/src/lib/rpc.ts
@@ -26,6 +26,10 @@ export const asCommandDispatch = (value: unknown): CommandDispatchResponse | nul
     return { type: 'skill', name: o.name, message: typeof o.message === 'string' ? o.message : undefined }
   }
 
+  if (t === 'send' && typeof o.message === 'string') {
+    return { type: 'send', message: o.message }
+  }
+
   return null
 }
 

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -93,6 +93,7 @@ declare module '@hermes/ink' {
   export function useHasSelection(): boolean
   export function useStdout(): { readonly stdout?: NodeJS.WriteStream }
   export function useTerminalFocus(): boolean
+  export function useTerminalTitle(title: string | null): void
   export function useDeclaredCursor(args: {
     readonly line: number
     readonly column: number

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -63,6 +63,7 @@ declare module '@hermes/ink' {
   export const Box: React.ComponentType<any>
   export const AlternateScreen: React.ComponentType<any>
   export const Ansi: React.ComponentType<any>
+  export const Link: React.ComponentType<{ readonly url: string; readonly children?: React.ReactNode; readonly fallback?: React.ReactNode }>
   export const NoSelect: React.ComponentType<any>
   export const ScrollBox: React.ComponentType<any>
   export const Text: React.ComponentType<any>


### PR DESCRIPTION
## Summary

Six TUI fixes across rendering, slash command dispatch, and UX.

### 1. Hyperlinks not clickable (Cmd+Click broken)

**Problem:** Links in TUI markdown responses rendered as colored underlined text only — no OSC 8 hyperlink escape sequences. Cmd+Click does nothing.

**Root cause:** `markdown.tsx` renders `[text](url)` and bare URLs with plain `<Text>` components, discarding the URL. The `<Link>` component from `@hermes/ink` exists and emits proper OSC 8 sequences but was never used.

**Fix:** Import `Link` and wrap all link rendering with it. Added missing `Link` type to `hermes-ink.d.ts`.

### 2. Skill slash commands silently do nothing (`/hermes-agent-dev` → "ready")

**Problem:** Typing `/hermes-agent-dev` does nothing — TUI stays in "ready" state.

**Root cause:** `slash.exec` → `_SlashWorker` → `cli.process_command()` → puts skill message on `_pending_input` Queue that nobody reads in the worker subprocess. `slash.exec` succeeds, so the TUI's `.catch()` → `command.dispatch` (which has correct skill handling) never fires.

**Fix:** Detect skill commands in `slash.exec` early, return error so `command.dispatch` handles them correctly.

### 3. `/plan` slash command silently lost

**Problem:** `/plan` does nothing in the TUI — same `_pending_input` bug as skills.

**Root cause:** Same pattern — `process_command()` builds the plan skill invocation message and queues it on `_pending_input`, which nobody reads in the slash worker.

**Fix:** Intercept `/plan` (and `/retry`, `/queue`, `/steer` as safety nets) in `slash.exec`. Added `command.dispatch` handlers that return a new `{type: 'send', message: ...}` payload. Added `'send'` to `CommandDispatchResponse` type, `asCommandDispatch` parser, and `createSlashHandler` handler.

### 4. Tool results strip ANSI (colors lost)

**Problem:** Tool results from `terminal`, `search_files` etc. lose all color/styling — displayed as plain dim text.

**Root cause:** `messageLine.tsx` unconditionally calls `stripAnsi()` + renders with `<Text>` for tool role messages, even though the `<Ansi>` component is imported and used for assistant messages.

**Fix:** Use `<Ansi>` component when ANSI codes are detected in tool results.

### 5. No terminal tab title

**Problem:** Users with multiple terminal tabs can't identify which tab is running Hermes or whether it's busy.

**Fix:** Added `useTerminalTitle` hook (already exists in `@hermes/ink`, never used) to show `✓ claude-sonnet-4 — Hermes` (ready) or `⏳ claude-sonnet-4 — Hermes` (busy).

### 6. Missing `Link` and `useTerminalTitle` type declarations

The build-time `hermes-ink.d.ts` was missing type declarations for both, causing `tsc -p tsconfig.build.json` to fail.

## Files Changed

| File | Change |
|------|--------|
| `ui-tui/src/components/markdown.tsx` | Wrap links in `<Link>` for OSC 8 hyperlinks |
| `ui-tui/src/components/messageLine.tsx` | Use `<Ansi>` for tool results with ANSI codes |
| `ui-tui/src/app/useMainApp.ts` | Add `useTerminalTitle` for tab title |
| `ui-tui/src/app/createSlashHandler.ts` | Handle `'send'` dispatch type |
| `ui-tui/src/gatewayTypes.ts` | Add `'send'` variant to `CommandDispatchResponse` |
| `ui-tui/src/lib/rpc.ts` | Parse `'send'` in `asCommandDispatch` |
| `ui-tui/src/types/hermes-ink.d.ts` | Add `Link` + `useTerminalTitle` type exports |
| `tui_gateway/server.py` | Intercept `_pending_input` commands + skill commands in `slash.exec`; add `/queue`, `/retry`, `/steer`, `/plan` handlers in `command.dispatch` |
| `ui-tui/src/__tests__/createSlashHandler.test.ts` | Tests: skill dispatch, plan/send dispatch |
| `ui-tui/src/__tests__/asCommandDispatch.test.ts` | Tests: `'send'` type parsing |
| `tests/tui_gateway/test_protocol.py` | Tests: slash.exec interception, command.dispatch handlers |

## Test Plan

- [x] `npm run build` — Full build passes
- [x] `npx tsc --noEmit -p tsconfig.json` — Type check clean
- [x] `npm test` — 53/53 vitest tests pass
- [x] `scripts/run_tests.sh tests/tui_gateway/` — 38/38 pytest tests pass

Fixes #12142
Fixes #12143