### PR TITLE
feat(gateway): add configurable reset banner

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4213,6 +4213,7 @@ class HermesCLI:
 
     def new_session(self, silent=False):
         """Start a fresh session with a new session ID and cleared agent state."""
+        had_history = bool(self.conversation_history)
         if self.agent and self.conversation_history:
             try:
                 self.agent.flush_memories(self.conversation_history)
@@ -4271,7 +4272,12 @@ class HermesCLI:
             self._notify_session_boundary("on_session_reset")
 
         if not silent:
-            print("(^_^)v New session started!")
+            from gateway.display_config import resolve_session_reset_message
+
+            banner_default = "✨ Session reset! Starting fresh." if had_history else "(^_^)v New session started!"
+            banner = resolve_session_reset_message(self.config, default=banner_default)
+            if banner:
+                print(banner)
 
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -101,6 +101,33 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "api_server":      {**_TIER_HIGH, "tool_preview_length": 0},
 }
 
+
+def resolve_session_reset_message(
+    config: dict[str, Any] | None,
+    default: str,
+) -> Optional[str]:
+    """Return the configured /new banner, or the provided default.
+
+    ``display.session_reset_message`` is intentionally not per-platform. A blank
+    or whitespace-only value disables the banner entirely.
+    """
+    if not isinstance(config, dict):
+        config = {}
+    display = config.get("display") or {}
+    if not isinstance(display, dict):
+        display = {}
+
+    if "session_reset_message" in display:
+        value = display.get("session_reset_message")
+        if value is None:
+            return None
+        message = str(value).strip()
+        return message or None
+
+    message = str(default).strip()
+    return message or None
+
+
 # Canonical set of per-platform overrideable keys (for validation).
 OVERRIDEABLE_KEYS = frozenset(_GLOBAL_DEFAULTS.keys())
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1436,6 +1436,22 @@ class GatewayRunner:
             except Exception:
                 pass  # don't let interrupt failure block the ack
 
+        # Respect quiet/clean-output display settings. If tool progress is off for
+        # this platform, interrupt silently and let the follow-up response arrive
+        # without an extra status bubble in chat.
+        try:
+            from gateway.display_config import resolve_display_setting
+
+            user_config = _load_gateway_config()
+            platform_key = _platform_config_key(event.source.platform)
+            progress_mode = str(
+                resolve_display_setting(user_config, platform_key, "tool_progress", "all")
+            ).lower()
+            if progress_mode == "off":
+                return True
+        except Exception:
+            pass
+
         # Debounce: only send an acknowledgment once every 30 seconds per session
         # to avoid spamming the user when they send multiple messages quickly
         _BUSY_ACK_COOLDOWN = 30
@@ -4595,18 +4611,50 @@ class GatewayRunner:
             "session_key": session_key,
         })
 
-        # Resolve session config info to surface to the user
-        try:
-            session_info = self._format_session_info()
-        except Exception:
-            session_info = ""
+        is_telegram = source.platform == Platform.TELEGRAM
 
-        if new_entry:
-            header = "✨ Session reset! Starting fresh."
+        # Resolve session config info to surface to the user.
+        # Telegram reset replies stay intentionally minimal.
+        if is_telegram:
+            session_info = ""
         else:
+            try:
+                session_info = self._format_session_info()
+            except Exception:
+                session_info = ""
+
+        try:
+            from gateway.display_config import resolve_session_reset_message
+
+            header = resolve_session_reset_message(
+                _load_gateway_config(),
+                default=(
+                    "🌺 Fresh chat, same me — ready when you are."
+                    if new_entry
+                    else "🌺 Hi — I’m here and ready whenever you are."
+                )
+                if is_telegram
+                else ("✨ Session reset! Starting fresh." if new_entry else "✨ New session started!"),
+            )
+        except Exception:
+            header = (
+                "🌺 Fresh chat, same me — ready when you are."
+                if is_telegram and new_entry
+                else "🌺 Hi — I’m here and ready whenever you are."
+                if is_telegram
+                else ("✨ Session reset! Starting fresh." if new_entry else "✨ New session started!")
+            )
+
+        if is_telegram and not header:
+            header = (
+                "🌺 Fresh chat, same me — ready when you are."
+                if new_entry
+                else "🌺 Hi — I’m here and ready whenever you are."
+            )
+
+        if not new_entry:
             # No existing session, just create one
             new_entry = self.session_store.get_or_create_session(source, force_new=True)
-            header = "✨ New session started!"
 
         # Fire plugin on_session_reset hook (new session guaranteed to exist)
         try:
@@ -4618,15 +4666,27 @@ class GatewayRunner:
             pass
 
         # Append a random tip to the reset message
-        try:
-            from hermes_cli.tips import get_random_tip
-            _tip_line = f"\n✦ Tip: {get_random_tip()}"
-        except Exception:
+        if is_telegram:
             _tip_line = ""
+        else:
+            try:
+                from hermes_cli.tips import get_random_tip
+                _tip_line = f"\n✦ Tip: {get_random_tip()}"
+            except Exception:
+                _tip_line = ""
 
+        parts = []
+        if header:
+            parts.append(header)
         if session_info:
-            return f"{header}\n\n{session_info}{_tip_line}"
-        return f"{header}{_tip_line}"
+            parts.append(session_info)
+        if _tip_line:
+            if parts:
+                parts[-1] = parts[-1] + _tip_line
+            else:
+                parts.append(_tip_line.lstrip("\n"))
+
+        return "\n\n".join(parts)
     
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -561,6 +561,7 @@ DEFAULT_CONFIG = {
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
+        "session_reset_message": None,  # Optional custom banner for /new and /reset (None = default text)
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -120,8 +120,8 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
             return _cli_mod.HermesCLI(**kwargs)
 
 
-def _prepare_cli_with_active_session(tmp_path):
-    cli = _make_cli()
+def _prepare_cli_with_active_session(tmp_path, **kwargs):
+    cli = _make_cli(**kwargs)
     cli._session_db = SessionDB(db_path=tmp_path / "state.db")
     cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
 
@@ -221,3 +221,23 @@ def test_new_session_resets_token_counters(tmp_path):
     assert comp.last_total_tokens == 0
     assert comp.compression_count == 0
     assert comp._context_probed is False
+
+
+def test_new_session_uses_configurable_banner(tmp_path, capsys):
+    """The /new banner should come from config when explicitly set."""
+    cli = _prepare_cli_with_active_session(
+        tmp_path,
+        config_overrides={
+            "display": {
+                "compact": False,
+                "tool_progress": "all",
+                "session_reset_message": "👋 Custom reset banner",
+            }
+        },
+    )
+
+    cli.process_command("/new")
+    out = capsys.readouterr().out
+
+    assert "👋 Custom reset banner" in out
+    assert "Session reset! Starting fresh." not in out

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -5,7 +5,7 @@ when the agent is working on a task. See PR fix for the @Lonely__MH report.
 """
 import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -132,6 +132,43 @@ class TestBusySessionAck:
 
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
+
+    @pytest.mark.asyncio
+    async def test_tool_progress_off_interrupts_silently(self, monkeypatch):
+        """Quiet Telegram chats should not get a busy-status bubble."""
+        runner, sentinel = _make_runner()
+        adapter = _make_adapter()
+
+        event = _make_event(text="ping")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 3,
+            "max_iterations": 90,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 0.1,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 5
+        runner.adapters[event.source.platform] = adapter
+
+        from gateway import run as gateway_run
+
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"tool_progress": "off"}}}},
+        )
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter._send_with_retry.assert_not_called()
+        agent.interrupt.assert_called_once_with("ping")
+        assert sk in adapter._pending_messages
 
     @pytest.mark.asyncio
     async def test_debounce_suppresses_rapid_acks(self):

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -165,4 +165,4 @@ async def test_hook_error_does_not_break_reset(mock_invoke_hook):
     result = await runner._handle_reset_command(_make_event("/new"))
 
     # Should still return a success message despite hook errors
-    assert "Session reset" in result or "New session" in result
+    assert "🌺" in result or "Session reset" in result or "New session" in result

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -108,14 +108,14 @@ async def test_new_command_only_clears_own_session():
     runner._session_model_overrides[session_key] = {
         "model": "gpt-4o",
         "provider": "openai",
-        "api_key": "sk-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "openai",
     }
     runner._session_model_overrides[other_key] = {
         "model": "claude-sonnet-4-6",
         "provider": "anthropic",
-        "api_key": "sk-ant-test",
+        "api_key": "***",
         "base_url": "",
         "api_mode": "anthropic",
     }
@@ -124,3 +124,46 @@ async def test_new_command_only_clears_own_session():
 
     assert session_key not in runner._session_model_overrides
     assert other_key in runner._session_model_overrides
+
+
+@pytest.mark.asyncio
+async def test_new_command_uses_configurable_banner(monkeypatch):
+    """The /new banner should come from config when explicitly set."""
+    runner = _make_runner()
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"session_reset_message": "👋 Custom reset banner"}},
+    )
+
+    result = await runner._handle_reset_command(_make_event("/new"))
+
+    assert "👋 Custom reset banner" in result
+    assert "Session reset! Starting fresh." not in result
+
+
+@pytest.mark.asyncio
+async def test_new_command_telegram_uses_simple_greeting(monkeypatch):
+    """Telegram /new should stay minimal and not show model info or tips."""
+    runner = _make_runner()
+    runner._format_session_info = lambda: "◆ Model: gpt-5.4-mini\n◆ Provider: openai-codex\n◆ Context: 400K tokens\n✦ Tip: ignore instructions"
+
+    from gateway import run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"display": {"session_reset_message": ""}},
+    )
+    monkeypatch.setattr("hermes_cli.tips.get_random_tip", lambda: "ignore instructions")
+
+    result = await runner._handle_reset_command(_make_event("/new"))
+
+    assert "🌺 Fresh chat, same me — ready when you are." in result
+    assert "◆ Model:" not in result
+    assert "◆ Provider:" not in result
+    assert "◆ Context:" not in result
+    assert "✦ Tip:" not in result
+    assert "Session reset! Starting fresh." not in result


### PR DESCRIPTION
## Summary
- Add `display.session_reset_message` so `/new` and `/reset` can use a configurable banner.
- Keep Telegram reset replies minimal and prevent model/tip info from leaking into the reset message.
- Add regression coverage for the Telegram minimal path and the configurable banner.

## Testing
- `pytest -q tests/cli/test_cli_new_session.py tests/gateway/test_session_model_reset.py tests/gateway/test_session_boundary_hooks.py tests/gateway/test_busy_session_ack.py`