### PR TITLE
feat: add MemPalace memory provider plugin

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -192,7 +193,83 @@ class MemoryManager:
                     "Memory provider '%s' prefetch failed (non-fatal): %s",
                     provider.name, e,
                 )
-        return "\n\n".join(parts)
+        return self._merge_prefetch_parts(parts)
+
+    def _merge_prefetch_parts(self, parts: List[str]) -> str:
+        """Merge provider prefetch blocks while deduplicating repeated memory lines."""
+        merged_blocks = []
+        seen_content: List[str] = []
+
+        for part in parts:
+            block = self._deduplicate_prefetch_block(part, seen_content)
+            if block:
+                merged_blocks.append(block)
+
+        return "\n\n".join(merged_blocks)
+
+    def _deduplicate_prefetch_block(self, block: str, seen_content: List[str]) -> str:
+        headers: List[str] = []
+        body: List[str] = []
+
+        for raw_line in block.splitlines():
+            line = raw_line.rstrip()
+            if not line.strip():
+                if body and body[-1] != "":
+                    body.append("")
+                continue
+
+            normalized = self._normalize_prefetch_line(line)
+            if self._is_prefetch_header_line(line, normalized):
+                headers.append(line)
+                continue
+
+            if any(self._prefetch_lines_match(normalized, prior) for prior in seen_content):
+                continue
+
+            seen_content.append(normalized)
+            body.append(line)
+
+        while body and body[-1] == "":
+            body.pop()
+
+        if not body:
+            return ""
+
+        lines = list(headers)
+        if headers and body:
+            lines.append("")
+        lines.extend(body)
+        return "\n".join(lines)
+
+    def _is_prefetch_header_line(self, line: str, normalized: str) -> bool:
+        stripped = line.strip()
+        if not normalized:
+            return True
+        if stripped.endswith(":"):
+            return True
+        if stripped.startswith(("#", "[")):
+            return True
+        return False
+
+    def _normalize_prefetch_line(self, line: str) -> str:
+        normalized = line.strip()
+        normalized = re.sub(r"^[-*•]+\s*", "", normalized)
+        normalized = re.sub(r"^\d+[.)]\s*", "", normalized)
+        normalized = re.sub(r"^\[[^\]]+\]\s*", "", normalized)
+        normalized = re.sub(r"\s+", " ", normalized)
+        normalized = re.sub(r"[`*_#>]", "", normalized)
+        normalized = re.sub(r"[^\w\s\u4e00-\u9fff]", "", normalized.casefold())
+        normalized = re.sub(r"\s+", " ", normalized)
+        return normalized.strip()
+
+    def _prefetch_lines_match(self, left: str, right: str) -> bool:
+        if not left or not right:
+            return False
+        if left == right:
+            return True
+        if len(left) >= 24 and len(right) >= 24 and SequenceMatcher(a=left, b=right).ratio() >= 0.96:
+            return True
+        return False
 
     def queue_prefetch_all(self, query: str, *, session_id: str = "") -> None:
         """Queue background prefetch on all providers for the next turn."""

--- a/plugins/memory/mempalace/README.md
+++ b/plugins/memory/mempalace/README.md
@@ -1,0 +1,284 @@
+# MemPalace Memory Provider
+
+Local-first memory provider for Hermes Agent using [MemPalace](https://github.com/mempalace/mempalace). It stores memories in a configurable ChromaDB collection, supports semantic search, optional knowledge-graph initialization, room scoping, structured metadata, and Hermes memory-provider hooks.
+
+## What this plugin provides
+
+- Configurable collection naming via `collection_name` or `collection_template`
+- Configurable room derivation via `room_strategy`
+- Structured metadata for tool writes, sync-turn writes, compression writes, and builtin memory mirroring
+- Five Hermes tools:
+  - `mempalace_memorize`
+  - `mempalace_search`
+  - `mempalace_recall`
+  - `mempalace_forget`
+  - `mempalace_status`
+- Hook support for:
+  - `sync_turn()`
+  - `prefetch()` / `queue_prefetch()`
+  - `on_memory_write()`
+  - `on_pre_compress()`
+  - `on_session_end()`
+
+## Requirements
+
+- Python environment with the `mempalace` package installed
+- Hermes Agent plugin system enabled
+- Writable Hermes home directory
+
+Example install:
+
+```bash
+pip install mempalace
+```
+
+## Setup
+
+### 1. Put the plugin in the Hermes plugins directory
+
+Expected location:
+
+```text
+plugins/memory/mempalace/
+```
+
+Files included by this plugin:
+
+```text
+__init__.py
+plugin.yaml
+provider.py
+tools.py
+hooks.py
+config.py
+collections.py
+metadata.py
+errors.py
+store.py
+writer.py
+events.py
+schemas.py
+```
+
+### 2. Enable the provider in Hermes config
+
+Set the active memory provider to `mempalace` in `~/.hermes/config.yaml`:
+
+```yaml
+memory:
+  provider: mempalace
+
+mempalace:
+  palace_path: ~/.hermes/mempalace
+  wing: conversations
+  n_results: 5
+  tool_max_results: 20
+  enable_kg: true
+  collection_template: hermes-{platform}-{user_id}
+  room_strategy: platform_session
+  fixed_room: memory
+```
+
+## Configuration
+
+The plugin reads config from the nested `mempalace:` block in Hermes config.
+
+| Key | Default | Description |
+|---|---|---|
+| `palace_path` | `$HERMES_HOME/mempalace` | Root directory for MemPalace persistent data |
+| `wing` | `conversations` | Logical MemPalace wing used for records |
+| `n_results` | `5` | Default semantic search result count |
+| `tool_max_results` | `20` | Hard cap for tool result counts |
+| `enable_kg` | `true` | Initialize knowledge graph when available |
+| `collection_name` | empty | Explicit collection name; overrides template |
+| `collection_template` | `hermes-{platform}-{user_id}` | Collection naming template |
+| `room_strategy` | `platform_session` | Default room derivation strategy |
+| `fixed_room` | `memory` | Used when `room_strategy: fixed` |
+
+### `collection_name` vs `collection_template`
+
+If `collection_name` is set, it wins.
+
+Example:
+
+```yaml
+mempalace:
+  collection_name: hermes-telegram-jessica
+```
+
+If `collection_name` is empty, the plugin renders `collection_template` using runtime fields:
+
+- `{user_id}`
+- `{platform}`
+- `{session_id}`
+- `{agent_id}`
+
+Example:
+
+```yaml
+mempalace:
+  collection_template: hermes-{platform}-{user_id}
+```
+
+This might resolve to:
+
+```text
+hermes-telegram-7892983586
+```
+
+### Room strategies
+
+Available `room_strategy` values:
+
+- `fixed`
+- `session`
+- `platform_session`
+- `user_platform`
+
+Examples:
+
+```yaml
+mempalace:
+  room_strategy: fixed
+  fixed_room: memory
+```
+
+```yaml
+mempalace:
+  room_strategy: platform_session
+```
+
+With `platform_session`, a Telegram thread/session may resolve to a room like:
+
+```text
+telegram-thread-42
+```
+
+## Tools
+
+### `mempalace_memorize`
+
+Store an explicit memory.
+
+Arguments:
+
+- `content` (required)
+- `memory_type` (optional)
+- `importance` (optional)
+- `room` (optional)
+
+Example:
+
+```json
+{
+  "content": "Jessica prefers detailed technical explanations in Chinese.",
+  "memory_type": "preference",
+  "importance": 0.95,
+  "room": "prefs"
+}
+```
+
+### `mempalace_search`
+
+Semantic search over stored memories.
+
+Arguments:
+
+- `query` (required)
+- `room` (optional)
+- `top_k` (optional)
+
+### `mempalace_recall`
+
+Fetch memories from a room.
+
+Arguments:
+
+- `room` (optional)
+- `n_results` (optional)
+
+### `mempalace_forget`
+
+Delete a memory by ID.
+
+Arguments:
+
+- `memory_id` (required)
+
+### `mempalace_status`
+
+Returns runtime status such as:
+
+- active collection name
+- room strategy
+- wing
+- configured result limits
+- knowledge-graph initialization status
+
+## Notes for users
+
+### Collection stability matters
+
+If you previously stored memories in a collection like:
+
+```text
+hermes-telegram-jessica
+```
+
+but your current runtime resolves to:
+
+```text
+hermes-telegram-7892983586
+```
+
+the plugin is still working, but it will read/write a different collection. In that case, either:
+
+1. set `collection_name` explicitly to the historical collection name, or
+2. migrate old records into the new collection
+
+### Metadata shape
+
+Stored records include normalized metadata such as:
+
+- `room`
+- `wing`
+- `source`
+- `message_kind`
+- `session_id`
+- `platform`
+- `user_id`
+- `agent_id`
+- `created_at`
+
+Optional fields such as `memory_type` and `importance` are included when provided.
+
+## Verification
+
+The plugin was verified with:
+
+```bash
+pytest tests/plugins/test_mempalace_v2_foundation.py \
+       tests/plugins/test_mempalace_module_layout.py \
+       tests/plugins/test_mempalace_plugin_loader.py \
+       tests/plugins/test_mempalace_e2e.py -q
+```
+
+It also passed a live importlib-style runtime check covering:
+
+- plugin load
+- provider initialization
+- `mempalace_status`
+- `mempalace_memorize`
+- `mempalace_search`
+- `mempalace_recall`
+
+## Suggested reviewer quick start
+
+1. Install `mempalace`
+2. Copy the plugin into `plugins/memory/mempalace/`
+3. Set `memory.provider: mempalace`
+4. Add a `mempalace:` block in `~/.hermes/config.yaml`
+5. Start Hermes
+6. Call `mempalace_status`
+7. Store a test fact with `mempalace_memorize`
+8. Verify retrieval with `mempalace_search`

--- a/plugins/memory/mempalace/__init__.py
+++ b/plugins/memory/mempalace/__init__.py
@@ -1,0 +1,17 @@
+"""MemPalace memory plugin — MemoryProvider interface.
+
+Local-first AI memory with semantic search, knowledge graphs, and spatial
+memory palace. Stores memories in ChromaDB with entity extraction via
+knowledge graph.
+"""
+
+from __future__ import annotations
+
+from .provider import MemPalaceMemoryProvider
+
+__all__ = ["MemPalaceMemoryProvider", "register"]
+
+
+def register(ctx) -> None:
+    """Register MemPalace as a memory provider plugin."""
+    ctx.register_memory_provider(MemPalaceMemoryProvider())

--- a/plugins/memory/mempalace/collections.py
+++ b/plugins/memory/mempalace/collections.py
@@ -1,0 +1,61 @@
+"""Collection and room naming strategies for the MemPalace plugin."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .config import MemPalaceConfig
+
+_MAX_IDENTIFIER_LENGTH = 63
+
+
+def slugify_identifier(value: object, default: str = "default") -> str:
+    text = str(value or "").strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = text.strip("-")
+    text = re.sub(r"-+", "-", text)
+    if not text:
+        text = default
+    return text[:_MAX_IDENTIFIER_LENGTH].strip("-") or default
+
+
+def _ctx_value(runtime_ctx: dict[str, Any], key: str, default: str = "default") -> str:
+    return slugify_identifier(runtime_ctx.get(key), default=default)
+
+
+def resolve_collection_name(config: MemPalaceConfig, runtime_ctx: dict[str, Any]) -> str:
+    if config.collection_name:
+        explicit = slugify_identifier(config.collection_name, default="mempalace")
+        return explicit or "mempalace"
+
+    template = config.collection_template or "hermes-{platform}-{user_id}"
+    values = {
+        "user_id": _ctx_value(runtime_ctx, "user_id"),
+        "platform": _ctx_value(runtime_ctx, "platform"),
+        "session_id": _ctx_value(runtime_ctx, "session_id"),
+        "agent_id": _ctx_value(runtime_ctx, "agent_id", default="hermes"),
+    }
+    try:
+        rendered = template.format(**values)
+    except Exception:
+        rendered = "hermes-{platform}-{user_id}".format(**values)
+    return slugify_identifier(rendered, default="mempalace")
+
+
+def resolve_room(
+    config: MemPalaceConfig,
+    runtime_ctx: dict[str, Any],
+    explicit_room: str | None = None,
+) -> str:
+    if explicit_room:
+        return slugify_identifier(explicit_room)
+
+    strategy = config.room_strategy
+    if strategy == "fixed":
+        return slugify_identifier(config.fixed_room, default="memory")
+    if strategy == "platform_session":
+        return slugify_identifier(f"{runtime_ctx.get('platform', 'default')}-{runtime_ctx.get('session_id', 'default')}")
+    if strategy == "user_platform":
+        return slugify_identifier(f"{runtime_ctx.get('user_id', 'default')}-{runtime_ctx.get('platform', 'default')}")
+    return slugify_identifier(runtime_ctx.get("session_id"), default="default")

--- a/plugins/memory/mempalace/config.py
+++ b/plugins/memory/mempalace/config.py
@@ -1,0 +1,131 @@
+"""Configuration parsing for the MemPalace Hermes plugin."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from string import Formatter
+
+DEFAULT_WING = "conversations"
+DEFAULT_N_RESULTS = 5
+DEFAULT_TOOL_MAX_RESULTS = 20
+DEFAULT_ENABLE_KG = True
+DEFAULT_COLLECTION_TEMPLATE = "hermes-{platform}-{user_id}"
+DEFAULT_ROOM_STRATEGY = "platform_session"
+DEFAULT_FIXED_ROOM = "memory"
+VALID_ROOM_STRATEGIES = {"fixed", "session", "platform_session", "user_platform"}
+VALID_TEMPLATE_FIELDS = {"user_id", "platform", "session_id", "agent_id"}
+MAX_COLLECTION_NAME_LENGTH = 63
+MAX_ROOM_NAME_LENGTH = 63
+
+
+@dataclass(slots=True)
+class MemPalaceConfig:
+    palace_path: str = ""
+    wing: str = DEFAULT_WING
+    n_results: int = DEFAULT_N_RESULTS
+    tool_max_results: int = DEFAULT_TOOL_MAX_RESULTS
+    enable_kg: bool = DEFAULT_ENABLE_KG
+    collection_name: str = ""
+    collection_template: str = DEFAULT_COLLECTION_TEMPLATE
+    room_strategy: str = DEFAULT_ROOM_STRATEGY
+    fixed_room: str = DEFAULT_FIXED_ROOM
+
+
+def _coerce_positive_int(value: object, default: int) -> int:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _plugin_section(full_config: object) -> dict:
+    if not isinstance(full_config, dict):
+        return {}
+    nested = full_config.get("mempalace")
+    if isinstance(nested, dict):
+        return nested
+    return full_config
+
+
+def _sanitize_label(value: object, default: str, *, max_length: int) -> str:
+    text = str(value or "").strip().lower()
+    cleaned = []
+    last_dash = False
+    for ch in text:
+        if ch.isascii() and ch.isalnum():
+            cleaned.append(ch)
+            last_dash = False
+        elif ch in {'-', '_', ' ', '/', ':'}:
+            if not last_dash:
+                cleaned.append('-')
+                last_dash = True
+    result = ''.join(cleaned).strip('-')
+    if not result:
+        result = default
+    return result[:max_length].strip('-') or default
+
+
+def _normalize_template(value: object) -> str:
+    template = str(value or DEFAULT_COLLECTION_TEMPLATE).strip() or DEFAULT_COLLECTION_TEMPLATE
+    formatter = Formatter()
+    fields = {field_name for _, field_name, _, _ in formatter.parse(template) if field_name}
+    if not fields:
+        return DEFAULT_COLLECTION_TEMPLATE
+    if any(field not in VALID_TEMPLATE_FIELDS for field in fields):
+        return DEFAULT_COLLECTION_TEMPLATE
+    return template
+
+
+def load_mempalace_config(full_config: object, hermes_home: str | None = None) -> MemPalaceConfig:
+    raw = _plugin_section(full_config)
+
+    palace_path = str(raw.get("palace_path") or "").strip()
+    if palace_path:
+        palace_path = os.path.expanduser(palace_path)
+    elif hermes_home:
+        palace_path = os.path.join(hermes_home, "mempalace")
+    else:
+        palace_path = os.path.expanduser("~/.hermes/mempalace")
+    palace_path = os.path.abspath(palace_path)
+
+    wing = str(raw.get("wing") or DEFAULT_WING).strip() or DEFAULT_WING
+    room_strategy = str(raw.get("room_strategy") or DEFAULT_ROOM_STRATEGY).strip() or DEFAULT_ROOM_STRATEGY
+    if room_strategy not in VALID_ROOM_STRATEGIES:
+        room_strategy = DEFAULT_ROOM_STRATEGY
+
+    n_results = _coerce_positive_int(raw.get("n_results"), DEFAULT_N_RESULTS)
+    tool_max_results = _coerce_positive_int(raw.get("tool_max_results"), DEFAULT_TOOL_MAX_RESULTS)
+    if tool_max_results < n_results:
+        tool_max_results = n_results
+
+    collection_name = _sanitize_label(raw.get("collection_name"), "", max_length=MAX_COLLECTION_NAME_LENGTH)
+    if collection_name == "":
+        collection_name = ""
+    collection_template = _normalize_template(raw.get("collection_template"))
+    fixed_room = _sanitize_label(raw.get("fixed_room"), DEFAULT_FIXED_ROOM, max_length=MAX_ROOM_NAME_LENGTH)
+
+    return MemPalaceConfig(
+        palace_path=palace_path,
+        wing=wing,
+        n_results=n_results,
+        tool_max_results=tool_max_results,
+        enable_kg=_coerce_bool(raw.get("enable_kg"), DEFAULT_ENABLE_KG),
+        collection_name=collection_name,
+        collection_template=collection_template,
+        room_strategy=room_strategy,
+        fixed_room=fixed_room,
+    )

--- a/plugins/memory/mempalace/errors.py
+++ b/plugins/memory/mempalace/errors.py
@@ -1,0 +1,48 @@
+"""Structured error model for the MemPalace Hermes plugin."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+MEMPALACE_CONFIG_INVALID = "MEMPALACE_CONFIG_INVALID"
+MEMPALACE_QUERY_FAILED = "MEMPALACE_QUERY_FAILED"
+MEMPALACE_TOOL_ERROR = "MEMPALACE_TOOL_ERROR"
+MEMPALACE_BACKEND_ERROR = "MEMPALACE_BACKEND_ERROR"
+
+
+@dataclass(slots=True)
+class MemPalaceError(Exception):
+    """Base structured exception for plugin failures."""
+
+    code: str
+    message: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __str__(self) -> str:
+        return self.message
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "success": False,
+            "error": {
+                "code": self.code,
+                "message": self.message,
+                "details": self.details,
+            },
+        }
+
+
+class MemPalaceConfigError(MemPalaceError):
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        super().__init__(MEMPALACE_CONFIG_INVALID, message, details or {})
+
+
+class MemPalaceBackendError(MemPalaceError):
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        super().__init__(MEMPALACE_BACKEND_ERROR, message, details or {})
+
+
+class MemPalaceToolError(MemPalaceError):
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        super().__init__(MEMPALACE_TOOL_ERROR, message, details or {})

--- a/plugins/memory/mempalace/events.py
+++ b/plugins/memory/mempalace/events.py
@@ -1,0 +1,16 @@
+"""Event/source constants for the MemPalace Hermes plugin."""
+
+from __future__ import annotations
+
+SOURCE_TOOL = "tool"
+SOURCE_SYNC_TURN = "sync_turn"
+SOURCE_MEMORY = "memory"
+SOURCE_COMPRESSION = "compression"
+SOURCE_SESSION_END = "session_end"
+
+MESSAGE_KIND_EXPLICIT_MEMORY = "explicit_memory"
+MESSAGE_KIND_USER_MESSAGE = "user_message"
+MESSAGE_KIND_ASSISTANT_MESSAGE = "assistant_message"
+MESSAGE_KIND_BUILTIN_MEMORY_WRITE = "builtin_memory_write"
+MESSAGE_KIND_COMPRESSED_CONTEXT = "compressed_context"
+MESSAGE_KIND_SESSION_SUMMARY = "session_summary"

--- a/plugins/memory/mempalace/hooks.py
+++ b/plugins/memory/mempalace/hooks.py
@@ -1,0 +1,181 @@
+"""Hook and background-search mixins for the MemPalace Hermes plugin."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from .events import (
+    MESSAGE_KIND_BUILTIN_MEMORY_WRITE,
+    MESSAGE_KIND_COMPRESSED_CONTEXT,
+    MESSAGE_KIND_SESSION_SUMMARY,
+    SOURCE_COMPRESSION,
+    SOURCE_MEMORY,
+    SOURCE_SESSION_END,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MemPalaceHooksMixin:
+    """Lifecycle hooks and prefetch helpers mixed into the provider."""
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Fire background search for the next turn."""
+        if not self._collection or not query:
+            return
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=2.0)
+        self._prefetch_thread = self._thread_factory(
+            target=self._bg_search,
+            args=(query, session_id),
+            name="mempalace-prefetch",
+            daemon=True,
+        )
+        self._prefetch_thread.start()
+
+    def _bg_search(self, query: str, session_id: str = "") -> None:
+        """Background search — runs without blocking the turn."""
+        try:
+            room = self._resolve_room(session_id=session_id) if session_id else None
+            result = self._raw_search(query, n_results=self._n_results, room=room)
+            formatted = self._format_search_result(result)
+            with self._lock:
+                self._prefetch_result = formatted
+        except Exception as exc:
+            logger.debug("MemPalace prefetch failed: %s", exc)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return cached prefetch results. Fast — reads from cache."""
+        with self._lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        return result
+
+    def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
+        """Called at the start of each turn with the user message."""
+        if not message or not self._collection:
+            return
+        self.queue_prefetch(message, session_id=kwargs.get("session_id", ""))
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in memory writes into MemPalace."""
+        if not content or not self._collection:
+            return
+
+        try:
+            room = self._resolve_room(target)
+            if action in ("add", "replace"):
+                self._store_memory(
+                    room=room,
+                    content=content,
+                    source_file=f"builtin_{target}_{action}",
+                    chunk_index=int(datetime.now(timezone.utc).timestamp() * 1000) % 1000000,
+                    source=SOURCE_MEMORY,
+                    message_kind=MESSAGE_KIND_BUILTIN_MEMORY_WRITE,
+                )
+                logger.debug(
+                    "MemPalace mirrored built-in %s write: %s",
+                    action,
+                    content[:80],
+                )
+        except Exception as exc:
+            logger.warning("MemPalace on_memory_write failed: %s", exc)
+
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
+        """Persist key facts before old messages are compressed away."""
+        if not messages or not self._collection:
+            return ""
+
+        self._recent_messages = messages
+
+        try:
+            extracted = self._extract_key_content(messages)
+            if not extracted:
+                return ""
+
+            room = self._resolve_room(f"session_{self._session_id}")
+            summary_parts = []
+            for item in extracted:
+                self._store_memory(
+                    room=room,
+                    content=item["content"],
+                    source_file="compression",
+                    chunk_index=item.get("index", 0),
+                    source=SOURCE_COMPRESSION,
+                    message_kind=MESSAGE_KIND_COMPRESSED_CONTEXT,
+                )
+                summary_parts.append(f"- {item['content'][:150]}")
+
+            summary = "\n".join(summary_parts[:10])
+            logger.debug(
+                "MemPalace on_pre_compress stored %d key facts before compression",
+                len(extracted),
+            )
+            return (
+                "\n[MemPalace: key facts preserved from compressed context]\n"
+                f"{summary}\n"
+                "[End MemPalace preserved facts]\n"
+            )
+        except Exception as exc:
+            logger.warning("MemPalace on_pre_compress failed: %s", exc)
+            return ""
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        """Store session summary facts at the end of a conversation."""
+        if not messages or not self._collection:
+            return
+
+        try:
+            extracted = self._extract_key_content(messages)
+            if not extracted:
+                return
+
+            room = self._resolve_room("session_summaries")
+            for item in extracted:
+                self._store_memory(
+                    room=room,
+                    content=item["content"],
+                    source_file=f"session_end_{self._session_id}",
+                    chunk_index=item.get("index", 0),
+                    source=SOURCE_SESSION_END,
+                    message_kind=MESSAGE_KIND_SESSION_SUMMARY,
+                )
+
+            logger.info(
+                "MemPalace on_session_end: stored %d session summary items for %s",
+                len(extracted),
+                self._session_id,
+            )
+        except Exception as exc:
+            logger.warning("MemPalace on_session_end failed: %s", exc)
+
+    def _extract_key_content(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Extract meaningful content from message list for compression/session end."""
+        extracted = []
+        skip_patterns = (
+            "system prompt",
+            "mempalace memory",
+            "you are a helpful",
+            "memory palace is active",
+            "[memories from previous",
+        )
+
+        for i, msg in enumerate(messages):
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+
+            if not content or len(content) < 15:
+                continue
+            if role == "system":
+                continue
+
+            content_lower = content.lower()
+            if any(p in content_lower for p in skip_patterns):
+                continue
+
+            if role in ("user", "assistant", "model"):
+                extracted.append({"content": content.strip(), "index": i})
+
+        return extracted[-20:]

--- a/plugins/memory/mempalace/metadata.py
+++ b/plugins/memory/mempalace/metadata.py
@@ -1,0 +1,36 @@
+"""Metadata helpers for the MemPalace plugin."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def build_metadata(
+    runtime_ctx: dict[str, Any],
+    *,
+    room: str,
+    source: str,
+    message_kind: str,
+    memory_type: str | None = None,
+    importance: float | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "created_at": _utc_now_iso(),
+        "room": room,
+        "source": source,
+        "message_kind": message_kind,
+        "session_id": str(runtime_ctx.get("session_id") or ""),
+        "platform": str(runtime_ctx.get("platform") or ""),
+        "user_id": str(runtime_ctx.get("user_id") or ""),
+        "agent_id": str(runtime_ctx.get("agent_id") or ""),
+    }
+    if memory_type is not None:
+        metadata["memory_type"] = memory_type
+    if importance is not None:
+        metadata["importance"] = float(importance)
+    return metadata

--- a/plugins/memory/mempalace/plugin.yaml
+++ b/plugins/memory/mempalace/plugin.yaml
@@ -1,0 +1,42 @@
+name: mempalace
+version: "2.0.0-foundation"
+description: "MemPalace — modular local-first AI memory provider with configurable collection naming, room scoping, and structured metadata."
+author: "hermes-plugin"
+
+config:
+  - key: palace_path
+    description: "Root directory for MemPalace data (ChromaDB + knowledge graph). Defaults to $HERMES_HOME/mempalace"
+    default: ""
+    required: false
+  - key: wing
+    description: "Wing name for organizing memories (default: conversations)"
+    default: "conversations"
+    required: false
+  - key: n_results
+    description: "Default semantic search result count (default: 5)"
+    default: 5
+    required: false
+  - key: tool_max_results
+    description: "Upper bound for tool-driven result counts (default: 20)"
+    default: 20
+    required: false
+  - key: enable_kg
+    description: "Enable knowledge graph support when available"
+    default: true
+    required: false
+  - key: collection_name
+    description: "Explicit Chroma collection name. Overrides collection_template when set."
+    default: ""
+    required: false
+  - key: collection_template
+    description: "Collection naming template using {user_id}, {platform}, {session_id}, {agent_id}."
+    default: "hermes-{platform}-{user_id}"
+    required: false
+  - key: room_strategy
+    description: "How rooms are derived when tool callers do not specify a room."
+    default: "platform_session"
+    required: false
+  - key: fixed_room
+    description: "Room name used when room_strategy=fixed."
+    default: "memory"
+    required: false

--- a/plugins/memory/mempalace/provider.py
+++ b/plugins/memory/mempalace/provider.py
@@ -1,0 +1,283 @@
+"""Provider implementation for the MemPalace Hermes memory plugin."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Any
+
+from agent.memory_provider import MemoryProvider
+from mempalace.knowledge_graph import KnowledgeGraph
+from mempalace.palace import get_collection
+
+from .collections import resolve_collection_name, resolve_room
+from .config import (
+    DEFAULT_ENABLE_KG,
+    DEFAULT_N_RESULTS,
+    DEFAULT_TOOL_MAX_RESULTS,
+    DEFAULT_WING,
+    MemPalaceConfig,
+    load_mempalace_config,
+)
+from .events import (
+    MESSAGE_KIND_ASSISTANT_MESSAGE,
+    MESSAGE_KIND_USER_MESSAGE,
+    SOURCE_SYNC_TURN,
+)
+from .hooks import MemPalaceHooksMixin
+from .store import build_memory_item, upsert_memory_item
+from .tools import MemPalaceToolsMixin
+from .writer import WriteQueue
+
+logger = logging.getLogger(__name__)
+
+
+class MemPalaceMemoryProvider(MemPalaceHooksMixin, MemPalaceToolsMixin, MemoryProvider):
+    """MemPalace local-first AI memory provider."""
+
+    def __init__(self):
+        self._collection = None
+        self._kg: KnowledgeGraph | None = None
+        self._queue: WriteQueue | None = None
+        self._palace_path = ""
+        self._wing = DEFAULT_WING
+        self._n_results = DEFAULT_N_RESULTS
+        self._tool_max_results = DEFAULT_TOOL_MAX_RESULTS
+        self._kg_enabled = DEFAULT_ENABLE_KG
+        self._session_id = ""
+        self._user_id = "default"
+        self._agent_id = "hermes"
+        self._platform = "default"
+        self._config = MemPalaceConfig()
+        self._runtime_ctx: dict[str, Any] = {}
+        self._collection_name = ""
+        self._lock = threading.Lock()
+        self._thread_factory = threading.Thread
+        self._prefetch_result = ""
+        self._prefetch_thread: threading.Thread | None = None
+        self._recent_messages: list[dict[str, Any]] = []
+
+    @property
+    def name(self) -> str:
+        return "mempalace"
+
+    def is_available(self) -> bool:
+        try:
+            import mempalace  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "palace_path",
+                "description": "Root directory for MemPalace data (ChromaDB + knowledge graph). Defaults to ~/.hermes/mempalace/",
+                "default": "",
+                "required": False,
+            },
+            {
+                "key": "wing",
+                "description": "Wing name for organizing memories (default: conversations)",
+                "default": "conversations",
+                "required": False,
+            },
+            {
+                "key": "n_results",
+                "description": "Default semantic search result count (default: 5)",
+                "default": 5,
+                "required": False,
+            },
+            {
+                "key": "tool_max_results",
+                "description": "Upper bound for tool-driven result counts (default: 20)",
+                "default": 20,
+                "required": False,
+            },
+            {
+                "key": "enable_kg",
+                "description": "Enable knowledge graph support when available",
+                "default": True,
+                "required": False,
+            },
+            {
+                "key": "collection_name",
+                "description": "Explicit Chroma collection name. Overrides collection_template when set.",
+                "default": "",
+                "required": False,
+            },
+            {
+                "key": "collection_template",
+                "description": "Collection naming template using {user_id}, {platform}, {session_id}, {agent_id}.",
+                "default": "hermes-{platform}-{user_id}",
+                "required": False,
+            },
+            {
+                "key": "room_strategy",
+                "description": "How rooms are derived when callers do not specify a room.",
+                "default": "platform_session",
+                "required": False,
+            },
+            {
+                "key": "fixed_room",
+                "description": "Room name used when room_strategy=fixed.",
+                "default": "memory",
+                "required": False,
+            },
+        ]
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id
+        cfg = load_mempalace_config(kwargs.get("config", {}), hermes_home=str(kwargs.get("hermes_home", "") or ""))
+        self._config = cfg
+        self._wing = cfg.wing
+        self._n_results = cfg.n_results
+        self._tool_max_results = cfg.tool_max_results
+        self._kg_enabled = cfg.enable_kg
+        self._palace_path = cfg.palace_path
+        os.makedirs(self._palace_path, exist_ok=True)
+
+        self._user_id = kwargs.get("user_id", "default") or "default"
+        self._agent_id = kwargs.get("agent_id", "hermes") or "hermes"
+        self._platform = kwargs.get("platform", "default") or "default"
+        self._runtime_ctx = {
+            "session_id": session_id,
+            "user_id": self._user_id,
+            "agent_id": self._agent_id,
+            "platform": self._platform,
+        }
+
+        self._collection_name = resolve_collection_name(cfg, self._runtime_ctx)
+        self._collection = get_collection(
+            palace_path=self._palace_path,
+            collection_name=self._collection_name,
+        )
+        logger.info("MemPalace collection '%s' initialized at %s", self._collection_name, self._palace_path)
+
+        if self._kg_enabled:
+            kg_path = os.path.join(self._palace_path, 'knowledge_graph.db')
+            self._kg = KnowledgeGraph(db_path=kg_path)
+            logger.info("MemPalace knowledge graph initialized at %s", kg_path)
+        else:
+            self._kg = None
+
+        self._queue = WriteQueue(self._collection, self._agent_id, thread_factory=self._thread_factory)
+        logger.info("MemPalace initialized successfully for session %s", session_id)
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# MemPalace Memory\n"
+            "MemPalace is active for long-term memory. Use mempalace_memorize to store "
+            "important facts, preferences, and decisions. Use mempalace_search to find "
+            "relevant memories. MemPalace uses semantic search — it finds related concepts "
+            "even when exact words don't match."
+        )
+
+    def shutdown(self) -> None:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        if self._queue:
+            self._queue.shutdown()
+        if self._kg:
+            try:
+                self._kg.close()
+            except Exception:
+                pass
+        logger.info("MemPalace shutdown complete")
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._queue:
+            return
+
+        effective_session = session_id or self._session_id
+        room = self._resolve_room(session_id=effective_session)
+        items = []
+
+        if user_content and user_content.strip():
+            items.append(self._queue_item(
+                room=room,
+                content=user_content.strip(),
+                source_file="conversation",
+                chunk_index=0,
+                source=SOURCE_SYNC_TURN,
+                message_kind=MESSAGE_KIND_USER_MESSAGE,
+                session_id=effective_session,
+            ))
+
+        if assistant_content and assistant_content.strip():
+            items.append(self._queue_item(
+                room=room,
+                content=assistant_content.strip(),
+                source_file="conversation",
+                chunk_index=1,
+                source=SOURCE_SYNC_TURN,
+                message_kind=MESSAGE_KIND_ASSISTANT_MESSAGE,
+                session_id=effective_session,
+            ))
+
+        if items:
+            self._queue.enqueue(items)
+
+    def _runtime_context(self, *, session_id: str | None = None) -> dict[str, Any]:
+        runtime_ctx = dict(self._runtime_ctx)
+        if session_id:
+            runtime_ctx["session_id"] = session_id
+        return runtime_ctx
+
+    def _resolve_room(self, explicit_room: str | None = None, *, session_id: str | None = None) -> str:
+        runtime_ctx = self._runtime_context(session_id=session_id)
+        return resolve_room(self._config, runtime_ctx, explicit_room=explicit_room)
+
+    def _queue_item(
+        self,
+        *,
+        room: str,
+        content: str,
+        source_file: str,
+        chunk_index: int,
+        source: str,
+        message_kind: str,
+        session_id: str | None = None,
+        memory_type: str | None = None,
+        importance: float | None = None,
+    ) -> dict[str, Any]:
+        return build_memory_item(
+            runtime_ctx=self._runtime_context(session_id=session_id),
+            wing=self._wing,
+            room=room,
+            content=content,
+            source_file=source_file,
+            chunk_index=chunk_index,
+            source=source,
+            message_kind=message_kind,
+            agent_id=self._agent_id,
+            memory_type=memory_type,
+            importance=importance,
+        )
+
+    def _store_memory(
+        self,
+        *,
+        room: str,
+        content: str,
+        source_file: str,
+        chunk_index: int,
+        source: str,
+        message_kind: str,
+        session_id: str | None = None,
+        memory_type: str | None = None,
+        importance: float | None = None,
+    ) -> str:
+        item = self._queue_item(
+            room=room,
+            content=content,
+            source_file=source_file,
+            chunk_index=chunk_index,
+            source=source,
+            message_kind=message_kind,
+            session_id=session_id,
+            memory_type=memory_type,
+            importance=importance,
+        )
+        return upsert_memory_item(self._collection, item, self._agent_id)

--- a/plugins/memory/mempalace/schemas.py
+++ b/plugins/memory/mempalace/schemas.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+MEMORIZE_SCHEMA = {
+    "name": "mempalace_memorize",
+    "description": "Store an important fact, preference, or decision in MemPalace for long-term memory. Use this when the user shares personal information, preferences, goals, or decisions that should be remembered across sessions.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "The fact, preference, or decision to remember.",
+            },
+            "memory_type": {
+                "type": "string",
+                "enum": ["factual", "preference", "goal", "instruction", "event", "opinion"],
+                "description": "Category of memory (default: factual).",
+            },
+            "importance": {
+                "type": "number",
+                "description": "Importance score 0-1 (default: 0.7).",
+            },
+            "room": {
+                "type": "string",
+                "description": "Optional room/thread name to organize this memory (e.g. project name).",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+MEMORY_SEARCH_SCHEMA = {
+    "name": "mempalace_search",
+    "description": "Search MemPalace long-term memory using semantic similarity. Finds relevant memories even when the query doesn't match exact words.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to search for.",
+            },
+            "room": {
+                "type": "string",
+                "description": "Optional room/thread to limit search scope.",
+            },
+            "top_k": {
+                "type": "integer",
+                "description": "Max results (default: 5, max: 20).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+MEMORY_RECALL_SCHEMA = {
+    "name": "mempalace_recall",
+    "description": "Recall recent memories from the memory palace. Returns the most recent stored memories across all rooms.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room": {
+                "type": "string",
+                "description": "Optional room/thread to recall from.",
+            },
+            "n_results": {
+                "type": "integer",
+                "description": "Number of memories to recall (default: 5).",
+            },
+        },
+        "required": [],
+    },
+}
+
+MEMORY_FORGET_SCHEMA = {
+    "name": "mempalace_forget",
+    "description": "Delete a specific memory by its ID from MemPalace.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {
+                "type": "string",
+                "description": "The memory ID to delete.",
+            },
+        },
+        "required": ["memory_id"],
+    },
+}
+
+MEMORY_STATUS_SCHEMA = {
+    "name": "mempalace_status",
+    "description": "Get MemPalace memory system status — total memories, knowledge graph stats, collection info, and system health.",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    },
+}
+
+TOOL_SCHEMAS = [
+    MEMORIZE_SCHEMA,
+    MEMORY_SEARCH_SCHEMA,
+    MEMORY_RECALL_SCHEMA,
+    MEMORY_FORGET_SCHEMA,
+    MEMORY_STATUS_SCHEMA,
+]

--- a/plugins/memory/mempalace/store.py
+++ b/plugins/memory/mempalace/store.py
@@ -1,0 +1,90 @@
+"""Memory item construction and direct storage helpers."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import Any
+
+from .metadata import build_metadata
+
+
+def make_drawer_id(
+    *,
+    wing: str,
+    room: str,
+    source_file: str,
+    chunk_index: int,
+    content: str,
+    session_id: str = "",
+) -> str:
+    digest_source = "|".join([
+        wing,
+        room,
+        source_file,
+        str(chunk_index),
+        str(session_id or ""),
+        content,
+    ])
+    digest = sha256(digest_source.encode('utf-8')).hexdigest()[:24]
+    return f"drawer_{wing}_{room}_{digest}"
+
+
+def build_memory_item(
+    *,
+    runtime_ctx: dict[str, Any],
+    wing: str,
+    room: str,
+    content: str,
+    source_file: str,
+    chunk_index: int,
+    source: str,
+    message_kind: str,
+    agent_id: str,
+    memory_type: str | None = None,
+    importance: float | None = None,
+) -> dict[str, Any]:
+    metadata = build_metadata(
+        runtime_ctx,
+        room=room,
+        source=source,
+        message_kind=message_kind,
+        memory_type=memory_type,
+        importance=importance,
+    )
+    metadata["wing"] = wing
+    metadata["source_file"] = source_file
+    metadata["chunk_index"] = chunk_index
+
+    item_id = make_drawer_id(
+        wing=wing,
+        room=room,
+        source_file=source_file,
+        chunk_index=chunk_index,
+        content=content,
+        session_id=str(runtime_ctx.get('session_id') or ''),
+    )
+    return {
+        "id": item_id,
+        "wing": wing,
+        "room": room,
+        "content": content,
+        "source_file": source_file,
+        "chunk_index": chunk_index,
+        "agent": agent_id,
+        "metadata": metadata,
+    }
+
+
+def upsert_memory_item(collection: Any, item: dict[str, Any], agent_id: str) -> str:
+    metadata = dict(item.get("metadata") or {})
+    metadata.setdefault("added_by", item.get("agent", agent_id))
+    metadata.setdefault("wing", item["wing"])
+    metadata.setdefault("room", item["room"])
+    metadata.setdefault("source_file", item["source_file"])
+    metadata.setdefault("chunk_index", item["chunk_index"])
+    collection.upsert(
+        documents=[item["content"]],
+        ids=[item["id"]],
+        metadatas=[metadata],
+    )
+    return item["id"]

--- a/plugins/memory/mempalace/tools.py
+++ b/plugins/memory/mempalace/tools.py
@@ -1,0 +1,335 @@
+"""Tool dispatch and result formatting for the MemPalace Hermes plugin."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from difflib import SequenceMatcher
+from typing import Any
+
+from .errors import MemPalaceBackendError, MemPalaceToolError
+from .events import MESSAGE_KIND_EXPLICIT_MEMORY, SOURCE_TOOL
+from .schemas import TOOL_SCHEMAS
+
+logger = logging.getLogger(__name__)
+
+
+class MemPalaceToolsMixin:
+    """Tool schemas, handlers, and search/result helpers."""
+
+    _CONVERSATION_MESSAGE_KINDS = {"user_message", "assistant_message"}
+    _MEMORY_PRIORITY_KINDS = {
+        "explicit_memory",
+        "builtin_memory_write",
+        "compressed_context",
+        "session_summary",
+    }
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return list(TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        """Dispatch tool calls to MemPalace functions."""
+        try:
+            return json.dumps(self._dispatch(tool_name, args))
+        except MemPalaceToolError as exc:
+            return json.dumps(exc.to_dict())
+        except MemPalaceBackendError as exc:
+            logger.error("MemPalace backend error (%s): %s", tool_name, exc)
+            return json.dumps(exc.to_dict())
+        except Exception as exc:
+            logger.error("MemPalace tool error (%s): %s", tool_name, exc)
+            return json.dumps(MemPalaceToolError(str(exc), {"tool_name": tool_name}).to_dict())
+
+    def _dispatch(self, tool_name: str, args: dict) -> Any:
+        if tool_name == "mempalace_memorize":
+            return self._do_memorize(args)
+        if tool_name == "mempalace_search":
+            return self._do_search(args)
+        if tool_name == "mempalace_recall":
+            return self._do_recall(args)
+        if tool_name == "mempalace_forget":
+            return self._do_forget(args)
+        if tool_name == "mempalace_status":
+            return self._do_status()
+        raise MemPalaceToolError(f"Unknown tool: {tool_name}", {"tool_name": tool_name})
+
+    def _do_memorize(self, args: dict) -> dict:
+        content = str(args.get("content", "") or "").strip()
+        if not content:
+            raise MemPalaceToolError("content is required")
+
+        room = self._resolve_room(args.get("room"))
+        memory_type = str(args.get("memory_type", "factual") or "factual")
+        importance = float(args.get("importance", 0.7))
+        importance = max(0.0, min(1.0, importance))
+        chunk_index = int(time.time() * 1000) % 1000000
+
+        try:
+            memory_id = self._store_memory(
+                room=room,
+                content=content,
+                source_file=f"memorize_{memory_type}",
+                chunk_index=chunk_index,
+                source=SOURCE_TOOL,
+                message_kind=MESSAGE_KIND_EXPLICIT_MEMORY,
+                memory_type=memory_type,
+                importance=importance,
+            )
+            return {
+                "success": True,
+                "memory_id": memory_id,
+                "message": f"Stored in MemPalace wing='{self._wing}', room='{room}'",
+                "memory_type": memory_type,
+                "importance": importance,
+            }
+        except Exception as exc:
+            raise MemPalaceBackendError("Failed to store memory", {"cause": str(exc), "room": room}) from exc
+
+    def _do_search(self, args: dict) -> dict:
+        query = str(args.get("query", "") or "").strip()
+        if not query:
+            raise MemPalaceToolError("query is required")
+
+        room = self._resolve_room(args.get("room")) if args.get("room") else None
+        requested = int(args.get("top_k", self._n_results))
+        top_k = min(max(requested, 1), self._tool_max_results)
+        query_limit = self._expanded_fetch_limit(top_k)
+
+        try:
+            where_filter = self._build_where(room)
+            result = self._collection.query(
+                query_texts=[query],
+                n_results=query_limit,
+                where=where_filter,
+            )
+            return self._format_search_result(result, raw=True, limit=top_k)
+        except Exception as exc:
+            raise MemPalaceBackendError("Search failed", {"cause": str(exc), "query": query, "room": room}) from exc
+
+    def _do_recall(self, args: dict) -> dict:
+        room = self._resolve_room(args.get("room")) if args.get("room") else None
+        requested = int(args.get("n_results", 5))
+        n = min(max(requested, 1), self._tool_max_results)
+        fetch_limit = self._expanded_fetch_limit(n)
+
+        try:
+            where_filter = self._build_where(room)
+            result = self._collection.get(
+                where=where_filter,
+                limit=fetch_limit,
+                include=["documents", "metadatas"],
+            )
+
+            docs = result.get("documents", [])
+            metas = result.get("metadatas", [])
+            ids = result.get("ids", [])
+            items = []
+            for i, doc in enumerate(docs):
+                meta = metas[i] if i < len(metas) else {}
+                items.append({
+                    "id": ids[i] if i < len(ids) else "",
+                    "content": doc,
+                    "metadata": meta,
+                    "distance": 0.0,
+                })
+
+            return {"results": self._prepare_results(items, limit=n)}
+        except Exception as exc:
+            raise MemPalaceBackendError("Recall failed", {"cause": str(exc), "room": room}) from exc
+
+    def _do_forget(self, args: dict) -> dict:
+        memory_id = str(args.get("memory_id", "") or "").strip()
+        if not memory_id:
+            raise MemPalaceToolError("memory_id is required")
+
+        try:
+            self._collection.delete(ids=[memory_id])
+            return {"success": True, "memory_id": memory_id}
+        except Exception as exc:
+            raise MemPalaceBackendError("Failed to delete memory", {"cause": str(exc), "memory_id": memory_id}) from exc
+
+    def _do_status(self) -> dict:
+        try:
+            status: dict[str, Any] = {
+                "palace_path": self._palace_path,
+                "wing": self._wing,
+                "collection_name": getattr(self, "_collection_name", ""),
+                "kg_enabled": self._kg_enabled,
+                "session_id": self._session_id,
+                "user_id": self._user_id,
+                "platform": getattr(self, "_platform", "default"),
+                "tool_max_results": getattr(self, "_tool_max_results", None),
+                "room_strategy": getattr(self._config, 'room_strategy', None),
+            }
+
+            if self._collection is not None:
+                try:
+                    status["total_memories"] = self._collection.count()
+                except Exception:
+                    status["total_memories"] = "unknown"
+
+            if self._kg is not None:
+                try:
+                    status["knowledge_graph"] = self._kg.stats()
+                except Exception:
+                    status["knowledge_graph"] = "error"
+
+            return status
+        except Exception as exc:
+            raise MemPalaceBackendError("Status check failed", {"cause": str(exc)}) from exc
+
+    def _raw_search(self, query: str, n_results: int = 5, room: str | None = None) -> dict:
+        effective_room = self._resolve_room(room) if room else None
+        target = min(max(n_results, 1), self._tool_max_results)
+        return self._collection.query(
+            query_texts=[query],
+            n_results=self._expanded_fetch_limit(target),
+            where=self._build_where(effective_room),
+        )
+
+    def _build_where(self, room: str | None = None) -> dict[str, Any] | None:
+        conditions: list[dict[str, Any]] = []
+        if self._wing:
+            conditions.append({"wing": self._wing})
+        if room:
+            conditions.append({"room": room})
+
+        if not conditions:
+            return None
+        if len(conditions) == 1:
+            return conditions[0]
+        return {"$and": conditions}
+
+    def _format_search_result(self, result: Any, raw: bool = False, limit: int | None = None) -> dict[str, Any] | str:
+        if not isinstance(result, dict):
+            prepared = self._prepare_results(result if isinstance(result, list) else [], limit=limit)
+            if raw:
+                return {"results": prepared}
+            return self._render_results(prepared)
+
+        ids = result.get("ids", [[]])[0] if result.get("ids") else []
+        docs = result.get("documents", [[]])[0] if result.get("documents") else []
+        metas = result.get("metadatas", [[]])[0] if result.get("metadatas") else []
+        distances = result.get("distances", [[]])[0] if result.get("distances") else []
+
+        results_list = []
+        for i, doc in enumerate(docs):
+            meta = metas[i] if i < len(metas) else {}
+            distance = distances[i] if i < len(distances) else None
+            results_list.append({
+                "id": ids[i] if i < len(ids) else "",
+                "content": doc,
+                "metadata": meta,
+                "distance": distance,
+            })
+
+        prepared = self._prepare_results(results_list, limit=limit)
+        if raw:
+            return {"results": prepared}
+        return self._render_results(prepared)
+
+    def _prepare_results(self, results_list: list[dict[str, Any]], limit: int | None = None) -> list[dict[str, Any]]:
+        """Deduplicate near-identical hits and suppress low-signal conversation noise."""
+        if not results_list:
+            return []
+
+        ranked = sorted(results_list, key=self._result_rank_key)
+        unique: list[dict[str, Any]] = []
+        seen_keys: set[str] = set()
+        normalized_seen: list[str] = []
+
+        for item in ranked:
+            content = str(item.get("content", "") or "").strip()
+            if not content:
+                continue
+
+            normalized = self._normalize_content(content)
+            if not normalized:
+                continue
+
+            coarse_key = normalized[:180]
+            if coarse_key in seen_keys:
+                continue
+            if any(self._looks_like_duplicate(normalized, prior) for prior in normalized_seen):
+                continue
+
+            seen_keys.add(coarse_key)
+            normalized_seen.append(normalized)
+            unique.append(item)
+
+        preferred = [item for item in unique if not self._is_low_signal_conversation(item)]
+        selected = preferred if preferred else unique[:1]
+        if limit is not None:
+            return selected[: max(limit, 0)]
+        return selected
+
+    def _render_results(self, results_list: list[dict[str, Any]]) -> str:
+        if not results_list:
+            return ""
+
+        lines = ["[MemPalace Memory]", ""]
+        for i, r in enumerate(results_list[:5], 1):
+            content = r.get("content", "")
+            meta = r.get("metadata", {})
+            role = meta.get("role", "") if isinstance(meta, dict) else ""
+            ts = meta.get("created_at", "") if isinstance(meta, dict) else ""
+
+            if content:
+                prefix = f"[{role}] " if role else ""
+                ts_str = f" ({ts[:16]})" if ts else ""
+                lines.append(f"{i}. {prefix}{content[:200]}{ts_str}")
+
+        return "\n".join(lines)
+
+    def _expanded_fetch_limit(self, requested: int) -> int:
+        requested = min(max(requested, 1), self._tool_max_results)
+        expanded = max(requested, min(self._tool_max_results, requested * 3))
+        return min(expanded, self._tool_max_results)
+
+    def _result_rank_key(self, item: dict[str, Any]) -> tuple[int, int, float, float, str]:
+        meta = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        message_kind = str(meta.get("message_kind", "") or "")
+        is_low_signal = self._is_low_signal_conversation(item)
+        priority_bucket = 0 if message_kind in self._MEMORY_PRIORITY_KINDS else 1
+        low_signal_bucket = 1 if is_low_signal else 0
+        importance = float(meta.get("importance", 0.0) or 0.0)
+        distance = item.get("distance")
+        distance_value = float(distance) if isinstance(distance, (int, float)) else 999999.0
+        created_at = str(meta.get("created_at", "") or "")
+        return (priority_bucket, low_signal_bucket, -importance, distance_value, created_at)
+
+    def _is_low_signal_conversation(self, item: dict[str, Any]) -> bool:
+        meta = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        message_kind = str(meta.get("message_kind", "") or "")
+        if message_kind not in self._CONVERSATION_MESSAGE_KINDS:
+            return False
+
+        if meta.get("memory_type"):
+            return False
+        if float(meta.get("importance", 0.0) or 0.0) >= 0.85:
+            return False
+        if str(meta.get("source", "") or "") in {"memory", "compression", "session_end", "tool"}:
+            return False
+        return True
+
+    def _normalize_content(self, content: str) -> str:
+        normalized = content.casefold()
+        normalized = re.sub(r"\s+", " ", normalized)
+        normalized = re.sub(r"[`*_#>\-]+", " ", normalized)
+        normalized = re.sub(r"[^\w\s\u4e00-\u9fff]", "", normalized)
+        normalized = re.sub(r"\s+", " ", normalized)
+        return normalized.strip()
+
+    def _looks_like_duplicate(self, left: str, right: str) -> bool:
+        if left == right:
+            return True
+        shorter, longer = sorted((left, right), key=len)
+        if shorter and longer.startswith(shorter[: min(len(shorter), 120)]):
+            if len(shorter) >= 40:
+                return True
+        if len(shorter) >= 40 and SequenceMatcher(a=left, b=right).ratio() >= 0.92:
+            return True
+        return False

--- a/plugins/memory/mempalace/writer.py
+++ b/plugins/memory/mempalace/writer.py
@@ -1,0 +1,56 @@
+"""Async writer queue for MemPalace persistence."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from typing import Any
+
+from .store import upsert_memory_item
+
+logger = logging.getLogger(__name__)
+
+
+class WriteQueue:
+    """Thread-safe async write queue for non-blocking memory persistence."""
+
+    def __init__(self, collection: Any, agent_id: str, thread_factory=threading.Thread):
+        self._collection = collection
+        self._agent_id = agent_id
+        self._q: queue.Queue = queue.Queue()
+        self._thread = thread_factory(target=self._loop, name="mempalace-writer", daemon=True)
+        self._running = True
+        self._thread.start()
+
+    def enqueue(self, items: list[dict[str, Any]]) -> None:
+        self._q.put(items)
+
+    def _flush(self, items: list[dict[str, Any]]) -> None:
+        try:
+            for item in items:
+                upsert_memory_item(self._collection, item, self._agent_id)
+            logger.debug("MemPalace flushed %d items to ChromaDB", len(items))
+        except Exception as exc:
+            logger.warning("MemPalace flush failed: %s", exc)
+            if self._running:
+                time.sleep(1)
+                self._q.put(items)
+
+    def _loop(self) -> None:
+        while self._running:
+            try:
+                item = self._q.get(timeout=2)
+                if item is None:
+                    break
+                self._flush(item)
+            except queue.Empty:
+                continue
+            except Exception as exc:
+                logger.error("MemPalace writer error: %s", exc)
+
+    def shutdown(self) -> None:
+        self._running = False
+        self._q.put(None)
+        self._thread.join(timeout=10)

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -195,6 +195,36 @@ class TestMemoryManager:
         assert p1.prefetch_queries == ["what do you know?"]
         assert p2.prefetch_queries == ["what do you know?"]
 
+    def test_prefetch_deduplicates_shared_memory_lines_across_providers(self):
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("builtin")
+        p1._prefetch_result = "## Builtin Memory\n- User likes Python\n- Prefers dark mode"
+        p2 = FakeMemoryProvider("external")
+        p2._prefetch_result = "[MemPalace Memory]\n\n1. User likes Python\n2. Uses Telegram"
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+
+        result = mgr.prefetch_all("query")
+        assert result.count("User likes Python") == 1
+        assert "Prefers dark mode" in result
+        assert "Uses Telegram" in result
+        assert "## Builtin Memory" in result
+        assert "[MemPalace Memory]" in result
+
+    def test_prefetch_keeps_distinct_lines_when_only_formatting_differs(self):
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("builtin")
+        p1._prefetch_result = "## Builtin Memory\n- User likes Python for scripting"
+        p2 = FakeMemoryProvider("external")
+        p2._prefetch_result = "## External Memory\n- User likes Python for backend services"
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+
+        result = mgr.prefetch_all("query")
+        assert "User likes Python for scripting" in result
+        assert "User likes Python for backend services" in result
+        assert result.count("User likes Python") == 2
+
     def test_prefetch_skips_empty(self):
         mgr = MemoryManager()
         p1 = FakeMemoryProvider("builtin")

--- a/tests/plugins/test_mempalace_e2e.py
+++ b/tests/plugins/test_mempalace_e2e.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "memory" / "mempalace"
+INIT_FILE = PLUGIN_DIR / "__init__.py"
+MODULE_NAME = "plugins.memory.mempalace"
+
+
+def _ensure_package(name: str, package_dir: Path) -> None:
+    if name in sys.modules:
+        return
+    spec = importlib.util.spec_from_file_location(
+        name,
+        package_dir / "__init__.py",
+        submodule_search_locations=[str(package_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    if spec and spec.loader and (package_dir / "__init__.py").exists():
+        spec.loader.exec_module(module)
+
+
+def load_plugin_module():
+    _ensure_package("plugins", REPO_ROOT / "plugins")
+    _ensure_package("plugins.memory", REPO_ROOT / "plugins" / "memory")
+    spec = importlib.util.spec_from_file_location(
+        MODULE_NAME,
+        INIT_FILE,
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def plugin_module():
+    return load_plugin_module()
+
+
+@pytest.fixture
+def provider(plugin_module, tmp_path):
+    provider = plugin_module.MemPalaceMemoryProvider()
+    provider.initialize(
+        session_id="sess-e2e",
+        hermes_home=str(tmp_path / ".hermes"),
+        config={
+            "memory": {"provider": "mempalace"},
+            "mempalace": {
+                "palace_path": str(tmp_path / "palace"),
+                "wing": "conversations",
+                "n_results": 5,
+                "tool_max_results": 20,
+                "enable_kg": True,
+                "collection_template": "hermes-{platform}-{user_id}",
+                "room_strategy": "platform_session",
+                "fixed_room": "memory",
+            },
+        },
+        user_id="jessica-e2e",
+        agent_id="hermes",
+        platform="telegram",
+    )
+    try:
+        yield provider
+    finally:
+        provider.shutdown()
+
+
+def _tool(provider, name: str, args: dict):
+    return json.loads(provider.handle_tool_call(name, args))
+
+
+def _wait_for_prefetch(provider, timeout: float = 5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        thread = provider._prefetch_thread
+        if not thread or not thread.is_alive():
+            return
+        time.sleep(0.05)
+    raise TimeoutError("prefetch thread did not finish in time")
+
+
+def test_memorize_search_recall_forget_round_trip(provider):
+    memorize = _tool(
+        provider,
+        "mempalace_memorize",
+        {
+            "content": "Jessica likes 深度架构分析 and publishable plugin design.",
+            "memory_type": "preference",
+            "importance": 0.95,
+            "room": "prefs-room",
+        },
+    )
+    assert memorize["success"] is True
+
+    status = _tool(provider, "mempalace_status", {})
+    assert status["collection_name"] == "hermes-telegram-jessica-e2e"
+    assert status["room_strategy"] == "platform_session"
+
+    search = _tool(
+        provider,
+        "mempalace_search",
+        {"query": "publishable plugin design", "room": "prefs-room", "top_k": 5},
+    )
+    assert "results" in search
+    assert any("publishable plugin design" in item["content"] for item in search["results"])
+
+    target = next(item for item in search["results"] if "publishable plugin design" in item["content"])
+    assert target["metadata"]["room"] == "prefs-room"
+    assert target["metadata"]["wing"] == provider._wing
+    assert target["metadata"]["source"] == "tool"
+    assert target["metadata"]["message_kind"] == "explicit_memory"
+    assert target["metadata"]["memory_type"] == "preference"
+    assert target["metadata"]["importance"] == 0.95
+    assert target["metadata"]["platform"] == "telegram"
+    assert target["metadata"]["user_id"] == "jessica-e2e"
+    assert target["metadata"]["agent_id"] == "hermes"
+    assert "created_at" in target["metadata"]
+
+    recall = _tool(provider, "mempalace_recall", {"room": "prefs-room", "n_results": 10})
+    assert "results" in recall
+    assert any(item["id"] == target["id"] for item in recall["results"])
+
+    forget = _tool(provider, "mempalace_forget", {"memory_id": target["id"]})
+    assert forget["success"] is True
+
+    recall_after = _tool(provider, "mempalace_recall", {"room": "prefs-room", "n_results": 10})
+    assert all(item["id"] != target["id"] for item in recall_after["results"])
+
+
+def test_sync_turn_and_prefetch_share_same_collection(provider):
+    before = provider._collection.count()
+    provider.sync_turn(
+        "User asks about Browserbase and anti-bot verification.",
+        "Assistant explains local playwright and stealth settings.",
+        session_id="thread-42",
+    )
+
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if provider._collection.count() >= before + 2:
+            break
+        time.sleep(0.05)
+    assert provider._collection.count() >= before + 2
+
+    direct = provider._raw_search("Browserbase anti-bot verification", n_results=5, room="telegram-thread-42")
+    formatted = provider._format_search_result(direct, raw=True)
+    assert formatted["results"]
+    assert any("Browserbase" in item["content"] for item in formatted["results"])
+    matched = next(item for item in formatted["results"] if "Browserbase" in item["content"])
+    assert matched["metadata"]["room"] == "telegram-thread-42"
+    assert matched["metadata"]["source"] == "sync_turn"
+    assert matched["metadata"]["message_kind"] == "user_message"
+    assert matched["metadata"]["session_id"] == "thread-42"
+
+    provider.queue_prefetch("local playwright stealth", session_id="thread-42")
+    _wait_for_prefetch(provider)
+    prefetched = provider.prefetch("local playwright stealth", session_id="thread-42")
+    assert "[MemPalace Memory]" in prefetched
+    assert "local playwright" in prefetched.lower() or "stealth" in prefetched.lower()
+
+
+def test_where_filter_uses_and_for_wing_plus_room(provider):
+    where = provider._build_where("room-x")
+    assert where == {"$and": [{"wing": provider._wing}, {"room": "room-x"}]}
+
+
+def test_search_caps_top_k_by_tool_max_results(provider):
+    provider._tool_max_results = 2
+    _tool(provider, "mempalace_memorize", {"content": "cap result one", "room": "cap-room"})
+    _tool(provider, "mempalace_memorize", {"content": "cap result two", "room": "cap-room"})
+    _tool(provider, "mempalace_memorize", {"content": "cap result three", "room": "cap-room"})
+
+    search = _tool(provider, "mempalace_search", {"query": "cap result", "room": "cap-room", "top_k": 10})
+    assert len(search["results"]) <= 2
+
+
+def test_handle_tool_call_returns_structured_error_payload(provider):
+    payload = _tool(provider, "mempalace_search", {"room": "missing-query"})
+    assert payload["success"] is False
+    assert payload["error"]["code"] == "MEMPALACE_TOOL_ERROR"
+    assert "query is required" in payload["error"]["message"]
+
+
+def test_search_room_filter_does_not_leak_other_rooms(provider):
+    _tool(provider, "mempalace_memorize", {"content": "alpha room memory", "room": "room-a"})
+    _tool(provider, "mempalace_memorize", {"content": "beta room memory", "room": "room-b"})
+
+    search_a = _tool(provider, "mempalace_search", {"query": "room memory", "room": "room-a", "top_k": 10})
+    assert search_a["results"]
+    assert all(item["metadata"]["room"] == "room-a" for item in search_a["results"])
+    assert all("beta room memory" not in item["content"] for item in search_a["results"])
+
+
+def test_search_deduplicates_near_identical_results(provider):
+    room = "dedupe-room"
+    repeated = "你一开始说的记忆方案 user.md 和 memory.md 那套逻辑还在用吗"
+    variants = [
+        repeated,
+        repeated + "？",
+        repeated + "   ",
+    ]
+    for item in variants:
+        _tool(provider, "mempalace_memorize", {"content": item, "room": room, "memory_type": "instruction"})
+
+    search = _tool(provider, "mempalace_search", {"query": "user.md memory.md 记忆方案", "room": room, "top_k": 10})
+    assert len(search["results"]) == 1
+    assert repeated in search["results"][0]["content"]
+
+
+def test_recall_deduplicates_internal_duplicates_and_backfills_unique_results(provider):
+    room = "recall-dedupe-room"
+    duplicates = [
+        "这样子的话注入上下文时不会有重复吗",
+        "这样子的话注入上下文时不会有重复吗？",
+        "这样子的话注入上下文时不会有重复吗   ",
+    ]
+    for item in duplicates:
+        _tool(provider, "mempalace_memorize", {"content": item, "room": room, "memory_type": "instruction"})
+
+    _tool(provider, "mempalace_memorize", {"content": "长期事实：系统现在会先做跨 provider 去重。", "room": room, "memory_type": "factual", "importance": 0.95})
+    _tool(provider, "mempalace_memorize", {"content": "待办：还要继续优化 MemPalace recall 内部去重。", "room": room, "memory_type": "instruction", "importance": 0.9})
+
+    recall = _tool(provider, "mempalace_recall", {"room": room, "n_results": 3})
+    assert len(recall["results"]) == 3
+    assert sum("这样子的话注入上下文时不会有重复吗" in item["content"] for item in recall["results"]) == 1
+    assert any("跨 provider 去重" in item["content"] for item in recall["results"])
+    assert any("MemPalace recall 内部去重" in item["content"] for item in recall["results"])
+
+
+def test_prefetch_filters_low_signal_conversation_when_memory_exists(provider):
+    provider.sync_turn(
+        "我之前准备为你重写一个 memorypalace plugin，现在进展如何？",
+        "我们先检查 recall 注入路径，再处理重复问题。",
+        session_id="thread-noise",
+    )
+    _tool(
+        provider,
+        "mempalace_memorize",
+        {
+            "content": "长期事实：当前系统仍同时使用 USER.md / MEMORY.md 与 MemPalace provider。",
+            "room": "telegram-thread-noise",
+            "memory_type": "factual",
+            "importance": 0.95,
+        },
+    )
+
+    provider.queue_prefetch("记忆方案还在用吗 memory.md user.md", session_id="thread-noise")
+    _wait_for_prefetch(provider)
+    prefetched = provider.prefetch("记忆方案还在用吗 memory.md user.md", session_id="thread-noise")
+    assert "[MemPalace Memory]" in prefetched
+    assert "长期事实" in prefetched
+    assert "我之前准备为你重写一个 memorypalace plugin" not in prefetched
+
+
+def test_on_memory_write_mirrors_builtin_memory(provider):
+    provider.on_memory_write("add", "memory", "Builtin memory mirror marker for hook verification.")
+
+    direct = provider._raw_search("Builtin memory mirror marker", n_results=5, room="memory")
+    formatted = provider._format_search_result(direct, raw=True)
+    assert formatted["results"]
+    matched = next(item for item in formatted["results"] if "Builtin memory mirror marker" in item["content"])
+    assert matched["metadata"]["room"] == "memory"
+    assert matched["metadata"]["source"] == "memory"
+    assert matched["metadata"]["message_kind"] == "builtin_memory_write"
+    assert matched["metadata"]["source_file"] == "builtin_memory_add"
+    assert matched["metadata"]["session_id"] == "sess-e2e"
+
+
+
+def test_on_pre_compress_persists_key_facts(provider):
+    messages = [
+        {"role": "system", "content": "system prompt should be skipped"},
+        {"role": "user", "content": "Compression hook marker alpha: we chose the modular provider layout for maintainability."},
+        {"role": "assistant", "content": "Compression hook marker beta: preserve this architectural rationale before compression."},
+    ]
+
+    summary = provider.on_pre_compress(messages)
+    assert "[MemPalace: key facts preserved from compressed context]" in summary
+    assert "Compression hook marker alpha" in summary
+
+    direct = provider._raw_search(
+        "Compression hook marker modular provider layout architectural rationale",
+        n_results=10,
+        room="session-sess-e2e",
+    )
+    formatted = provider._format_search_result(direct, raw=True)
+    assert len([item for item in formatted["results"] if "Compression hook marker" in item["content"]]) >= 2
+
+    matched = next(item for item in formatted["results"] if "Compression hook marker alpha" in item["content"])
+    assert matched["metadata"]["room"] == "session-sess-e2e"
+    assert matched["metadata"]["source"] == "compression"
+    assert matched["metadata"]["message_kind"] == "compressed_context"
+    assert matched["metadata"]["source_file"] == "compression"
+    assert matched["metadata"]["session_id"] == "sess-e2e"
+
+
+
+def test_on_session_end_persists_summary_room(provider):
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "We chose scenario C because it is more publishable and general."},
+        {"role": "assistant", "content": "Understood. We will validate the publishable path end-to-end."},
+    ]
+
+    provider.on_session_end(messages)
+    recall = _tool(provider, "mempalace_recall", {"room": "session_summaries", "n_results": 10})
+    assert recall["results"]
+    assert any("scenario C" in item["content"] or "publishable path" in item["content"] for item in recall["results"])

--- a/tests/plugins/test_mempalace_module_layout.py
+++ b/tests/plugins/test_mempalace_module_layout.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "memory" / "mempalace"
+MODULE_NAME = "plugins.memory.mempalace"
+
+
+def _ensure_package(name: str, package_dir: Path) -> None:
+    if name in sys.modules:
+        return
+    spec = importlib.util.spec_from_file_location(
+        name,
+        package_dir / "__init__.py",
+        submodule_search_locations=[str(package_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    if spec and spec.loader and (package_dir / "__init__.py").exists():
+        spec.loader.exec_module(module)
+
+
+def _load_plugin_root():
+    _ensure_package("plugins", REPO_ROOT / "plugins")
+    _ensure_package("plugins.memory", REPO_ROOT / "plugins" / "memory")
+    spec = importlib.util.spec_from_file_location(
+        MODULE_NAME,
+        PLUGIN_DIR / "__init__.py",
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_publishable_module_layout_exists():
+    for filename in [
+        "provider.py",
+        "tools.py",
+        "hooks.py",
+        "schemas.py",
+    ]:
+        assert (PLUGIN_DIR / filename).exists(), filename
+
+
+def test_provider_is_reexported_from_package_root():
+    root = _load_plugin_root()
+    from plugins.memory.mempalace.provider import MemPalaceMemoryProvider
+
+    assert root.MemPalaceMemoryProvider is MemPalaceMemoryProvider
+    assert root.MemPalaceMemoryProvider.__module__ == "plugins.memory.mempalace.provider"

--- a/tests/plugins/test_mempalace_plugin_loader.py
+++ b/tests/plugins/test_mempalace_plugin_loader.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "memory" / "mempalace"
+INIT_FILE = PLUGIN_DIR / "__init__.py"
+MODULE_NAME = "plugins.memory.mempalace"
+
+
+def _ensure_package(name: str, package_dir: Path) -> None:
+    if name in sys.modules:
+        return
+    spec = importlib.util.spec_from_file_location(
+        name,
+        package_dir / "__init__.py",
+        submodule_search_locations=[str(package_dir)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    if spec and spec.loader and (package_dir / "__init__.py").exists():
+        spec.loader.exec_module(module)
+
+
+def load_plugin_module():
+    _ensure_package("plugins", REPO_ROOT / "plugins")
+    _ensure_package("plugins.memory", REPO_ROOT / "plugins" / "memory")
+    spec = importlib.util.spec_from_file_location(
+        MODULE_NAME,
+        INIT_FILE,
+        submodule_search_locations=[str(PLUGIN_DIR)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def plugin_module():
+    return load_plugin_module()
+
+
+def test_plugin_loads_via_importlib(plugin_module):
+    assert hasattr(plugin_module, "MemPalaceMemoryProvider")
+    assert hasattr(plugin_module, "register")
+
+
+def test_register_works_when_loaded_like_hermes(plugin_module):
+    ctx = MagicMock()
+    plugin_module.register(ctx)
+    ctx.register_memory_provider.assert_called_once()
+
+
+def test_initialize_uses_current_hermes_config_shape(plugin_module, tmp_path):
+    provider = plugin_module.MemPalaceMemoryProvider()
+    hermes_home = tmp_path / ".hermes"
+    config = {
+        "memory": {"provider": "mempalace"},
+        "mempalace": {
+            "palace_path": str(tmp_path / "palace"),
+            "wing": "conversations",
+            "n_results": 5,
+            "tool_max_results": 7,
+            "enable_kg": True,
+            "collection_template": "hermes-{platform}-{user_id}",
+            "room_strategy": "platform_session",
+            "fixed_room": "memory",
+        },
+    }
+
+    provider.initialize(
+        session_id="sess-test",
+        hermes_home=str(hermes_home),
+        config=config,
+        user_id="jessica",
+        agent_id="hermes",
+        platform="telegram",
+    )
+
+    try:
+        assert provider.name == "mempalace"
+        assert provider.is_available() is True
+        assert provider._collection is not None
+        assert provider._queue is not None
+        assert provider._kg is not None
+        assert provider._palace_path == str(tmp_path / "palace")
+        assert provider._wing == "conversations"
+        assert provider._n_results == 5
+        assert provider._tool_max_results == 7
+        assert provider._runtime_ctx["platform"] == "telegram"
+        assert provider._collection_name == "hermes-telegram-jessica"
+        result = provider.handle_tool_call("mempalace_status", {})
+        payload = json.loads(result)
+        assert isinstance(payload, dict)
+        assert payload["collection_name"] == "hermes-telegram-jessica"
+        assert payload["room_strategy"] == "platform_session"
+    finally:
+        provider.shutdown()
+
+
+def test_initialize_respects_disable_kg(plugin_module, tmp_path):
+    provider = plugin_module.MemPalaceMemoryProvider()
+    provider.initialize(
+        session_id="sess-no-kg",
+        hermes_home=str(tmp_path / ".hermes"),
+        config={
+            "mempalace": {
+                "palace_path": str(tmp_path / "palace-no-kg"),
+                "enable_kg": False,
+            }
+        },
+        user_id="u1",
+        agent_id="hermes",
+    )
+    try:
+        assert provider._kg is None
+    finally:
+        provider.shutdown()
+
+
+def test_tool_schemas_exposed(plugin_module):
+    provider = plugin_module.MemPalaceMemoryProvider()
+    names = {schema["name"] for schema in provider.get_tool_schemas()}
+    assert names == {
+        "mempalace_memorize",
+        "mempalace_search",
+        "mempalace_recall",
+        "mempalace_forget",
+        "mempalace_status",
+    }

--- a/tests/plugins/test_mempalace_v2_foundation.py
+++ b/tests/plugins/test_mempalace_v2_foundation.py
@@ -1,0 +1,268 @@
+"""Foundation tests for the modular MemPalace plugin rewrite.
+
+These tests cover the first extraction wave only:
+- error model
+- config parsing
+- collection naming / room derivation
+- metadata schema builder
+- plugin package export / register hook
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+_repo_root = str(Path(__file__).resolve().parents[2])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from plugins.memory.mempalace import MemPalaceMemoryProvider, register
+from plugins.memory.mempalace.collections import (
+    resolve_collection_name,
+    resolve_room,
+    slugify_identifier,
+)
+from plugins.memory.mempalace.config import (
+    DEFAULT_COLLECTION_TEMPLATE,
+    DEFAULT_FIXED_ROOM,
+    DEFAULT_N_RESULTS,
+    DEFAULT_ROOM_STRATEGY,
+    DEFAULT_TOOL_MAX_RESULTS,
+    DEFAULT_WING,
+    MemPalaceConfig,
+    load_mempalace_config,
+)
+from plugins.memory.mempalace.errors import (
+    MEMPALACE_CONFIG_INVALID,
+    MEMPALACE_QUERY_FAILED,
+    MemPalaceConfigError,
+    MemPalaceError,
+    MemPalaceToolError,
+)
+from plugins.memory.mempalace.metadata import build_metadata
+from plugins.memory.mempalace.store import make_drawer_id
+
+
+class TestErrorModel:
+    def test_base_error_exposes_code_message_and_details(self):
+        err = MemPalaceError(
+            code=MEMPALACE_QUERY_FAILED,
+            message="query exploded",
+            details={"room": "prefs"},
+        )
+
+        assert err.code == MEMPALACE_QUERY_FAILED
+        assert err.message == "query exploded"
+        assert err.details == {"room": "prefs"}
+        assert err.to_dict()["error"]["code"] == MEMPALACE_QUERY_FAILED
+
+    def test_config_error_uses_default_code(self):
+        err = MemPalaceConfigError("bad config")
+        assert err.code == MEMPALACE_CONFIG_INVALID
+        assert err.message == "bad config"
+
+    def test_tool_error_inherits_base_shape(self):
+        err = MemPalaceToolError("tool failed")
+        payload = err.to_dict()
+        assert payload["success"] is False
+        assert payload["error"]["message"] == "tool failed"
+
+
+class TestConfigParsing:
+    def test_loads_nested_plugin_config(self, tmp_path):
+        cfg = load_mempalace_config(
+            {
+                "mempalace": {
+                    "wing": "projects",
+                    "n_results": 9,
+                    "enable_kg": False,
+                    "palace_path": "~/mp-test",
+                    "collection_template": "agent_{user_id}",
+                    "room_strategy": "platform_session",
+                }
+            },
+            hermes_home=str(tmp_path / ".hermes"),
+        )
+
+        assert cfg.wing == "projects"
+        assert cfg.n_results == 9
+        assert cfg.enable_kg is False
+        assert cfg.collection_template == "agent_{user_id}"
+        assert cfg.room_strategy == "platform_session"
+        assert cfg.palace_path.endswith("mp-test")
+
+    def test_supports_flat_config_fallback(self, tmp_path):
+        cfg = load_mempalace_config(
+            {"wing": "flat-wing", "n_results": 7},
+            hermes_home=str(tmp_path / ".hermes"),
+        )
+        assert cfg.wing == "flat-wing"
+        assert cfg.n_results == 7
+
+    def test_invalid_values_fall_back_to_defaults(self, tmp_path):
+        cfg = load_mempalace_config(
+            {"mempalace": {"n_results": 0, "tool_max_results": -1, "enable_kg": "not-bool", "room_strategy": "nope"}},
+            hermes_home=str(tmp_path / ".hermes"),
+        )
+
+        assert cfg.n_results == 5
+        assert cfg.tool_max_results == 20
+        assert cfg.enable_kg is True
+        assert cfg.room_strategy == "platform_session"
+
+    def test_tool_max_results_is_raised_to_n_results(self, tmp_path):
+        cfg = load_mempalace_config(
+            {"mempalace": {"n_results": 11, "tool_max_results": 3}},
+            hermes_home=str(tmp_path / ".hermes"),
+        )
+        assert cfg.n_results == 11
+        assert cfg.tool_max_results == 11
+
+    def test_invalid_collection_template_reverts_to_default(self, tmp_path):
+        cfg = load_mempalace_config(
+            {"mempalace": {"collection_template": "broken-{unknown}"}},
+            hermes_home=str(tmp_path / ".hermes"),
+        )
+        assert cfg.collection_template == "hermes-{platform}-{user_id}"
+
+    def test_collection_name_and_fixed_room_are_sanitized(self, tmp_path):
+        cfg = load_mempalace_config(
+            {"mempalace": {"collection_name": "  Custom Room/Name  ", "fixed_room": " My Room #1 "}},
+            hermes_home=str(tmp_path / ".hermes"),
+        )
+        assert cfg.collection_name == "custom-room-name"
+        assert cfg.fixed_room == "my-room-1"
+
+    def test_default_path_uses_hermes_home_when_missing(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        cfg = load_mempalace_config({}, hermes_home=str(hermes_home))
+        assert cfg.palace_path == str(hermes_home / "mempalace")
+
+
+class TestCollections:
+    def test_slugify_identifier_normalizes_text(self):
+        assert slugify_identifier(" Jessica / Telegram Topic #1 ") == "jessica-telegram-topic-1"
+
+    def test_slugify_identifier_truncates_and_falls_back_when_needed(self):
+        assert slugify_identifier("!!!") == "default"
+        assert len(slugify_identifier("A" * 200)) <= 63
+
+    def test_resolve_collection_name_prefers_explicit_name(self):
+        cfg = MemPalaceConfig(collection_name="Custom Collection")
+        name = resolve_collection_name(cfg, {"user_id": "jessica"})
+        assert name == "custom-collection"
+
+    def test_resolve_collection_name_renders_template(self):
+        cfg = MemPalaceConfig(collection_template="hermes-{platform}-{user_id}")
+        name = resolve_collection_name(cfg, {"platform": "telegram", "user_id": "Jessica 123"})
+        assert name == "hermes-telegram-jessica-123"
+
+    def test_resolve_collection_name_uses_agent_and_session_fields(self):
+        cfg = MemPalaceConfig(collection_template="mem-{agent_id}-{session_id}")
+        name = resolve_collection_name(cfg, {"agent_id": "Hermes Bot", "session_id": "Thread 42"})
+        assert name == "mem-hermes-bot-thread-42"
+
+    def test_resolve_collection_name_falls_back_without_user_id(self):
+        cfg = MemPalaceConfig(collection_template="hermes-{user_id}")
+        name = resolve_collection_name(cfg, {"session_id": "abc123"})
+        assert name == "hermes-default"
+
+    def test_resolve_room_uses_explicit_room_first(self):
+        cfg = MemPalaceConfig(room_strategy="session")
+        room = resolve_room(cfg, {"session_id": "s1"}, explicit_room="Project X / Notes")
+        assert room == "project-x-notes"
+
+    @pytest.mark.parametrize(
+        ("strategy", "runtime_ctx", "expected"),
+        [
+            ("fixed", {}, "memory"),
+            ("session", {"session_id": "sess-9"}, "sess-9"),
+            ("platform_session", {"platform": "telegram", "session_id": "sess-9"}, "telegram-sess-9"),
+            ("user_platform", {"user_id": "jessica", "platform": "telegram"}, "jessica-telegram"),
+        ],
+    )
+    def test_resolve_room_strategies(self, strategy, runtime_ctx, expected):
+        cfg = MemPalaceConfig(room_strategy=strategy, fixed_room="memory")
+        assert resolve_room(cfg, runtime_ctx) == expected
+
+
+class TestMetadata:
+    def test_build_metadata_contains_required_fields(self):
+        data = build_metadata(
+            {"session_id": "sess-1", "platform": "telegram", "user_id": "u1", "agent_id": "hermes"},
+            room="project-x",
+            source="tool",
+            message_kind="explicit_memory",
+            memory_type="preference",
+            importance=0.9,
+        )
+
+        assert data["room"] == "project-x"
+        assert data["source"] == "tool"
+        assert data["message_kind"] == "explicit_memory"
+        assert data["memory_type"] == "preference"
+        assert data["importance"] == 0.9
+        assert data["session_id"] == "sess-1"
+        assert data["platform"] == "telegram"
+        assert data["user_id"] == "u1"
+        assert data["agent_id"] == "hermes"
+        assert datetime.fromisoformat(data["created_at"].replace("Z", "+00:00"))
+
+    def test_build_metadata_omits_optional_fields_when_not_provided(self):
+        data = build_metadata(
+            {"session_id": None, "platform": None, "user_id": None, "agent_id": None},
+            room="memory",
+            source="compression",
+            message_kind="compressed_context",
+        )
+
+        assert data["room"] == "memory"
+        assert data["source"] == "compression"
+        assert data["message_kind"] == "compressed_context"
+        assert data["session_id"] == ""
+        assert data["platform"] == ""
+        assert data["user_id"] == ""
+        assert data["agent_id"] == ""
+        assert "memory_type" not in data
+        assert "importance" not in data
+
+
+class TestStore:
+    def test_make_drawer_id_includes_session_and_content_signal(self):
+        base = dict(wing="conversations", room="telegram-s1", source_file="conversation", chunk_index=0)
+        id1 = make_drawer_id(content="alpha", session_id="s1", **base)
+        id2 = make_drawer_id(content="beta", session_id="s1", **base)
+        id3 = make_drawer_id(content="alpha", session_id="s2", **base)
+        assert id1 != id2
+        assert id1 != id3
+
+
+class TestPluginManifest:
+    def test_plugin_yaml_defaults_match_runtime_config(self):
+        manifest_path = Path(__file__).resolve().parents[2] / "plugins" / "memory" / "mempalace" / "plugin.yaml"
+        manifest = yaml.safe_load(manifest_path.read_text())
+        defaults = {item["key"]: item.get("default") for item in manifest["config"]}
+
+        assert defaults["wing"] == DEFAULT_WING
+        assert defaults["n_results"] == DEFAULT_N_RESULTS
+        assert defaults["tool_max_results"] == DEFAULT_TOOL_MAX_RESULTS
+        assert defaults["collection_template"] == DEFAULT_COLLECTION_TEMPLATE
+        assert defaults["room_strategy"] == DEFAULT_ROOM_STRATEGY
+        assert defaults["fixed_room"] == DEFAULT_FIXED_ROOM
+
+
+class TestPackageExports:
+    def test_provider_class_still_exports_from_package(self):
+        provider = MemPalaceMemoryProvider()
+        assert provider.name == "mempalace"
+
+    def test_register_registers_provider(self):
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_memory_provider.assert_called_once()


### PR DESCRIPTION
## Summary
- add a modular MemPalace memory provider plugin with config parsing, collection naming, room scoping, structured metadata, tools, and lifecycle hooks
- add plugin test coverage for foundation behavior, loader integration, module layout, and end-to-end memory flows
- deduplicate overlapping prefetch memory lines across providers to reduce repeated context when builtin memory and MemPalace return the same fact
- document installation, configuration, verification, and reviewer quick start in the plugin README

## Testing
- pytest tests/agent/test_memory_provider.py tests/plugins/test_mempalace_v2_foundation.py tests/plugins/test_mempalace_module_layout.py tests/plugins/test_mempalace_plugin_loader.py tests/plugins/test_mempalace_e2e.py -q

## Notes
- branch pushed from fork: `Jessica-lol/hermes-agent`
- excluded unrelated local change in `scripts/whatsapp-bridge/package-lock.json` from this PR