### PR TITLE
feat(model): per-source model selection via model.by_source

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from utils import is_truthy_value
 
@@ -193,3 +193,87 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
             tuple(runtime.get("args") or ()),
         ),
     }
+
+
+# Recognised source kinds for ``model.by_source``. Callers pass one of these
+# strings; unknown kinds are ignored (treated as no override).
+SOURCE_KIND_OWNER = "owner"
+SOURCE_KIND_HUB_PEER = "hub_peer"
+SOURCE_KIND_STRANGER = "stranger"
+SOURCE_KIND_CRON = "cron"
+KNOWN_SOURCE_KINDS = frozenset({
+    SOURCE_KIND_OWNER,
+    SOURCE_KIND_HUB_PEER,
+    SOURCE_KIND_STRANGER,
+    SOURCE_KIND_CRON,
+})
+
+_OVERRIDE_RUNTIME_KEYS = ("api_key", "base_url", "provider", "api_mode", "command", "args")
+
+
+def apply_source_override(
+    model: str,
+    runtime_kwargs: Dict[str, Any],
+    model_config: Optional[Dict[str, Any]],
+    source_kind: Optional[str],
+) -> Tuple[str, Dict[str, Any]]:
+    """Apply per-source model-bundle overrides from ``model.by_source.<kind>``.
+
+    ``config.yaml`` may optionally declare::
+
+        model:
+          default: my-fast-model
+          provider: custom
+          api_key: sk-default
+          base_url: https://example.com/v1
+          by_source:
+            owner:    { model: my-strong-model, api_key: sk-owner }
+            hub_peer: { model: my-fast-model }
+            stranger: { }             # empty → use base
+            cron:     { model: my-fast-model }
+
+    When a ``by_source`` entry exists for ``source_kind``, its fields override
+    the passed-in ``(model, runtime_kwargs)`` pair. Missing fields inherit the
+    base values (partial overrides are supported). If ``source_kind`` is empty
+    or no entry exists, the inputs are returned unchanged.
+
+    Callers are responsible for classifying the source (``"owner"``,
+    ``"hub_peer"``, ``"stranger"``, ``"cron"``) using whatever signals they
+    have: the gateway uses home-channel identity; cron hardcodes ``"cron"``;
+    the CLI hardcodes ``"owner"``.
+    """
+    if not source_kind:
+        return model, runtime_kwargs
+    if not isinstance(model_config, dict):
+        return model, runtime_kwargs
+    by_source = model_config.get("by_source")
+    if not isinstance(by_source, dict):
+        return model, runtime_kwargs
+    entry = by_source.get(source_kind)
+    if not isinstance(entry, dict) or not entry:
+        return model, runtime_kwargs
+
+    new_model = model
+    new_runtime = dict(runtime_kwargs or {})
+    applied = []
+
+    if entry.get("model"):
+        new_model = str(entry["model"])
+        applied.append("model")
+    for key in _OVERRIDE_RUNTIME_KEYS:
+        val = entry.get(key)
+        if val in (None, "", []):
+            continue
+        if key == "args":
+            new_runtime[key] = list(val)
+        else:
+            new_runtime[key] = val
+        applied.append(key)
+
+    if applied:
+        import logging
+        logging.getLogger(__name__).info(
+            "by_source override applied: source_kind=%s fields=%s model=%s provider=%s",
+            source_kind, applied, new_model, new_runtime.get("provider"),
+        )
+    return new_model, new_runtime

--- a/cli.py
+++ b/cli.py
@@ -2835,20 +2835,33 @@ class HermesCLI:
 
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Resolve model/runtime overrides for a single user turn."""
-        from agent.smart_model_routing import resolve_turn_route
+        from agent.smart_model_routing import resolve_turn_route, apply_source_override
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        # CLI is always the owner (operator-driven). Apply
+        # ``model.by_source.owner`` override if present before routing.
+        _cli_model = self.model
+        _cli_runtime = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+            "provider": self.provider,
+            "api_mode": self.api_mode,
+            "command": self.acp_command,
+            "args": list(self.acp_args or []),
+        }
+        _cli_cfg_model = CLI_CONFIG.get("model") if isinstance(CLI_CONFIG, dict) else None
+        if not isinstance(_cli_cfg_model, dict):
+            _cli_cfg_model = None
+        _cli_model, _cli_runtime = apply_source_override(
+            _cli_model, _cli_runtime, _cli_cfg_model, "owner",
+        )
 
         route = resolve_turn_route(
             user_message,
             self._smart_model_routing,
             {
-                "model": self.model,
-                "api_key": self.api_key,
-                "base_url": self.base_url,
-                "provider": self.provider,
-                "api_mode": self.api_mode,
-                "command": self.acp_command,
-                "args": list(self.acp_args or []),
+                "model": _cli_model,
+                **_cli_runtime,
                 "credential_pool": getattr(self, "_credential_pool", None),
             },
         )

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -777,18 +777,30 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
-        from agent.smart_model_routing import resolve_turn_route
+        # Apply ``model.by_source.cron`` override (if any) before routing.
+        # Source kind is always "cron" here; this is the single hook point for
+        # cron-specific model/provider selection.
+        from agent.smart_model_routing import resolve_turn_route, apply_source_override
+        _cron_primary_runtime = {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+        }
+        _cron_cfg_model = _cfg.get("model") if isinstance(_cfg, dict) else None
+        if not isinstance(_cron_cfg_model, dict):
+            _cron_cfg_model = None
+        model, _cron_primary_runtime = apply_source_override(
+            model, _cron_primary_runtime, _cron_cfg_model, "cron",
+        )
         turn_route = resolve_turn_route(
             prompt,
             smart_routing,
             {
                 "model": model,
-                "api_key": runtime.get("api_key"),
-                "base_url": runtime.get("base_url"),
-                "provider": runtime.get("provider"),
-                "api_mode": runtime.get("api_mode"),
-                "command": runtime.get("command"),
-                "args": list(runtime.get("args") or []),
+                **_cron_primary_runtime,
             },
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -464,20 +464,76 @@ def _load_gateway_config() -> dict:
     return {}
 
 
-def _resolve_gateway_model(config: dict | None = None) -> str:
+def _resolve_gateway_model(config: dict | None = None, platform: str | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
     Without this, temporary AIAgent instances (memory flush, /compress) fall
     back to the hardcoded default which fails when the active provider is
     openai-codex.
+
+    When *platform* is provided, checks ``model.platforms.{platform}`` first,
+    falling back to the default model. This allows per-platform model overrides
+    (e.g. a cheaper model for Hub conversations).
     """
     cfg = config if config is not None else _load_gateway_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg
     elif isinstance(model_cfg, dict):
+        # Per-platform override (string shorthand or dict with model key)
+        if platform:
+            platforms = model_cfg.get("platforms")
+            if isinstance(platforms, dict):
+                override = platforms.get(platform)
+                if isinstance(override, str) and override:
+                    return override
+                if isinstance(override, dict) and override.get("model"):
+                    return override["model"]
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
+
+
+def _resolve_platform_provider_overrides(
+    config: dict | None = None,
+    platform: str | None = None,
+) -> dict | None:
+    """Return per-platform provider overrides (base_url, api_key) if configured.
+
+    Supports two config forms::
+
+        # String shorthand — model name only, same provider
+        model:
+          platforms:
+            hub: slate-2
+
+        # Dict — full provider override
+        model:
+          platforms:
+            hub:
+              model: slate-2
+              base_url: "https://other-endpoint/v1"
+              api_key: "sk-..."
+
+    Returns a dict with keys to merge into runtime_kwargs, or None.
+    """
+    if not platform:
+        return None
+    cfg = config if config is not None else _load_gateway_config()
+    model_cfg = cfg.get("model", {})
+    if not isinstance(model_cfg, dict):
+        return None
+    platforms = model_cfg.get("platforms")
+    if not isinstance(platforms, dict):
+        return None
+    override = platforms.get(platform)
+    if not isinstance(override, dict):
+        return None
+    result = {}
+    if override.get("base_url"):
+        result["base_url"] = override["base_url"]
+    if override.get("api_key"):
+        result["api_key"] = override["api_key"]
+    return result or None
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -919,6 +975,10 @@ class GatewayRunner:
         If the session override already contains a complete provider bundle
         (provider/api_key/base_url/api_mode), prefer it directly instead of
         resolving fresh global runtime state first.
+
+        When *source* is provided, per-platform model/provider overrides from
+        ``config.yaml`` (``model.platforms.<platform>``) are applied underneath
+        any session override.
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -927,7 +987,9 @@ class GatewayRunner:
             except Exception:
                 resolved_session_key = None
 
-        model = _resolve_gateway_model(user_config)
+        platform_key = _platform_config_key(source.platform) if source is not None else None
+
+        model = _resolve_gateway_model(user_config, platform=platform_key)
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
             override_model = override.get("model", model)
@@ -958,6 +1020,9 @@ class GatewayRunner:
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        platform_overrides = _resolve_platform_provider_overrides(user_config, platform=platform_key)
+        if platform_overrides:
+            runtime_kwargs = {**runtime_kwargs, **platform_overrides}
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs
@@ -6263,7 +6328,6 @@ class GatewayRunner:
                 )
                 return
 
-            platform_key = _platform_config_key(source.platform)
             reasoning_config = self._load_reasoning_config()
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
@@ -9882,7 +9946,8 @@ class GatewayRunner:
             _result_for_fb = result_holder[0]
             _run_failed = _result_for_fb.get("failed") if _result_for_fb else False
             if _agent is not None and hasattr(_agent, 'model') and not _run_failed:
-                _cfg_model = _resolve_gateway_model()
+                _platform_key = _platform_config_key(source.platform) if source else None
+                _cfg_model = _resolve_gateway_model(platform=_platform_key)
                 if _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
                     # Fallback activated on a successful run — evict cached
                     # agent so the next message retries the primary model.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -963,6 +963,46 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _classify_source_kind(self, source) -> str:
+        """Classify an inbound source for ``model.by_source`` lookup.
+
+        Returns one of ``"owner"``, ``"hub_peer"``, ``"stranger"``, or ``""``
+        when the source is absent/unclassifiable. Classification is coarse on
+        purpose — detail lives in config, not in this helper.
+
+        * ``owner`` — DM to a configured home channel.
+        * ``hub_peer`` — any inbound from the ``hub`` platform (agent-to-agent).
+        * ``stranger`` — any other inbound.
+        """
+        if source is None:
+            return ""
+        platform = getattr(source, "platform", None)
+        if platform is None:
+            return ""
+
+        # Hub detection by platform value string avoids a hard dependency on
+        # a ``Platform.HUB`` enum member (which may be absent in base builds
+        # that don't ship the Hub adapter).
+        try:
+            if str(getattr(platform, "value", "")).lower() == "hub":
+                return "hub_peer"
+        except Exception:
+            pass
+
+        # Owner detection: DM whose chat_id matches a configured home channel.
+        try:
+            cfg = getattr(self, "config", None)
+            get_hc = getattr(cfg, "get_home_channel", None) if cfg is not None else None
+            if callable(get_hc):
+                hc = get_hc(platform)
+                if hc is not None and getattr(source, "chat_type", None) == "dm":
+                    if str(getattr(source, "chat_id", "")) == str(getattr(hc, "chat_id", "")):
+                        return "owner"
+        except Exception:
+            pass
+
+        return "stranger"
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -1043,6 +1083,24 @@ class GatewayRunner:
                     )
             except Exception:
                 pass
+
+        # Apply ``model.by_source.<kind>`` override as the final layer. Stacks
+        # below session /model overrides (already applied above) and above the
+        # base config. Leaves ``(model, runtime_kwargs)`` unchanged when no
+        # source_kind classification or no ``by_source`` entry applies.
+        try:
+            from agent.smart_model_routing import apply_source_override
+            source_kind = self._classify_source_kind(source) if source is not None else ""
+            user_config_model = None
+            if isinstance(user_config, dict):
+                _m = user_config.get("model")
+                if isinstance(_m, dict):
+                    user_config_model = _m
+            model, runtime_kwargs = apply_source_override(
+                model, runtime_kwargs, user_config_model, source_kind,
+            )
+        except Exception as _exc:
+            logger.debug("apply_source_override failed (ignored): %s", _exc)
 
         return model, runtime_kwargs
 

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,4 +1,4 @@
-from agent.smart_model_routing import choose_cheap_model_route
+from agent.smart_model_routing import apply_source_override, choose_cheap_model_route
 
 
 _BASE_CONFIG = {
@@ -59,3 +59,84 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+# ----- apply_source_override (model.by_source.<kind>) -----
+
+def test_source_override_returns_unchanged_when_kind_missing():
+    m, r = apply_source_override("base-model", {"api_key": "k1"}, {"default": "base-model"}, None)
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_source_override_returns_unchanged_when_no_by_source():
+    m, r = apply_source_override("base-model", {"api_key": "k1"}, {"default": "base-model"}, "owner")
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_source_override_applies_full_bundle():
+    cfg = {
+        "default": "base-model",
+        "by_source": {
+            "owner": {
+                "model": "strong-model",
+                "api_key": "sk-owner",
+                "base_url": "https://owner.example/v1",
+                "provider": "custom",
+            },
+        },
+    }
+    m, r = apply_source_override("base-model", {"api_key": "k1"}, cfg, "owner")
+    assert m == "strong-model"
+    assert r["api_key"] == "sk-owner"
+    assert r["base_url"] == "https://owner.example/v1"
+    assert r["provider"] == "custom"
+
+
+def test_source_override_partial_preserves_base_fields():
+    cfg = {"by_source": {"cron": {"model": "cheap-model"}}}
+    m, r = apply_source_override(
+        "base-model",
+        {"api_key": "k1", "base_url": "https://base.example/v1", "provider": "custom"},
+        cfg,
+        "cron",
+    )
+    assert m == "cheap-model"
+    # Unset fields in entry → inherit base runtime values
+    assert r == {"api_key": "k1", "base_url": "https://base.example/v1", "provider": "custom"}
+
+
+def test_source_override_empty_entry_is_no_op():
+    cfg = {"by_source": {"stranger": {}}}
+    m, r = apply_source_override("base-model", {"api_key": "k1"}, cfg, "stranger")
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_source_override_unknown_kind_is_no_op():
+    cfg = {"by_source": {"owner": {"model": "strong-model"}}}
+    m, r = apply_source_override("base-model", {"api_key": "k1"}, cfg, "some_unrecognised_kind")
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_source_override_handles_null_model_config():
+    m, r = apply_source_override("base-model", {"api_key": "k1"}, None, "owner")
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_source_override_accepts_args_list():
+    cfg = {"by_source": {"cron": {"args": ["--flag", "value"]}}}
+    _, r = apply_source_override("base-model", {"args": ["old"]}, cfg, "cron")
+    assert r["args"] == ["--flag", "value"]
+
+
+def test_source_override_ignores_empty_field_values():
+    # Empty strings / None / empty list in an entry should NOT overwrite base
+    cfg = {"by_source": {"owner": {"api_key": "", "base_url": None, "args": []}}}
+    m, r = apply_source_override(
+        "base-model",
+        {"api_key": "k1", "base_url": "https://base.example/v1"},
+        cfg,
+        "owner",
+    )
+    assert m == "base-model"
+    assert r["api_key"] == "k1"
+    assert r["base_url"] == "https://base.example/v1"

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -220,7 +220,7 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None, platform=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -140,7 +140,7 @@ async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None, platform=None: "gpt-5.4")
 
     response = await runner._handle_fast_command(_make_event("/fast fast"))
 
@@ -161,7 +161,7 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None, platform=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
         "_resolve_runtime_agent_kwargs",

--- a/tests/gateway/test_per_platform_model.py
+++ b/tests/gateway/test_per_platform_model.py
@@ -1,0 +1,272 @@
+"""Unit tests for per-platform model overrides (PR #7297).
+
+Covers the helpers added in ``gateway/run.py``:
+
+* ``_resolve_gateway_model(config, platform=...)`` — per-platform model lookup
+  with fallback to ``model.default``.
+* ``_resolve_platform_provider_overrides(config, platform=...)`` — per-platform
+  provider bundle (``base_url``, ``api_key``).
+* ``GatewayRunner._resolve_session_agent_runtime`` — central helper the PR
+  pushes platform-awareness into.  Verifies:
+  - ``source=None`` (memory flush / hygiene-less paths) → default model.
+  - ``source=<platform>`` → platform override applied.
+  - Session ``/model`` override takes precedence over platform override.
+"""
+
+import threading
+from unittest.mock import AsyncMock, MagicMock
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+# ── _resolve_gateway_model ──────────────────────────────────────────
+
+
+def test_resolve_gateway_model_no_platform_returns_default():
+    cfg = {"model": {"default": "slate-1", "platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_gateway_model(cfg) == "slate-1"
+    assert gateway_run._resolve_gateway_model(cfg, platform=None) == "slate-1"
+
+
+def test_resolve_gateway_model_string_shorthand_override():
+    cfg = {"model": {"default": "slate-1", "platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-2"
+
+
+def test_resolve_gateway_model_dict_override():
+    cfg = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://other/v1",
+                    "api_key": "sk-zzz",
+                }
+            },
+        }
+    }
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-2"
+
+
+def test_resolve_gateway_model_platform_missing_falls_back_to_default():
+    cfg = {"model": {"default": "slate-1", "platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_gateway_model(cfg, platform="discord") == "slate-1"
+
+
+def test_resolve_gateway_model_platforms_key_absent():
+    cfg = {"model": {"default": "slate-1"}}
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-1"
+
+
+def test_resolve_gateway_model_string_model_config():
+    # model: "slate-1" (bare string, not a dict) — no platform overrides possible.
+    cfg = {"model": "slate-1"}
+    assert gateway_run._resolve_gateway_model(cfg) == "slate-1"
+    assert gateway_run._resolve_gateway_model(cfg, platform="telegram") == "slate-1"
+
+
+# ── _resolve_platform_provider_overrides ────────────────────────────
+
+
+def test_resolve_platform_provider_overrides_none_without_platform():
+    cfg = {"model": {"platforms": {"telegram": {"base_url": "x"}}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg) is None
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform=None) is None
+
+
+def test_resolve_platform_provider_overrides_string_shorthand_returns_none():
+    # String shorthand means "same provider, different model" — no provider bundle.
+    cfg = {"model": {"platforms": {"telegram": "slate-2"}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform="telegram") is None
+
+
+def test_resolve_platform_provider_overrides_dict_full_bundle():
+    cfg = {
+        "model": {
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://other/v1",
+                    "api_key": "sk-zzz",
+                }
+            }
+        }
+    }
+    result = gateway_run._resolve_platform_provider_overrides(cfg, platform="telegram")
+    assert result == {"base_url": "https://other/v1", "api_key": "sk-zzz"}
+
+
+def test_resolve_platform_provider_overrides_dict_model_only_returns_none():
+    cfg = {"model": {"platforms": {"telegram": {"model": "slate-2"}}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform="telegram") is None
+
+
+def test_resolve_platform_provider_overrides_missing_platform():
+    cfg = {"model": {"platforms": {"telegram": {"base_url": "x"}}}}
+    assert gateway_run._resolve_platform_provider_overrides(cfg, platform="discord") is None
+
+
+# ── _resolve_session_agent_runtime ──────────────────────────────────
+
+
+def _make_runner(monkeypatch, platform_base="https://default/v1", platform_api_key="sk-default"):
+    """Build a minimal GatewayRunner with fake runtime resolution."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+
+    def _fake_runtime_kwargs():
+        return {
+            "provider": "custom",
+            "api_key": platform_api_key,
+            "base_url": platform_base,
+            "api_mode": "chat",
+        }
+
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", _fake_runtime_kwargs)
+    return runner
+
+
+def test_session_runtime_no_source_uses_default_model(monkeypatch):
+    """Memory flush (source=None) must ignore platform overrides."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {"model": "slate-2", "base_url": "https://hub/v1"},
+            },
+        }
+    }
+    model, runtime = runner._resolve_session_agent_runtime(user_config=user_config)
+    assert model == "slate-1"
+    assert runtime["base_url"] == "https://default/v1"
+
+
+def test_session_runtime_platform_override_applied(monkeypatch):
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://hub/v1",
+                    "api_key": "sk-hub",
+                }
+            },
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, user_config=user_config
+    )
+    assert model == "slate-2"
+    assert runtime["base_url"] == "https://hub/v1"
+    assert runtime["api_key"] == "sk-hub"
+
+
+def test_session_runtime_string_shorthand_only_swaps_model(monkeypatch):
+    """String shorthand swaps the model but preserves the default provider bundle."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {"telegram": "slate-2"},
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, user_config=user_config
+    )
+    assert model == "slate-2"
+    # base_url/api_key stay on the default runtime, not swapped.
+    assert runtime["base_url"] == "https://default/v1"
+    assert runtime["api_key"] == "sk-default"
+
+
+def test_session_runtime_session_override_beats_platform_override(monkeypatch):
+    """A complete session /model override must fully replace the platform override."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://hub/v1",
+                    "api_key": "sk-hub",
+                }
+            },
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    session_key = "agent:main:telegram:dm:other"
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_key": "sk-session",
+        "base_url": "https://chatgpt/codex",
+        "api_mode": "codex_responses",
+    }
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, session_key=session_key, user_config=user_config
+    )
+    assert model == "gpt-5.4"
+    assert runtime["provider"] == "openai-codex"
+    assert runtime["base_url"] == "https://chatgpt/codex"
+    assert runtime["api_key"] == "sk-session"
+    assert runtime["api_mode"] == "codex_responses"
+
+
+def test_session_runtime_partial_session_override_keeps_platform_bundle(monkeypatch):
+    """A session override that only sets *model* should leave the platform
+    override's base_url / api_key intact."""
+    runner = _make_runner(monkeypatch)
+    user_config = {
+        "model": {
+            "default": "slate-1",
+            "platforms": {
+                "telegram": {
+                    "model": "slate-2",
+                    "base_url": "https://hub/v1",
+                    "api_key": "sk-hub",
+                }
+            },
+        }
+    }
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="tg-chat-1",
+        chat_type="dm",
+        user_id="other",
+    )
+    session_key = "agent:main:telegram:dm:other"
+    # Model-only override — no api_key means the "complete bundle" short-circuit
+    # at line 936 does NOT fire, and we fall through to platform-aware merge.
+    runner._session_model_overrides[session_key] = {"model": "slate-turbo"}
+    model, runtime = runner._resolve_session_agent_runtime(
+        source=source, session_key=session_key, user_config=user_config
+    )
+    assert model == "slate-turbo"
+    assert runtime["base_url"] == "https://hub/v1"
+    assert runtime["api_key"] == "sk-hub"


### PR DESCRIPTION
## Summary

Add a `model.by_source.<kind>` override so the agent's model and provider bundle can vary by **who** triggered the turn, not just the message text.

Supported kinds: `owner` (DM to a configured home channel), `hub_peer` (inbound from a Hub-style agent platform — detected by platform-value string for forward-compat), `stranger` (any other inbound), `cron` (scheduled jobs). Unknown kinds are silently ignored.

> **Note on stacking:** this PR is stacked on top of [#7297 (per-platform model overrides)](https://github.com/NousResearch/hermes-agent/pull/7297) because both hook into `_resolve_session_agent_runtime` in `gateway/run.py`. The two features are complementary: #7297 routes by *platform* (e.g. Hub gets a different model than Telegram), this PR routes by *source identity within a platform* (e.g. owner on Telegram gets a different model than a stranger on Telegram). When reviewing, diff against #7297's head — the commit-on-top is a single focused change.

## Why

Today the only alternate-model hook is `smart_model_routing.cheap_model`, which routes by message length + keyword heuristics. It can't distinguish the operator asking a hard question from a bot pinging `/status` — they get the same model. For agents that mix high-value owner interactions with high-volume background traffic (cron fires, peer coordination), the identity axis lets you use a stronger model for work that needs it and a cheaper one for routine traffic, without changing the text-based routing.

Example config:

```yaml
model:
  default: my-fast-model
  provider: custom
  api_key: sk-default
  base_url: https://example.com/v1
  by_source:
    owner:    { model: my-strong-model, api_key: sk-owner }
    hub_peer: { model: my-fast-model }
    stranger: { }            # empty → use base
    cron:     { model: my-fast-model }
```

Missing sources, missing fields within a source, and empty entries all fall back to the base `model:` block. When no `by_source` is present, behavior is identical to today.

## How it works

- New `agent.smart_model_routing.apply_source_override(model, runtime_kwargs, model_config, source_kind)` — pure helper, layers `by_source.<kind>` over `(model, runtime_kwargs)`. Partial overrides supported; empty values ignored.
- New `GatewayRuntime._classify_source_kind(source)` — classifies based on home-channel match (owner), platform-value string `"hub"` (hub_peer), otherwise stranger. No dependency on any specific platform enum value or helper that isn't already upstream.
- Hook point: `GatewayRuntime._resolve_session_agent_runtime` applies the override as the final layer, below session `/model` overrides and above base config. Silent fallback on exception — never blocks a turn. Stacks cleanly with #7297's platform-override logic.
- Cron scheduler applies override with `source_kind="cron"` before calling `resolve_turn_route`.
- HermesCLI applies override with `source_kind="owner"` in `_resolve_turn_agent_config`.

The router (`resolve_turn_route`), AIAgent construction signature, session keys, agent cache, and sub-agent inheritance are all **untouched**. Existing `smart_model_routing.cheap_model` still works exactly as before — it's a peer hook, not a replacement.

## Tests

9 new unit tests for `apply_source_override` covering:
- no-op paths (missing kind, missing config, empty entry, unknown kind, null values)
- full overrides, partial overrides (base fields preserved)
- args-list handling

All 6 existing `smart_model_routing` tests still pass.

## Test plan

- [x] Unit: 15/15 pass (`pytest tests/agent/test_smart_model_routing.py`)
- [x] Live: verified end-to-end on a test VM — CLI turn with `by_source.owner` pointing to a different model/endpoint correctly swaps both model and base_url in the outbound request; default model path unchanged for auxiliary calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)