### PR TITLE
fix(cron): respect configured timezone for naive timestamps

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -19,7 +19,7 @@ from typing import Optional, Dict, List, Any
 
 logger = logging.getLogger(__name__)
 
-from hermes_time import now as _hermes_now
+from hermes_time import now as _hermes_now, get_timezone as _hermes_get_tz
 
 try:
     from croniter import croniter
@@ -172,8 +172,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             dt = datetime.fromisoformat(schedule.replace('Z', '+00:00'))
             # Make naive timestamps timezone-aware at parse time so the stored
             # value doesn't depend on the system timezone matching at check time.
+            # When the user says "17:30", they mean 17:30 in THEIR timezone,
+            # not the server's.  Use the Hermes-configured timezone when available
+            # (set via HERMES_TIMEZONE env var or timezone key in config.yaml).
             if dt.tzinfo is None:
-                dt = dt.astimezone()  # Interpret as local timezone
+                hermes_tz = _hermes_get_tz()
+                if hermes_tz is not None:
+                    dt = dt.replace(tzinfo=hermes_tz)
+                else:
+                    dt = dt.astimezone()  # Fallback: interpret as system local
             return {
                 "kind": "once",
                 "run_at": dt.isoformat(),

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -12,7 +12,7 @@ import tempfile
 import os
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any
@@ -177,7 +177,13 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             # (set via HERMES_TIMEZONE env var or timezone key in config.yaml).
             if dt.tzinfo is None:
                 hermes_tz = _hermes_get_tz()
-                if hermes_tz is not None:
+                # Defensive: get_timezone() is typed to return Optional[ZoneInfo],
+                # but guard in case a future refactor returns a string name or
+                # any object without tzinfo-protocol support.  dt.replace() would
+                # otherwise raise an opaque error at runtime.  Note: assigning a
+                # ZoneInfo via replace() during a DST transition defaults to the
+                # standard-time offset — acceptable for cron scheduling.
+                if hermes_tz is not None and isinstance(hermes_tz, tzinfo):
                     dt = dt.replace(tzinfo=hermes_tz)
                 else:
                     dt = dt.astimezone()  # Fallback: interpret as system local

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1465,28 +1465,50 @@ def setup_timezone(config: dict):
     print_info("causing reminders to fire at the wrong time.")
     print()
 
-    # Detect current system timezone
-    import subprocess
+    # Detect current system timezone.
+    # macOS: prefer reading /etc/localtime symlink (no elevated privileges needed,
+    # works on all recent macOS versions); fall back to `systemsetup -gettimezone`.
+    # Linux: try `timedatectl` first, then /etc/timezone, then /etc/localtime.
+    import subprocess  # local import: only needed in this setup path
     detected_tz = ""
+
+    def _tz_from_localtime() -> str:
+        link = Path("/etc/localtime")
+        try:
+            if link.is_symlink():
+                target = str(link.resolve())
+                if "zoneinfo/" in target:
+                    return target.split("zoneinfo/", 1)[1]
+        except OSError:
+            pass
+        return ""
+
     try:
         if sys.platform == "darwin":
-            result = subprocess.run(
-                ["systemsetup", "-gettimezone"],
-                capture_output=True, text=True, timeout=5,
-            )
-            # Output: "Time Zone: Europe/Paris"
-            if result.returncode == 0 and ":" in result.stdout:
-                detected_tz = result.stdout.split(":", 1)[1].strip()
+            detected_tz = _tz_from_localtime()
+            if not detected_tz:
+                result = subprocess.run(
+                    ["systemsetup", "-gettimezone"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                # Output: "Time Zone: Europe/Paris"
+                if result.returncode == 0 and ":" in result.stdout:
+                    detected_tz = result.stdout.split(":", 1)[1].strip()
         else:
-            # Linux: try timedatectl first, then /etc/timezone
-            result = subprocess.run(
-                ["timedatectl", "show", "-p", "Timezone", "--value"],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                detected_tz = result.stdout.strip()
-            elif Path("/etc/timezone").exists():
+            # Linux: try timedatectl first, then /etc/timezone, then /etc/localtime
+            try:
+                result = subprocess.run(
+                    ["timedatectl", "show", "-p", "Timezone", "--value"],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.returncode == 0:
+                    detected_tz = result.stdout.strip()
+            except FileNotFoundError:
+                pass
+            if not detected_tz and Path("/etc/timezone").exists():
                 detected_tz = Path("/etc/timezone").read_text().strip()
+            if not detected_tz:
+                detected_tz = _tz_from_localtime()
     except Exception:
         pass
 
@@ -1518,13 +1540,19 @@ def setup_timezone(config: dict):
         tz_value = tz_input.strip()
         # Validate the timezone
         try:
-            from zoneinfo import ZoneInfo
-            ZoneInfo(tz_value)  # Raises ZoneInfoNotFoundError if invalid
+            from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+        except ImportError:
+            print_warning("zoneinfo unavailable — cannot validate. Saving as-is.")
             config["timezone"] = tz_value
-            print_success(f"Timezone set to {tz_value}")
-        except Exception:
-            print_warning(f"'{tz_value}' is not a valid IANA timezone ID.")
-            print_info("Skipping timezone configuration. You can set it later in config.yaml.")
+            print_success(f"Timezone set to {tz_value} (unvalidated)")
+        else:
+            try:
+                ZoneInfo(tz_value)  # Raises ZoneInfoNotFoundError if invalid
+                config["timezone"] = tz_value
+                print_success(f"Timezone set to {tz_value}")
+            except (ZoneInfoNotFoundError, ValueError):
+                print_warning(f"'{tz_value}' is not a valid IANA timezone ID.")
+                print_info("Skipping timezone configuration. You can set it later in config.yaml.")
     else:
         print_info("Timezone not configured. Cron jobs will use the server's system timezone.")
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1448,6 +1448,89 @@ def _apply_default_agent_settings(config: dict):
     print_info("  Run `hermes setup agent` later to customize.")
 
 
+def setup_timezone(config: dict):
+    """Configure the IANA timezone for cron jobs and timestamps.
+
+    When a user creates a cron job with a naive timestamp like "17:30",
+    Hermes needs to know which timezone that refers to.  On servers
+    running UTC (most VPS), "17:30" would fire at 17:30 UTC — often
+    not what the user expects.
+
+    The timezone is stored in config.yaml and also available via
+    the HERMES_TIMEZONE environment variable.
+    """
+    print_header("Timezone")
+    print_info("Used by cron jobs to interpret naive timestamps (e.g. \"17:30\").")
+    print_info("If unset, the server's system timezone is used — which is UTC on most VPS,")
+    print_info("causing reminders to fire at the wrong time.")
+    print()
+
+    # Detect current system timezone
+    import subprocess
+    detected_tz = ""
+    try:
+        if sys.platform == "darwin":
+            result = subprocess.run(
+                ["systemsetup", "-gettimezone"],
+                capture_output=True, text=True, timeout=5,
+            )
+            # Output: "Time Zone: Europe/Paris"
+            if result.returncode == 0 and ":" in result.stdout:
+                detected_tz = result.stdout.split(":", 1)[1].strip()
+        else:
+            # Linux: try timedatectl first, then /etc/timezone
+            result = subprocess.run(
+                ["timedatectl", "show", "-p", "Timezone", "--value"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                detected_tz = result.stdout.strip()
+            elif Path("/etc/timezone").exists():
+                detected_tz = Path("/etc/timezone").read_text().strip()
+    except Exception:
+        pass
+
+    current_tz = config.get("timezone", "") or ""
+    env_tz = os.environ.get("HERMES_TIMEZONE", "").strip()
+
+    if env_tz:
+        print_info(f"HERMES_TIMEZONE env var is set to: {env_tz}")
+        print_info("(env var takes precedence over config.yaml)")
+        print()
+
+    if current_tz:
+        print_info(f"Current config.yaml timezone: {current_tz}")
+    elif detected_tz:
+        print_info(f"Detected system timezone: {detected_tz}")
+    else:
+        print_info("No timezone detected.")
+
+    print()
+    print_info("Common IANA timezone IDs:")
+    print_info("  Europe/Paris, Europe/London, America/New_York, America/Los_Angeles,")
+    print_info("  Asia/Tokyo, Asia/Kolkata, Indian/Reunion, Pacific/Auckland, UTC")
+    print()
+
+    default_val = current_tz or env_tz or detected_tz or ""
+    tz_input = prompt("Timezone (IANA ID, or empty to skip)", default_val)
+
+    if tz_input.strip():
+        tz_value = tz_input.strip()
+        # Validate the timezone
+        try:
+            from zoneinfo import ZoneInfo
+            ZoneInfo(tz_value)  # Raises ZoneInfoNotFoundError if invalid
+            config["timezone"] = tz_value
+            print_success(f"Timezone set to {tz_value}")
+        except Exception:
+            print_warning(f"'{tz_value}' is not a valid IANA timezone ID.")
+            print_info("Skipping timezone configuration. You can set it later in config.yaml.")
+    else:
+        print_info("Timezone not configured. Cron jobs will use the server's system timezone.")
+
+    save_config(config)
+
+
 def setup_agent_settings(config: dict):
     """Configure agent behavior: iterations, progress display, compression, session reset."""
 
@@ -2724,6 +2807,7 @@ SETUP_SECTIONS = [
     ("model", "Model & Provider", setup_model_provider),
     ("tts", "Text-to-Speech", setup_tts),
     ("terminal", "Terminal Backend", setup_terminal_backend),
+    ("timezone", "Timezone", setup_timezone),
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),
     ("agent", "Agent Settings", setup_agent_settings),
@@ -2735,6 +2819,7 @@ SETUP_SECTIONS = [
 RETURNING_USER_MENU_SECTION_KEYS = [
     "model",
     "terminal",
+    "timezone",
     "gateway",
     "tools",
     "agent",
@@ -2749,6 +2834,7 @@ def run_setup_wizard(args):
       hermes setup model     — just model/provider
       hermes setup tts       — just text-to-speech
       hermes setup terminal  — just terminal backend
+      hermes setup timezone  — just timezone
       hermes setup gateway   — just messaging platforms
       hermes setup tools     — just tool configuration
       hermes setup agent     — just agent settings

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -103,6 +103,57 @@ class TestParseSchedule:
         assert result["kind"] == "once"
         assert "2030-01-15" in result["run_at"]
 
+    def test_naive_iso_uses_configured_tz(self, monkeypatch):
+        """Naive ISO timestamps must be interpreted in the Hermes-configured
+        timezone, not the server's system timezone.  This is the core bug
+        this module was patched to fix."""
+        from zoneinfo import ZoneInfo
+        kolkata = ZoneInfo("Asia/Kolkata")  # UTC+5:30, no DST
+        monkeypatch.setattr("cron.jobs._hermes_get_tz", lambda: kolkata)
+
+        result = parse_schedule("2030-06-15T14:00:00")
+
+        assert result["kind"] == "once"
+        dt = datetime.fromisoformat(result["run_at"])
+        assert dt.tzinfo is not None, "naive timestamp should be made tz-aware"
+        # Wall-clock preserved (14:00), and offset reflects Asia/Kolkata
+        assert (dt.year, dt.month, dt.day, dt.hour, dt.minute) == (2030, 6, 15, 14, 0)
+        assert dt.utcoffset() == timedelta(hours=5, minutes=30)
+
+    def test_naive_iso_fallback_when_no_tz_configured(self, monkeypatch):
+        """When no Hermes timezone is configured, naive timestamps fall back
+        to the original astimezone() behavior (system local).  Guarantees
+        backward compatibility — no breaking change for existing deployments."""
+        monkeypatch.setattr("cron.jobs._hermes_get_tz", lambda: None)
+
+        result = parse_schedule("2030-06-15T14:00:00")
+
+        assert result["kind"] == "once"
+        dt = datetime.fromisoformat(result["run_at"])
+        assert dt.tzinfo is not None
+        # Wall-clock preserved; offset is whatever the system reports
+        assert (dt.year, dt.month, dt.day, dt.hour, dt.minute) == (2030, 6, 15, 14, 0)
+
+    def test_naive_iso_guards_against_non_tzinfo_return(self, monkeypatch):
+        """Defensive: if _hermes_get_tz() ever returns a non-tzinfo object
+        (e.g. a string name from a future refactor), parse_schedule must
+        fall back safely instead of raising an opaque TypeError at runtime."""
+        monkeypatch.setattr("cron.jobs._hermes_get_tz", lambda: "Europe/Paris")
+
+        result = parse_schedule("2030-06-15T14:00:00")
+
+        assert result["kind"] == "once"
+        dt = datetime.fromisoformat(result["run_at"])
+        assert dt.tzinfo is not None, "should fall back to astimezone()"
+
+    def test_aware_iso_timestamp_preserved(self):
+        """A timezone-aware ISO timestamp must be passed through unchanged —
+        the user explicitly declared the zone and must not be overridden."""
+        result = parse_schedule("2030-06-15T14:00:00+09:00")
+        assert result["kind"] == "once"
+        dt = datetime.fromisoformat(result["run_at"])
+        assert dt.utcoffset() == timedelta(hours=9)
+
     def test_invalid_schedule_raises(self):
         with pytest.raises(ValueError):
             parse_schedule("not_a_schedule")


### PR DESCRIPTION
## Problem

When a user creates a cron job with a naive timestamp like `"2026-04-18T17:30"`, `parse_schedule()` calls `dt.astimezone()` which interprets it in the **server's system timezone**. On most VPS/cloud servers this is UTC, so `"17:30"` fires at 17:30 UTC — not the user's local 17:30.

This is a **silent bug**: the cron job fires, but hours off from when the user expected. Examples:
- Reunion (GMT+4): reminder fires 4 hours late
- India (GMT+5:30): 5.5 hours late  
- Any non-UTC server: wrong time

The infrastructure to fix this **already exists** — `hermes_time.get_timezone()` reads the timezone from `config.yaml` or `HERMES_TIMEZONE` env var — but `parse_schedule()` never uses it.

## Fix

**`cron/jobs.py`** (2 lines changed): When a naive timestamp is encountered, use `_hermes_get_tz()` to assign the configured timezone instead of the system timezone. Falls back to the original `astimezone()` behavior when no timezone is configured — **zero breaking change**.

**`hermes_cli/setup.py`** (~80 lines added): Add a `timezone` section to the setup wizard (`hermes setup timezone`) so users can configure their timezone during initial setup. Auto-detects the system timezone via `timedatectl` (Linux) or `systemsetup` (macOS) and validates the IANA ID.

## Testing

All 55 existing cron tests pass with the patch applied.

## Example

Before (VPS in UTC, user in Europe/Paris):
```
User: "Remind me at 17:30"
→ Cron fires at 17:30 UTC = 19:30 Paris time (2h late)
```

After (with `timezone: "Europe/Paris"` in config.yaml):
```
User: "Remind me at 17:30"
→ Cron fires at 17:30 Paris time ✅
```

If no timezone is configured → behavior unchanged (uses system timezone).