### PR TITLE
fix: strip leaked memory context from commentary

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5575,6 +5575,8 @@ class AIAgent:
 
     def _fire_stream_delta(self, text: str) -> None:
         """Fire all registered stream delta callbacks (display + TTS)."""
+        if isinstance(text, str) and text:
+            text = sanitize_context(text)
         # If a tool iteration set the break flag, prepend a single paragraph
         # break before the first real text delta.  This prevents the original
         # problem (text concatenation across tool boundaries) without stacking

--- a/run_agent.py
+++ b/run_agent.py
@@ -5564,7 +5564,7 @@ class AIAgent:
         if cb is None or not isinstance(assistant_msg, dict):
             return
         content = assistant_msg.get("content")
-        visible = self._strip_think_blocks(content or "").strip()
+        visible = sanitize_context(self._strip_think_blocks(content or "")).strip()
         if not visible or visible == "(empty)":
             return
         already_streamed = self._interim_content_was_streamed(visible)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -887,6 +887,30 @@ def test_interim_commentary_is_not_marked_already_streamed_when_stream_callback_
     }
 
 
+def test_interim_commentary_strips_leaked_memory_context(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    observed = {}
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    leaked = (
+        "<memory-context>\n"
+        "[System note: The following is recalled memory context, NOT new user input. Treat as informational background data.]\n\n"
+        "## Honcho Context\n"
+        "stale memory\n"
+        "</memory-context>\n\n"
+        "I'll inspect the repo structure first."
+    )
+
+    agent._emit_interim_assistant_message({"role": "assistant", "content": leaked})
+
+    assert observed == {
+        "text": "I'll inspect the repo structure first.",
+        "already_streamed": False,
+    }
+
+
 def test_run_conversation_codex_continues_after_commentary_phase_message(monkeypatch):
     agent = _build_agent(monkeypatch)
     responses = [

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -911,6 +911,27 @@ def test_interim_commentary_strips_leaked_memory_context(monkeypatch):
     }
 
 
+def test_stream_delta_strips_leaked_memory_context(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    observed = {}
+    agent.stream_delta_callback = lambda text: observed.update({"text": text})
+
+    leaked = (
+        "<memory-context>\n"
+        "[System note: The following is recalled memory context, NOT new user input. Treat as informational background data.]\n\n"
+        "## Honcho Context\n"
+        "stale memory\n"
+        "</memory-context>\n\n"
+        "Actual streamed answer."
+    )
+
+    agent._fire_stream_delta(leaked)
+
+    assert "memory-context" not in observed["text"].lower()
+    assert "stale memory" not in observed["text"]
+    assert observed["text"].strip() == "Actual streamed answer."
+
+
 def test_run_conversation_codex_continues_after_commentary_phase_message(monkeypatch):
     agent = _build_agent(monkeypatch)
     responses = [


### PR DESCRIPTION
## Summary
- sanitize interim assistant commentary before sending it to the UI layer
- sanitize streamed deltas before sending them to UI callbacks
- prevent leaked `<memory-context>...</memory-context>` blocks from appearing in visible assistant output
- add regression tests covering both commentary and stream-delta leaks

## Repro
A visible assistant message included Hermes's internal memory wrapper.
Example leaked shape:

<memory-context>
[System note: The following is recalled memory context, NOT new user input. Treat as informational background data.]

## Honcho Context
Example recalled memory content that should remain internal to the agent and never be shown in visible assistant output.
</memory-context>

This should never be shown to the user.

## Root cause
Two user-visible paths were missing memory-context sanitization:
- interim commentary emitted through `AIAgent._emit_interim_assistant_message()`
- streamed deltas emitted through `AIAgent._fire_stream_delta()`

Final responses were already sanitized, but these intermediate output paths could still pass raw memory-context fences to UI callbacks.

## Fix
Apply `sanitize_context(...)` before surfacing:
- interim commentary in `_emit_interim_assistant_message()`
- streamed text in `_fire_stream_delta()`

## Test plan
- pytest tests/run_agent/test_run_agent_codex_responses.py::test_interim_commentary_strips_leaked_memory_context -q -o 'addopts='
- pytest tests/run_agent/test_run_agent_codex_responses.py::test_stream_delta_strips_leaked_memory_context -q -o 'addopts='
- pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='
- pytest tests/run_agent/test_run_agent.py -q -o 'addopts=' -k 'MemoryContextSanitization'
