### PR TITLE
fix(gateway): pass session_key (not session_id) to active-process check during prune

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -833,12 +833,18 @@ class SessionStore:
                     continue
                 # Never prune sessions with an active background process
                 # attached — the user may still be waiting on output.
+                # The callback is keyed by session_key (see process_registry.
+                # has_active_for_session); passing session_id here used to
+                # never match, so active sessions got pruned anyway.
                 if self._has_active_processes_fn is not None:
                     try:
-                        if self._has_active_processes_fn(entry.session_id):
+                        if self._has_active_processes_fn(entry.session_key):
                             continue
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug(
+                            "has_active_processes_fn raised during prune for %s: %s",
+                            entry.session_key, exc,
+                        )
                 if entry.updated_at < cutoff:
                     removed_keys.append(key)
             for key in removed_keys:

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -117,11 +117,20 @@ class TestPruneBasics:
         assert "idle" not in store._entries
 
     def test_prune_skips_entries_with_active_processes(self, tmp_path):
-        """Sessions with active bg processes aren't pruned even if old."""
-        active_session_ids = {"sid_active"}
+        """Sessions with active bg processes aren't pruned even if old.
 
-        def _has_active(session_id: str) -> bool:
-            return session_id in active_session_ids
+        The callback is keyed by session_key — matching what
+        process_registry.has_active_for_session() actually consumes in
+        gateway/run.py.  Prior to the fix this test passed the callback a
+        session_id, which silently matched an implementation bug where
+        prune_old_entries was also passing session_id; real-world usage
+        (via process_registry) takes a session_key and never matched, so
+        active sessions were still being pruned.
+        """
+        active_session_keys = {"active"}
+
+        def _has_active(session_key: str) -> bool:
+            return session_key in active_session_keys
 
         store = _make_store(tmp_path, has_active_processes_fn=_has_active)
         store._entries["active"] = _entry(
@@ -136,6 +145,26 @@ class TestPruneBasics:
         assert removed == 1
         assert "active" in store._entries
         assert "idle" not in store._entries
+
+    def test_prune_active_check_uses_session_key_not_session_id(self, tmp_path):
+        """Regression guard: a callback that only recognises session_ids must
+        NOT protect entries during prune.  This pins the fix so a future
+        refactor can't silently revert to passing session_id again.
+        """
+        def _recognises_only_ids(identifier: str) -> bool:
+            return identifier.startswith("sid_")
+
+        store = _make_store(tmp_path, has_active_processes_fn=_recognises_only_ids)
+        store._entries["active"] = _entry(
+            "active", age_days=1000, session_id="sid_active"
+        )
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        # Entry is pruned because the callback receives "active" (session_key),
+        # not "sid_active" (session_id), so _recognises_only_ids returns False.
+        assert removed == 1
+        assert "active" not in store._entries
 
     def test_prune_does_not_write_disk_when_no_removals(self, tmp_path):
         """If nothing is evictable, _save() should NOT be called."""


### PR DESCRIPTION
## Summary

`SessionStore.prune_old_entries` in `gateway/session.py` was calling its active-process guard with the wrong identifier:

```python
if self._has_active_processes_fn(entry.session_id):
    continue
```

But the callback installed in `gateway/run.py:606` is `process_registry.has_active_for_session(key)`, which in `tools/process_registry.py:932` compares the argument against `s.session_key`, not `s.session_id`. The two live in different namespaces (`session_key` looks like `agent:main:discord:group:…`, `session_id` looks like `20260417_123045_a1b2c3d4`), so the guard never fired.

Every other caller in `session.py` — `_is_session_expired` (line 591) and `_should_reset` (line 632) — already passes `session_key`. Prune was the only outlier.

Symptom in production: sessions with live background processes (queued cron output, detached agents, long-running Bash) were pruned out of `_entries` despite the docstring promising they'd be preserved. When the process eventually finished and tried to deliver output back to its origin session, the `session_key → session_id` mapping was gone and the work was effectively orphaned — exactly the scenario the docstring says it prevents.

### Changes

- `gateway/session.py`: pass `entry.session_key` to `_has_active_processes_fn`; demote the silent `except Exception: pass` to a debug log so future callback bugs don't vanish.
- `tests/gateway/test_session_store_prune.py`: the existing `test_prune_skips_entries_with_active_processes` was validating the wrong interface — its mock callback took `session_id`, so the test agreed with the buggy implementation and passed. Updated it to use a `session_key`-based mock that matches the production callback's real contract. Added a new `test_prune_active_check_uses_session_key_not_session_id` regression guard.

## Test plan

- [x] `test_prune_skips_entries_with_active_processes` — session_key-based mock now protects the active entry
- [x] `test_prune_active_check_uses_session_key_not_session_id` — a mock that only recognises session_ids does NOT protect entries, confirming session_key (not session_id) is what reaches the callback
- [x] `py_compile` on both changed files
- [ ] Run the full gateway test suite to confirm no other test relied on the old behaviour