### PR TITLE
fix(docker): add venv bin to PATH so hermes is accessible in exec shells

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN uv venv && \
 
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
+# Add virtualenv bin to PATH so hermes command is available when entering container
+ENV PATH=/opt/hermes/.venv/bin:$PATH
 ENV HERMES_HOME=/opt/data
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]


### PR DESCRIPTION
When using `docker exec -it <container> /bin/bash` the entrypoint script is not sourced, so the virtualenv is never activated and the hermes command is not found in $PATH.

Add ENV PATH=/opt/hermes/.venv/bin:$PATH to the Dockerfile so the hermes binary is accessible in all container shell sessions.

## What does this PR do?

Adds `ENV PATH=/opt/hermes/.venv/bin:$PATH` to the Dockerfile so that the hermes command is accessible in all container shell sessions, including when using `docker exec` to enter a running container.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `Dockerfile`: Added `ENV PATH=/opt/hermes/.venv/bin:$PATH` so the Python virtualenv bin directory is in the container's PATH

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Build the Docker image with this change
2. Run a container: `docker run -d --name hermes-test <image>`
3. Exec into the container: `docker exec -it hermes-test /bin/bash`
4. Verify hermes is in PATH: `which hermes` (should return `/opt/hermes/.venv/bin/hermes`)
5. Verify hermes command works: `hermes --version`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the `https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md`
- [x] My commit messages follow `https://www.conventionalcommits.org/`  (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for `https://github.com/NousResearch/hermes-agent/pulls`  to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (no test files for Dockerfile)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A
- [x] I've tested on my platform: macOS (Docker Desktop)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — N/A (Dockerfile is self-documenting)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the `https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility` — N/A (Dockerfile change, not platform-specific code)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

**Before fix:**


```
hermes@c29ea15bf6f7:/opt/hermes$ hermes
bash: hermes: command not found
```

After the fix:

```
hermes@c29ea15bf6f7:/opt/hermes$ hermes --version
Hermes Agent v0.10.0 (2026.4.16)
Project: /opt/hermes
Python: 3.13.5
OpenAI SDK: 2.32.0
```