### PR TITLE
fix: add Bedrock Converse cache points for Claude

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -244,6 +244,22 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
     return model_lower.startswith("anthropic.claude")
 
 
+def _bedrock_prompt_cache_enabled(model_id: str) -> bool:
+    """Return True when Bedrock prompt caching should be enabled for this model."""
+    env_value = (os.environ.get("HERMES_BEDROCK_PROMPT_CACHE", "1") or "").strip().lower()
+    if env_value in {"0", "false", "no", "off"}:
+        return False
+    return is_anthropic_bedrock_model(model_id)
+
+
+def _bedrock_prompt_cache_point() -> Dict[str, Dict[str, str]]:
+    """Build a Bedrock Converse cachePoint block with validated TTL."""
+    ttl = (os.environ.get("HERMES_BEDROCK_CACHE_TTL", "5m") or "5m").strip().lower()
+    if ttl not in {"5m", "1h"}:
+        ttl = "5m"
+    return {"cachePoint": {"type": "default", "ttl": ttl}}
+
+
 # ---------------------------------------------------------------------------
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
@@ -717,6 +733,16 @@ def build_converse_kwargs(
     Converts OpenAI-format inputs to Converse API parameters.
     """
     system_prompt, converse_messages = convert_messages_to_converse(messages)
+    cache_point = _bedrock_prompt_cache_point() if _bedrock_prompt_cache_enabled(model) else None
+
+    if cache_point and system_prompt:
+        system_prompt = list(system_prompt) + [cache_point]
+
+    if cache_point:
+        for message in reversed(converse_messages):
+            if message.get("role") == "user" and isinstance(message.get("content"), list):
+                message["content"] = list(message["content"]) + [cache_point]
+                break
 
     kwargs: Dict[str, Any] = {
         "modelId": model,
@@ -747,6 +773,8 @@ def build_converse_kwargs(
             # Strip tools for known non-tool-calling models and warn the user.
             # Ref: PR #7920 feedback from @ptlally, pattern from PR #4346.
             if _model_supports_tool_use(model):
+                if cache_point:
+                    converse_tools = list(converse_tools) + [cache_point]
                 kwargs["toolConfig"] = {"tools": converse_tools}
             else:
                 logger.warning(

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -605,6 +605,74 @@ class TestBuildConverseKwargs:
         )
         assert "toolConfig" not in kwargs
 
+    def test_claude_models_add_cache_points_to_converse_fields(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "First question"},
+            {"role": "assistant", "content": "First answer"},
+            {"role": "user", "content": "Second question"},
+        ]
+        tools = [{"type": "function", "function": {
+            "name": "lookup_weather", "description": "Look up weather", "parameters": {},
+        }}]
+
+        kwargs = build_converse_kwargs(
+            model="global.anthropic.claude-opus-4-7",
+            messages=messages,
+            tools=tools,
+        )
+
+        assert kwargs["system"][-1]["cachePoint"] == {"type": "default", "ttl": "5m"}
+        assert kwargs["toolConfig"]["tools"][-1]["cachePoint"] == {"type": "default", "ttl": "5m"}
+        assert kwargs["messages"][-1]["role"] == "user"
+        assert kwargs["messages"][-1]["content"][-1]["cachePoint"] == {"type": "default", "ttl": "5m"}
+
+    def test_bedrock_cache_ttl_env_accepts_one_hour(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        with patch.dict(os.environ, {"HERMES_BEDROCK_CACHE_TTL": "1h"}, clear=False):
+            kwargs = build_converse_kwargs(
+                model="anthropic.claude-sonnet-4-20250514-v1:0",
+                messages=[
+                    {"role": "system", "content": "Be helpful."},
+                    {"role": "user", "content": "Hi"},
+                ],
+            )
+
+        assert kwargs["system"][-1]["cachePoint"] == {"type": "default", "ttl": "1h"}
+        assert kwargs["messages"][-1]["content"][-1]["cachePoint"] == {"type": "default", "ttl": "1h"}
+
+    def test_invalid_bedrock_cache_ttl_falls_back_to_five_minutes(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        with patch.dict(os.environ, {"HERMES_BEDROCK_CACHE_TTL": "2h"}, clear=False):
+            kwargs = build_converse_kwargs(
+                model="anthropic.claude-sonnet-4-20250514-v1:0",
+                messages=[
+                    {"role": "system", "content": "Be helpful."},
+                    {"role": "user", "content": "Hi"},
+                ],
+            )
+
+        assert kwargs["system"][-1]["cachePoint"] == {"type": "default", "ttl": "5m"}
+        assert kwargs["messages"][-1]["content"][-1]["cachePoint"] == {"type": "default", "ttl": "5m"}
+
+    def test_non_claude_models_do_not_add_cache_points(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+        kwargs = build_converse_kwargs(
+            model="amazon.nova-pro-v1:0",
+            messages=[
+                {"role": "system", "content": "Be helpful."},
+                {"role": "user", "content": "Hi"},
+            ],
+            tools=[{"type": "function", "function": {
+                "name": "lookup_weather", "description": "Look up weather", "parameters": {},
+            }}],
+        )
+
+        assert "cachePoint" not in kwargs["system"][-1]
+        assert "cachePoint" not in kwargs["messages"][-1]["content"][-1]
+        assert "cachePoint" not in kwargs["toolConfig"]["tools"][-1]
+
 
 # ---------------------------------------------------------------------------
 # Model discovery


### PR DESCRIPTION
## Summary
- add Bedrock Converse `cachePoint` blocks for Claude models in `build_converse_kwargs()`
- attach checkpoints to the stable prefix segments Bedrock supports: system prompt, tool list, and the last user message
- validate `HERMES_BEDROCK_CACHE_TTL` (`5m` / `1h`) and add regression coverage for Claude vs non-Claude models

Bedrock prompt caching uses Converse `cachePoint` blocks rather than Anthropic-native `cache_control`, so this fix keeps the change scoped to the Bedrock adapter instead of trying to reuse the Anthropic path.

Closes #11970.

## Testing
- python3 -m pytest -o addopts= tests/agent/test_bedrock_adapter.py
