### PR TITLE
feat: rate limit cooldown — skip primary restoration during sustained rate limiting

### DIFF
--- a/rate_limit_cooldown.py
+++ b/rate_limit_cooldown.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Rate Limit Cooldown Tracker
+
+Generic rate limit cooldown cache for any provider.
+Records rate limit events and tracks cooldown periods so subsequent
+requests can skip the primary provider instead of repeatedly hitting
+the limit before falling back.
+
+File format (~/.hermes/rate_limits/{provider}.json):
+{
+    "model_slug": {
+        "error_type": "rate_limit",
+        "timestamp": "2026-04-18T18:30:00Z",
+        "reset_after": 60,  # seconds from timestamp
+        "http_status": 429
+    }
+}
+
+This file lives in ~/.hermes/ and survives hermes-agent git resets.
+"""
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COOLDOWN_SECONDS = 60  # Fallback when API doesn't provide reset time
+RATE_LIMIT_DIR_NAME = "rate_limits"
+
+
+def _get_rate_limit_dir(hermes_home: Optional[str] = None) -> Path:
+    """Get the rate limits cache directory."""
+    if hermes_home:
+        base = Path(hermes_home)
+    else:
+        # Try HERMES_HOME env, then ~/.hermes/
+        base = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return base / RATE_LIMIT_DIR_NAME
+
+
+def _get_provider_file(provider: str, hermes_home: Optional[str] = None) -> Path:
+    """Get the rate limit cache file for a specific provider."""
+    provider_slug = provider.lower().replace("-", "_").replace("/", "_")
+    return _get_rate_limit_dir(hermes_home) / f"{provider_slug}.json"
+
+
+def _ensure_dir(path: Path) -> None:
+    """Ensure directory exists."""
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _load_cache(file_path: Path) -> Dict[str, Any]:
+    """Load cache from file, return empty dict if not exists or invalid."""
+    if not file_path.exists():
+        return {}
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning("Failed to load rate limit cache %s: %s", file_path, e)
+        return {}
+
+
+def _save_cache(file_path: Path, data: Dict[str, Any]) -> None:
+    """Save cache to file atomically."""
+    _ensure_dir(file_path.parent)
+    try:
+        # Atomic write via temp file
+        temp_path = file_path.with_suffix(".tmp")
+        with open(temp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        temp_path.replace(file_path)
+    except IOError as e:
+        logger.warning("Failed to save rate limit cache %s: %s", file_path, e)
+
+
+def record_rate_limit(
+    provider: str,
+    model: str,
+    error_type: str = "rate_limit",
+    reset_after: Optional[int] = None,
+    http_status: Optional[int] = None,
+    hermes_home: Optional[str] = None,
+) -> None:
+    """Record a rate limit event for a provider/model.
+
+    Args:
+        provider: Provider name (e.g., "zai", "openrouter", "openai")
+        model: Model slug (e.g., "glm-5-turbo", "claude-sonnet-4")
+        error_type: Error type string for classification
+        reset_after: Cooldown duration in seconds (from API retry-after or default)
+        http_status: HTTP status code (e.g., 429)
+        hermes_home: Override Hermes home directory
+    """
+    cooldown_seconds = reset_after or DEFAULT_COOLDOWN_SECONDS
+
+    file_path = _get_provider_file(provider, hermes_home)
+    cache = _load_cache(file_path)
+
+    # Normalize model key (strip provider prefix if present)
+    model_key = model.split("/")[-1] if "/" in model else model
+
+    cache[model_key] = {
+        "error_type": error_type,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "reset_after": cooldown_seconds,
+        "http_status": http_status,
+    }
+
+    _save_cache(file_path, cache)
+    logger.info(
+        "Rate limit recorded for %s/%s: cooldown %ds",
+        provider, model_key, cooldown_seconds
+    )
+
+
+def is_in_cooldown(
+    provider: str,
+    model: str,
+    hermes_home: Optional[str] = None,
+) -> bool:
+    """Check if a provider/model is currently in rate limit cooldown.
+
+    Returns True if:
+    - A rate limit event was recorded for this provider/model
+    - The cooldown period hasn't expired yet
+
+    Args:
+        provider: Provider name
+        model: Model slug
+        hermes_home: Override Hermes home directory
+    """
+    file_path = _get_provider_file(provider, hermes_home)
+    cache = _load_cache(file_path)
+
+    model_key = model.split("/")[-1] if "/" in model else model
+
+    if model_key not in cache:
+        return False
+
+    entry = cache[model_key]
+    try:
+        recorded_time = datetime.fromisoformat(entry["timestamp"])
+        cooldown_seconds = entry.get("reset_after", DEFAULT_COOLDOWN_SECONDS)
+    except (KeyError, ValueError):
+        return False
+
+    elapsed = (datetime.now(timezone.utc) - recorded_time).total_seconds()
+    if elapsed < cooldown_seconds:
+        remaining = int(cooldown_seconds - elapsed)
+        logger.debug(
+            "Provider %s/%s in cooldown: %ds remaining",
+            provider, model_key, remaining
+        )
+        return True
+
+    # Cooldown expired, clean up entry
+    del cache[model_key]
+    _save_cache(file_path, cache)
+    logger.info("Cooldown expired for %s/%s, cleared cache", provider, model_key)
+    return False
+
+
+def get_cooldown_remaining(
+    provider: str,
+    model: str,
+    hermes_home: Optional[str] = None,
+) -> int:
+    """Get remaining cooldown seconds for a provider/model.
+
+    Returns 0 if not in cooldown.
+    """
+    file_path = _get_provider_file(provider, hermes_home)
+    cache = _load_cache(file_path)
+
+    model_key = model.split("/")[-1] if "/" in model else model
+
+    if model_key not in cache:
+        return 0
+
+    entry = cache[model_key]
+    try:
+        recorded_time = datetime.fromisoformat(entry["timestamp"])
+        cooldown_seconds = entry.get("reset_after", DEFAULT_COOLDOWN_SECONDS)
+    except (KeyError, ValueError):
+        return 0
+
+    elapsed = (datetime.now(timezone.utc) - recorded_time).total_seconds()
+    remaining = max(0, int(cooldown_seconds - elapsed))
+    return remaining
+
+
+def clear_cooldown(
+    provider: str,
+    model: str,
+    hermes_home: Optional[str] = None,
+) -> bool:
+    """Manually clear cooldown for a provider/model.
+
+    Returns True if entry existed and was cleared.
+    """
+    file_path = _get_provider_file(provider, hermes_home)
+    cache = _load_cache(file_path)
+
+    model_key = model.split("/")[-1] if "/" in model else model
+
+    if model_key in cache:
+        del cache[model_key]
+        _save_cache(file_path, cache)
+        logger.info("Manually cleared cooldown for %s/%s", provider, model_key)
+        return True
+    return False
+
+
+def clear_all_cooldowns(hermes_home: Optional[str] = None) -> int:
+    """Clear all rate limit cooldown caches.
+
+    Returns number of files cleared.
+    """
+    rate_limit_dir = _get_rate_limit_dir(hermes_home)
+    if not rate_limit_dir.exists():
+        return 0
+
+    count = 0
+    for f in rate_limit_dir.glob("*.json"):
+        try:
+            f.unlink()
+            count += 1
+        except IOError:
+            pass
+
+    logger.info("Cleared %d rate limit cache files", count)
+    return count

--- a/run_agent.py
+++ b/run_agent.py
@@ -49,6 +49,12 @@ from hermes_constants import get_hermes_home
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
 
+from rate_limit_cooldown import (
+    record_rate_limit as _record_rate_limit,
+    is_in_cooldown as _is_in_cooldown,
+    get_cooldown_remaining as _get_cooldown_remaining,
+)
+
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
 _loaded_env_paths = load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
@@ -6073,6 +6079,24 @@ class AIAgent:
         if not self._fallback_activated:
             return False
 
+        # ── Rate limit cooldown check ──
+        # If the primary provider is in cooldown from a recent rate limit,
+        # skip restoration and continue using fallback.
+        rt = self._primary_runtime
+        primary_provider = rt.get("provider", "")
+        primary_model = rt.get("model", "")
+        if _is_in_cooldown(primary_provider, primary_model):
+            remaining = _get_cooldown_remaining(primary_provider, primary_model)
+            self._emit_status(
+                f"⏳ Primary ({primary_model}) in rate limit cooldown "
+                f"({remaining}s remaining) — continuing with fallback"
+            )
+            logging.info(
+                "Skipping primary restoration: %s/%s in cooldown (%ds)",
+                primary_provider, primary_model, remaining
+            )
+            return False
+
         rt = self._primary_runtime
         try:
             # ── Core runtime state ──
@@ -9826,6 +9850,31 @@ class AIAgent:
                         if not pool_may_recover:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                             if self._try_activate_fallback():
+                                # ── Record rate limit cooldown ──
+                                # Only record for rate_limit errors (not billing/quota)
+                                if classified.reason == FailoverReason.rate_limit:
+                                    try:
+                                        primary_model = getattr(self, "_primary_runtime", {}).get("model", self.model)
+                                        primary_provider = getattr(self, "_primary_runtime", {}).get("provider", self.provider)
+                                        # Parse reset_after from error if available
+                                        reset_after = None
+                                        _err_resp = getattr(api_error, "response", None)
+                                        if _err_resp:
+                                            _retry_after = getattr(_err_resp.headers, "get", lambda k: None)("retry-after")
+                                            if _retry_after:
+                                                try:
+                                                    reset_after = int(_retry_after)
+                                                except ValueError:
+                                                    pass
+                                        _record_rate_limit(
+                                            provider=primary_provider,
+                                            model=primary_model,
+                                            error_type="rate_limit",
+                                            reset_after=reset_after,
+                                            http_status=429,
+                                        )
+                                    except Exception as e:
+                                        logging.warning("Failed to record rate limit cooldown: %s", e)
                                 retry_count = 0
                                 compression_attempts = 0
                                 primary_recovery_attempted = False

--- a/tests/test_rate_limit_cooldown.py
+++ b/tests/test_rate_limit_cooldown.py
@@ -1,0 +1,225 @@
+"""Tests for the rate limit cooldown tracker (rate_limit_cooldown.py)."""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from rate_limit_cooldown import (
+    DEFAULT_COOLDOWN_SECONDS,
+    RATE_LIMIT_DIR_NAME,
+    _get_provider_file,
+    _load_cache,
+    _save_cache,
+    clear_all_cooldowns,
+    clear_cooldown,
+    get_cooldown_remaining,
+    is_in_cooldown,
+    record_rate_limit,
+)
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    """Provide a temporary Hermes home directory."""
+    return str(tmp_path)
+
+
+class TestProviderFileResolution:
+    """Tests for _get_provider_file path logic."""
+
+    def test_simple_provider_name(self, hermes_home, tmp_path):
+        path = _get_provider_file("zai", hermes_home)
+        expected = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        assert path == expected
+
+    def test_dashes_normalized_to_underscores(self, hermes_home, tmp_path):
+        path = _get_provider_file("open-router", hermes_home)
+        expected = tmp_path / RATE_LIMIT_DIR_NAME / "open_router.json"
+        assert path == expected
+
+    def test_slashes_normalized(self, hermes_home, tmp_path):
+        path = _get_provider_file("org/provider", hermes_home)
+        expected = tmp_path / RATE_LIMIT_DIR_NAME / "org_provider.json"
+        assert path == expected
+
+
+class TestCachePersistence:
+    """Tests for _load_cache and _save_cache file I/O."""
+
+    def test_load_missing_file(self, tmp_path):
+        result = _load_cache(tmp_path / "nonexistent.json")
+        assert result == {}
+
+    def test_load_invalid_json(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text("not json{{{", encoding="utf-8")
+        result = _load_cache(f)
+        assert result == {}
+
+    def test_save_and_load_roundtrip(self, tmp_path):
+        f = tmp_path / "test.json"
+        data = {"model_a": {"error_type": "rate_limit", "reset_after": 60}}
+        _save_cache(f, data)
+        loaded = _load_cache(f)
+        assert loaded == data
+
+    def test_save_creates_parent_dir(self, tmp_path):
+        f = tmp_path / "nested" / "dir" / "test.json"
+        _save_cache(f, {"a": 1})
+        assert f.exists()
+
+    def test_save_atomic(self, tmp_path):
+        """Verify temp file is cleaned up after save."""
+        f = tmp_path / "test.json"
+        _save_cache(f, {"a": 1})
+        # No leftover .tmp file
+        assert not f.with_suffix(".tmp").exists()
+
+
+class TestRecordRateLimit:
+    """Tests for record_rate_limit."""
+
+    def test_record_creates_cache_file(self, hermes_home, tmp_path):
+        record_rate_limit("zai", "glm-5-turbo", hermes_home=hermes_home)
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        assert cache_file.exists()
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert "glm-5-turbo" in cache
+
+    def test_record_stores_metadata(self, hermes_home, tmp_path):
+        record_rate_limit(
+            "zai", "glm-5-turbo",
+            error_type="rate_limit",
+            reset_after=120,
+            http_status=429,
+            hermes_home=hermes_home,
+        )
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        entry = json.loads(cache_file.read_text(encoding="utf-8"))["glm-5-turbo"]
+        assert entry["error_type"] == "rate_limit"
+        assert entry["reset_after"] == 120
+        assert entry["http_status"] == 429
+        assert "timestamp" in entry
+
+    def test_record_strips_provider_prefix(self, hermes_home, tmp_path):
+        record_rate_limit("zai", "zai/glm-5-turbo", hermes_home=hermes_home)
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
+        # Key should be "glm-5-turbo", not "zai/glm-5-turbo"
+        assert "glm-5-turbo" in cache
+        assert "zai/glm-5-turbo" not in cache
+
+    def test_record_default_cooldown(self, hermes_home, tmp_path):
+        record_rate_limit("openai", "gpt-4o", hermes_home=hermes_home)
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "openai.json"
+        entry = json.loads(cache_file.read_text(encoding="utf-8"))["gpt-4o"]
+        assert entry["reset_after"] == DEFAULT_COOLDOWN_SECONDS
+
+    def test_record_multiple_models(self, hermes_home, tmp_path):
+        record_rate_limit("zai", "glm-5-turbo", hermes_home=hermes_home)
+        record_rate_limit("zai", "glm-4", hermes_home=hermes_home)
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert "glm-5-turbo" in cache
+        assert "glm-4" in cache
+
+    def test_record_overwrites_existing(self, hermes_home, tmp_path):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        record_rate_limit("zai", "glm-5-turbo", reset_after=120, hermes_home=hermes_home)
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        entry = json.loads(cache_file.read_text(encoding="utf-8"))["glm-5-turbo"]
+        assert entry["reset_after"] == 120
+
+
+class TestIsInCooldown:
+    """Tests for is_in_cooldown."""
+
+    def test_not_recorded(self, hermes_home):
+        assert not is_in_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home)
+
+    def test_in_cooldown(self, hermes_home):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert is_in_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home)
+
+    def test_cooldown_expires(self, hermes_home):
+        # Use a very short cooldown and wait
+        record_rate_limit("zai", "glm-5-turbo", reset_after=1, hermes_home=hermes_home)
+        time.sleep(1.1)
+        assert not is_in_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home)
+
+    def test_expired_entry_cleaned(self, hermes_home, tmp_path):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=1, hermes_home=hermes_home)
+        time.sleep(1.1)
+        is_in_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home)
+        cache_file = tmp_path / RATE_LIMIT_DIR_NAME / "zai.json"
+        cache = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert "glm-5-turbo" not in cache
+
+    def test_different_model_not_affected(self, hermes_home):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert not is_in_cooldown("zai", "glm-4", hermes_home=hermes_home)
+
+    def test_different_provider_not_affected(self, hermes_home):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert not is_in_cooldown("openai", "glm-5-turbo", hermes_home=hermes_home)
+
+    def test_strips_provider_prefix(self, hermes_home):
+        record_rate_limit("zai", "zai/glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert is_in_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home)
+
+
+class TestGetCooldownRemaining:
+    """Tests for get_cooldown_remaining."""
+
+    def test_not_recorded(self, hermes_home):
+        assert get_cooldown_remaining("zai", "glm-5-turbo", hermes_home=hermes_home) == 0
+
+    def test_returns_remaining_seconds(self, hermes_home):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        remaining = get_cooldown_remaining("zai", "glm-5-turbo", hermes_home=hermes_home)
+        assert 0 < remaining <= 60
+
+    def test_returns_zero_after_expiry(self, hermes_home):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=1, hermes_home=hermes_home)
+        time.sleep(1.1)
+        assert get_cooldown_remaining("zai", "glm-5-turbo", hermes_home=hermes_home) == 0
+
+    def test_strips_provider_prefix(self, hermes_home):
+        record_rate_limit("zai", "zai/glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert get_cooldown_remaining("zai", "glm-5-turbo", hermes_home=hermes_home) > 0
+
+
+class TestClearCooldown:
+    """Tests for clear_cooldown."""
+
+    def test_clear_existing(self, hermes_home):
+        record_rate_limit("zai", "glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert clear_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home) is True
+        assert not is_in_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home)
+
+    def test_clear_nonexistent(self, hermes_home):
+        assert clear_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home) is False
+
+    def test_strips_provider_prefix(self, hermes_home):
+        record_rate_limit("zai", "zai/glm-5-turbo", reset_after=60, hermes_home=hermes_home)
+        assert clear_cooldown("zai", "glm-5-turbo", hermes_home=hermes_home) is True
+
+
+class TestClearAllCooldowns:
+    """Tests for clear_all_cooldowns."""
+
+    def test_clear_multiple_providers(self, hermes_home, tmp_path):
+        record_rate_limit("zai", "glm-5-turbo", hermes_home=hermes_home)
+        record_rate_limit("openai", "gpt-4o", hermes_home=hermes_home)
+        count = clear_all_cooldowns(hermes_home=hermes_home)
+        assert count == 2
+        assert not (tmp_path / RATE_LIMIT_DIR_NAME / "zai.json").exists()
+        assert not (tmp_path / RATE_LIMIT_DIR_NAME / "openai.json").exists()
+
+    def test_clear_empty_dir(self, hermes_home):
+        assert clear_all_cooldowns(hermes_home=hermes_home) == 0
+
+    def test_clear_nonexistent_dir(self, hermes_home):
+        assert clear_all_cooldowns(hermes_home=hermes_home) == 0


### PR DESCRIPTION
## Problem

When the primary provider is rate limited (HTTP 429), the agent switches to fallback. However, `_restore_primary_runtime()` runs at every turn start, causing repeated failed requests to the same rate-limited endpoint.

## Solution

Add a persistent cooldown cache that records rate limit events with their duration (from retry-after header or 60s default) and skips primary restoration while cooldown is active.

## Changes

- `rate_limit_cooldown.py`: new generic cooldown tracker with JSON-backed cache
- `run_agent.py`: check cooldown in `_restore_primary_runtime()`, record cooldown when fallback activates due to rate_limit

## Behavior

- Rate limit + fallback activation → record cooldown
- Next turn → cooldown active → skip primary, continue with fallback
- Cooldown expires → restore primary normally
- No change when rate limiting does not occur