### PR TITLE
feat(slack): add strict_mention gate for channel threads

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -601,6 +601,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(slack_cfg, dict):
                 if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
                     os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
+                if "strict_mention" in slack_cfg and not os.getenv("SLACK_STRICT_MENTION"):
+                    os.environ["SLACK_STRICT_MENTION"] = str(slack_cfg["strict_mention"]).lower()
                 if "allow_bots" in slack_cfg and not os.getenv("SLACK_ALLOW_BOTS"):
                     os.environ["SLACK_ALLOW_BOTS"] = str(slack_cfg["allow_bots"]).lower()
                 frc = slack_cfg.get("free_response_channels")

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1038,6 +1038,8 @@ class SlackAdapter(BasePlatformAdapter):
                 pass  # Free-response channel — always process
             elif not self._slack_require_mention():
                 pass  # Mention requirement disabled globally for Slack
+            elif self._slack_strict_mention() and not is_mentioned:
+                return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
                 reply_to_bot_thread = (
                     is_thread_reply and event_thread_ts in self._bot_message_ts
@@ -1682,6 +1684,18 @@ class SlackAdapter(BasePlatformAdapter):
                 return configured.lower() not in ("false", "0", "no", "off")
             return bool(configured)
         return os.getenv("SLACK_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
+
+    def _slack_strict_mention(self) -> bool:
+        """When true, channel threads require an explicit @-mention on every
+        message. Disables all auto-triggers (mentioned-thread memory,
+        bot-message follow-up, session-presence). Defaults to False.
+        """
+        configured = self.config.extra.get("strict_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv("SLACK_STRICT_MENTION", "false").lower() in ("true", "1", "yes", "on")
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -55,10 +55,12 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, free_response_channels=None):
+def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
+    if strict_mention is not None:
+        extra["strict_mention"] = strict_mention
     if free_response_channels is not None:
         extra["free_response_channels"] = free_response_channels
 
@@ -132,6 +134,48 @@ def test_require_mention_env_var_default_true(monkeypatch):
     monkeypatch.delenv("SLACK_REQUIRE_MENTION", raising=False)
     adapter = _make_adapter()
     assert adapter._slack_require_mention() is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: _slack_strict_mention
+# ---------------------------------------------------------------------------
+
+def test_strict_mention_defaults_to_false(monkeypatch):
+    monkeypatch.delenv("SLACK_STRICT_MENTION", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_strict_mention() is False
+
+
+def test_strict_mention_true():
+    adapter = _make_adapter(strict_mention=True)
+    assert adapter._slack_strict_mention() is True
+
+
+def test_strict_mention_false():
+    adapter = _make_adapter(strict_mention=False)
+    assert adapter._slack_strict_mention() is False
+
+
+def test_strict_mention_string_true():
+    adapter = _make_adapter(strict_mention="true")
+    assert adapter._slack_strict_mention() is True
+
+
+def test_strict_mention_string_off():
+    adapter = _make_adapter(strict_mention="off")
+    assert adapter._slack_strict_mention() is False
+
+
+def test_strict_mention_malformed_stays_false():
+    """Unrecognised values keep strict mode OFF (fail-open to legacy behavior)."""
+    adapter = _make_adapter(strict_mention="maybe")
+    assert adapter._slack_strict_mention() is False
+
+
+def test_strict_mention_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_STRICT_MENTION", "true")
+    adapter = _make_adapter()  # no config value -> falls back to env
+    assert adapter._slack_strict_mention() is True
 
 
 # ---------------------------------------------------------------------------
@@ -310,3 +354,24 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     import os as _os
     assert _os.environ["SLACK_REQUIRE_MENTION"] == "false"
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
+
+
+def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  strict_mention: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_STRICT_MENTION", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    import os as _os
+    assert _os.environ["SLACK_STRICT_MENTION"] == "true"


### PR DESCRIPTION
## Problem

In Slack channel threads, once the bot has been @-mentioned once (or has any active session for that thread), it auto-responds to **every** subsequent message — even when humans are talking to each other and not addressing the bot. This makes it noisy and intrusive in multi-person threads.

The existing `require_mention` flag only gates the *first* message; once triggered, the bot sticks around forever.

## Summary

Adds an opt-in `strict_mention` config for Slack. When enabled, the bot only responds in channel threads when **explicitly @-mentioned in the specific message** — disabling the 'once mentioned, forever in the thread', bot-message follow-up, and session-presence auto-triggers. Want a follow-up? @-mention again.

DMs and free-response channels are unaffected.

## Changes

- `gateway/platforms/slack.py` — new `_slack_strict_mention()` helper (reads `platforms.slack.extra.strict_mention` or `SLACK_STRICT_MENTION` env) + one-line gate in the channel mention-gating block
- `gateway/config.py` — bridges top-level `slack.strict_mention` yaml → `SLACK_STRICT_MENTION` env, matching how `require_mention` / `allow_bots` / `free_response_channels` are already bridged
- `tests/gateway/test_slack_mention.py` — 7 unit tests for the helper + 1 config bridge test

## Config

```yaml
slack:
  strict_mention: true   # default: false (backward-compatible)
```

Or via env: `SLACK_STRICT_MENTION=true`

## Behavior matrix

| Context | Default | `strict_mention: true` |
|---|---|---|
| DM | Always responds | Always responds |
| Free-response channel | Always responds | Always responds |
| Channel, explicit @mention | Responds | Responds |
| Channel thread, previously mentioned | Responds (auto-trigger) | **Ignores** until re-mentioned |
| Channel thread, has active session | Responds (auto-trigger) | **Ignores** until re-mentioned |
| Reply to bot's own message | Responds | **Ignores** until @mentioned |