### PR TITLE
fix(docker): build web/ dashboard assets in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,12 @@ RUN npm install --prefer-offline --no-audit && \
     npm install --prefer-offline --no-audit && \
     npm cache clean --force
 
+# Build the web/ dashboard so FastAPI at :9119 can serve the Vite assets
+RUN cd /opt/hermes/web && \
+    npm install --prefer-offline --no-audit && \
+    npm run build && \
+    npm cache clean --force
+
 # Hand ownership to hermes user, then install Python deps in a virtualenv
 RUN chown -R hermes:hermes /opt/hermes
 USER hermes


### PR DESCRIPTION
## What does this PR do?

The `Dockerfile` installs root-level npm dependencies (for Playwright) and the `whatsapp-bridge` bundle, but never builds the `web/` Vite project. As a result, `hermes dashboard` starts FastAPI on `:9119` but serves a broken SPA because `hermes_cli/web_dist/` is empty and requests to `/assets/index-<hash>.js` return 404.

This PR adds a `RUN` step that installs `web/` dependencies and runs `npm run build`, so the Vite output is baked into the image.

## Related Issue

Fixes #12177

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `Dockerfile`: add a `RUN cd /opt/hermes/web && npm install --prefer-offline --no-audit && npm run build && npm cache clean --force` layer between the existing npm install block and the `chown` step.

## How to Test

Before:

```bash
docker build -t hermes-repro -f Dockerfile .
docker run --rm -p 9119:9119 hermes-repro hermes dashboard
curl -sI http://localhost:9119/assets/ | head -1   # -> 404
```

After this patch: `/assets/` returns the Vite-built asset path (non-404), and the dashboard SPA loads cleanly.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(docker): ...`)
- [x] I searched for existing PRs — the open web-dashboard PRs (#9307, #9502, #11621) all target the Nix build path; #9343 targeted `scripts/install.sh` (closed). No existing PR touches the Docker image path.
- [x] My PR contains **only** changes related to this fix (single-line additive layer in `Dockerfile`)
- [ ] `pytest tests/ -q` not run — this PR touches only `Dockerfile`; no Python code surface is modified and no Python behavior can change. Happy to run it if maintainers prefer.
- [ ] No tests added — a Dockerfile build-step regression test is out of scope; the repro steps above are the verification path.

### Cross-platform

- No OS-specific code paths added; the added step is standard `npm install && npm run build` identical to the existing adjacent `whatsapp-bridge` layer.