### PR TITLE
fix: wire ephemeral max_tokens into chat_completions + NVIDIA NIM default

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5868,7 +5868,15 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                entry["function"]["name"] += tc_delta.function.name
+                                # Use assignment, not +=.  Function names are
+                                # atomic identifiers delivered complete in the
+                                # first chunk (OpenAI spec).  Some providers
+                                # (MiniMax M2.7 via NVIDIA NIM) resend the full
+                                # name in every chunk; concatenation would
+                                # produce "read_fileread_file".  Assignment
+                                # (matching the OpenAI Node SDK / LiteLLM /
+                                # Vercel AI patterns) is immune to this.
+                                entry["function"]["name"] = tc_delta.function.name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -264,6 +264,7 @@ AUTHOR_MAP = {
     "asurla@nvidia.com": "anniesurla",
     "limkuan24@gmail.com": "WideLee",
     "aviralarora002@gmail.com": "AviArora02-commits",
+    "jarvischer@gmail.com": "maxchernin",
 }
 
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -143,6 +143,50 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_name_not_duplicated_when_resent_per_chunk(self, mock_close, mock_create):
+        """MiniMax M2.7 via NVIDIA NIM resends the full name in every chunk.
+
+        Bug #8259: the old += accumulation produced "read_fileread_file".
+        Assignment (matching OpenAI Node SDK / LiteLLM) prevents this.
+        """
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_nim", name="read_file")
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_nim", name="read_file", arguments='{"path":')
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_nim", name="read_file", arguments=' "x.py"}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert len(tc) == 1
+        assert tc[0].function.name == "read_file"
+        assert tc[0].function.arguments == '{"path": "x.py"}'
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_tool_call_extra_content_preserved(self, mock_close, mock_create):
         """Streamed tool calls preserve provider-specific extra_content metadata."""
         from run_agent import AIAgent


### PR DESCRIPTION
## Summary

Salvage of #12152 by @LVT382009.

### What this fixes

1. **`_ephemeral_max_output_tokens` not consumed by chat_completions** — The error-recovery ephemeral override (set when the API returns "max_tokens too large given prompt") was only consumed in the `anthropic_messages` branch of `_build_api_kwargs`. All `chat_completions` providers (OpenRouter, NVIDIA NIM, Qwen, Alibaba, custom, etc.) silently ignored it. Now consumed at highest priority in the cascade, matching the anthropic pattern.

2. **NVIDIA NIM max_tokens default (16384)** — NVIDIA NIM falls back to a very low internal default when `max_tokens` is omitted, causing models like GLM-4.7 to truncate immediately (thinking tokens exhaust the budget before the response starts).

3. **Progressive length-continuation boost** — When `finish_reason='length'` triggers a continuation retry, the output budget now grows progressively (2× base on retry 1, 3× on retry 2, capped at 32768) via `_ephemeral_max_output_tokens`. Previously the retry loop re-sent the same token limit on all 3 attempts.

### Changes vs original PR

| Issue in #12152 | Fix in this salvage |
|---|---|
| Ephemeral consumption placed after `self.max_tokens` check — user value could shadow error-recovery override | Ephemeral is now highest priority (top of cascade), matching the anthropic pattern |
| Duplicate Qwen Portal comment introduced | Clean — no duplicate |
| No tests | E2E validated: 9/9 pass (NIM default, ephemeral priority, user override, non-NVIDIA omission, OpenRouter ephemeral, boost math, cap) |

### Test plan

- [x] `pytest tests/run_agent/ tests/agent/test_auxiliary_client.py` → 851 passed (3 pre-existing failures on main due to missing anthropic SDK locally)
- [x] E2E: 9 scenarios covering the full priority cascade

Closes #12152