### PR TITLE
fix: prevent streaming tool name duplication (MiniMax/NVIDIA NIM)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5868,7 +5868,15 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                entry["function"]["name"] += tc_delta.function.name
+                                # Use assignment, not +=.  Function names are
+                                # atomic identifiers delivered complete in the
+                                # first chunk (OpenAI spec).  Some providers
+                                # (MiniMax M2.7 via NVIDIA NIM) resend the full
+                                # name in every chunk; concatenation would
+                                # produce "read_fileread_file".  Assignment
+                                # (matching the OpenAI Node SDK / LiteLLM /
+                                # Vercel AI patterns) is immune to this.
+                                entry["function"]["name"] = tc_delta.function.name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -266,6 +266,7 @@ AUTHOR_MAP = {
     "limkuan24@gmail.com": "WideLee",
     "aviralarora002@gmail.com": "AviArora02-commits",
     "junminliu@gmail.com": "JimLiu",
+    "jarvischer@gmail.com": "maxchernin",
 }
 
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -143,6 +143,50 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_name_not_duplicated_when_resent_per_chunk(self, mock_close, mock_create):
+        """MiniMax M2.7 via NVIDIA NIM resends the full name in every chunk.
+
+        Bug #8259: the old += accumulation produced "read_fileread_file".
+        Assignment (matching OpenAI Node SDK / LiteLLM) prevents this.
+        """
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_nim", name="read_file")
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_nim", name="read_file", arguments='{"path":')
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_nim", name="read_file", arguments=' "x.py"}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert len(tc) == 1
+        assert tc[0].function.name == "read_file"
+        assert tc[0].function.arguments == '{"path": "x.py"}'
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_tool_call_extra_content_preserved(self, mock_close, mock_create):
         """Streamed tool calls preserve provider-specific extra_content metadata."""
         from run_agent import AIAgent


### PR DESCRIPTION
## Summary

Salvage of #11984 by @maxchernin. Fixes #8259.

### Problem

The streaming tool call accumulator used `+=` to build function names from deltas:

```python
entry["function"]["name"] += tc_delta.function.name
```

Per the OpenAI spec, most providers send the name in the first chunk only (`name=null` in subsequent chunks), so `+=` works by accident. But MiniMax M2.7 via NVIDIA NIM resends the full name in every chunk, producing `read_fileread_file`, `terminalterminal`, etc.

### Fix

Changed to simple assignment (`=`), matching the industry best practice:

| SDK | Name Handling | Arguments Handling |
|-----|-------------|-------------------|
| **OpenAI Node SDK** | Assignment (`=`) | Append (`+=`) |
| **LiteLLM** | Assignment (`=`) | List append + join |
| **Vercel AI SDK** | Set once | Append (`+=`) |
| **Anthropic SDK** | Arrives complete (not in deltas) | Append |
| **OpenAI Python SDK** | Append (`+=`) — same bug as us | Append (`+=`) |
| **Hermes (after this fix)** | **Assignment (`=`)** | Append (`+=`) |

Function names are atomic identifiers — no provider splits them across chunks. Concatenation was never correct semantics.

### Changes vs original PR

- Used simple `=` assignment instead of the original's `endswith` guard (which has a theoretical edge case with repeated characters in char-by-char streaming)
- Added AUTHOR_MAP entry for the contributor

### Test plan

- [x] `pytest tests/run_agent/test_streaming.py` — 27/27 passed
- [x] New test: `test_tool_name_not_duplicated_when_resent_per_chunk` — simulates MiniMax/NIM behavior with name in every chunk
- [x] Existing `test_tool_call_response` still passes (normal single-chunk name delivery)

Closes #11984