### PR TITLE
fix(homeassistant): don't consume cooldown on no-op state_changed events (#12062)

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -283,12 +283,14 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             # No filters configured and watch_all is off — drop the event
             return
 
-        # Apply cooldown
+        # Apply cooldown check — but do NOT record the timestamp yet.
+        # Unchanged or malformed events (where ``_format_state_change``
+        # returns ``None`` below) must not consume the cooldown window
+        # and suppress the next real state change.  See #12062.
         now = time.time()
         last = self._last_event_time.get(entity_id, 0)
         if (now - last) < self._cooldown_seconds:
             return
-        self._last_event_time[entity_id] = now
 
         # Build human-readable message
         old_state = event_data.get("old_state", {})
@@ -297,6 +299,9 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
         if not message:
             return
+
+        # Only consume the cooldown window for events we actually forward.
+        self._last_event_time[entity_id] = now
 
         # Build MessageEvent and forward to handler
         source = self.build_source(

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -416,6 +416,115 @@ class TestCooldown:
 
 
 # ---------------------------------------------------------------------------
+# Regression coverage: #12062 — no-op events must not consume cooldown.
+#
+# The cooldown timestamp is meant to throttle *forwarded* messages. Events
+# that the adapter decides not to forward (state didn't actually change,
+# new_state missing, etc.) must leave the cooldown window untouched so the
+# next genuine change still reaches handle_message.
+# ---------------------------------------------------------------------------
+
+
+class TestCooldownIssue12062:
+    @pytest.mark.asyncio
+    async def test_no_op_state_change_does_not_consume_cooldown(self):
+        """Reporter's repro: no-op followed by a real change within the
+        cooldown window must still forward the real change."""
+        adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
+
+        # First event: old_state == new_state — adapter must not forward,
+        # and must not consume the cooldown window.
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "20", "20",
+                        new_attrs={"friendly_name": "Temp"})
+        )
+        adapter.handle_message.assert_not_called()
+
+        # Second event: real change, fired immediately. Under the bug the
+        # no-op had already written _last_event_time, so this gets dropped.
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "20", "21",
+                        new_attrs={"friendly_name": "Temp"})
+        )
+        assert adapter.handle_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_op_does_not_write_last_event_time(self):
+        """Direct structural pin: the cooldown map must be empty after
+        a no-op event so a future refactor can't reintroduce the leak."""
+        adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
+
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "on", "on",
+                        new_attrs={"friendly_name": "Temp"})
+        )
+
+        assert adapter.handle_message.await_count == 0
+        assert "sensor.temp" not in adapter._last_event_time
+
+    @pytest.mark.asyncio
+    async def test_missing_new_state_does_not_consume_cooldown(self):
+        """Malformed event (no new_state payload) must also not block the
+        next real change."""
+        adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
+
+        # _format_state_change returns None for empty new_state too;
+        # cooldown must not be consumed in that branch either.
+        await adapter._handle_ha_event({
+            "data": {
+                "entity_id": "sensor.temp",
+                "old_state": {"state": "20", "attributes": {}},
+                "new_state": {},  # empty → formatter returns None
+            }
+        })
+        adapter.handle_message.assert_not_called()
+        assert "sensor.temp" not in adapter._last_event_time
+
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "20", "21",
+                        new_attrs={"friendly_name": "Temp"})
+        )
+        assert adapter.handle_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_forwarded_event_still_consumes_cooldown(self):
+        """Preserved behaviour canary: once an event *is* forwarded, the
+        cooldown window must close for subsequent rapid events."""
+        adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
+
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "20", "21",
+                        new_attrs={"friendly_name": "Temp"})
+        )
+        assert adapter.handle_message.await_count == 1
+        assert "sensor.temp" in adapter._last_event_time
+
+        # Rapid follow-up real change — cooldown blocks it (unchanged).
+        await adapter._handle_ha_event(
+            _make_event("sensor.temp", "21", "22",
+                        new_attrs={"friendly_name": "Temp"})
+        )
+        assert adapter.handle_message.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_op_then_real_change_across_entities(self):
+        """Regression: a no-op for entity A must not affect entity B's
+        independent cooldown accounting."""
+        adapter = _make_adapter(watch_all=True, cooldown_seconds=60)
+
+        await adapter._handle_ha_event(
+            _make_event("sensor.a", "1", "1", new_attrs={"friendly_name": "A"})
+        )
+        await adapter._handle_ha_event(
+            _make_event("sensor.b", "3", "4", new_attrs={"friendly_name": "B"})
+        )
+        # A was a no-op (not forwarded), B is a real change (forwarded once)
+        assert adapter.handle_message.await_count == 1
+        assert "sensor.a" not in adapter._last_event_time
+        assert "sensor.b" in adapter._last_event_time
+
+
+# ---------------------------------------------------------------------------
 # Config integration (env overrides, round-trip)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #12062.

## TL;DR

`HomeAssistantAdapter._handle_ha_event` writes the per-entity cooldown timestamp *before* it knows whether the event will actually produce a forwarded message. A no-op `state_changed` event (`old_state == new_state`) therefore consumes the cooldown window and suppresses the next real state change.

Fix: keep the cooldown **check** early, but delay the cooldown **write** until after `_format_state_change` returns a non-empty message. Only events that forward consume the window.

Two lines effectively swapped; one comment added.

## Root cause

`gateway/platforms/homeassistant.py:286-299` (pre-fix):

```python
# Apply cooldown
now = time.time()
last = self._last_event_time.get(entity_id, 0)
if (now - last) < self._cooldown_seconds:
    return
self._last_event_time[entity_id] = now      # ← advanced before we know
                                              #   whether the event forwards

old_state = event_data.get("old_state", {})
new_state = event_data.get("new_state", {})
message = self._format_state_change(entity_id, old_state, new_state)

if not message:                               # ← no-op / malformed → None,
    return                                    #   cooldown already burned
```

`_format_state_change` returns `None` in two cases (both legitimate non-forward paths):
- `new_state` missing/empty
- `old_val == new_val` — state didn't actually change

## Fix

```python
# Apply cooldown check — but do NOT record the timestamp yet.
# Unchanged or malformed events (where _format_state_change returns
# None below) must not consume the cooldown window and suppress the
# next real state change. See #12062.
now = time.time()
last = self._last_event_time.get(entity_id, 0)
if (now - last) < self._cooldown_seconds:
    return

old_state = event_data.get("old_state", {})
new_state = event_data.get("new_state", {})
message = self._format_state_change(entity_id, old_state, new_state)

if not message:
    return

# Only consume the cooldown window for events we actually forward.
self._last_event_time[entity_id] = now
```

## Reproduction on clean `origin/main` (`6fb69229`)

Direct copy of reporter's repro:

```python
ha = HomeAssistantAdapter(PlatformConfig(enabled=True, token='t', extra={
    'url': 'http://x', 'watch_all': True, 'cooldown_seconds': 60,
}))
ha.handle_message = AsyncMock()

await ha._handle_ha_event({'data': {
    'entity_id': 'sensor.temp',
    'old_state': {'state': '20'},
    'new_state': {'state': '20', 'attributes': {}},
}})
await ha._handle_ha_event({'data': {
    'entity_id': 'sensor.temp',
    'old_state': {'state': '20'},
    'new_state': {'state': '21', 'attributes': {}},
}})

assert ha.handle_message.await_count == 1   # fails on main: actual 0
```

## Narrow scope — explicitly not changed

* **Cooldown check placement.** Still runs before `_format_state_change`. Not doing wasted format work on throttled events, and not widening the cooldown check semantics to "every non-None formatter output" (which would entangle the throttle policy with formatting logic).
* **`handle_message` failure handling.** If `handle_message` raises after the timestamp is recorded, the cooldown still counts — same behaviour as before the fix. Out of scope.
* **Dict pruning.** `_last_event_time` is not otherwise bounded. This fix happens to stop no-op entities from accumulating entries (side benefit, not the goal).
* **`_format_state_change` semantics.** Pure formatter, unchanged.

## Behaviour matrix

| Event | Old state | New state | `_format_state_change` | Before: cooldown written? | After: cooldown written? |
| --- | --- | --- | --- | --- | --- |
| A: real change | `20` | `21` | message | yes | **yes** |
| B: no-op | `20` | `20` | `None` | yes (**bug**) | **no** |
| C: missing new_state | `20` | `{}` | `None` | yes (**bug**) | **no** |
| D: throttled (within cooldown) | — | — | not reached | no | **no** |
| E: ignored / domain-not-watched | — | — | not reached | no | **no** |

Rows A, D, E match pre-fix behaviour. Rows B and C change from "consumes window" to "passes through without consuming".

## Regression coverage

`tests/gateway/test_homeassistant.py` gets a new `TestCooldownIssue12062` class with 5 cases:

- `test_no_op_state_change_does_not_consume_cooldown` — reporter's exact scenario.
- `test_no_op_does_not_write_last_event_time` — structural pin on `_last_event_time`.
- `test_missing_new_state_does_not_consume_cooldown` — covers the other `_format_state_change → None` branch.
- `test_forwarded_event_still_consumes_cooldown` — preserved-behaviour canary so the fix can't silently disable cooldown.
- `test_no_op_then_real_change_across_entities` — independent per-entity accounting.

**4 of 5 fail on clean `origin/main`** with symptoms like:

```
AssertionError: assert 0 == 1  (handle_message.await_count)
AssertionError: assert 'sensor.temp' not in {'sensor.temp': 1776522437.86081}
```

The 5th pins preserved behaviour.

## Validation

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_homeassistant.py -q
# 50 passed (45 pre-existing + 5 new)
```

Broader `tests/gateway` under `-n auto` → 13 pre-existing baseline failures (dingtalk card lifecycle, matrix encrypted upload, approve/deny E2E, whatsapp bridge runtime / xdist flakes). **Zero in `test_homeassistant.py` or any touched code path.** Happy to post the per-test baseline audit as a PR comment.

## Pre-empted review questions

**Q. Could this cause runaway forwarding if an entity emits thousands of no-ops?**
No. `_format_state_change` still returns `None` for no-ops, so they don't forward regardless of cooldown state. Cooldown only throttles the stream of *forwarded* messages.

**Q. Why not move the cooldown check itself later, past `_format_state_change`?**
Two reasons:
1. Format work would run even for entities within the cooldown window — wasted CPU.
2. It would spread throttle policy into the formatter's return contract — the formatter is a pure function, not a throttling arbiter.

**Q. Concurrency?**
`_handle_ha_event` is async but there are no `await`s between the cooldown read and the new `self._last_event_time[entity_id] = now` write (`_format_state_change` is synchronous and pure). Same atomicity as before.

**Q. Was `_last_event_time` ever pruned?**
No, and this PR doesn't add pruning — but the fix does stop unbounded growth from entities that only ever emit no-op events. Explicit pruning is a separate concern if long-lived deployments need it.

---

<sub>Co-authored via LLM assistance; I've reviewed every line and am responsible for correctness.</sub>
