### PR TITLE
fix(gateway): cron ticker cleanup on failure + /new None session guard

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4513,8 +4513,9 @@ class GatewayRunner:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _old_sid = old_entry.session_id if old_entry else None
-            _invoke_hook("on_session_finalize", session_id=_old_sid,
-                         platform=source.platform.value if source.platform else "")
+            if _old_sid is not None:
+                _invoke_hook("on_session_finalize", session_id=_old_sid,
+                             platform=source.platform.value if source.platform else "")
         except Exception:
             pass
 
@@ -10357,21 +10358,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
-    if runner.should_exit_with_failure:
-        if runner.exit_reason:
-            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
-        return False
-    
-    # Stop cron ticker cleanly
-    cron_stop.set()
-    cron_thread.join(timeout=5)
-
-    # Close MCP server connections
     try:
-        from tools.mcp_tool import shutdown_mcp_servers
-        shutdown_mcp_servers()
-    except Exception:
-        pass
+        if runner.should_exit_with_failure:
+            if runner.exit_reason:
+                logger.error("Gateway exiting with failure: %s", runner.exit_reason)
+            return False
+    finally:
+        # Stop cron ticker cleanly (must run even on failure path)
+        cron_stop.set()
+        cron_thread.join(timeout=5)
+
+        # Close MCP server connections
+        try:
+            from tools.mcp_tool import shutdown_mcp_servers
+            shutdown_mcp_servers()
+        except Exception:
+            pass
 
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)


### PR DESCRIPTION
Two small fixes for gateway lifecycle bugs.

1. Cron ticker and MCP cleanup on failure path (#12175)

When should_exit_with_failure is True, return False skipped both
cron_stop.set() and shutdown_mcp_servers(), leaking the cron ticker
thread and MCP connections. Wrap the early return in try/finally so
cleanup always runs.

2. Guard /new against None session in finalize hook (#12176)

_handle_reset_command() called on_session_finalize(session_id=None)
when no prior session existed (old_entry is None). Downstream hooks
that expect a valid session_id could crash. Skip the hook invocation
when _old_sid is None.

Testing: 3233 passed, 0 new failures.