### PR TITLE
fix: route Discord attachments to metadata thread

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1095,6 +1095,7 @@ class DiscordAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -1104,11 +1105,12 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
+        target_id = metadata.get("thread_id") if metadata and metadata.get("thread_id") else chat_id
+        channel = self._client.get_channel(int(target_id))
         if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
+            channel = await self._client.fetch_channel(int(target_id))
         if not channel:
-            return SendResult(success=False, error=f"Channel {chat_id} not found")
+            return SendResult(success=False, error=f"Channel {target_id} not found")
 
         filename = file_name or os.path.basename(file_path)
         with open(file_path, "rb") as fh:
@@ -1574,7 +1576,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(chat_id, image_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -1739,7 +1741,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(chat_id, video_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -1757,7 +1759,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -386,3 +386,42 @@ async def test_forum_post_file_creation_failure():
 
     assert result.success is False
     assert "missing perms" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_send_document_routes_attachment_to_metadata_thread(tmp_path):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    file_path = tmp_path / "report.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    parent_channel = SimpleNamespace(
+        id=67890,
+        send=AsyncMock(return_value=SimpleNamespace(id=111)),
+    )
+    thread_channel = SimpleNamespace(
+        id=123,
+        send=AsyncMock(return_value=SimpleNamespace(id=222)),
+    )
+
+    def get_channel(channel_id):
+        return {
+            67890: parent_channel,
+            123: thread_channel,
+        }.get(channel_id)
+
+    adapter._client = SimpleNamespace(
+        get_channel=get_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send_document(
+        chat_id="67890",
+        file_path=str(file_path),
+        metadata={"thread_id": "123"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "222"
+    parent_channel.send.assert_not_awaited()
+    thread_channel.send.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes Discord local attachment delivery so media/document sends honor `metadata.thread_id` like text sends do.

## Root cause

Text delivery resolves `metadata["thread_id"]` before sending, but the local attachment helper only resolved the parent `chat_id`. The local image, video, and document paths all used that helper, so threaded conversations posted attachments to the parent channel.

## Changes

- Let `_send_file_attachment()` accept metadata and resolve `metadata.thread_id` as the target channel when present.
- Pass metadata through from `send_image_file()`, `send_video()`, and `send_document()`.
- Added regression coverage for `send_document()` routing an attachment to a metadata thread instead of the parent channel.

## Validation

- `python -m pytest tests/gateway/test_discord_send.py::test_send_document_routes_attachment_to_metadata_thread -q -n0`
- `python -m pytest tests/gateway/test_discord_send.py -q -n0`
- `python -m py_compile gateway/platforms/discord.py tests/gateway/test_discord_send.py`
- `git diff --check`

Fixes #12174