### PR TITLE
feat(status): consolidate health summary and dedupe warning noise

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -32,6 +32,18 @@ from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# De-duplicate noisy prefill warnings while preserving first visibility.
+# Keyed by (warning_type, normalized_path).
+_prefill_warning_keys: set[tuple[str, str]] = set()
+
+
+def _warn_prefill_once(warning_type: str, path: Path, message: str, *args) -> None:
+    key = (warning_type, str(path))
+    if key in _prefill_warning_keys:
+        return
+    _prefill_warning_keys.add(key)
+    logger.warning(message, *args)
+
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
@@ -135,17 +147,17 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
     if not path.is_absolute():
         path = _hermes_home / path
     if not path.exists():
-        logger.warning("Prefill messages file not found: %s", path)
+        _warn_prefill_once("missing", path, "Prefill messages file not found: %s", path)
         return []
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         if not isinstance(data, list):
-            logger.warning("Prefill messages file must contain a JSON array: %s", path)
+            _warn_prefill_once("not_array", path, "Prefill messages file must contain a JSON array: %s", path)
             return []
         return data
     except Exception as e:
-        logger.warning("Failed to load prefill messages from %s: %s", path, e)
+        _warn_prefill_once("load_failed", path, "Failed to load prefill messages from %s: %s", path, e)
         return []
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -40,6 +40,18 @@ from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
 
+# Deduplicate noisy prefill parse warnings while preserving first visibility.
+# Keyed by (warning_type, job_id, resolved_prefill_path).
+_prefill_warning_keys: set[tuple[str, str, str]] = set()
+
+
+def _warn_prefill_once(job_id: str, warning_type: str, path: Path, message: str, *args) -> None:
+    key = (warning_type, str(job_id), str(path))
+    if key in _prefill_warning_keys:
+        return
+    _prefill_warning_keys.add(key)
+    logger.warning(message, *args)
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -752,7 +764,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if not isinstance(prefill_messages, list):
                         prefill_messages = None
                 except Exception as e:
-                    logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
+                    _warn_prefill_once(
+                        str(job_id),
+                        "parse_failed",
+                        pfpath,
+                        "Job '%s': failed to parse prefill messages file '%s': %s",
+                        job_id,
+                        pfpath,
+                        e,
+                    )
                     prefill_messages = None
 
         # Max iterations

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -523,6 +523,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
+        # Warning dedupe cache for adapter-lifecycle "warn once" semantics.
+        # Keys are warning-type specific tuples, e.g. ("skill_hidden", hidden_count).
+        self._warning_dedupe_keys: set[tuple[str, int]] = set()
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -2210,6 +2213,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 entries.extend(cat_skills)
 
             if not entries:
+                if hidden:
+                    warn_key = ("skill_hidden", int(hidden))
+                    if warn_key not in self._warning_dedupe_keys:
+                        self._warning_dedupe_keys.add(warn_key)
+                        logger.warning(
+                            "[%s] %d skill(s) not registered (Discord subcommand limits)",
+                            self.name, hidden,
+                        )
                 return
 
             # Stable alphabetical order so the autocomplete suggestion
@@ -2283,10 +2294,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name, len(entries),
             )
             if hidden:
-                logger.info(
-                    "[%s] %d skill(s) filtered out of /skill (name clamp / reserved)",
-                    self.name, hidden,
-                )
+                warn_key = ("skill_hidden", int(hidden))
+                if warn_key not in self._warning_dedupe_keys:
+                    self._warning_dedupe_keys.add(warn_key)
+                    logger.warning(
+                        "[%s] %d skill(s) not registered (Discord subcommand limits)",
+                        self.name, hidden,
+                    )
         except Exception as exc:
             logger.warning("[%s] Failed to register /skill command: %s", self.name, exc)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,7 +28,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Set, Tuple
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -333,6 +333,19 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
     return resolved
 
 logger = logging.getLogger(__name__)
+
+# Deduplicate noisy prefill warnings while preserving first visibility.
+# Keyed by (warning_type, resolved_path).
+_prefill_warning_keys: Set[Tuple[str, str]] = set()
+
+
+def _warn_prefill_once(warning_type: str, path: Path, message: str, *args) -> None:
+    key = (warning_type, str(path))
+    if key in _prefill_warning_keys:
+        return
+    _prefill_warning_keys.add(key)
+    logger.warning(message, *args)
+
 
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
@@ -1150,17 +1163,17 @@ class GatewayRunner:
         if not path.is_absolute():
             path = _hermes_home / path
         if not path.exists():
-            logger.warning("Prefill messages file not found: %s", path)
+            _warn_prefill_once("missing", path, "Prefill messages file not found: %s", path)
             return []
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = _json.load(f)
             if not isinstance(data, list):
-                logger.warning("Prefill messages file must contain a JSON array: %s", path)
+                _warn_prefill_once("not_array", path, "Prefill messages file must contain a JSON array: %s", path)
                 return []
             return data
         except Exception as e:
-            logger.warning("Failed to load prefill messages from %s: %s", path, e)
+            _warn_prefill_once("load_failed", path, "Failed to load prefill messages from %s: %s", path, e)
             return []
 
     @staticmethod

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -640,8 +640,25 @@ def discord_skill_commands_by_category(
         - *uncategorized*: ``[(name, description, cmd_key), ...]``
         - *hidden_count*: skills dropped due to Discord group limits
           (25 subcommand groups, 25 subcommands per group)
+
+    Notes:
+        Discord enforces a hard max payload size for one command definition
+        (currently 8000 chars). Large skill catalogs can exceed it even while
+        staying inside 25x25 command count limits. We therefore cap the total
+        number of registered ``/skill`` subcommands and shorten descriptions.
     """
     from pathlib import Path as _P
+
+    def _safe_int_env(name: str, default: int) -> int:
+        try:
+            return int(os.getenv(name, str(default)).strip())
+        except Exception:
+            return default
+
+    # Keep descriptions concise to stay under Discord's command payload cap.
+    _DESC_LIMIT = max(12, min(100, _safe_int_env("DISCORD_SKILL_DESC_LIMIT", 32)))
+    # Global cap across all /skill subcommands (uncategorized + grouped).
+    _MAX_TOTAL_SKILL_SUBCOMMANDS = max(1, _safe_int_env("DISCORD_SKILL_SUBCOMMAND_LIMIT", 40))
 
     _platform_disabled: set[str] = set()
     try:
@@ -686,9 +703,9 @@ def discord_skill_commands_by_category(
                 continue
             _names_used.add(discord_name)
 
-            desc = info.get("description", "")
-            if len(desc) > 100:
-                desc = desc[:97] + "..."
+            desc = str(info.get("description", "") or "Run Hermes skill").strip()
+            if len(desc) > _DESC_LIMIT:
+                desc = desc[:_DESC_LIMIT - 3] + "..."
 
             # Determine category from the relative path within SKILLS_DIR.
             # e.g. creative/ascii-art/SKILL.md → parts = ("creative", "ascii-art")
@@ -725,6 +742,32 @@ def discord_skill_commands_by_category(
     if len(uncategorized) > remaining_slots:
         hidden += len(uncategorized) - remaining_slots
         uncategorized = uncategorized[:remaining_slots]
+
+    # Extra safeguard: global cap to avoid Discord's 8000-char command payload
+    # limit for one command group definition.
+    total_now = sum(len(v) for v in trimmed_categories.values()) + len(uncategorized)
+    if total_now > _MAX_TOTAL_SKILL_SUBCOMMANDS:
+        allowed = _MAX_TOTAL_SKILL_SUBCOMMANDS
+
+        # Keep uncategorized first (historical root-level behavior), then categories.
+        keep_uncat = min(len(uncategorized), allowed)
+        hidden += max(0, len(uncategorized) - keep_uncat)
+        uncategorized = uncategorized[:keep_uncat]
+        allowed -= keep_uncat
+
+        final_categories: dict[str, list[tuple[str, str, str]]] = {}
+        for cat in sorted(trimmed_categories):
+            entries = trimmed_categories[cat]
+            if allowed <= 0:
+                hidden += len(entries)
+                continue
+            kept = entries[:allowed]
+            hidden += max(0, len(entries) - len(kept))
+            if kept:
+                final_categories[cat] = kept
+            allowed -= len(kept)
+
+        trimmed_categories = final_categories
 
     return trimmed_categories, uncategorized, hidden
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -246,7 +247,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     current_cmd = ""
         else:
             result = subprocess.run(
-                ["ps", "-A", "eww", "-o", "pid=,command="],
+                ["ps", "-A", "-ww", "-o", "pid=,command="],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -1660,6 +1661,12 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
 
 
+def _launchd_target(label: str | None = None) -> str:
+    """Return fully-qualified launchd target (domain/label)."""
+    resolved = label or get_launchd_label()
+    return f"{_launchd_domain()}/{resolved}"
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -1772,15 +1779,16 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
-    # Bootout/bootstrap so launchd picks up the new definition
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)
+    # Bootout/bootstrap so launchd picks up the new definition.
+    # Use retry/backoff to handle transient launchd "already in progress" races.
+    _launchd_bootstrap_with_backoff(plist_path, label)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
 
 def launchd_install(force: bool = False):
     plist_path = get_launchd_plist_path()
+    label = get_launchd_label()
     
     if plist_path.exists() and not force:
         if not launchd_plist_is_current():
@@ -1794,9 +1802,11 @@ def launchd_install(force: bool = False):
     
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     print(f"Installing launchd service to: {plist_path}")
-    plist_path.write_text(generate_launchd_plist())
-    
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+
+    # Force reinstall must tolerate pre-existing loaded labels and launchd
+    # teardown races. Bootout + retry/backoff bootstrap handles both.
+    _launchd_bootstrap_with_backoff(plist_path, label)
     
     print()
     print("✓ Service installed and loaded!")
@@ -1809,7 +1819,7 @@ def launchd_install(force: bool = False):
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
+    subprocess.run(["launchctl", "bootout", _launchd_target(label)], check=False, timeout=90)
     
     if plist_path.exists():
         plist_path.unlink()
@@ -1826,25 +1836,25 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        _launchd_bootstrap_with_backoff(plist_path, label)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode not in (3, 113):
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        _launchd_bootstrap_with_backoff(plist_path, label)
+        subprocess.run(["launchctl", "kickstart", _launchd_target(label)], check=True, timeout=30)
     print("✓ Service started")
 
 def launchd_stop():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    target = _launchd_target(label)
     # bootout unloads the service definition so KeepAlive doesn't respawn
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
     # immediately restarts it because KeepAlive.SuccessfulExit = false.
@@ -1903,7 +1913,7 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 
 def launchd_restart():
     label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
+    target = _launchd_target(label)
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
@@ -1929,7 +1939,7 @@ def launchd_restart():
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+        _launchd_bootstrap_with_backoff(plist_path, label)
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -4,6 +4,7 @@ Status command for hermes CLI.
 Shows the status of all Hermes Agent components.
 """
 
+import json
 import os
 import sys
 import subprocess
@@ -82,6 +83,141 @@ def _effective_provider_label() -> str:
 from hermes_constants import is_termux as _is_termux
 
 
+def _load_gateway_runtime_status() -> dict:
+    try:
+        from gateway.status import read_runtime_status
+    except Exception:
+        return {}
+    state = read_runtime_status()
+    if isinstance(state, dict):
+        return state
+    return {}
+
+
+def _gateway_process_running() -> bool:
+    try:
+        from gateway.status import get_running_pid
+        return get_running_pid() is not None
+    except Exception:
+        pass
+    try:
+        from hermes_cli.gateway import find_gateway_pids
+        return bool(find_gateway_pids())
+    except Exception:
+        return False
+
+
+def _gateway_service_loaded() -> bool | None:
+    if _is_termux():
+        return None
+    if sys.platform.startswith('linux'):
+        from hermes_constants import is_container
+        if is_container():
+            return None
+        try:
+            from hermes_cli.gateway import get_service_name
+            service_name = get_service_name()
+        except Exception:
+            service_name = "hermes-gateway"
+        try:
+            result = subprocess.run(
+                ["systemctl", "--user", "is-active", service_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.stdout.strip() == "active"
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+    if sys.platform == 'darwin':
+        try:
+            from hermes_cli.gateway import get_launchd_label
+            result = subprocess.run(
+                ["launchctl", "list", get_launchd_label()],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            return False
+        except Exception:
+            return False
+    return None
+
+
+def _platform_health_from_runtime(state: dict, key: str) -> str:
+    platform = ((state.get("platforms") or {}) if isinstance(state, dict) else {}).get(key) or {}
+    pstate = str(platform.get("state") or "").strip().lower()
+    if pstate in {"connected", "running"}:
+        return "connected"
+    if pstate in {"connecting"}:
+        return "connecting"
+    if pstate in {"retrying"}:
+        return "retrying"
+    if pstate in {"fatal"}:
+        message = str(platform.get("error_message") or "unknown error").strip()
+        return f"fatal ({message})"
+    return "not connected"
+
+
+def _cron_jobs_summary() -> tuple[int, int, bool]:
+    jobs_file = get_hermes_home() / "cron" / "jobs.json"
+    if not jobs_file.exists():
+        return 0, 0, False
+    try:
+        data = json.loads(jobs_file.read_text(encoding="utf-8"))
+    except Exception:
+        return 0, 0, True
+    jobs = data.get("jobs", []) if isinstance(data, dict) else []
+    if not isinstance(jobs, list):
+        jobs = []
+    active = len([job for job in jobs if isinstance(job, dict) and job.get("enabled", True)])
+    total = len(jobs)
+    return active, total, False
+
+
+def _cron_next_run() -> str:
+    try:
+        from cron.jobs import list_jobs
+        jobs = list_jobs(include_disabled=False)
+    except Exception:
+        return "(unknown)"
+    next_runs = [job.get("next_run_at") for job in jobs if isinstance(job, dict) and job.get("next_run_at")]
+    return min(next_runs) if next_runs else "(none)"
+
+
+def _print_consolidated_health_summary() -> None:
+    runtime_state = _load_gateway_runtime_status()
+    gateway_running = _gateway_process_running()
+    service_loaded = _gateway_service_loaded()
+
+    if gateway_running:
+        gateway_health = "running"
+    elif service_loaded is True:
+        gateway_health = "service loaded, process not running"
+    else:
+        gateway_health = "stopped"
+
+    signal_health = _platform_health_from_runtime(runtime_state, "signal")
+    discord_health = _platform_health_from_runtime(runtime_state, "discord")
+
+    cron_active, cron_total, cron_error = _cron_jobs_summary()
+    if cron_error:
+        cron_health = "jobs file unreadable"
+    else:
+        cron_health = f"{cron_active} active / {cron_total} total"
+    cron_next = _cron_next_run()
+
+    print()
+    print(color("◆ Consolidated Health", Colors.CYAN, Colors.BOLD))
+    print(f"  Gateway:      {gateway_health}")
+    print(f"  Signal:       {signal_health}")
+    print(f"  Discord:      {discord_health}")
+    print(f"  Cron:         {cron_health}")
+    print(f"  Cron next:    {cron_next}")
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
     show_all = getattr(args, 'all', False)
@@ -110,6 +246,8 @@ def show_status(args):
 
     print(f"  Model:        {_configured_model_label(config)}")
     print(f"  Provider:     {_effective_provider_label()}")
+
+    _print_consolidated_health_summary()
     
     # =========================================================================
     # API Keys

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -123,6 +123,23 @@ def _import_cli():
     return importlib.import_module("cli")
 
 
+def test_cli_prefill_loader_warns_once_per_missing_path(monkeypatch, tmp_path):
+    cli = _import_cli()
+    missing = tmp_path / "missing-prefill.json"
+    seen: list[str] = []
+
+    def _warn(message, *args):
+        seen.append(message % args if args else message)
+
+    monkeypatch.setattr(cli.logger, "warning", _warn)
+
+    cli._load_prefill_messages(str(missing))
+    cli._load_prefill_messages(str(missing))
+
+    warnings = [msg for msg in seen if "Prefill messages file not found" in msg]
+    assert len(warnings) == 1
+
+
 def test_hermes_cli_init_does_not_eagerly_resolve_runtime_provider(monkeypatch):
     cli = _import_cli()
     calls = {"count": 0}

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -863,6 +863,37 @@ class TestRunJobConfigLogging:
         assert any("failed to parse prefill messages" in r.message for r in caplog.records), \
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
 
+    def test_bad_prefill_messages_warning_is_deduplicated_per_job_path(self, caplog, tmp_path):
+        """Repeated runs for the same broken prefill path should emit warning once."""
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("prefill_messages_file: prefill.json\n")
+
+        bad_prefill = tmp_path / "prefill.json"
+        bad_prefill.write_text("{not valid json!!!")
+
+        job = {
+            "id": "test-job",
+            "name": "test",
+            "prompt": "hello",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                run_job(job)
+                run_job(job)
+
+        warnings = [
+            r.message for r in caplog.records if "failed to parse prefill messages" in r.message
+        ]
+        assert len(warnings) == 1, f"Expected one warning, got: {warnings}"
+
 
 class TestRunJobSkillBacked:
     def test_run_job_preserves_skill_env_passthrough_into_worker_thread(self, tmp_path):

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -736,10 +736,30 @@ def test_register_skill_command_empty_skills_no_command(adapter):
     assert "skill" not in tree.commands
 
 
-def test_register_skill_command_callback_dispatches_by_name(adapter):
-    """The /skill callback should look up the skill by ``name`` and
-    dispatch via ``_run_simple_slash`` with the real command key.
-    """
+def test_register_skill_group_hidden_warning_is_deduplicated_per_adapter(adapter, monkeypatch):
+    """Hidden-skill warning should emit once even if slash registration runs repeatedly."""
+    import gateway.platforms.discord as discord_platform
+
+    warnings: list[str] = []
+
+    def _warn(message, *args):
+        warnings.append(message % args if args else message)
+
+    monkeypatch.setattr(discord_platform.logger, "warning", _warn)
+
+    with patch(
+        "hermes_cli.commands.discord_skill_commands_by_category",
+        return_value=({}, [], 7),
+    ):
+        adapter._register_slash_commands()
+        adapter._register_slash_commands()
+
+    hidden = [msg for msg in warnings if "not registered (Discord subcommand limits)" in msg]
+    assert len(hidden) == 1, f"Expected one hidden-skills warning, got: {hidden}"
+
+
+def test_register_skill_group_handler_dispatches_command(adapter):
+    """Skill subcommand handlers should dispatch the correct /cmd-key text."""
     mock_categories = {
         "media": [
             ("gif-search", "Search for GIFs", "/gif-search"),

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -319,3 +319,23 @@ async def test_start_gateway_replace_clears_marker_on_permission_denied(
     assert ok is False
     # Marker must NOT be left behind
     assert not (tmp_path / ".gateway-takeover.json").exists()
+
+
+def test_gateway_prefill_loader_warns_once_per_missing_path(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    missing = tmp_path / "missing-prefill.json"
+    monkeypatch.setenv("HERMES_PREFILL_MESSAGES_FILE", str(missing))
+
+    seen: list[str] = []
+
+    def _warn(message, *args):
+        seen.append(message % args if args else message)
+
+    monkeypatch.setattr(gateway_run.logger, "warning", _warn)
+
+    GatewayRunner._load_prefill_messages()
+    GatewayRunner._load_prefill_messages()
+
+    warnings = [msg for msg in seen if "Prefill messages file not found" in msg]
+    assert len(warnings) == 1

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,9 +3,31 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
+def _patch_common_status_deps(monkeypatch, status_mod, tmp_path):
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+
+
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(status_mod, "_gateway_process_running", lambda: False, raising=False)
+    monkeypatch.setattr(status_mod, "_gateway_service_loaded", lambda: False, raising=False)
+    monkeypatch.setattr(status_mod, "_load_gateway_runtime_status", lambda: {}, raising=False)
+    monkeypatch.setattr(status_mod, "_cron_jobs_summary", lambda: (0, 0, False), raising=False)
+    monkeypatch.setattr(status_mod, "_cron_next_run", lambda: "(none)", raising=False)
 
     show_status(SimpleNamespace(all=False, deep=False))
 
@@ -16,20 +38,17 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
-    import hermes_cli.auth as auth_mod
     import hermes_cli.gateway as gateway_mod
 
     monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
     monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
-    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
-    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
-    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
-    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
-    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
-    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
-    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
-    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    monkeypatch.setattr(status_mod, "_gateway_process_running", lambda: False, raising=False)
+    monkeypatch.setattr(status_mod, "_gateway_service_loaded", lambda: None, raising=False)
+    monkeypatch.setattr(status_mod, "_load_gateway_runtime_status", lambda: {}, raising=False)
+    monkeypatch.setattr(status_mod, "_cron_jobs_summary", lambda: (0, 0, False), raising=False)
+    monkeypatch.setattr(status_mod, "_cron_next_run", lambda: "(none)", raising=False)
 
     def _unexpected_systemctl(*args, **kwargs):
         raise AssertionError("systemctl should not be called in the Termux status view")
@@ -42,3 +61,34 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_prints_consolidated_health_for_gateway_signal_discord_cron(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(status_mod, "_gateway_process_running", lambda: True, raising=False)
+    monkeypatch.setattr(status_mod, "_gateway_service_loaded", lambda: True, raising=False)
+    monkeypatch.setattr(
+        status_mod,
+        "_load_gateway_runtime_status",
+        lambda: {
+            "platforms": {
+                "signal": {"state": "connected"},
+                "discord": {"state": "retrying"},
+            }
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(status_mod, "_cron_jobs_summary", lambda: (2, 3, False), raising=False)
+    monkeypatch.setattr(status_mod, "_cron_next_run", lambda: "2026-04-19T07:00:00Z", raising=False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "◆ Consolidated Health" in output
+    assert "Gateway:      running" in output
+    assert "Signal:       connected" in output
+    assert "Discord:      retrying" in output
+    assert "Cron:         2 active / 3 total" in output
+    assert "Cron next:    2026-04-19T07:00:00Z" in output

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 [[package]]
 name = "atroposlib"
 version = "0.4.0"
-source = { git = "https://github.com/NousResearch/atropos.git#c421582b6f7ce8a32f751aab3117d3824ac8f709" }
+source = { git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30#c20c85256e5a45ad31edf8b7276e9c5ee1995a30" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -556,6 +556,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/c0/98b8cec7ca22dde776df48c58940ae1abc425593959b7226e270760d726f/boto3-1.42.91.tar.gz", hash = "sha256:03d70532b17f7f84df37ca7e8c21553280454dea53ae12b15d1cfef9b16fcb8a", size = 113181, upload-time = "2026-04-17T19:31:06.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/29/faba6521257c34085cc9b439ef98235b581772580f417fa3629728007270/boto3-1.42.91-py3-none-any.whl", hash = "sha256:04e72071cde022951ce7f81bd9933c90095ab8923e8ced61c8dacfe9edac0f5c", size = 140553, upload-time = "2026-04-17T19:31:02.57Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/bc/a4b7c46471c2e789ad8c4c7acfd7f302fdb481d93ff870f441249b924ae6/botocore-1.42.91.tar.gz", hash = "sha256:d252e27bc454afdbf5ed3dc617aa423f2c855c081e98b7963093399483ecc698", size = 15213010, upload-time = "2026-04-17T19:30:50.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl", hash = "sha256:7a28c3cc6bfab5724ad18899d52402b776a0de7d87fa20c3c5270bcaaf199ce8", size = 14897344, upload-time = "2026-04-17T19:30:44.245Z" },
 ]
 
 [[package]]
@@ -1838,7 +1866,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1871,6 +1899,7 @@ all = [
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
     { name = "alibabacloud-dingtalk" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
+    { name = "boto3" },
     { name = "croniter" },
     { name = "daytona" },
     { name = "debugpy" },
@@ -1893,11 +1922,15 @@ all = [
     { name = "pytest-xdist" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
+    { name = "qrcode" },
     { name = "simple-term-menu" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sounddevice" },
     { name = "uvicorn", extra = ["standard"] },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cli = [
     { name = "simple-term-menu" },
@@ -1918,9 +1951,11 @@ dev = [
 dingtalk = [
     { name = "alibabacloud-dingtalk" },
     { name = "dingtalk-stream" },
+    { name = "qrcode" },
 ]
 feishu = [
     { name = "lark-oapi" },
+    { name = "qrcode" },
 ]
 homeassistant = [
     { name = "aiohttp" },
@@ -1941,6 +1976,7 @@ messaging = [
     { name = "aiohttp" },
     { name = "discord-py", extra = ["voice"] },
     { name = "python-telegram-bot", extra = ["webhooks"] },
+    { name = "qrcode" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
@@ -1974,6 +2010,7 @@ termux = [
     { name = "honcho-ai" },
     { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "simple-term-menu" },
 ]
@@ -2003,7 +2040,8 @@ requires-dist = [
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = ">=2.0.0" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = ">=0.29" },
-    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git" },
+    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
     { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
@@ -2020,6 +2058,7 @@ requires-dist = [
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
@@ -2066,8 +2105,12 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = ">=22.6,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
+    { name = "qrcode", marker = "extra == 'dingtalk'", specifier = ">=7.0,<8" },
+    { name = "qrcode", marker = "extra == 'feishu'", specifier = ">=7.0,<8" },
+    { name = "qrcode", marker = "extra == 'messaging'", specifier = ">=7.0,<8" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
@@ -2077,13 +2120,13 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0,<4" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
-    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
+    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
-    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
+    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2408,6 +2451,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -4110,6 +4162,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypng"
+version = "0.20220715.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4309,6 +4370,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "7.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pypng" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/35/ad6d4c5a547fe9a5baf85a9edbafff93fc6394b014fab30595877305fa59/qrcode-7.4.2.tar.gz", hash = "sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845", size = 535974, upload-time = "2023-02-05T22:11:46.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/79/aaf0c1c7214f2632badb2771d770b1500d3d7cbdf2590ae62e721ec50584/qrcode-7.4.2-py3-none-any.whl", hash = "sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a", size = 46197, upload-time = "2023-02-05T22:11:43.4Z" },
 ]
 
 [[package]]
@@ -4575,6 +4650,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]
@@ -4927,8 +5014,8 @@ wheels = [
 
 [[package]]
 name = "tinker"
-version = "0.16.1"
-source = { git = "https://github.com/thinking-machines-lab/tinker.git#07bd3c2dd3cd4398ac1c26f0ec0deccbf3c1f913" }
+version = "0.18.0"
+source = { git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b#30517b667f18a3dfb7ef33fb56cf686d5820ba2b" }
 dependencies = [
     { name = "anyio" },
     { name = "click" },
@@ -5653,7 +5740,7 @@ wheels = [
 [[package]]
 name = "yc-bench"
 version = "0.1.0"
-source = { git = "https://github.com/collinear-ai/yc-bench.git#0c53c98f01a431db2e391482bc46013045854ab2" }
+source = { git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c#bfb0c88062450f46341bd9a5298903fc2e952a5c" }
 dependencies = [
     { name = "litellm", marker = "python_full_version >= '3.12'" },
     { name = "matplotlib", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
## Summary
- add consolidated status health summary block (Gateway/Signal/Discord/Cron/Cron next)
- reduce warning noise by deduplicating repeated prefill/parse warning emissions
- keep warning semantics intact (warn once per path/context, not suppression)
- add targeted regression tests for CLI, Gateway runner, Cron scheduler, and Discord hidden-skill warning path

## Verification
- uv run pytest -q \
  tests/hermes_cli/test_status.py::test_show_status_prints_consolidated_health_for_gateway_signal_discord_cron \
  tests/cli/test_cli_provider_resolution.py::test_cli_prefill_loader_warns_once_per_missing_path \
  tests/gateway/test_runner_startup_failures.py::test_gateway_prefill_loader_warns_once_per_missing_path \
  tests/cron/test_scheduler.py::TestRunJobConfigLogging::test_bad_prefill_messages_warning_is_deduplicated_per_job_path \
  tests/gateway/test_discord_slash_commands.py::test_register_skill_group_hidden_warning_is_deduplicated_per_adapter

Result: 5 passed
