### PR TITLE
fix: report expired Weixin sessions

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1254,10 +1254,13 @@ class WeixinAdapter(BasePlatformAdapter):
                 errcode = response.get("errcode", 0)
                 if ret not in (0, None) or errcode not in (0, None):
                     if ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE:
-                        logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
-                        await asyncio.sleep(600)
-                        consecutive_failures = 0
-                        continue
+                        message = (
+                            "Weixin iLink session expired; run QR login again to refresh credentials"
+                        )
+                        logger.error("[%s] %s", self.name, message)
+                        self._set_fatal_error("weixin_session_expired", message, retryable=False)
+                        await self._notify_fatal_error()
+                        break
                     consecutive_failures += 1
                     logger.warning(
                         "[%s] getUpdates failed ret=%s errcode=%s errmsg=%s (%d/%d)",

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -359,6 +359,30 @@ class TestWeixinChunkDelivery:
         assert first_try["client_id"] == retry["client_id"]
 
 
+class TestWeixinPollLoop:
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._get_updates", new_callable=AsyncMock)
+    def test_session_expiry_reports_fatal_error_without_long_pause(self, get_updates_mock, sleep_mock):
+        adapter = _make_adapter()
+        adapter._poll_session = object()
+        adapter._running = True
+        notify_mock = AsyncMock()
+        adapter.set_fatal_error_handler(notify_mock)
+        get_updates_mock.side_effect = [
+            {"ret": weixin.SESSION_EXPIRED_ERRCODE, "errmsg": "session expired"},
+            asyncio.CancelledError(),
+        ]
+
+        asyncio.run(adapter._poll_loop())
+
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "weixin_session_expired"
+        assert adapter.fatal_error_retryable is False
+        assert "QR login" in (adapter.fatal_error_message or "")
+        sleep_mock.assert_not_awaited()
+        notify_mock.assert_awaited_once_with(adapter)
+
+
 class TestWeixinOutboundMedia:
     def test_send_image_file_accepts_keyword_image_path(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- Stop pausing the Weixin polling loop for 10 minutes when iLink reports an expired session.
- Surface the expired-session state through the adapter fatal-error path so the gateway can report that QR login is required.
- Add regression coverage for the expired-session polling response.

## Root cause
The Weixin poll loop handled iLink session expiration by sleeping for 10 minutes and then retrying the same expired credentials. That kept the adapter in a connected-looking state without making progress or clearly reporting the required re-authentication step.

## Changes
- Convert iLink -14 responses from getUpdates into a non-retryable weixin_session_expired fatal error.
- Notify the gateway fatal-error handler immediately instead of sleeping in the poll loop.
- Cover the behavior with a poll-loop test that ensures no long pause is scheduled.

## Validation
- .\\venv\\Scripts\\python.exe -m pytest tests\\gateway\\test_weixin.py::TestWeixinPollLoop::test_session_expiry_reports_fatal_error_without_long_pause -q -n0
- .\\venv\\Scripts\\python.exe -m pytest tests\\gateway\\test_weixin.py -q -n0
- .\\venv\\Scripts\\python.exe -m py_compile gateway\\platforms\\weixin.py tests\\gateway\\test_weixin.py
- git diff --check

Fixes #12154