### PR TITLE
fix(agent): skip model name normalization for third-party anthropic-messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6419,13 +6419,33 @@ class AIAgent:
         return transformed
 
     def _anthropic_preserve_dots(self) -> bool:
-        """True when using an anthropic-compatible endpoint that preserves dots in model names.
-        Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        MiniMax keeps dots (e.g. MiniMax-M2.7).
-        OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
+        """
+        Determine whether to skip model name normalization for the current provider.
+
+        The native Anthropic API expects model names in hyphenated format
+        (e.g. claude-sonnet-4-5), so the normalize logic converts dots to
+        hyphens — which is correct for that case.
+
+        Third-party providers that speak the Anthropic protocol forward the
+        model name as-is, where dots carry real meaning. Normalizing those
+        would break the request with HTTP 404, so we skip normalization for:
+
+        1. Any provider using api_mode=anthropic_messages that is not the
+           native Anthropic provider (catches all custom/compatible endpoints).
+        2. Known providers by name: alibaba, minimax, minimax-cn, opencode-go,
+           opencode-zen, zai (legacy fallback for cases where api_mode is not set).
+        3. Known base URLs: dashscope, aliyuncs, minimax, opencode.ai/zen/,
+           bigmodel.cn (legacy fallback for url-based detection).
+
+        Returns True if normalization should be skipped (dots preserved).
+        """
+        # Primary: any third-party Anthropic-compatible provider
+        if getattr(self, "api_mode", "") == "anthropic_messages" and getattr(self, "provider", "") != "anthropic":
+            return True
+        # Legacy fallback: known provider names
         if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
             return True
+        # Legacy fallback: known base URLs
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base
 


### PR DESCRIPTION
## What changed and why

`_anthropic_preserve_dots()` previously maintained an allowlist of known third-party provider names (alibaba, minimax, zai, etc.) to decide whether to skip model name normalization.

This approach is fragile — any new third-party provider not in the list gets its model name incorrectly normalized (dots → hyphens), causing HTTP 404 errors.

The new logic is simpler and more correct: skip normalization for **any** provider using `api_mode=anthropic_messages` that is not the native Anthropic provider. Native Anthropic is the only case where normalization is actually needed.

## How to test

1. Configure a third-party Anthropic-compatible provider (e.g. OneAPI)
2. Set a model name containing dots (e.g. `GLM-4.1-Air`)
3. Send a message — verify the model name is forwarded as-is, no 404

## Platforms tested

Linux

## Related

Fixes incorrect behavior when using custom Anthropic-compatible endpoints with dot-containing model names.


# We need to respect users and DO NOT modify their input MODEL NAME.