### PR TITLE
fix(gemini): hide bad Google models and restore bearer auth

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -782,15 +782,6 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
-            elif "generativelanguage.googleapis.com" in base_url.lower():
-                # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-                # Passing api_key= causes the SDK to inject Authorization: Bearer,
-                # which Google rejects with HTTP 400 "Multiple authentication
-                # credentials received". Use a placeholder for api_key and pass
-                # the real key via x-goog-api-key header instead.
-                # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-                extra["default_headers"] = {"x-goog-api-key": api_key}
-                api_key = "not-used"
             return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -812,15 +803,6 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
-        elif "generativelanguage.googleapis.com" in base_url.lower():
-            # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-            # Passing api_key= causes the SDK to inject Authorization: Bearer,
-            # which Google rejects with HTTP 400 "Multiple authentication
-            # credentials received". Use a placeholder for api_key and pass
-            # the real key via x-goog-api-key header instead.
-            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-            extra["default_headers"] = {"x-goog-api-key": api_key}
-            api_key = "not-used"
         return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
     return None, None
@@ -1666,16 +1648,6 @@ def resolve_provider_client(
             from hermes_cli.models import copilot_default_headers
 
             headers.update(copilot_default_headers())
-        elif "generativelanguage.googleapis.com" in base_url.lower():
-            # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-            # Passing api_key= causes the OpenAI SDK to inject Authorization: Bearer,
-            # which Google rejects with HTTP 400 "Multiple authentication credentials
-            # received". Use a placeholder for api_key and pass the real key via
-            # x-goog-api-key header instead.
-            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-            headers["x-goog-api-key"] = api_key
-            api_key = "not-used"
-
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -420,7 +420,10 @@ def list_provider_models(provider: str) -> List[str]:
     models = _get_provider_models(provider)
     if models is None:
         return []
-    return list(models.keys())
+    return [
+        mid for mid in models.keys()
+        if not _should_hide_from_provider_catalog(provider, mid)
+    ]
 
 
 # Patterns that indicate non-agentic or noise models (TTS, embedding,
@@ -431,6 +434,29 @@ _NOISE_PATTERNS: re.Pattern = re.compile(
     r"-image\b|-image-preview\b|-customtools\b",
     re.IGNORECASE,
 )
+
+# Google-hosted Gemma models currently have very low TPM quotas for agent-style
+# traffic (for example 15K/16K TPM tiers in AI Studio) and are not practical as
+# normal Hermes picks even though they advertise large context windows. Keep the
+# capability metadata available for direct/manual use, but hide them from the
+# Gemini model catalogs we surface in setup and model selection.
+_GOOGLE_GEMMA_HIDDEN_MODELS = frozenset({
+    "gemma-4-31b-it",
+    "gemma-4-26b-a4b-it",
+    "gemma-3-1b",
+    "gemma-3-2b",
+    "gemma-3-4b",
+    "gemma-3-12b",
+    "gemma-3-27b",
+})
+
+
+def _should_hide_from_provider_catalog(provider: str, model_id: str) -> bool:
+    provider_lower = (provider or "").strip().lower()
+    model_lower = (model_id or "").strip().lower()
+    if provider_lower in {"gemini", "google"} and model_lower in _GOOGLE_GEMMA_HIDDEN_MODELS:
+        return True
+    return False
 
 
 def list_agentic_models(provider: str) -> List[str]:
@@ -447,6 +473,8 @@ def list_agentic_models(provider: str) -> List[str]:
     result = []
     for mid, entry in models.items():
         if not isinstance(entry, dict):
+            continue
+        if _should_hide_from_provider_catalog(provider, mid):
             continue
         if not entry.get("tool_call", False):
             continue
@@ -582,5 +610,3 @@ def get_model_info(
             return _parse_model_info(mid, mdata, mdev_id)
 
     return None
-
-

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -435,26 +435,40 @@ _NOISE_PATTERNS: re.Pattern = re.compile(
     re.IGNORECASE,
 )
 
-# Google-hosted Gemma models currently have very low TPM quotas for agent-style
-# traffic (for example 15K/16K TPM tiers in AI Studio) and are not practical as
-# normal Hermes picks even though they advertise large context windows. Keep the
-# capability metadata available for direct/manual use, but hide them from the
-# Gemini model catalogs we surface in setup and model selection.
-_GOOGLE_GEMMA_HIDDEN_MODELS = frozenset({
+# Google's live Gemini catalogs currently include a mix of stale slugs and
+# Gemma models whose TPM quotas are too small for normal Hermes agent traffic.
+# Keep capability metadata available for direct/manual use, but hide these from
+# the Gemini model catalogs we surface in setup and model selection.
+_GOOGLE_HIDDEN_MODELS = frozenset({
+    # Low-TPM Gemma models that trip Google input-token quota walls under
+    # agent-style traffic despite advertising large context windows.
     "gemma-4-31b-it",
+    "gemma-4-26b-it",
     "gemma-4-26b-a4b-it",
     "gemma-3-1b",
+    "gemma-3-1b-it",
     "gemma-3-2b",
+    "gemma-3-2b-it",
     "gemma-3-4b",
+    "gemma-3-4b-it",
     "gemma-3-12b",
+    "gemma-3-12b-it",
     "gemma-3-27b",
+    "gemma-3-27b-it",
+    # Stale/retired Google slugs that still surface through models.dev-backed
+    # Gemini selection but 404 on the current Google endpoints.
+    "gemini-1.5-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash-8b",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
 })
 
 
 def _should_hide_from_provider_catalog(provider: str, model_id: str) -> bool:
     provider_lower = (provider or "").strip().lower()
     model_lower = (model_id or "").strip().lower()
-    if provider_lower in {"gemini", "google"} and model_lower in _GOOGLE_GEMMA_HIDDEN_MODELS:
+    if provider_lower in {"gemini", "google"} and model_lower in _GOOGLE_HIDDEN_MODELS:
         return True
     return False
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,8 +133,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-2.5-pro",
         "gemini-2.5-flash",
         "gemini-2.5-flash-lite",
-        # Gemma open models (also served via AI Studio)
-        "gemma-4-31b-it",
     ],
     "google-gemini-cli": [
         "gemini-2.5-pro",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -91,7 +91,6 @@ _DEFAULT_PROVIDER_MODELS = {
     "gemini": [
         "gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
         "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
-        "gemma-4-31b-it",
     ],
     "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],

--- a/run_agent.py
+++ b/run_agent.py
@@ -1054,16 +1054,6 @@ class AIAgent:
                     }
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
-                elif "generativelanguage.googleapis.com" in effective_base.lower():
-                    # Google's OpenAI-compatible endpoint only accepts x-goog-api-key.
-                    # The OpenAI SDK auto-injects Authorization: Bearer when api_key= is
-                    # set to a real value, causing HTTP 400 "Multiple authentication
-                    # credentials received".  Pass a placeholder so the SDK does not
-                    # emit Bearer, and carry the real key via x-goog-api-key instead.
-                    # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-                    real_key = client_kwargs["api_key"]
-                    client_kwargs["api_key"] = "not-used"
-                    client_kwargs["default_headers"] = {"x-goog-api-key": real_key}
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -5245,17 +5235,6 @@ class AIAgent:
             self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.30.0"}
         elif "portal.qwen.ai" in normalized:
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
-        elif "generativelanguage.googleapis.com" in normalized:
-            # Google's endpoint rejects Bearer tokens; use x-goog-api-key instead.
-            # Swap the real key out of api_key and into the header so the OpenAI
-            # SDK does not emit Authorization: Bearer.
-            # Fixes: https://github.com/NousResearch/hermes-agent/issues/7893
-            real_key = self._client_kwargs.get("api_key", "")
-            if real_key and real_key != "not-used":
-                self._client_kwargs["api_key"] = "not-used"
-            self._client_kwargs["default_headers"] = {
-                "x-goog-api-key": real_key or self._client_kwargs.get("api_key", ""),
-            }
         else:
             self._client_kwargs.pop("default_headers", None)
 

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -130,7 +130,7 @@ class TestGeminiModelCatalog:
         models = _PROVIDER_MODELS["gemini"]
         assert "gemini-2.5-pro" in models
         assert "gemini-2.5-flash" in models
-        assert "gemma-4-31b-it" in models
+        assert "gemma-4-31b-it" not in models
 
     def test_provider_models_has_3x(self):
         models = _PROVIDER_MODELS["gemini"]
@@ -313,9 +313,28 @@ class TestGeminiModelsDev:
             result = list_agentic_models("gemini")
         assert "gemini-3-flash-preview" in result
         assert "gemini-2.5-pro" in result
-        assert "gemma-4-31b-it" in result
+        assert "gemma-4-31b-it" not in result
         # Filtered out:
         assert "gemini-embedding-001" not in result      # no tool_call
         assert "gemini-2.5-flash-preview-tts" not in result  # no tool_call
         assert "gemini-live-2.5-flash" not in result     # noise: live-
         assert "gemini-2.5-flash-preview-04-17" not in result  # noise: dated preview
+
+    def test_list_provider_models_hides_low_tpm_google_gemmas(self):
+        mock_data = {
+            "google": {
+                "models": {
+                    "gemini-2.5-pro": {},
+                    "gemma-4-31b-it": {},
+                    "gemma-3-1b": {},
+                }
+            }
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=mock_data):
+            from agent.models_dev import list_provider_models
+
+            result = list_provider_models("gemini")
+
+        assert "gemini-2.5-pro" in result
+        assert "gemma-4-31b-it" not in result
+        assert "gemma-3-1b" not in result

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -326,7 +326,9 @@ class TestGeminiModelsDev:
                 "models": {
                     "gemini-2.5-pro": {},
                     "gemma-4-31b-it": {},
-                    "gemma-3-1b": {},
+                    "gemma-3-27b-it": {},
+                    "gemini-1.5-pro": {},
+                    "gemini-2.0-flash": {},
                 }
             }
         }
@@ -337,4 +339,6 @@ class TestGeminiModelsDev:
 
         assert "gemini-2.5-pro" in result
         assert "gemma-4-31b-it" not in result
-        assert "gemma-3-1b" not in result
+        assert "gemma-3-27b-it" not in result
+        assert "gemini-1.5-pro" not in result
+        assert "gemini-2.0-flash" not in result

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -207,14 +207,8 @@ class TestGeminiAgentInit:
             assert agent.api_mode == "chat_completions"
             assert agent.provider == "gemini"
 
-    def test_gemini_uses_x_goog_api_key_not_bearer(self, monkeypatch):
-        """Regression test for issue #7893.
-
-        When provider=gemini, the OpenAI client must be constructed with
-        api_key='not-used' and default_headers={'x-goog-api-key': real_key}.
-        This prevents the SDK from injecting Authorization: Bearer, which
-        Google's endpoint rejects with HTTP 400.
-        """
+    def test_gemini_uses_bearer_auth(self, monkeypatch):
+        """Gemini OpenAI-compatible endpoint should receive the real API key."""
         monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy_REAL_KEY")
         real_key = "AIzaSy_REAL_KEY"
         with patch("run_agent.OpenAI") as mock_openai:
@@ -227,37 +221,22 @@ class TestGeminiAgentInit:
                 base_url="https://generativelanguage.googleapis.com/v1beta/openai",
             )
         call_kwargs = mock_openai.call_args[1]
-        # The SDK must NOT receive the real key as api_key (which would emit Bearer)
-        assert call_kwargs.get("api_key") == "not-used", (
-            "api_key must be 'not-used' to suppress Authorization: Bearer for Gemini"
-        )
-        # The real key must be in x-goog-api-key header
+        assert call_kwargs.get("api_key") == real_key
         headers = call_kwargs.get("default_headers", {})
-        assert headers.get("x-goog-api-key") == real_key, (
-            "x-goog-api-key header must carry the real Gemini API key"
-        )
+        assert "x-goog-api-key" not in headers
 
     def test_gemini_resolve_provider_client_auth(self, monkeypatch):
-        """Regression test for issue #7893 — resolve_provider_client path.
-
-        When resolve_provider_client('gemini') is called, the returned OpenAI
-        client must use x-goog-api-key header, not Authorization: Bearer.
-        """
+        """resolve_provider_client('gemini') should pass the real API key through."""
         monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy_TEST_KEY")
         real_key = "AIzaSy_TEST_KEY"
         with patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_openai.return_value = MagicMock()
-            mock_openai.return_value.api_key = "not-used"
             from agent.auxiliary_client import resolve_provider_client
             resolve_provider_client("gemini")
         call_kwargs = mock_openai.call_args[1]
-        assert call_kwargs.get("api_key") == "not-used", (
-            "api_key must be 'not-used' to prevent Bearer injection for Gemini"
-        )
+        assert call_kwargs.get("api_key") == real_key
         headers = call_kwargs.get("default_headers", {})
-        assert headers.get("x-goog-api-key") == real_key, (
-            "x-goog-api-key header must carry the real Gemini API key"
-        )
+        assert "x-goog-api-key" not in headers
 
 
 # ── models.dev Integration ──


### PR DESCRIPTION
## What does this PR do?

Hides Google-hosted Gemini/Gemma model slugs that are currently a bad fit for Hermes agent use, and restores the working auth shape for the standard `gemini` provider on Google's OpenAI-compatible endpoint.

This branch fixes two real issues that were getting mixed together during testing:

- low-TPM Google Gemma models and stale/retired Google slugs were still surfacing in Gemini setup and model selection
- the standard `gemini` provider path was still using the old `x-goog-api-key` rewrite instead of passing the real API key through as normal Bearer auth

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed `gemma-4-31b-it` from the static Gemini provider lists in `hermes_cli/models.py` and `hermes_cli/setup.py`.
- Added provider-catalog filtering in `agent/models_dev.py` so these models do not reappear through models.dev-backed Gemini selection:
  - low-TPM Gemma family slugs such as `gemma-4-31b-it`, `gemma-4-26b-it`, `gemma-4-26b-a4b-it`, and the surfaced Gemma 3 variants
  - stale/retired Gemini slugs such as `gemini-1.5-flash`, `gemini-1.5-pro`, `gemini-1.5-flash-8b`, `gemini-2.0-flash`, and `gemini-2.0-flash-lite`
- Removed the stale Gemini `x-goog-api-key` / `api_key="not-used"` rewrite from `run_agent.py` and `agent/auxiliary_client.py` so the standard `gemini` provider once again sends the real API key through the OpenAI-compatible route.
- Updated `tests/hermes_cli/test_gemini_provider.py` to cover both the filtered exposure behavior and the corrected Gemini auth behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_gemini_provider.py tests/agent/test_models_dev.py -q`
2. Confirm the targeted suites pass.
3. Confirm Gemini model selection no longer surfaces the stale or low-TPM Google models above.
4. Smoke test a remaining Gemini model, for example `hermes chat --provider gemini --model gemini-2.5-flash-lite -q "hello"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test run:

`69 passed, 7 warnings in 9.18s`

Live smoke test:

`hermes chat --provider gemini --model gemini-2.5-flash-lite -q "hello"`

confirmed a normal Gemini response on this branch.

Full suite with the CI-shaped wrapper (`scripts/run_tests.sh tests/ -q`, 4 workers):

`18 failed, 12934 passed, 36 skipped, 184 warnings in 349.98s (0:05:49)`
