### PR TITLE
fix(gateway): add finalize parameter to TelegramAdapter.edit_message()

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1081,6 +1081,8 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         message_id: str,
         content: str,
+        *,
+        finalize: bool = False,
     ) -> SendResult:
         """Edit a previously sent Telegram message."""
         if not self._bot:


### PR DESCRIPTION
## Bug Description

The streaming consumer in v0.10.0 calls `edit_message()` with a `finalize` keyword argument to signal the end of a streaming sequence. The DingTalk adapter was updated in commit 4459913f to accept this parameter, but the Telegram adapter was missed.

This causes a **TypeError** exception during streaming:

```
TelegramAdapter.edit_message() got an unexpected keyword argument 'finalize'
```

## Fix

Added the `finalize: bool = False` parameter to `TelegramAdapter.edit_message()` method.

## Testing

- Verified the method signature now accepts the finalize parameter
- Confirmed streaming operations complete without TypeError
- Parameter defaults to False for backwards compatibility

Fixes: TypeError during Telegram streaming