### PR TITLE
fix: NVIDIA NIM models always truncate due to missing max_tokens default and ephemeral boost not wired to chat_completions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7053,9 +7053,17 @@ class AIAgent:
         if self.tools:
             api_kwargs["tools"] = self.tools
 
-        if self.max_tokens is not None:
+        _ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
+        if _ephemeral_out is not None:
+            self._ephemeral_max_output_tokens = None  # consume immediately
+            api_kwargs.update(self._max_tokens_param(_ephemeral_out))
+        elif self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))
+        elif "integrate.api.nvidia.com" in self._base_url_lower:
+            api_kwargs.update(self._max_tokens_param(16384))
         elif self._is_qwen_portal():
+
+            # Qwen Portal defaults to a very low max_tokens when omitted.
             # Qwen Portal defaults to a very low max_tokens when omitted.
             # Reasoning models (qwen3-coder-plus) exhaust that budget on
             # thinking tokens alone, causing the portal to return
@@ -10796,6 +10804,9 @@ class AIAgent:
                 continue
 
             if restart_with_length_continuation:
+                _boost_base = self.max_tokens if self.max_tokens else 4096
+                _boost = _boost_base * (length_continue_retries + 1)
+                self._ephemeral_max_output_tokens = min(_boost, 32768)
                 continue
 
             # Guard: if all retries exhausted without a successful response


### PR DESCRIPTION
## Fix `finish_reason='length'` truncation loop on NVIDIA NIM (GLM-4.7 and others)

So I've been using Hermes with GLM-4.7 on NVIDIA NIM and kept hitting this super frustrating issue where even a simple "hi" would just loop through 3 truncation warnings and then die with "Response remained truncated after 3 continuation attempts". Spent a while digging through `run_agent.py` to figure out what was actually going on and found two separate things both working against each other.

---

### What's actually happening

**Problem 1 — NVIDIA NIM never gets a `max_tokens` value**

When you don't set `max_tokens` in your config (or even when you do, since it never gets passed to `AIAgent` anyway), `self.max_tokens` ends up as `None`. Most providers are fine with that and just use a sensible default. NVIDIA NIM is not — it falls back to a really low internal default that GLM-4.7's thinking tokens alone can blow through before it even starts writing the actual response. So it truncates immediately, every single time, on the first call.

**Problem 2 — The retry boost only works for Anthropic, not NVIDIA NIM**

There's already a retry boost mechanism in the code — when a length truncation happens, it sets `_ephemeral_max_output_tokens` to a growing multiple of the base token budget before retrying. Good idea. The problem is that `_build_api_kwargs()` only consumes `_ephemeral_max_output_tokens` inside the `anthropic_messages` branch. NVIDIA NIM goes through `chat_completions`, so the boost is set but never actually sent to the API. All 3 retries hit the exact same token limit and fail identically.

---

### The fix

Three small changes to `run_agent.py`:

**1. Add the boost logic to the retry loop**

Around the `if restart_with_length_continuation:` block, add the growing budget before `continue`:

```python
if restart_with_length_continuation:
    _boost_base = self.max_tokens if self.max_tokens else 4096
    _boost = _boost_base * (length_continue_retries + 1)
    self._ephemeral_max_output_tokens = min(_boost, 32768)
    continue
```

Retry 1 gets `base × 2`, retry 2 gets `base × 3`, capped at 32K.

**2. Wire up ephemeral consumption in the `chat_completions` path**

In `_build_api_kwargs()`, the section that builds `max_tokens` for `chat_completions` currently just checks `self.max_tokens`. Replace it with:

```python
_ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
if _ephemeral_out is not None:
    self._ephemeral_max_output_tokens = None  # consume immediately
    api_kwargs.update(self._max_tokens_param(_ephemeral_out))
elif self.max_tokens is not None:
    api_kwargs.update(self._max_tokens_param(self.max_tokens))
elif "integrate.api.nvidia.com" in self._base_url_lower:
    api_kwargs.update(self._max_tokens_param(16384))
elif self._is_qwen_portal():
    ...
```

**3. Set a sane default for NVIDIA NIM**

Even with the boost working, the *first* call still truncates because nothing sets a `max_tokens` for NVIDIA NIM upfront. The `elif "integrate.api.nvidia.com"` line above handles this — sends 16384 as the default so the first call has enough room and the boost rarely needs to kick in at all.

---

### Result

Before: `hi` → ⚠️ ⚠️ ⚠️ → ❌ dead

After: `hi` → ✅ response, no warnings

Tested on GLM-4.7 via `https://integrate.api.nvidia.com/v1`. Should also help any other model on NVIDIA NIM that suffers from the same low default.