### PR TITLE
fix(cron): respect shebang in pre-run scripts instead of forcing sys.executable

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -531,7 +531,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     try:
         result = subprocess.run(
-            [sys.executable, str(path)],
+            [str(path)],
             capture_output=True,
             text=True,
             timeout=script_timeout,


### PR DESCRIPTION
## Problem

In `cron/scheduler.py`, the `_run_job_script` function runs pre-run scripts using:

```python
result = subprocess.run(
    [sys.executable, str(path)],
    ...
)
```

This means `sys.executable` (the Python running Hermes, e.g. the venv Python) is always used to execute the script, ignoring any shebang the script itself declares (`#!/bin/bash`, `#!/usr/bin/env python3`, etc.).

## Solution

Replace `[sys.executable, str(path)]` with `[str(path)]` so the OS respects the script's shebang. This matches how `cron run` already invokes scripts — directly, letting the shebang do its job.

## Why it matters

Pre-run scripts that aren't Python get forcibly executed by the Hermes venv Python interpreter. For example, a bash script that sources environment variables, or a Node.js script, will silently fail or misbehave because the wrong interpreter runs them.

Closes #12195