### PR TITLE
chore: enforce LF line endings for container entrypoints

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 # Auto-generated files — collapse diffs and exclude from language stats
 web/package-lock.json linguist-generated=true
+
+# Enforce LF for scripts that run inside Linux containers.
+# Without this, Windows checkout converts to CRLF and breaks `exec` in the
+# container entrypoint with "no such file or directory".
+*.sh        text eol=lf
+Dockerfile  text eol=lf
+*.dockerfile text eol=lf
+docker/entrypoint.sh text eol=lf


### PR DESCRIPTION
## What does this PR do?

Adds a `.gitattributes` rule that locks LF line endings for shell scripts, the `Dockerfile`, and `docker/entrypoint.sh`.

**Preventive, not corrective.** The tree at `v2026.4.16` is already LF — this change only takes effect if a contributor on Windows (with `core.autocrlf=true`, the Git-for-Windows default) touches these files in a future PR and git would otherwise convert them to CRLF on checkout.

## Related Issue

None — this is a forward-looking hardening PR with no current user-visible bug. Happy to close if maintainers would rather address only on a repro.

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `.gitattributes`: add `text eol=lf` rules for `*.sh`, `Dockerfile`, `*.dockerfile`, and the specific `docker/entrypoint.sh`.

## How to Test

On a Windows host with `core.autocrlf=true` (Git for Windows default):

```bash
# Without this PR — checkout introduces CRLF
git clone <repo> repro && cd repro
file docker/entrypoint.sh
# -> "... with CRLF line terminators"

# With this PR — git enforces LF on checkout
# -> "... executable"  (no CRLF)
```

The failure mode this prevents: COPYing a CRLF-ended `docker/entrypoint.sh` into a Linux image yields `ENTRYPOINT` errors like `/opt/hermes/docker/entrypoint.sh: not found` because the kernel treats the trailing `\r` as part of the interpreter path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`chore: ...`)
- [x] I searched for existing PRs — no existing `.gitattributes` hardening PR.
- [x] My PR contains **only** changes related to this hardening (single-file `.gitattributes` edit).
- [ ] `pytest tests/ -q` not run — `.gitattributes` does not affect any Python code path.
- [ ] No tests added — line-ending behavior is host-environment-dependent and not suitable for in-repo test coverage.

### Cross-platform

- The rule is intentionally no-op on non-Windows (POSIX hosts already check out LF). No runtime behavior changes.