### PR TITLE
Harden local Chrome CDP discovery and add attached render evidence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "exa-py>=2.9.0,<3",
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",
+  "trafilatura>=2.0.0,<3",
   "fal-client>=0.13.1,<1",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts>=7.2.7,<8",

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 
@@ -27,6 +28,19 @@ class TestResolveCdpOverride:
         assert resolved == WS_URL
         mock_get.assert_called_once_with(VERSION_URL, timeout=10)
 
+    def test_resolves_bare_hostport_to_discovery_websocket(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
+
+        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+            resolved = _resolve_cdp_override(f"{HOST}:{PORT}")
+
+        assert resolved == WS_URL
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
     def test_resolves_bare_ws_hostport_to_discovery_websocket(self):
         from tools.browser_tool import _resolve_cdp_override
 
@@ -45,6 +59,25 @@ class TestResolveCdpOverride:
 
         with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
             assert _resolve_cdp_override(HTTP_URL) == HTTP_URL
+
+    def test_falls_back_to_devtools_active_port_when_local_json_version_is_unavailable(self, monkeypatch, tmp_path):
+        import tools.browser_tool as browser_tool
+
+        chrome_home = tmp_path / "home"
+        active_port = chrome_home / "Library" / "Application Support" / "Google" / "Chrome" / "DevToolsActivePort"
+        active_port.parent.mkdir(parents=True)
+        active_port.write_text("9222\n/devtools/browser/local-abc\n", encoding="utf-8")
+
+        browser_tool._devtools_activeport_candidates.cache_clear()
+        monkeypatch.setattr(browser_tool.Path, "home", lambda: Path(chrome_home))
+
+        try:
+            with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("404")):
+                resolved = browser_tool._resolve_cdp_override("http://127.0.0.1:9222")
+        finally:
+            browser_tool._devtools_activeport_candidates.cache_clear()
+
+        assert resolved == "ws://127.0.0.1:9222/devtools/browser/local-abc"
 
     def test_normalizes_provider_returned_http_cdp_url_when_creating_session(self, monkeypatch):
         import tools.browser_tool as browser_tool

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -17,6 +17,20 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
 
+class _AsyncClientStub:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url):
+        return self._response
+
+
 class TestFirecrawlClientConfig:
     """Test suite for Firecrawl client initialization."""
 
@@ -383,11 +397,11 @@ class TestBackendSelection:
              patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             assert _get_backend() == "firecrawl"
 
-    def test_fallback_no_keys_defaults_to_firecrawl(self):
-        """No keys, no config → 'firecrawl' (will fail at client init)."""
+    def test_fallback_no_keys_defaults_to_duckduckgo(self):
+        """No keys, no config → 'duckduckgo' fallback backend."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}):
-            assert _get_backend() == "firecrawl"
+            assert _get_backend() == "duckduckgo"
 
     def test_invalid_config_falls_through_to_fallback(self):
         """web.backend=invalid → ignored, uses key-based fallback."""
@@ -476,6 +490,472 @@ class TestWebSearchErrorHandling:
         assert "traceback" not in result
 
 
+class TestDuckDuckGoFallbackDispatch:
+    """Fallback dispatch tests when no provider backend is configured."""
+
+    def test_search_dispatches_to_duckduckgo(self):
+        import tools.web_tools
+
+        expected = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "Duck Result",
+                        "url": "https://example.com",
+                        "description": "fallback result",
+                        "position": 1,
+                    }
+                ]
+            },
+        }
+
+        with patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools._duckduckgo_search", return_value=expected) as mock_search, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = json.loads(tools.web_tools.web_search_tool("fallback query", limit=2))
+
+        assert result == expected
+        mock_search.assert_called_once_with("fallback query", 2)
+
+    @pytest.mark.asyncio
+    async def test_extract_dispatches_to_direct_http_fallback(self):
+        import tools.web_tools
+
+        expected = [
+            {
+                "url": "https://example.com",
+                "title": "Example",
+                "content": "hello",
+                "raw_content": "hello",
+                "metadata": {"sourceURL": "https://example.com"},
+            }
+        ]
+
+        with patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=expected)) as mock_extract, \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None):
+            result = json.loads(await tools.web_tools.web_extract_tool(["https://example.com"], use_llm_processing=False))
+
+        assert result["results"][0]["url"] == "https://example.com"
+        assert result["results"][0]["content"] == "hello"
+        mock_extract.assert_awaited_once_with(["https://example.com"], None)
+
+    @pytest.mark.asyncio
+    async def test_direct_extract_prefers_trafilatura_when_available(self):
+        import tools.web_tools
+
+        html = """
+        <html>
+          <head><title>Example Article</title></head>
+          <body>
+            <article><h1>Headline</h1><p>Alpha beta gamma.</p></article>
+          </body>
+        </html>
+        """
+        response = MagicMock()
+        response.text = html
+        response.headers = {"content-type": "text/html; charset=utf-8"}
+        response.url = "https://example.com/article"
+        response.raise_for_status = MagicMock()
+
+        fake_trafilatura = types.SimpleNamespace(
+            extract=MagicMock(return_value="# Headline\n\nAlpha beta gamma.")
+        )
+
+        with patch.dict(sys.modules, {"trafilatura": fake_trafilatura}), \
+             patch("tools.web_tools.httpx.AsyncClient", return_value=_AsyncClientStub(response)), \
+             patch("tools.web_tools.check_website_access", return_value=None):
+            result = await tools.web_tools._direct_extract_urls(["https://example.com/article"], format="markdown")
+
+        assert result[0]["title"] == "Example Article"
+        assert result[0]["content"] == "# Headline\n\nAlpha beta gamma."
+        assert result[0]["raw_content"] == "# Headline\n\nAlpha beta gamma."
+        assert result[0]["excerpt"] == "Headline Alpha beta gamma."
+        assert result[0]["metadata"]["sourceURL"] == "https://example.com/article"
+        assert result[0]["metadata"]["contentType"] == "text/html; charset=utf-8"
+        assert result[0]["metadata"]["extractor"] == "trafilatura"
+        assert result[0]["metadata"]["fallbackUsed"] is True
+        assert result[0]["metadata"]["contentLength"] == len("# Headline\n\nAlpha beta gamma.")
+        assert result[0]["metadata"]["qualityStatus"] == "ok"
+        assert result[0]["metadata"]["qualityFlags"] == []
+        fake_trafilatura.extract.assert_called_once_with(
+            html,
+            url="https://example.com/article",
+            output_format="markdown",
+        )
+
+    @pytest.mark.asyncio
+    async def test_direct_extract_falls_back_to_html_cleanup_when_trafilatura_returns_none(self):
+        import tools.web_tools
+
+        html = """
+        <html>
+          <head><title>Example Article</title></head>
+          <body>
+            <article><h1>Headline</h1><p>Alpha beta gamma.</p></article>
+          </body>
+        </html>
+        """
+        response = MagicMock()
+        response.text = html
+        response.headers = {"content-type": "text/html; charset=utf-8"}
+        response.url = "https://example.com/article"
+        response.raise_for_status = MagicMock()
+
+        fake_trafilatura = types.SimpleNamespace(extract=MagicMock(return_value=None))
+
+        with patch.dict(sys.modules, {"trafilatura": fake_trafilatura}), \
+             patch("tools.web_tools.httpx.AsyncClient", return_value=_AsyncClientStub(response)), \
+             patch("tools.web_tools.check_website_access", return_value=None):
+            result = await tools.web_tools._direct_extract_urls(["https://example.com/article"], format="markdown")
+
+        assert "Headline" in result[0]["content"]
+        assert "Alpha beta gamma." in result[0]["content"]
+        assert result[0]["raw_content"] == result[0]["content"]
+        assert result[0]["metadata"]["extractor"] == "html_cleanup"
+        assert result[0]["metadata"]["qualityStatus"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_direct_extract_marks_thin_content(self):
+        import tools.web_tools
+
+        response = MagicMock()
+        response.text = "ok"
+        response.headers = {"content-type": "text/plain; charset=utf-8"}
+        response.url = "https://example.com/tiny"
+        response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools.httpx.AsyncClient", return_value=_AsyncClientStub(response)), \
+             patch("tools.web_tools.check_website_access", return_value=None):
+            result = await tools.web_tools._direct_extract_urls(["https://example.com/tiny"], format="markdown")
+
+        assert result[0]["content"] == "ok"
+        assert result[0]["excerpt"] == "ok"
+        assert result[0]["metadata"]["extractor"] == "plain_text"
+        assert result[0]["metadata"]["qualityStatus"] == "thin"
+        assert result[0]["metadata"]["qualityFlags"] == ["thin_content"]
+
+    @pytest.mark.asyncio
+    async def test_web_extract_output_keeps_excerpt_and_metadata(self):
+        import tools.web_tools
+
+        expected = [
+            {
+                "url": "https://example.com/article",
+                "title": "Example",
+                "content": "Body text",
+                "raw_content": "Body text",
+                "excerpt": "Body text",
+                "metadata": {
+                    "sourceURL": "https://example.com/article",
+                    "extractor": "trafilatura",
+                    "qualityStatus": "ok",
+                    "qualityFlags": [],
+                },
+            }
+        ]
+
+        with patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=expected)), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None):
+            result = json.loads(await tools.web_tools.web_extract_tool(["https://example.com/article"], use_llm_processing=False))
+
+        assert result["results"][0]["excerpt"] == "Body text"
+        assert result["results"][0]["metadata"]["extractor"] == "trafilatura"
+        assert result["results"][0]["metadata"]["qualityStatus"] == "ok"
+
+    def test_web_extract_schema_exposes_dynamic_mode(self):
+        from tools.web_tools import WEB_EXTRACT_SCHEMA
+
+        props = WEB_EXTRACT_SCHEMA["parameters"]["properties"]
+        assert "mode" in props
+        assert props["mode"]["enum"] == ["static", "dynamic", "attached"]
+        assert props["mode"]["default"] == "static"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_dynamic_mode_uses_browser_rendering(self):
+        import tools.web_tools
+
+        with patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.browser_tool.browser_navigate", return_value=json.dumps({
+                 "success": True,
+                 "url": "https://example.com/app",
+                 "title": "Rendered App",
+             })) as mock_nav, \
+             patch("tools.browser_tool._browser_eval", return_value=json.dumps({
+                 "success": True,
+                 "result": {
+                     "title": "Rendered App",
+                     "content": "Loaded content from hydrated page",
+                 },
+             })) as mock_eval, \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=[])) as mock_static:
+            result = json.loads(await tools.web_tools.web_extract_tool(
+                ["https://example.com/app"],
+                mode="dynamic",
+                use_llm_processing=False,
+            ))
+
+        first = result["results"][0]
+        assert first["title"] == "Rendered App"
+        assert first["content"] == "Loaded content from hydrated page"
+        assert first["metadata"]["extractor"] == "browser_rendered"
+        assert first["metadata"]["requestedMode"] == "dynamic"
+        assert first["metadata"]["extractionMode"] == "dynamic"
+        assert mock_nav.call_args.args[0] == "https://example.com/app"
+        assert "document.body" in mock_eval.call_args.args[0]
+        mock_static.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_web_extract_dynamic_mode_retries_thin_rendered_content_before_accepting_result(self):
+        import tools.web_tools
+
+        with patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.browser_tool.browser_navigate", return_value=json.dumps({
+                 "success": True,
+                 "url": "https://example.com/app",
+                 "title": "Rendered App",
+             })), \
+             patch("tools.browser_tool._browser_eval", side_effect=[
+                 json.dumps({
+                     "success": True,
+                     "result": {
+                         "title": "Rendered App",
+                         "content": "Loading...",
+                         "readyState": "interactive",
+                         "contentScope": "body",
+                         "observedContentLength": 10,
+                     },
+                 }),
+                 json.dumps({
+                     "success": True,
+                     "result": {
+                         "title": "Rendered App",
+                         "content": "Loaded content from hydrated page after retry",
+                         "readyState": "complete",
+                         "contentScope": "main",
+                         "observedContentLength": 44,
+                     },
+                 }),
+             ]) as mock_eval, \
+             patch("tools.web_tools.asyncio.sleep", new=AsyncMock()) as mock_sleep, \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=[])) as mock_static:
+            result = json.loads(await tools.web_tools.web_extract_tool(
+                ["https://example.com/app"],
+                mode="dynamic",
+                use_llm_processing=False,
+            ))
+
+        first = result["results"][0]
+        assert first["title"] == "Rendered App"
+        assert first["content"] == "Loaded content from hydrated page after retry"
+        assert first["metadata"]["extractor"] == "browser_rendered"
+        assert first["metadata"]["requestedMode"] == "dynamic"
+        assert first["metadata"]["extractionMode"] == "dynamic"
+        assert first["metadata"]["renderAttemptCount"] == 2
+        assert first["metadata"]["renderWaitStrategy"] == "retry_on_empty_or_thin_content"
+        assert first["metadata"]["renderReadyState"] == "complete"
+        assert first["metadata"]["renderContentScope"] == "main"
+        assert first["metadata"]["renderObservedContentLength"] == 44
+        assert mock_eval.call_count == 2
+        mock_sleep.assert_awaited_once()
+        mock_static.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_web_extract_dynamic_mode_falls_back_to_static_when_browser_eval_fails(self):
+        import tools.web_tools
+
+        static_expected = [
+            {
+                "url": "https://example.com/app",
+                "title": "Static Example",
+                "content": "Static fallback body",
+                "raw_content": "Static fallback body",
+                "excerpt": "Static fallback body",
+                "metadata": {
+                    "sourceURL": "https://example.com/app",
+                    "extractor": "html_cleanup",
+                    "qualityStatus": "ok",
+                    "qualityFlags": [],
+                },
+            }
+        ]
+
+        with patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.browser_tool.browser_navigate", return_value=json.dumps({
+                 "success": True,
+                 "url": "https://example.com/app",
+                 "title": "Rendered App",
+             })), \
+             patch("tools.browser_tool._browser_eval", return_value=json.dumps({
+                 "success": False,
+                 "error": "JavaScript evaluation is not supported by this browser backend.",
+             })), \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=static_expected)) as mock_static:
+            result = json.loads(await tools.web_tools.web_extract_tool(
+                ["https://example.com/app"],
+                mode="dynamic",
+                use_llm_processing=False,
+            ))
+
+        first = result["results"][0]
+        assert first["title"] == "Static Example"
+        assert first["content"] == "Static fallback body"
+        assert first["metadata"]["extractor"] == "html_cleanup"
+        assert first["metadata"]["requestedMode"] == "dynamic"
+        assert first["metadata"]["extractionMode"] == "static"
+        assert first["metadata"]["dynamicFallbackUsed"] is True
+        assert first["metadata"]["dynamicFallbackReason"] == "browser_eval_failed"
+        mock_static.assert_awaited_once_with(["https://example.com/app"], "markdown")
+
+    @pytest.mark.asyncio
+    async def test_web_extract_attached_mode_marks_profile_and_login_state_unverified_without_explicit_evidence(self):
+        import tools.web_tools
+
+        with patch.dict(os.environ, {"BROWSER_CDP_URL": "ws://127.0.0.1:9222/devtools/browser/test"}, clear=False), \
+             patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.browser_tool.browser_navigate", return_value=json.dumps({
+                 "success": True,
+                 "url": "https://example.com/dashboard",
+                 "title": "Attached Dashboard",
+             })) as mock_nav, \
+             patch("tools.browser_tool._browser_eval", return_value=json.dumps({
+                 "success": True,
+                 "result": {
+                     "url": "https://example.com/dashboard",
+                     "title": "Attached Dashboard",
+                     "content": "Logged-in rendered content from attached session",
+                     "evidence": {
+                         "visibleCookieCount": 0,
+                         "localStorageCount": 0,
+                         "sessionStorageCount": 0,
+                     },
+                 },
+             })) as mock_eval, \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=[])) as mock_static:
+            result = json.loads(await tools.web_tools.web_extract_tool(
+                ["https://example.com/dashboard"],
+                mode="attached",
+                use_llm_processing=False,
+            ))
+
+        first = result["results"][0]
+        assert first["title"] == "Attached Dashboard"
+        assert first["content"] == "Logged-in rendered content from attached session"
+        assert first["metadata"]["extractor"] == "browser_attached"
+        assert first["metadata"]["requestedMode"] == "attached"
+        assert first["metadata"]["extractionMode"] == "attached"
+        assert first["metadata"]["cdpAttached"] is True
+        assert first["metadata"]["cdpUrl"] == "ws://127.0.0.1:9222/devtools/browser/test"
+        assert first["metadata"]["browserSessionReused"] is True
+        assert first["metadata"]["profileInherited"] is None
+        assert first["metadata"]["loginStateInherited"] is None
+        assert first["metadata"]["inheritanceVerification"] == "not_verified"
+        assert first["metadata"]["attachedClientStateEvidence"] == {
+            "visibleCookieCount": 0,
+            "localStorageCount": 0,
+            "sessionStorageCount": 0,
+        }
+        assert mock_nav.call_args.args[0] == "https://example.com/dashboard"
+        assert "document.body" in mock_eval.call_args.args[0]
+        mock_static.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_web_extract_attached_mode_marks_client_state_observed_when_browser_evidence_exists(self):
+        import tools.web_tools
+
+        with patch.dict(os.environ, {"BROWSER_CDP_URL": "ws://127.0.0.1:9222/devtools/browser/test"}, clear=False), \
+             patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.browser_tool.browser_navigate", return_value=json.dumps({
+                 "success": True,
+                 "url": "https://example.com/dashboard",
+                 "title": "Attached Dashboard",
+             })), \
+             patch("tools.browser_tool._browser_eval", return_value=json.dumps({
+                 "success": True,
+                 "result": {
+                     "url": "https://example.com/dashboard",
+                     "title": "Attached Dashboard",
+                     "content": "Rendered content with browser state evidence",
+                     "evidence": {
+                         "visibleCookieCount": 2,
+                         "localStorageCount": 1,
+                         "sessionStorageCount": 0,
+                     },
+                 },
+             })), \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=[])):
+            result = json.loads(await tools.web_tools.web_extract_tool(
+                ["https://example.com/dashboard"],
+                mode="attached",
+                use_llm_processing=False,
+            ))
+
+        first = result["results"][0]
+        assert first["metadata"]["inheritanceVerification"] == "client_state_observed"
+        assert first["metadata"]["attachedClientStateEvidence"] == {
+            "visibleCookieCount": 2,
+            "localStorageCount": 1,
+            "sessionStorageCount": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_web_extract_attached_mode_falls_back_to_static_when_browser_navigate_fails(self):
+        import tools.web_tools
+
+        static_expected = [
+            {
+                "url": "https://example.com/dashboard",
+                "title": "Static Dashboard",
+                "content": "Static fallback body",
+                "raw_content": "Static fallback body",
+                "excerpt": "Static fallback body",
+                "metadata": {
+                    "sourceURL": "https://example.com/dashboard",
+                    "extractor": "html_cleanup",
+                    "qualityStatus": "ok",
+                    "qualityFlags": [],
+                },
+            }
+        ]
+
+        with patch.dict(os.environ, {"BROWSER_CDP_URL": "ws://127.0.0.1:9222/devtools/browser/test"}, clear=False), \
+             patch("tools.web_tools._get_backend", return_value="duckduckgo"), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.browser_tool.browser_navigate", return_value=json.dumps({
+                 "success": False,
+                 "error": "Failed to attach to CDP session",
+             })), \
+             patch("tools.web_tools._direct_extract_urls", new=AsyncMock(return_value=static_expected)) as mock_static:
+            result = json.loads(await tools.web_tools.web_extract_tool(
+                ["https://example.com/dashboard"],
+                mode="attached",
+                use_llm_processing=False,
+            ))
+
+        first = result["results"][0]
+        assert first["title"] == "Static Dashboard"
+        assert first["metadata"]["requestedMode"] == "attached"
+        assert first["metadata"]["extractionMode"] == "static"
+        assert first["metadata"]["dynamicFallbackUsed"] is True
+        assert first["metadata"]["dynamicFallbackReason"] == "browser_navigate_failed"
+        mock_static.assert_awaited_once_with(["https://example.com/dashboard"], "markdown")
+
+
 class TestCheckWebApiKey:
     """Test suite for check_web_api_key() unified availability check."""
 
@@ -532,9 +1012,9 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
-    def test_no_keys_returns_false(self):
+    def test_no_keys_returns_true_via_duckduckgo_fallback(self):
         from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        assert check_web_api_key() is True
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {
@@ -564,6 +1044,16 @@ class TestCheckWebApiKey:
                 with patch.dict(os.environ, {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"}, clear=False):
                     from tools.web_tools import check_web_api_key
                     assert check_web_api_key() is False
+
+    def test_configured_parallel_without_key_returns_false(self):
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "parallel"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
+
+    def test_configured_exa_without_key_returns_false(self):
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "exa"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is False
 
     def test_configured_firecrawl_backend_accepts_managed_gateway(self):
         with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}):

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -399,6 +399,8 @@ def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypat
 async def test_web_extract_blocks_redirected_final_url(monkeypatch):
     from tools import web_tools
 
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fake-key")
+
     # Allow test URLs past SSRF check so website policy is what gets tested
     monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -65,6 +65,7 @@ import time
 import requests
 from typing import Dict, Any, Optional, List
 from pathlib import Path
+from urllib.parse import urlparse
 from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 
@@ -210,6 +211,96 @@ def _get_extraction_model() -> Optional[str]:
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
 
 
+def _is_loopback_host(host: Optional[str]) -> bool:
+    """Return True for local-only CDP hosts we can safely augment from disk."""
+    normalized = (host or "").strip().lower().strip("[]")
+    return normalized in {"127.0.0.1", "localhost", "::1"}
+
+
+@functools.lru_cache(maxsize=1)
+def _devtools_activeport_candidates() -> tuple[Path, ...]:
+    """Likely Chrome/Chromium DevToolsActivePort paths for this OS."""
+    home = Path.home()
+    candidates: list[Path] = []
+
+    if sys.platform == "darwin":
+        app_support = home / "Library" / "Application Support"
+        roots = [
+            app_support / "Google" / "Chrome",
+            app_support / "Google" / "Chrome Beta",
+            app_support / "Google" / "Chrome Dev",
+            app_support / "Chromium",
+        ]
+    elif sys.platform == "win32":
+        local_appdata_raw = os.environ.get("LOCALAPPDATA", "").strip()
+        roots = []
+        if local_appdata_raw:
+            local_appdata = Path(local_appdata_raw).expanduser()
+            roots.extend([
+                local_appdata / "Google" / "Chrome" / "User Data",
+                local_appdata / "Chromium" / "User Data",
+            ])
+    else:
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+        config_root = Path(xdg_config_home).expanduser() if xdg_config_home else home / ".config"
+        roots = [
+            config_root / "google-chrome",
+            config_root / "google-chrome-beta",
+            config_root / "google-chrome-unstable",
+            config_root / "chromium",
+        ]
+
+    for root in roots:
+        candidates.append(root / "DevToolsActivePort")
+
+    return tuple(candidates)
+
+
+def _resolve_devtools_activeport_fallback(discovery_url: str) -> str:
+    """Resolve loopback CDP endpoints from Chrome's DevToolsActivePort file.
+
+    This covers real-user Chrome instances that expose a browser websocket in
+    DevToolsActivePort but do not serve ``/json/version`` on the same port.
+    """
+    try:
+        parsed = urlparse(discovery_url if "://" in discovery_url else f"http://{discovery_url}")
+    except Exception:
+        return ""
+
+    host = parsed.hostname or ""
+    port = parsed.port
+    if not _is_loopback_host(host) or port is None:
+        return ""
+
+    ws_scheme = "wss" if parsed.scheme in {"https", "wss"} else "ws"
+
+    for candidate in _devtools_activeport_candidates():
+        try:
+            lines = candidate.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        if len(lines) < 2:
+            continue
+
+        candidate_port = lines[0].strip()
+        candidate_path = lines[1].strip()
+        if not candidate_port.isdigit() or int(candidate_port) != port:
+            continue
+        if not candidate_path:
+            continue
+
+        if not candidate_path.startswith("/"):
+            candidate_path = "/" + candidate_path
+        if "/devtools/browser/" not in candidate_path:
+            continue
+
+        ws_url = f"{ws_scheme}://{host}:{port}{candidate_path}"
+        logger.info("Resolved CDP endpoint %s via %s -> %s", discovery_url, candidate, ws_url)
+        return ws_url
+
+    return ""
+
+
 def _resolve_cdp_override(cdp_url: str) -> str:
     """Normalize a user-supplied CDP endpoint into a concrete connectable URL.
 
@@ -231,7 +322,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         return raw
 
     discovery_url = raw
-    if lowered.startswith(("ws://", "wss://")):
+    if "://" not in raw:
+        discovery_url = f"http://{raw}"
+    elif lowered.startswith(("ws://", "wss://")):
         if raw.count(":") == 2 and raw.rstrip("/").rsplit(":", 1)[-1].isdigit() and "/" not in raw.split(":", 2)[-1]:
             discovery_url = ("http://" if lowered.startswith("ws://") else "https://") + raw.split("://", 1)[1]
         else:
@@ -247,6 +340,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        fallback_ws_url = _resolve_devtools_activeport_fallback(discovery_url)
+        if fallback_ws_url:
+            return fallback_ws_url
         logger.warning("Failed to resolve CDP endpoint %s via %s: %s", raw, version_url, exc)
         return raw
 
@@ -254,6 +350,10 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     if ws_url:
         logger.info("Resolved CDP endpoint %s -> %s", raw, ws_url)
         return ws_url
+
+    fallback_ws_url = _resolve_devtools_activeport_fallback(discovery_url)
+    if fallback_ws_url:
+        return fallback_ws_url
 
     logger.warning("CDP discovery at %s did not return webSocketDebuggerUrl; using raw endpoint", version_url)
     return raw

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -40,11 +40,14 @@ Usage:
     crawl_data = web_crawl_tool("example.com", "Find contact information")
 """
 
+import importlib
 import json
 import logging
 import os
 import re
 import asyncio
+import html as html_lib
+from urllib.parse import parse_qs, unquote, urlparse
 from typing import List, Dict, Any, Optional
 import httpx
 from firecrawl import Firecrawl
@@ -88,7 +91,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "duckduckgo"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -104,7 +107,7 @@ def _get_backend() -> str:
         if available:
             return backend
 
-    return "firecrawl"  # default (backward compat)
+    return "duckduckgo"
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -117,7 +120,375 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "duckduckgo":
+        return True
     return False
+
+
+_DUCKDUCKGO_HTML_SEARCH_URL = "https://html.duckduckgo.com/html/"
+_FALLBACK_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0; +https://github.com/muzzleishen/hermes-agent)",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def _decode_duckduckgo_result_url(href: str) -> str:
+    """Resolve DuckDuckGo redirect/result URLs into the destination URL."""
+    if not href:
+        return ""
+    if href.startswith("//"):
+        href = f"https:{href}"
+    parsed = urlparse(href)
+    if parsed.netloc.endswith("duckduckgo.com") and parsed.path.startswith("/l/"):
+        target = parse_qs(parsed.query).get("uddg", [""])[0]
+        if target:
+            return unquote(target)
+    return href
+
+
+def _strip_html_fragment(fragment: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", fragment or "")
+    text = html_lib.unescape(text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _html_to_text(html_content: str) -> str:
+    cleaned = re.sub(r"(?is)<(script|style|noscript|svg)[^>]*>.*?</\1>", " ", html_content or "")
+    cleaned = re.sub(r"(?i)</(p|div|section|article|h1|h2|h3|h4|h5|h6|li|tr|td|th|blockquote|pre|br)>", "\n", cleaned)
+    cleaned = re.sub(r"<[^>]+>", " ", cleaned)
+    cleaned = html_lib.unescape(cleaned)
+    cleaned = re.sub(r"\n\s*\n+", "\n\n", cleaned)
+    cleaned = re.sub(r"[ \t]+", " ", cleaned)
+    return cleaned.strip()
+
+
+def _extract_html_title(html_content: str) -> str:
+    match = re.search(r"(?is)<title[^>]*>(.*?)</title>", html_content or "")
+    if match:
+        return _strip_html_fragment(match.group(1))
+    og_match = re.search(
+        r'(?is)<meta[^>]+property=["\']og:title["\'][^>]+content=["\'](.*?)["\']',
+        html_content or "",
+    )
+    if og_match:
+        return _strip_html_fragment(og_match.group(1))
+    return ""
+
+
+def _extract_with_trafilatura(html_content: str, url: str, format: Optional[str] = None) -> Optional[str]:
+    if not html_content or format == "html":
+        return None
+
+    output_format = "markdown" if format in (None, "markdown") else "txt"
+
+    try:
+        trafilatura = importlib.import_module("trafilatura")
+    except Exception:
+        return None
+
+    try:
+        extracted = trafilatura.extract(
+            html_content,
+            url=url,
+            output_format=output_format,
+        )
+    except TypeError:
+        try:
+            extracted = trafilatura.extract(html_content, output_format=output_format)
+        except Exception as exc:
+            logger.debug("Trafilatura fallback extract failed for %s: %s", url, exc)
+            return None
+    except Exception as exc:
+        logger.debug("Trafilatura extract failed for %s: %s", url, exc)
+        return None
+
+    if isinstance(extracted, str):
+        extracted = extracted.strip()
+    return extracted or None
+
+
+def _build_extract_excerpt(content: str, max_length: int = 280) -> str:
+    """Build a compact plain-text excerpt from extracted content."""
+    text = content or ""
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1", text)
+    text = re.sub(r"(?m)^#+\s*", "", text)
+    text = re.sub(r"[`*_~>|]+", " ", text)
+    text = html_lib.unescape(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= max_length:
+        return text
+    clipped = text[:max_length].rsplit(" ", 1)[0].strip() or text[:max_length].strip()
+    return f"{clipped.rstrip()}..."
+
+
+def _assess_extract_quality(content: str) -> Dict[str, Any]:
+    """Return lightweight quality signals for extracted content."""
+    normalized = (content or "").strip()
+    content_length = len(normalized)
+    flags: List[str] = []
+    if content_length == 0:
+        flags.append("empty_content")
+    elif content_length < 20:
+        flags.append("thin_content")
+
+    if "empty_content" in flags:
+        status = "empty"
+    elif "thin_content" in flags:
+        status = "thin"
+    else:
+        status = "ok"
+
+    return {
+        "content_length": content_length,
+        "quality_flags": flags,
+        "quality_status": status,
+    }
+
+
+def _enrich_extract_result(result: Dict[str, Any], backend: str) -> Dict[str, Any]:
+    """Ensure extract results carry excerpt + stable metadata/quality signals."""
+    enriched = dict(result)
+    metadata = enriched.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    content_source = enriched.get("raw_content") or enriched.get("content") or ""
+    excerpt = enriched.get("excerpt") or _build_extract_excerpt(content_source)
+    quality = _assess_extract_quality(content_source)
+
+    metadata.setdefault("sourceURL", enriched.get("url", ""))
+    metadata.setdefault("extractor", backend)
+    metadata.setdefault("fallbackUsed", backend == "duckduckgo")
+    metadata.setdefault("contentLength", quality["content_length"])
+    metadata.setdefault("qualityFlags", quality["quality_flags"])
+    metadata.setdefault("qualityStatus", quality["quality_status"])
+
+    enriched["metadata"] = metadata
+    if excerpt:
+        enriched["excerpt"] = excerpt
+    return enriched
+
+
+def _duckduckgo_search(query: str, limit: int) -> dict:
+    """Zero-key HTML search fallback via DuckDuckGo."""
+    response = httpx.get(
+        _DUCKDUCKGO_HTML_SEARCH_URL,
+        params={"q": query},
+        headers=_FALLBACK_HEADERS,
+        follow_redirects=True,
+        timeout=20,
+    )
+    response.raise_for_status()
+    html_body = response.text
+
+    web_results = []
+    matches = list(
+        re.finditer(
+            r'(?is)<a[^>]+class=["\'][^"\']*result__a[^"\']*["\'][^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+            html_body,
+        )
+    )
+
+    for index, match in enumerate(matches[:max(limit, 1)]):
+        href, raw_title = match.groups()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(html_body)
+        chunk = html_body[start:end]
+        snippet_match = re.search(r'(?is)class=["\'][^"\']*result__snippet[^"\']*["\'][^>]*>(.*?)</', chunk)
+        snippet = _strip_html_fragment(snippet_match.group(1)) if snippet_match else ""
+        web_results.append(
+            {
+                "title": _strip_html_fragment(raw_title),
+                "url": _decode_duckduckgo_result_url(html_lib.unescape(href)),
+                "description": snippet,
+                "position": index + 1,
+            }
+        )
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+async def _direct_extract_urls(urls: List[str], format: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Zero-key fallback extractor using direct HTTP GET + lightweight HTML cleaning."""
+    results: List[Dict[str, Any]] = []
+    async with httpx.AsyncClient(headers=_FALLBACK_HEADERS, follow_redirects=True, timeout=20) as client:
+        for url in urls:
+            blocked = check_website_access(url)
+            if blocked:
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": blocked["message"],
+                    "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
+                })
+                continue
+            try:
+                response = await client.get(url)
+                response.raise_for_status()
+                final_url = str(response.url)
+                final_blocked = check_website_access(final_url)
+                if final_blocked:
+                    results.append({
+                        "url": final_url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": final_blocked["message"],
+                        "blocked_by_policy": {"host": final_blocked["host"], "rule": final_blocked["rule"], "source": final_blocked["source"]},
+                    })
+                    continue
+
+                content_type = response.headers.get("content-type", "")
+                body = response.text
+                title = _extract_html_title(body)
+                extractor = "raw_html" if format == "html" else "plain_text"
+                if format == "html":
+                    chosen_content = body
+                else:
+                    looks_like_html = "html" in content_type.lower() or "<html" in body[:1000].lower()
+                    if looks_like_html:
+                        trafilatura_content = _extract_with_trafilatura(body, final_url, format=format)
+                        if trafilatura_content:
+                            chosen_content = trafilatura_content
+                            extractor = "trafilatura"
+                        else:
+                            chosen_content = _html_to_text(body)
+                            extractor = "html_cleanup"
+                    else:
+                        chosen_content = body.strip()
+                        extractor = "plain_text"
+
+                results.append(_enrich_extract_result({
+                    "url": final_url,
+                    "title": title,
+                    "content": chosen_content,
+                    "raw_content": chosen_content,
+                    "metadata": {
+                        "sourceURL": final_url,
+                        "contentType": content_type,
+                        "extractor": extractor,
+                    },
+                }, backend="duckduckgo"))
+            except Exception as exc:
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": str(exc),
+                })
+    return results
+
+
+def _mark_extract_mode(
+    results: List[Dict[str, Any]],
+    *,
+    requested_mode: str,
+    extraction_mode: str,
+    dynamic_fallback_reason: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Attach stable mode/fallback metadata to extraction results."""
+    marked: List[Dict[str, Any]] = []
+    for result in results:
+        updated = dict(result)
+        metadata = updated.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            metadata = {}
+        metadata["requestedMode"] = requested_mode
+        metadata["extractionMode"] = extraction_mode
+        if dynamic_fallback_reason:
+            metadata["dynamicFallbackUsed"] = True
+            metadata["dynamicFallbackReason"] = dynamic_fallback_reason
+        updated["metadata"] = metadata
+        marked.append(updated)
+    return marked
+
+
+def _normalize_attached_client_state_evidence(rendered: Dict[str, Any]) -> Dict[str, Optional[int]]:
+    """Extract safe, comparable client-state evidence from browser-rendered output."""
+    raw_evidence = rendered.get("evidence") if isinstance(rendered.get("evidence"), dict) else {}
+
+    def _int_or_none(value: Any) -> Optional[int]:
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+    return {
+        "visibleCookieCount": _int_or_none(raw_evidence.get("visibleCookieCount")),
+        "localStorageCount": _int_or_none(raw_evidence.get("localStorageCount")),
+        "sessionStorageCount": _int_or_none(raw_evidence.get("sessionStorageCount")),
+    }
+
+
+_BROWSER_RENDER_MAX_ATTEMPTS = 3
+_BROWSER_RENDER_RETRY_DELAY_SECONDS = 0.5
+
+
+def _normalize_browser_render_observation(rendered: Dict[str, Any]) -> Dict[str, Any]:
+    """Return safe, observable browser-render metadata for rendered extraction."""
+
+    def _str_or_none(value: Any) -> Optional[str]:
+        if isinstance(value, str):
+            normalized = value.strip()
+            return normalized or None
+        return None
+
+    observed_length = rendered.get("observedContentLength")
+    if not isinstance(observed_length, int) or isinstance(observed_length, bool):
+        observed_length = None
+
+    return {
+        "renderReadyState": _str_or_none(rendered.get("readyState")),
+        "renderContentScope": _str_or_none(rendered.get("contentScope")),
+        "renderObservedContentLength": observed_length,
+    }
+
+
+def _should_retry_browser_render(content: str, attempt: int) -> bool:
+    """Retry rendered extraction briefly when content still looks empty/thin."""
+    if attempt >= _BROWSER_RENDER_MAX_ATTEMPTS:
+        return False
+    quality = _assess_extract_quality(content or "")
+    return quality["quality_status"] in {"empty", "thin"}
+
+
+_DYNAMIC_EXTRACT_EVAL = r"""
+(() => {
+  const body = document.body;
+  const main = document.querySelector('main, article, [role="main"]');
+  const root = main || body;
+  const title = (document.title || '').trim();
+  const url = window.location.href;
+  const content = ((root && root.innerText) || (body && body.innerText) || '').trim();
+  const visibleCookieCount = (document.cookie || '')
+    .split(';')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .length;
+  const safeStorageLength = (storage) => {
+    try {
+      return storage ? storage.length : null;
+    } catch (_) {
+      return null;
+    }
+  };
+  const evidence = {
+    visibleCookieCount,
+    localStorageCount: safeStorageLength(window.localStorage),
+    sessionStorageCount: safeStorageLength(window.sessionStorage),
+  };
+  return JSON.stringify({
+    title,
+    url,
+    content,
+    readyState: document.readyState || '',
+    contentScope: main ? 'main' : (body ? 'body' : 'none'),
+    observedContentLength: content.length,
+    evidence,
+  });
+})()
+""".strip()
+
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -1118,6 +1489,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "duckduckgo":
+            response_data = _duckduckgo_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
 
         response = _get_firecrawl_client().search(
@@ -1162,12 +1542,247 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         return tool_error(error_msg)
 
 
+async def _extract_urls_via_backend(urls: List[str], format: Optional[str], backend: str) -> List[Dict[str, Any]]:
+    """Dispatch extraction through the configured static backend."""
+    if backend == "parallel":
+        return await _parallel_extract(urls)
+    if backend == "exa":
+        return _exa_extract(urls)
+    if backend == "tavily":
+        logger.info("Tavily extract: %d URL(s)", len(urls))
+        raw = _tavily_request("extract", {
+            "urls": urls,
+            "include_images": False,
+        })
+        return _normalize_tavily_documents(raw, fallback_url=urls[0] if urls else "")
+    if backend == "duckduckgo":
+        return await _direct_extract_urls(urls, format)
+
+    formats: List[str] = []
+    if format == "markdown":
+        formats = ["markdown"]
+    elif format == "html":
+        formats = ["html"]
+    else:
+        formats = ["markdown", "html"]
+
+    results: List[Dict[str, Any]] = []
+    from tools.interrupt import is_interrupted
+    for url in urls:
+        if is_interrupted():
+            results.append({"url": url, "error": "Interrupted", "title": ""})
+            continue
+
+        blocked = check_website_access(url)
+        if blocked:
+            logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
+            results.append({
+                "url": url, "title": "", "content": "",
+                "error": blocked["message"],
+                "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
+            })
+            continue
+
+        try:
+            logger.info("Scraping: %s", url)
+            try:
+                scrape_result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        _get_firecrawl_client().scrape,
+                        url=url,
+                        formats=formats,
+                    ),
+                    timeout=60,
+                )
+            except asyncio.TimeoutError:
+                logger.warning("Firecrawl scrape timed out for %s", url)
+                results.append({
+                    "url": url, "title": "", "content": "",
+                    "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
+                })
+                continue
+
+            scrape_payload = _extract_scrape_payload(scrape_result)
+            metadata = scrape_payload.get("metadata", {})
+            title = ""
+            content_markdown = scrape_payload.get("markdown")
+            content_html = scrape_payload.get("html")
+
+            if not isinstance(metadata, dict):
+                if hasattr(metadata, 'model_dump'):
+                    metadata = metadata.model_dump()
+                elif hasattr(metadata, '__dict__'):
+                    metadata = metadata.__dict__
+                else:
+                    metadata = {}
+
+            title = metadata.get("title", "")
+
+            final_url = metadata.get("sourceURL", url)
+            final_blocked = check_website_access(final_url)
+            if final_blocked:
+                logger.info("Blocked redirected web_extract for %s by rule %s", final_blocked["host"], final_blocked["rule"])
+                results.append({
+                    "url": final_url, "title": title, "content": "", "raw_content": "",
+                    "error": final_blocked["message"],
+                    "blocked_by_policy": {"host": final_blocked["host"], "rule": final_blocked["rule"], "source": final_blocked["source"]},
+                })
+                continue
+
+            chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
+
+            results.append({
+                "url": final_url,
+                "title": title,
+                "content": chosen_content,
+                "raw_content": chosen_content,
+                "metadata": metadata,
+            })
+
+        except Exception as scrape_err:
+            logger.debug("Scrape failed for %s: %s", url, scrape_err)
+            results.append({
+                "url": url,
+                "title": "",
+                "content": "",
+                "raw_content": "",
+                "error": str(scrape_err)
+            })
+
+    return results
+
+
+async def _browser_extract_urls(
+    urls: List[str],
+    format: Optional[str],
+    backend: str,
+    *,
+    requested_mode: str,
+) -> List[Dict[str, Any]]:
+    """Render pages in the browser stack, with optional attached/CDP session semantics."""
+    from tools.browser_tool import _browser_eval, _get_cdp_override, browser_navigate
+
+    requested_format = format or "markdown"
+    cdp_url = _get_cdp_override()
+    results: List[Dict[str, Any]] = []
+
+    if requested_mode == "attached" and not cdp_url:
+        fallback_results = await _extract_urls_via_backend(urls, requested_format, backend)
+        return _mark_extract_mode(
+            fallback_results,
+            requested_mode="attached",
+            extraction_mode="static",
+            dynamic_fallback_reason="cdp_not_configured",
+        )
+
+    for url in urls:
+        navigate_response = browser_navigate(url)
+        try:
+            navigate_data = json.loads(navigate_response)
+        except (TypeError, json.JSONDecodeError, ValueError):
+            navigate_data = {"success": False, "error": "Invalid browser navigate response"}
+
+        if not navigate_data.get("success"):
+            fallback_results = await _extract_urls_via_backend([url], requested_format, backend)
+            results.extend(_mark_extract_mode(
+                fallback_results,
+                requested_mode=requested_mode,
+                extraction_mode="static",
+                dynamic_fallback_reason="browser_navigate_failed",
+            ))
+            continue
+
+        eval_data: Dict[str, Any] = {"success": False, "error": "Browser eval not attempted"}
+        rendered: Dict[str, Any] = {}
+        content = ""
+        render_attempt_count = 0
+
+        for attempt in range(1, _BROWSER_RENDER_MAX_ATTEMPTS + 1):
+            render_attempt_count = attempt
+            eval_response = _browser_eval(_DYNAMIC_EXTRACT_EVAL)
+            try:
+                eval_data = json.loads(eval_response)
+            except (TypeError, json.JSONDecodeError, ValueError):
+                eval_data = {"success": False, "error": "Invalid browser eval response"}
+
+            rendered = eval_data.get("result") if isinstance(eval_data.get("result"), dict) else {}
+            content = (rendered.get("content") or "").strip()
+
+            if not eval_data.get("success"):
+                break
+            if not _should_retry_browser_render(content, attempt):
+                break
+            await asyncio.sleep(_BROWSER_RENDER_RETRY_DELAY_SECONDS * attempt)
+
+        final_url = rendered.get("url") or navigate_data.get("url") or url
+        title = (rendered.get("title") or navigate_data.get("title") or "").strip()
+
+        if not eval_data.get("success") or not content:
+            fallback_reason = "browser_eval_failed" if not eval_data.get("success") else "empty_rendered_content"
+            fallback_results = await _extract_urls_via_backend([url], requested_format, backend)
+            results.extend(_mark_extract_mode(
+                fallback_results,
+                requested_mode=requested_mode,
+                extraction_mode="static",
+                dynamic_fallback_reason=fallback_reason,
+            ))
+            continue
+
+        metadata = {
+            "sourceURL": final_url,
+            "extractor": "browser_attached" if requested_mode == "attached" else "browser_rendered",
+            "requestedMode": requested_mode,
+            "extractionMode": requested_mode,
+            "rendered": True,
+            "fallbackUsed": False,
+            "renderAttemptCount": render_attempt_count,
+            "renderWaitStrategy": "retry_on_empty_or_thin_content",
+        }
+        metadata.update({
+            key: value
+            for key, value in _normalize_browser_render_observation(rendered).items()
+            if value is not None
+        })
+        if requested_mode == "attached":
+            attached_evidence = _normalize_attached_client_state_evidence(rendered)
+            evidence_detected = any(
+                isinstance(value, int) and value > 0
+                for value in attached_evidence.values()
+            )
+            metadata["cdpAttached"] = True
+            metadata["cdpUrl"] = cdp_url
+            metadata["browserSessionReused"] = True
+            metadata["profileInherited"] = None
+            metadata["loginStateInherited"] = None
+            metadata["inheritanceVerification"] = (
+                "client_state_observed" if evidence_detected else "not_verified"
+            )
+            metadata["attachedClientStateEvidence"] = attached_evidence
+
+        rendered_result = _enrich_extract_result({
+            "url": final_url,
+            "title": title,
+            "content": content,
+            "raw_content": content,
+            "metadata": metadata,
+        }, backend="browser_rendered")
+        results.append(rendered_result)
+
+    return results
+
+
+async def _dynamic_extract_urls(urls: List[str], format: Optional[str], backend: str) -> List[Dict[str, Any]]:
+    """Render pages in the existing browser stack, then fall back to static extraction."""
+    return await _browser_extract_urls(urls, format, backend, requested_mode="dynamic")
+
+
 async def web_extract_tool(
     urls: List[str],
     format: str = None,
     use_llm_processing: bool = True,
     model: Optional[str] = None,
-    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
+    min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION,
+    mode: str = "static",
 ) -> str:
     """
     Extract content from specific web pages using available extraction API backend.
@@ -1209,7 +1824,8 @@ async def web_extract_tool(
             "format": format,
             "use_llm_processing": use_llm_processing,
             "model": model,
-            "min_length": min_length
+            "min_length": min_length,
+            "mode": mode,
         },
         "error": None,
         "pages_extracted": 0,
@@ -1235,132 +1851,34 @@ async def web_extract_tool(
             else:
                 safe_urls.append(url)
 
+        backend = _get_backend()
+        requested_mode = (mode or "static").strip().lower()
+        if requested_mode not in {"static", "dynamic", "attached"}:
+            return tool_error("Invalid web_extract mode. Expected 'static', 'dynamic', or 'attached'.")
+
         # Dispatch only safe URLs to the configured backend
         if not safe_urls:
             results = []
+        elif requested_mode in {"dynamic", "attached"}:
+            results = await _browser_extract_urls(
+                safe_urls,
+                format,
+                backend,
+                requested_mode=requested_mode,
+            )
         else:
-            backend = _get_backend()
-
-            if backend == "parallel":
-                results = await _parallel_extract(safe_urls)
-            elif backend == "exa":
-                results = _exa_extract(safe_urls)
-            elif backend == "tavily":
-                logger.info("Tavily extract: %d URL(s)", len(safe_urls))
-                raw = _tavily_request("extract", {
-                    "urls": safe_urls,
-                    "include_images": False,
-                })
-                results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
-            else:
-                # ── Firecrawl extraction ──
-                # Determine requested formats for Firecrawl v2
-                formats: List[str] = []
-                if format == "markdown":
-                    formats = ["markdown"]
-                elif format == "html":
-                    formats = ["html"]
-                else:
-                    # Default: request markdown for LLM-readiness and include html as backup
-                    formats = ["markdown", "html"]
-
-                # Always use individual scraping for simplicity and reliability
-                # Batch scraping adds complexity without much benefit for small numbers of URLs
-                results: List[Dict[str, Any]] = []
-
-                from tools.interrupt import is_interrupted as _is_interrupted
-                for url in safe_urls:
-                    if _is_interrupted():
-                        results.append({"url": url, "error": "Interrupted", "title": ""})
-                        continue
-
-                    # Website policy check — block before fetching
-                    blocked = check_website_access(url)
-                    if blocked:
-                        logger.info("Blocked web_extract for %s by rule %s", blocked["host"], blocked["rule"])
-                        results.append({
-                            "url": url, "title": "", "content": "",
-                            "error": blocked["message"],
-                            "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
-                        })
-                        continue
-
-                    try:
-                        logger.info("Scraping: %s", url)
-                        # Run synchronous Firecrawl scrape in a thread with a
-                        # 60s timeout so a hung fetch doesn't block the session.
-                        try:
-                            scrape_result = await asyncio.wait_for(
-                                asyncio.to_thread(
-                                    _get_firecrawl_client().scrape,
-                                    url=url,
-                                    formats=formats,
-                                ),
-                                timeout=60,
-                            )
-                        except asyncio.TimeoutError:
-                            logger.warning("Firecrawl scrape timed out for %s", url)
-                            results.append({
-                                "url": url, "title": "", "content": "",
-                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
-                            })
-                            continue
-
-                        scrape_payload = _extract_scrape_payload(scrape_result)
-                        metadata = scrape_payload.get("metadata", {})
-                        title = ""
-                        content_markdown = scrape_payload.get("markdown")
-                        content_html = scrape_payload.get("html")
-
-                        # Ensure metadata is a dict (not an object)
-                        if not isinstance(metadata, dict):
-                            if hasattr(metadata, 'model_dump'):
-                                metadata = metadata.model_dump()
-                            elif hasattr(metadata, '__dict__'):
-                                metadata = metadata.__dict__
-                            else:
-                                metadata = {}
-
-                        # Get title from metadata
-                        title = metadata.get("title", "")
-
-                        # Re-check final URL after redirect
-                        final_url = metadata.get("sourceURL", url)
-                        final_blocked = check_website_access(final_url)
-                        if final_blocked:
-                            logger.info("Blocked redirected web_extract for %s by rule %s", final_blocked["host"], final_blocked["rule"])
-                            results.append({
-                                "url": final_url, "title": title, "content": "", "raw_content": "",
-                                "error": final_blocked["message"],
-                                "blocked_by_policy": {"host": final_blocked["host"], "rule": final_blocked["rule"], "source": final_blocked["source"]},
-                            })
-                            continue
-
-                        # Choose content based on requested format
-                        chosen_content = content_markdown if (format == "markdown" or (format is None and content_markdown)) else content_html or content_markdown or ""
-
-                        results.append({
-                            "url": final_url,
-                            "title": title,
-                            "content": chosen_content,
-                            "raw_content": chosen_content,
-                            "metadata": metadata  # Now guaranteed to be a dict
-                        })
-
-                    except Exception as scrape_err:
-                        logger.debug("Scrape failed for %s: %s", url, scrape_err)
-                        results.append({
-                            "url": url,
-                            "title": "",
-                            "content": "",
-                            "raw_content": "",
-                            "error": str(scrape_err)
-                        })
+            results = await _extract_urls_via_backend(safe_urls, format, backend)
+            results = _mark_extract_mode(
+                results,
+                requested_mode=requested_mode,
+                extraction_mode="static",
+            )
 
         # Merge any SSRF-blocked results back in
         if ssrf_blocked:
             results = ssrf_blocked + results
 
+        results = [_enrich_extract_result(result, backend=backend) for result in results]
         response = {"results": results}
         
         pages_extracted = len(response.get('results', []))
@@ -1447,14 +1965,16 @@ async def web_extract_tool(
                 content_length = len(result.get('raw_content', ''))
                 logger.info("%s (%d characters)", url, content_length)
         
-        # Trim output to minimal fields per entry: title, content, error
+        # Trim output to minimal useful fields per entry.
         trimmed_results = [
             {
                 "url": r.get("url", ""),
                 "title": r.get("title", ""),
                 "content": r.get("content", ""),
+                "excerpt": r.get("excerpt", ""),
+                "metadata": r.get("metadata", {}),
                 "error": r.get("error"),
-                **({  "blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
+                **({"blocked_by_policy": r["blocked_by_policy"]} if "blocked_by_policy" in r else {}),
             }
             for r in response.get("results", [])
         ]
@@ -1922,9 +2442,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "duckduckgo"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "duckduckgo"))
 
 
 def check_auxiliary_model() -> bool:
@@ -2071,6 +2591,12 @@ WEB_EXTRACT_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
                 "maxItems": 5
+            },
+            "mode": {
+                "type": "string",
+                "description": "Extraction mode: 'static' uses HTTP/provider extraction; 'dynamic' renders via the browser stack first; 'attached' prefers an existing CDP/browser session for profile/login-state reuse, then falls back to static extraction on failure.",
+                "enum": ["static", "dynamic", "attached"],
+                "default": "static"
             }
         },
         "required": ["urls"]
@@ -2092,7 +2618,10 @@ registry.register(
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
+        "markdown",
+        mode=args.get("mode", "static"),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     is_async=True,

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/a0/87/1d7019d23891897cb
 
 [[package]]
 name = "alibabacloud-dingtalk"
-version = "2.2.42"
+version = "2.2.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alibabacloud-endpoint-util" },
@@ -207,9 +207,9 @@ dependencies = [
     { name = "alibabacloud-tea-openapi" },
     { name = "alibabacloud-tea-util" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/66/36efc03a2a8ed16c2ce176fd5ab6ff9725d0048aef33eaf867e85e625401/alibabacloud_dingtalk-2.2.42.tar.gz", hash = "sha256:220b1d52f5ef82a23ea625d3c8a91a733a685417248e217cf5aa30fe0b3a8978", size = 2023797, upload-time = "2026-04-10T03:58:28.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/14/a99e47d457b861d69b30296e1c672cd2465dfade0a105d2f529e5713e46e/alibabacloud_dingtalk-2.2.43.tar.gz", hash = "sha256:91b954b1c9c01c8174e926dfaac664f48e6262cb31882f35cf575e319a9a7c87", size = 2033585, upload-time = "2026-04-16T06:52:52.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/80/7d1c1438e17c1fc90d037f1b73debe3fc2dfa348eb91e12818c2584d1865/alibabacloud_dingtalk-2.2.42-py3-none-any.whl", hash = "sha256:5f5c2ef3351b7926eb870af11089e14f802e4caa51d5f72920ad79a67f03d3e4", size = 2142688, upload-time = "2026-04-10T03:58:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d9/6ed5cff62932497d6d8a99f6ae6f1d04b80a5253f4d8c3d9d7a504e19ab5/alibabacloud_dingtalk-2.2.43-py3-none-any.whl", hash = "sha256:73a40a3e8fb0313c02e13f2c58462502b83cdcb9f54206f1c3830f902d955f32", size = 2152475, upload-time = "2026-04-16T06:52:50.356Z" },
 ]
 
 [[package]]
@@ -426,7 +426,7 @@ wheels = [
 [[package]]
 name = "atroposlib"
 version = "0.4.0"
-source = { git = "https://github.com/NousResearch/atropos.git#c421582b6f7ce8a32f751aab3117d3824ac8f709" }
+source = { git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30#c20c85256e5a45ad31edf8b7276e9c5ee1995a30" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -541,6 +541,15 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "base58"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -556,6 +565,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/c0/98b8cec7ca22dde776df48c58940ae1abc425593959b7226e270760d726f/boto3-1.42.91.tar.gz", hash = "sha256:03d70532b17f7f84df37ca7e8c21553280454dea53ae12b15d1cfef9b16fcb8a", size = 113181, upload-time = "2026-04-17T19:31:06.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/29/faba6521257c34085cc9b439ef98235b581772580f417fa3629728007270/boto3-1.42.91-py3-none-any.whl", hash = "sha256:04e72071cde022951ce7f81bd9933c90095ab8923e8ced61c8dacfe9edac0f5c", size = 140553, upload-time = "2026-04-17T19:31:02.57Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/bc/a4b7c46471c2e789ad8c4c7acfd7f302fdb481d93ff870f441249b924ae6/botocore-1.42.91.tar.gz", hash = "sha256:d252e27bc454afdbf5ed3dc617aa423f2c855c081e98b7963093399483ecc698", size = 15213010, upload-time = "2026-04-17T19:30:50.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl", hash = "sha256:7a28c3cc6bfab5724ad18899d52402b776a0de7d87fa20c3c5270bcaaf199ce8", size = 14897344, upload-time = "2026-04-17T19:30:44.245Z" },
 ]
 
 [[package]]
@@ -869,6 +906,20 @@ wheels = [
 ]
 
 [[package]]
+name = "courlan"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "tld" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/54/6d6ceeff4bed42e7a10d6064d35ee43a810e7b3e8beb4abeae8cff4713ae/courlan-1.3.2.tar.gz", hash = "sha256:0b66f4db3a9c39a6e22dd247c72cfaa57d68ea660e94bb2c84ec7db8712af190", size = 206382, upload-time = "2024-10-29T16:40:20.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/ca/6a667ccbe649856dcd3458bab80b016681b274399d6211187c6ab969fc50/courlan-1.3.2-py3-none-any.whl", hash = "sha256:d0dab52cf5b5b1000ee2839fbc2837e93b2514d3cb5bb61ae158a55b7a04c6be", size = 33848, upload-time = "2024-10-29T16:40:18.325Z" },
+]
+
+[[package]]
 name = "croniter"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1022,6 +1073,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/22/73e46ac7a8c25e7ef0b3bd6f10da3465021d90219a32eb0b4d2afea4c56e/datasets-4.8.4.tar.gz", hash = "sha256:a1429ed853275ce7943a01c6d2e25475b4501eb758934362106a280470df3a52", size = 604382, upload-time = "2026-03-23T14:21:17.987Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/e5/247d094108e42ac26363ab8dc57f168840cf7c05774b40ffeb0d78868fcc/datasets-4.8.4-py3-none-any.whl", hash = "sha256:cdc8bee4698e549d78bf1fed6aea2eebc760b22b084f07e6fc020c6577a6ce6d", size = 526991, upload-time = "2026-03-23T14:21:15.89Z" },
+]
+
+[[package]]
+name = "dateparser"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "regex" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/2d/a0ccdb78788064fa0dc901b8524e50615c42be1d78b78d646d0b28d09180/dateparser-1.4.0.tar.gz", hash = "sha256:97a21840d5ecdf7630c584f673338a5afac5dfe84f647baf4d7e8df98f9354a4", size = 321512, upload-time = "2026-03-26T09:56:10.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/0b/3c3bb7cbe757279e693a0be6049048012f794d01f81099609ecd53b899f0/dateparser-1.4.0-py3-none-any.whl", hash = "sha256:7902b8e85d603494bf70a5a0b1decdddb2270b9c6e6b2bc8a57b93476c0df378", size = 300379, upload-time = "2026-03-26T09:56:08.409Z" },
 ]
 
 [[package]]
@@ -1838,7 +1904,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1859,6 +1925,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "tenacity" },
+    { name = "trafilatura" },
 ]
 
 [package.optional-dependencies]
@@ -1871,6 +1938,7 @@ all = [
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
     { name = "alibabacloud-dingtalk" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
+    { name = "boto3" },
     { name = "croniter" },
     { name = "daytona" },
     { name = "debugpy" },
@@ -1893,11 +1961,15 @@ all = [
     { name = "pytest-xdist" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
+    { name = "qrcode" },
     { name = "simple-term-menu" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sounddevice" },
     { name = "uvicorn", extra = ["standard"] },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cli = [
     { name = "simple-term-menu" },
@@ -1918,9 +1990,11 @@ dev = [
 dingtalk = [
     { name = "alibabacloud-dingtalk" },
     { name = "dingtalk-stream" },
+    { name = "qrcode" },
 ]
 feishu = [
     { name = "lark-oapi" },
+    { name = "qrcode" },
 ]
 homeassistant = [
     { name = "aiohttp" },
@@ -1941,6 +2015,7 @@ messaging = [
     { name = "aiohttp" },
     { name = "discord-py", extra = ["voice"] },
     { name = "python-telegram-bot", extra = ["webhooks"] },
+    { name = "qrcode" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
@@ -1974,6 +2049,7 @@ termux = [
     { name = "honcho-ai" },
     { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "simple-term-menu" },
 ]
@@ -2003,7 +2079,8 @@ requires-dist = [
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = ">=2.0.0" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = ">=0.29" },
-    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git" },
+    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
     { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
@@ -2020,6 +2097,7 @@ requires-dist = [
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
@@ -2066,8 +2144,12 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = ">=22.6,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
+    { name = "qrcode", marker = "extra == 'dingtalk'", specifier = ">=7.0,<8" },
+    { name = "qrcode", marker = "extra == 'feishu'", specifier = ">=7.0,<8" },
+    { name = "qrcode", marker = "extra == 'messaging'", specifier = ">=7.0,<8" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
@@ -2077,13 +2159,14 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0,<4" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
-    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
+    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b" },
+    { name = "trafilatura", specifier = ">=2.0.0,<3" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
-    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
+    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2170,6 +2253,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
+name = "htmldate"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "dateparser" },
+    { name = "lxml" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/10/ead9dabc999f353c3aa5d0dc0835b1e355215a5ecb489a7f4ef2ddad5e33/htmldate-1.9.4.tar.gz", hash = "sha256:1129063e02dd0354b74264de71e950c0c3fcee191178321418ccad2074cc8ed0", size = 44690, upload-time = "2025-11-04T17:46:44.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/bd/adfcdaaad5805c0c5156aeefd64c1e868c05e9c1cd6fd21751f168cd88c7/htmldate-1.9.4-py3-none-any.whl", hash = "sha256:1b94bcc4e08232a5b692159903acf95548b6a7492dddca5bb123d89d6325921c", size = 31558, upload-time = "2025-11-04T17:46:43.258Z" },
 ]
 
 [[package]]
@@ -2411,6 +2510,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2465,6 +2573,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "justext"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml", extra = ["html-clean"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f3/45890c1b314f0d04e19c1c83d534e611513150939a7cf039664d9ab1e649/justext-3.0.2.tar.gz", hash = "sha256:13496a450c44c4cd5b5a75a5efcd9996066d2a189794ea99a49949685a0beb05", size = 828521, upload-time = "2025-02-25T20:21:49.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ac/52f4e86d1924a7fc05af3aeb34488570eccc39b4af90530dd6acecdf16b5/justext-3.0.2-py2.py3-none-any.whl", hash = "sha256:62b1c562b15c3c6265e121cc070874243a443bfd53060e869393f09d6b6cc9a7", size = 837940, upload-time = "2025-02-25T20:21:44.179Z" },
 ]
 
 [[package]]
@@ -2622,6 +2742,125 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/0c/62a0fdc5adae6d205338f9239175aa6a93818e58b75cf000a9c7214a3d9f/litellm-1.81.15.tar.gz", hash = "sha256:a8a6277a53280762051c5818ebc76dd5f036368b9426c6f21795ae7f1ac6ebdc", size = 16597039, upload-time = "2026-02-24T06:52:50.892Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/fd/da11826dda0d332e360b9ead6c0c992d612ecb85b00df494823843cfcda3/litellm-1.81.15-py3-none-any.whl", hash = "sha256:2fa253658702509ce09fe0e172e5a47baaadf697fb0f784c7fd4ff665ae76ae1", size = 14682123, upload-time = "2026-02-24T06:52:48.084Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/5d/3bccad330292946f97962df9d5f2d3ae129cce6e212732a781e856b91e07/lxml-6.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cec05be8c876f92a5aa07b01d60bbb4d11cfbdd654cad0561c0d7b5c043a61b9", size = 8526232, upload-time = "2026-04-18T04:27:40.389Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/adc8826570a112f83bb4ddb3a2ab510bbc2ccd62c1b9fe1f34fae2d90b57/lxml-6.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9c03e048b6ce8e77b09c734e931584894ecd58d08296804ca2d0b184c933ce50", size = 4595448, upload-time = "2026-04-18T04:27:44.208Z" },
+    { url = "https://files.pythonhosted.org/packages/54/84/5a9ec07cbe1d2334a6465f863b949a520d2699a755738986dcd3b6b89e3f/lxml-6.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:942454ff253da14218f972b23dc72fa4edf6c943f37edd19cd697618b626fac5", size = 4923771, upload-time = "2026-04-18T04:32:17.402Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/23/851cfa33b6b38adb628e45ad51fb27105fa34b2b3ba9d1d4aa7a9428dfe0/lxml-6.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d036ee7b99d5148072ac7c9b847193decdfeac633db350363f7bce4fff108f0e", size = 5068101, upload-time = "2026-04-18T04:32:21.437Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/38/41bf99c2023c6b79916ba057d83e9db21d642f473cac210201222882d38b/lxml-6.1.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ae5d8d5427f3cc317e7950f2da7ad276df0cfa37b8de2f5658959e618ea8512", size = 5002573, upload-time = "2026-04-18T04:32:25.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/20/053aa10bdc39747e1e923ce2d45413075e84f70a136045bb09e5eaca41d3/lxml-6.1.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:363e47283bde87051b821826e71dde47f107e08614e1aa312ba0c5711e77738c", size = 5202816, upload-time = "2026-04-18T04:32:29.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/da/bc710fad8bf04b93baee752c192eaa2210cd3a84f969d0be7830fea55802/lxml-6.1.0-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:f504d861d9f2a8f94020130adac88d66de93841707a23a86244263d1e54682f5", size = 5329999, upload-time = "2026-04-18T04:32:34.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/bf035dedbdf7fab49411aa52e4236f3445e98d38647d85419e6c0d2806b9/lxml-6.1.0-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:23a5dc68e08ed13331d61815c08f260f46b4a60fdd1640bbeb82cf89a9d90289", size = 4659643, upload-time = "2026-04-18T04:32:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/22be31f33727a5e4c7b01b0a874503026e50329b259d3587e0b923cf964b/lxml-6.1.0-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f15401d8d3dbf239e23c818afc10c7207f7b95f9a307e092122b6f86dd43209a", size = 5265963, upload-time = "2026-04-18T04:32:41.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2b/d44d0e5c79226017f4ab8c87a802ebe4f89f97e6585a8e4166dffcdd7b6e/lxml-6.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fcf3da95e93349e0647d48d4b36a12783105bcc74cb0c416952f9988410846a3", size = 5045444, upload-time = "2026-04-18T04:32:44.512Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/c3/3f034fec1594c331a6dbf9491238fdcc9d66f68cc529e109ec75b97197e1/lxml-6.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0d082495c5fcf426e425a6e28daaba1fcb6d8f854a4ff01effb1f1f381203eb9", size = 4712703, upload-time = "2026-04-18T04:32:47.16Z" },
+    { url = "https://files.pythonhosted.org/packages/12/16/0b83fccc158218aca75a7aa33e97441df737950734246b9fffa39301603d/lxml-6.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:e3c4f84b24a1fcba435157d111c4b755099c6ff00a3daee1ad281817de75ed11", size = 5252745, upload-time = "2026-04-18T04:32:50.427Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ee/12e6c1b39a77666c02eaa77f94a870aaf63c4ac3a497b2d52319448b01c6/lxml-6.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:976a6b39b1b13e8c354ad8d3f261f3a4ac6609518af91bdb5094760a08f132c4", size = 5226822, upload-time = "2026-04-18T04:32:53.437Z" },
+    { url = "https://files.pythonhosted.org/packages/34/20/c7852904858b4723af01d2fc14b5d38ff57cb92f01934a127ebd9a9e51aa/lxml-6.1.0-cp311-cp311-win32.whl", hash = "sha256:857efde87d365706590847b916baff69c0bc9252dc5af030e378c9800c0b10e3", size = 3594026, upload-time = "2026-04-18T04:27:31.903Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/d60c732b56da5085175c07c74b2df4e6d181b0c9a61e1691474f06ef4b39/lxml-6.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:183bfb45a493081943be7ea2b5adfc2b611e1cf377cefa8b8a8be404f45ef9a7", size = 4025114, upload-time = "2026-04-18T04:27:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/df/c84dcc175fd690823436d15b41cb920cd5ba5e14cd8bfb00949d5903b320/lxml-6.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:19f4164243fc206d12ed3d866e80e74f5bc3627966520da1a5f97e42c32a3f39", size = 3667742, upload-time = "2026-04-18T04:27:38.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+    { url = "https://files.pythonhosted.org/packages/08/03/69347590f1cf4a6d5a4944bb6099e6d37f334784f16062234e1f892fdb1d/lxml-6.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a0092f2b107b69601adf562a57c956fbb596e05e3e6651cabd3054113b007e45", size = 8559689, upload-time = "2026-04-18T04:31:57.785Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/25e00bb40b185c974cfe156c110474d9a8a8390d5f7c92a4e328189bb60e/lxml-6.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fc7140d7a7386e6b545d41b7358f4d02b656d4053f5fa6859f92f4b9c2572c4d", size = 4617892, upload-time = "2026-04-18T04:32:01.78Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/54/92ad98a94ac318dc4f97aaac22ff8d1b94212b2ae8af5b6e9b354bf825f7/lxml-6.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:419c58fc92cc3a2c3fa5f78c63dbf5da70c1fa9c1b25f25727ecee89a96c7de2", size = 4923489, upload-time = "2026-04-18T04:33:31.401Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/a20aecfab42bdf4f9b390590d345857ad3ffd7c51988d1c89c53a0c73faf/lxml-6.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37fabd1452852636cf38ecdcc9dd5ca4bba7a35d6c53fa09725deeb894a87491", size = 5082162, upload-time = "2026-04-18T04:33:34.262Z" },
+    { url = "https://files.pythonhosted.org/packages/45/26/2cdb3d281ac1bd175603e290cbe4bad6eff127c0f8de90bafd6f8548f0fd/lxml-6.1.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2853c8b2170cc6cd54a6b4d50d2c1a8a7aeca201f23804b4898525c7a152cfc", size = 4993247, upload-time = "2026-04-18T04:33:36.674Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/05/d735aef963740022a08185c84821f689fc903acb3d50326e6b1e9886cc22/lxml-6.1.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8e369cbd690e788c8d15e56222d91a09c6a417f49cbc543040cba0fe2e25a79e", size = 5613042, upload-time = "2026-04-18T04:33:39.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/ead7c10efff731738c72e59ed6eb5791854879fbed7ae98781a12006263a/lxml-6.1.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e69aa6805905807186eb00e66c6d97a935c928275182eb02ee40ba00da9623b2", size = 5228304, upload-time = "2026-04-18T04:33:41.647Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/10/e9842d2ec322ea65f0a7270aa0315a53abed06058b88ef1b027f620e7a5f/lxml-6.1.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:4bd1bdb8a9e0e2dd229de19b5f8aebac80e916921b4b2c6ef8a52bc131d0c1f9", size = 5341578, upload-time = "2026-04-18T04:33:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/89/54/40d9403d7c2775fa7301d3ddd3464689bfe9ba71acc17dfff777071b4fdc/lxml-6.1.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:cbd7b79cdcb4986ad78a2662625882747f09db5e4cd7b2ae178a88c9c51b3dfe", size = 4700209, upload-time = "2026-04-18T04:33:47.552Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/bbdcc2cf45dfc7dfffef4fd97e5c47b15919b6a365247d95d6f684ef5e82/lxml-6.1.0-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:43e4d297f11080ec9d64a4b1ad7ac02b4484c9f0e2179d9c4ef78e886e747b88", size = 5232365, upload-time = "2026-04-18T04:33:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/b06875665e53aaba7127611a7bed3b7b9658e20b22bc2dd217a0b7ab0091/lxml-6.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cc16682cc987a3da00aa56a3aa3075b08edb10d9b1e476938cfdbee8f3b67181", size = 5043654, upload-time = "2026-04-18T04:33:52.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9c/e71a069d09641c1a7abeb30e693f828c7c90a41cbe3d650b2d734d876f85/lxml-6.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:d6d8efe71429635f0559579092bb5e60560d7b9115ee38c4adbea35632e7fa24", size = 4769326, upload-time = "2026-04-18T04:33:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/06/7a9cd84b3d4ed79adf35f874750abb697dec0b4a81a836037b36e47c091a/lxml-6.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:7e39ab3a28af7784e206d8606ec0e4bcad0190f63a492bca95e94e5a4aef7f6e", size = 5635879, upload-time = "2026-04-18T04:33:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/9d57916befc1e54c451712c7ee48e9e74e80ae4d03bdce49914e0aee42cd/lxml-6.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9eb667bf50856c4a58145f8ca2d5e5be160191e79eb9e30855a476191b3c3495", size = 5224048, upload-time = "2026-04-18T04:34:00.943Z" },
+    { url = "https://files.pythonhosted.org/packages/99/75/90c4eefda0c08c92221fe0753db2d6699a4c628f76ff4465ec20dea84cc1/lxml-6.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7f4a77d6f7edf9230cee3e1f7f6764722a41604ee5681844f18db9a81ea0ec33", size = 5250241, upload-time = "2026-04-18T04:34:03.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/73/16596f7e4e38fa33084b9ccbccc22a15f82a290a055126f2c1541236d2ff/lxml-6.1.0-cp313-cp313-win32.whl", hash = "sha256:28902146ffbe5222df411c5d19e5352490122e14447e98cd118907ee3fd6ee62", size = 3596938, upload-time = "2026-04-18T04:31:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/63/981401c5680c1eb30893f00a19641ac80db5d1e7086c62cb4b13ed813038/lxml-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:4a1503c56e4e2b38dc76f2f2da7bae69670c0f1933e27cfa34b2fa5876410b16", size = 3995728, upload-time = "2026-04-18T04:31:58.763Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/c358a38ac3e541d16a1b527e4e9cb78c0419b0506a070ace11777e5e8404/lxml-6.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:e0af85773850417d994d019741239b901b22c6680206f46a34766926e466141d", size = 3658372, upload-time = "2026-04-18T04:32:03.629Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/45/cee4cf203ef0bab5c52afc118da61d6b460c928f2893d40023cfa27e0b80/lxml-6.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ab863fd37458fed6456525f297d21239d987800c46e67da5ef04fc6b3dd93ac8", size = 8576713, upload-time = "2026-04-18T04:32:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a7/eda05babeb7e046839204eaf254cd4d7c9130ce2bbf0d9e90ea41af5654d/lxml-6.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6fd8b1df8254ff4fd93fd31da1fc15770bde23ac045be9bb1f87425702f61cc9", size = 4623874, upload-time = "2026-04-18T04:32:10.755Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e9/db5846de9b436b91890a62f29d80cd849ea17948a49bf532d5278ee69a9e/lxml-6.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:47024feaae386a92a146af0d2aeed65229bf6fff738e6a11dda6b0015fb8fd03", size = 4949535, upload-time = "2026-04-18T04:34:06.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ba/0d3593373dcae1d68f40dc3c41a5a92f2544e68115eb2f62319a4c2a6500/lxml-6.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f00972f84450204cd5d93a5395965e348956aaceaadec693a22ec743f8ae3eb", size = 5086881, upload-time = "2026-04-18T04:34:09.556Z" },
+    { url = "https://files.pythonhosted.org/packages/43/76/759a7484539ad1af0d125a9afe9c3fb5f82a8779fd1f5f56319d9e4ea2fd/lxml-6.1.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97faa0860e13b05b15a51fb4986421ef7a30f0b3334061c416e0981e9450ca4c", size = 5031305, upload-time = "2026-04-18T04:34:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/c1f0daf981a11e47636126901fd4ab82429e18c57aeb0fc3ad2940b42d8b/lxml-6.1.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:972a6451204798675407beaad97b868d0c733d9a74dafefc63120b81b8c2de28", size = 5647522, upload-time = "2026-04-18T04:34:14.89Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/1f533dcd205275363d9ba3511bcec52fa2df86abf8abe6a5f2c599f0dc31/lxml-6.1.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fe022f20bc4569ec66b63b3fb275a3d628d9d32da6326b2982584104db6d3086", size = 5239310, upload-time = "2026-04-18T04:34:17.652Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/8c/4175fb709c78a6e315ed814ed33be3defd8b8721067e70419a6cf6f971da/lxml-6.1.0-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:75c4c7c619a744f972f4451bf5adf6d0fb00992a1ffc9fd78e13b0bc817cc99f", size = 5350799, upload-time = "2026-04-18T04:34:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/77/6ffdebc5994975f0dde4acb59761902bd9d9bb84422b9a0bd239a7da9ca8/lxml-6.1.0-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3648f20d25102a22b6061c688beb3a805099ea4beb0a01ce62975d926944d292", size = 4697693, upload-time = "2026-04-18T04:34:23.541Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f1/565f36bd5c73294602d48e04d23f81ff4c8736be6ba5e1d1ec670ac9be80/lxml-6.1.0-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:77b9f99b17cbf14026d1e618035077060fc7195dd940d025149f3e2e830fbfcb", size = 5250708, upload-time = "2026-04-18T04:34:26.001Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/11/a68ab9dd18c5c499404deb4005f4bc4e0e88e5b72cd755ad96efec81d18d/lxml-6.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32662519149fd7a9db354175aa5e417d83485a8039b8aaa62f873ceee7ea4cad", size = 5084737, upload-time = "2026-04-18T04:34:28.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/78/e8f41e2c74f4af564e6a0348aea69fb6daaefa64bc071ef469823d22cc18/lxml-6.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:73d658216fc173cf2c939e90e07b941c5e12736b0bf6a99e7af95459cfe8eabb", size = 4737817, upload-time = "2026-04-18T04:34:30.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/2d/aa4e117aa2ce2f3b35d9ff246be74a2f8e853baba5d2a92c64744474603a/lxml-6.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:ac4db068889f8772a4a698c5980ec302771bb545e10c4b095d4c8be26749616f", size = 5670753, upload-time = "2026-04-18T04:34:33.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f5/dd745d50c0409031dbfcc4881740542a01e54d6f0110bd420fa7782110b8/lxml-6.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:45e9dfbd1b661eb64ba0d4dbe762bd210c42d86dd1e5bd2bdf89d634231beb43", size = 5238071, upload-time = "2026-04-18T04:34:36.12Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/ad424f36d0340a904665867dab310a3f1f4c96ff4039698de83b77f44c1f/lxml-6.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:89e8d73d09ac696a5ba42ec69787913d53284f12092f651506779314f10ba585", size = 5264319, upload-time = "2026-04-18T04:34:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/53/36/a15d8b3514ec889bfd6aa3609107fcb6c9189f8dc347f1c0b81eded8d87c/lxml-6.1.0-cp314-cp314-win32.whl", hash = "sha256:ebe33f4ec1b2de38ceb225a1749a2965855bffeef435ba93cd2d5d540783bf2f", size = 3657139, upload-time = "2026-04-18T04:32:20.006Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/263ebb0710851a3c6c937180a9a86df1206fdfe53cc43005aa2237fd7736/lxml-6.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:398443df51c538bd578529aa7e5f7afc6c292644174b47961f3bf87fe5741120", size = 4064195, upload-time = "2026-04-18T04:32:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/80/68/2000f29d323b6c286de077ad20b429fc52272e44eae6d295467043e56012/lxml-6.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:8c8984e1d8c4b3949e419158fda14d921ff703a9ed8a47236c6eb7a2b6cb4946", size = 3741870, upload-time = "2026-04-18T04:32:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e9/21383c7c8d43799f0da90224c0d7c921870d476ec9b3e01e1b2c0b8237c5/lxml-6.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1081dd10bc6fa437db2500e13993abf7cc30716d0a2f40e65abb935f02ec559c", size = 8827548, upload-time = "2026-04-18T04:32:15.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/01/c6bc11cd587030dd4f719f65c5657960649fe3e19196c844c75bf32cd0d6/lxml-6.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:dabecc48db5f42ba348d1f5d5afdc54c6c4cc758e676926c7cd327045749517d", size = 4735866, upload-time = "2026-04-18T04:32:18.924Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/757132fff5f4acf25463b5298f1a46099f3a94480b806547b29ce5e385de/lxml-6.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e3dd5fe19c9e0ac818a9c7f132a5e43c1339ec1cbbfecb1a938bd3a47875b7c9", size = 4969476, upload-time = "2026-04-18T04:34:41.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/fb/1bc8b9d27ed64be7c8903db6c89e74dc8c2cd9ec630a7462e4654316dc5b/lxml-6.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9e7b0a4ca6dcc007a4cef00a761bba2dea959de4bd2df98f926b33c92ca5dfb9", size = 5103719, upload-time = "2026-04-18T04:34:44.797Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/5bf82fa28133536a54601aae633b14988e89ed61d4c1eb6b899b023233aa/lxml-6.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d27bbe326c6b539c64b42638b18bc6003a8d88f76213a97ac9ed4f885efeab7", size = 5027890, upload-time = "2026-04-18T04:34:47.634Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/20/e048db5d4b4ea0366648aa595f26bb764b2670903fc585b87436d0a5032c/lxml-6.1.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4e425db0c5445ef0ad56b0eec54f89b88b2d884656e536a90b2f52aecb4ca86", size = 5596008, upload-time = "2026-04-18T04:34:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c2/d10807bc8da4824b39e5bd01b5d05c077b6fd01bd91584167edf6b269d22/lxml-6.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b89b098105b8599dc57adac95d1813409ac476d3c948a498775d3d0c6124bfb", size = 5224451, upload-time = "2026-04-18T04:34:54.263Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/15/2ebea45bea427e7f0057e9ce7b2d62c5aba20c6b001cca89ed0aadb3ad41/lxml-6.1.0-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:c4a699432846df86cc3de502ee85f445ebad748a1c6021d445f3e514d2cd4b1c", size = 5312135, upload-time = "2026-04-18T04:34:56.818Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e2/87eeae151b0be2a308d49a7ec444ff3eb192b14251e62addb29d0bf3778f/lxml-6.1.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:30e7b2ed63b6c8e97cca8af048589a788ab5c9c905f36d9cf1c2bb549f450d2f", size = 4639126, upload-time = "2026-04-18T04:34:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/51/8a3f6a20902ad604dd746ec7b4000311b240d389dac5e9d95adefd349e0c/lxml-6.1.0-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:022981127642fe19866d2907d76241bb07ed21749601f727d5d5dd1ce5d1b773", size = 5232579, upload-time = "2026-04-18T04:35:02.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d2/650d619bdbe048d2c3f2c31edb00e35670a5e2d65b4fe3b61bce37b19121/lxml-6.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:23cad0cc86046d4222f7f418910e46b89971c5a45d3c8abfad0f64b7b05e4a9b", size = 5084206, upload-time = "2026-04-18T04:35:05.175Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8a/672ca1a3cbeabd1f511ca275a916c0514b747f4b85bdaae103b8fa92f307/lxml-6.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:21c3302068f50d1e8728c67c87ba92aa87043abee517aa2576cca1855326b405", size = 4758906, upload-time = "2026-04-18T04:35:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f1/ef4b691da85c916cb2feb1eec7414f678162798ac85e042fa164419ac05c/lxml-6.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:be10838781cb3be19251e276910cd508fe127e27c3242e50521521a0f3781690", size = 5620553, upload-time = "2026-04-18T04:35:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/59/17/94e81def74107809755ac2782fdad4404420f1c92ca83433d117a6d5acf0/lxml-6.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2173a7bffe97667bbf0767f8a99e587740a8c56fdf3befac4b09cb29a80276fd", size = 5229458, upload-time = "2026-04-18T04:35:14.254Z" },
+    { url = "https://files.pythonhosted.org/packages/21/55/c4be91b0f830a871fc1b0d730943d56013b683d4671d5198260e2eae722b/lxml-6.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c6854e9cf99c84beb004eecd7d3a3868ef1109bf2b1df92d7bc11e96a36c2180", size = 5247861, upload-time = "2026-04-18T04:35:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ca/77123e4d77df3cb1e968ade7b1f808f5d3a5c1c96b18a33895397de292c1/lxml-6.1.0-cp314-cp314t-win32.whl", hash = "sha256:00750d63ef0031a05331b9223463b1c7c02b9004cef2346a5b2877f0f9494dd2", size = 3897377, upload-time = "2026-04-18T04:32:07.656Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ce/3554833989d074267c063209bae8b09815e5656456a2d332b947806b05ff/lxml-6.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:80410c3a7e3c617af04de17caa9f9f20adaa817093293d69eae7d7d0522836f5", size = 4392701, upload-time = "2026-04-18T04:32:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a0/9b916c68c0e57752c07f8f64b30138d9d4059dbeb27b90274dedbea128ff/lxml-6.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:26dd9f57ee3bd41e7d35b4c98a2ffd89ed11591649f421f0ec19f67d50ec67ac", size = 3817120, upload-time = "2026-04-18T04:32:15.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/55143966481409b1740a3ac669e611055f49efd68087a5ce41582325db3e/lxml-6.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:546b66c0dd1bb8d9fa89d7123e5fa19a8aff3a1f2141eb22df96112afb17b842", size = 3930134, upload-time = "2026-04-18T04:32:35.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/97/28b985c2983938d3cb696dd5501423afb90a8c3e869ef5d3c62569282c0f/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5cfa1a34df366d9dc0d5eaf420f4cf2bb1e1bebe1066d1c2fc28c179f8a4004c", size = 4210749, upload-time = "2026-04-18T04:36:03.626Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/dfab2b7d58214921935ccea7ce9b3df9b7d46f305d12f0f532ac7cf6b804/lxml-6.1.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db88156fcf544cdbf0d95588051515cfdfd4c876fc66444eb98bceb5d6db76de", size = 4318463, upload-time = "2026-04-18T04:36:06.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a2/4ac7eb32a4d997dd352c32c32399aae27b3f268d440e6f9cfa405b575d2f/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:07f98f5496f96bf724b1e3c933c107f0cbf2745db18c03d2e13a291c3afd2635", size = 4251124, upload-time = "2026-04-18T04:36:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/d6abd850bb4822f9b720cfe36b547a558e694881010ff7d012191e8769c6/lxml-6.1.0-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4642e04449a1e164b5ff71ffd901ddb772dfabf5c9adf1b7be5dffe1212bc037", size = 4401758, upload-time = "2026-04-18T04:36:11.803Z" },
+    { url = "https://files.pythonhosted.org/packages/40/44/3ee09a5b60cb44c4f2fbc1c9015cfd6ff5afc08f991cab295d3024dcbf2d/lxml-6.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:7da13bb6fbadfafb474e0226a30570a3445cfd47c86296f2446dafbd77079ace", size = 3508860, upload-time = "2026-04-18T04:32:48.619Z" },
+]
+
+[package.optional-dependencies]
+html-clean = [
+    { name = "lxml-html-clean" },
+]
+
+[[package]]
+name = "lxml-html-clean"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/a4/5c62acfacd69ff4f5db395100f5cfb9b54e7ac8c69a235e4e939fd13f021/lxml_html_clean-0.4.4.tar.gz", hash = "sha256:58f39a9d632711202ed1d6d0b9b47a904e306c85de5761543b90e3e3f736acfb", size = 23899, upload-time = "2026-02-27T09:35:52.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/76/7ffc1d3005cf7749123bc47cb3ea343cd97b0ac2211bab40f57283577d0e/lxml_html_clean-0.4.4-py3-none-any.whl", hash = "sha256:ce2ef506614ecb85ee1c5fe0a2aa45b06a19514ec7949e9c8f34f06925cfabcb", size = 14565, upload-time = "2026-02-27T09:35:51.86Z" },
 ]
 
 [[package]]
@@ -4110,6 +4349,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypng"
+version = "0.20220715.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4309,6 +4557,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "7.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pypng" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/35/ad6d4c5a547fe9a5baf85a9edbafff93fc6394b014fab30595877305fa59/qrcode-7.4.2.tar.gz", hash = "sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845", size = 535974, upload-time = "2023-02-05T22:11:46.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/79/aaf0c1c7214f2632badb2771d770b1500d3d7cbdf2590ae62e721ec50584/qrcode-7.4.2-py3-none-any.whl", hash = "sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a", size = 46197, upload-time = "2023-02-05T22:11:43.4Z" },
 ]
 
 [[package]]
@@ -4575,6 +4837,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]
@@ -4927,8 +5201,8 @@ wheels = [
 
 [[package]]
 name = "tinker"
-version = "0.16.1"
-source = { git = "https://github.com/thinking-machines-lab/tinker.git#07bd3c2dd3cd4398ac1c26f0ec0deccbf3c1f913" }
+version = "0.18.0"
+source = { git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b#30517b667f18a3dfb7ef33fb56cf686d5820ba2b" }
 dependencies = [
     { name = "anyio" },
     { name = "click" },
@@ -4940,6 +5214,15 @@ dependencies = [
     { name = "sniffio" },
     { name = "transformers" },
     { name = "typing-extensions" },
+]
+
+[[package]]
+name = "tld"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5d/76b4383ac4e5b5e254e50c09807b3e13820bed6d6c11cd540264988d6802/tld-0.13.2.tar.gz", hash = "sha256:d983fa92b9d717400742fca844e29d5e18271079c7bcfabf66d01b39b4a14345", size = 467175, upload-time = "2026-03-06T23:50:34.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/90/39a85a4b63c84213e78b3c17d22e1bf45328acf8ebb33ef93be30d0a3911/tld-0.13.2-py2.py3-none-any.whl", hash = "sha256:9b8fdbdb880e7ba65b216a4937f2c94c49a7226723783d5838fc958ac76f4e0c", size = 296743, upload-time = "2026-03-06T23:50:32.465Z" },
 ]
 
 [[package]]
@@ -5004,6 +5287,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "trafilatura"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "courlan" },
+    { name = "htmldate" },
+    { name = "justext" },
+    { name = "lxml" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/b6/097367f180b6383a3581ca1b86fcae284e52075fa941d1232df35293363c/trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d", size = 132557, upload-time = "2024-12-03T15:23:21.41Z" },
 ]
 
 [[package]]
@@ -5653,7 +5954,7 @@ wheels = [
 [[package]]
 name = "yc-bench"
 version = "0.1.0"
-source = { git = "https://github.com/collinear-ai/yc-bench.git#0c53c98f01a431db2e391482bc46013045854ab2" }
+source = { git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c#bfb0c88062450f46341bd9a5298903fc2e952a5c" }
 dependencies = [
     { name = "litellm", marker = "python_full_version >= '3.12'" },
     { name = "matplotlib", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
## Summary
- harden local Chrome CDP discovery so attached browser sessions can recover from `DevToolsActivePort` when `/json/version` is unavailable
- make attached extraction report observable client-state evidence instead of claiming profile/login inheritance without proof
- add bounded retry metadata for thin dynamic renders and update related regression coverage

## What changed
- browser: normalize local CDP URLs, parse `DevToolsActivePort`, preserve raw websocket endpoints, and improve local Chrome discovery fallback
- web extraction: add attached client-state evidence (`visibleCookieCount`, `localStorageCount`, `sessionStorageCount`), keep `profileInherited` / `loginStateInherited` unverified without evidence, and expose render-attempt metadata
- tests: extend CDP override coverage, add attached evidence + thin-render retry regression tests, and patch website policy tests with explicit `FIRECRAWL_API_KEY`
- deps: add `trafilatura>=2.0.0,<3` and refresh `uv.lock`

## Verification
- `uv run --extra dev pytest tests/tools/test_browser_cdp_override.py tests/tools/test_browser_cloud_fallback.py tests/tools/test_web_tools_config.py tests/tools/test_website_policy.py -q`
- result: `99 passed`

## Notes
- original local commits were isolated onto a clean branch from `origin/main` to avoid including unrelated local-only commits from `main`
- `uv.lock` conflicted during cherry-pick because upstream `main` had moved; it was regenerated from the current `pyproject.toml` before rerunning tests
