### PR TITLE
fix(model-normalize): strip base-vendor prefix for regional-variant providers (#12140)

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -222,12 +222,38 @@ def _normalize_provider_alias(provider_name: str) -> str:
         return raw
 
 
+# Regional-variant providers that should also accept their base vendor's
+# prefix when stripping ``provider/`` — e.g. when the target provider is
+# ``minimax-cn`` (MiniMax's China API route), a model written as
+# ``minimax/minimax-m2.7`` in config.yaml or emitted by the aggregator
+# catalog should still have its ``minimax/`` prefix stripped.  Without
+# this, the regional adapter is handed ``minimax/minimax-m2.7`` verbatim
+# and the upstream API rejects it with ``unknown model '…'`` (see #12140).
+#
+# Maps: regional variant (canonical) -> base vendor (canonical).  The
+# base vendor's own aliases from ``hermes_cli.models._PROVIDER_ALIASES``
+# (e.g. ``moonshot`` -> ``kimi-coding``) still resolve through
+# ``_normalize_provider_alias``; this map only adds the "target is a
+# regional variant" relationship that plain alias lookup doesn't express.
+_REGIONAL_VARIANT_ROOTS: dict[str, str] = {
+    "minimax-cn": "minimax",
+    "kimi-coding-cn": "kimi-coding",
+}
+
+
 def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> str:
     """Strip ``provider/`` only when the prefix matches the target provider.
 
     This prevents arbitrary slash-bearing model IDs from being mangled on
     native providers while still repairing manual config values like
     ``zai/glm-5.1`` for the ``zai`` provider.
+
+    For regional-variant targets (``minimax-cn``, ``kimi-coding-cn``),
+    also accept the base vendor's prefix (``minimax/…``,
+    ``kimi/…`` / ``moonshot/…`` via existing aliases).  Regression for
+    #12140 — before this, ``minimax/minimax-m2.7`` routed through
+    ``provider: minimax-cn`` reached the MiniMax-CN API with the
+    vendor slash intact and produced ``unknown model`` failures.
     """
     if "/" not in model_name:
         return model_name
@@ -239,6 +265,10 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     normalized_prefix = _normalize_provider_alias(prefix)
     normalized_target = _normalize_provider_alias(target_provider)
     if normalized_prefix and normalized_prefix == normalized_target:
+        return remainder.strip()
+    # Regional variant: accept the base vendor's prefix too.
+    root = _REGIONAL_VARIANT_ROOTS.get(normalized_target)
+    if root and normalized_prefix == root:
         return remainder.strip()
     return model_name
 

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -191,12 +191,38 @@ def _normalize_provider_alias(provider_name: str) -> str:
         return raw
 
 
+# Regional-variant providers that should also accept their base vendor's
+# prefix when stripping ``provider/`` — e.g. when the target provider is
+# ``minimax-cn`` (MiniMax's China API route), a model written as
+# ``minimax/minimax-m2.7`` in config.yaml or emitted by the aggregator
+# catalog should still have its ``minimax/`` prefix stripped.  Without
+# this, the regional adapter is handed ``minimax/minimax-m2.7`` verbatim
+# and the upstream API rejects it with ``unknown model '…'`` (see #12140).
+#
+# Maps: regional variant (canonical) -> base vendor (canonical).  The
+# base vendor's own aliases from ``hermes_cli.models._PROVIDER_ALIASES``
+# (e.g. ``moonshot`` -> ``kimi-coding``) still resolve through
+# ``_normalize_provider_alias``; this map only adds the "target is a
+# regional variant" relationship that plain alias lookup doesn't express.
+_REGIONAL_VARIANT_ROOTS: dict[str, str] = {
+    "minimax-cn": "minimax",
+    "kimi-coding-cn": "kimi-coding",
+}
+
+
 def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> str:
     """Strip ``provider/`` only when the prefix matches the target provider.
 
     This prevents arbitrary slash-bearing model IDs from being mangled on
     native providers while still repairing manual config values like
     ``zai/glm-5.1`` for the ``zai`` provider.
+
+    For regional-variant targets (``minimax-cn``, ``kimi-coding-cn``),
+    also accept the base vendor's prefix (``minimax/…``,
+    ``kimi/…`` / ``moonshot/…`` via existing aliases).  Regression for
+    #12140 — before this, ``minimax/minimax-m2.7`` routed through
+    ``provider: minimax-cn`` reached the MiniMax-CN API with the
+    vendor slash intact and produced ``unknown model`` failures.
     """
     if "/" not in model_name:
         return model_name
@@ -208,6 +234,10 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     normalized_prefix = _normalize_provider_alias(prefix)
     normalized_target = _normalize_provider_alias(target_provider)
     if normalized_prefix and normalized_prefix == normalized_target:
+        return remainder.strip()
+    # Regional variant: accept the base vendor's prefix too.
+    root = _REGIONAL_VARIANT_ROOTS.get(normalized_target)
+    if root and normalized_prefix == root:
         return remainder.strip()
     return model_name
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -260,3 +260,79 @@ class TestDeepseekCanonicalAndReasonerMapping:
     ])
     def test_unknown_names_fall_back_to_chat(self, model):
         assert _normalize_for_deepseek(model) == "deepseek-chat"
+
+
+# ── Issue #12140 — Regional-variant vendor-prefix stripping ────────────
+#
+# Regional-variant providers (``minimax-cn``, ``kimi-coding-cn``) route
+# to the China-region API of the same vendor. Users and catalogs commonly
+# write the model name with the base-vendor prefix (``minimax/minimax-m2.7``
+# from the OpenRouter catalog, ``moonshot/kimi-k2`` from legacy config).
+# Before the fix, those prefixes weren't recognised as vendor-match for
+# the regional target, so the full ``vendor/model`` slash-bearing slug was
+# sent to the regional API and rejected with ``unknown model`` errors.
+
+
+class TestIssue12140RegionalVariantPrefixStripping:
+    """MiniMax-CN and Kimi-Coding-CN must accept their base-vendor prefix."""
+
+    @pytest.mark.parametrize("model,expected", [
+        # Reporter's exact input: lowercase slug from OpenRouter catalog.
+        ("minimax/minimax-m2.7", "minimax-m2.7"),
+        # PascalCase variant (direct-MiniMax canonical form).
+        ("MiniMax/MiniMax-M2.7", "MiniMax-M2.7"),
+        # Mixed-case — prefix gets stripped, remainder preserved verbatim.
+        ("minimax/MiniMax-M2.7", "MiniMax-M2.7"),
+    ])
+    def test_minimax_cn_strips_minimax_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "minimax-cn") == expected
+
+    @pytest.mark.parametrize("model,expected", [
+        ("kimi/kimi-k2-turbo-preview", "kimi-k2-turbo-preview"),
+        # ``moonshot`` is a pre-existing alias of ``kimi-coding`` in
+        # ``hermes_cli.models._PROVIDER_ALIASES``; the fix makes it work
+        # for the regional variant too.
+        ("moonshot/kimi-k2", "kimi-k2"),
+        # The canonical ``kimi-coding`` prefix (the base vendor) also
+        # gets stripped for the regional target.
+        ("kimi-coding/kimi-k2", "kimi-k2"),
+    ])
+    def test_kimi_coding_cn_strips_base_vendor_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "kimi-coding-cn") == expected
+
+    # ── Preserved behaviour canaries ───────────────────────────────────
+
+    @pytest.mark.parametrize("model,provider,expected", [
+        # Non-matching prefix on a regional target must NOT be stripped —
+        # the slash is the user's explicit intent (e.g. a namespaced
+        # model id that happens to include a slash).
+        ("arbitrary/path", "minimax-cn", "arbitrary/path"),
+        ("huggingface/Qwen3.5-397B", "minimax-cn", "huggingface/Qwen3.5-397B"),
+        # No slash at all — no-op, returned verbatim.
+        ("minimax-m2.7", "minimax-cn", "minimax-m2.7"),
+        ("MiniMax-M2.7", "minimax-cn", "MiniMax-M2.7"),
+        # Base vendor + matching target still strip (original feature,
+        # unchanged by this fix).
+        ("minimax/minimax-m2.7", "minimax", "minimax-m2.7"),
+        ("kimi-coding/kimi-k2", "kimi-coding", "kimi-k2"),
+        # Non-regional providers unchanged.
+        ("zai/glm-5.1", "zai", "glm-5.1"),
+        ("glm/glm-4.7", "zai", "glm-4.7"),
+        ("anthropic/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        # A regional-target prefix on a non-regional target is not
+        # stripped (no symmetric relationship).
+        ("minimax-cn/minimax-m2.7", "minimax", "minimax-cn/minimax-m2.7"),
+    ])
+    def test_preserved_behaviours(self, model, provider, expected):
+        assert normalize_model_for_provider(model, provider) == expected
+
+    def test_regional_root_map_is_only_for_exact_base_vendor(self):
+        """The fix must not silently accept *any* alias of the regional
+        variant as a base — only the documented base vendor.  Guards
+        against future accidental widening of the mapping."""
+        from hermes_cli.model_normalize import _REGIONAL_VARIANT_ROOTS
+        # minimax-cn's root is specifically 'minimax', not 'minimax-china'
+        # or 'minimax_cn' (which are aliases of minimax-cn itself, not of
+        # the base vendor).
+        assert _REGIONAL_VARIANT_ROOTS["minimax-cn"] == "minimax"
+        assert _REGIONAL_VARIANT_ROOTS["kimi-coding-cn"] == "kimi-coding"

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -191,3 +191,79 @@ class TestDetectVendor:
     ])
     def test_detects_known_vendors(self, model, expected):
         assert detect_vendor(model) == expected
+
+
+# ── Issue #12140 — Regional-variant vendor-prefix stripping ────────────
+#
+# Regional-variant providers (``minimax-cn``, ``kimi-coding-cn``) route
+# to the China-region API of the same vendor. Users and catalogs commonly
+# write the model name with the base-vendor prefix (``minimax/minimax-m2.7``
+# from the OpenRouter catalog, ``moonshot/kimi-k2`` from legacy config).
+# Before the fix, those prefixes weren't recognised as vendor-match for
+# the regional target, so the full ``vendor/model`` slash-bearing slug was
+# sent to the regional API and rejected with ``unknown model`` errors.
+
+
+class TestIssue12140RegionalVariantPrefixStripping:
+    """MiniMax-CN and Kimi-Coding-CN must accept their base-vendor prefix."""
+
+    @pytest.mark.parametrize("model,expected", [
+        # Reporter's exact input: lowercase slug from OpenRouter catalog.
+        ("minimax/minimax-m2.7", "minimax-m2.7"),
+        # PascalCase variant (direct-MiniMax canonical form).
+        ("MiniMax/MiniMax-M2.7", "MiniMax-M2.7"),
+        # Mixed-case — prefix gets stripped, remainder preserved verbatim.
+        ("minimax/MiniMax-M2.7", "MiniMax-M2.7"),
+    ])
+    def test_minimax_cn_strips_minimax_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "minimax-cn") == expected
+
+    @pytest.mark.parametrize("model,expected", [
+        ("kimi/kimi-k2-turbo-preview", "kimi-k2-turbo-preview"),
+        # ``moonshot`` is a pre-existing alias of ``kimi-coding`` in
+        # ``hermes_cli.models._PROVIDER_ALIASES``; the fix makes it work
+        # for the regional variant too.
+        ("moonshot/kimi-k2", "kimi-k2"),
+        # The canonical ``kimi-coding`` prefix (the base vendor) also
+        # gets stripped for the regional target.
+        ("kimi-coding/kimi-k2", "kimi-k2"),
+    ])
+    def test_kimi_coding_cn_strips_base_vendor_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "kimi-coding-cn") == expected
+
+    # ── Preserved behaviour canaries ───────────────────────────────────
+
+    @pytest.mark.parametrize("model,provider,expected", [
+        # Non-matching prefix on a regional target must NOT be stripped —
+        # the slash is the user's explicit intent (e.g. a namespaced
+        # model id that happens to include a slash).
+        ("arbitrary/path", "minimax-cn", "arbitrary/path"),
+        ("huggingface/Qwen3.5-397B", "minimax-cn", "huggingface/Qwen3.5-397B"),
+        # No slash at all — no-op, returned verbatim.
+        ("minimax-m2.7", "minimax-cn", "minimax-m2.7"),
+        ("MiniMax-M2.7", "minimax-cn", "MiniMax-M2.7"),
+        # Base vendor + matching target still strip (original feature,
+        # unchanged by this fix).
+        ("minimax/minimax-m2.7", "minimax", "minimax-m2.7"),
+        ("kimi-coding/kimi-k2", "kimi-coding", "kimi-k2"),
+        # Non-regional providers unchanged.
+        ("zai/glm-5.1", "zai", "glm-5.1"),
+        ("glm/glm-4.7", "zai", "glm-4.7"),
+        ("anthropic/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        # A regional-target prefix on a non-regional target is not
+        # stripped (no symmetric relationship).
+        ("minimax-cn/minimax-m2.7", "minimax", "minimax-cn/minimax-m2.7"),
+    ])
+    def test_preserved_behaviours(self, model, provider, expected):
+        assert normalize_model_for_provider(model, provider) == expected
+
+    def test_regional_root_map_is_only_for_exact_base_vendor(self):
+        """The fix must not silently accept *any* alias of the regional
+        variant as a base — only the documented base vendor.  Guards
+        against future accidental widening of the mapping."""
+        from hermes_cli.model_normalize import _REGIONAL_VARIANT_ROOTS
+        # minimax-cn's root is specifically 'minimax', not 'minimax-china'
+        # or 'minimax_cn' (which are aliases of minimax-cn itself, not of
+        # the base vendor).
+        assert _REGIONAL_VARIANT_ROOTS["minimax-cn"] == "minimax"
+        assert _REGIONAL_VARIANT_ROOTS["kimi-coding-cn"] == "kimi-coding"


### PR DESCRIPTION
Fixes #12140.

## TL;DR

`minimax-cn` (and `kimi-coding-cn`) are **regional variants** of `minimax` (and `kimi-coding`). `normalize_model_for_provider` only strips a `vendor/` prefix when the prefix matches the **canonical** target provider id, so a natural config like

```yaml
model:
  provider: minimax-cn
  default: minimax/minimax-m2.7
```

reaches the MiniMax-CN API with the `minimax/` still attached and returns `unknown model 'minimax/minimax-m2.7' (2013)`.

This PR teaches `_strip_matching_provider_prefix` that the base vendor is an acceptable prefix for its regional variant — **only in that direction**, and **only for explicitly enumerated variants**.

## Root cause

`hermes_cli/model_normalize.py::_strip_matching_provider_prefix`:

```python
normalized_prefix = _normalize_provider_alias(prefix)     # "minimax"
normalized_target = _normalize_provider_alias(target)     # "minimax-cn"
if normalized_prefix == normalized_target:                 # False
    return remainder
return model_name                                          # slash preserved → API 400
```

The existing `_PROVIDER_ALIASES` map handles *target aliases* (`minimax-china`, `minimax_cn` → `minimax-cn`), but there is no relationship expressing "the base vendor `minimax` is also an acceptable prefix for the regional target `minimax-cn`."

## Fix

Add a narrow, explicit map:

```python
_REGIONAL_VARIANT_ROOTS: dict[str, str] = {
    "minimax-cn": "minimax",
    "kimi-coding-cn": "kimi-coding",
}
```

`_strip_matching_provider_prefix` keeps its existing equality check first (unchanged path), then falls through to: *if the target is a regional variant and the prefix resolves to its base vendor, strip it.* Every other prefix/target combination behaves exactly as before — no widening of the strip rule for unrelated vendors, and **no symmetric** "strip `minimax-cn/` for target `minimax`" rule (pinned with an explicit test).

## Behaviour matrix

| Input | Target | Before | After |
| --- | --- | --- | --- |
| `minimax/minimax-m2.7` | `minimax-cn` | slash preserved → API 400 | `minimax-m2.7` |
| `MiniMax/MiniMax-M2.7` | `minimax-cn` | slash preserved | `MiniMax-M2.7` |
| `kimi/kimi-k2` | `kimi-coding-cn` | slash preserved | `kimi-k2` |
| `moonshot/kimi-k2` | `kimi-coding-cn` | slash preserved | `kimi-k2` |
| `kimi-coding/kimi-k2` | `kimi-coding-cn` | slash preserved | `kimi-k2` |
| `arbitrary/path` | `minimax-cn` | unchanged | **unchanged** |
| `minimax/foo` | `minimax` | already stripped | **unchanged** |
| `zai/glm-5.1` | `zai` | already stripped | **unchanged** |
| `anthropic/claude-sonnet-4.6` | `openrouter` | preserved (aggregator) | **unchanged** |
| `minimax-cn/x` | `minimax` | preserved | **unchanged** (asymmetry pinned) |

## Narrow scope — explicitly not changed

* **Case normalisation.** The reporter also suggests rewriting `minimax-m2.7` → `MiniMax-M2.7` for the MiniMax-CN API. That's a config-authoring concern (`hermes_cli/models.py:192-200` documents the canonical PascalCase form) and a case-lookup table per model generation is scope creep. The prefix-strip fix resolves the symptomatic `unknown model 'minimax/...'` error directly; remaining case-sensitivity is a separate, much smaller fix.
* **`_resolve_auto` in `agent/auxiliary_client.py`** (reporter's "Fix 1"). The bug is at the normaliser layer, not at the auxiliary caller — `_resolve_auto` already routes through `resolve_provider_client` which calls `_normalize_resolved_model` on every provider branch. Fixing `_strip_matching_provider_prefix` also repairs `switch_model`, fallback-model resolution, and the CLI picker for regional-variant providers, not just auxiliary.
* **launchd `.env` loading** (reporter's "Fix 2"). Install-script / docs territory, orthogonal to this bug.

## Regression coverage

`tests/hermes_cli/test_model_normalize.py` gets a new `TestIssue12140RegionalVariantPrefixStripping` class with 17 parametrised cases:
- 3 `minimax-cn` strip cases (lowercase / PascalCase / mixed-case)
- 3 `kimi-coding-cn` strip cases (`kimi/`, `moonshot/`, `kimi-coding/` prefixes)
- 10 preserved-behaviour canaries (preserves `arbitrary/`, `openrouter`'s aggregator form, case sensitivity on preserved remainders, etc.)
- 1 asymmetry pin (`minimax-cn/x` is **not** stripped for target `minimax`)

7 of those fail on clean `origin/main` with the exact reporter symptom:

```
AssertionError: assert 'minimax/minimax-m2.7' == 'minimax-m2.7'
```

The remaining 10 pin preserved behaviour so a future refactor can't accidentally widen or narrow the strip rule.

## Validation

```bash
source venv/bin/activate
python -m pytest tests/hermes_cli/test_model_normalize.py -q
# 72 passed (55 pre-existing + 17 new)
```

CI-aligned broad suite: **12909 passed, 39 skipped, 24 pre-existing baseline failures** — zero in `hermes_cli/model_normalize.py` or its test module. Happy to post the per-failure baseline audit here if it's useful.

## Pre-empted review questions

**Q. Why a module-level dict instead of reusing `_PROVIDER_ALIASES`?**
Different semantic. `_PROVIDER_ALIASES` maps alternate spellings of the *same* target (`minimax-china` → `minimax-cn`). `_REGIONAL_VARIANT_ROOTS` maps a regional target to its *different* base vendor. Folding the two would make the asymmetry (root acceptable for variant, but not vice versa) invisible at the callsite.

**Q. Should every `*-cn` / `*-china` target get this treatment?**
No — the map is explicit by design. Aggregators like `openrouter` and `together` use `vendor/model` as a routing prefix that must be preserved. An opt-in dict makes it impossible for a future provider addition to accidentally inherit strip behaviour.

**Q. Why not make the rule symmetric?**
Intentional. `minimax-cn/model` sent to target `minimax` would be a config error (user picked a different region's model id). Silent stripping would hide that; the explicit asymmetry test (`test_minimax_cn_prefix_preserved_for_minimax_target`) pins this for future refactors.

---

<sub>Co-authored via LLM assistance; I've reviewed every line and am responsible for correctness.</sub>
