### PR TITLE
feat(skills): add gemini-cli delegation skill

### DIFF
--- a/skills/autonomous-ai-agents/gemini-cli/SKILL.md
+++ b/skills/autonomous-ai-agents/gemini-cli/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: gemini-cli
+description: Delegate coding tasks to Google Gemini CLI agent. Use for whole-repo audits, code reviews, refactors, batch issue fixing, and structured-output extraction. Requires the gemini CLI.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Coding-Agent, Gemini, Google, Code-Review, Refactoring, Audit]
+    related_skills: [claude-code, codex, opencode, hermes-agent]
+---
+
+# Gemini CLI
+
+Delegate coding tasks to [Gemini CLI](https://github.com/google-gemini/gemini-cli) via the Hermes terminal. Gemini CLI is Google's autonomous coding agent with a 1M-token context window — well-suited for whole-repo reads, multi-file refactors, and read-only audits.
+
+## Prerequisites
+
+- Gemini CLI installed: `npm install -g @google/gemini-cli` (or `brew install gemini-cli`)
+- Auth: run `gemini` once to sign in with Google (free tier: 60 req/min, 1k req/day), or set `GEMINI_API_KEY` for API-key auth
+- **No git repo required** (unlike Codex) — Gemini runs in any directory
+- **No PTY required** for `-p`/non-interactive mode — use plain `terminal()` calls
+
+## One-Shot Tasks
+
+```
+terminal(command="gemini -p 'Add dark mode toggle to settings' --approval-mode yolo", workdir="~/project", timeout=180)
+```
+
+For scratch work (no git init needed):
+```
+terminal(command="cd $(mktemp -d) && gemini -p 'Build a snake game in Python' --approval-mode yolo", timeout=180)
+```
+
+## Approval Modes
+
+| Mode | Effect | Use case |
+|------|--------|----------|
+| `--approval-mode default` | Prompts for every action | Interactive only — avoid in scripts |
+| `--approval-mode auto_edit` | Auto-approves edits, prompts for shell | Bounded write tasks |
+| `--approval-mode yolo` (or `-y`) | Auto-approves everything | One-shot builds, batch fixes |
+| `--approval-mode plan` | Read-only — refuses to write or run shell | Audits, code reviews, summaries |
+
+**`plan` mode is the killer feature** — safer than read-only flags on other CLIs because Gemini's planner explicitly knows it cannot mutate state. Use it for any task where you only need an answer.
+
+## Read-Only Audits (1M Context)
+
+Gemini's 1M-token window makes whole-repo questions practical:
+
+```
+terminal(command="gemini -p 'List every file that touches the auth flow and explain the request lifecycle' --approval-mode plan", workdir="~/project", timeout=240)
+```
+
+Multi-directory context:
+```
+terminal(command="gemini -p 'Compare the two auth implementations' --include-directories ../legacy-auth,../new-auth --approval-mode plan", workdir="~/project", timeout=240)
+```
+
+## Structured Output (JSON / stream-json)
+
+Parseable result with token + cost stats:
+```
+terminal(command="gemini -p 'Find all TODOs in src/' --approval-mode plan -o json", workdir="~/project", timeout=180)
+```
+
+Returns a JSON envelope with `stats.tokens`, `tools.totalCalls`, `files.totalLinesAdded/Removed`, etc.
+
+Streaming events for live monitoring:
+```
+terminal(command="gemini -p 'Refactor the user model' --approval-mode yolo -o stream-json", workdir="~/project", timeout=300)
+```
+
+Newline-delimited events: `init` → `message` (with `delta:true` chunks) → `result` (with stats). Filter with `jq`:
+```
+gemini -p "..." -o stream-json | jq -rj 'select(.role=="assistant" and .delta) | .content'
+```
+
+## Background Mode (Long Tasks)
+
+```
+# Start in background — no PTY needed for -p mode
+terminal(command="gemini -p 'Refactor the entire auth module' --approval-mode yolo", workdir="~/project", background=true)
+# Returns session_id
+
+# Monitor progress
+process(action="poll", session_id="<id>")
+process(action="log", session_id="<id>")
+
+# Kill if needed
+process(action="kill", session_id="<id>")
+```
+
+For interactive (multi-turn) sessions, use `pty=true` and send input via `process(action="submit", ...)`.
+
+## Parallel Issue Fixing with Worktrees
+
+Note: Gemini's built-in `-w/--worktree` flag is interactive-only — for scripted parallel work, use manual `git worktree add`:
+
+```
+# Create worktrees
+terminal(command="git worktree add -b fix/issue-78 /tmp/issue-78 main", workdir="~/project")
+terminal(command="git worktree add -b fix/issue-99 /tmp/issue-99 main", workdir="~/project")
+
+# Launch Gemini in each
+terminal(command="gemini -p 'Fix issue #78: <description>. Commit when done.' --approval-mode yolo", workdir="/tmp/issue-78", background=true)
+terminal(command="gemini -p 'Fix issue #99: <description>. Commit when done.' --approval-mode yolo", workdir="/tmp/issue-99", background=true)
+
+# Monitor
+process(action="list")
+
+# After completion, push and create PRs
+terminal(command="cd /tmp/issue-78 && git push -u origin fix/issue-78")
+terminal(command="gh pr create --repo user/repo --head fix/issue-78 --title 'fix: ...' --body '...'")
+
+# Cleanup
+terminal(command="git worktree remove /tmp/issue-78", workdir="~/project")
+```
+
+## PR Reviews
+
+Clone to a temp directory for safe review (plan mode = no risk of mutation):
+
+```
+terminal(command="REVIEW=$(mktemp -d) && git clone https://github.com/user/repo.git $REVIEW && cd $REVIEW && gh pr checkout 42 && gemini -p 'Review the diff against origin/main. Flag bugs, security issues, missing tests.' --approval-mode plan", timeout=300)
+```
+
+## Batch PR Reviews in Parallel
+
+```
+# Fetch all PR refs
+terminal(command="git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'", workdir="~/project")
+
+# Review multiple PRs in parallel
+terminal(command="gemini -p 'Review PR #86. git diff origin/main...origin/pr/86' --approval-mode plan", workdir="~/project", background=true)
+terminal(command="gemini -p 'Review PR #87. git diff origin/main...origin/pr/87' --approval-mode plan", workdir="~/project", background=true)
+
+# Post results
+terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
+```
+
+## Model Selection
+
+| Model | When to use |
+|-------|-------------|
+| `gemini-2.5-flash` (default for free tier) | Default — fast, cheap, handles most tasks |
+| `gemini-2.5-pro` | Deep reasoning, large refactors, tricky reviews |
+
+```
+terminal(command="gemini -p '...' -m gemini-2.5-pro --approval-mode yolo", workdir="~/project")
+```
+
+## Subcommands
+
+| Command | Purpose |
+|---------|---------|
+| `gemini mcp list` | List configured MCP servers |
+| `gemini mcp add <name> -- <cmd>` | Add an MCP server |
+| `gemini extensions list` | List installed extensions |
+| `gemini skills list` | List available skills |
+| `gemini hooks list` | List configured hooks |
+| `gemini --list-sessions` | List resumable sessions |
+| `gemini -r latest -p "continue"` | Resume the most recent session |
+
+## Rules
+
+1. **Use `-p` for one-shots** — `gemini -p "prompt"` runs and exits cleanly, no PTY needed
+2. **Always set an approval mode in scripts** — default mode prompts and will hang. Use `yolo` for builds, `plan` for reads, `auto_edit` for bounded writes
+3. **Prefer `plan` mode for read-only work** — it's a stronger guarantee than allowlists; the agent itself refuses to mutate
+4. **Use 1M context for whole-repo questions** — Gemini is the right tool when you need cross-file understanding in one pass
+5. **Use `-o json` or `-o stream-json` when piping into other tools** — text mode is for humans
+6. **Background for long tasks** — use `background=true` and monitor with `process` tool. No PTY needed for `-p` mode
+7. **Don't use `-w/--worktree` in scripted mode** — it's interactive-only. Use `git worktree add` instead
+8. **Parallel is fine** — run multiple Gemini processes for batch work; mind the free-tier 60 req/min ceiling


### PR DESCRIPTION
## What does this PR do?

Adds a bundled delegation skill for [Google Gemini CLI](https://github.com/google-gemini/gemini-cli), mirroring the existing pattern of `skills/autonomous-ai-agents/claude-code` and `skills/autonomous-ai-agents/codex`.

This lets Hermes delegate coding work to the `gemini` CLI the same way it already delegates to Claude Code and Codex — one-shot tasks, background long-runs, parallel worktree fixes, and PR reviews.

**Distinct from PR #11270:** that PR added Gemini as an *inference provider* (Gemini-as-a-model). This PR is orthogonal — it delegates to the gemini CLI *as an autonomous agent*, not using Gemini as Hermes' brain.

**What Gemini brings that the existing delegation skills don't:**
- 1M-token context (whole-repo audits in one pass)
- Native `--approval-mode plan` for stronger read-only guarantees than allowlists
- No git-repo requirement (Codex needs one)
- No PTY required for `-p` mode (cleaner than Codex's tmux/PTY plumbing)

## Related Issue

Fixes #10036

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- Add `skills/autonomous-ai-agents/gemini-cli/SKILL.md` (173 lines)
  - Frontmatter follows the project standard (`name`, `description`, `version`, `author`, `license`, `metadata.hermes.tags`, `metadata.hermes.related_skills`)
  - Documents: prerequisites, one-shot tasks, four approval modes, read-only audits with 1M context, JSON/stream-json output, background mode, worktree-based parallel work, PR-review patterns, batch reviews, model selection, subcommands, rules

## How to Test

Tested end-to-end against `gemini` CLI v0.38.1 on macOS (Darwin 25.1.0) before opening this PR. Each documented pattern was verified individually.

```bash
# 1. Confirm Hermes discovers the skill
hermes skills list | grep gemini-cli
# Expected: gemini-cli | autonomous-ai-agents | local | local

# 2. Inspect frontmatter
hermes skills inspect autonomous-ai-agents/gemini-cli

# 3. End-to-end delegation
mkdir -p /tmp/gem-test && echo "TODO: refactor" > /tmp/gem-test/file.py
hermes chat -Q -s autonomous-ai-agents/gemini-cli --max-turns 4 \
  -q "Use the gemini-cli skill to audit /tmp/gem-test for TODO comments. Use plan mode. Report in 1 line."
# Expected: Hermes invokes `gemini -p ... --approval-mode plan` and reports the TODO
```

Verified working patterns from the SKILL:
- ✅ `gemini -p` one-shot (no PTY, no git repo required)
- ✅ `--approval-mode plan` (read-only enforced — no writes possible)
- ✅ `--approval-mode yolo` (auto-approves writes; created a real file)
- ✅ `-o json` / `-o stream-json` (parseable envelope with token + cost stats)
- ✅ `--include-directories` (multi-dir workspace)
- ✅ Background via shell `&` (no PTY needed for `-p`)
- ✅ `git worktree add` + per-worktree gemini (parallel issue fixing)
- ✅ Piped stdin (`git diff | gemini -p ...`)
- ✅ `gemini mcp list`, `extensions list`, `skills list` subcommands

Caveat documented in SKILL: built-in `-w/--worktree` flag is interactive-only (silently dumps help when combined with `-p`). The skill documents `git worktree add` as the scripted alternative.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(skills): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no existing PR adds a `gemini-cli` delegation skill (PR #11270 is the inference-provider integration, different scope)
- [x] My PR contains **only** changes related to this skill (no unrelated commits)
- [x] I've tested on my platform: macOS 15 (Darwin 25.1.0), Hermes Agent v0.10.0, gemini CLI v0.38.1
- [ ] N/A — `pytest tests/ -q`: this PR is a bundled skill (Markdown only), no Python code paths changed
- [ ] N/A — Tests for changes: skill is documentation; end-to-end test steps included in "How to Test"

### Documentation & Housekeeping

- [ ] N/A — No `cli-config.yaml.example` change needed (skill auto-discovered)
- [ ] N/A — No `CONTRIBUTING.md` / `AGENTS.md` change needed
- [x] I've considered cross-platform impact: skill uses standard CLI flags; gemini CLI is npm-installable on macOS/Linux/Windows, brew on macOS/Linux. Background `&` syntax is bash/zsh; the rule "no PTY needed for -p" applies cross-platform
- [ ] N/A — No tool descriptions/schemas changed

## For New Skills

- [x] This skill is **broadly useful** — delegation to Gemini CLI is in the same category as `claude-code` and `codex`, both already bundled. Free-tier auth (60 req/min, 1k req/day) means most users can try it without paid keys
- [x] SKILL.md follows the standard format (frontmatter, prerequisites, patterns/sections, rules)
- [x] No external dependencies that aren't already available — only requires `gemini` CLI (npm or brew install) and the existing Hermes `terminal` + `process` tools
- [x] I've tested the skill end-to-end with `hermes chat -s autonomous-ai-agents/gemini-cli -q "..."` — working

## Screenshots / Logs

End-to-end run on macOS, Hermes v0.10.0, model `xiaomi/mimo-v2-pro`:

```
$ hermes chat -Q -s autonomous-ai-agents/gemini-cli --max-turns 4 \
    -q "Use the gemini-cli skill to audit /tmp/gem-e2e for TODO comments. Use plan mode. Report in 1 line."
session_id: 20260418_202739_fe5b63
1 TODO found: file.py:1 — "TODO: refactor this".
```