### PR TITLE
fix: route background-task media responses by type

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6107,13 +6107,34 @@ class GatewayRunner:
                     except Exception:
                         pass
 
+                _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a"}
+                _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+                _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+
                 # Send media files
-                for media_path, _is_voice in (media_files or []):
+                for media_path, is_voice in (media_files or []):
                     try:
-                        await adapter.send_document(
-                            chat_id=source.chat_id,
-                            file_path=media_path,
-                        )
+                        ext = Path(media_path).suffix.lower()
+                        if is_voice or ext in _AUDIO_EXTS:
+                            await adapter.send_voice(
+                                chat_id=source.chat_id,
+                                audio_path=media_path,
+                            )
+                        elif ext in _VIDEO_EXTS:
+                            await adapter.send_video(
+                                chat_id=source.chat_id,
+                                video_path=media_path,
+                            )
+                        elif ext in _IMAGE_EXTS:
+                            await adapter.send_image_file(
+                                chat_id=source.chat_id,
+                                image_path=media_path,
+                            )
+                        else:
+                            await adapter.send_document(
+                                chat_id=source.chat_id,
+                                file_path=media_path,
+                            )
                     except Exception:
                         pass
             else:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -237,6 +237,45 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_voice_media_is_sent_as_voice_in_background_task(self):
+        """Voice-tagged media responses should use send_voice, not send_document."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        mock_adapter.send_document = AsyncMock()
+        mock_adapter.send_video = AsyncMock()
+        mock_adapter.send_image_file = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([("/tmp/reply.ogg", True)], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "[[audio_as_voice]]\nMEDIA:/tmp/reply.ogg", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say it aloud", source, "bg_test")
+
+        mock_adapter.send_voice.assert_awaited_once_with(
+            chat_id="67890",
+            audio_path="/tmp/reply.ogg",
+        )
+        mock_adapter.send_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_agent_cleanup_runs_when_background_agent_raises(self):
         """Temporary background agents must be cleaned up on error paths too."""
         runner = _make_runner()


### PR DESCRIPTION
## Summary
- route background-task MEDIA outputs by file type instead of sending every extracted media path through the document path
- preserve the voice-media behavior for `[[audio_as_voice]]` responses so background tasks send audio replies through `send_voice()`
- add a regression test that exercises a background task response containing a voice MEDIA tag

This issue was partially mitigated on current `main` because the loop already unpacks `(media_path, is_voice)`, but the background-task delivery path still ignored the media type/voice flag and treated the extracted file as a generic document attachment.

Closes #12064.

## Testing
- python3 -m pytest -o addopts= tests/gateway/test_background_command.py
