### PR TITLE
feat(rate-limit): stepped cooldown — rebased + aux client coverage (supersedes #3910)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -46,6 +46,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from openai import OpenAI
 
 from agent.credential_pool import load_pool
+from agent.rate_limiter import rate_limiter as _rate_limiter
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 
@@ -1123,8 +1124,86 @@ def _is_payment_error(exc: Exception) -> bool:
     if status in (402, 429, None):
         if any(kw in err_lower for kw in ("credits", "insufficient funds",
                                            "can only afford", "billing",
-                                           "payment required")):
+                                           "payment required",
+                                           # z.ai returns 429 code 1311 when
+                                           # the plan lacks access — permanent,
+                                           # not transient.
+                                           "subscription plan",
+                                           "does not yet include",
+                                           "plan does not include")):
             return True
+    return False
+
+
+def _message_content_shape(messages: list) -> str:
+    """Summarise message shape for diagnostics without logging image bytes."""
+    if not messages:
+        return "empty"
+    parts = []
+    for m in messages:
+        role = m.get("role", "?") if isinstance(m, dict) else "?"
+        content = m.get("content") if isinstance(m, dict) else None
+        if isinstance(content, list):
+            block_types = [
+                b.get("type", "?") if isinstance(b, dict) else "?"
+                for b in content
+            ]
+            parts.append(f"{role}:[{','.join(block_types)}]")
+        elif isinstance(content, str):
+            parts.append(f"{role}:str({len(content)})")
+        else:
+            parts.append(f"{role}:{type(content).__name__}")
+    return " ".join(parts)
+
+
+def _log_400_diag(
+    exc: Exception,
+    task: Optional[str],
+    provider: Optional[str],
+    model: Optional[str],
+    kwargs: dict,
+) -> None:
+    """On HTTP 400, log request shape so the next regression is diagnosable.
+
+    Logs key names only — never message content (image data URLs would bloat
+    the log).  Quiet on non-400 errors.
+    """
+    status = getattr(exc, "status_code", None)
+    if status != 400:
+        return
+    try:
+        key_list = sorted(kwargs.keys())
+        shape = _message_content_shape(kwargs.get("messages") or [])
+        logger.warning(
+            "400 from %s task=%s provider=%s model=%s kwargs=%s msgs=%s err=%s",
+            getattr(exc, "__class__", type(exc)).__name__,
+            task or "call", provider, model, key_list, shape,
+            str(exc)[:300],
+        )
+    except Exception:
+        pass
+
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Detect transient rate-limit / overload errors (429 that aren't billing).
+
+    Distinct from ``_is_payment_error``: payment errors won't recover with a
+    cooldown, rate-limit errors will.
+    """
+    if _is_payment_error(exc):
+        return False
+    status = getattr(exc, "status_code", None)
+    if status == 429:
+        return True
+    from openai import RateLimitError  # imported lazily to avoid cycles
+    if isinstance(exc, RateLimitError):
+        return True
+    err_lower = str(exc).lower()
+    if any(kw in err_lower for kw in (
+        "rate limit", "rate-limit", "too many requests",
+        "temporarily overloaded",
+    )):
+        return True
     return False
 
 
@@ -2500,11 +2579,24 @@ def call_llm(
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
+    # Honour any active per-model cooldown before issuing the request.
+    # Prevents flooding a rate-limited model with repeated aux calls
+    # (e.g. vision_analyze fired once per message while still cooling down).
+    _rl_remaining = _rate_limiter.check_rate_limit(final_model or "unknown")
+    if _rl_remaining > 0:
+        raise RuntimeError(
+            f"rate_limit_cooldown: {final_model} cooling down, "
+            f"{_rl_remaining:.0f}s remaining"
+        )
+
     # Handle max_tokens vs max_completion_tokens retry, then payment fallback.
     try:
         return _validate_llm_response(
             client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        if _is_rate_limit_error(first_err):
+            _rate_limiter.record_rate_limit(final_model or "unknown")
+        _log_400_diag(first_err, task, resolved_provider, final_model, kwargs)
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
@@ -2513,6 +2605,8 @@ def call_llm(
                 return _validate_llm_response(
                     client.chat.completions.create(**kwargs), task)
             except Exception as retry_err:
+                if _is_rate_limit_error(retry_err):
+                    _rate_limiter.record_rate_limit(final_model or "unknown")
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err)):
@@ -2693,10 +2787,20 @@ async def async_call_llm(
     if _is_anthropic_compat_endpoint(resolved_provider, _client_base):
         kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
 
+    _rl_remaining = _rate_limiter.check_rate_limit(final_model or "unknown")
+    if _rl_remaining > 0:
+        raise RuntimeError(
+            f"rate_limit_cooldown: {final_model} cooling down, "
+            f"{_rl_remaining:.0f}s remaining"
+        )
+
     try:
         return _validate_llm_response(
             await client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        if _is_rate_limit_error(first_err):
+            _rate_limiter.record_rate_limit(final_model or "unknown")
+        _log_400_diag(first_err, task, resolved_provider, final_model, kwargs)
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
@@ -2705,6 +2809,8 @@ async def async_call_llm(
                 return _validate_llm_response(
                     await client.chat.completions.create(**kwargs), task)
             except Exception as retry_err:
+                if _is_rate_limit_error(retry_err):
+                    _rate_limiter.record_rate_limit(final_model or "unknown")
                 # If the max_tokens retry also hits a payment or connection
                 # error, fall through to the fallback chain below.
                 if not (_is_payment_error(retry_err) or _is_connection_error(retry_err)):

--- a/agent/rate_limiter.py
+++ b/agent/rate_limiter.py
@@ -1,0 +1,173 @@
+"""Per-model rate limit handler with stepped cooldown.
+
+Tracks 429 / rate-limit errors per model and applies a stepped cooldown
+ladder:
+
+    1st hit  →  30 s
+    2nd hit  →  60 s
+    3rd+ hit → 300 s  (5 min)
+
+The step counter resets automatically after 10 minutes of *no* rate-limit
+hits for a given model.
+
+Thread-safe: all mutable state is guarded by a single ``threading.Lock``.
+
+Usage example (inside an API retry loop)::
+
+    from agent.rate_limiter import rate_limiter
+
+    # Before calling the API – honour any active cooldown
+    remaining = rate_limiter.check_rate_limit(model)
+    if remaining > 0:
+        time.sleep(remaining)
+
+    try:
+        response = client.chat.completions.create(...)
+    except RateLimitError:
+        cooldown = rate_limiter.record_rate_limit(model)
+        print(f"Rate limited on {model}, cooling down for {cooldown}s")
+        time.sleep(cooldown)
+        # … retry …
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Stepped cooldown ladder (seconds)
+_COOLDOWN_STEPS: tuple[int, ...] = (30, 60, 300)
+
+# After this many seconds with no new rate-limit hits the step counter resets.
+_RESET_WINDOW: float = 600.0  # 10 minutes
+
+
+# ---------------------------------------------------------------------------
+# Internal per-model state
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _ModelCooldownState:
+    """Mutable cooldown state for a single model."""
+
+    # How many consecutive rate-limit hits (1-indexed).
+    step: int = 0
+
+    # ``time.monotonic()`` timestamp when the current cooldown ends.
+    cooldown_until: float = 0.0
+
+    # ``time.monotonic()`` of the last hit – used for the reset window.
+    last_hit: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Public API – singleton ``RateLimiter``
+# ---------------------------------------------------------------------------
+
+class RateLimiter:
+    """Thread-safe, per-model rate-limit handler with stepped cooldown."""
+
+    def __init__(
+        self,
+        cooldown_steps: tuple[int, ...] = _COOLDOWN_STEPS,
+        reset_window: float = _RESET_WINDOW,
+    ) -> None:
+        self._cooldown_steps = cooldown_steps
+        self._reset_window = reset_window
+        self._lock = threading.Lock()
+        self._models: Dict[str, _ModelCooldownState] = {}
+
+    # -- helpers ----------------------------------------------------------
+
+    def _get_state(self, model: str) -> _ModelCooldownState:
+        """Return (or create) the state object for *model*.  Caller must hold ``_lock``."""
+        if model not in self._models:
+            self._models[model] = _ModelCooldownState()
+        return self._models[model]
+
+    def _maybe_reset(self, state: _ModelCooldownState, now: float) -> None:
+        """Reset the step counter if the reset window has elapsed since the last hit.
+
+        Caller must hold ``_lock``.
+        """
+        if state.last_hit and (now - state.last_hit) >= self._reset_window:
+            state.step = 0
+
+    # -- public interface -------------------------------------------------
+
+    def check_rate_limit(self, model: str) -> float:
+        """Return remaining cooldown seconds for *model*, or ``0`` if none."""
+        now = time.monotonic()
+        with self._lock:
+            state = self._get_state(model)
+            remaining = max(0.0, state.cooldown_until - now)
+        return remaining
+
+    def record_rate_limit(self, model: str) -> float:
+        """Record a rate-limit hit for *model* and return the cooldown duration (seconds).
+
+        The returned value is the number of seconds to wait before the next
+        attempt.
+        """
+        now = time.monotonic()
+        with self._lock:
+            state = self._get_state(model)
+
+            # Reset step counter if the reset window elapsed.
+            self._maybe_reset(state, now)
+
+            # Advance the step (clamped to the ladder length).
+            state.step = min(state.step + 1, len(self._cooldown_steps))
+
+            # Look up the cooldown for this step (1-indexed → 0-indexed).
+            cooldown = self._cooldown_steps[state.step - 1]
+
+            state.cooldown_until = now + cooldown
+            state.last_hit = now
+
+        return float(cooldown)
+
+    def get_step(self, model: str) -> int:
+        """Return the current step number for *model* (0 means no active cooldown)."""
+        now = time.monotonic()
+        with self._lock:
+            state = self._get_state(model)
+            self._maybe_reset(state, now)
+            return state.step
+
+    def get_cooldown_status(self) -> Dict[str, Dict[str, float]]:
+        """Return a snapshot of all models with an active cooldown.
+
+        Returns a dict mapping model name → ``{"remaining": <secs>, "step": <int>}``.
+        Models whose cooldown has already expired are omitted.
+        """
+        now = time.monotonic()
+        result: Dict[str, Dict[str, float]] = {}
+        with self._lock:
+            for model, state in self._models.items():
+                remaining = max(0.0, state.cooldown_until - now)
+                if remaining > 0:
+                    result[model] = {
+                        "remaining": round(remaining, 2),
+                        "step": state.step,
+                    }
+        return result
+
+    def reset(self, model: str | None = None) -> None:
+        """Reset cooldown state.  If *model* is ``None``, reset everything."""
+        with self._lock:
+            if model is None:
+                self._models.clear()
+            elif model in self._models:
+                del self._models[model]
+
+
+# Module-level singleton for convenient import.
+rate_limiter = RateLimiter()

--- a/run_agent.py
+++ b/run_agent.py
@@ -77,6 +77,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block, sanitize_context
 from agent.retry_utils import jittered_backoff
+from agent.rate_limiter import rate_limiter as _rate_limiter
 from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
@@ -10463,7 +10464,28 @@ class AIAgent:
                                     _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
-                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                    # When we're rate-limited and the provider didn't supply a
+                    # Retry-After header, use the per-model stepped cooldown
+                    # (30s → 60s → 5min) instead of generic jittered backoff.
+                    # Generic backoff tops out at 60s and burns through retries
+                    # quickly on transient overloads — the stepped cooldown
+                    # gives the provider a real chance to recover.
+                    _stepped_cooldown = None
+                    if is_rate_limited and _retry_after is None:
+                        _rl_model = getattr(self, "model", "unknown") or "unknown"
+                        _stepped_cooldown = _rate_limiter.record_rate_limit(_rl_model)
+                        _rl_step = _rate_limiter.get_step(_rl_model)
+                        _rl_max_step = len(_rate_limiter._cooldown_steps)
+                        logging.warning(
+                            "%sRate limited on %s — stepped cooldown %ss (step %s/%s)",
+                            self.log_prefix, _rl_model, _stepped_cooldown,
+                            _rl_step, _rl_max_step,
+                        )
+                    wait_time = (
+                        _retry_after
+                        if _retry_after
+                        else (_stepped_cooldown or jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0))
+                    )
                     if is_rate_limited:
                         self._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                     else:

--- a/tests/agent/test_rate_limiter.py
+++ b/tests/agent/test_rate_limiter.py
@@ -1,0 +1,320 @@
+"""Tests for agent.rate_limiter – per-model stepped cooldown."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest import mock
+
+import pytest
+
+from agent.rate_limiter import RateLimiter, _COOLDOWN_STEPS, _RESET_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_limiter(steps: tuple[int, ...] = _COOLDOWN_STEPS, reset_window: float = _RESET_WINDOW) -> RateLimiter:
+    """Create a fresh RateLimiter (not the module-level singleton)."""
+    return RateLimiter(cooldown_steps=steps, reset_window=reset_window)
+
+
+# ---------------------------------------------------------------------------
+# Test stepped cooldown escalation
+# ---------------------------------------------------------------------------
+
+class TestSteppedCooldown:
+    """The cooldown should escalate through the ladder: 30s → 60s → 300s."""
+
+    def test_first_hit_returns_30s(self) -> None:
+        rl = _make_limiter()
+        assert rl.record_rate_limit("gpt-4") == 30
+
+    def test_second_hit_returns_60s(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("gpt-4")
+        assert rl.record_rate_limit("gpt-4") == 60
+
+    def test_third_hit_returns_300s(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("gpt-4")
+        rl.record_rate_limit("gpt-4")
+        assert rl.record_rate_limit("gpt-4") == 300
+
+    def test_fourth_hit_stays_at_max(self) -> None:
+        rl = _make_limiter()
+        for _ in range(3):
+            rl.record_rate_limit("gpt-4")
+        # 4th hit should stay clamped at step 3 (300s)
+        assert rl.record_rate_limit("gpt-4") == 300
+
+    def test_step_number_increments(self) -> None:
+        rl = _make_limiter()
+        assert rl.get_step("gpt-4") == 0
+        rl.record_rate_limit("gpt-4")
+        assert rl.get_step("gpt-4") == 1
+        rl.record_rate_limit("gpt-4")
+        assert rl.get_step("gpt-4") == 2
+        rl.record_rate_limit("gpt-4")
+        assert rl.get_step("gpt-4") == 3
+        # Stays clamped
+        rl.record_rate_limit("gpt-4")
+        assert rl.get_step("gpt-4") == 3
+
+    def test_custom_steps(self) -> None:
+        rl = _make_limiter(steps=(5, 10))
+        assert rl.record_rate_limit("m") == 5
+        assert rl.record_rate_limit("m") == 10
+        assert rl.record_rate_limit("m") == 10  # clamped
+
+
+# ---------------------------------------------------------------------------
+# Test cooldown reset after no hits
+# ---------------------------------------------------------------------------
+
+class TestCooldownReset:
+    """Step counter should reset after reset_window seconds of no hits."""
+
+    def test_reset_after_window(self) -> None:
+        rl = _make_limiter(reset_window=10.0)
+
+        # Bump to step 2
+        rl.record_rate_limit("gpt-4")
+        rl.record_rate_limit("gpt-4")
+        assert rl.get_step("gpt-4") == 2
+
+        # Simulate 10+ seconds passing by manipulating last_hit
+        with rl._lock:
+            state = rl._models["gpt-4"]
+            state.last_hit = time.monotonic() - 11.0
+            state.cooldown_until = 0  # clear active cooldown too
+
+        # Next recording should start from step 1 again (reset happened)
+        assert rl.record_rate_limit("gpt-4") == 30
+        assert rl.get_step("gpt-4") == 1
+
+    def test_no_reset_within_window(self) -> None:
+        rl = _make_limiter(reset_window=600.0)
+
+        rl.record_rate_limit("gpt-4")
+        rl.record_rate_limit("gpt-4")
+        assert rl.get_step("gpt-4") == 2
+
+        # No time manipulation → still within window
+        assert rl.record_rate_limit("gpt-4") == 300
+        assert rl.get_step("gpt-4") == 3
+
+    def test_get_step_resets_when_window_elapsed(self) -> None:
+        rl = _make_limiter(reset_window=5.0)
+        rl.record_rate_limit("x")
+        assert rl.get_step("x") == 1
+
+        with rl._lock:
+            rl._models["x"].last_hit = time.monotonic() - 6.0
+        assert rl.get_step("x") == 0
+
+
+# ---------------------------------------------------------------------------
+# Test per-model isolation
+# ---------------------------------------------------------------------------
+
+class TestPerModelIsolation:
+    """Each model should have its own independent cooldown state."""
+
+    def test_different_models_are_independent(self) -> None:
+        rl = _make_limiter()
+
+        rl.record_rate_limit("gpt-4")
+        rl.record_rate_limit("gpt-4")
+
+        # Claude has not been hit yet → should start at step 1
+        assert rl.record_rate_limit("claude-3") == 30
+        assert rl.get_step("claude-3") == 1
+
+        # GPT-4 should still be at step 2 (plus the third hit now)
+        assert rl.record_rate_limit("gpt-4") == 300
+        assert rl.get_step("gpt-4") == 3
+
+    def test_reset_single_model(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("a")
+        rl.record_rate_limit("b")
+
+        rl.reset("a")
+        assert rl.get_step("a") == 0
+        assert rl.get_step("b") == 1
+
+    def test_reset_all(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("a")
+        rl.record_rate_limit("b")
+        rl.reset()
+        assert rl.get_step("a") == 0
+        assert rl.get_step("b") == 0
+
+
+# ---------------------------------------------------------------------------
+# Test check_rate_limit returns correct remaining time
+# ---------------------------------------------------------------------------
+
+class TestCheckRateLimit:
+    """check_rate_limit should return remaining cooldown or 0."""
+
+    def test_no_cooldown_initially(self) -> None:
+        rl = _make_limiter()
+        assert rl.check_rate_limit("gpt-4") == 0.0
+
+    def test_remaining_time_after_hit(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("gpt-4")  # 30s cooldown
+
+        remaining = rl.check_rate_limit("gpt-4")
+        # Should be very close to 30 (within a small tolerance)
+        assert 28.0 < remaining <= 30.0
+
+    def test_remaining_decreases_over_time(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("gpt-4")
+
+        # Simulate 10 seconds passing by adjusting cooldown_until
+        with rl._lock:
+            rl._models["gpt-4"].cooldown_until = time.monotonic() + 20.0
+
+        remaining = rl.check_rate_limit("gpt-4")
+        assert 18.0 < remaining <= 20.0
+
+    def test_returns_zero_after_cooldown_expires(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("gpt-4")
+
+        # Expire the cooldown
+        with rl._lock:
+            rl._models["gpt-4"].cooldown_until = time.monotonic() - 1.0
+
+        assert rl.check_rate_limit("gpt-4") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test get_cooldown_status
+# ---------------------------------------------------------------------------
+
+class TestGetCooldownStatus:
+    """get_cooldown_status should report all models with active cooldowns."""
+
+    def test_empty_when_no_hits(self) -> None:
+        rl = _make_limiter()
+        assert rl.get_cooldown_status() == {}
+
+    def test_shows_active_cooldowns(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("gpt-4")
+        rl.record_rate_limit("claude-3")
+
+        status = rl.get_cooldown_status()
+        assert "gpt-4" in status
+        assert "claude-3" in status
+        assert status["gpt-4"]["step"] == 1
+        assert status["gpt-4"]["remaining"] > 0
+
+    def test_omits_expired_cooldowns(self) -> None:
+        rl = _make_limiter()
+        rl.record_rate_limit("old")
+        rl.record_rate_limit("new")
+
+        # Expire "old"
+        with rl._lock:
+            rl._models["old"].cooldown_until = time.monotonic() - 1.0
+
+        status = rl.get_cooldown_status()
+        assert "old" not in status
+        assert "new" in status
+
+
+# ---------------------------------------------------------------------------
+# Test thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    """Concurrent access should not corrupt state."""
+
+    def test_concurrent_record(self) -> None:
+        rl = _make_limiter()
+        errors: list[Exception] = []
+
+        def _hit(model: str, n: int) -> None:
+            try:
+                for _ in range(n):
+                    rl.record_rate_limit(model)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = []
+        for i in range(10):
+            t = threading.Thread(target=_hit, args=(f"model-{i % 3}", 50))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"Thread errors: {errors}"
+
+        # Each of the 3 models should have a valid step (clamped to max)
+        for i in range(3):
+            step = rl.get_step(f"model-{i}")
+            assert 1 <= step <= len(rl._cooldown_steps)
+
+    def test_concurrent_check_and_record(self) -> None:
+        rl = _make_limiter()
+        errors: list[Exception] = []
+
+        def _checker(model: str) -> None:
+            try:
+                for _ in range(100):
+                    remaining = rl.check_rate_limit(model)
+                    assert remaining >= 0
+            except Exception as exc:
+                errors.append(exc)
+
+        def _recorder(model: str) -> None:
+            try:
+                for _ in range(50):
+                    cd = rl.record_rate_limit(model)
+                    assert cd > 0
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=_checker, args=("m",)),
+            threading.Thread(target=_checker, args=("m",)),
+            threading.Thread(target=_recorder, args=("m",)),
+            threading.Thread(target=_recorder, args=("m",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert not errors, f"Thread errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Test module-level singleton
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+    """The module-level ``rate_limiter`` should be usable directly."""
+
+    def test_singleton_import(self) -> None:
+        from agent.rate_limiter import rate_limiter
+        assert isinstance(rate_limiter, RateLimiter)
+
+    def test_singleton_records(self) -> None:
+        from agent.rate_limiter import rate_limiter
+        # Reset to avoid pollution from other tests
+        rate_limiter.reset()
+        cd = rate_limiter.record_rate_limit("test-singleton-model")
+        assert cd == 30
+        rate_limiter.reset("test-singleton-model")

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -13,6 +13,8 @@ from tools.checkpoint_manager import (
     _run_git,
     _git_env,
     _dir_file_count,
+    _clear_stale_lock,
+    _STALE_LOCK_SECONDS,
     format_checkpoint_list,
     DEFAULT_EXCLUDES,
     CHECKPOINT_BASE,
@@ -597,6 +599,7 @@ class TestSecurity:
 # every time the agent took a background snapshot.
 
 import os as _os
+import time as _time
 
 
 class TestGpgAndGlobalConfigIsolation:
@@ -696,3 +699,55 @@ class TestGpgAndGlobalConfigIsolation:
         mgr = CheckpointManager(enabled=True)
         assert mgr.ensure_checkpoint(str(work_dir), reason="prefix-shadow") is True
         assert len(mgr.list_checkpoints(str(work_dir))) == 1
+
+
+class TestStaleLockCleanup:
+    """Stale index.lock cleanup prevents wedged checkpoints after a crashed
+    git process leaves a zombie lock file (observed in production: 56+ errors
+    over 6 days on one shadow repo)."""
+
+    def _backdate(self, path, seconds_ago):
+        ts = _time.time() - seconds_ago
+        _os.utime(path, (ts, ts))
+
+    def test_removes_old_stale_lock(self, tmp_path):
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        lock = shadow / "index.lock"
+        lock.touch()
+        self._backdate(lock, _STALE_LOCK_SECONDS + 30)
+        _clear_stale_lock(shadow)
+        assert not lock.exists()
+
+    def test_preserves_fresh_lock(self, tmp_path):
+        """A lock younger than the threshold may belong to a live git op —
+        leave it alone."""
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        lock = shadow / "index.lock"
+        lock.touch()
+        _clear_stale_lock(shadow)
+        assert lock.exists()
+
+    def test_noop_when_no_lock(self, tmp_path):
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        _clear_stale_lock(shadow)  # must not raise
+
+    def test_run_git_unwedges_after_stale_lock(
+        self, work_dir, checkpoint_base, monkeypatch
+    ):
+        """End-to-end: a stale lock predating a real git call is cleaned up
+        automatically, and the call succeeds."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        shadow = _shadow_repo_path(str(work_dir))
+        _init_shadow_repo(shadow, str(work_dir))
+
+        stale = shadow / "index.lock"
+        stale.touch()
+        self._backdate(stale, _STALE_LOCK_SECONDS + 30)
+
+        ok, _, _ = _run_git(["add", "-A"], shadow, str(work_dir))
+        assert ok, "git add -A should succeed after stale-lock cleanup"
+        assert not stale.exists()
+

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Optional, Set
@@ -159,6 +160,38 @@ def _git_env(shadow_repo: Path, working_dir: str) -> dict:
     return env
 
 
+_STALE_LOCK_SECONDS = 60.0
+
+
+def _clear_stale_lock(shadow_repo: Path) -> None:
+    """Remove a stale ``index.lock`` left behind by a crashed/killed git process.
+
+    Checkpoint ops against a shadow repo are strictly serial (one gateway
+    agent per session), so any ``index.lock`` older than ``_STALE_LOCK_SECONDS``
+    at entry to a new git call is unambiguously orphaned.  Without this,
+    a single crashed ``git add`` wedges checkpointing for that repo until
+    manual cleanup (seen in logs: 56+ errors over 6 days on one shadow).
+    """
+    lock_path = shadow_repo / "index.lock"
+    try:
+        age = time.time() - lock_path.stat().st_mtime
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+    if age < _STALE_LOCK_SECONDS:
+        return
+    try:
+        lock_path.unlink()
+        logger.warning(
+            "Removed stale index.lock (age=%.0fs) at %s", age, lock_path,
+        )
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Failed to remove stale index.lock at %s: %s", lock_path, exc)
+
+
 def _run_git(
     args: List[str],
     shadow_repo: Path,
@@ -181,6 +214,8 @@ def _run_git(
         msg = f"working directory is not a directory: {normalized_working_dir}"
         logger.error("Git command skipped: %s (%s)", " ".join(["git"] + list(args)), msg)
         return False, "", msg
+
+    _clear_stale_lock(shadow_repo)
 
     env = _git_env(shadow_repo, str(normalized_working_dir))
     cmd = ["git"] + list(args)


### PR DESCRIPTION
## Summary

Per-model stepped rate-limit cooldown (ladder: 30s → 60s → 5min, resets after 10 min idle, tracked per model). Replaces the generic jittered backoff on 429s when provider fallback and credential rotation can't save us.

Rate limiter module + tests are cherry-picked verbatim from @teknium1's **#3910**. This PR rebases that work onto current `main` and extends the wiring to cover the auxiliary client path.

## Why a new PR instead of updating #3910

I considered three options:

1. **Force-push onto `feat/rate-limiter`** to auto-update #3910. Rejected — that branch is authored by another contributor, and overwriting someone else's branch without coordination is the wrong default.
2. **Open a stacked/replacement PR**, preserving #3910 for history/credit. Chose this.
3. **Comment on #3910** asking the author to rebase. Rejected for now — the rebase itself is non-trivial (1818 commits, significant drift in `run_agent.py` / `auxiliary_client.py`) and easier to show than describe.

If maintainers prefer, #3910 can be closed in favor of this one; attribution to the original author is preserved via commit message. I'll leave the decision there to maintainers rather than commenting on #3910 until this has been reviewed.

## What changed vs. #3910

#3910 was cut 2026-03-30. Since then `run_agent.py` and `auxiliary_client.py` have evolved substantially (Opus 4.7 migration, vision resolver refactor, TCP keepalives, payment fallback chain, credential pool rotation). The original wiring no longer applies cleanly.

| Commit | Change |
|---|---|
| 4b2aee11 | `agent/rate_limiter.py` + 23 tests — **unchanged** from #3910 |
| 43398fdb | **New wiring against current main:** (a) `auxiliary_client.{call_llm,async_call_llm}` — check cooldown before `create()`, record on 429. Covers vision/session-search/compression, which #3910 didn't touch. (b) `run_agent.py` main loop — stepped cooldown replaces `jittered_backoff` when rate-limited without a `Retry-After` header. (c) `_is_payment_error` extended to classify z.ai `code 1311` ("subscription plan does not yet include") as payment, so it routes to the payment fallback chain instead of an infinitely-retripping cooldown. (d) `_log_400_diag` — logs kwargs keys + message block shape (no content) on HTTP 400s so the next `1210 Invalid API parameter` regression is diagnosable. |
| acc5906a | **Stacked fix, unrelated to rate-limiting:** `tools/checkpoint_manager._clear_stale_lock` — before any git op in a shadow repo, remove `index.lock` files older than 60s. A single crashed `git add` had been wedging checkpointing on one prod shadow for 6 days (56+ identical errors). Checkpoint ops per shadow are strictly serial, so any lock older than 60s is unambiguously orphaned. Happy to split into a separate PR if preferred. |

## Rationale for extending `_is_payment_error`

z.ai returns HTTP 429 for two very different conditions:
- `code 1305` / "temporarily overloaded" — **transient**, cooldown helps
- `code 1311` / "subscription plan does not yet include \<model\>" — **permanent**, cooldown is a trap

Without classification, the stepped cooldown would just keep firing against a model the plan doesn't include. Routing `1311` to the payment fallback chain lets a different vision backend pick up instead.

## Wiring order (existing logic preserved)

1. Provider fallback (if configured) — unchanged
2. Credential pool rotation — unchanged
3. **If rate-limited and `Retry-After` header present** — honor it (cap 120s) — unchanged
4. **If rate-limited and no header** — stepped cooldown (new; previously fell through to `jittered_backoff` which caps at 60s, too tight for provider overloads)

## Cooldown behavior (from #3910)

| Hit | Cooldown |
|---|---|
| 1st | 30s |
| 2nd | 60s |
| 3rd+ | 5 min |

Per-model state. Resets after 10 min of no hits.

## Test plan

- [x] `pytest tests/agent/test_rate_limiter.py` — **23/23** pass (unchanged from #3910)
- [x] `pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_config_bridge.py tests/agent/test_rate_limit_tracker.py tests/agent/test_nous_rate_guard.py` — **147/148** pass (1 pre-existing async-plugin failure on clean `main`, unchanged by this PR)
- [x] `pytest tests/run_agent/test_fallback_model.py tests/run_agent/test_long_context_tier_429.py tests/run_agent/test_provider_fallback.py tests/test_retry_utils.py` — **64/64** pass
- [x] `pytest tests/tools/test_checkpoint_manager.py tests/test_batch_runner_checkpoint.py` — **69/69** pass incl. 4 new stale-lock tests
- [x] Manual e2e: vision aux call hitting 429 records cooldown on first hit; subsequent calls within the window short-circuit with `RuntimeError: rate_limit_cooldown: <model> cooling down Ns remaining`
- [x] Classifier verified against real log error strings: `code 1311 → _is_payment_error=True, _is_rate_limit_error=False`; `code 1305 → _is_payment_error=False, _is_rate_limit_error=True`
- [x] Zero regressions confirmed via `git stash` + rerun on clean `main`

## For reviewers

- Original rate-limiter logic is byte-identical to #3910, so prior review effort on that module carries over.
- New surface is `auxiliary_client.py` (+108 lines) and `run_agent.py` (+24 lines). The aux-client change is small and defensively scoped — cooldown check gates the call, record happens on 429 only, errors other than rate-limit are untouched.
- The checkpoint fix is orthogonal; easy to split if you'd rather review separately.

Closes nothing automatically, since I can't close #3910 myself. Maintainers welcome to close #3910 at their discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)