### PR TITLE
fix(agent): repair malformed tool_call arguments before API send

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9179,7 +9179,81 @@ class AIAgent:
                                 ),
                             }}
                         except Exception:
-                            pass
+                            # GLM-5.1 and similar models can generate
+                            # malformed tool_call arguments (truncated JSON,
+                            # trailing commas, Python None, etc.).  The API
+                            # proxy rejects these with HTTP 400 "invalid tool
+                            # call arguments".  Attempt common repairs; if
+                            # all fail, replace with "{}" so the request
+                            # succeeds (better than crashing the session).
+                            raw_args = tc["function"]["arguments"]
+                            repaired = False
+                            raw_stripped = raw_args.strip() if isinstance(raw_args, str) else ""
+
+                            # Fast-path: empty / whitespace-only → empty object
+                            if not raw_stripped:
+                                tc["function"]["arguments"] = "{}"
+                                repaired = True
+                                logger.warning(
+                                    "Sanitized empty tool_call arguments for %s",
+                                    tc["function"].get("name", "?"),
+                                )
+                            # Python-literal None → JSON null → normalise to {}
+                            elif raw_stripped == "None":
+                                tc["function"]["arguments"] = "{}"
+                                repaired = True
+                                logger.warning(
+                                    "Sanitized Python-None tool_call arguments for %s",
+                                    tc["function"].get("name", "?"),
+                                )
+
+                            if not repaired:
+                                # Attempt common JSON repairs
+                                import re as _re
+                                fixed = raw_stripped
+                                # 1. Strip trailing commas before } or ]
+                                fixed = _re.sub(r',\s*([}\]])', r'\1', fixed)
+                                # 2. Close unclosed structures
+                                open_curly = fixed.count('{') - fixed.count('}')
+                                open_bracket = fixed.count('[') - fixed.count(']')
+                                if open_curly > 0:
+                                    fixed += '}' * open_curly
+                                if open_bracket > 0:
+                                    fixed += ']' * open_bracket
+                                # 3. Remove extra closing braces/brackets
+                                while True:
+                                    try:
+                                        json.loads(fixed)
+                                        break
+                                    except json.JSONDecodeError:
+                                        if fixed.endswith('}') and fixed.count('}') > fixed.count('{'):
+                                            fixed = fixed[:-1]
+                                        elif fixed.endswith(']') and fixed.count(']') > fixed.count('['):
+                                            fixed = fixed[:-1]
+                                        else:
+                                            break
+                                try:
+                                    json.loads(fixed)
+                                    tc["function"]["arguments"] = fixed
+                                    repaired = True
+                                    logger.warning(
+                                        "Repaired malformed tool_call arguments for %s: %s → %s",
+                                        tc["function"].get("name", "?"),
+                                        raw_stripped[:80], fixed[:80],
+                                    )
+                                except json.JSONDecodeError:
+                                    pass
+
+                            if not repaired:
+                                # Last resort: replace with empty object so the
+                                # API request doesn't crash the entire session.
+                                tc["function"]["arguments"] = "{}"
+                                logger.warning(
+                                    "Unrepairable tool_call arguments for %s — "
+                                    "replaced with empty object (was: %s)",
+                                    tc["function"].get("name", "?"),
+                                    raw_stripped[:80],
+                                )
                     new_tcs.append(tc)
                 am["tool_calls"] = new_tcs
 


### PR DESCRIPTION
## What does this PR do?

Adds a JSON repair pipeline at the pre-send normalization point in `run_agent.py` (~L9179) to fix malformed `tool_call.arguments` before they reach the API. Currently, when `json.loads()` fails inside the `except Exception: pass` block, the invalid JSON is silently passed through to the API — which rejects it with HTTP 400 "invalid tool call arguments", crashing the entire session.

## Related Issue

- #11001 — Death spiral: 400 invalid tool call arguments causes context compression loop
- #4662 — Malformed persisted tool calls can poison a session
- #6841 — Tool-calling pipeline can corrupt JSON arguments

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` ~L9179: Replaced `except Exception: pass` with a repair pipeline:
  1. Empty/whitespace-only arguments → `"{}"`
  2. Python `None` literal → `"{}"`
  3. Strip trailing commas before `}` or `]`
  4. Auto-close unclosed `{` and `[`
  5. Remove excess closing delimiters
  6. Last resort: replace with `"{}"` (saves session, loses args — logged at WARNING)
- All repairs logged at `WARNING` level for observability

## How to Test

1. Use a model that produces malformed tool_call arguments (e.g., GLM-5.1 via Ollama proxy)
2. Without this fix: agent crashes with HTTP 400, session becomes permanently stuck
3. With this fix: agent logs the repair with WARNING, continues execution

Manual reproduction — in a session where the model generates truncated arguments:
- Previously: `except Exception: pass` → 400 error → session death spiral
- Now: repaired to valid JSON → session continues

Tested with live `hermes chat` session — zero 400 errors after patch. Confirmed Ollama proxy rejects broken args (400) and accepts repaired args (200).

## How this differs from existing PRs

| PR | Scope | Location | Approach |
|---|---|---|---|
| #11617 | Compressor truncation | context_compressor.py | Changes Pass 3 truncation format |
| #11788 | Compressor truncation | context_compressor.py | JSON-safe truncation + tests |
| #6691 | Kimi models only | New kimi_json_sanitizer.py | Model-specific regex sanitizer |
| #5071 | Persistence filter | Message persistence | Filter malformed calls on save |
| **This PR** | **All models** | **run_agent.py pre-send** | **Model-agnostic repair at last line of defense** |

This PR is complementary, not competing — it catches what slips through upstream. It operates at the **pre-send normalization point**, which is the last chance to fix broken args before the API call goes out. Even if compressor fixes (#11617, #11788) land, models can still produce malformed args at inference time (truncation, Python None, etc.) — this catches those cases.

## Checklist

- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — this is distinct from #11617, #11788, #6691, #5071
- [x] My PR contains only changes related to this fix
- [ ] I have added tests for my changes — help wanted: guidance on test file location/conventions appreciated