### PR TITLE
fix(smart-routing): pass inline cheap_model api_key to runtime provider

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -142,6 +142,14 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
     api_key_env = str(route.get("api_key_env") or "").strip()
     if api_key_env:
         explicit_api_key = os.getenv(api_key_env) or None
+    # Fall back to the inline ``api_key`` on cheap_model. Without this,
+    # resolve_runtime_provider cannot see the inline key (explicit_base_url
+    # disables the use_config_base_url path) and drops through to
+    # OPENAI_API_KEY, which may be a stale placeholder.
+    if not explicit_api_key:
+        inline_api_key = str(route.get("api_key") or "").strip()
+        if inline_api_key:
+            explicit_api_key = inline_api_key
 
     try:
         runtime = resolve_runtime_provider(

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -59,3 +59,85 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"
     assert result["label"] is None
+
+
+def test_resolve_turn_route_passes_inline_cheap_model_api_key(monkeypatch):
+    """Inline ``api_key`` on cheap_model must reach resolve_runtime_provider.
+
+    Regression: without this, short-query turns would drop the inline key,
+    fall through to ``OPENAI_API_KEY`` env var, and 400 on the first attempt
+    before the fallback chain recovered.
+    """
+    from agent.smart_model_routing import resolve_turn_route
+
+    captured: dict = {}
+
+    def _fake_resolve(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": kwargs.get("explicit_base_url") or "",
+            "api_key": kwargs.get("explicit_api_key") or "",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _fake_resolve
+    )
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    cfg = {
+        "enabled": True,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "gemini-flash-latest",
+            "base_url": "https://example.com/v1/",
+            "api_key": "inline-cheap-key",
+        },
+    }
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        cfg,
+        {"model": "primary", "provider": "custom"},
+    )
+    assert captured["explicit_api_key"] == "inline-cheap-key"
+    assert result["runtime"]["api_key"] == "inline-cheap-key"
+
+
+def test_resolve_turn_route_prefers_api_key_env_over_inline(monkeypatch):
+    """``api_key_env`` takes precedence over inline ``api_key`` when set."""
+    from agent.smart_model_routing import resolve_turn_route
+
+    captured: dict = {}
+
+    def _fake_resolve(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": kwargs.get("explicit_base_url") or "",
+            "api_key": kwargs.get("explicit_api_key") or "",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", _fake_resolve
+    )
+    monkeypatch.setenv("CHEAP_MODEL_KEY", "env-wins")
+
+    cfg = {
+        "enabled": True,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "gemini-flash-latest",
+            "base_url": "https://example.com/v1/",
+            "api_key": "inline-loses",
+            "api_key_env": "CHEAP_MODEL_KEY",
+        },
+    }
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        cfg,
+        {"model": "primary", "provider": "custom"},
+    )
+    assert captured["explicit_api_key"] == "env-wins"
+    assert result["runtime"]["api_key"] == "env-wins"


### PR DESCRIPTION
> **Authorship note:** this patch was drafted with Claude (Anthropic, Opus 4.7) doing the root-cause investigation, code, and tests. I (john-dougherty) reviewed and validated the fix on a live gateway before submitting. Flagging transparently. The commit carries a `Co-Authored-By: Claude` trailer.

## Summary
`resolve_turn_route` only read `api_key_env` (indirect env var lookup), never the inline `api_key` on the `cheap_model` config. When smart routing fired, `resolve_runtime_provider` was called with `explicit_base_url` set, which disables its `use_config_base_url` path and skips `cfg_api_key`. The candidate chain then fell through to `OPENAI_API_KEY` — a common placeholder from Ollama-only setups (`sk-ollama`, etc.) — producing a guaranteed `HTTP 400 — API key not valid` on the first attempt of every short-query turn.

## Repro
- `config.yaml` with `smart_model_routing.cheap_model` pointing at a non-OpenAI custom endpoint (e.g. Gemini via the OpenAI-compat URL), inline `api_key` set, `api_key_env` unset.
- Any `OPENAI_API_KEY` in env that isn't valid for the cheap_model endpoint (empty, `sk-ollama`, an OpenAI key used against Google, etc.).
- Send any message ≤ 160 chars / ≤ 28 words that misses the complex-keyword list.

## Symptoms (observed on a Pi gateway)
- First API attempt: `HTTP 400 - API key not valid` from Google.
- `Fallback activated: gemini-flash-latest → gemini-flash-latest (custom)` — same model, different client built from `fallback_providers[0]` — which then sometimes hangs silently on streaming and cascades again to a third provider.
- Total: **4+ minutes** to respond to `test`. 7 API calls. Two fallback cascades.

## After the fix
Same turn: **7.3s. 1 API call. Zero fallbacks.**

## Change
When `api_key_env` isn't set (or resolves empty), use `route[\"api_key\"]` directly as `explicit_api_key`. `api_key_env` still wins when both are provided, so no behavior change for configs that rely on that override path.

## Tests
- Existing 6 tests unchanged and passing.
- New: `test_resolve_turn_route_passes_inline_cheap_model_api_key` — verifies the inline key reaches `resolve_runtime_provider` as `explicit_api_key`.
- New: `test_resolve_turn_route_prefers_api_key_env_over_inline` — verifies env var still wins when both are set.

All 8 tests pass: `pytest tests/agent/test_smart_model_routing.py -v`.

## Test plan
- [x] `pytest tests/agent/test_smart_model_routing.py -v` — 8 passed
- [x] End-to-end on Pi gateway: short DM `test` → single Gemini call, 7.3s, no fallback activation
- [ ] Confirm no regression in other paths that resolve a cheap_model runtime