### PR TITLE
fix(email): add email SMTP STARTTLS fallback

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -247,6 +247,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
+        self._smtp_use_starttls: Optional[bool] = None
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -270,6 +271,68 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    @staticmethod
+    def _close_smtp(smtp: smtplib.SMTP) -> None:
+        """Close an SMTP connection, falling back to close() if quit() fails."""
+        try:
+            smtp.quit()
+        except Exception:
+            smtp.close()
+
+    def _smtp_supports_starttls(self) -> bool:
+        """Probe whether this SMTP endpoint supports explicit STARTTLS."""
+        if self._smtp_use_starttls is not None:
+            return self._smtp_use_starttls
+
+        smtp: Optional[smtplib.SMTP] = None
+        try:
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+            smtp.ehlo()
+            self._smtp_use_starttls = bool(smtp.has_extn("starttls"))
+        except Exception as e:
+            logger.info(
+                "[Email] STARTTLS probe failed for %s:%s, falling back to SMTP_SSL: %s",
+                self._smtp_host,
+                self._smtp_port,
+                e,
+            )
+            self._smtp_use_starttls = False
+        finally:
+            if smtp is not None:
+                self._close_smtp(smtp)
+
+        if self._smtp_use_starttls:
+            logger.info(
+                "[Email] SMTP endpoint %s:%s supports STARTTLS.",
+                self._smtp_host,
+                self._smtp_port,
+            )
+        else:
+            logger.info(
+                "[Email] SMTP endpoint %s:%s does not support STARTTLS; using SMTP_SSL.",
+                self._smtp_host,
+                self._smtp_port,
+            )
+        return self._smtp_use_starttls
+
+    def _connect_smtp(self) -> smtplib.SMTP:
+        """Connect and authenticate using STARTTLS when supported, else SMTP_SSL."""
+        context = ssl.create_default_context()
+        if self._smtp_supports_starttls():
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+            smtp.ehlo()
+            smtp.starttls(context=context)
+            smtp.ehlo()
+        else:
+            smtp = smtplib.SMTP_SSL(
+                self._smtp_host,
+                self._smtp_port,
+                timeout=30,
+                context=context,
+            )
+        smtp.login(self._address, self._password)
+        return smtp
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
@@ -292,10 +355,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
-            smtp.quit()
+            smtp = self._connect_smtp()
+            self._close_smtp(smtp)
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
             logger.error("[Email] SMTP connection failed: %s", e)
@@ -523,16 +584,11 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
+            self._close_smtp(smtp)
 
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
@@ -724,16 +780,11 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
+            self._close_smtp(smtp)
 
         return msg_id
 

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -246,6 +246,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
+        self._smtp_use_starttls: Optional[bool] = None
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -269,6 +270,68 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    @staticmethod
+    def _close_smtp(smtp: smtplib.SMTP) -> None:
+        """Close an SMTP connection, falling back to close() if quit() fails."""
+        try:
+            smtp.quit()
+        except Exception:
+            smtp.close()
+
+    def _smtp_supports_starttls(self) -> bool:
+        """Probe whether this SMTP endpoint supports explicit STARTTLS."""
+        if self._smtp_use_starttls is not None:
+            return self._smtp_use_starttls
+
+        smtp: Optional[smtplib.SMTP] = None
+        try:
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+            smtp.ehlo()
+            self._smtp_use_starttls = bool(smtp.has_extn("starttls"))
+        except Exception as e:
+            logger.info(
+                "[Email] STARTTLS probe failed for %s:%s, falling back to SMTP_SSL: %s",
+                self._smtp_host,
+                self._smtp_port,
+                e,
+            )
+            self._smtp_use_starttls = False
+        finally:
+            if smtp is not None:
+                self._close_smtp(smtp)
+
+        if self._smtp_use_starttls:
+            logger.info(
+                "[Email] SMTP endpoint %s:%s supports STARTTLS.",
+                self._smtp_host,
+                self._smtp_port,
+            )
+        else:
+            logger.info(
+                "[Email] SMTP endpoint %s:%s does not support STARTTLS; using SMTP_SSL.",
+                self._smtp_host,
+                self._smtp_port,
+            )
+        return self._smtp_use_starttls
+
+    def _connect_smtp(self) -> smtplib.SMTP:
+        """Connect and authenticate using STARTTLS when supported, else SMTP_SSL."""
+        context = ssl.create_default_context()
+        if self._smtp_supports_starttls():
+            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+            smtp.ehlo()
+            smtp.starttls(context=context)
+            smtp.ehlo()
+        else:
+            smtp = smtplib.SMTP_SSL(
+                self._smtp_host,
+                self._smtp_port,
+                timeout=30,
+                context=context,
+            )
+        smtp.login(self._address, self._password)
+        return smtp
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
@@ -291,10 +354,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
-            smtp.quit()
+            smtp = self._connect_smtp()
+            self._close_smtp(smtp)
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
             logger.error("[Email] SMTP connection failed: %s", e)
@@ -509,16 +570,11 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
+            self._close_smtp(smtp)
 
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
@@ -601,16 +657,11 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
-            try:
-                smtp.quit()
-            except Exception:
-                smtp.close()
+            self._close_smtp(smtp)
 
         return msg_id
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -524,6 +524,7 @@ class TestThreadContext(unittest.TestCase):
         }):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
         return adapter
 
     def test_thread_context_stored_after_dispatch(self):
@@ -621,6 +622,7 @@ class TestSendMethods(unittest.TestCase):
         }):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
         return adapter
 
     def test_send_calls_smtp(self):
@@ -656,6 +658,30 @@ class TestSendMethods(unittest.TestCase):
 
             self.assertFalse(result.success)
             self.assertIn("Connection refused", result.error)
+
+    def test_send_falls_back_to_smtp_ssl_without_starttls(self):
+        """send() should use SMTP_SSL when STARTTLS is unavailable."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._smtp_use_starttls = None
+
+        probe_server = MagicMock()
+        probe_server.has_extn.return_value = False
+        ssl_server = MagicMock()
+
+        with patch("smtplib.SMTP", return_value=probe_server) as mock_smtp, \
+             patch("smtplib.SMTP_SSL", return_value=ssl_server) as mock_smtp_ssl:
+            result = asyncio.run(
+                adapter.send("user@test.com", "Hello from Hermes!")
+            )
+
+        self.assertTrue(result.success)
+        mock_smtp.assert_called_once()
+        probe_server.ehlo.assert_called_once()
+        mock_smtp_ssl.assert_called_once()
+        ssl_server.login.assert_called_once_with("hermes@test.com", "secret")
+        ssl_server.send_message.assert_called_once()
+        probe_server.starttls.assert_not_called()
 
     def test_send_image_includes_url(self):
         """send_image should include image URL in email body."""
@@ -706,6 +732,36 @@ class TestSendMethods(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
+    def test_send_document_falls_back_to_smtp_ssl_without_starttls(self):
+        """send_document() should use SMTP_SSL when STARTTLS is unavailable."""
+        import asyncio
+        import tempfile
+
+        adapter = self._make_adapter()
+        adapter._smtp_use_starttls = None
+
+        probe_server = MagicMock()
+        probe_server.has_extn.return_value = False
+        ssl_server = MagicMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Test document content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP", return_value=probe_server), \
+                 patch("smtplib.SMTP_SSL", return_value=ssl_server):
+                result = asyncio.run(
+                    adapter.send_document("user@test.com", tmp_path, "Here is the file")
+                )
+
+            self.assertTrue(result.success)
+            ssl_server.login.assert_called_once_with("hermes@test.com", "secret")
+            ssl_server.send_message.assert_called_once()
+            probe_server.starttls.assert_not_called()
+        finally:
+            os.unlink(tmp_path)
+
     def test_send_typing_is_noop(self):
         """send_typing should do nothing for email."""
         import asyncio
@@ -741,6 +797,7 @@ class TestConnectDisconnect(unittest.TestCase):
         }):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
         return adapter
 
     def test_connect_success(self):
@@ -789,6 +846,32 @@ class TestConnectDisconnect(unittest.TestCase):
              patch("smtplib.SMTP", side_effect=Exception("SMTP down")):
             result = asyncio.run(adapter.connect())
             self.assertFalse(result)
+
+    def test_connect_falls_back_to_smtp_ssl_without_starttls(self):
+        """connect() should use SMTP_SSL when STARTTLS is unavailable."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        adapter._smtp_use_starttls = None
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+        probe_server = MagicMock()
+        probe_server.has_extn.return_value = False
+        ssl_server = MagicMock()
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP", return_value=probe_server), \
+             patch("smtplib.SMTP_SSL", return_value=ssl_server) as mock_smtp_ssl:
+            result = asyncio.run(adapter.connect())
+
+        self.assertTrue(result)
+        mock_smtp_ssl.assert_called_once()
+        ssl_server.login.assert_called_once_with("hermes@test.com", "secret")
+        probe_server.starttls.assert_not_called()
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
 
     def test_disconnect_cancels_poll(self):
         """disconnect() should cancel the polling task."""
@@ -1027,7 +1110,9 @@ class TestSmtpConnectionCleanup(unittest.TestCase):
     def _make_adapter(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.email import EmailAdapter
-        return EmailAdapter(PlatformConfig(enabled=True))
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
+        return adapter
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -439,6 +439,7 @@ class TestThreadContext(unittest.TestCase):
         }):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
         return adapter
 
     def test_thread_context_stored_after_dispatch(self):
@@ -534,6 +535,7 @@ class TestSendMethods(unittest.TestCase):
         }):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
         return adapter
 
     def test_send_calls_smtp(self):
@@ -569,6 +571,30 @@ class TestSendMethods(unittest.TestCase):
 
             self.assertFalse(result.success)
             self.assertIn("Connection refused", result.error)
+
+    def test_send_falls_back_to_smtp_ssl_without_starttls(self):
+        """send() should use SMTP_SSL when STARTTLS is unavailable."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._smtp_use_starttls = None
+
+        probe_server = MagicMock()
+        probe_server.has_extn.return_value = False
+        ssl_server = MagicMock()
+
+        with patch("smtplib.SMTP", return_value=probe_server) as mock_smtp, \
+             patch("smtplib.SMTP_SSL", return_value=ssl_server) as mock_smtp_ssl:
+            result = asyncio.run(
+                adapter.send("user@test.com", "Hello from Hermes!")
+            )
+
+        self.assertTrue(result.success)
+        mock_smtp.assert_called_once()
+        probe_server.ehlo.assert_called_once()
+        mock_smtp_ssl.assert_called_once()
+        ssl_server.login.assert_called_once_with("hermes@test.com", "secret")
+        ssl_server.send_message.assert_called_once()
+        probe_server.starttls.assert_not_called()
 
     def test_send_image_includes_url(self):
         """send_image should include image URL in email body."""
@@ -619,6 +645,36 @@ class TestSendMethods(unittest.TestCase):
         finally:
             os.unlink(tmp_path)
 
+    def test_send_document_falls_back_to_smtp_ssl_without_starttls(self):
+        """send_document() should use SMTP_SSL when STARTTLS is unavailable."""
+        import asyncio
+        import tempfile
+
+        adapter = self._make_adapter()
+        adapter._smtp_use_starttls = None
+
+        probe_server = MagicMock()
+        probe_server.has_extn.return_value = False
+        ssl_server = MagicMock()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Test document content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP", return_value=probe_server), \
+                 patch("smtplib.SMTP_SSL", return_value=ssl_server):
+                result = asyncio.run(
+                    adapter.send_document("user@test.com", tmp_path, "Here is the file")
+                )
+
+            self.assertTrue(result.success)
+            ssl_server.login.assert_called_once_with("hermes@test.com", "secret")
+            ssl_server.send_message.assert_called_once()
+            probe_server.starttls.assert_not_called()
+        finally:
+            os.unlink(tmp_path)
+
     def test_send_typing_is_noop(self):
         """send_typing should do nothing for email."""
         import asyncio
@@ -654,6 +710,7 @@ class TestConnectDisconnect(unittest.TestCase):
         }):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
         return adapter
 
     def test_connect_success(self):
@@ -702,6 +759,32 @@ class TestConnectDisconnect(unittest.TestCase):
              patch("smtplib.SMTP", side_effect=Exception("SMTP down")):
             result = asyncio.run(adapter.connect())
             self.assertFalse(result)
+
+    def test_connect_falls_back_to_smtp_ssl_without_starttls(self):
+        """connect() should use SMTP_SSL when STARTTLS is unavailable."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        adapter._smtp_use_starttls = None
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+        probe_server = MagicMock()
+        probe_server.has_extn.return_value = False
+        ssl_server = MagicMock()
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("smtplib.SMTP", return_value=probe_server), \
+             patch("smtplib.SMTP_SSL", return_value=ssl_server) as mock_smtp_ssl:
+            result = asyncio.run(adapter.connect())
+
+        self.assertTrue(result)
+        mock_smtp_ssl.assert_called_once()
+        ssl_server.login.assert_called_once_with("hermes@test.com", "secret")
+        probe_server.starttls.assert_not_called()
+        adapter._running = False
+        if adapter._poll_task:
+            adapter._poll_task.cancel()
 
     def test_disconnect_cancels_poll(self):
         """disconnect() should cancel the polling task."""
@@ -935,7 +1018,9 @@ class TestSmtpConnectionCleanup(unittest.TestCase):
     def _make_adapter(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.email import EmailAdapter
-        return EmailAdapter(PlatformConfig(enabled=True))
+        adapter = EmailAdapter(PlatformConfig(enabled=True))
+        adapter._smtp_use_starttls = True
+        return adapter
 
     @patch.dict(os.environ, {
         "EMAIL_ADDRESS": "hermes@test.com",


### PR DESCRIPTION
## What does this PR do?

Fixes SMTP connection handling in the email gateway so both implicit TLS on port 465 and STARTTLS on port 587 work correctly.

Previously, the adapter expects a plain SMTP connection upgraded with STARTTLS on port 587 and can not handle SMTP servers with port 465 with `SMTP SSL`. This PR unifies SMTP connection paths behind a single flow:

 1. Probe whether the target SMTP server supports STARTTLS
 2. If STARTTLS is supported, connect with `smtplib.SMTP(...)` and upgrade via `starttls(...)`
 3. Otherwise, connect with `smtplib.SMTP_SSL(...)`

 This keeps 587-compatible servers working while preserving support for 465-only SMTP setups.

 ## Related Issue

 Fixes #11842

 ## Type of Change

 - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
 - [ ] ✨ New feature (non-breaking change that adds functionality)
 - [ ] 🔒 Security fix
 - [ ] 📝 Documentation update
 - [x] ✅ Tests (adding or improving test coverage)
 - [ ] ♻️ Refactor (no behavior change)
 - [ ] 🎯 New skill (bundled or hub)

 ## Changes Made

 - Unified SMTP connection setup in `gateway/platforms/email.py`
 - Added STARTTLS capability probing before selecting the SMTP transport
 - Updated all 3 SMTP call sites to use the shared connection logic:
   - SMTP connection test in `connect()`
   - Message sending in `_send_email()`
   - Attachment sending in `_send_email_with_attachment()`
 - Added regression coverage in `tests/gateway/test_email.py` for:
   - STARTTLS-capable SMTP servers
   - SMTP_SSL fallback when STARTTLS is unavailable
   - Send, send-with-attachment, and connect flows

 ## How to Test

 1. Configure the email gateway with an SMTP server that uses STARTTLS on port 587 and verify `connect()` and message sending still work
 2. Configure the email gateway with an SMTP server that uses implicit TLS on port 465 and verify `connect()` and message sending work via `SMTP_SSL`
 3. Run:
    - `scripts/run_tests.sh tests/gateway/test_email.py -q`
    - `scripts/run_tests.sh tests/gateway/ -q`

 ## Checklist

 ### Code

 - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
 - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
 - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
 - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
 - [x] I've run `pytest tests/ -q` and all tests pass
 - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
 - [x] I've tested on my platform: Linux

 ### Documentation & Housekeeping

 - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
 - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
 - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
 - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility 
guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
 - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

 ## Screenshots / Logs

 N/A
