### PR TITLE
Fix gemini auth header

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -746,14 +746,12 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
                 extra["default_headers"] = copilot_default_headers()
             elif "generativelanguage.googleapis.com" in base_url.lower():
-                # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-                # Passing api_key= causes the SDK to inject Authorization: Bearer,
-                # which Google rejects with HTTP 400 "Multiple authentication
-                # credentials received". Use a placeholder for api_key and pass
-                # the real key via x-goog-api-key header instead.
-                # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-                extra["default_headers"] = {"x-goog-api-key": api_key}
-                api_key = "not-used"
+                # Google's /openai endpoint now expects standard Bearer tokens.
+                # We only apply the legacy x-goog-api-key hack to non-openai endpoints.
+                if "/openai" not in base_url.lower():
+                    extra["default_headers"] = {"x-goog-api-key": api_key}
+                    api_key = "not-used"
+            
             return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -776,14 +774,12 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
             extra["default_headers"] = copilot_default_headers()
         elif "generativelanguage.googleapis.com" in base_url.lower():
-            # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-            # Passing api_key= causes the SDK to inject Authorization: Bearer,
-            # which Google rejects with HTTP 400 "Multiple authentication
-            # credentials received". Use a placeholder for api_key and pass
-            # the real key via x-goog-api-key header instead.
-            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-            extra["default_headers"] = {"x-goog-api-key": api_key}
-            api_key = "not-used"
+            # Google's /openai endpoint now expects standard Bearer tokens.
+            # We only apply the legacy x-goog-api-key hack to non-openai endpoints.
+            if "/openai" not in base_url.lower():
+               extra["default_headers"] = {"x-goog-api-key": api_key}
+               api_key = "not-used"
+        
         return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
     return None, None
@@ -1630,14 +1626,11 @@ def resolve_provider_client(
 
             headers.update(copilot_default_headers())
         elif "generativelanguage.googleapis.com" in base_url.lower():
-            # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-            # Passing api_key= causes the OpenAI SDK to inject Authorization: Bearer,
-            # which Google rejects with HTTP 400 "Multiple authentication credentials
-            # received". Use a placeholder for api_key and pass the real key via
-            # x-goog-api-key header instead.
-            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-            headers["x-goog-api-key"] = api_key
-            api_key = "not-used"
+        # Google's /openai endpoint now expects standard Bearer tokens.
+        # We only apply the legacy x-goog-api-key hack to non-openai endpoints.
+            if "/openai" not in base_url.lower():
+                headers["x-goog-api-key"] = api_key
+                api_key = "not-used"
 
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))

--- a/run_agent.py
+++ b/run_agent.py
@@ -1055,15 +1055,12 @@ class AIAgent:
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
                 elif "generativelanguage.googleapis.com" in effective_base.lower():
-                    # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-                    # The OpenAI SDK auto-injects Authorization: Bearer when api_key= is
-                    # set to a real value, causing HTTP 400 "Multiple authentication
-                    # credentials received".  Pass a placeholder so the SDK does not
-                    # emit Bearer, and carry the real key via x-goog-api-key instead.
-                    # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-                    real_key = client_kwargs["api_key"]
-                    client_kwargs["api_key"] = "not-used"
-                    client_kwargs["default_headers"] = {"x-goog-api-key": real_key}
+                    # Google's /openai endpoint now expects standard Bearer tokens.
+                    # We only apply the legacy x-goog-api-key hack to non-openai endpoints.
+                    if "/openai" not in effective_base.lower():
+                        real_key = client_kwargs["api_key"]
+                        client_kwargs["api_key"] = "not-used"
+                        client_kwargs["default_headers"] = {"x-goog-api-key": real_key}
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -5246,16 +5243,15 @@ class AIAgent:
         elif "portal.qwen.ai" in normalized:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif "generativelanguage.googleapis.com" in normalized:
-            # Google's endpoint rejects Bearer tokens; use x-goog-api-key instead.
-            # Swap the real key out of api_key and into the header so the OpenAI
-            # SDK does not emit Authorization: Bearer.
-            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-            real_key = self._client_kwargs.get("api_key", "")
-            if real_key and real_key != "not-used":
-                self._client_kwargs["api_key"] = "not-used"
-            self._client_kwargs["default_headers"] = {
-                "x-goog-api-key": real_key or self._client_kwargs.get("api_key", ""),
-            }
+            # Google's /openai endpoint now expects standard Bearer tokens.
+            # We only apply the legacy x-goog-api-key hack to non-openai endpoints.
+            if "/openai" not in normalized:
+                real_key = self._client_kwargs.get("api_key", "")
+                if real_key and real_key != "not-used":
+                    self._client_kwargs["api_key"] = "not-used"
+                self._client_kwargs["default_headers"] = {
+                    "x-goog-api-key": real_key or self._client_kwargs.get("api_key", ""),
+                }
         else:
             self._client_kwargs.pop("default_headers", None)
 


### PR DESCRIPTION
## What does this PR do?

When using the Gemini provider, Hermes defaults to Google's OpenAI compatibility endpoint (`.../v1beta/openai/`). The underlying `AsyncOpenAI` client handles the Bearer token authorization automatically. However, legacy code was forcefully injecting the native `x-goog-api-key` header to bypass an old API issue. Sending this native header to the updated `/openai` compatibility endpoint causes Google's API to throw a `400: API_KEY_INVALID` error due to conflicting auth methods. 

This PR wraps the legacy header injection in a conditional block, ensuring it is bypassed when connecting to an `/openai` endpoint, allowing the standard Bearer token to authorize successfully.

## Related Issue

Fixes #12168

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `run_agent.py` to conditionally apply the `x-goog-api-key` header hack only if the `base_url` does *not* contain `/openai`.
- Applied the exact same conditional logic to the three auxiliary client initializations in `auxiliary_client.py`.
- Preserved backward compatibility for users explicitly setting legacy non-openai Google endpoints.

## How to Test

1. Set up Hermes with a valid Gemini API key in `~/.hermes/.env` (or via config).
2. Run `hermes chat --provider gemini` using the default endpoint.
3. Observe a successful connection and chat response without the HTTP 400 error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(Note: Relying on CI pipeline)*
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A