### PR TITLE
fix(gateway): handle quoted MEDIA paths consistently across streaming and final deliveryy

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -20,6 +20,30 @@ from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
+_MEDIA_PATH_EXTS = (
+    "png", "jpg", "jpeg", "gif", "webp",
+    "mp4", "mov", "avi", "mkv", "webm",
+    "ogg", "opus", "mp3", "wav", "m4a",
+)
+_MEDIA_TAG_RE = re.compile(
+    r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:'''
+    + "|".join(_MEDIA_PATH_EXTS)
+    + r''')(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+)
+
+
+def extract_media_tag_paths(content: str) -> list[str]:
+    """Return normalized MEDIA tag paths without expanding ``~``."""
+    media_paths = []
+    for match in _MEDIA_TAG_RE.finditer(content):
+        path = match.group("path").strip()
+        if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
+            path = path[1:-1].strip()
+        path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+        if path:
+            media_paths.append(path)
+    return media_paths
+
 
 def utf16_len(s: str) -> int:
     """Count UTF-16 code units in *s*.
@@ -1313,22 +1337,12 @@ class BasePlatformAdapter(ABC):
         has_voice_tag = "[[audio_as_voice]]" in content
         cleaned = cleaned.replace("[[audio_as_voice]]", "")
         
-        # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
-        # and quoted/backticked paths for LLM-formatted outputs.
-        media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
-        )
-        for match in media_pattern.finditer(content):
-            path = match.group("path").strip()
-            if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
-                path = path[1:-1].strip()
-            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+        for path in extract_media_tag_paths(content):
+            media.append((os.path.expanduser(path), has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:
-            cleaned = media_pattern.sub('', cleaned)
+            cleaned = _MEDIA_TAG_RE.sub('', cleaned)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -281,6 +281,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    extract_media_tag_paths,
     merge_pending_message_event,
 )
 from gateway.restart import (
@@ -9333,10 +9334,8 @@ class GatewayRunner:
                 if _hm.get("role") in ("tool", "function"):
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
-                        for _match in re.finditer(r'MEDIA:(\S+)', _hc):
-                            _p = _match.group(1).strip().rstrip('",}')
-                            if _p:
-                                _history_media_paths.add(_p)
+                        for _p in extract_media_tag_paths(_hc):
+                            _history_media_paths.add(_p)
             
             # Register per-session gateway approval callback so dangerous
             # command approval blocks the agent thread (mirrors CLI input()).
@@ -9498,8 +9497,7 @@ class GatewayRunner:
                     if msg.get("role") in ("tool", "function"):
                         content = msg.get("content", "")
                         if "MEDIA:" in content:
-                            for match in re.finditer(r'MEDIA:(\S+)', content):
-                                path = match.group(1).strip().rstrip('",}')
+                            for path in extract_media_tag_paths(content):
                                 if path and path not in _history_media_paths:
                                     media_tags.append(f"MEDIA:{path}")
                             if "[[audio_as_voice]]" in content:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from gateway.platforms.base import _MEDIA_TAG_RE
+
 logger = logging.getLogger("gateway.stream_consumer")
 
 # Sentinel to signal the stream is complete
@@ -405,6 +407,17 @@ class GatewayStreamConsumer:
                             self._final_response_sent = await self._send_or_edit(
                                 self._accumulated, finalize=True,
                             )
+                            if (
+                                not self._final_response_sent
+                                and self._already_sent
+                                and self._message_id not in (None, "__no_edit__")
+                            ):
+                                # End-of-stream is the last chance to deliver
+                                # any unsent tail. If finalize=True still hits
+                                # flood control/backoff, stop waiting and send
+                                # the missing continuation once.
+                                self._fallback_prefix = self._visible_prefix()
+                                await self._send_fallback_final(self._accumulated)
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                     return
@@ -454,10 +467,9 @@ class GatewayStreamConsumer:
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
 
-    # Pattern to strip MEDIA:<path> tags (including optional surrounding quotes).
-    # Matches the simple cleanup regex used by the non-streaming path in
-    # gateway/platforms/base.py for post-processing.
-    _MEDIA_RE = re.compile(r'''[`"']?MEDIA:\s*\S+[`"']?''')
+    # Reuse the same MEDIA parser as the non-streaming path so quoted paths
+    # and spaces are stripped consistently from visible text.
+    _MEDIA_RE = _MEDIA_TAG_RE
 
     @staticmethod
     def _clean_for_display(text: str) -> str:

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -10,6 +10,8 @@ times per reply. (Regression test for #160)
 import pytest
 import re
 
+from gateway.platforms.base import extract_media_tag_paths
+
 
 def extract_media_tags_fixed(result_messages, history_len):
     """
@@ -33,10 +35,8 @@ def extract_media_tags_fixed(result_messages, history_len):
         if msg.get("role") == "tool" or msg.get("role") == "function":
             content = msg.get("content", "")
             if "MEDIA:" in content:
-                for match in re.finditer(r'MEDIA:(\S+)', content):
-                    path = match.group(1).strip().rstrip('",}')
-                    if path:
-                        media_tags.append(f"MEDIA:{path}")
+                for path in extract_media_tag_paths(content):
+                    media_tags.append(f"MEDIA:{path}")
                 if "[[audio_as_voice]]" in content:
                     has_voice_directive = True
     
@@ -178,6 +178,21 @@ class TestMediaExtraction:
         seen = set()
         unique = [t for t in tags if t not in seen and not seen.add(t)]
         assert len(unique) == 2  # After dedup: same.ogg and different.ogg
+
+    def test_quoted_media_paths_with_spaces_parse_as_single_path(self):
+        """Quoted MEDIA paths with spaces should match the gateway parser."""
+        history = [
+            {"role": "tool", "tool_call_id": "1", "content": "MEDIA: '/tmp/my image.png'"},
+        ]
+        new_messages = [
+            {"role": "tool", "tool_call_id": "2", "content": "MEDIA: '/tmp/my image.png'"},
+        ]
+
+        fixed_tags, _ = extract_media_tags_fixed(history + new_messages, len(history))
+        broken_tags, _ = extract_media_tags_broken(history + new_messages)
+
+        assert fixed_tags == ["MEDIA:/tmp/my image.png"]
+        assert broken_tags != fixed_tags
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -41,6 +41,15 @@ class TestCleanForDisplay:
             result = GatewayStreamConsumer._clean_for_display(text)
             assert "MEDIA:" not in result, f"Failed for wrapper: {wrapper}"
 
+    def test_media_tag_with_quoted_path_and_spaces(self):
+        """Quoted MEDIA paths with spaces should be stripped as one directive."""
+        text = "Here\nMEDIA: '/tmp/my image.png'\nAfter"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "MEDIA:" not in result
+        assert "Here" in result
+        assert "After" in result
+        assert "my image.png" not in result
+
     def test_audio_as_voice_stripped(self):
         """[[audio_as_voice]] directive is removed."""
         text = "[[audio_as_voice]]\nMEDIA:/tmp/voice.ogg"


### PR DESCRIPTION
## Summary

This fixes a gateway parsing mismatch for `MEDIA:` directives when the file path is quoted or contains spaces.

The adapter-side media parser already supported outputs like:

- `MEDIA: '/tmp/my image.png'`
- `MEDIA: "/tmp/my image.png"`
- ``MEDIA: `/tmp/my image.png` ``

But gateway-side handling still used simpler `MEDIA:(\S+)` / `MEDIA:\s*\S+` patterns in a few places. That caused inconsistent behavior across delivery paths:
- `gateway/run.py` could truncate the path at the first space during history/media dedupe
- `gateway/stream_consumer.py` could leave trailing path fragments visible in streamed text
- end-of-stream fallback could miss the unsent tail if the final edit was still rate-limited

## What changed

- Added a shared `MEDIA:` path parser helper in `gateway/platforms/base.py`
- Reused that parser in `gateway/run.py` for history scanning and final-response media extraction
- Reused the same parser in `gateway/stream_consumer.py` so quoted/spaced `MEDIA:` directives are stripped consistently from visible streamed text
- Hardened the end-of-stream fallback path so that if the final streaming edit still fails due to flood control/backoff, the missing tail is sent once instead of being dropped

## Why this is a bug

`BasePlatformAdapter.extract_media()` already treated quoted/spaced `MEDIA:` paths as valid. The gateway had drifted from that behavior, so the same tool output could work in one path and break in another. This patch brings the gateway paths back into alignment with the existing adapter contract.

## Regression coverage

Added tests for:
- stripping quoted/spaced `MEDIA:` directives from streamed visible text
- parsing quoted/spaced `MEDIA:` paths as a single path in gateway media extraction logic

## Test plan

Using the repo's Windows virtualenv at `.venv`:

- `tests/gateway/test_platform_base.py`
- `tests/gateway/test_stream_consumer.py`
- `tests/gateway/test_media_extraction.py`

Result:
- `145 passed, 4 warnings in 1.63s`

Also ran related gateway media tests:

- `tests/gateway/test_send_image_file.py`
- `tests/gateway/test_signal.py`

Result:
- `85 passed, 4 warnings in 1.42s`


