### PR TITLE
feat(model): match-based model routing via model.routes

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,183 @@
+"""Match-based model routing via ``model.routes``.
+
+A pure helper that lets callers pick a model + provider bundle based on a
+context dict describing the turn (``platform``, ``source_kind``, etc.).
+The router iterates ``model.routes`` — a list of ``{match, model, provider,
+api_key, base_url, ...}`` entries — and applies the first route whose
+``match`` predicates are all satisfied by the context.
+
+Two legacy shorthand forms are supported for backwards compatibility and
+config ergonomics (the ``routes`` list is canonical; shims synthesize
+entries from them at match time):
+
+    model.platforms.<name>:       routes by platform (pre-unify shorthand)
+    model.by_source.<kind>:       routes by source identity (owner /
+                                  hub_peer / stranger / cron)
+
+Example config::
+
+    model:
+      default: my-fast-model
+      routes:
+        - match: { source_kind: owner }
+          model: my-strong-model
+          api_key: sk-owner
+        - match: { platform: hub }
+          model: my-fast-model
+        - match: { source_kind: cron }
+          model: my-fast-model
+        - match: { platform: discord, source_kind: stranger }
+          model: some-other
+
+Explicit ``routes`` always evaluate first; legacy shims run last, so a new
+``routes:`` block always takes priority over an equivalent legacy entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+
+SOURCE_KIND_OWNER = "owner"
+SOURCE_KIND_HUB_PEER = "hub_peer"
+SOURCE_KIND_STRANGER = "stranger"
+SOURCE_KIND_CRON = "cron"
+KNOWN_SOURCE_KINDS = frozenset({
+    SOURCE_KIND_OWNER,
+    SOURCE_KIND_HUB_PEER,
+    SOURCE_KIND_STRANGER,
+    SOURCE_KIND_CRON,
+})
+
+_OVERRIDE_RUNTIME_KEYS = ("api_key", "base_url", "provider", "api_mode", "command", "args")
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_routes(model_config: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collect the effective ordered route list from ``model_config``.
+
+    Precedence (first match wins during lookup):
+
+    1. Explicit ``routes:`` list as declared in config.
+    2. Legacy ``platforms.<name>`` entries (synthesized as
+       ``{match: {platform: <name>}, ...}``).
+    3. Legacy ``by_source.<kind>`` entries (synthesized as
+       ``{match: {source_kind: <kind>}, ...}``).
+    """
+    if not isinstance(model_config, dict):
+        return []
+
+    routes: List[Dict[str, Any]] = []
+
+    explicit = model_config.get("routes")
+    if isinstance(explicit, list):
+        for item in explicit:
+            if isinstance(item, dict) and isinstance(item.get("match"), dict):
+                routes.append(item)
+
+    platforms = model_config.get("platforms")
+    if isinstance(platforms, dict):
+        for name, override in platforms.items():
+            if isinstance(override, str) and override:
+                routes.append({"match": {"platform": str(name)}, "model": override})
+            elif isinstance(override, dict) and override:
+                routes.append({"match": {"platform": str(name)}, **override})
+
+    by_source = model_config.get("by_source")
+    if isinstance(by_source, dict):
+        for kind, override in by_source.items():
+            if isinstance(override, dict) and override:
+                routes.append({"match": {"source_kind": str(kind)}, **override})
+
+    return routes
+
+
+def _route_matches(match_spec: Dict[str, Any], context: Dict[str, Any]) -> bool:
+    """Return True when every key in ``match_spec`` equals the context value.
+
+    Missing keys in ``context`` never match (empty context satisfies empty
+    match only). String comparison is case-sensitive.
+    """
+    if not isinstance(match_spec, dict) or not match_spec:
+        return False
+    for key, expected in match_spec.items():
+        actual = context.get(key)
+        if actual is None:
+            return False
+        if str(actual) != str(expected):
+            return False
+    return True
+
+
+def apply_route(
+    model: str,
+    runtime_kwargs: Dict[str, Any],
+    model_config: Optional[Dict[str, Any]],
+    context: Optional[Dict[str, Any]],
+) -> Tuple[str, Dict[str, Any]]:
+    """Apply the first matching ``model.routes`` entry to ``(model, runtime_kwargs)``.
+
+    ``context`` is a dict describing the turn. Current recognised keys:
+
+    * ``platform``   — inbound platform string ("telegram", "hub", "cli", ...)
+    * ``source_kind`` — ``"owner"`` / ``"hub_peer"`` / ``"stranger"`` /
+                        ``"cron"`` as classified by the caller.
+
+    Callers may add additional keys (e.g. ``user_id``); routes that don't
+    reference them are unaffected.
+
+    Each route entry has shape::
+
+        {
+          "match": { "platform": "hub", "source_kind": "stranger", ... },
+          "model": "my-model",            # optional; preserves base when missing
+          "provider": "custom",           # optional
+          "api_key": "sk-...",
+          "base_url": "https://...",
+          "api_mode": "chat_completions",
+          "command": [...],  "args": [...]
+        }
+
+    Partial overrides are supported — any field not set on the matched route
+    keeps its base value. First match wins; no match leaves inputs unchanged.
+    """
+    if not context:
+        return model, runtime_kwargs
+    routes = _normalize_routes(model_config)
+    if not routes:
+        return model, runtime_kwargs
+
+    for entry in routes:
+        match_spec = entry.get("match")
+        if not isinstance(match_spec, dict):
+            continue
+        if not _route_matches(match_spec, context):
+            continue
+
+        new_model = model
+        new_runtime = dict(runtime_kwargs or {})
+        applied = []
+
+        if entry.get("model"):
+            new_model = str(entry["model"])
+            applied.append("model")
+        for key in _OVERRIDE_RUNTIME_KEYS:
+            val = entry.get(key)
+            if val in (None, "", []):
+                continue
+            if key == "args":
+                new_runtime[key] = list(val)
+            else:
+                new_runtime[key] = val
+            applied.append(key)
+
+        if applied:
+            logger.info(
+                "model.routes matched: context=%s fields=%s model=%s provider=%s",
+                context, applied, new_model, new_runtime.get("provider"),
+            )
+        return new_model, new_runtime
+
+    return model, runtime_kwargs

--- a/cli.py
+++ b/cli.py
@@ -3187,21 +3187,40 @@ class HermesCLI:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from agent.smart_model_routing import apply_route
 
-        runtime = {
+        # CLI is always the owner (operator-driven). Apply ``model.routes``
+        # (or legacy ``model.by_source.owner`` / ``model.platforms.cli``)
+        # before building the route dict.
+        _cli_model = self.model
+        _cli_runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,
             "provider": self.provider,
             "api_mode": self.api_mode,
             "command": self.acp_command,
             "args": list(self.acp_args or []),
+        }
+        _cli_model_config = CLI_CONFIG.get("model") if isinstance(CLI_CONFIG, dict) else None
+        if not isinstance(_cli_model_config, dict):
+            _cli_model_config = None
+        try:
+            _cli_model, _cli_runtime = apply_route(
+                _cli_model, _cli_runtime, _cli_model_config,
+                {"platform": "cli", "source_kind": "owner"},
+            )
+        except Exception as _exc:
+            logger.debug("apply_route failed in CLI (ignored): %s", _exc)
+
+        runtime = {
+            **_cli_runtime,
             "credential_pool": getattr(self, "_credential_pool", None),
         }
         route = {
-            "model": self.model,
+            "model": _cli_model,
             "runtime": runtime,
             "signature": (
-                self.model,
+                _cli_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -882,6 +882,34 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
+        # Apply ``model.routes`` for this cron fire. Context is always
+        # ``{platform: cron, source_kind: cron}`` — cron jobs don't carry
+        # per-source identity. Silent fallback on exception.
+        try:
+            from agent.smart_model_routing import apply_route
+            _cron_runtime = {
+                "api_key": runtime.get("api_key"),
+                "base_url": runtime.get("base_url"),
+                "provider": runtime.get("provider"),
+                "api_mode": runtime.get("api_mode"),
+                "command": runtime.get("command"),
+                "args": list(runtime.get("args") or []),
+            }
+            _cron_model_config = _cfg.get("model") if isinstance(_cfg, dict) else None
+            if not isinstance(_cron_model_config, dict):
+                _cron_model_config = None
+            model, _cron_runtime = apply_route(
+                model, _cron_runtime, _cron_model_config,
+                {"platform": "cron", "source_kind": "cron"},
+            )
+            # Fold any routed overrides back into the shared ``runtime`` dict
+            # so downstream AIAgent construction picks them up.
+            for _k in ("api_key", "base_url", "provider", "api_mode", "command", "args"):
+                if _cron_runtime.get(_k) is not None:
+                    runtime[_k] = _cron_runtime[_k]
+        except Exception as _exc:
+            logger.debug("Job '%s': apply_route failed (ignored): %s", job_id, _exc)
+
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1047,6 +1047,59 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _classify_source_kind(self, source) -> str:
+        """Classify an inbound source for ``model.routes`` ``source_kind`` match.
+
+        Returns one of ``"owner"``, ``"hub_peer"``, ``"stranger"``, or ``""``
+        when the source is absent/unclassifiable. Classification is coarse —
+        detail lives in config, not here.
+
+        * ``owner`` — DM whose chat_id matches a configured home channel.
+        * ``hub_peer`` — any inbound from the ``hub`` platform (detected by
+          platform-value string so no hard dependency on a ``Platform.HUB``
+          enum member).
+        * ``stranger`` — any other inbound.
+        """
+        if source is None:
+            return ""
+        platform = getattr(source, "platform", None)
+        if platform is None:
+            return ""
+
+        try:
+            if str(getattr(platform, "value", "")).lower() == "hub":
+                return "hub_peer"
+        except Exception:
+            pass
+
+        try:
+            cfg = getattr(self, "config", None)
+            get_hc = getattr(cfg, "get_home_channel", None) if cfg is not None else None
+            if callable(get_hc):
+                hc = get_hc(platform)
+                if hc is not None and getattr(source, "chat_type", None) == "dm":
+                    if str(getattr(source, "chat_id", "")) == str(getattr(hc, "chat_id", "")):
+                        return "owner"
+        except Exception:
+            pass
+
+        return "stranger"
+
+    def _build_routing_context(self, source) -> Dict[str, Any]:
+        """Build the context dict passed to ``apply_route`` for this source."""
+        if source is None:
+            return {}
+        platform = getattr(source, "platform", None)
+        platform_value = ""
+        try:
+            platform_value = str(getattr(platform, "value", "")).lower() if platform is not None else ""
+        except Exception:
+            platform_value = ""
+        return {
+            "platform": platform_value,
+            "source_kind": self._classify_source_kind(source),
+        }
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -1118,6 +1171,25 @@ class GatewayRunner:
                     )
             except Exception:
                 pass
+
+        # Apply ``model.routes`` as the final layer. Stacks below session
+        # /model overrides (already applied above) and above base config.
+        # Supports legacy ``model.platforms.*`` and ``model.by_source.*``
+        # shorthand via the normalizer inside ``apply_route``. Silent
+        # fallback on exception — never blocks a turn.
+        try:
+            from agent.smart_model_routing import apply_route
+            model_config = None
+            if isinstance(user_config, dict):
+                _m = user_config.get("model")
+                if isinstance(_m, dict):
+                    model_config = _m
+            context = self._build_routing_context(source)
+            model, runtime_kwargs = apply_route(
+                model, runtime_kwargs, model_config, context,
+            )
+        except Exception as _exc:
+            logger.debug("apply_route failed (ignored): %s", _exc)
 
         return model, runtime_kwargs
 

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,0 +1,130 @@
+from agent.smart_model_routing import apply_route
+
+
+# ----- apply_route (match-based model.routes) -----
+
+def test_apply_route_no_op_when_context_empty():
+    cfg = {"routes": [{"match": {"platform": "hub"}, "model": "hub-model"}]}
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {})
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_apply_route_no_op_when_no_routes():
+    m, r = apply_route("base-model", {"api_key": "k1"}, {"default": "base-model"}, {"platform": "hub"})
+    assert m == "base-model" and r == {"api_key": "k1"}
+
+
+def test_apply_route_matches_by_platform():
+    cfg = {
+        "routes": [
+            {"match": {"platform": "hub"}, "model": "hub-model", "api_key": "sk-hub"},
+        ],
+    }
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {"platform": "hub", "source_kind": "hub_peer"})
+    assert m == "hub-model"
+    assert r["api_key"] == "sk-hub"
+
+
+def test_apply_route_matches_by_source_kind():
+    cfg = {
+        "routes": [
+            {"match": {"source_kind": "owner"}, "model": "strong-model"},
+        ],
+    }
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {"platform": "telegram", "source_kind": "owner"})
+    assert m == "strong-model"
+    assert r == {"api_key": "k1"}  # base runtime preserved
+
+
+def test_apply_route_requires_all_match_keys():
+    # Compound match: both platform AND source_kind must match
+    cfg = {
+        "routes": [
+            {"match": {"platform": "discord", "source_kind": "stranger"}, "model": "edge-case-model"},
+        ],
+    }
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "discord", "source_kind": "owner"})
+    assert m == "base-model"  # source_kind mismatched → no match
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "telegram", "source_kind": "stranger"})
+    assert m == "base-model"  # platform mismatched → no match
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "discord", "source_kind": "stranger"})
+    assert m == "edge-case-model"  # both matched → route fires
+
+
+def test_apply_route_first_match_wins():
+    cfg = {
+        "routes": [
+            {"match": {"source_kind": "owner"}, "model": "first-route-model"},
+            {"match": {"source_kind": "owner"}, "model": "second-route-model"},
+        ],
+    }
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "telegram", "source_kind": "owner"})
+    assert m == "first-route-model"
+
+
+def test_apply_route_legacy_platforms_shim_string():
+    # ``model.platforms.hub: "hub-model"`` is legacy shorthand
+    cfg = {"platforms": {"hub": "hub-model"}}
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "hub"})
+    assert m == "hub-model"
+
+
+def test_apply_route_legacy_platforms_shim_dict():
+    cfg = {"platforms": {"hub": {"model": "hub-model", "base_url": "https://hub.example/v1"}}}
+    m, r = apply_route("base-model", {}, cfg, {"platform": "hub"})
+    assert m == "hub-model"
+    assert r["base_url"] == "https://hub.example/v1"
+
+
+def test_apply_route_legacy_by_source_shim():
+    cfg = {"by_source": {"owner": {"model": "strong-model", "api_key": "sk-owner"}}}
+    m, r = apply_route("base-model", {"api_key": "k1"}, cfg, {"source_kind": "owner"})
+    assert m == "strong-model"
+    assert r["api_key"] == "sk-owner"
+
+
+def test_apply_route_explicit_routes_beat_legacy():
+    # Explicit routes come first in the effective list → they match before legacy shims.
+    cfg = {
+        "routes": [{"match": {"source_kind": "owner"}, "model": "new-explicit"}],
+        "by_source": {"owner": {"model": "old-legacy"}},
+    }
+    m, _ = apply_route("base-model", {}, cfg, {"source_kind": "owner"})
+    assert m == "new-explicit"
+
+
+def test_apply_route_partial_override_preserves_base_runtime():
+    cfg = {"routes": [{"match": {"source_kind": "cron"}, "model": "cheap-model"}]}
+    m, r = apply_route(
+        "base-model",
+        {"api_key": "k1", "base_url": "https://base.example/v1", "provider": "custom"},
+        cfg,
+        {"source_kind": "cron"},
+    )
+    assert m == "cheap-model"
+    assert r == {"api_key": "k1", "base_url": "https://base.example/v1", "provider": "custom"}
+
+
+def test_apply_route_empty_fields_dont_overwrite():
+    cfg = {"routes": [{"match": {"source_kind": "owner"}, "api_key": "", "base_url": None, "args": []}]}
+    m, r = apply_route(
+        "base-model",
+        {"api_key": "k1", "base_url": "https://base.example/v1"},
+        cfg,
+        {"source_kind": "owner"},
+    )
+    # Route matched but all fields are empty/nullish → inputs preserved
+    assert m == "base-model"
+    assert r["api_key"] == "k1"
+    assert r["base_url"] == "https://base.example/v1"
+
+
+def test_apply_route_context_missing_match_key_does_not_match():
+    cfg = {"routes": [{"match": {"source_kind": "owner"}, "model": "strong-model"}]}
+    m, _ = apply_route("base-model", {}, cfg, {"platform": "telegram"})  # no source_kind in context
+    assert m == "base-model"
+
+
+def test_apply_route_null_model_config():
+    m, r = apply_route("base-model", {"api_key": "k1"}, None, {"source_kind": "owner"})
+    assert m == "base-model" and r == {"api_key": "k1"}


### PR DESCRIPTION
## Summary

A single match-based router for per-turn model/provider selection based on a caller-supplied context. Replaces two previously-separate ideas (per-platform and per-source-identity overrides) with one generic hook.

Example config:

```yaml
model:
  default: my-fast-model
  routes:
    - match: { source_kind: owner }         # owner everywhere
      model: my-strong-model
      api_key: sk-owner
    - match: { platform: hub }              # all Hub peers
      model: my-fast-model
    - match: { source_kind: cron }
      model: my-fast-model
    - match: { platform: discord, source_kind: stranger }   # compound
      model: some-other
```

First match wins. No match → base `model:` block used. Partial overrides are supported (missing fields inherit base). Empty fields (`""`, `None`, `[]`) do not overwrite — explicit empty is treated as "no opinion" so base values survive.

## Backwards compatibility

Two shorthand forms are honored via an internal normalizer that synthesizes `routes` entries at match time:

| Shorthand | Synthesized route |
|---|---|
| `model.platforms.<name>: "X"` | `{match: {platform: <name>}, model: "X"}` |
| `model.platforms.<name>: {model, base_url, api_key, ...}` | `{match: {platform: <name>}, ...}` |
| `model.by_source.<kind>: {model, ...}` | `{match: {source_kind: <kind>}, ...}` |

Explicit `routes` always evaluate first, so any existing `model.platforms.*` config keeps working unchanged; a new `routes:` entry can be added alongside and will take precedence.

## Why unified

Routing by platform and routing by source identity are orthogonal — same function, different predicates. Shipping them as separate hooks (each with its own config key and function call) means `_resolve_session_agent_runtime` grows a new layer every time a new predicate is added, and the config surface grows with it. One matcher with a structured predicate is cleaner, and lets users compose (`platform + source_kind`) without any code change.

## Why `source_kind` matters on top of `platform`

Per-platform alone can't distinguish the operator from a random stranger on Telegram; per-source alone can't distinguish Hub from Telegram. Both axes together cover the common needs:

- \"Owner on any channel gets the strong model.\"
- \"Agent-to-agent Hub traffic uses the cheap model.\"
- \"Strangers on Discord get isolated to a compliance-friendly provider.\"

## How it works

- New `agent.smart_model_routing.apply_route(model, runtime_kwargs, model_config, context)` — pure helper. Normalizes legacy shorthand, iterates routes, returns `(model, runtime_kwargs)`.
- New `GatewayRuntime._classify_source_kind(source)` — classifies `owner` (home-channel DM match), `hub_peer` (platform value `\"hub\"` — forward-compatible with any enum definition), `stranger` (everything else).
- New `GatewayRuntime._build_routing_context(source)` — assembles `{platform, source_kind}`.
- Hook point: `_resolve_session_agent_runtime` calls `apply_route` as the final layer, below session `/model` overrides and above base config. Silent fallback on exception — never blocks a turn.
- Cron scheduler and HermesCLI apply `apply_route` with their own hardcoded context (`{platform: cron, source_kind: cron}` / `{platform: cli, source_kind: owner}`) before `resolve_turn_route`.

The existing message-text-based router (`resolve_turn_route` / `smart_model_routing.cheap_model`) is untouched — it's a peer hook on a different axis. AIAgent construction signature, session keys, agent caching, and sub-agent inheritance are all unchanged.

## Tests

14 new unit tests for `apply_route`:

- empty context, no routes, null config (all no-op)
- platform-only match, source_kind-only match, compound match
- first-match-wins ordering
- partial overrides (base fields preserved)
- empty fields don't overwrite
- missing context key → no match
- legacy `platforms` shim (string shorthand + dict)
- legacy `by_source` shim
- explicit routes beat legacy shims on the same predicate

All 6 existing `smart_model_routing` tests still pass. 20/20 green.

## Test plan

- [x] Unit: 20/20 pass (`pytest tests/agent/test_smart_model_routing.py`)
- [x] Live: verified end-to-end on a test VM — CLI turn with a matching `routes` entry swaps both model and base_url in the outbound API request; default model path unchanged for unmatched auxiliary calls.
- [x] Parse-check on all modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)