### PR TITLE
fix(gateway): respect busy_input_mode queue for normal busy sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1411,21 +1411,74 @@ class GatewayRunner:
             return True
 
         # --- Normal busy case (agent actively running a task) ---
-        # The user sent a message while the agent is working.  Interrupt the
-        # agent immediately so it stops the current tool-calling loop and
-        # processes the new message.  The pending message is stored in the
-        # adapter so the base adapter picks it up once the interrupted run
-        # returns.  A brief ack tells the user what's happening (debounced
-        # to avoid spam when they fire multiple messages quickly).
+        # The user sent a message while the agent is working.  By default we
+        # interrupt the agent immediately, but when busy_input_mode is "queue"
+        # we store the message for the next turn without interrupting.
 
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return False  # let default path handle it
 
-        # Store the message so it's processed as the next turn after the
-        # interrupt causes the current run to exit.
+        # Store the message so it's processed as the next turn.
         from gateway.platforms.base import merge_pending_message_event
         merge_pending_message_event(adapter._pending_messages, session_key, event)
+
+        # --- Queue mode: store message, send queued ack, do NOT interrupt ---
+        if self._busy_input_mode == "queue":
+            # Debounce: only send an acknowledgment once every 30 seconds per session
+            _BUSY_ACK_COOLDOWN = 30
+            now = time.time()
+            last_ack = self._busy_ack_ts.get(session_key, 0)
+            if now - last_ack < _BUSY_ACK_COOLDOWN:
+                return True  # message queued, ack already delivered recently
+
+            self._busy_ack_ts[session_key] = now
+
+            # Build a status-rich queued acknowledgment
+            running_agent = self._running_agents.get(session_key)
+            status_parts = []
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                try:
+                    summary = running_agent.get_activity_summary()
+                    iteration = summary.get("api_call_count", 0)
+                    max_iter = summary.get("max_iterations", 0)
+                    current_tool = summary.get("current_tool")
+                    start_ts = self._running_agents_ts.get(session_key, 0)
+                    if start_ts:
+                        elapsed_min = int((now - start_ts) / 60)
+                        if elapsed_min > 0:
+                            status_parts.append(f"{elapsed_min} min elapsed")
+                    if max_iter:
+                        status_parts.append(f"iteration {iteration}/{max_iter}")
+                    if current_tool:
+                        status_parts.append(f"running: {current_tool}")
+                except Exception:
+                    pass
+
+            status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+            message = (
+                f"📥 Queued for next turn{status_detail}. "
+                f"I'll get to your message when the current task finishes."
+            )
+
+            thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            try:
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content=message,
+                    reply_to=event.message_id,
+                    metadata=thread_meta,
+                )
+            except Exception as e:
+                logger.debug("Failed to send busy-ack: %s", e)
+
+            return True
+
+        # --- Interrupt mode (default): interrupt the running agent ---
+        # The pending message is already stored above.  Now interrupt the
+        # agent so it stops the current tool-calling loop and processes the
+        # new message.  A brief ack tells the user what's happening (debounced
+        # to avoid spam when they fire multiple messages quickly).
 
         # Interrupt the running agent — this aborts in-flight tool calls and
         # causes the agent loop to exit at the next check point.

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -55,7 +55,7 @@ def _make_event(text="hello", chat_id="123", platform_val="telegram"):
     return evt
 
 
-def _make_runner():
+def _make_runner(busy_input_mode="interrupt"):
     """Build a minimal GatewayRunner-like object for testing."""
     from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
 
@@ -64,6 +64,7 @@ def _make_runner():
     runner._running_agents_ts = {}
     runner._pending_messages = {}
     runner._busy_ack_ts = {}
+    runner._busy_input_mode = busy_input_mode
     runner._draining = False
     runner.adapters = {}
     runner.config = MagicMock()
@@ -291,3 +292,144 @@ class TestBusySessionAck:
 
         result = await runner._handle_active_session_busy_message(event, sk)
         assert result is False  # not handled, let default path try
+
+
+# ---------------------------------------------------------------------------
+# Queue-mode tests for busy_input_mode == "queue"
+# ---------------------------------------------------------------------------
+
+class TestBusySessionQueueMode:
+    """When busy_input_mode is "queue", messages are queued without interrupting."""
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_does_not_interrupt(self):
+        """Queue mode should NOT call agent.interrupt()."""
+        runner, sentinel = _make_runner(busy_input_mode="queue")
+        adapter = _make_adapter()
+
+        event = _make_event(text="hello again")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 5,
+            "max_iterations": 60,
+            "current_tool": "web_search",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "tool",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 120
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True  # handled
+        agent.interrupt.assert_not_called()  # key: no interrupt
+        # Message should still be queued
+        assert sk in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_sends_queued_ack(self):
+        """Queue mode ack should say 'Queued' not 'Interrupting'."""
+        runner, sentinel = _make_runner(busy_input_mode="queue")
+        adapter = _make_adapter()
+
+        event = _make_event(text="ping")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 3,
+            "max_iterations": 30,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 1.0,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 300  # 5 min
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        adapter._send_with_retry.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content", "")
+        assert "Queued" in content
+        assert "Interrupting" not in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_still_debounces(self):
+        """Queue mode should still debounce acks within 30s cooldown."""
+        runner, sentinel = _make_runner(busy_input_mode="queue")
+        adapter = _make_adapter()
+
+        event1 = _make_event(text="msg1")
+        event2 = MessageEvent(
+            text="msg2",
+            message_type=MessageType.TEXT,
+            source=event1.source,
+            message_id="msg2",
+        )
+        sk = build_session_key(event1.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 5,
+            "max_iterations": 60,
+            "current_tool": None,
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "api_call",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+        runner.adapters[event1.source.platform] = adapter
+
+        # First message — should get ack
+        result1 = await runner._handle_active_session_busy_message(event1, sk)
+        assert result1 is True
+        assert adapter._send_with_retry.call_count == 1
+
+        # Second message within cooldown — queued but no ack
+        result2 = await runner._handle_active_session_busy_message(event2, sk)
+        assert result2 is True
+        assert adapter._send_with_retry.call_count == 1  # still 1
+
+        # No interrupts should have been called
+        agent.interrupt.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_still_works(self):
+        """When busy_input_mode is 'interrupt' (default), existing behavior unchanged."""
+        runner, sentinel = _make_runner(busy_input_mode="interrupt")
+        adapter = _make_adapter()
+
+        event = _make_event(text="hello?")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 5,
+            "max_iterations": 60,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 60
+        runner.adapters[event.source.platform] = adapter
+
+        result = await runner._handle_active_session_busy_message(event, sk)
+
+        assert result is True
+        # Should still interrupt in interrupt mode
+        agent.interrupt.assert_called_once_with("hello?")
+        adapter._send_with_retry.assert_called_once()
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content", "")
+        assert "Interrupting" in content


### PR DESCRIPTION
When busy_input_mode is set to 'queue', the gateway now queues incoming messages during active agent runs instead of interrupting the agent. Previously, only the drain case respected the queue setting; the normal busy case always interrupted regardless of configuration.

Changes:
- gateway/run.py: Add queue-mode branch in _handle_active_session_busy_message that stores the message via merge_pending_message_event, sends a debounced 'Queued for next turn' ack (reusing _busy_ack_ts), and returns without calling agent.interrupt()
- tests/gateway/test_busy_session_ack.py: Add _busy_input_mode param to _make_runner helper, add TestBusySessionQueueMode with 4 tests covering queue-mode no-interrupt, queued ack text, debounce behavior, and interrupt mode regression

Fixes: NousResearch/hermes-agent#11118

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

