### PR TITLE
add memory list action

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -22,6 +22,7 @@ class TestMemorySchema:
         description = MEMORY_SCHEMA["description"]
         assert "Do NOT save task progress" in description
         assert "session_search" in description
+        assert "list (browse current entries)" in description
         assert "like a diary" not in description
         assert "temporary task state" in description
         assert ">80%" not in description
@@ -248,6 +249,14 @@ class TestMemoryToolDispatcher:
         result = json.loads(memory_tool(action="add", target="memory", content="via tool", store=store))
         assert result["success"] is True
 
+    def test_list_via_tool(self, store):
+        store.add("memory", "listed fact")
+        result = json.loads(memory_tool(action="list", target="memory", store=store))
+        assert result["success"] is True
+        assert result["entry_count"] == 1
+        assert "listed fact" in result["entries"]
+        assert "listed" in result["message"].lower()
+
     def test_replace_requires_old_text(self, store):
         result = json.loads(memory_tool(action="replace", content="new", store=store))
         assert result["success"] is False
@@ -255,3 +264,10 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+    def test_list_accepts_user_target(self, store):
+        store.add("user", "Alice")
+        result = json.loads(memory_tool(action="list", target="user", store=store))
+        assert result["success"] is True
+        assert result["target"] == "user"
+        assert result["entry_count"] == 1

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -17,7 +17,7 @@ Entry delimiter: § (section sign). Entries can be multiline.
 Character limits (not tokens) because char counts are model-independent.
 
 Design:
-- Single `memory` tool with action parameter: add, replace, remove, read
+- Single `memory` tool with action parameter: add, replace, remove, list
 - replace/remove use short unique substring matching (not full text or IDs)
 - Behavioral guidance lives in the tool schema description
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
@@ -201,6 +201,22 @@ class MemoryStore:
         if target == "user":
             return self.user_entries
         return self.memory_entries
+
+    def list_entries(self, target: str) -> Dict[str, Any]:
+        """Return the current entries without mutating anything."""
+        entries = self._entries_for(target)
+        current = self._char_count(target)
+        limit = self._char_limit(target)
+        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
+
+        return {
+            "success": True,
+            "target": target,
+            "entries": entries,
+            "usage": f"{pct}% — {current:,}/{limit:,} chars",
+            "entry_count": len(entries),
+            "message": "Entries listed.",
+        }
 
     def _set_entries(self, target: str, entries: List[str]):
         if target == "user":
@@ -495,8 +511,14 @@ def memory_tool(
             return tool_error("old_text is required for 'remove' action.", success=False)
         result = store.remove(target, old_text)
 
+    elif action == "list":
+        result = store.list_entries(target)
+
     else:
-        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
+        return tool_error(
+            f"Unknown action '{action}'. Use: add, replace, remove, list",
+            success=False,
+        )
 
     return json.dumps(result, ensure_ascii=False)
 
@@ -532,7 +554,7 @@ MEMORY_SCHEMA = {
         "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
-        "remove (delete -- old_text identifies it).\n\n"
+        "remove (delete -- old_text identifies it), list (browse current entries).\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
     ),
     "parameters": {
@@ -540,7 +562,7 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove"],
+                "enum": ["add", "replace", "remove", "list"],
                 "description": "The action to perform."
             },
             "target": {
@@ -578,7 +600,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

Adds a `list` action to the core `memory` tool so callers can inspect current entries without mutating state.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `tools/memory_tool.py`
  - Added `MemoryStore.list_entries()`
  - Added `action="list"` to the memory tool dispatcher
  - Updated the tool schema to expose `list`
- `tests/tools/test_memory_tool.py`
  - Added coverage for `list` on `memory` and `user`

## How to Test

1. `python3 -m pytest tests/tools/test_memory_tool.py -q -o addopts='-ra'`
2. Confirm `35 passed`
3. Call `memory(action="list", target="memory")`

## Checklist

- [x] I've read the Contributing Guide
- [x] My PR contains only related changes
- [x] I've run the targeted tests
- [x] I've added tests for the change
- [x] I've updated tool descriptions/schemas
