### PR TITLE
fix: scope gateway session resume by user

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6756,7 +6756,9 @@ class GatewayRunner:
             try:
                 user_source = source.platform.value if source.platform else None
                 sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
+                    source=user_source,
+                    user_id=source.user_id,
+                    limit=10,
                 )
                 titled = [s for s in sessions if s.get("title")]
                 if not titled:
@@ -6778,7 +6780,12 @@ class GatewayRunner:
                 return f"Could not list sessions: {e}"
 
         # Resolve the name to a session ID
-        target_id = self._session_db.resolve_session_by_title(name)
+        user_source = source.platform.value if source.platform else None
+        target_id = self._session_db.resolve_session_by_title(
+            name,
+            source=user_source,
+            user_id=source.user_id,
+        )
         if not target_id:
             return (
                 f"No session found matching '**{name}**'.\n"

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -641,16 +641,36 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(
+        self,
+        title: str,
+        source: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
+        where_clauses = ["title = ?"]
+        params = [title]
+        if source is not None:
+            where_clauses.append("source = ?")
+            params.append(source)
+        if user_id is not None:
+            where_clauses.append("user_id = ?")
+            params.append(user_id)
+
         with self._lock:
             cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
+                f"SELECT * FROM sessions WHERE {' AND '.join(where_clauses)}",
+                params,
             )
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self,
+        title: str,
+        source: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -659,16 +679,24 @@ class SessionDB:
         latest numbered variant (the most recent continuation).
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, source=source, user_id=user_id)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        where_clauses = ["title LIKE ? ESCAPE '\\'"]
+        params = [f"{escaped} #%"]
+        if source is not None:
+            where_clauses.append("source = ?")
+            params.append(source)
+        if user_id is not None:
+            where_clauses.append("user_id = ?")
+            params.append(user_id)
         with self._lock:
             cursor = self._conn.execute(
                 "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
+                f"WHERE {' AND '.join(where_clauses)} ORDER BY started_at DESC",
+                params,
             )
             numbered = cursor.fetchall()
 
@@ -717,6 +745,7 @@ class SessionDB:
     def list_sessions_rich(
         self,
         source: str = None,
+        user_id: str = None,
         exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -742,6 +771,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if user_id:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -80,16 +80,19 @@ class TestHandleResumeCommand:
         """With no argument, lists recently titled sessions."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")
-        db.create_session("sess_002", "telegram")
+        db.create_session("sess_001", "telegram", user_id="12345")
+        db.create_session("sess_002", "telegram", user_id="12345")
+        db.create_session("other_user_session", "telegram", user_id="other-user")
         db.set_session_title("sess_001", "Research")
         db.set_session_title("sess_002", "Coding")
+        db.set_session_title("other_user_session", "Hidden")
 
         event = _make_event(text="/resume")
         runner = _make_runner(session_db=db, event=event)
         result = await runner._handle_resume_command(event)
         assert "Research" in result
         assert "Coding" in result
+        assert "Hidden" not in result
         assert "Named Sessions" in result
         db.close()
 
@@ -98,7 +101,7 @@ class TestHandleResumeCommand:
         """With no arg and no titled sessions, shows instructions."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")  # No title
+        db.create_session("sess_001", "telegram", user_id="12345")  # No title
 
         event = _make_event(text="/resume")
         runner = _make_runner(session_db=db, event=event)
@@ -112,9 +115,9 @@ class TestHandleResumeCommand:
         """Resolves a title and switches to that session."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session_abc", "telegram")
+        db.create_session("old_session_abc", "telegram", user_id="12345")
         db.set_session_title("old_session_abc", "My Project")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume My Project")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -134,7 +137,7 @@ class TestHandleResumeCommand:
         """Returns error for unknown session name."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Nonexistent Session")
         runner = _make_runner(session_db=db, event=event)
@@ -143,11 +146,31 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_does_not_cross_user_or_source_scope(self, tmp_path):
+        """Gateway /resume should not bind a caller to another user's session."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("cli_session", "cli", user_id="cli-user")
+        db.set_session_title("cli_session", "Secret Plan")
+        db.create_session("other_user_session", "telegram", user_id="other-user")
+        db.set_session_title("other_user_session", "Other User Plan")
+        db.create_session("current_session_001", "telegram", user_id="12345")
+
+        event = _make_event(text="/resume Secret Plan", user_id="12345")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "No session found" in result
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_already_on_session(self, tmp_path):
         """Returns friendly message when already on the requested session."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
         db.set_session_title("current_session_001", "Active Project")
 
         event = _make_event(text="/resume Active Project")
@@ -162,11 +185,11 @@ class TestHandleResumeCommand:
         """Asking for 'My Project' when 'My Project #2' exists gets the latest."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_v1", "telegram")
+        db.create_session("sess_v1", "telegram", user_id="12345")
         db.set_session_title("sess_v1", "My Project")
-        db.create_session("sess_v2", "telegram")
+        db.create_session("sess_v2", "telegram", user_id="12345")
         db.set_session_title("sess_v2", "My Project #2")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume My Project")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -184,9 +207,9 @@ class TestHandleResumeCommand:
         """Switching sessions clears any cached running agent."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session", "telegram")
+        db.create_session("old_session", "telegram", user_id="12345")
         db.set_session_title("old_session", "Old Work")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Old Work")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -206,9 +229,9 @@ class TestHandleResumeCommand:
         from hermes_state import SessionDB
 
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session", "telegram")
+        db.create_session("old_session", "telegram", user_id="12345")
         db.set_session_title("old_session", "Old Work")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Old Work")
         runner = _make_runner(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1223,6 +1223,33 @@ class TestTitleLineage:
         # Resolving "my project #2" exactly should return s2
         assert db.resolve_session_by_title("my project #2") == "s2"
 
+    def test_resolve_title_honors_source_and_user_scope(self, db):
+        """Scoped lookups should not select another source/user's lineage."""
+        db.create_session("s1", "telegram", user_id="u1")
+        db.set_session_title("s1", "my project")
+        db.create_session("s2", "cli", user_id="cli-user")
+        db.set_session_title("s2", "my project #2")
+        db.create_session("s3", "telegram", user_id="u2")
+        db.set_session_title("s3", "other user project")
+
+        assert db.resolve_session_by_title("my project") == "s2"
+        assert (
+            db.resolve_session_by_title(
+                "my project",
+                source="telegram",
+                user_id="u1",
+            )
+            == "s1"
+        )
+        assert (
+            db.resolve_session_by_title(
+                "my project #2",
+                source="telegram",
+                user_id="u1",
+            )
+            is None
+        )
+
     def test_resolve_nonexistent_title(self, db):
         assert db.resolve_session_by_title("nonexistent") is None
 


### PR DESCRIPTION
## Summary
- Scope gateway /resume title lookup and listing to the caller's platform and user id.
- Keep existing global title resolution behavior for callers that do not pass scope filters.
- Add regression coverage for cross-source/user resume attempts and scoped title lineage resolution.

## Root cause
Gateway /resume passed only the requested title to the session database. The database resolved exact and numbered title variants globally, so a gateway caller could bind their current session key to an unrelated titled session from another source or user.

## Changes
- Added optional source and user_id filters to session title lookup, title lineage resolution, and rich session listing.
- Updated the gateway resume command to pass the current event source and user id into those lookups.
- Extended tests to verify cross-scope titles are hidden and do not trigger session switches.

## Validation
- .\\venv\\Scripts\\python.exe -m pytest tests\\gateway\\test_resume_command.py -q -n0
- .\\venv\\Scripts\\python.exe -m pytest tests\\test_hermes_state.py::TestTitleLineage -q -n0
- .\\venv\\Scripts\\python.exe -m pytest tests\\test_hermes_state.py -q -n0
- .\\venv\\Scripts\\python.exe -m py_compile gateway\\run.py hermes_state.py tests\\gateway\\test_resume_command.py tests\\test_hermes_state.py
- git diff --check

Fixes #12173