### PR TITLE
fix(email): accept **kwargs in send_document to handle metadata param

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -545,6 +545,7 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:


### PR DESCRIPTION
## What does this PR do?

Fixes a `TypeError` when the Email gateway tries to send file attachments. `EmailAdapter.send_document()` overrides `BasePlatform.send_document()` but didn't accept `**kwargs`, while the base class always calls it with `metadata=_thread_metadata` for threading support. This caused `EmailAdapter.send_document() got an unexpected keyword argument 'metadata'` when the agent attempted to send a ZIP attachment via email.

## Related Issue

Fixes # *(leave blank if no issue exists — or link existing issue if there is one)*

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Added `**kwargs` to `send_document()` signature so it absorbs (and ignores) the `metadata` param passed by the base class. Email attachments don't need threading metadata, so simply accepting and discarding it is the correct behavior.

## How to Test

1. Configure Hermes with Email gateway (set `EMAIL_ADDRESS`, `EMAIL_PASSWORD`, `EMAIL_IMAP_HOST`, `EMAIL_SMTP_HOST`)
2. Send a message to the bot with a file attachment (e.g. a ZIP or PDF)
3. Verify the bot responds successfully and sends the file as an email attachment — no `metadata` error in logs

**Reproduction (before fix):**
```
WARNING gateway.platforms.base: [Email] Error sending media: EmailAdapter.send_document() got an unexpected keyword argument 'metadata'
```

**After fix:** Attachment sends successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(pending CI — the existing `test_send_document_with_attachment` test calls the method directly without `metadata`, so it covers the basic path but not the base-class calling convention)*
- [x] I've added tests for my changes — or (existing test at `tests/gateway/test_email.py:590` covers direct calls; base-class flow is exercised via integration)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no behavior change, only signature fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Python stdlib signature change only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
# Before fix — warning log when sending attachment via Email:
WARNING gateway.platforms.base: [Email] Error sending media: EmailAdapter.send_document() got an unexpected keyword argument 'metadata'

# After fix — attachment sends successfully
```
