### PR TITLE
fix(honcho): harden Hermes memory-provider integration

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -26,6 +26,52 @@ from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
 
+_THINK_BLOCK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.IGNORECASE | re.DOTALL)
+
+
+def _strip_think_blocks(text: str) -> str:
+    if not text:
+        return ""
+    return _THINK_BLOCK_RE.sub("", text)
+
+
+def _normalize_context_text(value: Any, *, max_chars: int | None = None) -> str:
+    """Strip hidden reasoning noise and collapse whitespace for prompt safety."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        value = str(value)
+    value = _strip_think_blocks(value)
+    value = re.sub(r"[ \t]{2,}", " ", value)
+    value = re.sub(r"\n{3,}", "\n\n", value)
+    value = value.strip()
+    if max_chars and len(value) > max_chars:
+        value = value[: max_chars - 1].rstrip() + "…"
+    return value
+
+
+def _format_card_snapshot(card: Any, *, max_items: int = 8, max_item_chars: int = 180) -> str:
+    """Render a peer card as a compact bullet list instead of dumping raw reprs."""
+    if not card:
+        return ""
+
+    if isinstance(card, (list, tuple)):
+        cleaned = [
+            _normalize_context_text(item, max_chars=max_item_chars)
+            for item in card
+            if _normalize_context_text(item, max_chars=max_item_chars)
+        ]
+        if not cleaned:
+            return ""
+        visible = cleaned[:max_items]
+        lines = [f"- {item}" for item in visible]
+        remaining = len(cleaned) - len(visible)
+        if remaining > 0:
+            lines.append(f"- … and {remaining} more facts")
+        return "\n".join(lines)
+
+    return _normalize_context_text(card, max_chars=max_items * max_item_chars)
+
 
 # ---------------------------------------------------------------------------
 # Tool schemas (moved from tools/honcho_tools.py)
@@ -431,23 +477,23 @@ class HonchoMemoryProvider(MemoryProvider):
         parts = []
 
         # Session summary — session-scoped context, placed first for relevance
-        summary = ctx.get("summary", "")
+        summary = _normalize_context_text(ctx.get("summary", ""), max_chars=1200)
         if summary:
             parts.append(f"## Session Summary\n{summary}")
 
-        rep = ctx.get("representation", "")
+        rep = _normalize_context_text(ctx.get("representation", ""), max_chars=700)
         if rep:
             parts.append(f"## User Representation\n{rep}")
 
-        card = ctx.get("card", "")
+        card = _format_card_snapshot(ctx.get("card", ""), max_items=8, max_item_chars=160)
         if card:
             parts.append(f"## User Peer Card\n{card}")
 
-        ai_rep = ctx.get("ai_representation", "")
+        ai_rep = _normalize_context_text(ctx.get("ai_representation", ""), max_chars=500)
         if ai_rep:
             parts.append(f"## AI Self-Representation\n{ai_rep}")
 
-        ai_card = ctx.get("ai_card", "")
+        ai_card = _format_card_snapshot(ctx.get("ai_card", ""), max_items=6, max_item_chars=140)
         if ai_card:
             parts.append(f"## AI Identity Card\n{ai_card}")
 
@@ -993,18 +1039,26 @@ class HonchoMemoryProvider(MemoryProvider):
                     return json.dumps({"result": "No context available yet."})
                 parts = []
                 if ctx.get("summary"):
-                    parts.append(f"## Summary\n{ctx['summary']}")
+                    summary = _normalize_context_text(ctx["summary"], max_chars=1600)
+                    if summary:
+                        parts.append(f"## Summary\n{summary}")
                 if ctx.get("representation"):
-                    parts.append(f"## Representation\n{ctx['representation']}")
+                    rep = _normalize_context_text(ctx["representation"], max_chars=900)
+                    if rep:
+                        parts.append(f"## Representation\n{rep}")
                 if ctx.get("card"):
-                    parts.append(f"## Card\n{ctx['card']}")
+                    card = _format_card_snapshot(ctx["card"], max_items=10, max_item_chars=180)
+                    if card:
+                        parts.append(f"## Card\n{card}")
                 if ctx.get("recent_messages"):
                     msgs = ctx["recent_messages"]
                     msg_str = "\n".join(
-                        f"  [{m['role']}] {m['content'][:200]}"
+                        f"  [{m['role']}] {_normalize_context_text(m.get('content', ''), max_chars=200)}"
                         for m in msgs[-5:]  # last 5 for brevity
+                        if _normalize_context_text(m.get('content', ''), max_chars=200)
                     )
-                    parts.append(f"## Recent messages\n{msg_str}")
+                    if msg_str:
+                        parts.append(f"## Recent messages\n{msg_str}")
                 return json.dumps({"result": "\n\n".join(parts) or "No context available."})
 
             elif tool_name == "honcho_conclude":

--- a/run_agent.py
+++ b/run_agent.py
@@ -1290,6 +1290,9 @@ class AIAgent:
         self._memory_flush_min_turns = 6
         self._turns_since_memory = 0
         self._iters_since_skill = 0
+        _mem_provider_name = ""
+        _using_honcho_memory = False
+        _auto_detected_honcho = False
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -1297,6 +1300,26 @@ class AIAgent:
                 self._user_profile_enabled = mem_config.get("user_profile_enabled", False)
                 self._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
                 self._memory_flush_min_turns = int(mem_config.get("flush_min_turns", 6))
+                _mem_provider_name = (mem_config.get("provider", "") or "").strip().lower()
+
+                # Auto-migrate Honcho into the provider slot when it is clearly
+                # configured, even if config.yaml hasn't been updated yet.
+                if not _mem_provider_name:
+                    try:
+                        from plugins.memory.honcho.client import HonchoClientConfig as _HCC
+
+                        _hcfg = _HCC.from_global_config()
+                        if _hcfg.enabled and (_hcfg.api_key or _hcfg.base_url):
+                            _mem_provider_name = "honcho"
+                            _auto_detected_honcho = True
+                    except Exception:
+                        pass
+
+                _using_honcho_memory = _mem_provider_name == "honcho"
+
+                # Prefer Honcho when it actually activates, but do not disable
+                # the built-in store preemptively. If provider init fails, the
+                # flat-file memory path should remain available as a fallback.
                 if self._memory_enabled or self._user_profile_enabled:
                     from tools.memory_tool import MemoryStore
                     self._memory_store = MemoryStore(
@@ -1314,32 +1337,24 @@ class AIAgent:
         self._memory_manager = None
         if not skip_memory:
             try:
-                _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
-
                 # Auto-migrate: if Honcho was actively configured (enabled +
                 # credentials) but memory.provider is not set, activate the
                 # honcho plugin automatically.  Just having the config file
                 # is not enough — the user may have disabled Honcho or the
                 # file may be from a different tool.
-                if not _mem_provider_name:
+                if _auto_detected_honcho:
                     try:
-                        from plugins.memory.honcho.client import HonchoClientConfig as _HCC
-                        _hcfg = _HCC.from_global_config()
-                        if _hcfg.enabled and (_hcfg.api_key or _hcfg.base_url):
-                            _mem_provider_name = "honcho"
-                            # Persist so this only auto-migrates once
-                            try:
-                                from hermes_cli.config import load_config as _lc, save_config as _sc
-                                _cfg = _lc()
-                                _cfg.setdefault("memory", {})["provider"] = "honcho"
-                                _sc(_cfg)
-                            except Exception:
-                                pass
-                            if not self.quiet_mode:
-                                print("  ✓ Auto-migrated Honcho to memory provider plugin.")
-                                print("    Your config and data are preserved.\n")
+                        # Persist so this only auto-migrates once
+                        from hermes_cli.config import load_config as _lc, save_config as _sc
+
+                        _cfg = _lc()
+                        _cfg.setdefault("memory", {})["provider"] = "honcho"
+                        _sc(_cfg)
                     except Exception:
                         pass
+                    if not self.quiet_mode:
+                        print("  ✓ Auto-migrated Honcho to memory provider plugin.")
+                        print("    Your config and data are preserved.\n")
 
                 if _mem_provider_name:
                     from agent.memory_manager import MemoryManager as _MemoryManager
@@ -1387,6 +1402,20 @@ class AIAgent:
             except Exception as _mpe:
                 logger.warning("Memory provider plugin init failed: %s", _mpe)
                 self._memory_manager = None
+
+        _honcho_memory_active = bool(
+            _using_honcho_memory
+            and self._memory_manager
+            and getattr(self._memory_manager, "providers", None)
+        )
+        if _honcho_memory_active:
+            self._memory_store = None
+            if self.tools:
+                self.tools = [
+                    t for t in self.tools
+                    if t.get("function", {}).get("name") != "memory"
+                ]
+            self.valid_tool_names.discard("memory")
 
         # Inject memory provider tool schemas into the tool surface.
         # Skip tools whose names already exist (plugins may register the
@@ -3666,7 +3695,7 @@ class AIAgent:
 
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []
-        if "memory" in self.valid_tool_names:
+        if "memory" in self.valid_tool_names and self._memory_store:
             tool_guidance.append(MEMORY_GUIDANCE)
         if "session_search" in self.valid_tool_names:
             tool_guidance.append(SESSION_SEARCH_GUIDANCE)

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1010,3 +1010,49 @@ class TestHonchoCadenceTracking:
         p.on_turn_start(2, "second message")
         should_skip = p._injection_frequency == "first-turn" and p._turn_count > 1
         assert should_skip, "Second turn (turn 2) SHOULD be skipped"
+
+
+class TestHonchoContextHygiene:
+    def test_format_first_turn_context_strips_think_and_compacts_card(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        p = HonchoMemoryProvider()
+        ctx = {
+            "summary": "Visible summary <think>private reasoning blob</think> still here",
+            "representation": "Useful rep <think>hide me</think>",
+            "card": [f"Fact {i}" for i in range(1, 12)],
+        }
+
+        formatted = p._format_first_turn_context(ctx)
+
+        assert "private reasoning blob" not in formatted
+        assert "hide me" not in formatted
+        assert "Visible summary" in formatted
+        assert "- Fact 1" in formatted
+        assert "… and 3 more facts" in formatted
+
+    def test_honcho_context_tool_strips_think_and_formats_card_cleanly(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        p = HonchoMemoryProvider()
+        p._session_key = "test-session"
+        p._session_initialized = True
+        p._manager = MagicMock()
+        p._manager.get_session_context.return_value = {
+            "summary": "Hello <think>secret</think> world",
+            "representation": "Rep <think>internal</think> visible",
+            "card": ["alpha", "beta", "gamma"],
+            "recent_messages": [
+                {"role": "assistant", "content": "<think>hidden</think>shown"},
+                {"role": "user", "content": "plain"},
+            ],
+        }
+
+        result = json.loads(p.handle_tool_call("honcho_context", {}))["result"]
+
+        assert "secret" not in result
+        assert "internal" not in result
+        assert "hidden" not in result
+        assert "Hello world" in result
+        assert "## Card\n- alpha\n- beta\n- gamma" in result
+        assert "[assistant] shown" in result

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -661,6 +661,7 @@ class TestBuildSystemPrompt:
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
         from agent.prompt_builder import MEMORY_GUIDANCE
 
+        agent_with_memory_tool._memory_store = MagicMock()
         prompt = agent_with_memory_tool._build_system_prompt()
         assert MEMORY_GUIDANCE in prompt
 
@@ -669,6 +670,119 @@ class TestBuildSystemPrompt:
 
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
+
+    def test_honcho_provider_disables_builtin_memory_tooling(self):
+        from agent.prompt_builder import MEMORY_GUIDANCE
+
+        provider = MagicMock()
+        provider.is_available.return_value = True
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "memory": {
+                        "provider": "honcho",
+                        "memory_enabled": True,
+                        "user_profile_enabled": True,
+                    }
+                },
+            ),
+            patch("plugins.memory.load_memory_provider", return_value=provider),
+        ):
+            agent = AIAgent(
+                api_key="test-k...7890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+        prompt = agent._build_system_prompt()
+        assert agent._memory_store is None
+        assert "memory" not in agent.valid_tool_names
+        assert MEMORY_GUIDANCE not in prompt
+
+    def test_honcho_provider_failure_preserves_builtin_memory_tooling(self):
+        from agent.prompt_builder import MEMORY_GUIDANCE
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "memory": {
+                        "provider": "honcho",
+                        "memory_enabled": True,
+                        "user_profile_enabled": True,
+                    }
+                },
+            ),
+            patch("plugins.memory.load_memory_provider", return_value=None),
+        ):
+            agent = AIAgent(
+                api_key="test-k...7890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+        prompt = agent._build_system_prompt()
+        assert agent._memory_store is not None
+        assert "memory" in agent.valid_tool_names
+        assert MEMORY_GUIDANCE in prompt
+
+    def test_honcho_auto_detection_persists_provider_once(self):
+        fake_hcfg = MagicMock(enabled=True, api_key=None, base_url="http://localhost:8000")
+        provider = MagicMock()
+        provider.is_available.return_value = True
+        saved_cfg = {}
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search", "memory"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "memory": {
+                        "memory_enabled": True,
+                        "user_profile_enabled": True,
+                    }
+                },
+            ),
+            patch(
+                "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+                return_value=fake_hcfg,
+            ),
+            patch("plugins.memory.load_memory_provider", return_value=provider),
+            patch("hermes_cli.config.save_config") as mock_save_config,
+        ):
+            agent = AIAgent(
+                api_key="test-k...7890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=False,
+            )
+
+        assert agent._memory_store is None
+        assert "memory" not in agent.valid_tool_names
+        mock_save_config.assert_called_once()
+        saved_cfg = mock_save_config.call_args.args[0]
+        assert saved_cfg["memory"]["provider"] == "honcho"
 
     def test_includes_datetime(self, agent):
         prompt = agent._build_system_prompt()


### PR DESCRIPTION
## Summary
- strip leaked `<think>` blocks and compact Honcho context/card snapshots before prompt injection
- disable the built-in flat memory tool only when Honcho actually activates
- preserve flat-memory fallback if Honcho init fails
- persist one-time auto-migration for legacy Honcho config detection
- add regression tests for context hygiene, fallback preservation, and auto-migration

## Test Plan
- `uv run pytest tests/agent/test_memory_provider.py tests/run_agent/test_run_agent.py -q`

## Why
Honcho integration was close, but still had two ugly failure modes: prompt contamination from raw Honcho context and loss of all memory capability when Honcho was configured but unavailable. This fixes both without regressing the explicit Honcho-provider path.