### PR TITLE
fix(url_safety): allow NAT64 well-known prefix (RFC 6052)

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -198,7 +198,35 @@ class TestIsBlockedIp:
     @pytest.mark.parametrize("ip_str", [
         "8.8.8.8", "93.184.216.34", "1.1.1.1", "100.0.0.1",
         "2606:4700::1", "2001:4860:4860::8888",
+        # NAT64 Well-Known Prefix (RFC 6052, 64:ff9b::/96) — these are
+        # synthesized IPv6 representations of PUBLIC IPv4 services
+        # reachable via an upstream NAT64 translator. Python's
+        # ipaddress.is_reserved returns True for the prefix, but the
+        # embedded IPv4 (low 32 bits) is public. Must be allowed.
+        "64:ff9b::2.19.248.139",   # blogs.nvidia.com
+        "64:ff9b::8.8.8.8",        # Google DNS
+        "64:ff9b::1.1.1.1",        # Cloudflare DNS
+        "64:ff9b::0.0.0.0",        # prefix boundary
+        "64:ff9b::ffff:ffff",      # upper end of embedded IPv4
     ])
     def test_allowed_ips(self, ip_str):
         ip = ipaddress.ip_address(ip_str)
         assert _is_blocked_ip(ip) is False, f"{ip_str} should be allowed"
+
+    def test_nat64_url_allowed_end_to_end(self):
+        """`is_safe_url` must accept a hostname that resolves to a NAT64
+        synthesized IPv6 address alongside a public IPv4 address (common
+        dual-stack-lite DNS result from consumer ISPs)."""
+        with patch("socket.getaddrinfo", return_value=[
+            (2,  1, 6, "", ("2.19.248.139", 0)),
+            (10, 1, 6, "", ("64:ff9b::213:f88b", 0, 0, 0)),
+        ]):
+            assert is_safe_url("https://blogs.nvidia.com/") is True
+
+    def test_nat64_only_resolution_allowed(self):
+        """IPv6-only host on a DS-Lite network gets ONLY NAT64 addresses
+        back. Must still pass — the upstream IPv4 target is public."""
+        with patch("socket.getaddrinfo", return_value=[
+            (10, 1, 6, "", ("64:ff9b::8.8.8.8", 0, 0, 0)),
+        ]):
+            assert is_safe_url("https://dns.google/") is True

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -42,9 +42,19 @@ _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
+# 64:ff9b::/96 (NAT64 Well-Known Prefix, RFC 6052) is flagged by
+# ipaddress.is_reserved but represents public IPv4 services reachable via
+# an upstream NAT64 translator. Blocking it is a false-positive SSRF —
+# the embedded IPv4 address is public (e.g. many consumer ISPs on dual-stack
+# lite return NAT64 synthesized IPv6 addresses for any public IPv4 AAAA
+# lookup). Explicitly allow.
+_NAT64_NETWORK = ipaddress.ip_network("64:ff9b::/96")
+
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True if the IP should be blocked for SSRF protection."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_NETWORK:
+        return False
     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
         return True
     if ip.is_multicast or ip.is_unspecified:


### PR DESCRIPTION
## Problem

`is_safe_url` fails closed on legitimate public URLs when the client machine is on a NAT64-aware network (dual-stack lite, 464XLAT cellular, or any IPv6-only with CLAT).

Python's `IPv6Address.is_reserved` returns True for the entire NAT64 Well-Known Prefix `64:ff9b::/96` (RFC 6052). The existing `_is_blocked_ip` check treats any reserved IPv6 as an SSRF target, so `web_extract` rejects those URLs with:

```
Blocked: URL targets a private or internal network address
```

But NAT64 addresses are the IPv6 representation of **public** IPv4 services reachable via an upstream NAT64 translator — the embedded IPv4 address in the low 32 bits is public. Blocking them is a false positive.

### How I hit it

Consumer dual-stack-lite ISP returns both a public IPv4 and a NAT64 synthesized IPv6 for any AAAA lookup. e.g. `blogs.nvidia.com`:

```python
>>> socket.getaddrinfo("blogs.nvidia.com", None, socket.AF_UNSPEC, socket.SOCK_STREAM)
[(2,  ..., ('2.19.248.139', 0)),
 (10, ..., ('64:ff9b::213:f88b', 0, 0, 0))]
```

`is_safe_url` iterates addresses and bails on the first blocked one, so the NAT64 entry short-circuits the public IPv4.

Affects `sec.gov`, `investor.nvidia.com`, `blogs.nvidia.com`, Google/Cloudflare DNS, and countless others depending on network topology.

## Fix

Explicit allow for `64:ff9b::/96` at the top of `_is_blocked_ip`, before the generic `is_private / is_reserved` check. Mirrors the existing `_CGNAT_NETWORK` explicit handling.

```python
_NAT64_NETWORK = ipaddress.ip_network("64:ff9b::/96")

def _is_blocked_ip(ip):
    if isinstance(ip, ipaddress.IPv6Address) and ip in _NAT64_NETWORK:
        return False
    ...
```

Security posture is preserved: the NAT64 translator itself is a public gateway, so an attacker using a NAT64 IPv6 to reach an internal IPv4 would need to get Hermes onto the NAT64 operator's network AND configure their private IPv4 into the NAT64 mapping — infeasible in the threat model the SSRF check is defending against. (Truly internal IPv4s behind CGNAT/VPN are separately blocked via `_CGNAT_NETWORK` and the standard private ranges.)

## Tests

All 61 tests in `tests/tools/test_url_safety.py` pass, including new coverage:

- `TestIsBlockedIp.test_allowed_ips` — 5 new parametrized IPs across the `64:ff9b::/96` range (nvidia, Google DNS, Cloudflare, boundary cases)
- `test_nat64_url_allowed_end_to_end` — dual-stack hostname returning both a public IPv4 and a NAT64 IPv6
- `test_nat64_only_resolution_allowed` — IPv6-only resolution returning only a NAT64 address (DS-Lite scenario)

Ran with:

```bash
python -m pytest tests/tools/test_url_safety.py -x
# 61 passed in 1.33s
```

## Context

Found while building a Hermes Agent hackathon submission — `web_extract` kept erroring on legitimate public URLs because the dev machine is on a DS-Lite home ISP. Spent a bit figuring out this wasn't a Firecrawl auth / quota issue. Hopefully saves someone else the debugging.

Repo of the project that surfaced this: https://github.com/SergoVashakmadze/IoMarkets-Hermes (Hermes Creative Hackathon 2026).