### PR TITLE
fix(doctor): skip /models health check for /anthropic endpoints (MiniMax-CN)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -838,9 +838,12 @@ def run_doctor(args):
                     _base = "https://api.kimi.com/coding/v1"
                 # Anthropic-compat endpoints (/anthropic) don't support /models.
                 # Rewrite to the OpenAI-compat /v1 surface for health checks.
+                # BUT: some providers (MiniMax-CN) expose /anthropic as the PRIMARY
+                # surface — /v1/models does NOT exist and always 404s.
+                # Skip the health check for /anthropic endpoints to avoid false negatives.
                 if _base and _base.rstrip("/").endswith("/anthropic"):
-                    from agent.auxiliary_client import _to_openai_base_url
-                    _base = _to_openai_base_url(_base)
+                    print(f"\r  {color('✓', Colors.GREEN)} {_label} {color('(key configured, /anthropic endpoint — no /models check)', Colors.DIM)}           ")
+                    continue
                 _url = (_base.rstrip("/") + "/models") if _base else _default_url
                 _headers = {"Authorization": f"Bearer {_key}"}
                 if "api.kimi.com" in _url.lower():


### PR DESCRIPTION
## Problem

`hermes doctor` reports `⚠ MiniMax (China) (HTTP 404)` even when the API key is valid and working.

**Root cause:** `MINIMAX_CN_BASE_URL` is `https://api.minimaxi.com/anthropic`. The health check rewrites `/anthropic` → `/v1` to check `/v1/models`, which doesn't exist for MiniMax-CN.

## Fix

Skip the `/models` health check for providers using `/anthropic` endpoints.

```python
if _base and _base.rstrip("/").endswith("/anthropic"):
    print(f"\r  {color('✓', Colors.GREEN)} {_label} {color('(key configured, /anthropic endpoint — no /models check)', Colors.DIM)}")
    continue
```

## Verification

```bash
# /v1/models 404s (expected for MiniMax-CN)
curl -o /dev/null -w "%{http_code}" https://api.minimaxi.com/v1/models

# actual API works fine
curl -X POST -d '{"model":"MiniMax-M2.7-highspeed","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}' \
  https://api.minimaxi.com/anthropic/v1/messages
# → 200
```
