### PR TITLE
fix(email): attach local images/videos/voice as MIME parts instead of leaking paths

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -28,6 +28,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
+from email.mime.image import MIMEImage
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -538,6 +539,129 @@ class EmailAdapter(BasePlatformAdapter):
         text += f"\n\nImage: {image_url}"
         return await self.send(chat_id, text.strip(), reply_to)
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local image file as an email attachment."""
+        try:
+            loop = asyncio.get_running_loop()
+            message_id = await loop.run_in_executor(
+                None,
+                self._send_email_with_image_attachment,
+                chat_id,
+                caption or "",
+                image_path,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.error("[Email] Send image failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    def _send_email_with_image_attachment(
+        self,
+        to_addr: str,
+        body: str,
+        image_path: str,
+    ) -> str:
+        """Send an email with an image attachment."""
+        msg = MIMEMultipart()
+        msg["From"] = self._address
+        msg["To"] = to_addr
+
+        ctx = self._thread_context.get(to_addr, {})
+        subject = ctx.get("subject", "Hermes Agent")
+        if not subject.startswith("Re:"):
+            subject = f"Re: {subject}"
+        msg["Subject"] = subject
+
+        original_msg_id = ctx.get("message_id")
+        if original_msg_id:
+            msg["In-Reply-To"] = original_msg_id
+            msg["References"] = original_msg_id
+
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        msg["Message-ID"] = msg_id
+
+        if body:
+            msg.attach(MIMEText(body, "plain", "utf-8"))
+
+        # Attach image
+        p = Path(image_path)
+        with open(p, "rb") as f:
+            img = MIMEImage(f.read(), _subtype=p.suffix.lstrip(".").lower())
+            img.add_header("Content-Disposition", f"attachment; filename={p.name}")
+            msg.attach(img)
+
+        smtp = self._connect_smtp()
+        try:
+            smtp.send_message(msg)
+        finally:
+            self._close_smtp(smtp)
+
+        return msg_id
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local video file as an email attachment."""
+        try:
+            loop = asyncio.get_running_loop()
+            message_id = await loop.run_in_executor(
+                None,
+                self._send_email_with_attachment,
+                chat_id,
+                caption or "",
+                video_path,
+                None,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.error("[Email] Send video failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local audio file as an email attachment."""
+        try:
+            loop = asyncio.get_running_loop()
+            message_id = await loop.run_in_executor(
+                None,
+                self._send_email_with_attachment,
+                chat_id,
+                caption or "",
+                audio_path,
+                None,
+            )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as e:
+            logger.error("[Email] Send voice failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    async def play_tts(
+        self,
+        chat_id: str,
+        audio_path: str,
+        **kwargs,
+    ) -> SendResult:
+        """Send auto-TTS audio as an email attachment."""
+        return await self.send_voice(chat_id, audio_path, **kwargs)
+
     async def send_document(
         self,
         chat_id: str,
@@ -545,6 +669,7 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs when the Email gateway sends media attachments:

1. **Local image paths leaked as text**: When the agent response contained a local image path (auto-detected by `extract_local_files()`), `EmailAdapter` had no `send_image_file()` override — the base class fallback just sent `🖼️ Image: /local/path` as plain text. Recipients could not view the image.

2. **`metadata` kwarg error on `send_document`**: `BasePlatform.send_document()` always calls with `metadata=_thread_metadata`, but `EmailAdapter.send_document()` didn't accept `**kwargs`. This caused `TypeError: got an unexpected keyword argument 'metadata'` when sending file attachments.

The fix adds `send_image_file()`, `send_video()`, `send_voice()`, and `play_tts()` overrides to `EmailAdapter` that attach local files as proper MIME parts (images use `MIMEImage`, video/voice reuse the existing `_send_email_with_attachment`). All overrides accept `**kwargs` to absorb metadata params safely.

## Related Issue

Fixes # *(leave blank if no issue exists — or link existing issue if there is one)*

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`:
  - Added `MIMEImage` import
  - Added `**kwargs` to `send_document()` to handle base-class `metadata` param
  - Added `send_image_file()` — reads local image and attaches as `MIMEImage` with proper MIME subtype
  - Added `_send_email_with_image_attachment()` helper — builds multipart email with inline image attachment
  - Added `send_video()` — reuses existing `_send_email_with_attachment` for generic octet-stream
  - Added `send_voice()` — reuses existing `_send_email_with_attachment` for generic octet-stream
  - Added `play_tts()` — delegates to `send_voice` for auto-TTS audio delivery

## How to Test

1. Configure Hermes with Email gateway (set `EMAIL_ADDRESS`, `EMAIL_PASSWORD`, `EMAIL_IMAP_HOST`, `EMAIL_SMTP_HOST`)
2. Have the agent respond with a local image path (e.g. reference a PNG/JPG on the server filesystem), or attach a file to the incoming email
3. Verify:
   - The outgoing email contains the image as a proper attachment (not `🖼️ Image: /local/path` as text)
   - No `metadata` error in logs when sending documents
   - Video/audio files are also sent as attachments (not as text paths)

**Before fix — warning log:**
```
WARNING gateway.platforms.base: [Email] Error sending media: EmailAdapter.send_document() got an unexpected keyword argument 'metadata'
```

**Before fix — image sent as text:**
```
🖼️ Image: /root/projects/linux-uyun-automation-scripts/dist/linux-user-modify/linux-user-modify.png
```

**After fix:** Image/video/voice files arrive as email attachments.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (57 email tests pass)
- [x] I've added tests for my changes — N/A (existing `test_send_document_with_attachment` covers direct call; new overrides follow established patterns)
- [x] I've tested on my platform: Linux (Email gateway with SMTP/IMAP)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal API overrides, no behavior change to user-facing interfaces)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Python stdlib `email.mime` only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
# Before fix — image leaked as local path:
🖼️ Image: /root/projects/linux-uyun-automation-scripts/dist/linux-user-modify/linux-user-modify.png

# Before fix — error log when sending document attachment:
WARNING gateway.platforms.base: [Email] Error sending media: EmailAdapter.send_document() got an unexpected keyword argument 'metadata'

# After fix — image arrives as proper MIME attachment in email
```
