### PR TITLE
perf(docker): layer-cache npm/Playwright and skip redundant web rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,32 +21,36 @@ RUN useradd -u 10000 -m -d /opt/data hermes
 COPY --chmod=0755 --from=gosu_source /gosu /usr/local/bin/
 COPY --chmod=0755 --from=uv_source /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 
-COPY . /opt/hermes
 WORKDIR /opt/hermes
 
-# Install Node dependencies and Playwright as root (--with-deps needs apt)
+# ---------- Layer-cached dependency install ----------
+# Copy only package manifests first so npm install + Playwright are cached
+# unless the lockfiles themselves change.
+COPY package.json package-lock.json ./
+COPY scripts/whatsapp-bridge/package.json scripts/whatsapp-bridge/package-lock.json scripts/whatsapp-bridge/
+COPY web/package.json web/package-lock.json web/
+
 RUN npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
-    cd /opt/hermes/scripts/whatsapp-bridge && \
-    npm install --prefer-offline --no-audit && \
+    cd scripts/whatsapp-bridge && npm install --prefer-offline --no-audit && cd ../.. && \
+    cd web && npm install --prefer-offline --no-audit && cd .. && \
     npm cache clean --force
 
-# Build the web/ dashboard so FastAPI at :9119 can serve the Vite assets
-RUN cd /opt/hermes/web && \
-    npm install --prefer-offline --no-audit && \
-    npm run build && \
-    npm cache clean --force
+# ---------- Source code ----------
+# .dockerignore excludes node_modules, so the installs above survive.
+COPY --chown=hermes:hermes . .
 
-# Hand ownership to hermes user, then install Python deps in a virtualenv
-RUN chown -R hermes:hermes /opt/hermes
+# Build web dashboard (Vite outputs to hermes_cli/web_dist/)
+RUN cd web && npm run build
+
+# ---------- Python virtualenv ----------
+RUN chown hermes:hermes /opt/hermes
 USER hermes
-
 RUN uv venv && \
     uv pip install --no-cache-dir -e ".[all]"
 
-USER root
-RUN chmod +x /opt/hermes/docker/entrypoint.sh
-
+# ---------- Runtime ----------
+ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ COPY web/package.json web/package-lock.json web/
 
 RUN npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
-    cd scripts/whatsapp-bridge && npm install --prefer-offline --no-audit && cd ../.. && \
-    cd web && npm install --prefer-offline --no-audit && cd .. && \
+    (cd scripts/whatsapp-bridge && npm install --prefer-offline --no-audit) && \
+    (cd web && npm install --prefer-offline --no-audit) && \
     npm cache clean --force
 
 # ---------- Source code ----------


### PR DESCRIPTION
## Summary

- **Layer-cached npm + Playwright**: copy package manifests before source so the slow npm install + Playwright download (~5-10 min) only re-runs when lockfiles change, not on every code change
- **`COPY --chown`** replaces `chown -R hermes:hermes /opt/hermes` — avoids touching every file in the tree
- **`HERMES_WEB_DIST` env var set**: skips the redundant runtime `npm install && npm run build` since assets are already baked into the image
- **Removed `USER root` / `chmod +x` dance**: `entrypoint.sh` is already `100755` in git, Docker preserves the execute bit

## Test plan

- [x] `docker build --no-cache` succeeds
- [x] `docker run version` prints correct version
- [x] Web assets present at `/opt/hermes/hermes_cli/web_dist/`
- [x] `HERMES_WEB_DIST` env var set correctly
- [x] Rebuild after code-only change: npm + Playwright layer stays cached, only source copy + web build + Python install re-run (~28s)

