### PR TITLE
feat(feishu): add streaming cards, typing feedback, and completion metadata

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -8,7 +8,7 @@ Supports:
 - Gateway allowlist integration via FEISHU_ALLOWED_USERS
 - Persistent dedup state across restarts
 - Per-chat serial message processing (matches openclaw createChatQueue)
-- Persistent ACK emoji reaction on inbound messages
+- Typing-reaction indicator on inbound messages
 - Reaction events routed as synthetic text events (matches openclaw)
 - Interactive card button-click events routed as synthetic COMMAND events
 - Webhook anomaly tracking (matches openclaw createWebhookAnomalyTracker)
@@ -190,7 +190,8 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
 }
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
-_FEISHU_ACK_EMOJI = "OK"
+_FEISHU_TYPING_EMOJI = "Typing"
+_FEISHU_TYPING_MIN_VISIBLE_SECONDS = 1.2
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1126,6 +1127,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_drain_scheduled = False
         self._pending_inbound_max_depth = 1000  # cap queue; drop oldest beyond
         self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
+        self._pending_typing_reactions: Dict[str, tuple[str, float]] = {}  # inbound message_id → (typing reaction_id, created_at_monotonic)
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
@@ -1142,6 +1144,18 @@ class FeishuAdapter(BasePlatformAdapter):
         self._approval_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         self._load_seen_message_ids()
+
+    def create_stream_consumer(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> Any:
+        """Return a Feishu interactive-card stream consumer when enabled."""
+        extra = self.config.extra or {}
+        streaming_enabled = extra.get("interactive_card_streaming", extra.get("streaming", True))
+        render_mode = str(extra.get("render_mode", extra.get("renderMode", "card")) or "card").strip().lower()
+        if streaming_enabled is False or render_mode == "raw":
+            return None
+
+        from gateway.platforms.feishu_streaming_card import FeishuCardStreamConsumer
+
+        return FeishuCardStreamConsumer(adapter=self, chat_id=chat_id, metadata=metadata)
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -2051,11 +2065,11 @@ class FeishuAdapter(BasePlatformAdapter):
             emoji_type,
         )
         # Only process reactions from real users. Ignore app/bot-generated reactions
-        # and Hermes' own ACK emoji to avoid feedback loops.
+        # and Hermes' own typing emoji to avoid feedback loops.
         loop = self._loop
         if (
             operator_type in {"bot", "app"}
-            or emoji_type == _FEISHU_ACK_EMOJI
+            or emoji_type == _FEISHU_TYPING_EMOJI
             or not message_id
             or loop is None
             or bool(getattr(loop, "is_closed", lambda: False)())
@@ -2279,23 +2293,24 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _handle_message_with_guards(self, event: MessageEvent) -> None:
         """Dispatch a single event through the agent pipeline with per-chat serialization
-        and a persistent ACK emoji reaction before processing starts.
+        and a transient typing emoji reaction before processing starts.
 
         - Per-chat lock: ensures messages in the same chat are processed one at a time
           (matches openclaw's createChatQueue serial queue behaviour).
-        - ACK indicator: adds a CHECK reaction to the triggering message before handing
-          off to the agent and leaves it in place as a receipt marker.
+        - Typing indicator: adds a Typing reaction to the triggering message before handing
+          off to the agent and clears it only when an actual reply is sent.
         """
         chat_id = getattr(event.source, "chat_id", "") or "" if event.source else ""
         chat_lock = self._get_chat_lock(chat_id)
         async with chat_lock:
             message_id = event.message_id
             if message_id:
-                await self._add_ack_reaction(message_id)
+                reaction_id = await self._add_typing_reaction(message_id)
+                self._register_typing_reaction(message_id, reaction_id)
             await self.handle_message(event)
 
-    async def _add_ack_reaction(self, message_id: str) -> Optional[str]:
-        """Add a persistent ACK emoji reaction to signal the message was received."""
+    async def _add_typing_reaction(self, message_id: str) -> Optional[str]:
+        """Add the transient Typing reaction used as the Feishu typing indicator."""
         if not self._client or not message_id:
             return None
         try:
@@ -2305,7 +2320,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             body = (
                 CreateMessageReactionRequestBody.builder()
-                .reaction_type({"emoji_type": _FEISHU_ACK_EMOJI})
+                .reaction_type({"emoji_type": _FEISHU_TYPING_EMOJI})
                 .build()
             )
             request = (
@@ -2319,14 +2334,102 @@ class FeishuAdapter(BasePlatformAdapter):
                 data = getattr(response, "data", None)
                 return getattr(data, "reaction_id", None)
             logger.warning(
-                "[Feishu] Failed to add ack reaction to %s: code=%s msg=%s",
+                "[Feishu] Failed to add typing reaction to %s: code=%s msg=%s",
                 message_id,
                 getattr(response, "code", None),
                 getattr(response, "msg", None),
             )
         except Exception:
-            logger.warning("[Feishu] Failed to add ack reaction to %s", message_id, exc_info=True)
+            logger.warning("[Feishu] Failed to add typing reaction to %s", message_id, exc_info=True)
         return None
+
+    def _register_typing_reaction(self, message_id: Optional[str], reaction_id: Optional[str]) -> None:
+        """Track an inbound Typing reaction until a reply is actually emitted."""
+        if not message_id or not reaction_id:
+            return
+        self._pending_typing_reactions[str(message_id)] = (str(reaction_id), time.monotonic())
+
+    @staticmethod
+    def _resolve_typing_source_message_id(reply_to: Optional[str], metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if reply_to:
+            return reply_to
+        if isinstance(metadata, dict):
+            for key in ("source_message_id", "reply_to_message_id", "typing_source_message_id"):
+                value = metadata.get(key)
+                if value:
+                    return str(value)
+        return None
+
+    @staticmethod
+    def _typing_source_message_id(reply_to: Optional[str], metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Backward-compatible wrapper for older call sites/tests."""
+        return FeishuAdapter._resolve_typing_source_message_id(reply_to, metadata)
+
+    def _schedule_typing_cleanup_after_outbound(
+        self,
+        *,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        """Best-effort async cleanup of the Typing reaction after a reply is delivered."""
+        typing_source_message_id = self._resolve_typing_source_message_id(reply_to, metadata)
+        if not typing_source_message_id:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = self._loop
+        if loop is None or bool(getattr(loop, "is_closed", lambda: False)()):
+            return
+        loop.create_task(self._clear_pending_typing_reaction(typing_source_message_id))
+
+    async def _clear_pending_typing_reaction(self, message_id: Optional[str]) -> None:
+        """Remove any pending Typing reaction associated with an inbound message."""
+        if not message_id:
+            return
+        pending = self._pending_typing_reactions.pop(message_id, None)
+        if not pending:
+            return
+        reaction_id, created_at = pending
+        remaining = _FEISHU_TYPING_MIN_VISIBLE_SECONDS - (time.monotonic() - created_at)
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        await self._delete_reaction(message_id=message_id, reaction_id=reaction_id)
+
+    async def _delete_reaction(self, *, message_id: str, reaction_id: str) -> None:
+        """Delete a Feishu message reaction, ignoring cleanup failures."""
+        if not self._client or not message_id or not reaction_id:
+            return
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageReactionRequest
+
+            request = (
+                DeleteMessageReactionRequest.builder()
+                .message_id(message_id)
+                .reaction_id(reaction_id)
+                .build()
+            )
+            response = await asyncio.to_thread(self._client.im.v1.message_reaction.delete, request)
+            if response and getattr(response, "success", lambda: False)():
+                return
+            logger.warning(
+                "[Feishu] Failed to delete typing reaction %s on %s: code=%s msg=%s",
+                reaction_id,
+                message_id,
+                getattr(response, "code", None),
+                getattr(response, "msg", None),
+            )
+        except Exception:
+            logger.warning(
+                "[Feishu] Failed to delete typing reaction %s on %s",
+                reaction_id,
+                message_id,
+                exc_info=True,
+            )
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: Any) -> None:
+        """Fallback cleanup for rare paths that finish without sending a reply."""
+        await self._clear_pending_typing_reaction(getattr(event, "message_id", None))
 
     # =========================================================================
     # Webhook server and security
@@ -3220,6 +3323,15 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
             return None
 
+    def _store_message_text_cache(self, message_id: Optional[str], text: Optional[str]) -> None:
+        if not message_id:
+            return
+        normalized = str(text or "").strip()
+        if normalized:
+            self._message_text_cache[message_id] = normalized
+        else:
+            self._message_text_cache.pop(message_id, None)
+
     def _extract_text_from_raw_content(self, *, msg_type: str, raw_content: str) -> Optional[str]:
         normalized = normalize_feishu_message(message_type=msg_type, raw_content=raw_content)
         if normalized.text_content:
@@ -3560,16 +3672,20 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(reply_to, body)
-            return await asyncio.to_thread(self._client.im.v1.message.reply, request)
+            response = await asyncio.to_thread(self._client.im.v1.message.reply, request)
+        else:
+            body = self._build_create_message_body(
+                receive_id=chat_id,
+                msg_type=msg_type,
+                content=payload,
+                uuid_value=str(uuid.uuid4()),
+            )
+            request = self._build_create_message_request("chat_id", body)
+            response = await asyncio.to_thread(self._client.im.v1.message.create, request)
 
-        body = self._build_create_message_body(
-            receive_id=chat_id,
-            msg_type=msg_type,
-            content=payload,
-            uuid_value=str(uuid.uuid4()),
-        )
-        request = self._build_create_message_request("chat_id", body)
-        return await asyncio.to_thread(self._client.im.v1.message.create, request)
+        if self._response_succeeded(response):
+            self._schedule_typing_cleanup_after_outbound(reply_to=reply_to, metadata=metadata)
+        return response
 
     @staticmethod
     def _response_succeeded(response: Any) -> bool:

--- a/gateway/platforms/feishu_streaming_card.py
+++ b/gateway/platforms/feishu_streaming_card.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import queue
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_DONE = object()
+
+
+def _resolve_api_base(domain_name: str) -> str:
+    domain = (domain_name or "feishu").strip().lower()
+    if domain == "lark":
+        return "https://open.larksuite.com/open-apis"
+    return "https://open.feishu.cn/open-apis"
+
+
+def _merge_streaming_text(previous_text: str | None, next_text: str | None) -> str:
+    previous = previous_text or ""
+    next_value = next_text or ""
+    if not next_value:
+        return previous
+    if not previous or next_value == previous:
+        return next_value
+    if next_value.startswith(previous):
+        return next_value
+    if previous.startswith(next_value):
+        return previous
+    if next_value in previous:
+        return previous
+    if previous in next_value:
+        return next_value
+
+    max_overlap = min(len(previous), len(next_value))
+    for overlap in range(max_overlap, 0, -1):
+        if previous[-overlap:] == next_value[:overlap]:
+            return previous + next_value[overlap:]
+    return previous + next_value
+
+
+def _truncate_summary(text: str, max_chars: int = 50) -> str:
+    clean = (text or "").replace("\n", " ").strip()
+    if len(clean) <= max_chars:
+        return clean
+    return clean[: max_chars - 3] + "..."
+
+
+def _clean_visible_text(adapter: Any, text: Optional[str]) -> str:
+    cleaned = text or ""
+    if hasattr(adapter, "extract_media"):
+        _media_files, cleaned = adapter.extract_media(cleaned)
+    cleaned = cleaned.replace("[[audio_as_voice]]", "")
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def _format_elapsed(seconds: Optional[float]) -> str:
+    if seconds is None:
+        return "-"
+    if seconds < 10:
+        return f"{seconds:.1f}s"
+    return f"{int(round(seconds))}s"
+
+
+def _build_footer_markdown(
+    *,
+    model_label: Optional[str],
+    elapsed_seconds: Optional[float],
+    footer_text: Optional[str] = None,
+) -> str:
+    parts = []
+    if footer_text:
+        parts.append(str(footer_text).strip())
+    elif model_label or elapsed_seconds is not None:
+        if model_label:
+            parts.append(f"模型：{model_label}")
+        if elapsed_seconds is not None:
+            parts.append(f"耗时：{_format_elapsed(elapsed_seconds)}")
+    if not parts:
+        return ""
+    footer_text = " · ".join(parts)
+    return f"\n\n---\n<font color='grey'>{footer_text}</font>"
+
+
+class FeishuCardTokenCache:
+    def __init__(self) -> None:
+        self._cache: dict[str, tuple[str, float]] = {}
+
+    async def get_token(self, adapter: Any) -> str:
+        cache_key = f"{getattr(adapter, '_domain_name', 'feishu')}|{getattr(adapter, '_app_id', '')}"
+        cached = self._cache.get(cache_key)
+        if cached and cached[1] > time.time() + 60:
+            return cached[0]
+
+        if not getattr(adapter, "_app_id", "") or not getattr(adapter, "_app_secret", ""):
+            raise RuntimeError("Feishu app_id/app_secret missing")
+
+        if getattr(adapter, "_domain_name", "feishu") == "lark":
+            url = "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal"
+        else:
+            url = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal"
+
+        session = getattr(adapter, "_rest_session", None)
+        close_after = False
+        if session is None:
+            import aiohttp
+
+            session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+            close_after = True
+
+        try:
+            async with session.post(
+                url,
+                headers={"Content-Type": "application/json"},
+                json={"app_id": adapter._app_id, "app_secret": adapter._app_secret},
+            ) as response:
+                if response.status >= 400:
+                    raise RuntimeError(f"Feishu token request failed with HTTP {response.status}")
+                data = await response.json()
+        finally:
+            if close_after:
+                await session.close()
+
+        token = str(data.get("tenant_access_token") or "")
+        if int(data.get("code", -1)) != 0 or not token:
+            raise RuntimeError(f"Feishu token error: {data.get('msg') or 'unknown'}")
+
+        expires_in = int(data.get("expire") or 7200)
+        self._cache[cache_key] = (token, time.time() + expires_in)
+        return token
+
+
+_TOKEN_CACHE = FeishuCardTokenCache()
+
+
+@dataclass
+class _CompletionMeta:
+    final_text: Optional[str] = None
+    model_label: Optional[str] = None
+    elapsed_seconds: Optional[float] = None
+    footer_text: Optional[str] = None
+
+
+class _FeishuCardSession:
+    def __init__(self, adapter: Any, chat_id: str, metadata: Optional[dict] = None):
+        self.adapter = adapter
+        self.chat_id = chat_id
+        self.metadata = metadata or {}
+        self.card_id: Optional[str] = None
+        self.message_id: Optional[str] = None
+        self.sequence = 1
+        self.current_text = ""
+        self.closed = False
+        self._last_update_at = 0.0
+        self._pending_text: Optional[str] = None
+        self._throttle_ms = 100
+
+    async def _request(self, method: str, url: str, *, json_body: dict, audit_name: str) -> dict:
+        import aiohttp
+
+        token = await _TOKEN_CACHE.get_token(self.adapter)
+        session = getattr(self.adapter, "_rest_session", None)
+        close_after = False
+        if session is None:
+            session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+            close_after = True
+        try:
+            async with session.request(
+                method,
+                url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json; charset=utf-8",
+                },
+                json=json_body,
+            ) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    raise RuntimeError(f"{audit_name} failed with HTTP {response.status}: {body[:500]}")
+                data = await response.json()
+        finally:
+            if close_after:
+                await session.close()
+
+        if int(data.get("code", -1)) != 0:
+            raise RuntimeError(f"{audit_name} failed: {data.get('msg') or 'unknown'}")
+        return data
+
+    async def start(self) -> None:
+        if self.card_id:
+            return
+        api_base = _resolve_api_base(getattr(self.adapter, "_domain_name", "feishu"))
+        initial_card = {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": True,
+                "summary": {"content": "[Generating...]"},
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 50},
+                    "print_step": {"default": 1},
+                },
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": "⏳ Thinking...",
+                        "element_id": "content",
+                    }
+                ]
+            },
+        }
+
+        create_data = await self._request(
+            "POST",
+            f"{api_base}/cardkit/v1/cards",
+            json_body={"type": "card_json", "data": json.dumps(initial_card, ensure_ascii=False)},
+            audit_name="feishu.streaming-card.create",
+        )
+        self.card_id = str(((create_data.get("data") or {}).get("card_id") or "")).strip()
+        if not self.card_id:
+            raise RuntimeError("Feishu streaming card creation returned no card_id")
+
+        card_ref = json.dumps({"type": "card", "data": {"card_id": self.card_id}}, ensure_ascii=False)
+        response = await self.adapter._feishu_send_with_retry(
+            chat_id=self.chat_id,
+            msg_type="interactive",
+            payload=card_ref,
+            reply_to=None,
+            metadata=self.metadata,
+        )
+        result = self.adapter._finalize_send_result(response, "feishu streaming card send failed")
+        if not result.success or not result.message_id:
+            raise RuntimeError(result.error or "Feishu streaming card send failed")
+
+        self.message_id = result.message_id
+        self.adapter._store_message_text_cache(self.message_id, "⏳ Thinking...")
+
+    async def update(self, text: str) -> None:
+        if self.closed:
+            return
+        if not self.card_id:
+            await self.start()
+
+        merged = _merge_streaming_text(self._pending_text or self.current_text, text)
+        if not merged or merged == self.current_text:
+            return
+
+        now = time.time() * 1000
+        if now - self._last_update_at < self._throttle_ms:
+            self._pending_text = merged
+            return
+
+        self._pending_text = None
+        self._last_update_at = now
+        self.current_text = _merge_streaming_text(self.current_text, merged)
+        self.adapter._store_message_text_cache(self.message_id, self.current_text)
+        self.sequence += 1
+        api_base = _resolve_api_base(getattr(self.adapter, "_domain_name", "feishu"))
+        await self._request(
+            "PUT",
+            f"{api_base}/cardkit/v1/cards/{self.card_id}/elements/content/content",
+            json_body={
+                "content": self.current_text,
+                "sequence": self.sequence,
+                "uuid": f"s_{self.card_id}_{self.sequence}",
+            },
+            audit_name="feishu.streaming-card.update",
+        )
+
+    async def close(self, *, final_text: Optional[str], model_label: Optional[str], elapsed_seconds: Optional[float], footer_text: Optional[str] = None) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        if not self.card_id:
+            return
+
+        pending_merged = _merge_streaming_text(self.current_text, self._pending_text)
+        pending_visible = _clean_visible_text(self.adapter, pending_merged)
+        final_visible = _clean_visible_text(self.adapter, final_text)
+        display_text = final_visible or pending_visible
+        footer = _build_footer_markdown(
+            model_label=model_label,
+            elapsed_seconds=elapsed_seconds,
+            footer_text=footer_text,
+        )
+        if footer and footer not in display_text:
+            display_text = (display_text or "") + footer
+
+        if display_text and display_text != self.current_text:
+            self.sequence += 1
+            api_base = _resolve_api_base(getattr(self.adapter, "_domain_name", "feishu"))
+            await self._request(
+                "PUT",
+                f"{api_base}/cardkit/v1/cards/{self.card_id}/elements/content/content",
+                json_body={
+                    "content": display_text,
+                    "sequence": self.sequence,
+                    "uuid": f"s_{self.card_id}_{self.sequence}",
+                },
+                audit_name="feishu.streaming-card.final-update",
+            )
+            self.current_text = display_text
+
+        self.adapter._store_message_text_cache(self.message_id, self.current_text)
+        self.sequence += 1
+        api_base = _resolve_api_base(getattr(self.adapter, "_domain_name", "feishu"))
+        await self._request(
+            "PATCH",
+            f"{api_base}/cardkit/v1/cards/{self.card_id}/settings",
+            json_body={
+                "settings": json.dumps(
+                    {
+                        "config": {
+                            "streaming_mode": False,
+                            "summary": {"content": _truncate_summary(self.current_text)},
+                        }
+                    },
+                    ensure_ascii=False,
+                ),
+                "sequence": self.sequence,
+                "uuid": f"c_{self.card_id}_{self.sequence}",
+            },
+            audit_name="feishu.streaming-card.close",
+        )
+
+
+class FeishuCardStreamConsumer:
+    """Feishu-specific streaming consumer using interactive cards instead of message edits."""
+
+    def __init__(self, adapter: Any, chat_id: str, metadata: Optional[dict] = None):
+        self.adapter = adapter
+        self.chat_id = chat_id
+        self.metadata = metadata or {}
+        self._queue: queue.Queue = queue.Queue()
+        self._accumulated = ""
+        self._session = _FeishuCardSession(adapter=adapter, chat_id=chat_id, metadata=metadata)
+        self._completion = _CompletionMeta()
+        self._already_sent = False
+        self._final_response_sent = False
+
+    @property
+    def already_sent(self) -> bool:
+        return self._already_sent
+
+    @property
+    def final_response_sent(self) -> bool:
+        return self._final_response_sent
+
+    def on_delta(self, text: Optional[str]) -> None:
+        if text:
+            self._queue.put(text)
+
+    def on_segment_break(self) -> None:
+        return None
+
+    def on_commentary(self, text: str) -> None:
+        if text:
+            self._queue.put(text)
+
+    def set_completion_meta(
+        self,
+        *,
+        final_text: Optional[str] = None,
+        model_label: Optional[str] = None,
+        elapsed_seconds: Optional[float] = None,
+        footer_text: Optional[str] = None,
+    ) -> None:
+        self._completion = _CompletionMeta(
+            final_text=final_text,
+            model_label=model_label,
+            elapsed_seconds=elapsed_seconds,
+            footer_text=footer_text,
+        )
+
+    def finish(self) -> None:
+        self._queue.put(_DONE)
+
+    async def run(self) -> None:
+        try:
+            while True:
+                got_done = False
+                while True:
+                    try:
+                        item = self._queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if item is _DONE:
+                        got_done = True
+                        break
+                    self._accumulated = _merge_streaming_text(self._accumulated, str(item))
+
+                if self._accumulated:
+                    await self._session.update(self._accumulated)
+                    self._already_sent = True
+
+                if got_done:
+                    await self._session.close(
+                        final_text=self._completion.final_text or self._accumulated,
+                        model_label=self._completion.model_label,
+                        elapsed_seconds=self._completion.elapsed_seconds,
+                        footer_text=self._completion.footer_text,
+                    )
+                    delivered = bool(
+                        getattr(self._session, "message_id", None)
+                        or getattr(self._session, "card_id", None)
+                    )
+                    self._already_sent = self._already_sent or delivered
+                    self._final_response_sent = delivered
+                    return
+
+                await asyncio.sleep(0.05)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("Feishu interactive card streaming failed: %s", exc, exc_info=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9474,6 +9474,8 @@ class GatewayRunner:
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
+            # Track end-to-end turn duration for streaming footer metadata.
+            _stream_started_at = time.monotonic()
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None
             _stream_delta_cb = None
@@ -9518,18 +9520,26 @@ class GatewayRunner:
                         if source.platform == Platform.MATRIX:
                             _effective_cursor = ""
                             _buffer_only = True
-                        _consumer_cfg = StreamConsumerConfig(
-                            edit_interval=_scfg.edit_interval,
-                            buffer_threshold=_scfg.buffer_threshold,
-                            cursor=_effective_cursor,
-                            buffer_only=_buffer_only,
-                        )
-                        _stream_consumer = GatewayStreamConsumer(
-                            adapter=_adapter,
-                            chat_id=source.chat_id,
-                            config=_consumer_cfg,
-                            metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
-                        )
+                        _consumer_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else {}
+                        if event_message_id:
+                            _consumer_metadata["source_message_id"] = event_message_id
+                        _consumer_metadata = _consumer_metadata or None
+                        _adapter_factory = getattr(_adapter, "create_stream_consumer", None)
+                        if callable(_adapter_factory):
+                            _stream_consumer = _adapter_factory(source.chat_id, metadata=_consumer_metadata)
+                        if _stream_consumer is None:
+                            _consumer_cfg = StreamConsumerConfig(
+                                edit_interval=_scfg.edit_interval,
+                                buffer_threshold=_scfg.buffer_threshold,
+                                cursor=_effective_cursor,
+                                buffer_only=_buffer_only,
+                            )
+                            _stream_consumer = GatewayStreamConsumer(
+                                adapter=_adapter,
+                                chat_id=source.chat_id,
+                                config=_consumer_cfg,
+                                metadata=_consumer_metadata,
+                            )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
@@ -9905,10 +9915,6 @@ class GatewayRunner:
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
 
-            # Signal the stream consumer that the agent is done
-            if _stream_consumer is not None:
-                _stream_consumer.finish()
-            
             # Return final response, or a message if something went wrong
             final_response = result.get("final_response")
 
@@ -9922,6 +9928,20 @@ class GatewayRunner:
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _elapsed_seconds = max(0.0, time.monotonic() - _stream_started_at)
+
+            if _stream_consumer is not None:
+                try:
+                    if hasattr(_stream_consumer, "set_completion_meta"):
+                        _stream_consumer.set_completion_meta(
+                            final_text=final_response,
+                            model_label=_resolved_model,
+                            elapsed_seconds=_elapsed_seconds,
+                            footer_text=None,
+                        )
+                except Exception:
+                    pass
+                _stream_consumer.finish()
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -639,7 +639,7 @@ class TestAdapterBehavior(unittest.TestCase):
 
     @patch.dict(os.environ, {}, clear=True)
     @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
-    def test_add_ack_reaction_uses_ok_emoji(self):
+    def test_add_typing_reaction_uses_typing_emoji(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -662,13 +662,13 @@ class TestAdapterBehavior(unittest.TestCase):
             return func(*args, **kwargs)
 
         with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
-            reaction_id = asyncio.run(adapter._add_ack_reaction("om_msg"))
+            reaction_id = asyncio.run(adapter._add_typing_reaction("om_msg"))
 
         self.assertEqual(reaction_id, "r_typing")
-        self.assertEqual(captured["request"].request_body.reaction_type["emoji_type"], "OK")
+        self.assertEqual(captured["request"].request_body.reaction_type["emoji_type"], "Typing")
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_add_ack_reaction_logs_warning_on_failure(self):
+    def test_add_typing_reaction_logs_warning_on_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -689,16 +689,16 @@ class TestAdapterBehavior(unittest.TestCase):
             patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
             self.assertLogs("gateway.platforms.feishu", level="WARNING") as logs,
         ):
-            reaction_id = asyncio.run(adapter._add_ack_reaction("om_msg"))
+            reaction_id = asyncio.run(adapter._add_typing_reaction("om_msg"))
 
         self.assertIsNone(reaction_id)
         self.assertTrue(
-            any("Failed to add ack reaction to om_msg" in entry for entry in logs.output),
+            any("Failed to add typing reaction to om_msg" in entry for entry in logs.output),
             logs.output,
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_ack_reaction_events_are_ignored_to_avoid_feedback_loops(self):
+    def test_typing_reaction_events_are_ignored_to_avoid_feedback_loops(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -707,7 +707,7 @@ class TestAdapterBehavior(unittest.TestCase):
         event = SimpleNamespace(
             message_id="om_msg",
             operator_type="user",
-            reaction_type=SimpleNamespace(emoji_type="OK"),
+            reaction_type=SimpleNamespace(emoji_type="Typing"),
         )
         data = SimpleNamespace(event=event)
 
@@ -715,6 +715,123 @@ class TestAdapterBehavior(unittest.TestCase):
             adapter._on_reaction_event("im.message.reaction.created_v1", data)
 
         run_threadsafe.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_store_message_text_cache_updates_and_clears_values(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._store_message_text_cache("om_msg", " hello ")
+        self.assertEqual(adapter._message_text_cache["om_msg"], "hello")
+        adapter._store_message_text_cache("om_msg", "")
+        self.assertNotIn("om_msg", adapter._message_text_cache)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_create_stream_consumer_returns_card_consumer_when_enabled(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"interactive_card_streaming": True}))
+        consumer = adapter.create_stream_consumer("oc_chat", metadata={"source_message_id": "om_src"})
+        self.assertIsNotNone(consumer)
+        self.assertEqual(consumer.metadata.get("source_message_id"), "om_src")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_create_stream_consumer_returns_none_for_raw_render_mode(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"render_mode": "raw"}))
+        consumer = adapter.create_stream_consumer("oc_chat", metadata=None)
+        self.assertIsNone(consumer)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_typing_source_message_id_prefers_reply_to_then_metadata(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        self.assertEqual(
+            FeishuAdapter._typing_source_message_id("om_reply", {"source_message_id": "om_src"}),
+            "om_reply",
+        )
+        self.assertEqual(
+            FeishuAdapter._typing_source_message_id(None, {"source_message_id": "om_src"}),
+            "om_src",
+        )
+        self.assertEqual(
+            FeishuAdapter._typing_source_message_id(None, {"typing_source_message_id": "om_alt"}),
+            "om_alt",
+        )
+        self.assertIsNone(FeishuAdapter._typing_source_message_id(None, None))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_clear_pending_typing_reaction_deletes_registered_reaction(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._pending_typing_reactions["om_msg"] = ("r1", 0.0)
+
+        async def _fake_delete(*, message_id, reaction_id):
+            self.assertEqual(message_id, "om_msg")
+            self.assertEqual(reaction_id, "r1")
+
+        with patch("gateway.platforms.feishu.time.monotonic", return_value=10.0), patch.object(
+            adapter, "_delete_reaction", side_effect=_fake_delete
+        ) as delete_mock:
+            asyncio.run(adapter._clear_pending_typing_reaction("om_msg"))
+
+        delete_mock.assert_called_once()
+        self.assertNotIn("om_msg", adapter._pending_typing_reactions)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_on_processing_complete_clears_pending_typing_reaction(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        event = SimpleNamespace(message_id="om_msg")
+
+        with patch.object(adapter, "_clear_pending_typing_reaction", new=AsyncMock()) as clear_mock:
+            asyncio.run(adapter.on_processing_complete(event, outcome=None))
+
+        clear_mock.assert_awaited_once_with("om_msg")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_raw_message_schedules_typing_cleanup_only_after_success(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        success_response = Mock()
+        success_response.success.return_value = True
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(reply=Mock(return_value=success_response))
+                )
+            )
+        )
+
+        def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+            patch.object(adapter, "_schedule_typing_cleanup_after_outbound") as schedule_mock,
+        ):
+            response = asyncio.run(
+                adapter._send_raw_message(
+                    chat_id="oc_chat",
+                    msg_type="text",
+                    payload='{"text":"hi"}',
+                    reply_to="om_reply",
+                    metadata={"source_message_id": "om_src"},
+                )
+            )
+
+        self.assertIs(response, success_response)
+        schedule_mock.assert_called_once_with(reply_to="om_reply", metadata={"source_message_id": "om_src"})
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_message_requires_mentions_even_when_policy_open(self):

--- a/tests/gateway/test_feishu_streaming_card.py
+++ b/tests/gateway/test_feishu_streaming_card.py
@@ -1,0 +1,91 @@
+import pytest
+
+import gateway.platforms.feishu_streaming_card as feishu_streaming_card
+
+
+class _FakeSession:
+    def __init__(self, adapter, chat_id, metadata=None):
+        self.adapter = adapter
+        self.chat_id = chat_id
+        self.metadata = metadata or {}
+        self.updates = []
+        self.close_calls = []
+        self.card_id = "card_123"
+        self.message_id = "msg_123"
+
+    async def update(self, text: str) -> None:
+        self.updates.append(text)
+
+    async def close(self, *, final_text, model_label, elapsed_seconds, footer_text=None) -> None:
+        self.close_calls.append(
+            {
+                "final_text": final_text,
+                "model_label": model_label,
+                "elapsed_seconds": elapsed_seconds,
+                "footer_text": footer_text,
+            }
+        )
+
+
+class _FailingCloseSession(_FakeSession):
+    async def close(self, *, final_text, model_label, elapsed_seconds, footer_text=None) -> None:
+        raise RuntimeError("close failed")
+
+
+class _NoCardSession(_FakeSession):
+    def __init__(self, adapter, chat_id, metadata=None):
+        super().__init__(adapter, chat_id, metadata)
+        self.card_id = None
+        self.message_id = None
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_stream_consumer_marks_final_response_sent(monkeypatch):
+    monkeypatch.setattr(feishu_streaming_card, "_FeishuCardSession", _FakeSession)
+
+    consumer = feishu_streaming_card.FeishuCardStreamConsumer(adapter=object(), chat_id="chat_123")
+    consumer.on_delta("Hello")
+    consumer.set_completion_meta(final_text="Hello world", model_label="gpt-test", elapsed_seconds=1.2)
+    consumer.finish()
+
+    await consumer.run()
+
+    assert consumer.already_sent is True
+    assert consumer.final_response_sent is True
+    assert consumer._session.updates == ["Hello"]
+    assert consumer._session.close_calls == [
+        {
+            "final_text": "Hello world",
+            "model_label": "gpt-test",
+            "elapsed_seconds": 1.2,
+            "footer_text": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_stream_consumer_does_not_mark_final_when_close_fails(monkeypatch):
+    monkeypatch.setattr(feishu_streaming_card, "_FeishuCardSession", _FailingCloseSession)
+
+    consumer = feishu_streaming_card.FeishuCardStreamConsumer(adapter=object(), chat_id="chat_123")
+    consumer.on_delta("Hello")
+    consumer.finish()
+
+    await consumer.run()
+
+    assert consumer.already_sent is True
+    assert consumer.final_response_sent is False
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_stream_consumer_does_not_claim_final_delivery_without_card(monkeypatch):
+    monkeypatch.setattr(feishu_streaming_card, "_FeishuCardSession", _NoCardSession)
+
+    consumer = feishu_streaming_card.FeishuCardStreamConsumer(adapter=object(), chat_id="chat_123")
+    consumer.set_completion_meta(final_text="Hello world", model_label="gpt-test", elapsed_seconds=1.2)
+    consumer.finish()
+
+    await consumer.run()
+
+    assert consumer.already_sent is False
+    assert consumer.final_response_sent is False

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -20,6 +20,8 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         self.sent = []
         self.edits = []
         self.typing = []
+        self.created_consumers = []
+        self.enable_custom_stream_consumer = False
 
     async def connect(self) -> bool:
         return True
@@ -56,6 +58,44 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str):
         return {"id": chat_id}
+
+    def create_stream_consumer(self, chat_id, metadata=None):
+        if not self.enable_custom_stream_consumer:
+            return None
+        consumer = CaptureStreamConsumer(chat_id=chat_id, metadata=metadata)
+        self.created_consumers.append(consumer)
+        return consumer
+
+
+class CaptureStreamConsumer:
+    def __init__(self, *, chat_id, metadata=None):
+        self.chat_id = chat_id
+        self.metadata = metadata or {}
+        self.completion_meta = None
+        self.finished = False
+        self.final_response_sent = False
+        self._commentary = []
+
+    def on_delta(self, text):
+        return None
+
+    def on_commentary(self, text):
+        if text:
+            self._commentary.append(text)
+
+    def on_segment_break(self):
+        return None
+
+    async def run(self):
+        while not self.finished:
+            await asyncio.sleep(0.01)
+
+    def set_completion_meta(self, **kwargs):
+        self.completion_meta = kwargs
+
+    def finish(self):
+        self.finished = True
+        self.final_response_sent = True
 
 
 class FakeAgent:
@@ -430,6 +470,26 @@ class StreamingRefineAgent:
             self.stream_delta_callback(" Final answer.")
         return {
             "final_response": "Continuing to refine: Final answer.",
+            "response_previewed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class StreamingMetaAgent:
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+        self.model = "gpt-5-codex"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=12345, context_length=200000)
+        self.session_prompt_tokens = 12345
+        self.session_completion_tokens = 678
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback("Codex says hi")
+        return {
+            "final_response": "Codex says hi",
             "response_previewed": True,
             "messages": [],
             "api_calls": 1,
@@ -928,6 +988,55 @@ async def test_keep_typing_stops_immediately_when_interrupt_event_is_set():
     ]
     assert len(normal_typing_calls) == 1
     assert len(stopped_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_agent_streaming_sets_completion_meta(monkeypatch, tmp_path):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = StreamingMetaAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openai-codex"},
+    )
+
+    adapter = ProgressCaptureAdapter()
+    adapter.enable_custom_stream_consumer = True
+    runner = _make_runner(adapter)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-stream-meta",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "Codex says hi"
+    assert adapter.created_consumers
+    consumer = adapter.created_consumers[0]
+    assert consumer.finished is True
+    assert consumer.completion_meta is not None
+    assert consumer.completion_meta["final_text"] == "Codex says hi"
+    assert consumer.completion_meta["model_label"] == "gpt-5-codex"
+    assert consumer.completion_meta["footer_text"] is None
+    assert isinstance(consumer.completion_meta["elapsed_seconds"], float)
+    assert consumer.completion_meta["elapsed_seconds"] >= 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a Feishu-specific stream consumer that renders incremental responses via interactive cards
- switch the inbound Feishu receipt signal from a persistent ACK reaction to a transient Typing reaction
- attach completion metadata to streamed Feishu cards so the final card can show model / elapsed-time footer information
- keep the gateway fallback path safe when no streamed card was actually delivered

## Why
Feishu currently has a rougher streaming experience than some other platforms:
- users do not get a platform-native transient processing indicator
- token streaming falls back to generic message-edit behavior instead of a Feishu-native card experience
- the final response lacks lightweight completion metadata in the rendered card

This PR improves the end-to-end Feishu interaction loop:
message received -> transient Typing feedback -> incremental card rendering -> final card with completion details.

## Implementation notes
- `gateway/platforms/feishu.py`
  - add `create_stream_consumer()` hook for Feishu
  - replace the persistent ACK reaction with a transient Typing reaction
  - track pending typing reactions and clean them up after successful outbound delivery
- `gateway/platforms/feishu_streaming_card.py`
  - add a Feishu interactive-card stream consumer
  - merge partial text safely across deltas/commentary updates
  - finalize cards with completion metadata footer and a stable summary
- `gateway/run.py`
  - let adapters provide a custom stream consumer
  - pass completion metadata (`final_text`, `model_label`, `elapsed_seconds`) into the consumer before finish
  - preserve the normal final-send fallback if a custom consumer never actually delivered the final response

## Tests
- `python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_streaming_card.py tests/gateway/test_run_progress_topics.py -q`

Passed locally: `137 passed`
